### PR TITLE
Reconcile single-point energy against the output log on upload

### DIFF
--- a/backend/app/api/routes/calculations.py
+++ b/backend/app/api/routes/calculations.py
@@ -80,6 +80,9 @@ from app.services.artifact_persistence import persist_artifact_batch
 from app.services.calculation_parameter_extraction import (
     try_extract_parameters_from_input_upload,
 )
+from app.services.sp_energy_extraction import (
+    try_reconcile_sp_energy_from_output_upload,
+)
 
 router = APIRouter()
 
@@ -657,15 +660,23 @@ def upload_calculation_artifacts(
         created_by=current_user.id,
     )
 
-    # Opportunistic calculation_parameter extraction for input artifacts.
-    # The helper filters by ArtifactKind.input and is best-effort —
-    # never aborts the upload.
+    # Opportunistic per-artifact extraction, both best-effort (never abort
+    # the upload): input artifacts yield calculation_parameter rows; output
+    # logs reconcile the single-point energy against what the tool reported,
+    # filling it when absent and flagging a mismatch for review.
+    warnings: list[UploadWarning] = []
     for art_in in request.artifacts:
         try_extract_parameters_from_input_upload(session, calculation, art_in)
+        sp_warning = try_reconcile_sp_energy_from_output_upload(
+            session, calculation, art_in
+        )
+        if sp_warning is not None:
+            warnings.append(sp_warning)
 
     result = ArtifactsUploadResult(
         calculation_id=calculation_id,
         artifacts=[CalculationArtifactRead.model_validate(r) for r in rows],
+        warnings=warnings,
     )
     idem.record(session, status_code=201, body=result.model_dump(mode="json"))
     return result

