### PR TITLE
Gate raw artifact downloads behind authentication (ADR 0004)

### DIFF
--- a/backend/app/api/routes/scientific/artifacts.py
+++ b/backend/app/api/routes/scientific/artifacts.py
@@ -14,8 +14,9 @@ from urllib.parse import quote
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db
+from app.api.deps import get_current_user, get_db
 from app.api.routes.scientific._common import parse_include
+from app.db.models.app_user import AppUser
 from app.db.models.common import (
     ArtifactKind,
     CalculationQuality,
@@ -160,6 +161,7 @@ def artifacts_search_post(
     response_class=Response,
     responses={
         200: {"content": {"application/octet-stream": {}}},
+        401: {"description": "Authentication required."},
         404: {"description": "No approved artifact has this digest."},
         502: {"description": "Stored bytes failed integrity verification."},
         503: {"description": "Artifact storage is unavailable."},
@@ -167,9 +169,20 @@ def artifacts_search_post(
 )
 def download_approved_artifact(
     sha256: str = Path(pattern=r"^[0-9a-f]{64}$"),
+    _user: AppUser = Depends(get_current_user),
     session: Session = Depends(get_db),
 ) -> Response:
-    """Download curator-approved bytes by their content-addressed digest."""
+    """Download curator-approved bytes by their content-addressed digest.
+
+    Unlike the metadata search endpoints, which are part of the public
+    read surface, raw-artifact bytes are served only to authenticated
+    callers (any valid API key or session): unredacted logs may embed
+    producer-side scratch paths, usernames, and cluster hostnames that
+    must never reach anonymous clients. This gate is unconditional (no
+    opt-out flag) so no deployment can accidentally re-expose the bytes;
+    see ``docs/adr/0004-store-artifacts-verbatim-gate-raw-log-access.md``.
+    The digest is still re-verified against the stored bytes below.
+    """
 
     artifact = resolve_approved_artifact_by_sha256(session, sha256)
     if artifact is None:
@@ -199,7 +212,11 @@ def download_approved_artifact(
         content=content,
         media_type=media_type,
         headers={
-            "Cache-Control": "public, max-age=0, must-revalidate",
+            # Authenticated, potentially PII-bearing bytes: forbid shared
+            # caches from retaining them. ``public`` would let a CDN serve
+            # one user's raw log to a later anonymous request for the same
+            # URL, defeating the auth gate (ADR 0004).
+            "Cache-Control": "private, no-store",
             "Content-Disposition": (
                 f"attachment; filename*=UTF-8''{encoded_filename}"
             ),

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -50778,7 +50778,7 @@
     },
     "/api/v1/scientific/artifacts/{sha256}/download": {
       "get": {
-        "description": "Download curator-approved bytes by their content-addressed digest.",
+        "description": "Download curator-approved bytes by their content-addressed digest.\n\nUnlike the metadata search endpoints, which are part of the public\nread surface, raw-artifact bytes are served only to authenticated\ncallers (any valid API key or session): unredacted logs may embed\nproducer-side scratch paths, usernames, and cluster hostnames that\nmust never reach anonymous clients. This gate is unconditional (no\nopt-out flag) so no deployment can accidentally re-expose the bytes;\nsee ``docs/adr/0004-store-artifacts-verbatim-gate-raw-log-access.md``.\nThe digest is still re-verified against the stored bytes below.",
         "operationId": "download_approved_artifact_api_v1_scientific_artifacts__sha256__download_get",
         "parameters": [
           {
@@ -50790,6 +50790,38 @@
               "title": "Sha256",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "tckdb_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tckdb Session"
+            }
           }
         ],
         "responses": {
@@ -50798,6 +50830,9 @@
               "application/octet-stream": {}
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "description": "Authentication required."
           },
           "404": {
             "description": "No approved artifact has this digest."

--- a/backend/tests/api/scientific/test_api_scientific_artifact_download.py
+++ b/backend/tests/api/scientific/test_api_scientific_artifact_download.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import hashlib
 
+from fastapi.testclient import TestClient
+
+from app.api.app import create_app
+from app.api.deps import get_db, get_write_db
 from app.db.models.common import (
     RecordReviewStatus,
     SubmissionRecordType,
@@ -55,7 +59,8 @@ def test_approved_artifact_download_returns_verified_bytes(
     assert response.content == content
     assert response.headers["x-content-sha256"] == artifact.sha256
     assert response.headers["etag"] == f'"{artifact.sha256}"'
-    assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
+    # Authenticated PII-bearing bytes must not be retained by shared caches.
+    assert response.headers["cache-control"] == "private, no-store"
 
 
 def test_nonapproved_artifact_download_is_indistinguishable_from_missing(
@@ -108,3 +113,56 @@ def test_artifact_download_maps_integrity_failure_to_502(
 def test_artifact_download_rejects_malformed_digest(client, db_session) -> None:
     response = client.get("/api/v1/scientific/artifacts/not-a-digest/download")
     assert response.status_code == 422
+
+
+def test_anonymous_artifact_download_returns_401(db_session, monkeypatch) -> None:
+    """Raw approved bytes must never reach an unauthenticated caller.
+
+    The default ``client`` fixture overrides ``get_current_user`` to a
+    seeded test user, so it cannot exercise the anonymous path. Here we
+    build an app WITHOUT that override: the request carries no API key or
+    session cookie and must be rejected by the auth gate (401) before any
+    byte load. FastAPI resolves the auth sub-dependency before the
+    endpoint's own path-param validation, so an anonymous caller gets a
+    uniform 401 for every input (even a malformed digest) — no 401-vs-404
+    existence oracle. We use a well-formed but non-existent digest: the
+    point is that we get 401, not 404, and never touch storage.
+    """
+    called = False
+
+    def fake_load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return b"must not be returned"
+
+    monkeypatch.setattr(
+        "app.api.routes.scientific.artifacts.load_artifact_bytes", fake_load
+    )
+
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[get_write_db] = lambda: db_session
+    with TestClient(app) as anon:
+        response = anon.get(f"/api/v1/scientific/artifacts/{'0' * 64}/download")
+
+    assert response.status_code == 401
+    assert called is False
+
+
+def test_authenticated_user_can_download_approved_artifact(
+    client, db_session, monkeypatch
+) -> None:
+    """A regular authenticated user (the default client actor) may pull
+    approved bytes — the gate requires authentication, not a curator role."""
+    artifact, content = _downloadable_artifact(
+        db_session, status=RecordReviewStatus.approved
+    )
+    monkeypatch.setattr(
+        "app.api.routes.scientific.artifacts.load_artifact_bytes",
+        lambda *_a, **_k: content,
+    )
+    response = client.get(
+        f"/api/v1/scientific/artifacts/{artifact.sha256}/download"
+    )
+    assert response.status_code == 200
+    assert response.content == content


### PR DESCRIPTION
## Summary

Closes the concrete security gap flagged in ADR 0004: the approved-artifact download route (`GET /api/v1/scientific/artifacts/{sha256}/download`) served raw electronic-structure log bytes with **no authentication**. Those logs can embed producer-side scratch paths, usernames, and cluster hostnames. ADR 0004 requires raw-byte retrieval to reach only authenticated callers, while the parsed/metadata layer stays public.

## Change

- **Gate the download route** with `get_current_user` — any valid `X-API-Key` or session cookie passes; anonymous callers get **401**. The gate is **unconditional** (no opt-out flag) so no deployment can accidentally re-expose the bytes. The metadata **search** endpoints are untouched and remain public (the parsed layer is the public face, per ADR 0004).
- **Auth level = any authenticated user** (not curator-only, not owner-only): downloads are only ever served for curator-*approved* artifacts, and raw logs stay useful to all registered researchers. The future scrub-on-download egress transform is what would re-open anonymous access.
- **`Cache-Control: public` → `private, no-store`**: the response is now credentialed; `public` would let a shared cache (CDN/reverse-proxy) serve one user's log to a later anonymous request for the same URL, defeating the gate.

## Tests

- New `test_anonymous_artifact_download_returns_401` (builds an app without the auth override; asserts 401 and that byte-load never fires).
- New `test_authenticated_user_can_download_approved_artifact` (regular authenticated user succeeds — the gate requires authentication, not a curator role).
- Existing happy-path/integrity/404/422 tests still pass (the default `client` fixture is authenticated).
- OpenAPI golden regenerated — diff confined to the download path (adds `X-API-Key`/cookie params + 401).

## Verification

- 57 relevant tests pass locally (download, artifact search, legacy-auth, OpenAPI snapshot).
- `ruff` clean; `mypy` baseline-neutral (2 pre-existing errors on untouched search routes, unchanged).
- Adversarial (Fable-model) review: SHIP; its one MAJOR finding (the `Cache-Control` header) is folded into this PR.

## Ordering note

FastAPI resolves the auth sub-dependency **before** path-param validation, so an anonymous caller gets a uniform 401 for every input (even a malformed digest) — no 401-vs-404 existence oracle. The existing authenticated 404-indistinguishability design (non-approved looks like missing) is untouched.