### PR TITLE
Guard canonical image publishing

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   build-and-push:
+    if: github.repository == 'TCKDB/TCKDB'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- restrict the Docker image publishing job to TCKDB/TCKDB
- make mirrors skip authentication, building, and publishing
- prevent duplicate publishers from racing on shared Docker Hub tags

## Impact

Canonical pushes and manual dispatches continue unchanged. Mirrored repositories show the job as skipped.

## Validation

- YAML parse and exact guard assertion
- git diff --check
- independent adversarial review