### PR TITLE
Reject unavailable lowest-energy ranking

### DIFF
--- a/backend/app/services/scientific_read/species_calculations_search.py
+++ b/backend/app/services/scientific_read/species_calculations_search.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.error_contract import reject_unsupported_filters
+from app.api.error_contract import CodedValueError, reject_unsupported_filters
 from app.api.errors import NotFoundError
 from app.db.models.calculation import (
     Calculation,
@@ -265,6 +265,28 @@ def search_species_calculations(
     rows = [r for r in rows if badges[r.calc_id].status in visible]
     if not rows:
         return _empty_response(request, includes, offset, limit)
+
+    if (
+        request.ranking == CalculationRanking.lowest_energy
+        and all(row.energy_hartree is None for row in rows)
+    ):
+        energy_field = (
+            "electronic_energy_hartree"
+            if request.calculation_type == CalculationType.sp
+            else "final_energy_hartree"
+        )
+        raise CodedValueError(
+            "lowest_energy_unavailable",
+            "No lowest energy is available because none of the matching "
+            f"calculations has a recorded {energy_field} value.",
+            context={
+                "candidate_count": len(rows),
+                "calculation_type": request.calculation_type.value,
+                "energy_field": energy_field,
+                "species_entry_ref": request.species_entry_ref,
+                "level_of_theory_ref": request.level_of_theory_ref,
+            },
+        )
 
     # Bulk-load supporting blocks keyed by calculation_id.
     calc_ids = [r.calc_id for r in rows]

--- a/backend/docs/specs/machine_consumer_query_contract.md
+++ b/backend/docs/specs/machine_consumer_query_contract.md
@@ -1,10 +1,9 @@
 # Machine-consumer query contract
 
-Status: requirements 1–4 and 7–9 are implemented at the scopes stated below.
+Status: requirements 1–4 and 6–9 are implemented at the scopes stated below.
 Requirement 5 is exhaustive within the hosted traversal bound but still lacks a
-second post-collapse count. Requirement 6 enforces the principal comparability
-guards; its remaining all-null-energy case is called out explicitly. Requirement
-10 remains ongoing as each surface expands.
+second post-collapse count. Requirement 10 remains ongoing as each surface
+expands.
 
 ## Compatibility rules
 
@@ -25,7 +24,7 @@ guards; its remaining all-null-energy case is called out explicitly. Requirement
 
 5. **Exhaustive composed searches — bounded implementation.** Thermo, kinetics, and species-calculation composition walks every reachable identity page before downstream filtering, ordering, collapse, and pagination. If the complete identity set exceeds the hosted offset/limit traversal bound, the request fails with 422 `composed_search_candidate_limit_exceeded`; it is never silently truncated. `pagination.total` is the complete post-filter, pre-collapse candidate count and `pagination.returned` is the actual record-list length. A distinct post-collapse total is not yet exposed, so `collapse=first` can legitimately return one record while `pagination.total > 1`.
 
-6. **Comparable `lowest_energy` — guarded implementation.** Species-calculation `ranking=lowest_energy` requires `calculation_type=sp|opt`, one exact `species_entry_ref`, and one exact `level_of_theory_ref`; unsafe requests fail with coded 422 errors. SP ranks `electronic_energy_hartree`; opt ranks its final-energy field, so calculation types and energy meanings are not mixed within one query. Missing energies sort last rather than being compared numerically. The current implementation does not yet reject an all-null-energy candidate set; callers requiring a numeric minimum must verify the selected record's energy is non-null.
+6. **Comparable `lowest_energy` — implemented.** Species-calculation `ranking=lowest_energy` requires `calculation_type=sp|opt`, one exact `species_entry_ref`, and one exact `level_of_theory_ref`; unsafe requests fail with coded 422 errors. SP ranks `electronic_energy_hartree`; opt ranks its final-energy field, so calculation types and energy meanings are not mixed within one query. Missing energies sort last when at least one candidate has an energy. If candidates match but every energy is null, the request fails with 422 `lowest_energy_unavailable`; a search with no matching candidates remains a normal empty result.
 
 7. **Chemistry-first PDep results — implemented at the stated projections.** Network-kinetics search exposes public network/species refs and bounded, ordered source/sink composition blocks with stoichiometry and truncation metadata. Network search exposes participant counts and composition hashes, not full participant blocks; a full public participant projection there is a future enhancement. Network search supports participant species/reaction and network-ref filters. Network-kinetics search supports `network_ref` plus source/sink public species-entry-ref or canonical-SMILES multisets. Repeated requested values encode stoichiometry. The matching rule is multiset-subset containment: every requested participant must occur at least at the requested multiplicity; additional unmentioned channel participants are allowed. Ref and SMILES filters AND-combine.
 

--- a/backend/tests/api/scientific/test_api_species_calculations_search.py
+++ b/backend/tests/api/scientific/test_api_species_calculations_search.py
@@ -98,6 +98,41 @@ def test_lowest_energy_with_sp_returns_lowest_first(client, db_session):
     assert body["pagination"]["total"] == 2
 
 
+def test_lowest_energy_all_null_candidates_returns_coded_error(client, db_session):
+    _, entry = _seed(db_session, smiles="NOENERGY")
+    lot = make_lot(db_session)
+    make_calculation(
+        db_session,
+        type=CalculationType.sp,
+        species_entry_id=entry.id,
+        lot_id=lot.id,
+    )
+
+    resp = client.get(
+        "/api/v1/scientific/species-calculations/search"
+        f"?species_entry_ref={entry.public_ref}"
+        f"&level_of_theory_ref={lot.public_ref}"
+        "&calculation_type=sp&ranking=lowest_energy"
+    )
+
+    assert resp.status_code == 422
+    assert resp.json() == {
+        "code": "lowest_energy_unavailable",
+        "detail": (
+            "lowest_energy_unavailable: No lowest energy is available because "
+            "none of the matching calculations has a recorded "
+            "electronic_energy_hartree value."
+        ),
+        "context": {
+            "candidate_count": 1,
+            "calculation_type": "sp",
+            "energy_field": "electronic_energy_hartree",
+            "species_entry_ref": entry.public_ref,
+            "level_of_theory_ref": lot.public_ref,
+        },
+    }
+
+
 def test_lowest_energy_with_freq_returns_422(client, db_session):
     resp = client.get(
         "/api/v1/scientific/species-calculations/search"

--- a/backend/tests/services/scientific_read/test_search_species_calculations.py
+++ b/backend/tests/services/scientific_read/test_search_species_calculations.py
@@ -369,6 +369,66 @@ def test_lowest_energy_nulls_last(db_session):
     assert ordered.index(with_energy.id) < ordered.index(without_energy.id)
 
 
+@pytest.mark.parametrize(
+    ("calculation_type", "energy_field"),
+    [
+        (CalculationType.sp, "electronic_energy_hartree"),
+        (CalculationType.opt, "final_energy_hartree"),
+    ],
+)
+def test_lowest_energy_all_null_candidates_raise_clear_error(
+    db_session, calculation_type, energy_field
+):
+    _, entry = _entry(db_session, smiles=f"NULL-{calculation_type.value}")
+    lot = make_lot(db_session)
+    make_calculation(
+        db_session,
+        type=calculation_type,
+        species_entry_id=entry.id,
+        lot_id=lot.id,
+    )
+
+    with pytest.raises(CodedValueError) as exc_info:
+        search_species_calculations(
+            db_session,
+            SpeciesCalculationsSearchRequest(
+                species_entry_ref=entry.public_ref,
+                level_of_theory_ref=lot.public_ref,
+                calculation_type=calculation_type,
+                ranking=CalculationRanking.lowest_energy,
+            ),
+        )
+
+    error = exc_info.value
+    assert error.code == "lowest_energy_unavailable"
+    assert "No lowest energy is available" in error.detail
+    assert error.context == {
+        "candidate_count": 1,
+        "calculation_type": calculation_type.value,
+        "energy_field": energy_field,
+        "species_entry_ref": entry.public_ref,
+        "level_of_theory_ref": lot.public_ref,
+    }
+
+
+def test_lowest_energy_with_no_matching_candidates_remains_empty(db_session):
+    _, entry = _entry(db_session, smiles="NO-CANDIDATES")
+    lot = make_lot(db_session)
+
+    response = search_species_calculations(
+        db_session,
+        SpeciesCalculationsSearchRequest(
+            species_entry_ref=entry.public_ref,
+            level_of_theory_ref=lot.public_ref,
+            calculation_type=CalculationType.sp,
+            ranking=CalculationRanking.lowest_energy,
+        ),
+    )
+
+    assert response.records == []
+    assert response.pagination.total == 0
+
+
 # ---------------------------------------------------------------------------
 # Collapse + pagination
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- return 422 `lowest_energy_unavailable` when matching visible candidates all lack the required energy
- preserve normal empty results and mixed-energy nulls-last ranking
- document the completed query contract and cover SP, OPT, API-envelope, and empty-result boundaries

## Schema or migration impact

None.

## Verification

- GitNexus impact and pre-commit change detection
- Standards review: PASS
- Spec/scientific review: PASS
- `git diff --check`
- Full automated verification delegated to PR CI
