### PR TITLE
Add reproducibility curation operations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,12 @@ An explicit directed statement that a new scientific record corrects or replaces
 _Avoid_: Overwrite, edit, replacement in place
 
 **Reproducibility assessment**:
-An append-only, rubric-versioned evaluation of whether a scientific record is described, auditable, or rerunnable from preserved evidence.
+An append-only, rubric-versioned evaluation of whether a scientific record has insufficient evidence or is described, auditable, or rerunnable from preserved evidence.
 _Avoid_: Trust score, review status
+
+**Insufficient**:
+An assessed record that does not meet every minimum requirement for the described grade.
+_Avoid_: Described, unassessed
 
 **Described**:
 A record whose scientific meaning, conditions, and source attribution are sufficient to understand the assertion.

--- a/backend/alembic/versions/e9a3c5f7b1d2_add_insufficient_reproducibility_grade.py
+++ b/backend/alembic/versions/e9a3c5f7b1d2_add_insufficient_reproducibility_grade.py
@@ -1,0 +1,52 @@
+"""add insufficient reproducibility grade
+
+Adds an explicit level-zero outcome so a completed, fail-closed assessment can
+be persisted without falsely claiming that the record is described.
+
+Revision ID: e9a3c5f7b1d2
+Revises: c6f2a9d4e7b1
+Create Date: 2026-07-21
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e9a3c5f7b1d2"
+down_revision: Union[str, Sequence[str], None] = "c6f2a9d4e7b1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the truthful below-described assessment outcome."""
+    op.execute("ALTER TYPE reproducibility_grade ADD VALUE IF NOT EXISTS 'insufficient' BEFORE 'described'")
+
+
+def downgrade() -> None:
+    """Remove ``insufficient`` only when no assessment uses it."""
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM record_reproducibility_assessment
+                WHERE grade = 'insufficient'
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot remove reproducibility grade insufficient while assessments use it';
+            END IF;
+        END;
+        $$
+        """
+    )
+    op.execute("ALTER TYPE reproducibility_grade RENAME TO reproducibility_grade_with_insufficient")
+    op.execute("CREATE TYPE reproducibility_grade AS ENUM ('described', 'auditable', 'rerunnable')")
+    op.execute(
+        "ALTER TABLE record_reproducibility_assessment "
+        "ALTER COLUMN grade TYPE reproducibility_grade "
+        "USING grade::text::reproducibility_grade"
+    )
+    op.execute("DROP TYPE reproducibility_grade_with_insufficient")

--- a/backend/alembic/versions/e9a3c5f7b1d2_add_insufficient_reproducibility_grade.py
+++ b/backend/alembic/versions/e9a3c5f7b1d2_add_insufficient_reproducibility_grade.py
@@ -4,7 +4,7 @@ Adds an explicit level-zero outcome so a completed, fail-closed assessment can
 be persisted without falsely claiming that the record is described.
 
 Revision ID: e9a3c5f7b1d2
-Revises: c6f2a9d4e7b1
+Revises: b8e3f1a9c2d4
 Create Date: 2026-07-21
 """
 
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "e9a3c5f7b1d2"
-down_revision: Union[str, Sequence[str], None] = "c6f2a9d4e7b1"
+down_revision: Union[str, Sequence[str], None] = "b8e3f1a9c2d4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -18,6 +18,7 @@ from app.api.routes import (
     bundles,
     calculations,
     conformers,
+    curation,
     energy_corrections,
     geometries,
     health,
@@ -90,6 +91,9 @@ api_router.include_router(
 )
 api_router.include_router(
     record_reviews.router, prefix="/record-reviews", tags=["record-reviews"]
+)
+api_router.include_router(
+    curation.router, prefix="/curation", tags=["curation"]
 )
 
 # Legacy entity-read routers. Wrapped with the auth gate so a hosted

--- a/backend/app/api/routes/curation.py
+++ b/backend/app/api/routes/curation.py
@@ -1,0 +1,86 @@
+"""Curator operations for reproducibility and accepted-record replacement."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.client_version import require_supported_tckdb_client
+from app.api.deps import get_db, get_write_db, require_curator_or_admin
+from app.db.models.app_user import AppUser
+from app.db.models.common import SubmissionRecordType
+from app.schemas.entities.reproducibility_assessment import ReproducibilityAssessmentRead
+from app.schemas.entities.scientific_record_supersession import (
+    ScientificRecordSupersessionRead,
+    ScientificRecordSupersessionRequest,
+)
+from app.services.reproducibility_assessment import get_latest_reproducibility_assessment
+from app.services.reproducibility_rubric import evaluate_and_append_reproducibility_v1
+from app.services.scientific_record_supersession import supersede_scientific_record
+
+router = APIRouter()
+
+
+@router.post(
+    "/reproducibility-assessments/{record_type}/{record_id}/evaluate",
+    response_model=ReproducibilityAssessmentRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_supported_tckdb_client)],
+)
+def evaluate_reproducibility(
+    record_type: SubmissionRecordType,
+    record_id: int,
+    session: Session = Depends(get_write_db),
+    _actor: AppUser = Depends(require_curator_or_admin),
+) -> ReproducibilityAssessmentRead:
+    """Derive and append a system-owned v1 assessment for one target."""
+    row = evaluate_and_append_reproducibility_v1(
+        session,
+        record_type=record_type,
+        record_id=record_id,
+    )
+    return ReproducibilityAssessmentRead.model_validate(row)
+
+
+@router.get(
+    "/reproducibility-assessments/{record_type}/{record_id}/latest",
+    response_model=ReproducibilityAssessmentRead,
+)
+def read_latest_reproducibility_assessment(
+    record_type: SubmissionRecordType,
+    record_id: int,
+    session: Session = Depends(get_db),
+    _actor: AppUser = Depends(require_curator_or_admin),
+) -> ReproducibilityAssessmentRead:
+    """Return the latest immutable assessment for one record."""
+    row = get_latest_reproducibility_assessment(
+        session,
+        record_type=record_type,
+        record_id=record_id,
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="No reproducibility assessment found for this record.")
+    return ReproducibilityAssessmentRead.model_validate(row)
+
+
+@router.post(
+    "/scientific-record-supersessions",
+    response_model=ScientificRecordSupersessionRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_supported_tckdb_client)],
+)
+def create_scientific_record_supersession(
+    body: ScientificRecordSupersessionRequest,
+    session: Session = Depends(get_write_db),
+    actor: AppUser = Depends(require_curator_or_admin),
+) -> ScientificRecordSupersessionRead:
+    """Append a same-subject replacement edge and deprecate the older record."""
+    edge = supersede_scientific_record(
+        session,
+        record_type=body.record_type,
+        superseded_record_id=body.superseded_record_id,
+        superseding_record_id=body.superseding_record_id,
+        actor=actor,
+        reason=body.reason,
+    )
+    return ScientificRecordSupersessionRead.model_validate(edge)

--- a/backend/app/db/models/common.py
+++ b/backend/app/db/models/common.py
@@ -816,6 +816,7 @@ class ReproducibilityGrade(str, Enum):
     so consumers do not have to infer evidence from the grade alone.
     """
 
+    insufficient = "insufficient"
     described = "described"
     auditable = "auditable"
     rerunnable = "rerunnable"

--- a/backend/app/schemas/entities/scientific_record_supersession.py
+++ b/backend/app/schemas/entities/scientific_record_supersession.py
@@ -2,11 +2,22 @@
 
 from datetime import datetime
 
+from pydantic import Field
+
 from app.db.models.common import SubmissionRecordType
-from app.schemas.common import SchemaBase
+from app.schemas.common import ORMBaseSchema, SchemaBase
 
 
-class ScientificRecordSupersessionRead(SchemaBase):
+class ScientificRecordSupersessionRequest(SchemaBase):
+    """Curator request to replace one accepted record with another."""
+
+    record_type: SubmissionRecordType
+    superseded_record_id: int = Field(gt=0)
+    superseding_record_id: int = Field(gt=0)
+    reason: str = Field(min_length=1, max_length=2000)
+
+
+class ScientificRecordSupersessionRead(ORMBaseSchema):
     """One immutable scientific-record replacement edge."""
 
     id: int

--- a/backend/app/services/reproducibility_assessment.py
+++ b/backend/app/services/reproducibility_assessment.py
@@ -67,7 +67,17 @@ _RECORD_MODELS: dict[SubmissionRecordType, type[Any]] = {
     SubmissionRecordType.artifact: CalculationArtifact,
 }
 
+SUPPORTED_REPRODUCIBILITY_RECORD_TYPES = frozenset(_RECORD_MODELS)
+
 _MAX_FUTURE_ASSESSMENT_SKEW = timedelta(minutes=5)
+
+
+def resolve_reproducibility_record_model(
+    record_type: str | SubmissionRecordType,
+) -> tuple[SubmissionRecordType, type[Any]]:
+    """Return the normalized record type and its assessment target model."""
+    resolved_type = record_type if isinstance(record_type, SubmissionRecordType) else SubmissionRecordType(record_type)
+    return resolved_type, _RECORD_MODELS[resolved_type]
 
 
 def _naive_utc(value: datetime | None) -> datetime:
@@ -114,7 +124,7 @@ def _require_record_exists(
     record_id: int,
 ) -> None:
     """Reject an assessment whose polymorphic target row does not exist."""
