### PR TITLE
Report post-collapse pagination totals

### DIFF
--- a/backend/app/schemas/reads/scientific_common.py
+++ b/backend/app/schemas/reads/scientific_common.py
@@ -78,14 +78,16 @@ MAX_LIMIT = 200
 class Pagination(BaseModel):
     """Echoed pagination block per L5.
 
-    ``total``    pre-collapse, post-filter match count.
-    ``returned`` actual length of ``records``.
+    ``total``                pre-collapse, post-filter match count.
+    ``post_collapse_total``  count after collapse, before page slicing.
+    ``returned``             actual length of ``records``.
     """
 
     offset: int = Field(ge=0)
     limit: int = Field(ge=1, le=MAX_LIMIT)
     returned: int = Field(ge=0)
     total: int = Field(ge=0)
+    post_collapse_total: int = Field(ge=0)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/scientific_read/common.py
+++ b/backend/app/services/scientific_read/common.py
@@ -308,14 +308,25 @@ def review_rank(badge: RecordReviewBadge) -> int:
 
 
 def build_pagination(
-    *, offset: int, limit: int, returned: int, total: int
+    *,
+    offset: int,
+    limit: int,
+    returned: int,
+    total: int,
+    collapse_first: bool = False,
 ) -> Pagination:
     """Construct the response Pagination block.
 
-    ``total`` is the pre-collapse, post-filter count (per spec).
+    ``total`` is the pre-collapse, post-filter count. The additive
+    ``post_collapse_total`` is the count after collapse and before offset/limit
+    slicing; it equals ``total`` unless ``collapse=first`` was requested.
     """
     return Pagination(
-        offset=offset, limit=limit, returned=returned, total=total
+        offset=offset,
+        limit=limit,
+        returned=returned,
+        total=total,
+        post_collapse_total=min(total, 1) if collapse_first else total,
     )
 
 

--- a/backend/app/services/scientific_read/kinetics.py
+++ b/backend/app/services/scientific_read/kinetics.py
@@ -605,6 +605,7 @@ def get_reaction_kinetics(
             limit=limit,
             returned=len(returned),
             total=pre_collapse_total,
+            collapse_first=collapse_first,
         ),
     )
 

--- a/backend/app/services/scientific_read/kinetics_search.py
+++ b/backend/app/services/scientific_read/kinetics_search.py
@@ -250,6 +250,7 @@ def search_kinetics(
             limit=limit,
             returned=len(returned),
             total=pre_collapse_total,
+            collapse_first=collapse_first,
         ),
     )
 
@@ -305,5 +306,11 @@ def _empty_response(
         ),
         review_summary=ReviewStatusSummary(),
         records=[],
-        pagination=Pagination(offset=offset, limit=limit, returned=0, total=0),
+        pagination=Pagination(
+            offset=offset,
+            limit=limit,
+            returned=0,
+            total=0,
+            post_collapse_total=0,
+        ),
     )

--- a/backend/app/services/scientific_read/kinetics_search.py
+++ b/backend/app/services/scientific_read/kinetics_search.py
@@ -26,7 +26,6 @@ from sqlalchemy.orm import Session
 from app.schemas.reads.scientific_common import (
     REVIEW_RANK,
     CollapseMode,
-    Pagination,
     ReviewStatusSummary,
 )
 from app.schemas.reads.scientific_kinetics import KineticsReadRequest
@@ -306,11 +305,10 @@ def _empty_response(
         ),
         review_summary=ReviewStatusSummary(),
         records=[],
-        pagination=Pagination(
+        pagination=build_pagination(
             offset=offset,
             limit=limit,
             returned=0,
             total=0,
-            post_collapse_total=0,
         ),
     )

--- a/backend/app/services/scientific_read/reactions.py
+++ b/backend/app/services/scientific_read/reactions.py
@@ -351,6 +351,7 @@ def search_reactions(
             limit=limit,
             returned=len(returned_records),
             total=pre_collapse_total,
+            collapse_first=collapse_first,
         ),
     )
 

--- a/backend/app/services/scientific_read/species.py
+++ b/backend/app/services/scientific_read/species.py
@@ -275,6 +275,7 @@ def search_species(
         limit=limit,
         returned=len(returned_records),
         total=pre_collapse_total,
+        collapse_first=collapse_first,
     )
 
     request_filter = _filter_echo(request)

