### PR TITLE
ci(docs): allow Pages deploy on workflow_dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,9 @@ jobs:
 
   deploy:
     name: Deploy GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The GitHub Pages deploy failure on this repo had two parts: (1) the repo's Pages **Source** was still the legacy `gh-pages` branch while `docs.yml` deploys via GitHub Actions — **fixed** by switching Source → GitHub Actions; and (2) the deploy job was gated to `push` events, so a manual re-run built but **skipped** the deploy.

This PR fixes (2): the `Deploy GitHub Pages` job now also runs on `workflow_dispatch` (deploy still only from `main` on push). Merging this (which touches `.github/workflows/docs.yml`, a trigger path) fires a push-event docs run that publishes the mkdocs site to https://tckdb.github.io/TCKDB/. `mkdocs build --strict` already passes.

YAML validated. No other change.