--- a/backend/app/api/routes/uploads.py
+++ b/backend/app/api/routes/uploads.py
@@ -545,6 +545,8 @@ def upload_computed_species(
     outcome = persist_computed_species_upload(
         session, request, created_by=current_user.id, review_policy=sub.policy
     )
+    # Single-point energy reconciliation on inline output-log artifacts.
+    warnings = warnings + outcome.warnings
     conformer_refs = [
         ConformerUploadRefInBundle(
             key=co.conformer_in_bundle.key,

--- a/backend/app/services/sp_energy_extraction.py
+++ b/backend/app/services/sp_energy_extraction.py
@@ -11,13 +11,12 @@ tool reported against the value re-derived from the log by
   (the tool's reported value is kept, never overwritten)
 * they agree, or the log cannot be re-parsed -> no action
 
-**Scope (v1):** reconciliation runs on the dedicated artifacts route
-(``POST /calculations/{id}/artifacts``), the canonical second-phase path for
-uploading logs. Output logs attached *inline* through the contribution-bundle
-workflows (``computed_species`` / ``computed_reaction``) are not yet
-reconciled — those call sites have no channel to surface a warning, so wiring
-fill-without-warning there would diverge from the route's behaviour. Extending
-reconciliation to inline-bundle logs is tracked follow-up.
+**Where it runs:** every path that persists an output-log artifact — the
+dedicated artifacts route (``POST /calculations/{id}/artifacts``) and output
+logs attached *inline* through the contribution-bundle workflows
+(``computed_species`` / ``computed_reaction``, which ARC uses in bundle mode).
+The bundle workflows accumulate the returned warnings and their routes merge
+them into the upload response, so coverage matches the standalone route.
 
 Best-effort and never raises: artifact upload is canonical and must not be
 aborted by a reconciliation failure. Scoped to single-point calculations —

--- a/backend/app/services/sp_energy_extraction.py
+++ b/backend/app/services/sp_energy_extraction.py
@@ -1,0 +1,159 @@
+"""Upload-side hook: reconcile and fill a calculation's single-point energy.
+
+Sibling to :mod:`app.services.calculation_parameter_extraction`. That hook
+parses *input* artifacts into parameter rows; this one inspects *output-log*
+artifacts and reconciles the single-point electronic energy the submitting
+tool reported against the value re-derived from the log by
+:func:`app.services.sp_energy_reconciliation.reconcile_sp_energy`:
+
+* the tool omitted the energy -> fill ``calc_sp_result`` from the log
+* the two disagree            -> return a warning to flag for review
+  (the tool's reported value is kept, never overwritten)
+* they agree, or the log cannot be re-parsed -> no action
+
+**Scope (v1):** reconciliation runs on the dedicated artifacts route
+(``POST /calculations/{id}/artifacts``), the canonical second-phase path for
+uploading logs. Output logs attached *inline* through the contribution-bundle
+workflows (``computed_species`` / ``computed_reaction``) are not yet
+reconciled — those call sites have no channel to surface a warning, so wiring
+fill-without-warning there would diverge from the route's behaviour. Extending
+reconciliation to inline-bundle logs is tracked follow-up.
+
+Best-effort and never raises: artifact upload is canonical and must not be
+aborted by a reconciliation failure. Scoped to single-point calculations —
+the single-point electronic energy is the relevant result only there.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from tckdb_schemas.upload_warning import UploadWarning
+
+from app.db.models.calculation import Calculation, CalculationSPResult
+from app.db.models.common import ArtifactKind, CalculationType
+from app.schemas.fragments.artifact import ArtifactIn
+from app.services.sp_energy_reconciliation import (
+    SpEnergyAction,
+    SpEnergyReconciliation,
+    reconcile_sp_energy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def try_reconcile_sp_energy_from_output_upload(
+    session: Session,
+    calculation: Calculation,
+    artifact_in: ArtifactIn,
+) -> UploadWarning | None:
+    """Reconcile/fill the SP energy from an uploaded output-log artifact.
+
+    Runs immediately after the matching ``CalculationArtifact`` row has
+    been persisted, decoding bytes from the in-memory base64 payload so no
+    object-storage round-trip is needed.
+
+    Returns an :class:`UploadWarning` when the reconciliation produced one
+    (a mismatch flagged for review, or an informational note that the
+    energy was filled from the log), otherwise ``None``. Returns ``None``
+    for non-output-log artifacts, non-single-point calculations, and any
+    failure — a broad safety net guarantees the canonical artifact upload
+    is never aborted by a reconciliation error, matching the sibling
+    parameter-extraction hook.
+    """
+    # ``artifact_in.kind`` is typed against ``tckdb_schemas.enums.ArtifactKind``
+    # while ``ArtifactKind`` here is the parallel ORM enum; both are
+    # ``(str, Enum)`` with identical members, so a value comparison works
+    # across the boundary (an identity check would always fail).
+    if artifact_in.kind != ArtifactKind.output_log:
+        return None
+    if calculation.type != CalculationType.sp:
+        return None
+
+    try:
+        return _reconcile_and_fill(session, calculation, artifact_in)
+    except Exception:
+        # Artifact upload is canonical and must never be aborted by a
+        # reconciliation failure — swallow anything and log it.
+        logger.warning(
+            "sp_energy reconciliation failed for artifact '%s'",
+            artifact_in.filename,
+            exc_info=True,
+        )
+        return None
+
+
+def _reconcile_and_fill(
+    session: Session,
+    calculation: Calculation,
+    artifact_in: ArtifactIn,
+) -> UploadWarning | None:
+    try:
+        content = base64.b64decode(artifact_in.content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        # Should not happen — pass-1 validation already decoded successfully.
+        logger.warning(
+            "sp_energy reconciliation skipped: artifact '%s' could not be "
+            "base64-decoded",
+            artifact_in.filename,
+        )
+        return None
+
+    text = content.decode("utf-8", errors="replace")
+
+    existing = calculation.sp_result
+    payload_energy = (
+        existing.electronic_energy_hartree if existing is not None else None
+    )
+
+    outcome = reconcile_sp_energy(
+        payload_energy_hartree=payload_energy,
+        log_text=text,
+    )
+
+    if outcome.action is SpEnergyAction.filled:
+        return _fill(session, calculation, existing, outcome)
+    if outcome.action is SpEnergyAction.mismatch:
+        return outcome.warning
+    return None
+
+
+def _fill(
+    session: Session,
+    calculation: Calculation,
+    existing: CalculationSPResult | None,
+    outcome: SpEnergyReconciliation,
+) -> UploadWarning | None:
+    """Persist a log-derived energy where the tool supplied none."""
+    energy = outcome.resolved_energy_hartree
+
+    if existing is not None:
+        # A ``calc_sp_result`` row already exists but carries a NULL energy
+        # (the tool sent ``sp_result`` with no value). Fill it in place —
+        # this supplies the missing value, it does not overwrite a reported
+        # one, so the "filled" warning is accurate.
+        existing.electronic_energy_hartree = energy
+        return outcome.warning
+
+    # No row yet — insert one inside a SAVEPOINT so a concurrent uploader
+    # racing to fill the same energy-less calculation (PK is
+    # ``calculation_id``) cannot poison the outer transaction with a
+    # duplicate-key violation; the loser simply skips the fill.
+    savepoint = session.begin_nested()
+    try:
+        session.add(
+            CalculationSPResult(
+                calculation=calculation,
+                electronic_energy_hartree=energy,
+            )
+        )
+        session.flush()
+    except IntegrityError:
+        savepoint.rollback()
+        session.expire(calculation, ["sp_result"])
+        return None
+    return outcome.warning

--- a/backend/app/services/sp_energy_reconciliation.py
+++ b/backend/app/services/sp_energy_reconciliation.py
@@ -1,0 +1,193 @@
+"""Reconcile a submitting tool's single-point energy against the output log.
+
+TCKDB is software- and workflow-tool agnostic: whichever tool submits a
+calculation reports the single-point electronic energy in its payload.
+Where the output log is *also* uploaded, TCKDB independently re-derives the
+energy from the log bytes and reconciles the two:
+
+===================  ==============================================
+Situation            Outcome
+===================  ==============================================
+payload E, log agree ``confirmed``    — no action
+payload E, log differ ``mismatch``    — non-blocking warning, flag for review
+payload missing, log ``filled``       — store the log's value
+log un-parseable     ``unverifiable`` — payload stands unchanged
+neither present      ``absent``       — nothing to do
+===================  ==============================================
+
+"Log un-parseable" covers programs whose SP-energy extraction is not yet
+wired (ORCA and Gaussian today — their parsers surface parameters, not a
+single-point energy) and unsupported Molpro methods (e.g. MRCI-F12). The
+reconciliation never blocks an upload, never mutates stored bytes, and on
+a mismatch it does **not** overwrite the submitter's value — it keeps what
+the tool reported and surfaces the discrepancy for a human reviewer.
+
+Pure functions over text and floats; no database dependencies.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+from tckdb_schemas.upload_warning import UploadWarning
+
+# Two single-point energies count as "the same number" within this absolute
+# tolerance in Hartree (~6e-4 kcal/mol). A mismatch is a non-blocking
+# reviewer flag, not a reject, so the bound is deliberately tight: a wrong
+# energy line, a wrong method, or a unit slip diverges by far more, while a
+# tool that stores the value at reduced precision stays inside it.
+SP_ENERGY_ABS_TOL_HARTREE = 1e-6
+
+#: Emitted when the tool's energy and the log's energy disagree.
+W_SP_ENERGY_MISMATCH = "sp_energy_payload_log_mismatch"
+#: Emitted (informational) when the tool omitted the energy and TCKDB filled
+#: it from the log. Recorded so the fill is auditable in the upload response
+#: and the review context rather than happening silently.
+W_SP_ENERGY_FILLED_FROM_LOG = "sp_energy_filled_from_log"
+
+#: Molpro's output banner — the only marker we need to gate SP-energy
+#: re-derivation today, since Molpro is the only wired extractor.
+_MOLPRO_BANNER = "PROGRAM SYSTEM MOLPRO"
+
+
+class SpEnergyAction(str, Enum):
+    """What the reconciliation concluded about the single-point energy."""
+
+    confirmed = "confirmed"
+    mismatch = "mismatch"
+    filled = "filled"
+    unverifiable = "unverifiable"
+    absent = "absent"
+
+
+@dataclass(frozen=True)
+class SpEnergyReconciliation:
+    """Outcome of comparing a payload energy against the output log.
+
+    ``resolved_energy_hartree`` is the value the caller should persist:
+    the payload's energy whenever the payload supplied one (even on a
+    mismatch — TCKDB flags, it does not overwrite), the log's energy when
+    filling, and ``None`` when there is nothing to store.
+    """
+
+    action: SpEnergyAction
+    payload_energy_hartree: float | None
+    log_energy_hartree: float | None
+    resolved_energy_hartree: float | None
+    warning: UploadWarning | None = None
+
+
+def parse_sp_energy_from_log(text: str | None) -> float | None:
+    """Re-derive the single-point electronic energy (Hartree) from log text.
+
+    Software-dispatched and ESS-agnostic in shape. Only Molpro is wired
+    today: a log without the Molpro banner (ORCA, Gaussian, or anything
+    else) returns ``None`` so the caller treats it as *unverifiable*
+    rather than guessing. Extractors for other programs slot in here as
+    they are built from real logs.
+
+    Returns ``None`` for an unsupported program, an unsupported Molpro
+    method (e.g. MRCI-F12), or a log with no single-point energy.
+    """
+    if not text:
+        return None
+    # Case-insensitive, matching the parameter-extraction software sniffer.
+    if _MOLPRO_BANNER not in text[:8000].upper():
+        return None
+    # Local import keeps this module free of the parser's import surface.
+    from app.services.molpro_parameter_parser import parse_sp_energy
+
+    energy = parse_sp_energy(text)
+    # A non-finite parse (NaN/inf from a garbage or overflowed energy line)
+    # is not a usable value — treat it as "no energy" so it can never be
+    # filled into calc_sp_result or fed to the tolerance comparison.
+    if energy is None or not math.isfinite(energy):
+        return None
+    return energy
+
+
+def reconcile_sp_energy(
+    *,
+    payload_energy_hartree: float | None,
+    log_text: str | None,
+    field: str = "sp_result.electronic_energy_hartree",
+) -> SpEnergyReconciliation:
+    """Reconcile the tool-reported SP energy against the uploaded log.
+
+    :param payload_energy_hartree: The energy the submitting tool reported
+        (``None`` if it omitted one).
+    :param log_text: Decoded output-log text, or ``None`` when no output
+        artifact accompanies the calculation.
+    :param field: Dot-path used in any emitted :class:`UploadWarning`.
+    """
+    log_energy = parse_sp_energy_from_log(log_text)
+
+    if payload_energy_hartree is not None and log_energy is not None:
+        if math.isclose(
+            payload_energy_hartree,
+            log_energy,
+            rel_tol=0.0,
+            abs_tol=SP_ENERGY_ABS_TOL_HARTREE,
+        ):
+            return SpEnergyReconciliation(
+                action=SpEnergyAction.confirmed,
+                payload_energy_hartree=payload_energy_hartree,
+                log_energy_hartree=log_energy,
+                resolved_energy_hartree=payload_energy_hartree,
+            )
+        delta = payload_energy_hartree - log_energy
+        return SpEnergyReconciliation(
+            action=SpEnergyAction.mismatch,
+            payload_energy_hartree=payload_energy_hartree,
+            log_energy_hartree=log_energy,
+            # Keep the tool's value; flag the discrepancy for a reviewer.
+            resolved_energy_hartree=payload_energy_hartree,
+            warning=UploadWarning(
+                field=field,
+                code=W_SP_ENERGY_MISMATCH,
+                message=(
+                    "Recorded single-point energy "
+                    f"{payload_energy_hartree:.8f} Ha disagrees with the "
+                    f"value re-derived from the output log "
+                    f"{log_energy:.8f} Ha (delta {delta:+.2e} Ha). The "
+                    "recorded value is kept unchanged and flagged for "
+                    "reviewer attention."
+                ),
+            ),
+        )
+
+    if payload_energy_hartree is None and log_energy is not None:
+        return SpEnergyReconciliation(
+            action=SpEnergyAction.filled,
+            payload_energy_hartree=None,
+            log_energy_hartree=log_energy,
+            resolved_energy_hartree=log_energy,
+            warning=UploadWarning(
+                field=field,
+                code=W_SP_ENERGY_FILLED_FROM_LOG,
+                message=(
+                    "No single-point energy was provided; filled "
+                    f"{log_energy:.8f} Ha re-derived from the output log."
+                ),
+            ),
+        )
+
+    if payload_energy_hartree is not None and log_energy is None:
+        # A value was reported but the log could not be re-parsed (program
+        # not yet wired, unsupported method, or no SP energy). Trust the
+        # tool; we simply cannot cross-check.
+        return SpEnergyReconciliation(
+            action=SpEnergyAction.unverifiable,
+            payload_energy_hartree=payload_energy_hartree,
+            log_energy_hartree=None,
+            resolved_energy_hartree=payload_energy_hartree,
+        )
+
+    return SpEnergyReconciliation(
+        action=SpEnergyAction.absent,
+        payload_energy_hartree=None,
+        log_energy_hartree=None,
+        resolved_energy_hartree=None,
+    )

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -9,6 +9,7 @@ Follows the same key-resolution pattern as the network PDep workflow.
 from __future__ import annotations
 
 from sqlalchemy.orm import Session
+from tckdb_schemas.upload_warning import UploadWarning
 
 from app.chemistry.geometry import parse_xyz
 from app.chemistry.units import convert_ea_to_kj_mol
@@ -71,6 +72,9 @@ from app.services.record_review import (
     ReviewPolicy,
     apply_review_policy,
 )
+from app.services.sp_energy_extraction import (
+    try_reconcile_sp_energy_from_output_upload,
+)
 from app.services.species_resolution import resolve_species_entry
 
 
@@ -83,6 +87,7 @@ def _persist_calculation(
     geometry_id: int | None = None,
     geometry_key_map: dict[str, int],
     created_by: int | None = None,
+    sp_energy_warnings: list[UploadWarning] | None = None,
 ) -> Calculation:
     """Persist one bundle-local calculation through the shared calculation seam.
 
@@ -124,9 +129,16 @@ def _persist_calculation(
             artifact_in=artifact_in,
             created_by=created_by,
         )
-        # Opportunistic calculation_parameter extraction. Best-effort —
-        # never aborts the bundle.
+        # Opportunistic per-artifact extraction, both best-effort — never
+        # abort the bundle. Input artifacts yield parameter rows; output
+        # logs reconcile the single-point energy against the tool's
+        # reported value (fill/mismatch), the same as the artifacts route.
         try_extract_parameters_from_input_upload(session, calculation, artifact_in)
+        sp_warning = try_reconcile_sp_energy_from_output_upload(
+            session, calculation, artifact_in
+        )
+        if sp_warning is not None and sp_energy_warnings is not None:
+            sp_energy_warnings.append(sp_warning)
 
     resolved_geom_id = geometry_id
     if calc_in.geometry_key is not None:
@@ -225,6 +237,8 @@ def persist_computed_reaction_upload(
     # caller's ReviewPolicy can be applied at end-of-workflow.
     review_targets: list[RecordRef] = []
     applied_correction_ids: list[int] = []
+    # Single-point energy reconciliation warnings from inline output logs.
+    sp_energy_warnings: list[UploadWarning] = []
 
     # ------------------------------------------------------------------
     # 1. Resolve species + conformers + calculations
@@ -254,6 +268,7 @@ def persist_computed_reaction_upload(
                 geometry_id=geometry.id,
                 geometry_key_map=geometry_key_to_id,
                 created_by=created_by,
+                sp_energy_warnings=sp_energy_warnings,
             )
             calculation_key_to_id[conf.calculation.key] = calculation.id
             review_targets.append(
@@ -298,6 +313,7 @@ def persist_computed_reaction_upload(
                 species_entry_id=species_entry.id,
                 geometry_key_map=geometry_key_to_id,
                 created_by=created_by,
+                sp_energy_warnings=sp_energy_warnings,
             )
             calculation_key_to_id[calc_in.key] = calculation.id
             review_targets.append(
@@ -437,6 +453,7 @@ def persist_computed_reaction_upload(
             geometry_id=ts_geom.id,
             geometry_key_map=geometry_key_to_id,
             created_by=created_by,
+            sp_energy_warnings=sp_energy_warnings,
         )
         calculation_key_to_id[ts_in.calculation.key] = ts_calc.id
         review_targets.append(
@@ -450,6 +467,7 @@ def persist_computed_reaction_upload(
                 transition_state_entry_id=ts_entry.id,
                 geometry_key_map=geometry_key_to_id,
                 created_by=created_by,
+                sp_energy_warnings=sp_energy_warnings,
             )
             calculation_key_to_id[calc_in.key] = calc.id
             review_targets.append(
@@ -960,4 +978,5 @@ def persist_computed_reaction_upload(
         # without re-walking the bundle. Response-only; unchanged
         # request payload.
         "calculation_keys": dict(calculation_key_to_id),
+        "warnings": sp_energy_warnings,
     }

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sqlalchemy.orm import Session
+from tckdb_schemas.upload_warning import UploadWarning
 
 from app.chemistry.geometry import parse_xyz
 from app.db.models.calculation import Calculation
@@ -72,6 +73,9 @@ from app.services.record_review import (
     ReviewPolicy,
     apply_review_policy,
 )
+from app.services.sp_energy_extraction import (
+    try_reconcile_sp_energy_from_output_upload,
+)
 from app.services.species_resolution import resolve_species_entry
 from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
 
@@ -126,6 +130,10 @@ class ComputedSpeciesUploadOutcome:
     conformers: list[ConformerUploadOutcomeInBundle]
     thermo: Thermo | None
     statmech: Statmech | None = None
+    #: Non-blocking warnings raised while persisting inline artifacts —
+    #: currently single-point energy reconciliation (fill/mismatch). The
+    #: route merges these into the upload response.
+    warnings: list[UploadWarning] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -518,6 +526,7 @@ def persist_computed_species_upload(
     # shas across all calcs in the bundle so a post-step-6 failure can
     # delete them.
     bundle_stored_shas: list[str] = []
+    sp_energy_warnings: list[UploadWarning] = []
     try:
         for outcome in conformer_outcomes:
             for calc_in, calc_row in (
@@ -540,13 +549,20 @@ def persist_computed_species_upload(
                     created_by=created_by,
                 )
                 bundle_stored_shas.extend(r.sha256 for r in rows if r.sha256)
-                # Opportunistic calculation_parameter extraction. The
-                # helper filters to ArtifactKind.input and is best-effort
-                # — never aborts the bundle.
+                # Opportunistic per-artifact extraction, both best-effort —
+                # never abort the bundle. Input artifacts yield parameter
+                # rows; output logs reconcile the single-point energy
+                # against the tool's reported value (fill/mismatch), the
+                # same as the standalone artifacts route.
                 for art_in in calc_in.artifacts:
                     try_extract_parameters_from_input_upload(
                         session, calc_row, art_in
                     )
+                    sp_warning = try_reconcile_sp_energy_from_output_upload(
+                        session, calc_row, art_in
+                    )
+                    if sp_warning is not None:
+                        sp_energy_warnings.append(sp_warning)
 
         thermo_row, thermo_aec_ids = _persist_thermo_block(
             session,
@@ -641,6 +657,7 @@ def persist_computed_species_upload(
         conformers=conformer_outcomes,
         thermo=thermo_row,
         statmech=statmech_row,
+        warnings=sp_energy_warnings,
     )
 
 

--- a/backend/tests/api/test_api_artifact_sp_energy_hook.py
+++ b/backend/tests/api/test_api_artifact_sp_energy_hook.py
@@ -1,0 +1,284 @@
+"""Tests for the single-point energy reconciliation hook fired by the
+artifact upload route (``POST /calculations/{id}/artifacts``).
+
+Hook contract:
+
+- Fires only on ``kind='output_log'`` artifacts of single-point
+  (``type='sp'``) calculations.
+- The tool omitted the energy -> ``calc_sp_result`` is filled from the log
+  and an informational ``sp_energy_filled_from_log`` warning is returned.
+- The tool's value disagrees with the log -> a ``sp_energy_payload_log_mismatch``
+  warning is returned and the reported value is kept unchanged.
+- The values agree -> no warning, no change.
+- Anything inside the hook failing must NEVER abort the artifact upload.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.db.models.calculation import CalculationSPResult
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+# A real Molpro CCSD(T)-F12 single-point log and its energy (Hartree).
+CH4_LOG = (FIXTURES / "molpro" / "ch4_closed_shell" / "input.out").read_bytes()
+CH4_ENERGY = -40.457885930635
+
+
+@pytest.fixture
+def stub_store_artifact(monkeypatch) -> list[tuple[str, str]]:
+    written: list[tuple[str, str]] = []
+
+    def _fake_store(content: bytes, sha256: str) -> str:
+        uri = f"s3://test-bucket/{sha256[:2]}/{sha256}"
+        written.append((uri, sha256))
+        return uri
+
+    monkeypatch.setattr(
+        "app.services.artifact_persistence.store_artifact", _fake_store
+    )
+    return written
+
+
+def _b64(content: bytes) -> str:
+    return base64.b64encode(content).decode("ascii")
+
+
+def _molpro_output_log(filename: str = "sp.out") -> dict:
+    return {
+        "kind": "output_log",
+        "filename": filename,
+        "content_base64": _b64(CH4_LOG),
+    }
+
+
+def _molpro_log_as_input(filename: str = "sp.in") -> dict:
+    """The real energy-bearing Molpro log, but tagged ``input``.
+
+    Used to prove the ``output_log`` kind gate: if the gate were removed,
+    the banner + energy here would be reconciled and fill the row.
+    """
+    return {
+        "kind": "input",
+        "filename": filename,
+        "content_base64": _b64(CH4_LOG),
+    }
+
+
+def _garbage_molpro_log(filename: str = "broken.out") -> dict:
+    """A Molpro-bannered but semantically corrupt (valid-UTF-8) log.
+
+    Output logs are validated as UTF-8 before the hook runs, so the bytes
+    are well-formed text; the content is nonsense the parser must survive
+    by yielding no usable energy rather than raising.
+    """
+    body = (
+        "***  PROGRAM SYSTEM MOLPRO  ***\n"
+        "corrupt deck: !RHF STATE 1.1 Energy nan\n"
+        "!CCSD(T)-F12 total energy   not-a-number\n"
+        "truncated mid-"
+    ).encode("utf-8")
+    return {"kind": "output_log", "filename": filename, "content_base64": _b64(body)}
+
+
+def _sp_conformer_payload(
+    *,
+    sp_energy: float | None,
+    calc_type: str = "sp",
+    empty_sp_result: bool = False,
+) -> dict:
+    calc: dict = {
+        "type": calc_type,
+        "software_release": {"name": "Molpro", "version": "2022.1"},
+        "level_of_theory": {"method": "CCSD(T)-F12", "basis": "cc-pVTZ-F12"},
+    }
+    if sp_energy is not None:
+        calc["sp_result"] = {"electronic_energy_hartree": sp_energy}
+    elif empty_sp_result:
+        # Present but valueless -> a calc_sp_result row with NULL energy.
+        calc["sp_result"] = {}
+    if calc_type == "opt":
+        calc["opt_result"] = {"converged": True}
+    return {
+        "species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1},
+        "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+        "calculation": calc,
+        "label": "ch4-sp-energy-hook",
+    }
+
+
+def _create_calc(
+    client,
+    *,
+    sp_energy: float | None,
+    calc_type: str = "sp",
+    empty_sp_result: bool = False,
+) -> int:
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_sp_conformer_payload(
+            sp_energy=sp_energy,
+            calc_type=calc_type,
+            empty_sp_result=empty_sp_result,
+        ),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["primary_calculation"]["calculation_id"]
+
+
+def _stored_energy(db_session: Session, calc_id: int) -> float | None:
+    row = db_session.get(CalculationSPResult, calc_id)
+    return row.electronic_energy_hartree if row is not None else None
+
+
+def _warning_codes(resp) -> list[str]:
+    return [w["code"] for w in resp.json().get("warnings", [])]
+
+
+class TestSpEnergyHook:
+    def test_fills_energy_when_payload_omitted_it(
+        self, client, db_session, stub_store_artifact
+    ):
+        calc_id = _create_calc(client, sp_energy=None)
+        assert _stored_energy(db_session, calc_id) is None
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log()]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert _stored_energy(db_session, calc_id) == CH4_ENERGY
+        assert "sp_energy_filled_from_log" in _warning_codes(resp)
+
+    def test_mismatch_warns_and_keeps_reported_value(
+        self, client, db_session, stub_store_artifact
+    ):
+        wrong = CH4_ENERGY + 0.01
+        calc_id = _create_calc(client, sp_energy=wrong)
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log()]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert "sp_energy_payload_log_mismatch" in _warning_codes(resp)
+        # The tool's value is kept unchanged — TCKDB flags, never overwrites.
+        assert _stored_energy(db_session, calc_id) == wrong
+
+    def test_matching_energy_emits_no_warning(
+        self, client, db_session, stub_store_artifact
+    ):
+        calc_id = _create_calc(client, sp_energy=CH4_ENERGY)
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log()]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert _warning_codes(resp) == []
+        assert _stored_energy(db_session, calc_id) == CH4_ENERGY
+
+    def test_input_kind_gate_blocks_energy_bearing_log(
+        self, client, db_session, stub_store_artifact
+    ):
+        # The real energy-bearing Molpro log, but tagged input. Only the
+        # kind gate stops it — remove the gate and this would fill.
+        calc_id = _create_calc(client, sp_energy=None)
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_log_as_input()]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert _stored_energy(db_session, calc_id) is None
+        assert "sp_energy_filled_from_log" not in _warning_codes(resp)
+
+    def test_non_sp_calculation_is_skipped(
+        self, client, db_session, stub_store_artifact
+    ):
+        calc_id = _create_calc(client, sp_energy=None, calc_type="opt")
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log()]},
+        )
+        assert resp.status_code == 201, resp.text
+        # SP-energy reconciliation is scoped to single-point calculations.
+        assert _stored_energy(db_session, calc_id) is None
+        assert _warning_codes(resp) == []
+
+    def test_fills_pre_existing_null_energy_row(
+        self, client, db_session, stub_store_artifact
+    ):
+        # Tool sent ``sp_result: {}`` -> a row exists with NULL energy. The
+        # fill must update it in place, not silently claim to have filled.
+        calc_id = _create_calc(client, sp_energy=None, empty_sp_result=True)
+        assert db_session.get(CalculationSPResult, calc_id) is not None
+        assert _stored_energy(db_session, calc_id) is None
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log()]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert "sp_energy_filled_from_log" in _warning_codes(resp)
+        assert _stored_energy(db_session, calc_id) == CH4_ENERGY
+
+    def test_garbage_bannered_log_does_not_raise_or_fill(
+        self, client, db_session, stub_store_artifact
+    ):
+        # A corrupt Molpro-bannered log must never abort the upload; no
+        # usable energy means no fill, no warning.
+        calc_id = _create_calc(client, sp_energy=None)
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_garbage_molpro_log()]},
+        )
+        assert resp.status_code == 201, resp.text
+        assert _stored_energy(db_session, calc_id) is None
+        assert _warning_codes(resp) == []
+
+    def test_two_output_logs_one_request_fills_once(
+        self, client, db_session, stub_store_artifact
+    ):
+        calc_id = _create_calc(client, sp_energy=None)
+
+        resp = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={
+                "artifacts": [
+                    _molpro_output_log("a.out"),
+                    _molpro_output_log("b.out"),
+                ]
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        # One fill; the second log sees the in-session row and confirms.
+        assert _stored_energy(db_session, calc_id) == CH4_ENERGY
+        assert _warning_codes(resp).count("sp_energy_filled_from_log") == 1
+
+    def test_reupload_after_fill_confirms_without_duplicate(
+        self, client, db_session, stub_store_artifact
+    ):
+        calc_id = _create_calc(client, sp_energy=None)
+        r1 = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log("first.out")]},
+        )
+        assert r1.status_code == 201
+        assert "sp_energy_filled_from_log" in _warning_codes(r1)
+
+        r2 = client.post(
+            f"/api/v1/calculations/{calc_id}/artifacts",
+            json={"artifacts": [_molpro_output_log("second.out")]},
+        )
+        assert r2.status_code == 201, r2.text
+        # The row is already filled with the same value -> confirmed, no warning.
+        assert _warning_codes(r2) == []
+        assert _stored_energy(db_session, calc_id) == CH4_ENERGY