--- a/backend/app/services/scientific_read/species_calculations_search.py
+++ b/backend/app/services/scientific_read/species_calculations_search.py
@@ -70,7 +70,6 @@ from app.schemas.reads.scientific_common import (
     REVIEW_RANK,
     CollapseMode,
     LevelOfTheorySummary,
-    Pagination,
     ReviewStatusSummary,
     SCFStabilitySummary,
     SoftwareReleaseSummary,
@@ -1097,11 +1096,10 @@ def _empty_response(
         ),
         review_summary=ReviewStatusSummary(),
         records=[],
-        pagination=Pagination(
+        pagination=build_pagination(
             offset=offset,
             limit=limit,
             returned=0,
             total=0,
-            post_collapse_total=0,
         ),
     )

--- a/backend/app/services/scientific_read/species_calculations_search.py
+++ b/backend/app/services/scientific_read/species_calculations_search.py
@@ -366,6 +366,7 @@ def search_species_calculations(
             limit=limit,
             returned=len(returned),
             total=pre_collapse_total,
+            collapse_first=collapse_first,
         ),
     )
 
@@ -1096,5 +1097,11 @@ def _empty_response(
         ),
         review_summary=ReviewStatusSummary(),
         records=[],
-        pagination=Pagination(offset=offset, limit=limit, returned=0, total=0),
+        pagination=Pagination(
+            offset=offset,
+            limit=limit,
+            returned=0,
+            total=0,
+            post_collapse_total=0,
+        ),
     )

--- a/backend/app/services/scientific_read/species_statmech.py
+++ b/backend/app/services/scientific_read/species_statmech.py
@@ -187,7 +187,11 @@ def get_species_statmech(
         review_summary=summary,
         records=records,
         pagination=build_pagination(
-            offset=offset, limit=limit, returned=len(records), total=total
+            offset=offset,
+            limit=limit,
+            returned=len(records),
+            total=total,
+            collapse_first=collapse_first,
         ),
     )
 

--- a/backend/app/services/scientific_read/species_transport.py
+++ b/backend/app/services/scientific_read/species_transport.py
@@ -184,7 +184,11 @@ def get_species_transport(
         review_summary=summary,
         records=records,
         pagination=build_pagination(
-            offset=offset, limit=limit, returned=len(records), total=total
+            offset=offset,
+            limit=limit,
+            returned=len(records),
+            total=total,
+            collapse_first=collapse_first,
         ),
     )
 

--- a/backend/app/services/scientific_read/thermo.py
+++ b/backend/app/services/scientific_read/thermo.py
@@ -499,6 +499,7 @@ def get_species_thermo(
             limit=limit,
             returned=len(returned),
             total=pre_collapse_total,
+            collapse_first=collapse_first,
         ),
     )
 

--- a/backend/app/services/scientific_read/thermo_search.py
+++ b/backend/app/services/scientific_read/thermo_search.py
@@ -28,7 +28,6 @@ from sqlalchemy.orm import Session
 from app.schemas.reads.scientific_common import (
     REVIEW_RANK,
     CollapseMode,
-    Pagination,
     ReviewStatusSummary,
 )
 from app.schemas.reads.scientific_species import SpeciesSearchRequest
@@ -327,11 +326,10 @@ def _empty_response(
         ),
         review_summary=ReviewStatusSummary(),
         records=[],
-        pagination=Pagination(
+        pagination=build_pagination(
             offset=offset,
             limit=limit,
             returned=0,
             total=0,
-            post_collapse_total=0,
         ),
     )

--- a/backend/app/services/scientific_read/thermo_search.py
+++ b/backend/app/services/scientific_read/thermo_search.py
@@ -272,6 +272,7 @@ def search_thermo(
             limit=limit,
             returned=len(returned),
             total=pre_collapse_total,
+            collapse_first=collapse_first,
         ),
     )
 
@@ -326,5 +327,11 @@ def _empty_response(
         ),
         review_summary=ReviewStatusSummary(),
         records=[],
-        pagination=Pagination(offset=offset, limit=limit, returned=0, total=0),
+        pagination=Pagination(
+            offset=offset,
+            limit=limit,
+            returned=0,
+            total=0,
+            post_collapse_total=0,
+        ),
     )

--- a/backend/docs/specs/machine_consumer_query_contract.md
+++ b/backend/docs/specs/machine_consumer_query_contract.md
@@ -1,16 +1,14 @@
 # Machine-consumer query contract
 
-Status: requirements 1–4 and 6–9 are implemented at the scopes stated below.
-Requirement 5 is exhaustive within the hosted traversal bound but still lacks a
-second post-collapse count. Requirement 10 remains ongoing as each surface
-expands.
+Status: requirements 1–9 are implemented at the scopes stated below.
+Requirement 10 remains ongoing as each surface expands.
 
 ## Compatibility rules
 
 - Additive response fields are backward compatible. Removing or changing the meaning/type of a field requires a versioned contract.
 - A declared filter is either enforced or rejected. It must never be accepted and ignored.
 - Public refs are stable identifiers. Integer database IDs are deployment-policy fields and are optional in hosted response schemas.
