### PR TITLE
Contain the archive tests' non-transactional sequence rewind

### DIFF
--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -129,9 +129,31 @@ make test-fast ARGS="path/to/test_file.py::TestClass::test_case -vv -s"
 ```
 
 If a test is flaky, run it three times in a row before concluding.
-Test isolation in this repo is per-test transaction rollback (see
-[`tests/conftest.py`](../tests/conftest.py)); intermittent failures
-are usually fixture-ordering or shared-state bugs surfacing.
+
+Test isolation here is **two-tier**, and knowing which tier a test is in
+matters when diagnosing cross-file failures (see
+[`tests/conftest.py`](../tests/conftest.py)):
+
+- `db_session` / `db_conn` / `client` roll back per test. Rows written
+  through these never outlive the test.
+- The session-scoped `db_engine` fixture does **not**. Around 45 test
+  files use it with `with session.begin():`, which commits, so the shared
+  test database genuinely accumulates committed rows for the whole
+  pytest session.
+
+Two consequences worth remembering. Committed rows from tier two are
+visible to every later test file in the same run. And rollback does not
+undo everything even in tier one: PostgreSQL sequences are
+non-transactional, so a `setval` (as `restore_archive` performs when
+repairing primary-key sequences) survives a rollback and leaks into the
+rest of the session — see
+[`tests/services/archive/conftest.py`](../tests/services/archive/conftest.py)
+for the containment fixture and the failure it prevents.
+
+Because each CI gate job gets a fresh database, this class of bug is
+invisible in CI and only reproduces when several files share one local
+database. Intermittent or combination-only failures are usually
+fixture-ordering or shared-state bugs of exactly this kind.
 
 ### Recovering from a local test-database port conflict
 

--- a/backend/tests/services/archive/__init__.py
+++ b/backend/tests/services/archive/__init__.py
@@ -1,0 +1,11 @@
+"""Archive service tests.
+
+This package marker is load-bearing. Without it, pytest imports the
+sibling ``conftest.py`` under the bare top-level module name ``conftest``
+and prepends this directory to ``sys.path`` — shadowing
+``tests/conftest.py`` for the tests that do ``from conftest import ...``
+(``tests/test_db_name_resolution.py``, ``tests/db/*_migration.py``).
+Keeping the directory a package makes the fixture module
+``tests.services.archive.conftest`` instead, which cannot collide. The
+sibling ``tests/services/scientific_read/`` package does the same.
+"""

--- a/backend/tests/services/archive/conftest.py
+++ b/backend/tests/services/archive/conftest.py
@@ -1,0 +1,120 @@
+"""Sequence-state containment for the archive tests.
+
+``restore_archive`` finishes by repairing every primary-key sequence to
+``max(id)`` of the rows it just inserted (``_repair_sequences`` in
+`app/services/archive/core.py`). That is correct in production, where a
+restore targets a genuinely empty database and commits.
+
+Under pytest it is a cross-file isolation leak. PostgreSQL sequences live
+outside MVCC: ``setval`` is **not** undone when the surrounding
+transaction rolls back (see the PostgreSQL docs on ``setval`` —
+"because sequences are non-transactional, changes made by setval are not
+undone if the transaction rolls back"). So although every archive test
+rolls its rows back, the rewound sequence counters survive into the rest
+of the pytest session.
+
+The damage is only visible when several test files share one database.
+Many suites in this repo legitimately use the session-scoped
+``db_engine`` fixture and commit (``tests/services/test_calculation_resolution.py``
+and ~40 others), so the shared test database really does hold committed
+rows at low ids. A rewound sequence then hands those ids out a second
+time and the next insert dies on a duplicate-key violation, e.g.::
+
+    duplicate key value violates unique constraint "pk_species"
+    DETAIL:  Key (id)=(2) already exists.
+
+Every archive test passes on its own, which is why CI — one fresh
+database per gate job — never saw this.
+
+The fixture below makes the archive tests clean up after themselves: it
+snapshots every user sequence before the test and restores the exact
+``(last_value, is_called)`` pair afterwards, so the tests leave sequence
+state exactly as they found it. Sequence writes are non-transactional in
+both directions, so the restore is effective whether it lands before or
+after the test transaction's rollback, and it uses its own connection so
+an aborted test transaction cannot prevent cleanup.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy import Engine, text
+
+# Fixtures that imply the test touches the shared test database. Tests that
+# use none of these (the pure registry/codec checks) need no containment and
+# must not pay for a database round trip.
+_DB_FIXTURES = frozenset({"db_session", "db_conn", "db_engine", "client"})
+
+_SequenceState = dict[str, tuple[int, bool]]
+
+
+def _user_sequences(connection) -> list[str]:
+    """Return every non-system sequence as a quoted ``schema.name``."""
+    return list(
+        connection.scalars(
+            text(
+                """
+                SELECT quote_ident(schemaname) || '.' || quote_ident(sequencename)
+                FROM pg_sequences
+                WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+                ORDER BY schemaname, sequencename
+                """
+            )
+        )
+    )
+
+
+def _snapshot_sequences(engine: Engine) -> _SequenceState:
+    with engine.connect() as connection:
+        names = _user_sequences(connection)
+        if not names:
+            return {}
+        # One round trip instead of one per sequence: selecting from a sequence
+        # relation yields its current (last_value, is_called).
+        union = " UNION ALL ".join(
+            f"SELECT {index} AS ord, last_value, is_called FROM {name}"
+            for index, name in enumerate(names)
+        )
+        return {
+            names[row.ord]: (row.last_value, row.is_called)
+            for row in connection.execute(text(union))
+        }
+
+
+def _restore_sequences(engine: Engine, snapshot: _SequenceState) -> None:
+    if not snapshot:
+        return
+    with engine.begin() as connection:
+        for name, (last_value, is_called) in snapshot.items():
+            connection.execute(
+                text("SELECT setval(CAST(:sequence AS regclass), :value, :is_called)"),
+                {"sequence": name, "value": last_value, "is_called": is_called},
+            )
+
+
+@pytest.fixture(autouse=True)
+def _preserve_sequence_state(request) -> Iterator[None]:
+    """Leave PostgreSQL sequence counters as the archive test found them.
+
+    Autouse rather than opt-in: any archive test may call
+    ``restore_archive``, and forgetting the guard reintroduces a failure
+    that only reproduces when test files are combined — exactly the class
+    of bug per-job-fresh-database CI cannot catch.
+    """
+    if not _DB_FIXTURES & set(request.fixturenames):
+        yield
+        return
+
+    engine: Engine = request.getfixturevalue("db_engine")
+    # Resolve the session-scoped API user first: it commits an app_user and an
+    # api_key row, advancing those sequences. Snapshotting before that commit
+    # would restore counters to a value that re-issues the committed user's id.
+    request.getfixturevalue("_api_test_user")
+
+    snapshot = _snapshot_sequences(engine)
+    try:
+        yield
+    finally:
+        _restore_sequences(engine, snapshot)


### PR DESCRIPTION
## Summary

Fix a pre-existing test-isolation defect: 34 backend tests fail when certain test files run together in one pytest invocation, while every one of them passes alone. Test-only change — no production code touched (`detect_changes` reports `changed_symbols: []`).

## Root cause

**PostgreSQL sequences live outside MVCC, so `setval` is not undone by a rollback.**

`restore_archive` finishes by repairing every primary-key sequence to `max(id)` of the rows it inserted (`backend/app/services/archive/core.py:614-635`). That is correct in production, where a restore targets an empty database and commits. Under pytest the rows roll back but the **rewound counters survive the whole session**. `test_restore_accepts_exact_fresh_migration_seeds` (`test_archive.py:141`) empties every table then restores, so `max(id)` is `None` for most tables and they get `setval(seq, 1, false)`.

That alone is harmless. It needs a second ingredient: ~45 test files use the session-scoped `db_engine` fixture with `with session.begin():`, which **commits**, so the shared test database genuinely holds committed rows at low ids. A rewound sequence hands one out a second time:

```
duplicate key value violates unique constraint "pk_species"
DETAIL:  Key (id)=(2) already exists.
```

Proof the bug is strictly the interaction, and order-dependent (archive must run *after* a committing file):

| combination | result |
|---|---|
| committing files + scientific tests | 182 passed |
| archive + scientific tests | 174 passed |
| both, archive last | fails |

Sequences are the *only* escaping state — `_empty_archive_tables` uses transaction-local `SET LOCAL session_replication_role` and rolls back cleanly.

CI never saw this because each gate job gets a fresh database.

## The fix

Preferred shape: make the offending tests clean up after themselves.

- `backend/tests/services/archive/conftest.py` — autouse fixture snapshots every user sequence's `(last_value, is_called)` and restores it at teardown on its own connection, so it works even if the test transaction aborted. It resolves `db_engine` and `_api_test_user` *before* snapshotting, so it cannot rewind past the committed session user. No-ops for the pure registry tests that touch no database.
- `backend/tests/services/archive/__init__.py` — **load-bearing, not decorative.** Without it pytest imports the new conftest as bare module `conftest` and prepends the directory to `sys.path`, shadowing `tests/conftest.py` and breaking `from conftest import ...` in `tests/db/*_migration.py` and `tests/test_db_name_resolution.py`. The sibling `tests/services/scientific_read/` already does this.
- `backend/docs/testing.md` — corrected. It claimed isolation *is* per-test transaction rollback, which is true only for `db_session`/`db_conn`/`client`. That inaccuracy is why this bug class stayed invisible: it told readers rollback covers everything, and it covers neither committed `db_engine` rows nor non-transactional sequence writes.

Rejected alternatives: containing sequences globally would cost two round trips for all ~2200 tests to fix a leak one module causes; a dedicated database per archive test would add a full `alembic upgrade` (~40s) to CI for no extra correctness.

## No test was weakened

Every archive assertion is unchanged — byte-exact round-trip, `password_hash is None`, excluded `api_key`, and `ArchiveNotEmptyError` on both a non-empty target and seed drift. Nothing skipped, xfailed, deleted, or loosened; no migrations, CI workflows, or `NAMING_CONVENTION` touched.

## Validation

| check | result |
|---|---|
| Combined repro (original order) | **198 passed** (was 34 failed / 162 passed / 2 errors) |
| Combined repro (hostile permutation, archive mid-run) | **198 passed** |
| Six files individually | 19 + 2 + 11 + 3 + 142 + 21 = **198**, zero failures |
| `test-api.sh` | **2212 passed** |
| `test-scientific.sh` | **1692 passed** |
| `ruff check app tests` / `mypy` | clean / clean on 140 files |

A/B proof the fixture is load-bearing: with it removed, the hostile permutation gives **35 failed**; restored, **198 passed**. Both combined runs were re-verified independently of the authoring agent.

Impact analysis: `_repair_sequences` and `restore_archive` are both LOW risk (1 and 0 dependents) — and neither was modified.

## Incidental findings, not addressed here

- **`pytest-randomly` is not installed** in `tckdb_env`. `-p no:randomly` has therefore been a silent no-op wherever it appears in local workflows; order-independence was verified with explicit file permutations instead.
- **903 leaked `tckdb_test%` databases totalling 12 GB** on the local dev Postgres, from the pid-based fallback in `_resolve_test_db_name` minting a database per run without dropping it. Tracked separately.