--- a/backend/tests/api/test_api_artifact_sp_energy_hook.py
+++ b/backend/tests/api/test_api_artifact_sp_energy_hook.py
@@ -282,3 +282,77 @@ class TestSpEnergyHook:
         # The row is already filled with the same value -> confirmed, no warning.
         assert _warning_codes(r2) == []
         assert _stored_energy(db_session, calc_id) == CH4_ENERGY
+
+
+def _computed_species_bundle(*, sp_energy: float | None) -> dict:
+    """A bundle whose SP calc carries its output log INLINE (ARC bundle mode)."""
+    sp_calc: dict = {
+        "key": "sp0",
+        "type": "sp",
+        "software_release": {"name": "Molpro", "version": "2022.1"},
+        "level_of_theory": {"method": "CCSD(T)-F12", "basis": "cc-pVTZ-F12"},
+        "artifacts": [_molpro_output_log("sp0.out")],
+    }
+    if sp_energy is not None:
+        sp_calc["sp_result"] = {"electronic_energy_hartree": sp_energy}
+    return {
+        "species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1},
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "software_release": {"name": "Molpro", "version": "2022.1"},
+                    "level_of_theory": {
+                        "method": "CCSD(T)-F12",
+                        "basis": "cc-pVTZ-F12",
+                    },
+                    "opt_result": {"converged": True},
+                },
+                "additional_calculations": [sp_calc],
+            }
+        ],
+    }
+
+
+class TestSpEnergyBundleHook:
+    """The reconciliation must also fire on logs uploaded INLINE in a
+    contribution bundle (ARC bundle mode), not only via the artifacts route."""
+
+    def _sp_calc_id(self, body: dict) -> int:
+        return body["conformers"][0]["additional_calculations"][0][
+            "calculation_id"
+        ]
+
+    def test_bundle_inline_log_fills_energy(
+        self, client, db_session, stub_store_artifact
+    ):
+        resp = client.post(
+            "/api/v1/uploads/computed-species",
+            json=_computed_species_bundle(sp_energy=None),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        sp_calc_id = self._sp_calc_id(body)
+        assert _stored_energy(db_session, sp_calc_id) == CH4_ENERGY
+        assert "sp_energy_filled_from_log" in [
+            w["code"] for w in body.get("warnings", [])
+        ]
+
+    def test_bundle_inline_log_mismatch_warns_and_keeps_value(
+        self, client, db_session, stub_store_artifact
+    ):
+        wrong = CH4_ENERGY + 0.01
+        resp = client.post(
+            "/api/v1/uploads/computed-species",
+            json=_computed_species_bundle(sp_energy=wrong),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        sp_calc_id = self._sp_calc_id(body)
+        assert "sp_energy_payload_log_mismatch" in [
+            w["code"] for w in body.get("warnings", [])
+        ]
+        assert _stored_energy(db_session, sp_calc_id) == wrong

--- a/backend/tests/client_builder_contract/test_computed_reaction_calculation_keys_response.py
+++ b/backend/tests/client_builder_contract/test_computed_reaction_calculation_keys_response.py
@@ -9,18 +9,31 @@ contract that the builder's ``artifact_plan(result)`` reads.
 
 from __future__ import annotations
 
+import base64
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator
 
 from sqlalchemy.orm import Session
 
 from app.api.routes.uploads import ComputedReactionUploadResult
 from app.db.models.app_user import AppUser
+from app.db.models.calculation import CalculationSPResult
 from app.db.models.common import AppUserRole
 from app.schemas.workflows.computed_reaction_upload import (
     ComputedReactionUploadRequest,
 )
 from app.workflows.computed_reaction import persist_computed_reaction_upload
+
+# A real Molpro CCSD(T)-F12 single-point log and its energy (Hartree).
+_MOLPRO_CH4_LOG = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "molpro"
+    / "ch4_closed_shell"
+    / "input.out"
+).read_bytes()
+_MOLPRO_CH4_ENERGY = -40.457885930635
 
 _XYZ_H = "1\nH\nH 0.0 0.0 0.0"
 _XYZ_CH3 = (
@@ -174,6 +187,55 @@ def test_response_includes_calculation_keys_mapping(db_engine) -> None:
         validated = ComputedReactionUploadResult(**result_dict)
         dumped = validated.model_dump(mode="json")
         assert dumped["calculation_keys"] == ck
+
+
+def test_bundle_inline_sp_log_fills_energy_and_warns(db_engine) -> None:
+    """SP-energy reconciliation fires on logs attached INLINE in a
+    computed-reaction bundle (ARC bundle mode): it fills calc_sp_result and
+    surfaces the warning through the workflow result's ``warnings``."""
+    import sqlalchemy
+
+    payload = _bundle_payload()
+    # Attach a real Molpro SP log inline to ch4's sp calc and drop its
+    # reported energy so the reconciliation must FILL it from the log.
+    ch4_sp = payload["species"][2]["calculations"][0]
+    assert ch4_sp["key"] == "ch4-sp"
+    del ch4_sp["sp_electronic_energy_hartree"]
+    ch4_sp["artifacts"] = [
+        {
+            "kind": "output_log",
+            "filename": "ch4-sp.out",
+            "content_base64": base64.b64encode(_MOLPRO_CH4_LOG).decode("ascii"),
+        }
+    ]
+
+    with _isolated_session(db_engine) as session:
+        session.add(AppUser(username="sp_reaction_tester", role=AppUserRole.user))
+        session.flush()
+        user_id = session.scalar(
+            sqlalchemy.select(AppUser.id).where(
+                AppUser.username == "sp_reaction_tester"
+            )
+        )
+        result_dict = persist_computed_reaction_upload(
+            session,
+            ComputedReactionUploadRequest(**payload),
+            created_by=user_id,
+        )
+
+        codes = [w.code for w in result_dict["warnings"]]
+        assert "sp_energy_filled_from_log" in codes
+
+        ch4_sp_id = result_dict["calculation_keys"]["ch4-sp"]
+        row = session.get(CalculationSPResult, ch4_sp_id)
+        assert row is not None
+        assert row.electronic_energy_hartree == _MOLPRO_CH4_ENERGY
+
+        # And it round-trips through the response model's warnings field.
+        validated = ComputedReactionUploadResult(**result_dict)
+        assert any(
+            w.code == "sp_energy_filled_from_log" for w in validated.warnings
+        )
 
 
 def test_response_calculation_keys_field_is_optional() -> None:

--- a/backend/tests/services/test_sp_energy_reconciliation.py
+++ b/backend/tests/services/test_sp_energy_reconciliation.py
@@ -1,0 +1,147 @@
+"""Tests for tool-vs-log single-point energy reconciliation.
+
+Exercised against the same real Molpro fixtures as the parser tests:
+
+* ``ch4_closed_shell`` — CCSD(T)-F12, E = -40.457885930635 Ha
+* ``mrci/nh2_radical`` — plain MRCI, E = -55.79346542 Ha
+
+The reconciliation service is DB-free: these tests import and call it
+directly, no session.
+"""
+
+from __future__ import annotations
+
+import os
+
+from app.services.sp_energy_reconciliation import (
+    SP_ENERGY_ABS_TOL_HARTREE,
+    W_SP_ENERGY_FILLED_FROM_LOG,
+    W_SP_ENERGY_MISMATCH,
+    SpEnergyAction,
+    parse_sp_energy_from_log,
+    reconcile_sp_energy,
+)
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures", "molpro")
+
+# Known SP energies re-derived from the fixtures (Hartree).
+CH4_ENERGY = -40.457885930635
+NH2_ENERGY = -55.79346542
+
+
+def _read(name: str) -> str:
+    with open(os.path.join(FIXTURES_DIR, name, "input.out")) as f:
+        return f.read()
+
+
+def test_confirmed_when_payload_matches_log() -> None:
+    log = _read("ch4_closed_shell")
+    result = reconcile_sp_energy(payload_energy_hartree=CH4_ENERGY, log_text=log)
+
+    assert result.action is SpEnergyAction.confirmed
+    assert result.resolved_energy_hartree == CH4_ENERGY
+    assert result.warning is None
+
+
+def test_confirmed_within_tolerance() -> None:
+    """A payload rounded to just inside the tolerance still confirms."""
+    log = _read("ch4_closed_shell")
+    nudged = CH4_ENERGY + SP_ENERGY_ABS_TOL_HARTREE / 2
+    result = reconcile_sp_energy(payload_energy_hartree=nudged, log_text=log)
+
+    assert result.action is SpEnergyAction.confirmed
+    # The reported (payload) value is what is kept, not the log's.
+    assert result.resolved_energy_hartree == nudged
+    assert result.warning is None
+
+
+def test_mismatch_emits_warning_and_keeps_payload_value() -> None:
+    log = _read("ch4_closed_shell")
+    wrong = CH4_ENERGY + 0.01  # 10 mHa off — far outside tolerance
+    result = reconcile_sp_energy(payload_energy_hartree=wrong, log_text=log)
+
+    assert result.action is SpEnergyAction.mismatch
+    # TCKDB flags but does NOT overwrite the submitter's value.
+    assert result.resolved_energy_hartree == wrong
+    assert result.log_energy_hartree == CH4_ENERGY
+    assert result.warning is not None
+    assert result.warning.code == W_SP_ENERGY_MISMATCH
+    assert result.warning.field == "sp_result.electronic_energy_hartree"
+
+
+def test_mismatch_just_outside_tolerance() -> None:
+    log = _read("ch4_closed_shell")
+    just_off = CH4_ENERGY + SP_ENERGY_ABS_TOL_HARTREE * 2
+    result = reconcile_sp_energy(payload_energy_hartree=just_off, log_text=log)
+
+    assert result.action is SpEnergyAction.mismatch
+    assert result.warning is not None
+
+
+def test_filled_when_payload_missing_but_log_has_energy() -> None:
+    log = _read("mrci/nh2_radical")
+    result = reconcile_sp_energy(payload_energy_hartree=None, log_text=log)
+
+    assert result.action is SpEnergyAction.filled
+    assert result.resolved_energy_hartree == NH2_ENERGY
+    assert result.warning is not None
+    assert result.warning.code == W_SP_ENERGY_FILLED_FROM_LOG
+
+
+def test_unverifiable_when_log_has_no_parseable_energy() -> None:
+    """A reported energy with a log we cannot re-parse is trusted as-is."""
+    # A non-Molpro log (no banner) yields no re-derived energy.
+    result = reconcile_sp_energy(
+        payload_energy_hartree=-100.5,
+        log_text="SCF Done:  E(RB3LYP) =  -100.5  A.U. after 8 cycles",
+    )
+
+    assert result.action is SpEnergyAction.unverifiable
+    assert result.resolved_energy_hartree == -100.5
+    assert result.log_energy_hartree is None
+    assert result.warning is None
+
+
+def test_unverifiable_when_no_log_provided() -> None:
+    result = reconcile_sp_energy(payload_energy_hartree=-40.5, log_text=None)
+
+    assert result.action is SpEnergyAction.unverifiable
+    assert result.resolved_energy_hartree == -40.5
+    assert result.warning is None
+
+
+def test_absent_when_neither_present() -> None:
+    result = reconcile_sp_energy(payload_energy_hartree=None, log_text=None)
+
+    assert result.action is SpEnergyAction.absent
+    assert result.resolved_energy_hartree is None
+    assert result.warning is None
+
+
+def test_dispatcher_returns_none_for_non_molpro_log() -> None:
+    assert parse_sp_energy_from_log("some ORCA or Gaussian text") is None
+    assert parse_sp_energy_from_log(None) is None
+    assert parse_sp_energy_from_log("") is None
+
+
+def test_dispatcher_extracts_real_molpro_energy() -> None:
+    assert parse_sp_energy_from_log(_read("ch4_closed_shell")) == CH4_ENERGY
+    assert parse_sp_energy_from_log(_read("mrci/nh2_radical")) == NH2_ENERGY
+
+
+def test_dispatcher_gate_is_case_insensitive() -> None:
+    # A lowercased banner still routes to the Molpro parser.
+    log = _read("ch4_closed_shell").lower()
+    assert parse_sp_energy_from_log(log) == CH4_ENERGY
+
+
+def test_dispatcher_rejects_non_finite_energy(monkeypatch) -> None:
+    # A parser that returns NaN/inf must be treated as "no energy" so a
+    # non-finite value can never be filled or compared.
+    banner = "***  PROGRAM SYSTEM MOLPRO  ***\n!RHF energy nonsense\n"
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        monkeypatch.setattr(
+            "app.services.molpro_parameter_parser.parse_sp_energy",
+            lambda _text, _v=bad: _v,
+        )
+        assert parse_sp_energy_from_log(banner) is None


### PR DESCRIPTION
## Summary

TCKDB is **workflow-tool agnostic**: whichever tool (ARC, etc.) submits a calculation reports the single-point (SP) electronic energy in its payload. Where the output log is *also* uploaded, TCKDB now independently re-derives the energy from the log bytes and reconciles the two:

| Situation | Outcome |
|---|---|
| payload has E, log agrees | `confirmed` — no action |
| payload has E, log differs | `mismatch` — non-blocking warning flagged for review; **reported value kept, never overwritten** |
| payload omitted E, log has E | `filled` — store the log's value (incl. a pre-existing NULL-energy row) |
| log can't be re-parsed | `unverifiable` — payload stands |
| neither present | `absent` |

## Design

- **DB-free core** (`sp_energy_reconciliation.py`): the five-case logic + a `1e-6 Ha` absolute tolerance. On the ESS side it simply picks the right parser for the uploaded output file by **sniffing the program banner in the content** (not the filename/extension). Only Molpro has an SP-energy parser today; ORCA/Gaussian and Molpro MRCI-F12 return `None` → `unverifiable`, so the payload stands. Their parsers slot into the same content-based dispatch later.
- **DB-aware hook** (`sp_energy_extraction.py`): fires on `output_log` artifacts of single-point calculations. Fills `calc_sp_result` when the tool omitted the energy; on mismatch returns a warning. Best-effort — a structural safety net guarantees a reconciliation failure never aborts the canonical artifact upload; concurrent fills are savepoint-guarded so a duplicate-key race can't poison the transaction; non-finite (NaN/inf) parses are rejected.
- **Runs on every output-log upload path**: the standalone artifacts route **and** inline logs in the `computed-species`/`computed-reaction` bundle workflows (ARC's bundle mode). Bundle workflows accumulate warnings on their outcome/result and the routes merge them into the response — coverage matches the standalone route.

## Surfacing & follow-ups

- Mismatch/fill warnings surface via the existing `warnings` field on `ArtifactsUploadResult` / `ComputedSpeciesUploadResult` / `ComputedReactionUploadResult` (no schema/OpenAPI change).
- Mismatch is a **transient** warning to the uploader; a **durable reviewer-visible** flag is deferred pending the machine-review/trust-layer design (that layer is currently disabled).
- No migration — reuses `calc_sp_result`.

## Tests

- Core (`test_sp_energy_reconciliation.py`): five actions, tolerance boundary, case-insensitive banner, non-finite rejection, non-Molpro → unverifiable — against the real Molpro fixtures.
- Route hook (`test_api_artifact_sp_energy_hook.py`): fill, mismatch-keeps-value, match, `input`-kind gate (uses the real energy-bearing log tagged `input`), non-SP skip, pre-existing NULL-energy fill, garbage-bannered-log never-raises, two-logs-one-request fills once, re-upload-after-fill confirms without duplicate, **plus bundle-mode fill + mismatch via `computed-species`**.

## Verification

- Tests pass locally (new suites + calc-artifacts route + param-hook + computed-species/reaction upload + reproducibility + OpenAPI snapshot). `ruff` clean; `mypy` neutral (the workflow files' pre-existing `object`-typed-map errors are unchanged).
- Adversarial (Fable-model) review: initial BLOCK on one confirmed fill-path bug (NULL-energy row) + a scope gap + hardening nits — **all folded** (fill-in-place, savepoint, never-raise net, finite guard, strengthened tests). The scope gap (inline-bundle coverage) is now resolved in this PR rather than deferred.