-- Pagination metadata describes the complete filtered candidate set before collapse and page slicing. Collapse is applied first, so `collapse=first&offset=1` returns an empty page while retaining the pre-collapse `total`.
+- Pagination metadata reports `total` for the complete filtered candidate set before collapse and `post_collapse_total` after collapse but before page slicing. Collapse is applied first, so `collapse=first&offset=1` returns an empty page while retaining `total >= 1` and `post_collapse_total = 1`.
 
 ## Ordered requirements
 
@@ -22,7 +20,7 @@ expands.
 
 4. **Canonical pressure query — implemented.** `pressure_bar` is canonical on reaction-entry and chemistry-first kinetics reads; `pressure` remains a deprecated alias. Both accept only finite positive values at every GET/POST request boundary. After numeric parsing, equal aliases (for example `1` and `1.0`) are canonicalized to `pressure_bar`; any exact inequality returns 422 `pressure_alias_conflict` without tolerance. A valid pressure includes pressure-independent rates; matches exact apparent-pressure records; applies bounded PLOG/Chebyshev coverage; accepts populated falloff/third-body models; and excludes high-pressure-limit, out-of-range, or indeterminate pressure-dependent records. Incompatible records are filtered out rather than silently broadened. A non-null `reaction_path_degeneracy` reports an explicit `convention`: `already_applied` maps to `true/false`, `not_applied` maps to `false/true`, and `unknown` maps to `null/null` for `reported_rate_coefficient_includes_degeneracy` / `apply_to_rate_coefficient`. Legacy rows are backfilled as `unknown`; semantics are never inferred from the numeric degeneracy. Null degeneracy remains unknown, not one.
 
-5. **Exhaustive composed searches — bounded implementation.** Thermo, kinetics, and species-calculation composition walks every reachable identity page before downstream filtering, ordering, collapse, and pagination. If the complete identity set exceeds the hosted offset/limit traversal bound, the request fails with 422 `composed_search_candidate_limit_exceeded`; it is never silently truncated. `pagination.total` is the complete post-filter, pre-collapse candidate count and `pagination.returned` is the actual record-list length. A distinct post-collapse total is not yet exposed, so `collapse=first` can legitimately return one record while `pagination.total > 1`.
+5. **Exhaustive composed searches — bounded implementation.** Thermo, kinetics, and species-calculation composition walks every reachable identity page before downstream filtering, ordering, collapse, and pagination. If the complete identity set exceeds the hosted offset/limit traversal bound, the request fails with 422 `composed_search_candidate_limit_exceeded`; it is never silently truncated. `pagination.total` is the complete post-filter, pre-collapse candidate count, `pagination.post_collapse_total` is the count after collapse and before page slicing, and `pagination.returned` is the actual record-list length. The same additive pagination contract applies across scientific reads; without collapse, `post_collapse_total == total`.
 
 6. **Comparable `lowest_energy` — implemented.** Species-calculation `ranking=lowest_energy` requires `calculation_type=sp|opt`, one exact `species_entry_ref`, and one exact `level_of_theory_ref`; unsafe requests fail with coded 422 errors. SP ranks `electronic_energy_hartree`; opt ranks its final-energy field, so calculation types and energy meanings are not mixed within one query. Missing energies sort last when at least one candidate has an energy. If candidates match but every energy is null, the request fails with 422 `lowest_energy_unavailable`; a search with no matching candidates remains a normal empty result.
 
@@ -30,7 +28,7 @@ expands.
 
 8. **Compact trust and reproducibility summaries — implemented for kinetics and thermo.** The single opt-in token is `include=assessments`; it is deliberately excluded from `include=all`. The block contains current deterministic trust (`rubric`, version, grade, optional hard fail) and the latest immutable reproducibility assessment (`current|stale|unassessed`, rubric/version, grade, timestamp). Absence serializes as `unassessed`, never approval. No assessment-grade filter is offered because filtering without freshness enforcement would mix current and stale claims. The compact projection does not currently expose an assessment public ref. Statmech and transport retain their existing deterministic `trust` fragments; their reproducibility-assessment projection is deferred.
 
-9. **Typed Python models and complete iterators — implemented for the supported client search surface.** The dependency-light client exports `TypedDict` wire models for errors and species, reaction, thermo, kinetics, species-calculation, network, network-kinetics, statmech, transport, and artifact search responses. Thermo and kinetics use distinct flat detail-record types and composed search-row types. Existing methods still return ordinary dictionaries. Matching lazy `iter_*` methods preserve filters/includes, advance using returned pagination metadata, stop at the reported total, and fail on malformed, changing, empty-before-total, or non-advancing pages. Because hosted collapse reports a pre-collapse total, `collapse=first` yields at most the one collapsed record and stops; an initial offset of one or more yields an empty page.
+9. **Typed Python models and complete iterators — implemented for the supported client search surface.** The dependency-light client exports `TypedDict` wire models for errors and species, reaction, thermo, kinetics, species-calculation, network, network-kinetics, statmech, transport, artifact search responses, and additive `post_collapse_total` pagination metadata. Thermo and kinetics use distinct flat detail-record types and composed search-row types. Existing methods still return ordinary dictionaries. Matching lazy `iter_*` methods preserve filters/includes, advance using returned pagination metadata, stop at `post_collapse_total`, and fail on malformed, changing, empty-before-total, or non-advancing pages. When talking to an older server that omits the additive field, the client falls back to `total` plus the legacy `collapse=first` stop rule.
 
 10. **Guides and regression coverage — partial, ongoing.** Every requirement lands with positive, conflict, empty-result, policy-hidden, and legacy-compatibility tests as applicable. Public examples use supported ranking fields and the actual nested geometry shape. Guides identify planned behavior explicitly and never demonstrate accepted-but-ignored filters.
 

