### PR TITLE
Parallelize backend CI gates

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -23,10 +23,18 @@ permissions:
   contents: read
 
 jobs:
-  backend-ci:
-    name: Backend CI
+  backend-gate:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gate: api
+            name: Backend API gate
+          - gate: scientific
+            name: Scientific read and service gate
 
     services:
       postgres:
@@ -34,11 +42,11 @@ jobs:
         env:
           POSTGRES_USER: tckdb
           POSTGRES_PASSWORD: tckdb
-          POSTGRES_DB: tckdb_test_ci
+          POSTGRES_DB: tckdb_${{ matrix.gate }}_ci
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U tckdb -d tckdb_test_ci"
+          --health-cmd "pg_isready -U tckdb -d tckdb_${{ matrix.gate }}_ci"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
@@ -62,9 +70,9 @@ jobs:
       DB_PORT: "5432"
       DB_USER: tckdb
       DB_PASSWORD: tckdb
-      DB_NAME: tckdb_test_ci
+      DB_NAME: tckdb_${{ matrix.gate }}_ci
       DB_CLIENT_ENCODING: utf8
-      DB_TEST_NAME: tckdb_test_${{ github.run_id }}_${{ github.run_attempt }}
+      DB_TEST_NAME: tckdb_${{ matrix.gate }}_${{ github.run_id }}_${{ github.run_attempt }}
       AUTH_ALLOW_OPEN_REGISTRATION: "true"
       DEPLOYMENT_MODE: local
       EXPOSE_API_DOCS: "true"
@@ -74,7 +82,7 @@ jobs:
       S3_ENDPOINT_URL: http://127.0.0.1:9000
       S3_ACCESS_KEY: tckdb
       S3_SECRET_KEY: tckdb_secret
-      S3_BUCKET: tckdb-artifacts-test
+      S3_BUCKET: tckdb-${{ matrix.gate }}-${{ github.run_id }}-${{ github.run_attempt }}
       S3_REGION: us-east-1
 
     defaults:
@@ -101,14 +109,17 @@ jobs:
           conda run -n tckdb_env python -m pip install -e "backend[dev]"
 
       - name: Lint (ruff)
+        if: matrix.gate == 'api'
         working-directory: backend
         run: conda run -n tckdb_env ruff check app tests
 
       - name: Type check (mypy, scoped)
+        if: matrix.gate == 'api'
         working-directory: backend
         run: conda run -n tckdb_env mypy
 
       - name: Hygiene checks
+        if: matrix.gate == 'api'
         run: |
           git diff --check
           bash -n backend/scripts/test-fast.sh
@@ -154,11 +165,28 @@ jobs:
           PY
 
       - name: OpenAPI golden snapshot
+        if: matrix.gate == 'api'
         working-directory: backend
         run: conda run -n tckdb_env pytest tests/api/test_openapi_snapshot.py -q
 
       - name: API test gate
-        run: conda run -n tckdb_env bash backend/scripts/test-api.sh --maxfail=5
+        if: matrix.gate == 'api'
+        run: >-
+          conda run -n tckdb_env bash backend/scripts/test-api.sh
+          --ignore=tests/api/scientific/
+          --ignore=tests/api/test_openapi_snapshot.py --maxfail=5
 
       - name: Scientific read and service gate
+        if: matrix.gate == 'scientific'
         run: conda run -n tckdb_env bash backend/scripts/test-scientific.sh --maxfail=5
+
+  backend-ci:
+    name: Backend CI
+    needs: backend-gate
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all backend gates to succeed
+        env:
+          GATE_RESULT: ${{ needs.backend-gate.result }}
+        run: test "$GATE_RESULT" = success

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -205,9 +205,12 @@ moment a caller sets `PYTEST_XDIST_WORKER`.
   every save.
 - Land Tier 1 green at minimum before pushing. Land Tier 3 green
   before opening a PR. Tier 4 is required before merging.
