### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Calvin Pieters, Alon Grinberg Dana, and
+Technion - Israel Institute of Technology
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -579,6 +579,6 @@ stable public service yet.
 
 ## License
 
-License: TBD. Until a `LICENSE` file is added at the repo root, treat
-the code as "source-available, all rights reserved" and contact the
-maintainers before redistribution.
+TCKDB is released under the [MIT License](LICENSE). Copyright (c) 2026
+Calvin Pieters, Alon Grinberg Dana, and Technion -- Israel Institute of
+Technology.


### PR DESCRIPTION
Release TCKDB under the **MIT License** (copyright the authors + Technion), replacing the README's `License: TBD` placeholder. This makes the code formally open source so self-hosting, redistribution, and community contribution are unambiguously permitted — and lets the paper's "open" claim and Data/Code Availability statement stand.

- `LICENSE` (MIT) at repo root.
- README license section updated to reference it.