-    model = _RECORD_MODELS[record_type]
+    _, model = resolve_reproducibility_record_model(record_type)
     if session.get(model, record_id) is None:
         raise ValueError(f"{record_type.value} record {record_id} does not exist")
 

--- a/backend/app/services/reproducibility_rubric.py
+++ b/backend/app/services/reproducibility_rubric.py
@@ -1,0 +1,804 @@
+"""Deterministic, fail-closed reproducibility rubric v1.
+
+Version 1 can award ``auditable`` only to calculations. It verifies preserved
+output bytes through the artifact read path, snapshots every evaluated datum,
+and deliberately cannot award ``rerunnable`` until TCKDB has a typed execution
+environment manifest and dependency closure contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import Session
+
+from app.db.models.calculation import Calculation, CalculationArtifact
+from app.db.models.common import (
+    ArtifactKind,
+    CalculationType,
+    ReproducibilityAssessorKind,
+    ReproducibilityGrade,
+    SubmissionRecordType,
+)
+from app.db.models.energy_correction import AppliedEnergyCorrection
+from app.db.models.kinetics import Kinetics
+from app.db.models.network import Network
+from app.db.models.network_pdep import NetworkSolve
+from app.db.models.reaction import ChemReaction, ReactionEntry
+from app.db.models.reproducibility_assessment import RecordReproducibilityAssessment
+from app.db.models.species import ConformerGroup, ConformerObservation, Species, SpeciesEntry
+from app.db.models.statmech import Statmech
+from app.db.models.thermo import Thermo
+from app.db.models.transition_state import TransitionState, TransitionStateEntry
+from app.db.models.transport import Transport
+from app.services.artifact_storage import (
+    ArtifactIntegrityError,
+    ArtifactStorageUnavailable,
+    load_artifact_bytes,
+)
+from app.services.reproducibility_assessment import (
+    append_reproducibility_assessment,
+    resolve_reproducibility_record_model,
+)
+
+RUBRIC_NAME = "tckdb_reproducibility"
+RUBRIC_VERSION = "v1"
+#: Maximum output bytes fetched during one verification (50 MiB, matching the
+#: repository's per-artifact upload ceiling).
+MAX_ARTIFACT_VERIFICATION_BYTES = 50 * 1024 * 1024
+MAX_ARTIFACT_VERIFICATION_COUNT = 8
+MAX_ARTIFACT_VERIFICATION_TOTAL_BYTES = 50 * 1024 * 1024
+
+ArtifactLoader = Callable[..., bytes]
+
+
+class CheckLevel(str, Enum):
+    described = "described"
+    auditable = "auditable"
+    rerunnable = "rerunnable"
+
+
+class CheckOutcome(str, Enum):
+    passed = "passed"
+    missing = "missing"
+    not_applicable = "not_applicable"
+
+
+class ArtifactVerificationStatus(str, Enum):
+    verified = "verified"
+    not_requested = "not_requested"
+    unavailable = "unavailable"
+    integrity_failed = "integrity_failed"
+    size_limit_exceeded = "size_limit_exceeded"
+    count_budget_exceeded = "count_budget_exceeded"
+    aggregate_budget_exceeded = "aggregate_budget_exceeded"
+
+
+@dataclass(frozen=True)
+class ReproducibilityCheck:
+    """One typed rubric result with the exact evidence used by the check."""
+
+    name: str
+    level: CheckLevel
+    outcome: CheckOutcome
+    evidence: dict[str, Any]
+
+    def snapshot(self) -> dict[str, Any]:
+        return _json_value(asdict(self))
+
+
+@dataclass(frozen=True)
+class ReproducibilityWarning:
+    code: str
+    evidence: dict[str, Any]
+
+    def snapshot(self) -> dict[str, Any]:
+        return _json_value(asdict(self))
+
+
+@dataclass(frozen=True)
+class ReproducibilityEvaluation:
+    record_type: SubmissionRecordType
+    record_id: int
+    grade: ReproducibilityGrade
+    context_json: dict[str, Any]
+    passed: tuple[dict[str, Any], ...]
+    missing: tuple[dict[str, Any], ...]
+    warnings: tuple[dict[str, Any], ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _nonblank_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _mapped_columns(row: Any) -> dict[str, Any]:
+    """Snapshot all persisted scalar columns on an ORM row."""
+    mapper = sa_inspect(type(row))
+    return {column.key: _json_value(getattr(row, column.key)) for column in mapper.columns}
+
+
+def _rows(rows: Any) -> list[dict[str, Any]]:
+    snapshots = [_mapped_columns(row) for row in rows]
+    return sorted(snapshots, key=lambda item: tuple(str(value) for value in item.values()))
+
+
+def _geometry_snapshot(geometry: Any | None) -> dict[str, Any] | None:
+    """Snapshot geometry identity, serialized coordinates, and atom rows."""
+    if geometry is None:
+        return None
+    return {
+        "columns": _mapped_columns(geometry),
+        "atoms": _rows(geometry.atoms),
+    }
+
+
+def _geometry_link_snapshot(link: Any) -> dict[str, Any]:
+    return {
+        "columns": _mapped_columns(link),
+        "geometry": _geometry_snapshot(link.geometry),
+    }
+
+
+def _point_geometry_snapshot(point: Any) -> dict[str, Any]:
+    snapshot = {
+        "columns": _mapped_columns(point),
+        "geometry": _geometry_snapshot(point.geometry),
+    }
+    if hasattr(point, "coordinate_values"):
+        snapshot["coordinate_values"] = _rows(point.coordinate_values)
+    return snapshot
+
+
+_TARGET_RELATIONSHIPS: dict[type[Any], tuple[str, ...]] = {
+    ChemReaction: ("participants",),
+    ReactionEntry: ("structure_participants",),
+    Thermo: ("points", "nasa9_intervals"),
+    Kinetics: ("arrhenius_entries", "plog_entries", "third_body_efficiencies"),
+    Statmech: ("torsions", "electronic_levels"),
+    Network: ("reactions", "species_links", "states", "channels"),
+    NetworkSolve: ("bath_gases", "energy_transfers"),
+}
+
+_TARGET_SINGLE_RELATIONSHIPS: dict[type[Any], tuple[str, ...]] = {
+    Thermo: ("nasa", "wilhoit"),
+    Kinetics: ("falloff", "chebyshev"),
+}
+
+
+def _target_snapshot(target: Any, record_type: SubmissionRecordType) -> dict[str, Any]:
+    reference = (
+        f"sha256:{target.sha256}"
+        if isinstance(target, CalculationArtifact)
+        else getattr(target, "public_ref", None) or f"{record_type.value}:{target.id}"
+    )
+    relationships: dict[str, Any] = {}
+    for model, names in _TARGET_RELATIONSHIPS.items():
+        if isinstance(target, model):
+            relationships.update({name: _rows(getattr(target, name)) for name in names})
+    for model, names in _TARGET_SINGLE_RELATIONSHIPS.items():
+        if isinstance(target, model):
+            for name in names:
+                row = getattr(target, name)
+                relationships[name] = None if row is None else _mapped_columns(row)
+    if isinstance(target, Statmech):
+        relationships["torsions"] = [
+            {
+                "columns": _mapped_columns(torsion),
+                "coordinates": _rows(torsion.coordinates),
+            }
+            for torsion in sorted(target.torsions, key=lambda row: row.torsion_index)
+        ]
+    if isinstance(target, Network):
+        relationships["states"] = [
+            {
+                "columns": _mapped_columns(state),
+                "participants": _rows(state.participants),
+            }
+            for state in sorted(target.states, key=lambda row: row.id)
+        ]
+    if isinstance(target, NetworkSolve):
+        relationships["network"] = {
+            "columns": _mapped_columns(target.network),
+            "reactions": _rows(target.network.reactions),
+            "species_links": _rows(target.network.species_links),
+            "states": [
+                {
+                    "columns": _mapped_columns(state),
+                    "participants": _rows(state.participants),
+                }
+                for state in sorted(target.network.states, key=lambda row: row.id)
+            ],
+            "channels": _rows(target.network.channels),
+        }
+    return {
+        "record_type": record_type.value,
+        "record_id": target.id,
+        "reference": reference,
+        "columns": _mapped_columns(target),
+        "relationships": relationships,
+    }
+
+
+def _source_refs(target: Any) -> list[tuple[Calculation, str]]:
+    refs: list[tuple[Calculation, str]] = []
+    if isinstance(target, Calculation):
+        return [(target, "self")]
+    if isinstance(target, CalculationArtifact):
+        return [(target.calculation, "artifact_calculation")]
+    if isinstance(target, (ConformerObservation, TransitionStateEntry)):
+        refs.extend((calculation, "attached_calculation") for calculation in target.calculations)
+    elif isinstance(target, AppliedEnergyCorrection):
+        if target.source_calculation is not None:
+            refs.append((target.source_calculation, "source_calculation"))
+        if target.source_conformer_observation is not None:
+            refs.extend(
+                (calculation, "source_conformer_observation_calculation")
+                for calculation in target.source_conformer_observation.calculations
+            )
+    elif hasattr(target, "source_calculations"):
+        refs.extend(
+            (link.calculation, getattr(getattr(link, "role", None), "value", "unspecified"))
+            for link in target.source_calculations
+            if getattr(link, "calculation", None) is not None
+        )
+    unique = {(calculation.id, role): (calculation, role) for calculation, role in refs}
+    return [unique[key] for key in sorted(unique)]
+
+
+def _calculation_closure(roots: list[Calculation]) -> tuple[list[Calculation], bool]:
+    rows: dict[int, Calculation] = {}
+    visiting: set[int] = set()
+    cycle = False
+
+    def visit(calculation: Calculation) -> None:
+        nonlocal cycle
+        if calculation.id in visiting:
+            cycle = True
+            return
+        if calculation.id in rows:
+            return
+        visiting.add(calculation.id)
+        rows[calculation.id] = calculation
+        for edge in sorted(
+            calculation.child_dependencies,
+            key=lambda item: (item.dependency_role.value, item.parent_calculation_id),
+        ):
+            visit(edge.parent_calculation)
+        visiting.remove(calculation.id)
+
+    for root in roots:
+        visit(root)
+    return [rows[key] for key in sorted(rows)], cycle
+
+
+def _typed_output_snapshot(calculation: Calculation) -> tuple[bool, dict[str, Any]]:
+    attr_by_type = {
+        CalculationType.sp: "sp_result",
+        CalculationType.opt: "opt_result",
+        CalculationType.freq: "freq_result",
+        CalculationType.scan: "scan_result",
+        CalculationType.irc: "irc_result",
+        CalculationType.path_search: "path_search_result",
+    }
+    attr = attr_by_type.get(calculation.type)
+    if attr is None:
+        return False, {"calculation_type": calculation.type.value, "reason": "no_typed_result_contract_v1"}
+    result = getattr(calculation, attr)
+    if result is None:
+        return False, {"calculation_type": calculation.type.value, "result": None}
+
+    snapshot: dict[str, Any] = {"calculation_type": calculation.type.value, "result": _mapped_columns(result)}
+    if calculation.type is CalculationType.freq:
+        snapshot["modes"] = _rows(result.modes)
+        meaningful = result.n_imag is not None or result.zpe_hartree is not None or bool(result.modes)
+    elif calculation.type is CalculationType.scan:
+        snapshot["coordinates"] = _rows(result.coordinates)
+        snapshot["constraints"] = _rows(result.constraints)
+        snapshot["points"] = [_point_geometry_snapshot(point) for point in result.points]
+        meaningful = bool(result.points) or result.zero_energy_reference_hartree is not None
+    elif calculation.type is CalculationType.irc:
+        snapshot["points"] = [_point_geometry_snapshot(point) for point in result.points]
+        meaningful = bool(result.points) or result.has_forward or result.has_reverse
+    elif calculation.type is CalculationType.path_search:
+        snapshot["points"] = [_point_geometry_snapshot(point) for point in result.points]
+        meaningful = bool(result.points) or result.converged is not None
+    elif calculation.type is CalculationType.sp:
+        meaningful = result.electronic_energy_hartree is not None
+    else:
+        meaningful = result.final_energy_hartree is not None or result.converged is not None
+    return bool(meaningful), snapshot
+
+
+def _verify_artifact(
+    artifact: CalculationArtifact,
+    *,
+    artifact_loader: ArtifactLoader,
+    verify_output: bool,
+) -> tuple[dict[str, Any], ReproducibilityWarning | None]:
+    snapshot = _mapped_columns(artifact)
+    if artifact.kind is not ArtifactKind.output_log or not verify_output:
+        snapshot["verification"] = ArtifactVerificationStatus.not_requested.value
+        return snapshot, None
+    if artifact.bytes > MAX_ARTIFACT_VERIFICATION_BYTES:
+        snapshot["verification"] = ArtifactVerificationStatus.size_limit_exceeded.value
+        return snapshot, ReproducibilityWarning(
+            code="artifact_verification_size_limit",
+            evidence={
+                "artifact_id": artifact.id,
+                "persisted_bytes": artifact.bytes,
+                "verification_limit_bytes": MAX_ARTIFACT_VERIFICATION_BYTES,
+            },
+        )
+    try:
+        content = artifact_loader(artifact.sha256, expected_bytes=artifact.bytes)
+    except ArtifactStorageUnavailable:
+        snapshot["verification"] = ArtifactVerificationStatus.unavailable.value
+        return snapshot, ReproducibilityWarning(
+            code="artifact_storage_unavailable",
+            evidence={"artifact_id": artifact.id, "sha256": artifact.sha256},
+        )
+    except ArtifactIntegrityError:
+        snapshot["verification"] = ArtifactVerificationStatus.integrity_failed.value
+        return snapshot, ReproducibilityWarning(
+            code="artifact_integrity_failed",
+            evidence={"artifact_id": artifact.id, "sha256": artifact.sha256},
+        )
+    snapshot["verification"] = ArtifactVerificationStatus.verified.value
+    snapshot["verified_bytes"] = len(content)
+    return snapshot, None
+
+
+def _calculation_snapshot(
+    calculation: Calculation,
+    *,
+    artifact_loader: ArtifactLoader,
+    verify_output_artifacts: bool,
+) -> tuple[dict[str, Any], list[ReproducibilityWarning]]:
+    artifact_rows: list[dict[str, Any]] = []
+    warnings: list[ReproducibilityWarning] = []
+    verification_count = 0
+    verification_bytes = 0
+    for artifact in sorted(calculation.artifacts, key=lambda row: (row.kind.value, row.sha256, row.id)):
+        budget_status: ArtifactVerificationStatus | None = None
+        budget_warning: ReproducibilityWarning | None = None
+        should_verify = verify_output_artifacts and artifact.kind is ArtifactKind.output_log
+        if should_verify and artifact.bytes <= MAX_ARTIFACT_VERIFICATION_BYTES:
+            if verification_count >= MAX_ARTIFACT_VERIFICATION_COUNT:
+                budget_status = ArtifactVerificationStatus.count_budget_exceeded
+                budget_warning = ReproducibilityWarning(
+                    code="artifact_verification_count_budget",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "verification_count_limit": MAX_ARTIFACT_VERIFICATION_COUNT,
+                    },
+                )
+            elif verification_bytes + artifact.bytes > MAX_ARTIFACT_VERIFICATION_TOTAL_BYTES:
+                budget_status = ArtifactVerificationStatus.aggregate_budget_exceeded
+                budget_warning = ReproducibilityWarning(
+                    code="artifact_verification_aggregate_budget",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "verification_total_bytes": verification_bytes,
+                        "persisted_bytes": artifact.bytes,
+                        "verification_total_limit_bytes": MAX_ARTIFACT_VERIFICATION_TOTAL_BYTES,
+                    },
+                )
+            else:
+                verification_count += 1
+                verification_bytes += artifact.bytes
+        if budget_status is not None:
+            snapshot = _mapped_columns(artifact)
+            snapshot["verification"] = budget_status.value
+            artifact_rows.append(snapshot)
+            warnings.append(budget_warning)
+            continue
+        snapshot, warning = _verify_artifact(
+            artifact,
+            artifact_loader=artifact_loader,
+            verify_output=should_verify,
+        )
+        artifact_rows.append(snapshot)
+        if warning is not None:
+            warnings.append(warning)
+    typed_present, typed_output = _typed_output_snapshot(calculation)
+    return (
+        {
+            "columns": _mapped_columns(calculation),
+            "software_release": (
+                None
+                if calculation.software_release is None
+                else {
+                    "columns": _mapped_columns(calculation.software_release),
+                    "software": _mapped_columns(calculation.software_release.software),
+                }
+            ),
+            "workflow_tool_release": None
+            if calculation.workflow_tool_release is None
+            else _mapped_columns(calculation.workflow_tool_release),
+            "level_of_theory": None if calculation.lot is None else _mapped_columns(calculation.lot),
+            "parameters_json": _json_value(calculation.parameters_json),
+            "parameters": _rows(calculation.parameters),
+            "input_geometries": [_geometry_link_snapshot(link) for link in calculation.input_geometries],
+            "output_geometries": [_geometry_link_snapshot(link) for link in calculation.output_geometries],
+            "scan_coordinates": _rows(calculation.scan_coordinates),
+            "constraints": _rows(calculation.constraints),
+            "scan_points": [_point_geometry_snapshot(point) for point in calculation.scan_points],
+            "irc_points": [_point_geometry_snapshot(point) for point in calculation.irc_points],
+            "path_search_points": [_point_geometry_snapshot(point) for point in calculation.path_search_points],
+            "typed_output_present": typed_present,
+            "typed_output": typed_output,
+            "artifacts": artifact_rows,
+            "upstream_dependencies": _rows(calculation.child_dependencies),
+        },
+        warnings,
+    )
+
+
+def _scientific_context(target: Any, snapshot: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    columns = snapshot["columns"]
+    relationships = snapshot["relationships"]
+    if isinstance(target, Species):
+        passed = bool(target.smiles and target.inchi_key and target.multiplicity >= 1)
+    elif isinstance(target, SpeciesEntry):
+        passed = bool(target.species_id and target.kind)
+    elif isinstance(target, ConformerGroup):
+        passed = bool(target.species_entry_id)
+    elif isinstance(target, ConformerObservation):
+        passed = bool(target.conformer_group_id and target.scientific_origin)
+    elif isinstance(target, ChemReaction):
+        roles = {row["role"] for row in relationships["participants"]}
+        passed = {"reactant", "product"}.issubset(roles)
+    elif isinstance(target, ReactionEntry):
+        passed = bool(target.reaction_id and relationships["structure_participants"])
+    elif isinstance(target, TransitionState):
+        passed = bool(target.reaction_entry_id)
+    elif isinstance(target, TransitionStateEntry):
+        passed = bool(target.transition_state_id and target.multiplicity >= 1)
+    elif isinstance(target, Calculation):
+        passed = bool(target.type and ((target.species_entry_id is None) != (target.transition_state_entry_id is None)))
+    elif isinstance(target, Thermo):
+        representation = any(
+            value is not None
+            for value in (target.h298_kj_mol, target.s298_j_mol_k, target.enthalpy_formation_0k_kj_mol)
+        ) or any(relationships.get(name) for name in ("points", "nasa9_intervals", "nasa", "wilhoit"))
+        passed = bool(target.species_entry_id and target.scientific_origin and representation)
+    elif isinstance(target, Kinetics):
+        representation = target.a is not None or any(
+            relationships.get(name) for name in ("arrhenius_entries", "plog_entries", "falloff", "chebyshev")
+        )
+        passed = bool(target.reaction_entry_id and target.scientific_origin and target.model_kind and representation)
+    elif isinstance(target, Statmech):
+        passed = bool(
+            target.species_entry_id and target.scientific_origin and (target.external_symmetry or target.point_group)
+        )
+    elif isinstance(target, Transport):
+        passed = bool(
+            target.species_entry_id
+            and target.scientific_origin
+            and any(
+                value is not None
+                for value in (
+                    target.sigma_angstrom,
+                    target.epsilon_over_k_k,
+                    target.dipole_debye,
+                    target.polarizability_angstrom3,
+                    target.rotational_relaxation,
+                )
+            )
+        )
+    elif isinstance(target, Network):
+        passed = bool(relationships["reactions"] and relationships["species_links"])
+    elif isinstance(target, NetworkSolve):
+        passed = bool(
+            target.network_id
+            and target.me_method
+            and all(value is not None for value in (target.tmin_k, target.tmax_k, target.pmin_bar, target.pmax_bar))
+        )
+    elif isinstance(target, AppliedEnergyCorrection):
+        passed = bool(target.application_role and target.value_unit)
+    elif isinstance(target, CalculationArtifact):
+        passed = bool(target.calculation_id and target.filename and target.bytes > 0)
+    else:
+        passed = False
+    return passed, {"columns": columns, "relationships": relationships}
+
+
+def _source_attribution(
+    target: Any,
+    source_refs: list[tuple[Calculation, str]],
+) -> tuple[CheckOutcome, dict[str, Any]]:
+    refs = [{"calculation_id": calculation.id, "role": role} for calculation, role in source_refs]
+    if isinstance(
+        target,
+        (
+            Species,
+            SpeciesEntry,
+            ChemReaction,
+            ReactionEntry,
+            TransitionState,
+        ),
+    ):
+        return CheckOutcome.not_applicable, {"reason": "canonical_identity"}
+    if isinstance(target, Calculation):
+        passed = target.literature_id is not None or (
+            target.software_release_id is not None and target.lot_id is not None
+        )
+        return (CheckOutcome.passed if passed else CheckOutcome.missing), {
+            "literature_id": target.literature_id,
+            "software_release_id": target.software_release_id,
+            "level_of_theory_id": target.lot_id,
+        }
+    if isinstance(target, (ConformerGroup, Network)):
+        return CheckOutcome.missing, {
+            "reason": "selected_collection_requires_scientific_provenance_v1",
+            "created_by_excluded": getattr(target, "created_by", None),
+        }
+
+    origin = getattr(getattr(target, "scientific_origin", None), "value", None)
+    literature_id = getattr(target, "literature_id", None)
+    if origin == "experimental":
+        passed = literature_id is not None
+    elif origin == "estimated":
+        passed = literature_id is not None or getattr(target, "applied_group_additivity", None) is not None
+    elif origin == "computed":
+        passed = bool(refs and all(ref["role"] != "unspecified" for ref in refs))
+    else:
+        passed = literature_id is not None or bool(refs)
+    return (CheckOutcome.passed if passed else CheckOutcome.missing), {
+        "scientific_origin": origin,
+        "literature_id": literature_id,
+        "source_calculations": refs,
+    }
+
+
+def _check(
+    name: str,
+    level: CheckLevel,
+    passed: bool,
+    evidence: dict[str, Any],
+) -> ReproducibilityCheck:
+    return ReproducibilityCheck(
+        name=name,
+        level=level,
+        outcome=CheckOutcome.passed if passed else CheckOutcome.missing,
+        evidence=evidence,
+    )
+
+
+def evaluate_reproducibility_v1(
+    session: Session,
+    *,
+    record_type: str | SubmissionRecordType,
+    record_id: int,
+    artifact_loader: ArtifactLoader = load_artifact_bytes,
+) -> ReproducibilityEvaluation:
+    """Evaluate one record and snapshot all evidence consumed by rubric v1."""
+    resolved_type, model = resolve_reproducibility_record_model(record_type)
+    if record_id <= 0:
+        raise ValueError("record_id must be positive")
+    target = session.get(model, record_id)
+    if target is None:
+        raise ValueError(f"{resolved_type.value} record {record_id} does not exist")
+
+    target_evidence = _target_snapshot(target, resolved_type)
+    source_refs = _source_refs(target)
+    roots = sorted({calculation.id: calculation for calculation, _ in source_refs}.values(), key=lambda row: row.id)
+    closure, dependency_cycle = _calculation_closure(roots)
+    calculations: dict[str, Any] = {}
+    warnings: list[ReproducibilityWarning] = []
+    for calculation in closure:
+        snapshot, calculation_warnings = _calculation_snapshot(
+            calculation,
+            artifact_loader=artifact_loader,
+            verify_output_artifacts=(isinstance(target, Calculation) and calculation.id == target.id),
+        )
+        calculations[str(calculation.id)] = snapshot
+        warnings.extend(calculation_warnings)
+
+    context_present, context_detail = _scientific_context(target, target_evidence)
+    attribution_outcome, attribution_detail = _source_attribution(target, source_refs)
+    direct_calculation = target if isinstance(target, Calculation) else None
+    direct_snapshot = calculations.get(str(target.id)) if direct_calculation is not None else None
+    typed_output_present = bool(direct_snapshot and direct_snapshot["typed_output_present"])
+    verified_outputs = (
+        []
+        if direct_snapshot is None
+        else [
+            artifact
+            for artifact in direct_snapshot["artifacts"]
+            if artifact["kind"] == ArtifactKind.output_log.value
+            and artifact["verification"] == ArtifactVerificationStatus.verified.value
+        ]
+    )
+    output_artifacts = (
+        []
+        if direct_snapshot is None
+        else [
+            artifact for artifact in direct_snapshot["artifacts"] if artifact["kind"] == ArtifactKind.output_log.value
+        ]
+    )
+    input_artifacts = (
+        []
+        if direct_snapshot is None
+        else [artifact for artifact in direct_snapshot["artifacts"] if artifact["kind"] == ArtifactKind.input.value]
+    )
+    software_release = None if direct_snapshot is None else direct_snapshot["software_release"]
+    level_of_theory = None if direct_snapshot is None else direct_snapshot["level_of_theory"]
+    release_columns = None if software_release is None else software_release["columns"]
+    software_columns = None if software_release is None else software_release["software"]
+    exact_release_token = bool(
+        release_columns
+        and any(_nonblank_text(release_columns.get(field)) for field in ("version", "revision", "build"))
+    )
+    reconciliation_status = (
+        None
+        if direct_calculation is None
+        else getattr(direct_calculation.software_reconciliation_status, "value", None)
+    )
+    nonconflicting_software_identity = bool(
+        software_columns
+        and _nonblank_text(software_columns.get("name"))
+        and exact_release_token
+        and reconciliation_status != "mismatch"
+    )
+
+    checks = [
+        _check("target_identity", CheckLevel.described, bool(target_evidence["reference"]), target_evidence),
+        _check("scientific_context", CheckLevel.described, context_present, context_detail),
+        ReproducibilityCheck(
+            name="source_attribution",
+            level=CheckLevel.described,
+            outcome=attribution_outcome,
+            evidence=attribution_detail,
+        ),
+        _check(
+            "record_type_audit_policy_v1",
+            CheckLevel.auditable,
+            direct_calculation is not None,
+            {"supported_record_type": SubmissionRecordType.calculation.value},
+        ),
+        _check(
+            "calculation_metadata",
+            CheckLevel.auditable,
+            bool(level_of_theory and nonconflicting_software_identity),
+            {
+                "level_of_theory": level_of_theory,
+                "software_release": software_release,
+                "exact_release_token": exact_release_token,
+                "software_reconciliation_status": reconciliation_status,
+                "nonconflicting_software_identity": nonconflicting_software_identity,
+            },
+        ),
+        _check(
+            "typed_output_evidence",
+            CheckLevel.auditable,
+            typed_output_present,
+            {} if direct_snapshot is None else direct_snapshot["typed_output"],
+        ),
+        _check(
+            "verified_output_artifact_bytes",
+            CheckLevel.auditable,
+            bool(verified_outputs),
+            {"output_artifacts": output_artifacts},
+        ),
+        ReproducibilityCheck(
+            name="source_role_preservation",
+            level=CheckLevel.auditable,
+            outcome=CheckOutcome.not_applicable if direct_calculation is not None else CheckOutcome.missing,
+            evidence={
+                "reason": "calculation_is_the_evidence_root"
+                if direct_calculation is not None
+                else "product_policy_deferred_v1",
+                "source_calculations": attribution_detail.get("source_calculations", []),
+            },
+        ),
+        _check(
+            "preserved_input_artifacts",
+            CheckLevel.rerunnable,
+            bool(input_artifacts),
+            {"input_artifacts": input_artifacts},
+        ),
+        _check(
+            "execution_parameter_snapshot",
+            CheckLevel.rerunnable,
+            bool(direct_snapshot and (direct_snapshot["parameters_json"] or direct_snapshot["parameters"])),
+            {
+                "parameters_json": None if direct_snapshot is None else direct_snapshot["parameters_json"],
+                "parameters": [] if direct_snapshot is None else direct_snapshot["parameters"],
+            },
+        ),
+        _check(
+            "upstream_dependency_snapshot",
+            CheckLevel.rerunnable,
+            bool(direct_calculation is not None and not dependency_cycle),
+            {"cycle_detected": dependency_cycle, "calculation_ids": sorted(calculations)},
+        ),
+        _check(
+            "execution_environment_manifest",
+            CheckLevel.rerunnable,
+            False,
+            {"reason": "typed_execution_environment_manifest_not_supported_by_v1"},
+        ),
+    ]
+
+    def level_passed(level: CheckLevel) -> bool:
+        return all(check.outcome is not CheckOutcome.missing for check in checks if check.level is level)
+
+    if not level_passed(CheckLevel.described):
+        grade = ReproducibilityGrade.insufficient
+    elif not level_passed(CheckLevel.auditable):
+        grade = ReproducibilityGrade.described
+    elif not level_passed(CheckLevel.rerunnable):
+        grade = ReproducibilityGrade.auditable
+    else:  # pragma: no cover - v1's environment-manifest check is intentionally missing
+        grade = ReproducibilityGrade.rerunnable
+
+    check_snapshots = tuple(check.snapshot() for check in checks)
+    warning_snapshots = tuple(warning.snapshot() for warning in warnings)
+    context = {
+        "rubric": {"name": RUBRIC_NAME, "version": RUBRIC_VERSION},
+        "target": target_evidence,
+        "source_roles": [{"calculation_id": calculation.id, "role": role} for calculation, role in source_refs],
+        "calculation_evidence": calculations,
+        "checks": list(check_snapshots),
+        "warnings": list(warning_snapshots),
+    }
+    return ReproducibilityEvaluation(
+        record_type=resolved_type,
+        record_id=record_id,
+        grade=grade,
+        context_json=context,
+        passed=tuple(check for check in check_snapshots if check["outcome"] in {"passed", "not_applicable"}),
+        missing=tuple(check for check in check_snapshots if check["outcome"] == "missing"),
+        warnings=warning_snapshots,
+    )
+
+
+def evaluate_and_append_reproducibility_v1(
+    session: Session,
+    *,
+    record_type: str | SubmissionRecordType,
+    record_id: int,
+    artifact_loader: ArtifactLoader = load_artifact_bytes,
+) -> RecordReproducibilityAssessment:
+    """Derive and append a system-owned v1 assessment; callers provide no claims."""
+    evaluation = evaluate_reproducibility_v1(
+        session,
+        record_type=record_type,
+        record_id=record_id,
+        artifact_loader=artifact_loader,
+    )
+    return append_reproducibility_assessment(
+        session,
+        record_type=evaluation.record_type,
+        record_id=evaluation.record_id,
+        grade=evaluation.grade,
+        rubric_name=RUBRIC_NAME,
+        rubric_version=RUBRIC_VERSION,
+        context_json=evaluation.context_json,
+        passed=evaluation.passed,
+        missing=evaluation.missing,
+        warnings=evaluation.warnings,
+        assessor_kind=ReproducibilityAssessorKind.system,
+    )

--- a/backend/docs/specs/reproducibility_assessments.md
+++ b/backend/docs/specs/reproducibility_assessments.md
@@ -16,6 +16,8 @@ unapproved record can have a complete execution package.
 
 ## Grades
 
+- `insufficient`: the assessment completed, but at least one minimum
+  `described` requirement was not met. This is not the same as unassessed.
 - `described`: the target, scientific claim, conditions, and origin-appropriate
   attribution are identifiable.
 - `auditable`: `described`, plus enough role-labelled provenance, calculation
@@ -25,7 +27,7 @@ unapproved record can have a complete execution package.
   settings, upstream dependency graph, and execution identity needed to run the
   workflow again.
 
-The grades are ordered claims, but the row's `passed_json`, `missing_json`, and
+The grades are ordered outcomes, but the row's `passed_json`, `missing_json`, and
 `warnings_json` are the auditable explanation. Callers must not infer that a
 grade alone proves that the rubric was applied correctly or guarantees bitwise
 reproducibility.
@@ -50,6 +52,41 @@ committing. `get_latest_reproducibility_assessment(...)` is the sole initial
 read helper. The service does not modify science, submissions, reviews, or
 trust projections.
 
+## System rubric v1
+
+`tckdb_reproducibility:v1` is deterministic and fail-closed across the record
+types supported by the assessment table. It derives every grade and check from
+persisted structured evidence; an API caller supplies only the record address.
+Version 1 caps every non-calculation record at `described`; product derivation
+and source-role policies remain explicit missing checks until their complete
+recipes are modeled. A calculation reaches `auditable` only when it has an
+exact software release, level-of-theory identity, type-appropriate structured
+output, and an output artifact whose bytes are reachable and pass digest and
+size verification through the normal artifact read path.
+
+Artifact reads are restricted to output logs attached directly to a
+calculation being assessed. Product records and transitive parent calculations
+are metadata-only in v1 and never trigger downloads. A direct output larger
+than 50 MiB fails the verification check with a typed warning rather than being
+read. Each assessment reads at most eight output logs and at most 50 MiB in
+aggregate; further logs receive explicit count/aggregate budget statuses and
+warnings. One successfully verified qualifying output remains sufficient for
+the auditable artifact check. Software evidence includes both package and release identity, requires a
+nonblank version/revision/build token, and fails when declared-versus-parsed
+software reconciliation is `mismatch`; this is a nonconflicting declared
+identity, not a verified runtime environment.
+
+Canonical chemical identity/alignment rows use `not_applicable` source
+attribution. Selected collections such as conformer groups and networks do
+not: `created_by` is administrative provenance, so they remain below
+`described` until explicit scientific collection provenance is modeled.
+
+Version 1 never awards `rerunnable`. Deposited inputs, parameters, and the full
+upstream calculation snapshot are recorded, but the mandatory typed execution
+environment manifest is not yet supported. This explicit missing check avoids
+treating software labels or filenames as environment closure and makes no
+byte-exact claim. Reassessment always appends a new system-owned snapshot.
+
 ## Attribution
 
 `assessor_kind=system` has no user. `assessor_kind=curator` requires an
@@ -60,6 +97,7 @@ workflow's responsibility.
 ## Append-only guarantee
 
 The database rejects every `UPDATE` and `DELETE` on the assessment table via a
-PostgreSQL trigger. Reassessment and correction always append. The Alembic
-downgrade removes the trigger, table, and the two enums owned by the revision;
-it leaves the shared `submission_record_type` enum untouched.
+PostgreSQL trigger. Reassessment and correction always append. The base-table
+migration downgrade removes the trigger, table, and its two enums. The later
+`insufficient`-grade migration downgrade only removes that enum value and
+refuses to run while any assessment uses it.

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -25065,6 +25065,132 @@
         "title": "RegisterRequest",
         "type": "object"
       },
+      "ReproducibilityAssessmentRead": {
+        "description": "Read projection for one immutable assessment row.",
+        "properties": {
+          "assessed_at": {
+            "format": "date-time",
+            "title": "Assessed At",
+            "type": "string"
+          },
+          "assessor_kind": {
+            "$ref": "#/components/schemas/ReproducibilityAssessorKind"
+          },
+          "assessor_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessor User Id"
+          },
+          "context_hash": {
+            "title": "Context Hash",
+            "type": "string"
+          },
+          "context_json": {
+            "additionalProperties": true,
+            "title": "Context Json",
+            "type": "object"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "grade": {
+            "$ref": "#/components/schemas/ReproducibilityGrade"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "missing": {
+            "items": {},
+            "title": "Missing",
+            "type": "array"
+          },
+          "passed": {
+            "items": {},
+            "title": "Passed",
+            "type": "array"
+          },
+          "record_id": {
+            "title": "Record Id",
+            "type": "integer"
+          },
+          "record_type": {
+            "$ref": "#/components/schemas/SubmissionRecordType"
+          },
+          "rubric_name": {
+            "title": "Rubric Name",
+            "type": "string"
+          },
+          "rubric_version": {
+            "title": "Rubric Version",
+            "type": "string"
+          },
+          "source_submission_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Submission Id"
+          },
+          "warnings": {
+            "items": {},
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "record_type",
+          "record_id",
+          "grade",
+          "rubric_name",
+          "rubric_version",
+          "context_hash",
+          "context_json",
+          "passed",
+          "missing",
+          "warnings",
+          "assessor_kind",
+          "assessor_user_id",
+          "source_submission_id",
+          "assessed_at",
+          "created_at"
+        ],
+        "title": "ReproducibilityAssessmentRead",
+        "type": "object"
+      },
+      "ReproducibilityAssessorKind": {
+        "description": "Who produced a reproducibility assessment snapshot.",
+        "enum": [
+          "system",
+          "curator"
+        ],
+        "title": "ReproducibilityAssessorKind",
+        "type": "string"
+      },
+      "ReproducibilityGrade": {
+        "description": "Highest reproducibility claim supported by one assessment snapshot.\n\nThis vocabulary is independent of record-review state and deterministic\ntrust badges.  The values form an increasing evidence ladder, but the\npersisted assessment also records its passed, missing, and warning checks\nso consumers do not have to infer evidence from the grade alone.",
+        "enum": [
+          "insufficient",
+          "described",
+          "auditable",
+          "rerunnable"
+        ],
+        "title": "ReproducibilityGrade",
+        "type": "string"
+      },
       "ResourceLink": {
         "description": "Links to canonical REST resources.",
         "properties": {
@@ -28070,6 +28196,83 @@
           "pagination"
         ],
         "title": "ScientificReactionSearchResponse",
+        "type": "object"
+      },
+      "ScientificRecordSupersessionRead": {
+        "description": "One immutable scientific-record replacement edge.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "title": "Created By",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "record_type": {
+            "$ref": "#/components/schemas/SubmissionRecordType"
+          },
+          "superseded_record_id": {
+            "title": "Superseded Record Id",
+            "type": "integer"
+          },
+          "superseding_record_id": {
+            "title": "Superseding Record Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "record_type",
+          "superseded_record_id",
+          "superseding_record_id",
+          "reason",
+          "created_by",
+          "created_at"
+        ],
+        "title": "ScientificRecordSupersessionRead",
+        "type": "object"
+      },
+      "ScientificRecordSupersessionRequest": {
+        "additionalProperties": false,
+        "description": "Curator request to replace one accepted record with another.",
+        "properties": {
+          "reason": {
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Reason",
+            "type": "string"
+          },
+          "record_type": {
+            "$ref": "#/components/schemas/SubmissionRecordType"
+          },
+          "superseded_record_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Superseded Record Id",
+            "type": "integer"
+          },
+          "superseding_record_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Superseding Record Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "record_type",
+          "superseded_record_id",
+          "superseding_record_id",
+          "reason"
+        ],
+        "title": "ScientificRecordSupersessionRequest",
         "type": "object"
       },
       "ScientificSpeciesCalculationsSearchResponse": {
@@ -45103,6 +45306,312 @@
         "summary": "Get Conformer Observation",
         "tags": [
           "conformer-observations"
+        ]
+      }
+    },
+    "/api/v1/curation/reproducibility-assessments/{record_type}/{record_id}/evaluate": {
+      "post": {
+        "description": "Derive and append a system-owned v1 assessment for one target.",
+        "operationId": "evaluate_reproducibility_api_v1_curation_reproducibility_assessments__record_type___record_id__evaluate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "record_type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SubmissionRecordType"
+            }
+          },
+          {
+            "in": "path",
+            "name": "record_id",
+            "required": true,
+            "schema": {
+              "title": "Record Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-TCKDB-Client-Name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Tckdb-Client-Name"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-TCKDB-Client-Version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Tckdb-Client-Version"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "tckdb_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tckdb Session"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReproducibilityAssessmentRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Evaluate Reproducibility",
+        "tags": [
+          "curation"
+        ]
+      }
+    },
+    "/api/v1/curation/reproducibility-assessments/{record_type}/{record_id}/latest": {
+      "get": {
+        "description": "Return the latest immutable assessment for one record.",
+        "operationId": "read_latest_reproducibility_assessment_api_v1_curation_reproducibility_assessments__record_type___record_id__latest_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "record_type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SubmissionRecordType"
+            }
+          },
+          {
+            "in": "path",
+            "name": "record_id",
+            "required": true,
+            "schema": {
+              "title": "Record Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "tckdb_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tckdb Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReproducibilityAssessmentRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Latest Reproducibility Assessment",
+        "tags": [
+          "curation"
+        ]
+      }
+    },
+    "/api/v1/curation/scientific-record-supersessions": {
+      "post": {
+        "description": "Append a same-subject replacement edge and deprecate the older record.",
+        "operationId": "create_scientific_record_supersession_api_v1_curation_scientific_record_supersessions_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-TCKDB-Client-Name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Tckdb-Client-Name"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-TCKDB-Client-Version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Tckdb-Client-Version"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "tckdb_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tckdb Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScientificRecordSupersessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScientificRecordSupersessionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Scientific Record Supersession",
+        "tags": [
+          "curation"
         ]
       }
     },

--- a/backend/tests/api/test_api_curation_operations.py
+++ b/backend/tests/api/test_api_curation_operations.py
@@ -1,0 +1,103 @@
+"""API coverage for curator reproducibility and supersession operations."""
+
+from __future__ import annotations
+
+from app.db.models.app_user import AppUser
+from app.db.models.common import RecordReviewStatus, ReproducibilityGrade, SubmissionRecordType
+from app.db.models.network import Network
+from app.db.models.reaction import ChemReaction
+from app.services.record_review import ensure_record_review, set_record_review_status
+
+
+def _assessment_url(record_type: str, record_id: int) -> str:
+    return f"/api/v1/curation/reproducibility-assessments/{record_type}/{record_id}"
+
+
+def _approved_network(db_session, *, name: str, actor: AppUser) -> Network:
+    network = Network(name=name, created_by=actor.id)
+    db_session.add(network)
+    db_session.flush()
+    ensure_record_review(
+        db_session,
+        record_type=SubmissionRecordType.network,
+        record_id=network.id,
+    )
+    set_record_review_status(
+        db_session,
+        record_type=SubmissionRecordType.network,
+        record_id=network.id,
+        status=RecordReviewStatus.approved,
+        actor=actor,
+    )
+    return network
+
+
+def test_evaluation_is_curator_gated_and_server_derived(
+    client,
+    db_session,
+    login_as,
+    _api_curator_user,
+) -> None:
+    reaction = ChemReaction(reversible=True)
+    db_session.add(reaction)
+    db_session.flush()
+    url = _assessment_url("reaction", reaction.id) + "/evaluate"
+
+    assert client.post(url).status_code == 403
+    login_as(_api_curator_user)
+    response = client.post(url)
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["grade"] == ReproducibilityGrade.insufficient.value
+    assert body["rubric_name"] == "tckdb_reproducibility"
+    assert body["rubric_version"] == "v1"
+    assert body["assessor_kind"] == "system"
+    assert body["assessor_user_id"] is None
+
+
+def test_latest_assessment_read_is_curator_gated(
+    client,
+    db_session,
+    login_as,
+    _api_curator_user,
+) -> None:
+    reaction = ChemReaction(reversible=True)
+    db_session.add(reaction)
+    db_session.flush()
+    base = _assessment_url("reaction", reaction.id)
+    login_as(_api_curator_user)
+
+    assert client.get(base + "/latest").status_code == 404
+    created = client.post(base + "/evaluate")
+    latest = client.get(base + "/latest")
+
+    assert created.status_code == 201
+    assert latest.status_code == 200
+    assert latest.json()["id"] == created.json()["id"]
+
+
+def test_curator_can_supersede_approved_same_subject_records(
+    client,
+    db_session,
+    login_as,
+    _api_curator_user,
+) -> None:
+    actor = db_session.get(AppUser, _api_curator_user)
+    old = _approved_network(db_session, name="same subject", actor=actor)
+    new = _approved_network(db_session, name="same subject", actor=actor)
+    login_as(_api_curator_user)
+
+    response = client.post(
+        "/api/v1/curation/scientific-record-supersessions",
+        json={
+            "record_type": "network",
+            "superseded_record_id": old.id,
+            "superseding_record_id": new.id,
+            "reason": "corrected network evidence",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["created_by"] == _api_curator_user
+    assert response.json()["superseded_record_id"] == old.id

--- a/backend/tests/services/test_reproducibility_rubric.py
+++ b/backend/tests/services/test_reproducibility_rubric.py
@@ -1,0 +1,633 @@
+"""Focused tests for the conservative reproducibility rubric v1."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+import pytest
+
+from app.db.models.calculation import (
+    Calculation,
+    CalculationArtifact,
+    CalculationDependency,
+    CalculationParameter,
+    CalculationScanCoordinate,
+    CalculationSPResult,
+)
+from app.db.models.common import (
+    ArtifactKind,
+    CalculationDependencyRole,
+    CalculationType,
+    CoordinateUnit,
+    MoleculeKind,
+    ParameterSource,
+    ReproducibilityAssessorKind,
+    ReproducibilityGrade,
+    ScanCoordinateKind,
+    ScientificOriginKind,
+    SoftwareReconciliationStatus,
+    StereoKind,
+    SubmissionRecordType,
+    ThermoCalculationRole,
+)
+from app.db.models.geometry import Geometry, GeometryAtom
+from app.db.models.level_of_theory import LevelOfTheory
+from app.db.models.reaction import ChemReaction
+from app.db.models.software import Software, SoftwareRelease
+from app.db.models.species import Species, SpeciesEntry
+from app.db.models.thermo import Thermo, ThermoSourceCalculation
+from app.services.artifact_storage import ArtifactIntegrityError, ArtifactStorageUnavailable
+from app.services.reproducibility_assessment import SUPPORTED_REPRODUCIBILITY_RECORD_TYPES
+from app.services.reproducibility_rubric import (
+    MAX_ARTIFACT_VERIFICATION_BYTES,
+    MAX_ARTIFACT_VERIFICATION_COUNT,
+    MAX_ARTIFACT_VERIFICATION_TOTAL_BYTES,
+    _geometry_snapshot,
+    _rows,
+    evaluate_and_append_reproducibility_v1,
+    evaluate_reproducibility_v1,
+)
+
+
+def _snapshot_hash(snapshot) -> str:
+    encoded = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _verified_loader(objects: dict[str, bytes]):
+    def load(sha256: str, *, expected_bytes: int | None = None) -> bytes:
+        if sha256 not in objects:
+            raise ArtifactStorageUnavailable("missing mocked object")
+        content = objects[sha256]
+        if not hmac.compare_digest(hashlib.sha256(content).hexdigest(), sha256):
+            raise ArtifactIntegrityError("mocked digest mismatch")
+        if expected_bytes is not None and len(content) != expected_bytes:
+            raise ArtifactIntegrityError("mocked size mismatch")
+        return content
+
+    return load
+
+
+def _calculation(
+    db_session,
+    *,
+    complete: bool,
+    created_by: int,
+    objects: dict[str, bytes],
+    typed_output: bool = True,
+) -> Calculation:
+    token = str(created_by) + str(db_session.query(Calculation).count())
+    species = Species(
+        kind=MoleculeKind.molecule,
+        smiles=f"repro-{token}",
+        inchi_key=hashlib.sha256(token.encode()).hexdigest()[:27].upper(),
+        charge=0,
+        multiplicity=1,
+        stereo_kind=StereoKind.achiral,
+    )
+    db_session.add(species)
+    db_session.flush()
+    entry = SpeciesEntry(species_id=species.id, created_by=created_by)
+    software = Software(name=f"repro-software-{token}")
+    lot = LevelOfTheory(
+        method="wb97xd",
+        basis="def2tzvp",
+        lot_hash=hashlib.sha256(f"lot-{token}".encode()).hexdigest(),
+    )
+    db_session.add_all([entry, software, lot])
+    db_session.flush()
+    release = SoftwareRelease(software_id=software.id, version="1.0")
+    db_session.add(release)
+    db_session.flush()
+    calculation = Calculation(
+        type=CalculationType.sp,
+        species_entry_id=entry.id,
+        software_release_id=release.id,
+        lot_id=lot.id,
+        created_by=created_by,
+    )
+    db_session.add(calculation)
+    db_session.flush()
+    output = f"Entering Gaussian System output {token}".encode()
+    output_sha = hashlib.sha256(output).hexdigest()
+    objects[output_sha] = output
+    db_session.add(
+        CalculationArtifact(
+            calculation_id=calculation.id,
+            kind=ArtifactKind.output_log,
+            uri=f"s3://repro/{token}.log",
+            sha256=output_sha,
+            bytes=len(output),
+            filename="job.log",
+            created_by=created_by,
+        )
+    )
+    if typed_output:
+        db_session.add(
+            CalculationSPResult(
+                calculation_id=calculation.id,
+                electronic_energy_hartree=-40.0,
+            )
+        )
+    if complete:
+        input_bytes = f"# wb97xd/def2tzvp input {token}".encode()
+        input_sha = hashlib.sha256(input_bytes).hexdigest()
+        objects[input_sha] = input_bytes
+        db_session.add_all(
+            [
+                CalculationArtifact(
+                    calculation_id=calculation.id,
+                    kind=ArtifactKind.input,
+                    uri=f"s3://repro/{token}.inp",
+                    sha256=input_sha,
+                    bytes=len(input_bytes),
+                    filename="job.inp",
+                    created_by=created_by,
+                ),
+                CalculationParameter(
+                    calculation_id=calculation.id,
+                    raw_key="scf_convergence",
+                    raw_value="tight",
+                    source=ParameterSource.upload,
+                ),
+            ]
+        )
+    db_session.flush()
+    db_session.refresh(calculation)
+    return calculation
+
+
+def _evaluate(db_session, calculation: Calculation, objects: dict[str, bytes]):
+    return evaluate_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=calculation.id,
+        artifact_loader=_verified_loader(objects),
+    )
+
+
+def test_below_described_result_is_persisted_as_insufficient(db_session) -> None:
+    reaction = ChemReaction(reversible=True)
+    db_session.add(reaction)
+    db_session.flush()
+
+    row = evaluate_and_append_reproducibility_v1(
+        db_session,
+        record_type=SubmissionRecordType.reaction,
+        record_id=reaction.id,
+    )
+
+    assert row.grade is ReproducibilityGrade.insufficient
+    assert row.assessor_kind is ReproducibilityAssessorKind.system
+    assert {item["name"] for item in row.missing_json} >= {"scientific_context"}
+
+
+def test_verified_typed_output_can_be_auditable_but_v1_never_rerunnable(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+
+    result = _evaluate(db_session, calculation, objects)
+
+    assert result.grade is ReproducibilityGrade.auditable
+    assert "verified_output_artifact_bytes" in {item["name"] for item in result.passed}
+    assert "execution_environment_manifest" in {item["name"] for item in result.missing}
+
+
+@pytest.mark.parametrize("failure", ["unavailable", "integrity"])
+def test_artifact_verification_failure_fails_closed(
+    db_session,
+    _api_test_user,
+    failure,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=False,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+
+    def failing_loader(_sha256: str, *, expected_bytes: int | None = None) -> bytes:
+        del expected_bytes
+        if failure == "unavailable":
+            raise ArtifactStorageUnavailable("mock unavailable")
+        raise ArtifactIntegrityError("mock corrupt")
+
+    result = evaluate_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=calculation.id,
+        artifact_loader=failing_loader,
+    )
+
+    assert result.grade is ReproducibilityGrade.described
+    assert "verified_output_artifact_bytes" in {item["name"] for item in result.missing}
+    assert (
+        result.warnings[0]["code"]
+        == f"artifact_{'storage_unavailable' if failure == 'unavailable' else 'integrity_failed'}"
+    )
+
+
+def test_typed_output_absence_caps_calculation_at_described(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=False,
+        created_by=_api_test_user,
+        objects=objects,
+        typed_output=False,
+    )
+
+    result = _evaluate(db_session, calculation, objects)
+
+    assert result.grade is ReproducibilityGrade.described
+    assert "typed_output_evidence" in {item["name"] for item in result.missing}
+
+
+def test_software_reconciliation_mismatch_caps_calculation_at_described(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    calculation.software_reconciliation_status = SoftwareReconciliationStatus.mismatch
+    db_session.flush()
+
+    result = _evaluate(db_session, calculation, objects)
+
+    assert result.grade is ReproducibilityGrade.described
+    metadata = next(item for item in result.missing if item["name"] == "calculation_metadata")
+    assert metadata["evidence"]["software_reconciliation_status"] == "mismatch"
+    assert metadata["evidence"]["nonconflicting_software_identity"] is False
+
+
+def test_whitespace_only_release_token_is_not_exact(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    calculation.software_release.version = "   "
+    db_session.flush()
+
+    result = _evaluate(db_session, calculation, objects)
+
+    assert result.grade is ReproducibilityGrade.described
+    metadata = next(item for item in result.missing if item["name"] == "calculation_metadata")
+    assert metadata["evidence"]["exact_release_token"] is False
+
+
+def test_oversized_output_fails_closed_without_loading(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=False,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    calculation.artifacts[0].bytes = MAX_ARTIFACT_VERIFICATION_BYTES + 1
+    db_session.flush()
+    calls = 0
+
+    def loader(_sha256: str, *, expected_bytes: int | None = None) -> bytes:
+        nonlocal calls
+        calls += 1
+        raise AssertionError(expected_bytes)
+
+    result = evaluate_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=calculation.id,
+        artifact_loader=loader,
+    )
+
+    assert calls == 0
+    assert result.grade is ReproducibilityGrade.described
+    assert result.warnings[0]["code"] == "artifact_verification_size_limit"
+
+
+def test_multiple_outputs_respect_count_budget_and_keep_auditable(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=False,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    for index in range(MAX_ARTIFACT_VERIFICATION_COUNT + 1):
+        db_session.add(
+            CalculationArtifact(
+                calculation_id=calculation.id,
+                kind=ArtifactKind.output_log,
+                uri=f"s3://repro/extra-{index}.log",
+                sha256=hashlib.sha256(f"extra-{index}".encode()).hexdigest(),
+                bytes=1,
+                filename=f"extra-{index}.log",
+                created_by=_api_test_user,
+            )
+        )
+    db_session.flush()
+    calls: list[int] = []
+
+    def loader(_sha256: str, *, expected_bytes: int | None = None) -> bytes:
+        calls.append(expected_bytes or 0)
+        return b"verified"
+
+    result = evaluate_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=calculation.id,
+        artifact_loader=loader,
+    )
+
+    assert len(calls) == MAX_ARTIFACT_VERIFICATION_COUNT
+    assert sum(calls) <= MAX_ARTIFACT_VERIFICATION_TOTAL_BYTES
+    assert result.grade is ReproducibilityGrade.auditable
+    assert any(warning["code"] == "artifact_verification_count_budget" for warning in result.warnings)
+
+
+def test_multiple_outputs_respect_aggregate_byte_budget(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=False,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    for index in range(2):
+        db_session.add(
+            CalculationArtifact(
+                calculation_id=calculation.id,
+                kind=ArtifactKind.output_log,
+                uri=f"s3://repro/large-{index}.log",
+                sha256=hashlib.sha256(f"large-{index}".encode()).hexdigest(),
+                bytes=30 * 1024 * 1024,
+                filename=f"large-{index}.log",
+                created_by=_api_test_user,
+            )
+        )
+    db_session.flush()
+    calls: list[int] = []
+
+    def loader(_sha256: str, *, expected_bytes: int | None = None) -> bytes:
+        calls.append(expected_bytes or 0)
+        return b"verified"
+
+    result = evaluate_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=calculation.id,
+        artifact_loader=loader,
+    )
+
+    assert sum(calls) <= MAX_ARTIFACT_VERIFICATION_TOTAL_BYTES
+    assert result.grade is ReproducibilityGrade.auditable
+    assert any(warning["code"] == "artifact_verification_aggregate_budget" for warning in result.warnings)
+
+
+def test_non_calculation_is_capped_at_described_and_preserves_source_roles(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    thermo = Thermo(
+        species_entry_id=calculation.species_entry_id,
+        scientific_origin=ScientificOriginKind.computed,
+        h298_kj_mol=-10.0,
+        created_by=_api_test_user,
+    )
+    db_session.add(thermo)
+    db_session.flush()
+    db_session.add(
+        ThermoSourceCalculation(
+            thermo_id=thermo.id,
+            calculation_id=calculation.id,
+            role=ThermoCalculationRole.sp,
+        )
+    )
+    db_session.flush()
+
+    calls = 0
+
+    def loader(_sha256: str, *, expected_bytes: int | None = None) -> bytes:
+        nonlocal calls
+        calls += 1
+        raise AssertionError(expected_bytes)
+
+    result = evaluate_reproducibility_v1(
+        db_session,
+        record_type="thermo",
+        record_id=thermo.id,
+        artifact_loader=loader,
+    )
+
+    assert calls == 0
+    assert result.grade is ReproducibilityGrade.described
+    assert result.context_json["source_roles"] == [
+        {"calculation_id": calculation.id, "role": ThermoCalculationRole.sp.value}
+    ]
+    assert "record_type_audit_policy_v1" in {item["name"] for item in result.missing}
+
+
+def test_target_and_direct_source_mutations_change_context_hash(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    calculation = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    thermo = Thermo(
+        species_entry_id=calculation.species_entry_id,
+        scientific_origin=ScientificOriginKind.computed,
+        h298_kj_mol=-10.0,
+        created_by=_api_test_user,
+    )
+    db_session.add(thermo)
+    db_session.flush()
+    db_session.add(
+        ThermoSourceCalculation(
+            thermo_id=thermo.id,
+            calculation_id=calculation.id,
+            role=ThermoCalculationRole.sp,
+        )
+    )
+    db_session.flush()
+    loader = _verified_loader(objects)
+
+    first = evaluate_and_append_reproducibility_v1(
+        db_session,
+        record_type="thermo",
+        record_id=thermo.id,
+        artifact_loader=loader,
+    )
+    thermo.h298_kj_mol = -11.0
+    db_session.flush()
+    target_changed = evaluate_and_append_reproducibility_v1(
+        db_session,
+        record_type="thermo",
+        record_id=thermo.id,
+        artifact_loader=loader,
+    )
+    calculation.parameters[0].raw_value = "very_tight"
+    db_session.flush()
+    source_changed = evaluate_and_append_reproducibility_v1(
+        db_session,
+        record_type="thermo",
+        record_id=thermo.id,
+        artifact_loader=loader,
+    )
+
+    assert first.context_hash != target_changed.context_hash
+    assert target_changed.context_hash != source_changed.context_hash
+
+
+def test_transitive_parent_mutation_changes_context_hash(
+    db_session,
+    _api_test_user,
+) -> None:
+    objects: dict[str, bytes] = {}
+    parent = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    child = _calculation(
+        db_session,
+        complete=True,
+        created_by=_api_test_user,
+        objects=objects,
+    )
+    db_session.add(
+        CalculationDependency(
+            parent_calculation_id=parent.id,
+            child_calculation_id=child.id,
+            dependency_role=CalculationDependencyRole.single_point_on,
+        )
+    )
+    db_session.flush()
+    loader = _verified_loader(objects)
+
+    first = evaluate_and_append_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=child.id,
+        artifact_loader=loader,
+    )
+    parent.parameters[0].raw_value = "ultratight"
+    db_session.flush()
+    second = evaluate_and_append_reproducibility_v1(
+        db_session,
+        record_type="calculation",
+        record_id=child.id,
+        artifact_loader=loader,
+    )
+
+    assert first.grade is ReproducibilityGrade.auditable
+    assert second.grade is ReproducibilityGrade.auditable
+    assert first.context_hash != second.context_hash
+
+
+def test_geometry_atom_coordinate_mutation_changes_snapshot_hash() -> None:
+    geometry = Geometry(
+        id=1,
+        public_ref="geom_test",
+        natoms=1,
+        geom_hash="a" * 64,
+        xyz_text="1\nH\nH 0 0 0",
+    )
+    atom = GeometryAtom(geometry_id=1, atom_index=1, element="H", x=0.0, y=0.0, z=0.0)
+    geometry.atoms.append(atom)
+
+    before = _snapshot_hash(_geometry_snapshot(geometry))
+    atom.x = 0.125
+    after = _snapshot_hash(_geometry_snapshot(geometry))
+
+    assert before != after
+
+
+def test_scan_coordinate_mutation_changes_snapshot_hash() -> None:
+    coordinate = CalculationScanCoordinate(
+        calculation_id=1,
+        coordinate_index=1,
+        coordinate_kind=ScanCoordinateKind.bond,
+        atom1_index=1,
+        atom2_index=2,
+        step_count=8,
+        step_size=0.1,
+        value_unit=CoordinateUnit.angstrom,
+    )
+
+    before = _snapshot_hash(_rows([coordinate]))
+    coordinate.step_size = 0.2
+    after = _snapshot_hash(_rows([coordinate]))
+
+    assert before != after
+
+
+def test_registry_covers_all_addressable_assessment_types() -> None:
+    assert SUPPORTED_REPRODUCIBILITY_RECORD_TYPES == frozenset(SubmissionRecordType)
+
+
+def test_missing_record_fails_closed(db_session) -> None:
+    with pytest.raises(ValueError, match="calculation record 999999999 does not exist"):
+        evaluate_reproducibility_v1(
+            db_session,
+            record_type="calculation",
+            record_id=999_999_999,
+        )
+
+
+def test_insufficient_grade_migration_layers_on_current_head() -> None:
+    migration = (
+        Path(__file__).resolve().parents[2]
+        / "alembic"
+        / "versions"
+        / "e9a3c5f7b1d2_add_insufficient_reproducibility_grade.py"
+    ).read_text()
+
+    assert 'down_revision: Union[str, Sequence[str], None] = "c6f2a9d4e7b1"' in migration
+    assert "ADD VALUE IF NOT EXISTS 'insufficient' BEFORE 'described'" in migration

--- a/backend/tests/services/test_reproducibility_rubric.py
+++ b/backend/tests/services/test_reproducibility_rubric.py
@@ -629,5 +629,5 @@ def test_insufficient_grade_migration_layers_on_current_head() -> None:
         / "e9a3c5f7b1d2_add_insufficient_reproducibility_grade.py"
     ).read_text()
 
-    assert 'down_revision: Union[str, Sequence[str], None] = "c6f2a9d4e7b1"' in migration
+    assert 'down_revision: Union[str, Sequence[str], None] = "b8e3f1a9c2d4"' in migration
     assert "ADD VALUE IF NOT EXISTS 'insufficient' BEFORE 'described'" in migration


### PR DESCRIPTION
## Summary
- add a deterministic, fail-closed reproducibility rubric v1 and explicit insufficient outcome
- add curator/admin operations to evaluate/read assessments and supersede accepted records
- verify bounded output bytes for calculation auditability; cap non-calculations at described and v1 at auditable

## Schema impact
Adds Alembic revision e9a3c5f7b1d2, extending reproducibility_grade with insufficient. The downgrade refuses while that value is in use.

## Verification
- 47 focused assessment/API/supersession/OpenAPI tests passed
- final rubric subset: 18 passed
- Ruff, formatting, compile, and diff checks passed
- independent adversarial review: no remaining blockers

Molpro and paper files were not touched.