--- a/backend/docs/specs/read_query_api_audit.md
+++ b/backend/docs/specs/read_query_api_audit.md
@@ -1116,7 +1116,8 @@ or a calculation type** — only species-rooted search exists.
 Scientific endpoints use a richer envelope
 (`backend/app/schemas/reads/scientific_common.py:55-65`):
 `offset` (≥0, default 0), `limit` (1–200, default 50),
-`returned` (actual count), `total` (pre-collapse, post-filter).
+`returned` (actual page count), `total` (pre-collapse, post-filter), and
+`post_collapse_total` (post-collapse, pre-page count).
 Bounds enforced in `validate_pagination()` (services/scientific_read/common.py:59-83):
 `offset` capped at `settings.public_max_offset`, `limit` capped at
 `min(MAX_LIMIT=200, settings.public_max_limit)`. Excess → 422.

--- a/backend/docs/specs/scientific_product_candidacy.md
+++ b/backend/docs/specs/scientific_product_candidacy.md
@@ -88,7 +88,9 @@ Read paths return candidates, and collapse to one only under explicit policy:
 - **Single-record collapse is explicit and named.** `collapse=first` returns
   exactly one record, chosen by an explicit, named `selection_policy`. The
   chosen `collapse` and `selection_policy` are echoed in the response; the
-  pre-collapse candidate count stays in `pagination.total`.
+  pre-collapse candidate count stays in `pagination.total`, while
+  `pagination.post_collapse_total` reports the count after selection collapse
+  and before offset/limit slicing.
 
 ### Named selection policies
 

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -23422,7 +23422,7 @@
         "type": "object"
       },
       "Pagination": {
-        "description": "Echoed pagination block per L5.\n\n``total``    pre-collapse, post-filter match count.\n``returned`` actual length of ``records``.",
+        "description": "Echoed pagination block per L5.\n\n``total``                pre-collapse, post-filter match count.\n``post_collapse_total``  count after collapse, before page slicing.\n``returned``             actual length of ``records``.",
         "properties": {
           "limit": {
             "maximum": 200.0,
@@ -23433,6 +23433,11 @@
           "offset": {
             "minimum": 0.0,
             "title": "Offset",
+            "type": "integer"
+          },
+          "post_collapse_total": {
+            "minimum": 0.0,
+            "title": "Post Collapse Total",
             "type": "integer"
           },
           "returned": {
@@ -23450,7 +23455,8 @@
           "offset",
           "limit",
           "returned",
-          "total"
+          "total",
+          "post_collapse_total"
         ],
         "title": "Pagination",
         "type": "object"

--- a/backend/tests/api/scientific/test_api_species_statmech.py
+++ b/backend/tests/api/scientific/test_api_species_statmech.py
@@ -307,6 +307,7 @@ def test_collapse_first_returns_single_record_with_pre_collapse_total(
     assert len(body["records"]) == 1
     # total stays pre-collapse so clients see how many candidates exist.
     assert body["pagination"]["total"] == 2
+    assert body["pagination"]["post_collapse_total"] == 1
 
 
 def test_collapse_first_offset_one_returns_empty(client, db_session):
@@ -317,6 +318,7 @@ def test_collapse_first_offset_one_returns_empty(client, db_session):
 
     assert body["records"] == []
     assert body["pagination"]["total"] == 1
+    assert body["pagination"]["post_collapse_total"] == 1
 
 
 def test_default_policy_selects_best_reviewed(client, db_session):

--- a/backend/tests/api/scientific/test_api_species_transport.py
+++ b/backend/tests/api/scientific/test_api_species_transport.py
@@ -305,6 +305,7 @@ def test_collapse_first_returns_single_record_with_pre_collapse_total(
     assert body["request"]["collapse"] == "first"
     assert len(body["records"]) == 1
     assert body["pagination"]["total"] == 2
+    assert body["pagination"]["post_collapse_total"] == 1
 
 
 def test_collapse_first_offset_one_returns_empty(client, db_session):
@@ -315,6 +316,7 @@ def test_collapse_first_offset_one_returns_empty(client, db_session):
 
     assert body["records"] == []
     assert body["pagination"]["total"] == 1
+    assert body["pagination"]["post_collapse_total"] == 1
 
 
 def test_default_policy_selects_best_reviewed(client, db_session):

--- a/backend/tests/services/scientific_read/test_common_pagination.py
+++ b/backend/tests/services/scientific_read/test_common_pagination.py
@@ -7,6 +7,7 @@ import pytest
 from app.api.config import settings
 from app.schemas.reads.scientific_common import Pagination
 from app.services.scientific_read.common import (
+    build_pagination,
     collect_bounded_pages,
     slice_for_pagination,
 )
@@ -19,6 +20,27 @@ def test_slice_for_pagination_applies_offset_after_collapse():
         limit=1,
         collapse_first=True,
     ) == []
+
+
+@pytest.mark.parametrize(
+    ("total", "collapse_first", "expected_post_collapse_total"),
+    [(4, False, 4), (4, True, 1), (0, True, 0)],
+)
+def test_build_pagination_reports_post_collapse_total(
+    total: int,
+    collapse_first: bool,
+    expected_post_collapse_total: int,
+):
+    pagination = build_pagination(
+        offset=0,
+        limit=50,
+        returned=min(total, 1) if collapse_first else total,
+        total=total,
+        collapse_first=collapse_first,
+    )
+
+    assert pagination.total == total
+    assert pagination.post_collapse_total == expected_post_collapse_total
 
 
 def test_collect_bounded_pages_walks_past_first_page(monkeypatch):
@@ -36,6 +58,7 @@ def test_collect_bounded_pages_walks_past_first_page(monkeypatch):
                 limit=limit,
                 returned=len(records),
                 total=len(values),
+                post_collapse_total=len(values),
             ),
         )
 
@@ -55,6 +78,7 @@ def test_collect_bounded_pages_rejects_unreachable_total(monkeypatch):
                 limit=limit,
                 returned=2,
                 total=6,
+                post_collapse_total=6,
             ),
         )
 

