### PR TITLE
Add Python client CI

### DIFF
--- a/.github/workflows/python-client-ci.yml
+++ b/.github/workflows/python-client-ci.yml
@@ -1,0 +1,42 @@
+name: Python Client CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/python-client-ci.yml"
+      - "clients/python/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/python-client-ci.yml"
+      - "clients/python/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python client tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: clients/python/pyproject.toml
+
+      - name: Install Python client and test dependencies
+        working-directory: clients/python
+        run: python -m pip install -e ".[test,notebook]"
+
+      - name: Run Python client tests
+        working-directory: clients/python
+        run: python -m pytest

--- a/clients/python/tests/test_computed_reaction_upload_builder.py
+++ b/clients/python/tests/test_computed_reaction_upload_builder.py
@@ -162,6 +162,7 @@ def test_to_payload_snapshot(minimal_upload):
                 "model_kind": "modified_arrhenius",
                 "a": 1.2e13,
                 "a_units": "cm3_mol_s",
+                "degeneracy_convention": "unknown",
                 "n": 0.5,
                 "reported_ea": 10.0,
                 "reported_ea_units": "kj_mol",


### PR DESCRIPTION
## Summary

- update the computed-reaction payload snapshot for the intentional `degeneracy_convention: unknown` field
- add dedicated Python-client pytest CI for client changes and workflow changes
- install notebook dependencies so executable notebook tests cannot silently skip

## Schema and migration impact

None.

## Verification

- complete Python client suite: `919 passed`
- Ruff on the touched Python test: passed
- workflow YAML parsing: passed
- `git diff --check`: passed
- GitNexus change detection: low risk, no affected flows
- Standards review: PASS
- Spec review: PASS

`actionlint` was not available locally; this PR's new workflow run provides the authoritative GitHub Actions validation.