-- The initial backend CI gate runs Tier 3 plus the scientific Tier 2/3
-  slice. Local Tier 4 remains the pre-push and pre-merge insurance
-  until full-suite CI runtime is known.
+- The initial backend CI gate runs two independent jobs in parallel: the API
+  job runs Tier 3 with `tests/api/scientific/` ignored, while the scientific
+  job runs the scientific API directory plus `tests/services/scientific_read/`
+  through Tier 2. Together they cover every API test once and every
+  scientific-read service test once. Local Tier 4 remains the pre-push and
+  pre-merge insurance until full-suite CI runtime is known.
 
 ## CI gate
 
@@ -249,10 +252,19 @@ The gate runs:
 - the scientific read/service gate via
   [`../scripts/test-scientific.sh`](../scripts/test-scientific.sh)
 
-`DB_TEST_NAME` includes the GitHub run id and run attempt so concurrent
-workflow runs do not share the same pytest-created database on one
-Postgres service. The workflow does not enable pytest-xdist yet, so the
-fixture-level worker isolation remains available for a later CI slice.
+The API gate ignores both `tests/api/scientific/` (covered by the scientific
+job) and `tests/api/test_openapi_snapshot.py` (run once by its dedicated
+golden-snapshot step). The final `Backend CI` job is a stable aggregate status
+check: it runs even after an upstream failure or cancellation and fails unless
+the matrix result is `success`, while leaving both detailed gate checks visible.
+
+Each CI job owns an isolated Postgres service and MinIO service. Its
+`DB_TEST_NAME` and `S3_BUCKET` include both the GitHub run id/attempt and the
+job role, so concurrent jobs and workflow runs do not share test resources.
+The workflow does not enable pytest-xdist: an explicit `DB_TEST_NAME` takes
+precedence over `PYTEST_XDIST_WORKER`, so adding `-n` would still make workers
+race on one recreated database. The scientific test factories also need
+worker-aware isolation before xdist can safely be added.
 
 The full Tier 4 suite is intentionally not part of this v0 PR workflow.
 Keep running `make test-full` locally before push/merge until a
@@ -342,13 +354,17 @@ Things to verify before enabling xdist by default:
 - The test DB is named per worker (`tckdb_test_gw0`, `tckdb_test_gw1`,
   ...) so workers do not race on the same `alembic upgrade head` /
   drop-and-recreate sequence in [`tests/conftest.py`](../tests/conftest.py).
-  **Done** — `_resolve_test_db_name` in `conftest.py` honors
-  `PYTEST_XDIST_WORKER` automatically (see "Concurrent runs" above).
+  This requires omitting `DB_TEST_NAME` (or making it worker-specific),
+  because explicit names intentionally take precedence over
+  `PYTEST_XDIST_WORKER`.
 - The rate-limit middleware in-memory store is disabled per test
   (already the case via `_disable_rate_limit_by_default` autouse
   fixture) so two workers do not poison each other's bucket counters
   when they happen to land on the same IP.
 - The MinIO/artifact-storage tests that skip on `not _minio_available()`
-  do the right thing under parallel workers.
+  do the right thing under parallel workers, including worker-isolated object
+  keys/buckets and subprocess inheritance.
+- The process-global scientific-read factory counters use worker-distinct
+  prefixes or another isolation mechanism.
 
 Until that work is done, the scripts run pytest single-threaded.


### PR DESCRIPTION
## Summary
- run the general API gate and scientific read/service gate concurrently through a two-entry matrix
- remove duplicate scientific API and OpenAPI execution while preserving complete API coverage
- isolate PostgreSQL databases and MinIO buckets per gate
- retain a stable aggregate Backend CI status check
- document why pytest-xdist remains deferred pending worker-safe DB, factory, subprocess, and artifact isolation

## Expected impact
Recent sequential timing was approximately 25m for API plus 17.5m for scientific/service. Parallel execution should reduce Backend CI wall time toward the slower gate rather than their sum.

## Verification
- YAML/matrix structural assertions passed
- API partition: 2200 total = 822 general + 1376 scientific + 2 dedicated OpenAPI, with zero overlap or omissions
- scientific gate additionally collects 305 scientific-read service tests
- bash syntax and git diff --check passed
- xdist DB-name resolution tests: 4 passed
- independent Standards and Spec reviews completed; Spec passed