--- a/backend/tests/services/scientific_read/test_get_reaction_kinetics.py
+++ b/backend/tests/services/scientific_read/test_get_reaction_kinetics.py
@@ -78,6 +78,7 @@ def test_collapse_first_applies_before_offset(db_session):
 
     assert response.records == []
     assert response.pagination.total == 1
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 0
 
 

--- a/backend/tests/services/scientific_read/test_get_species_thermo.py
+++ b/backend/tests/services/scientific_read/test_get_species_thermo.py
@@ -69,6 +69,7 @@ def test_collapse_first_applies_before_offset(db_session):
 
     assert response.records == []
     assert response.pagination.total == 1
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 0
 
 

--- a/backend/tests/services/scientific_read/test_search_kinetics.py
+++ b/backend/tests/services/scientific_read/test_search_kinetics.py
@@ -141,6 +141,7 @@ def test_collapse_first_preserves_plural_records_with_pre_collapse_total(db_sess
 
     assert len(response.records) == 1
     assert response.pagination.total == 2
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 1
 
 

--- a/backend/tests/services/scientific_read/test_search_reactions.py
+++ b/backend/tests/services/scientific_read/test_search_reactions.py
@@ -287,4 +287,5 @@ def test_collapse_first_applies_before_offset(db_session):
 
     assert response.records == []
     assert response.pagination.total == 1
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 0

--- a/backend/tests/services/scientific_read/test_search_species.py
+++ b/backend/tests/services/scientific_read/test_search_species.py
@@ -370,6 +370,7 @@ def test_collapse_first_returns_at_most_one_with_pre_collapse_total(db_session):
     assert len(response.records) == 1
     # Pre-collapse total should reflect both candidates.
     assert response.pagination.total == 2
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 1
 
 

--- a/backend/tests/services/scientific_read/test_search_species_calculations.py
+++ b/backend/tests/services/scientific_read/test_search_species_calculations.py
@@ -452,6 +452,7 @@ def test_collapse_first_preserves_plural_records_with_pre_collapse_total(db_sess
 
     assert len(response.records) == 1
     assert response.pagination.total == 2
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 1
 
 

--- a/backend/tests/services/scientific_read/test_search_thermo.py
+++ b/backend/tests/services/scientific_read/test_search_thermo.py
@@ -107,6 +107,7 @@ def test_collapse_first_preserves_plural_records_with_pre_collapse_total(db_sess
 
     assert len(response.records) == 1
     assert response.pagination.total == 2
+    assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 1
 
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -231,7 +231,9 @@ Each supported paginated search also has a lazy ``iter_*`` form. It keeps
 filters and include tokens unchanged, follows returned pagination metadata,
 and raises ``TCKDBPaginationError`` on malformed, changing, or non-advancing
 pages. ``collapse="first"`` yields the one collapsed record and stops because
-hosted ``pagination.total`` intentionally remains the pre-collapse count.
+hosted responses report both the pre-collapse ``pagination.total`` and the
+post-collapse, pre-page ``pagination.post_collapse_total``. The client retains
+the legacy stop rule for older servers that omit the additive field.
 
 ```python
 for record in client.iter_network_kinetics(

--- a/clients/python/examples/scientific_reads.py
+++ b/clients/python/examples/scientific_reads.py
@@ -320,8 +320,12 @@ def _print_envelope_summary(label: str, response: dict[str, Any]) -> None:
     pagination = response.get("pagination") or {}
     review = response.get("review_summary") or {}
     total = pagination.get("total", 0)
+    post_collapse_total = pagination.get("post_collapse_total", total)
     returned = pagination.get("returned", len(response.get("records", []) or []))
-    print(f"  {label}: returned={returned}, pre-collapse total={total}")
+    print(
+        f"  {label}: returned={returned}, post-collapse total="
+        f"{post_collapse_total}, pre-collapse total={total}"
+    )
     print(
         "    review counts:",
         f"approved={review.get('approved', 0)},",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.28.0"
+version = "0.28.1"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/pagination.py
+++ b/clients/python/src/tckdb_client/pagination.py
@@ -58,6 +58,7 @@ def iter_paginated_records(
         minimum=1,
     )
     expected_total: int | None = None
+    expected_post_collapse_total: int | None = None
 
     while True:
         page = fetch_page(
@@ -81,10 +82,21 @@ def iter_paginated_records(
         page_limit = _integer_field(pagination, "limit")
         returned = _integer_field(pagination, "returned")
         total = _integer_field(pagination, "total")
+        has_post_collapse_total = "post_collapse_total" in pagination
+        post_collapse_total = (
+            _integer_field(pagination, "post_collapse_total")
+            if has_post_collapse_total
+            else total
+        )
         if page_offset < 0 or page_limit < 1 or returned < 0 or total < 0:
             raise TCKDBPaginationError(
                 "Malformed pagination: offset/returned/total must be non-negative "
                 "and limit must be positive."
+            )
+        if post_collapse_total < 0 or post_collapse_total > total:
+            raise TCKDBPaginationError(
+                "Malformed pagination: post_collapse_total must be between zero "
+                "and total."
             )
         if page_offset != requested_offset:
             raise TCKDBPaginationError(
@@ -104,22 +116,30 @@ def iter_paginated_records(
             raise TCKDBPaginationError(
                 "Pagination total changed while iterating; restart the query."
             )
-        if returned == 0 and page_offset >= total:
-            return
-        if page_offset + returned > total:
+        if expected_post_collapse_total is None:
+            expected_post_collapse_total = post_collapse_total
+        elif post_collapse_total != expected_post_collapse_total:
             raise TCKDBPaginationError(
-                "Malformed pagination: page extends beyond the reported total."
+                "Pagination post_collapse_total changed while iterating; "
+                "restart the query."
+            )
+        if returned == 0 and page_offset >= post_collapse_total:
+            return
+        if page_offset + returned > post_collapse_total:
+            raise TCKDBPaginationError(
+                "Malformed pagination: page extends beyond the reported "
+                "post-collapse total."
             )
 
         yield from cast(list[RecordT], records)
 
         next_offset = page_offset + returned
-        if next_offset >= total:
+        if next_offset >= post_collapse_total:
             return
-        # The collapsed result set has at most one row. A valid empty page at
-        # offset > 0 is therefore complete, even though ``total`` reports the
-        # larger pre-collapse candidate count.
-        if collapse_first:
+        # Compatibility fallback for servers predating post_collapse_total.
+        # Their collapsed result set has at most one row even though ``total``
+        # reports the larger pre-collapse candidate count.
+        if collapse_first and not has_post_collapse_total:
             return
         if returned == 0 or next_offset <= requested_offset:
             raise TCKDBPaginationError(

--- a/clients/python/src/tckdb_client/pagination.py
+++ b/clients/python/src/tckdb_client/pagination.py
@@ -58,7 +58,6 @@ def iter_paginated_records(
         minimum=1,
     )
     expected_total: int | None = None
-    expected_post_collapse_total: int | None = None
 
     while True:
         page = fetch_page(
@@ -98,6 +97,13 @@ def iter_paginated_records(
                 "Malformed pagination: post_collapse_total must be between zero "
                 "and total."
             )
+        if has_post_collapse_total:
+            expected_post_total = min(total, 1) if collapse_first else total
+            if post_collapse_total != expected_post_total:
+                raise TCKDBPaginationError(
+                    "Malformed pagination: post_collapse_total does not match "
+                    "the requested collapse mode."
+                )
         if page_offset != requested_offset:
             raise TCKDBPaginationError(
                 "Malformed pagination: server offset does not match the requested offset."
@@ -110,18 +116,17 @@ def iter_paginated_records(
             raise TCKDBPaginationError(
                 "Malformed pagination: returned exceeds the server page limit."
             )
+        if collapse_first and not has_post_collapse_total:
+            if returned > 1 or (page_offset >= 1 and returned > 0):
+                raise TCKDBPaginationError(
+                    "Malformed pagination: legacy collapsed pages may return only "
+                    "one record at offset zero."
+                )
         if expected_total is None:
             expected_total = total
         elif total != expected_total:
             raise TCKDBPaginationError(
                 "Pagination total changed while iterating; restart the query."
-            )
-        if expected_post_collapse_total is None:
-            expected_post_collapse_total = post_collapse_total
-        elif post_collapse_total != expected_post_collapse_total:
-            raise TCKDBPaginationError(
-                "Pagination post_collapse_total changed while iterating; "
-                "restart the query."
             )
         if returned == 0 and page_offset >= post_collapse_total:
             return
@@ -140,7 +145,8 @@ def iter_paginated_records(
         # Their collapsed result set has at most one row even though ``total``
         # reports the larger pre-collapse candidate count.
         if collapse_first and not has_post_collapse_total:
-            return
+            if returned == 1 or page_offset >= 1:
+                return
         if returned == 0 or next_offset <= requested_offset:
             raise TCKDBPaginationError(
                 "Pagination did not advance before reaching the reported total."

--- a/clients/python/src/tckdb_client/scientific_types.py
+++ b/clients/python/src/tckdb_client/scientific_types.py
@@ -17,6 +17,7 @@ class Pagination(TypedDict):
     limit: int
     returned: int
     total: int
+    post_collapse_total: NotRequired[int]
 
 
 class ScientificRequestEcho(TypedDict, total=False):

--- a/clients/python/tests/test_typed_scientific.py
+++ b/clients/python/tests/test_typed_scientific.py
@@ -485,7 +485,9 @@ def test_iterator_uses_post_collapse_total_as_authoritative_bound() -> None:
         page["pagination"]["post_collapse_total"] = 1
         return page
 
-    records = list(iter_paginated_records(fetch, {"limit": 1}))
+    records = list(
+        iter_paginated_records(fetch, {"collapse": "first", "limit": 1})
+    )
 
     assert records == [{"ordinal": 0}]
     assert calls == 1
@@ -502,15 +504,62 @@ def test_iterator_rejects_invalid_post_collapse_total(
         list(iter_paginated_records(lambda **_kwargs: page, {"limit": 1}))
 
 
-def test_iterator_rejects_post_collapse_total_that_changes() -> None:
-    first = _page(limit=1, total=2)
-    first["pagination"]["post_collapse_total"] = 2
-    second = _page(offset=1, limit=1, total=2)
-    second["pagination"]["post_collapse_total"] = 1
-    pages = iter([first, second])
+@pytest.mark.parametrize(
+    ("collapse", "total", "post_collapse_total"),
+    [
+        ("all", 8, 0),
+        ("all", 8, 1),
+        ("first", 8, 0),
+        ("first", 8, 8),
+    ],
+)
+def test_iterator_rejects_post_collapse_total_that_disagrees_with_mode(
+    collapse: str,
+    total: int,
+    post_collapse_total: int,
+) -> None:
+    page = _page(limit=1, total=total)
+    page["pagination"]["post_collapse_total"] = post_collapse_total
 
-    with pytest.raises(TCKDBPaginationError, match="post_collapse_total changed"):
-        list(iter_paginated_records(lambda **_kwargs: next(pages), {"limit": 1}))
+    with pytest.raises(TCKDBPaginationError, match="collapse mode"):
+        list(
+            iter_paginated_records(
+                lambda **_kwargs: page,
+                {"collapse": collapse, "limit": 1},
+            )
+        )
+
+
+def test_legacy_collapsed_iterator_rejects_empty_first_page_before_total() -> None:
+    page = _page(limit=1, total=8)
+    page["records"] = []
+    page["pagination"]["returned"] = 0
+
+    with pytest.raises(TCKDBPaginationError, match="did not advance"):
+        list(
+            iter_paginated_records(
+                lambda **_kwargs: page,
+                {"collapse": "first", "limit": 1},
+            )
+        )
+
+
+@pytest.mark.parametrize(("offset", "returned"), [(0, 2), (1, 1)])
+def test_legacy_collapsed_iterator_rejects_records_outside_single_result(
+    offset: int,
+    returned: int,
+) -> None:
+    page = _page(offset=offset, limit=2, total=8)
+    page["records"] = [{"ordinal": offset + index} for index in range(returned)]
+    page["pagination"]["returned"] = returned
+
+    with pytest.raises(TCKDBPaginationError, match="legacy collapsed"):
+        list(
+            iter_paginated_records(
+                lambda **_kwargs: page,
+                {"collapse": "first", "offset": offset, "limit": 2},
+            )
+        )
 
 
 def test_collapsed_iterator_accepts_empty_page_after_offset() -> None:

--- a/clients/python/tests/test_typed_scientific.py
+++ b/clients/python/tests/test_typed_scientific.py
@@ -475,6 +475,44 @@ def test_collapsed_iterator_stops_after_the_single_collapsed_record() -> None:
     assert calls == 1
 
 
+def test_iterator_uses_post_collapse_total_as_authoritative_bound() -> None:
+    calls = 0
+
+    def fetch(**_kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        page = _page(limit=1, total=8)
+        page["pagination"]["post_collapse_total"] = 1
+        return page
+
+    records = list(iter_paginated_records(fetch, {"limit": 1}))
+
+    assert records == [{"ordinal": 0}]
+    assert calls == 1
+
+
+@pytest.mark.parametrize("post_collapse_total", [-1, 3])
+def test_iterator_rejects_invalid_post_collapse_total(
+    post_collapse_total: int,
+) -> None:
+    page = _page(limit=1, total=2)
+    page["pagination"]["post_collapse_total"] = post_collapse_total
+
+    with pytest.raises(TCKDBPaginationError, match="post_collapse_total"):
+        list(iter_paginated_records(lambda **_kwargs: page, {"limit": 1}))
+
+
+def test_iterator_rejects_post_collapse_total_that_changes() -> None:
+    first = _page(limit=1, total=2)
+    first["pagination"]["post_collapse_total"] = 2
+    second = _page(offset=1, limit=1, total=2)
+    second["pagination"]["post_collapse_total"] = 1
+    pages = iter([first, second])
+
+    with pytest.raises(TCKDBPaginationError, match="post_collapse_total changed"):
+        list(iter_paginated_records(lambda **_kwargs: next(pages), {"limit": 1}))
+
+
 def test_collapsed_iterator_accepts_empty_page_after_offset() -> None:
     calls = 0
 

--- a/docs/guides/workflow_tool_scientific_reads.md
+++ b/docs/guides/workflow_tool_scientific_reads.md
@@ -610,8 +610,11 @@ Important rules:
   distance, then review rank, then evidence completeness, then
   `created_at`, then `id`).
 - `pagination.total` is the **pre-collapse, post-filter** match count.
-  When `collapse="first"`, `total` may be larger than `returned`
-  (returned is then 0 or 1).
+- `pagination.post_collapse_total` is the count **after collapse and before
+  offset/limit slicing**. It equals `total` for `collapse="all"` and is 0 or 1
+  for `collapse="first"`.
+- `pagination.returned` is the actual page length, so it can be smaller than
+  either total because of page slicing.
 - `review_summary` counts the **pre-collapse filtered candidate set**,
   so callers see the trust posture of every candidate, not only the one
   record returned.

--- a/docs/specs/species_calculation_search_api.md
+++ b/docs/specs/species_calculation_search_api.md
@@ -579,7 +579,7 @@ ranking=lowest_energy without both exact comparability refs → 422 unsafe_lowes
 ranking=latest orders by created_at DESC
 ranking=earliest orders by created_at ASC
 NULLS LAST: a calc with null energy ranks below a calc with populated energy under lowest_energy
-collapse=first preserves plural records array; pagination.total reflects pre-collapse count
+collapse=first preserves plural records array; pagination.total reflects the pre-collapse count and pagination.post_collapse_total reflects the collapsed count
 level_of_theory_id filters Calculation.lot_id directly
 method/basis filter via LoT join on the calculation row
 software filter via SoftwareRelease.software join


### PR DESCRIPTION
## Summary

- add `pagination.post_collapse_total` to every paginated scientific read response
- preserve `total` as the pre-collapse candidate count and report the post-collapse count before offset/limit
- update the Python iterator for the new authoritative bound with strict legacy-server compatibility checks
- update OpenAPI, docs, examples, and regression coverage; bump the Python client patch version to 0.28.1

## Schema / migration impact

None. This is an additive API response-contract change with no database migration.

## Verification

- GitNexus impact analysis completed before edits; final `detect_changes` reports the expected 33 files and no affected indexed flows
- standards review: PASS
- specification review: PASS
- `git diff --check`
- `UPDATE_OPENAPI_GOLDEN=1 conda run -n tckdb_env pytest backend/tests/api/test_openapi_snapshot.py -q` — 2 passed
- focused backend pagination/search tests — 220 passed during review; 63 affected empty-response tests passed after review cleanup
- `env PYTHONPATH=/tmp/tckdb-post-collapse/clients/python/src conda run -n tckdb_env pytest clients/python/tests/test_typed_scientific.py -q` — 64 passed

Full verification is delegated to PR CI.
