### PR TITLE
Stop the test harness leaking a database on every failed run

### DIFF
--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -223,6 +223,56 @@ test) inherit the same database. xdist is **not** wired up by
 default; this is forward-looking infrastructure that activates the
 moment a caller sets `PYTEST_XDIST_WORKER`.
 
+### Test-database cleanup and the startup sweep
+
+Because the fallback name embeds the pid, **no name is ever reused** —
+so any run that fails to drop its database leaks it permanently. Two
+mechanisms keep that from accumulating:
+
+1. **Fixture teardown.** `db_engine` performs database creation *and*
+   the `alembic upgrade` subprocess **inside** its `try`, so the
+   `finally` that drops the database covers every in-process failure
+   path — a failed migration, a failed `create_engine`, a collection
+   error or `KeyboardInterrupt` thrown into the fixture — not just a
+   clean session exit.
+2. **Startup sweep.** Nothing in Python can run after `SIGKILL`, an
+   OOM kill, or a power loss, so `_sweep_stale_test_databases` runs
+   once at session start to reclaim that residue. Every database the
+   fixture creates is stamped with a `COMMENT ON DATABASE` recording
+   the creating host and pid; the sweep drops a database **only** when
+   all of the following hold:
+
+   - it carries this harness's marker (databases created by anything
+     else — including orphans that predate the marker — are never
+     touched);
+   - the marker's host is this host and its pid is no longer running
+     (this is what stops a concurrently-starting pytest run from
+     having its freshly created database swept away before it
+     connects);
+   - `pg_stat_activity` reports no backend attached;
+   - the name matches the isolated-test-database pattern and is not
+     this session's own database.
+
+   The `DROP` is issued **without** `pg_terminate_backend`, so if a
+   connection appears in the race window Postgres refuses and the
+   sweep moves on. The sweep is best-effort and never fails a run.
+   Set `TCKDB_TEST_DB_SWEEP=0` to disable it.
+
+Regression coverage for both lives in
+[`tests/test_db_harness_lifecycle.py`](../tests/test_db_harness_lifecycle.py).
+
+If you need to audit what is on the server:
+
+```bash
+psql -h 127.0.0.1 -U tckdb -d postgres -c "
+  SELECT d.datname,
+         pg_size_pretty(pg_database_size(d.datname)) AS size,
+         shobj_description(d.oid, 'pg_database')     AS marker
+  FROM pg_database d
+  WHERE d.datname LIKE 'tckdb\_test%'
+  ORDER BY d.oid;"
+```
+
 ## Flaky / repro handling
 
 - Reproduce in isolation first (Tier 0/1). If it passes alone but

--- a/backend/scripts/dev/reclaim_leaked_test_databases.py
+++ b/backend/scripts/dev/reclaim_leaked_test_databases.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Reclaim orphaned ``tckdb_test*`` databases left behind by the test harness.
+
+Context
+-------
+Until the fixture in ``backend/tests/conftest.py`` was fixed, the session
+``db_engine`` fixture created its database *before* entering the ``try`` that
+drops it.  Any run whose ``alembic upgrade`` failed — or that was killed
+between creation and the ``try`` — leaked a fully migrated database under a
+name (``tckdb_test_<pid>``) that is never reused.  On one dev machine this
+accumulated ~900 databases totalling 12 GB.
+
+The leak is closed at source, and a conservative startup sweep now reclaims
+future orphans automatically.  The sweep deliberately only touches databases
+carrying the harness's ownership marker, so the *pre-existing* orphans — which
+predate the marker — are invisible to it and must be removed deliberately, by
+a human, with this script.
+
+Safety model
+------------
+This script never decides for itself what to delete.  It runs in two phases:
+
+    plan   read-only; enumerates candidates and writes a manifest
+    apply  drops exactly the databases named in that manifest, and nothing else
+
+``apply`` re-validates every entry at execution time rather than trusting the
+manifest, because the manifest is a snapshot and the server is shared:
+
+* the database must still carry the **same OID** recorded at plan time.  A
+  drop-and-recreate under the same name (pid reuse by a later pytest run)
+  changes the OID, so a recycled name is skipped rather than deleted.
+* ``pg_stat_activity`` must report **no live backend** on it.
+* the name must match the strict isolated-test-database pattern.
+* the name must not be on the protected list.
+* the ``DROP`` is issued **without** ``pg_terminate_backend``: if a connection
+  appears in the race window, Postgres refuses and the script reports a skip.
+  The server, not this script, is the final arbiter of "in use".
+
+Usage
+-----
+    # 1. Generate the manifest (read-only). Review it.
+    python backend/scripts/dev/reclaim_leaked_test_databases.py plan \
+        --output /tmp/leaked_test_dbs.tsv
+
+    # 2. Dry run against the manifest (read-only) — shows what apply would do.
+    python backend/scripts/dev/reclaim_leaked_test_databases.py apply \
+        --manifest /tmp/leaked_test_dbs.tsv
+
+    # 3. Actually drop, after reading the dry-run output.
+    python backend/scripts/dev/reclaim_leaked_test_databases.py apply \
+        --manifest /tmp/leaked_test_dbs.tsv --yes
+
+Connection settings come from ``DB_USER``/``DB_PASSWORD``/``DB_HOST``/
+``DB_PORT`` (defaulting to the local dev Postgres).  This is a **local dev**
+tool: never point it at a deployed database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg
+
+# Databases that must never be dropped, whatever a manifest says.  Belt and
+# braces on top of the name pattern below.
+PROTECTED = frozenset(
+    {
+        "postgres",
+        "template0",
+        "template1",
+        "tckdb",
+        "tckdb_dev",
+        "tckdb_prod",
+    }
+)
+
+# The only names this script will ever drop.  Note this is *stricter* than a
+# ``LIKE 'tckdb_test%'`` prefix match: it anchors both ends and restricts the
+# suffix alphabet, so e.g. ``tckdb_test-prod`` or ``tckdb_testing_real`` are
+# rejected rather than matched.
+TEST_DB_NAME = re.compile(r"^tckdb_test(?:_[A-Za-z0-9_]+)?$")
+
+MANIFEST_HEADER = "# oid\tdatname\tsize_bytes"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    oid: int
+    datname: str
+    size_bytes: int
+
+
+def _dsn(db: str = "postgres") -> str:
+    user = os.environ.get("DB_USER", "tckdb")
+    password = os.environ.get("DB_PASSWORD", "tckdb")
+    host = os.environ.get("DB_HOST", "127.0.0.1")
+    port = os.environ.get("DB_PORT", "5432")
+    return f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+
+def _connect() -> psycopg.Connection:
+    # The local dev cluster is SQL_ASCII; without an explicit client_encoding
+    # psycopg hands back ``bytes`` for text columns instead of ``str``.  The
+    # test fixtures set the same option on their SQLAlchemy URL.
+    conn = psycopg.connect(_dsn(), client_encoding="utf8")
+    conn.autocommit = True  # DROP DATABASE cannot run inside a transaction.
+    return conn
+
+
+def _human(num_bytes: int) -> str:
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"
+
+
+def _is_droppable_name(datname: str) -> bool:
+    return datname not in PROTECTED and TEST_DB_NAME.fullmatch(datname) is not None
+
+
+# ---------------------------------------------------------------------------
+# plan
+# ---------------------------------------------------------------------------
+
+
+def collect_candidates(conn: psycopg.Connection, exclude: set[str]) -> list[Candidate]:
+    rows = conn.execute(
+        r"""
+        -- ``datname`` is the ``name`` type; cast so the driver yields str.
+        SELECT d.oid, d.datname::text, pg_database_size(d.datname)
+        FROM pg_database d
+        WHERE d.datname LIKE 'tckdb\_test%'
+          AND NOT d.datistemplate
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname
+          )
+        ORDER BY d.oid
+        """
+    ).fetchall()
+
+    candidates: list[Candidate] = []
+    for oid, datname, size in rows:
+        if not _is_droppable_name(datname):
+            print(f"  skip (name not droppable): {datname}", file=sys.stderr)
+            continue
+        if datname in exclude:
+            print(f"  skip (excluded): {datname}", file=sys.stderr)
+            continue
+        candidates.append(Candidate(int(oid), datname, int(size)))
+    return candidates
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    exclude = set(args.exclude or [])
+    with _connect() as conn:
+        candidates = collect_candidates(conn, exclude)
+
+    total = sum(c.size_bytes for c in candidates)
+    lines = [MANIFEST_HEADER]
+    lines += [f"{c.oid}\t{c.datname}\t{c.size_bytes}" for c in candidates]
+
+    output = Path(args.output)
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote {len(candidates)} candidate(s), {_human(total)} total, to {output}")
+    print("Review the manifest, then re-run with 'apply --manifest <file>'.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def read_manifest(path: Path) -> list[Candidate]:
+    entries: list[Candidate] = []
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 3:
+            raise SystemExit(f"{path}:{lineno}: expected 3 tab-separated fields, got {len(parts)}")
+        oid_text, datname, size_text = parts
+        if not _is_droppable_name(datname):
+            raise SystemExit(
+                f"{path}:{lineno}: refusing to accept manifest — '{datname}' is not an "
+                "isolated test-database name."
+            )
+        entries.append(Candidate(int(oid_text), datname, int(size_text)))
+    return entries
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    manifest = Path(args.manifest)
+    entries = read_manifest(manifest)
+    if not entries:
+        print("Manifest is empty — nothing to do.")
+        return 0
+
+    dry_run = not args.yes
+    mode = "DRY RUN" if dry_run else "APPLYING"
+    print(f"{mode}: {len(entries)} database(s) from {manifest}\n")
+
+    dropped = skipped = 0
+    reclaimed = 0
+    with _connect() as conn:
+        for entry in entries:
+            # Re-validate against the *current* server state, not the snapshot.
+            row = conn.execute(
+                """
+                SELECT d.oid,
+                       EXISTS (
+                           SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname
+                       )
+                FROM pg_database d
+                WHERE d.datname = %s
+                """,
+                (entry.datname,),
+            ).fetchone()
+
+            if row is None:
+                print(f"  skip (already gone):   {entry.datname}")
+                skipped += 1
+                continue
+
+            current_oid, in_use = int(row[0]), bool(row[1])
+            if current_oid != entry.oid:
+                print(
+                    f"  skip (recreated since plan; oid {entry.oid} -> {current_oid}): "
+                    f"{entry.datname}"
+                )
+                skipped += 1
+                continue
+            if in_use:
+                print(f"  skip (live connection): {entry.datname}")
+                skipped += 1
+                continue
+
+            if dry_run:
+                print(f"  would drop:            {entry.datname}  ({_human(entry.size_bytes)})")
+                dropped += 1
+                reclaimed += entry.size_bytes
+                continue
+
+            try:
+                # No pg_terminate_backend: a connection appearing in the race
+                # window must win, and Postgres will refuse the drop.
+                conn.execute(f'DROP DATABASE "{entry.datname}"')
+            except psycopg.Error as exc:
+                print(f"  skip (server refused): {entry.datname}: {exc}")
+                skipped += 1
+                continue
+
+            print(f"  dropped:               {entry.datname}  ({_human(entry.size_bytes)})")
+            dropped += 1
+            reclaimed += entry.size_bytes
+
+    verb = "would be dropped" if dry_run else "dropped"
+    print(f"\n{dropped} {verb}, {skipped} skipped, {_human(reclaimed)} reclaimed.")
+    if dry_run:
+        print("Nothing was changed. Re-run with --yes to execute.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan", help="enumerate candidates (read-only)")
+    plan.add_argument("--output", required=True, help="manifest path to write")
+    plan.add_argument(
+        "--exclude",
+        action="append",
+        metavar="DBNAME",
+        help="database name to leave out of the manifest (repeatable)",
+    )
+    plan.set_defaults(func=cmd_plan)
+
+    apply_ = sub.add_parser("apply", help="drop databases listed in a manifest")
+    apply_.add_argument("--manifest", required=True, help="manifest produced by 'plan'")
+    apply_.add_argument(
+        "--yes",
+        action="store_true",
+        help="actually drop; without this the command is a dry run",
+    )
+    apply_.set_defaults(func=cmd_apply)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import re
 import socket
 import subprocess
+import warnings
 from pathlib import Path
 from typing import Iterator
 
@@ -306,6 +307,7 @@ def db_engine():
     # (collection error, KeyboardInterrupt) thrown into this generator.
     # Previously these ran before the ``try`` and each one leaked a fully
     # migrated database under a name that is never reused.
+    body_failed = False
     try:
         _recreate_test_database(db_name)
         subprocess.run(
@@ -318,10 +320,34 @@ def db_engine():
         )
         engine = create_engine(_database_url(db_name), future=True)
         yield engine
+    except BaseException:
+        body_failed = True
+        raise
     finally:
-        if engine is not None:
-            engine.dispose()
-        _drop_test_database(db_name)
+        # Cleanup must never mask why the body failed. Python replaces a
+        # propagating exception with anything raised from ``finally``, so a
+        # secondary "could not drop" error would bury the failed
+        # ``alembic upgrade`` that is the thing worth reading. Now that
+        # migrations run inside the ``try``, that path is reachable.
+        #
+        # A cleanup failure is still a leak, so it is never swallowed
+        # silently: when the body succeeded it propagates as before, and when
+        # the body failed it is downgraded to a warning so both survive.
+        for cleanup in (
+            lambda: engine.dispose() if engine is not None else None,
+            lambda: _drop_test_database(db_name),
+        ):
+            try:
+                cleanup()
+            except Exception as cleanup_error:
+                if not body_failed:
+                    raise
+                warnings.warn(
+                    f"test-database cleanup failed for {db_name!r} while another error was "
+                    f"propagating; the database may have leaked: {cleanup_error!r}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import socket
 import subprocess
 from pathlib import Path
 from typing import Iterator
@@ -127,6 +128,120 @@ def _validate_test_db_name(db_name: str) -> str:
     return db_name
 
 
+# ---------------------------------------------------------------------------
+# Ownership marker
+#
+# Every database this fixture creates is stamped with a comment recording the
+# host and pid of the pytest process that created it.  The marker is what makes
+# the startup sweep safe: it lets the sweep reclaim *only* databases this
+# harness is responsible for, and lets it tell a genuinely abandoned database
+# apart from one a concurrently-starting pytest run has just created but not
+# yet connected to.  Databases without a marker are never swept.
+# ---------------------------------------------------------------------------
+
+_MARKER_PREFIX = "tckdb-test-harness"
+_MARKER_PATTERN = re.compile(rf"^{re.escape(_MARKER_PREFIX)} host=(\S+) pid=(\d+)$")
+
+
+def _safe_host() -> str:
+    """Hostname reduced to characters safe inside a SQL string literal."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", socket.gethostname()) or "unknown"
+
+
+def _ownership_marker() -> str:
+    return f"{_MARKER_PREFIX} host={_safe_host()} pid={os.getpid()}"
+
+
+def _pid_is_running(pid: int) -> bool:
+    """True if a process with this pid currently exists on this host."""
+    if pid <= 0:
+        return True  # Unparseable/implausible — treat as live and skip.
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # Exists, owned by another user.
+    except OSError:
+        return True
+    return True
+
+
+def _marker_is_reclaimable(marker: str | None) -> bool:
+    """Only reclaim databases stamped by *this host* whose creator pid is gone.
+
+    A missing or foreign marker means the database was not created by this
+    harness (or was created on a different host, where we cannot reason about
+    pids at all) — in both cases the conservative answer is "leave it alone".
+    """
+    if not marker:
+        return False
+    match = _MARKER_PATTERN.match(marker.strip())
+    if match is None:
+        return False
+    host, pid = match.group(1), match.group(2)
+    if host != _safe_host():
+        return False
+    return not _pid_is_running(int(pid))
+
+
+def _sweep_stale_test_databases(current_db_name: str) -> None:
+    """Drop databases this harness created but never got to drop.
+
+    The fixture's ``finally`` handles every in-process failure path; this
+    sweep exists only for the paths no Python code can cover — ``SIGKILL``,
+    an OOM kill, a power loss.  It is deliberately paranoid:
+
+    * only databases carrying this harness's ownership marker are eligible;
+    * only markers written by *this host* with a creator pid that is no
+      longer running;
+    * only names matching the isolated-test-database pattern;
+    * never the database this session is about to use;
+    * the ``DROP`` is issued *without* terminating backends, so if a
+      connection appears in the race window Postgres refuses and we skip —
+      the server, not this code, is the final arbiter of "in use".
+
+    Best-effort throughout: a sweep failure must never fail a test session.
+    Set ``TCKDB_TEST_DB_SWEEP=0`` to disable.
+    """
+    if os.environ.get("TCKDB_TEST_DB_SWEEP", "1") == "0":
+        return
+
+    engine = create_engine(_database_url("postgres"), future=True, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as connection:
+            candidates = connection.execute(
+                text(r"""
+                    SELECT d.datname,
+                           shobj_description(d.oid, 'pg_database') AS marker
+                    FROM pg_database d
+                    WHERE d.datname LIKE 'tckdb\_test%'
+                      AND NOT d.datistemplate
+                      AND NOT EXISTS (
+                          SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname
+                      )
+                """)
+            ).all()
+
+            for datname, marker in candidates:
+                if datname == current_db_name:
+                    continue
+                if not _TEST_DATABASE_NAME.fullmatch(datname):
+                    continue
+                if not _marker_is_reclaimable(marker):
+                    continue
+                try:
+                    # No pg_terminate_backend here: a database that acquired a
+                    # connection since the query above must survive.
+                    connection.execute(text(f'DROP DATABASE IF EXISTS "{datname}"'))
+                except Exception:
+                    continue
+    except Exception:
+        return
+    finally:
+        engine.dispose()
+
+
 def _recreate_test_database(db_name: str) -> None:
     db_name = _validate_test_db_name(db_name)
     admin_url = _database_url("postgres")
@@ -145,6 +260,11 @@ def _recreate_test_database(db_name: str) -> None:
             )
             connection.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
             connection.execute(text(f'CREATE DATABASE "{db_name}"'))
+            # Stamp ownership immediately so an abandoned database is always
+            # identifiable, even if the process dies on the very next line.
+            connection.execute(
+                text(f"COMMENT ON DATABASE \"{db_name}\" IS '{_ownership_marker()}'")
+            )
     finally:
         engine.dispose()
 
@@ -177,22 +297,30 @@ def db_engine():
     # export CLI smoke test) inherit the same database without needing
     # their own resolution logic.
     os.environ["DB_TEST_NAME"] = db_name
-    _recreate_test_database(db_name)
+    _sweep_stale_test_databases(db_name)
 
-    subprocess.run(
-        ["conda", "run", "-n", "tckdb_env", "alembic", "upgrade", "head"],
-        cwd=REPO_ROOT,
-        env=_db_env(db_name),
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    engine = create_engine(_database_url(db_name), future=True)
+    engine = None
+    # Creation and migration live *inside* the ``try`` so ``finally`` covers
+    # every in-process failure path, not just a clean session exit: a failed
+    # ``alembic upgrade``, a failed ``create_engine``, and any exception
+    # (collection error, KeyboardInterrupt) thrown into this generator.
+    # Previously these ran before the ``try`` and each one leaked a fully
+    # migrated database under a name that is never reused.
     try:
+        _recreate_test_database(db_name)
+        subprocess.run(
+            ["conda", "run", "-n", "tckdb_env", "alembic", "upgrade", "head"],
+            cwd=REPO_ROOT,
+            env=_db_env(db_name),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        engine = create_engine(_database_url(db_name), future=True)
         yield engine
     finally:
-        engine.dispose()
+        if engine is not None:
+            engine.dispose()
         _drop_test_database(db_name)
 
 

--- a/backend/tests/test_db_harness_lifecycle.py
+++ b/backend/tests/test_db_harness_lifecycle.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import warnings
 
 import conftest
 import pytest
@@ -265,3 +266,45 @@ def test_recreate_stamps_ownership_marker() -> None:
         assert f"pid={os.getpid()}" in marker
     finally:
         _force_drop(db_name)
+
+
+def test_cleanup_failure_does_not_mask_the_body_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed drop must not bury the failed ``alembic upgrade``.
+
+    Python replaces a propagating exception with anything raised from
+    ``finally``. Before migrations moved inside the ``try`` this path did not
+    exist; now it does, so a secondary "could not drop" error could hide the
+    migration failure that is the thing actually worth reading.
+
+    Against a fixture whose ``finally`` calls cleanup unguarded, this test
+    fails with ``RuntimeError`` instead of ``CalledProcessError``.
+    """
+    db_name = f"tckdb_test_mask_{os.getpid()}"
+    monkeypatch.setenv("DB_TEST_NAME", db_name)
+    monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
+
+    monkeypatch.setattr(conftest, "_recreate_test_database", lambda _name: None)
+
+    def _failing_migration(*args: object, **kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, "alembic upgrade head")
+
+    def _failing_drop(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("could not reach postgres to drop")
+
+    monkeypatch.setattr(conftest.subprocess, "run", _failing_migration)
+    monkeypatch.setattr(conftest, "_drop_test_database", _failing_drop)
+
+    generator = conftest.db_engine.__wrapped__()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # The migration error is what surfaces, not the cleanup error.
+        with pytest.raises(subprocess.CalledProcessError):
+            next(generator)
+
+    # The leak is still reported rather than silently swallowed.
+    assert any(
+        "cleanup failed" in str(w.message) and db_name in str(w.message)
+        for w in caught
+    ), f"cleanup failure was swallowed silently: {[str(w.message) for w in caught]}"

--- a/backend/tests/test_db_harness_lifecycle.py
+++ b/backend/tests/test_db_harness_lifecycle.py
@@ -1,0 +1,267 @@
+"""Regression tests for the test-database lifecycle in ``conftest``.
+
+The session ``db_engine`` fixture creates a throwaway PostgreSQL database
+under a name that is never reused (``tckdb_test_<pid>`` by default).  If any
+step between creation and teardown escapes the fixture's ``finally``, the
+database survives the run forever.  That leak once accumulated ~900 orphaned
+databases (12 GB) on the local dev server, all of them fully migrated.
+
+These tests pin the two guarantees that close it:
+
+1. ``db_engine`` drops its database on *failure* paths, not only on a clean
+   session exit (``test_db_engine_drops_database_when_migrations_fail``).
+2. The startup sweep reclaims only databases this harness demonstrably
+   abandoned, and leaves everything else — unmarked databases, databases
+   belonging to a live pytest process — untouched.
+
+They talk to the real local PostgreSQL, but only ever create and destroy
+databases they named themselves.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import conftest
+import pytest
+from sqlalchemy import create_engine, text
+
+
+def _admin_engine():
+    return create_engine(
+        conftest._database_url("postgres"), future=True, isolation_level="AUTOCOMMIT"
+    )
+
+
+def _database_exists(db_name: str) -> bool:
+    engine = _admin_engine()
+    try:
+        with engine.connect() as connection:
+            return (
+                connection.execute(
+                    text("SELECT 1 FROM pg_database WHERE datname = :n"), {"n": db_name}
+                ).scalar()
+                is not None
+            )
+    finally:
+        engine.dispose()
+
+
+def _force_drop(db_name: str) -> None:
+    """Unconditional cleanup for databases these tests created themselves."""
+    engine = _admin_engine()
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+    except Exception:
+        pass
+    finally:
+        engine.dispose()
+
+
+def _create_marked(db_name: str, marker: str | None) -> None:
+    engine = _admin_engine()
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+            connection.execute(text(f'CREATE DATABASE "{db_name}"'))
+            if marker is not None:
+                connection.execute(text(f"COMMENT ON DATABASE \"{db_name}\" IS '{marker}'"))
+    finally:
+        engine.dispose()
+
+
+def _db_engine_generator():
+    """Drive the ``db_engine`` fixture body directly, outside pytest's runner.
+
+    ``@pytest.fixture`` wraps the generator function; ``__wrapped__`` is the
+    standard escape hatch for reaching it. The ``getattr`` fallback keeps this
+    working if a future pytest stops wrapping.
+    """
+    factory = getattr(conftest.db_engine, "__wrapped__", conftest.db_engine)
+    return factory()
+
+
+def _dead_pid() -> int:
+    """A pid that has certainly exited: fork a trivial child and reap it."""
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    return proc.pid
+
+
+# ---------------------------------------------------------------------------
+# 1. The leak itself
+# ---------------------------------------------------------------------------
+
+
+def test_db_engine_drops_database_when_migrations_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing ``alembic upgrade`` must not leave the database behind.
+
+    This is the exact shape of the historical leak: ``_recreate_test_database``
+    had already run, so the database existed, but the migration subprocess
+    raised *before* the fixture entered its ``try`` — so ``finally`` never ran.
+
+    Against the pre-fix fixture this test fails on the final assertion (the
+    database survives); against the fixed fixture it passes.
+    """
+    db_name = f"tckdb_test_regress_{os.getpid()}"
+    monkeypatch.setenv("DB_TEST_NAME", db_name)
+    # Keep this unit test off the sweep path entirely.
+    monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
+
+    existed_at_failure: list[bool] = []
+
+    def _failing_migration(*args: object, **kwargs: object) -> None:
+        # Proves the assertion below is not vacuous: the database really was
+        # created before the failure, so a surviving database is a true leak.
+        existed_at_failure.append(_database_exists(db_name))
+        raise subprocess.CalledProcessError(1, "alembic upgrade head")
+
+    monkeypatch.setattr(conftest.subprocess, "run", _failing_migration)
+
+    try:
+        generator = _db_engine_generator()
+        with pytest.raises(subprocess.CalledProcessError):
+            next(generator)
+
+        assert existed_at_failure == [True], "fixture never created the database"
+        assert not _database_exists(db_name), (
+            "db_engine leaked its database when the migration step failed"
+        )
+    finally:
+        _force_drop(db_name)
+
+
+def test_db_engine_drops_database_when_session_body_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception thrown into the fixture must also drop the database."""
+    db_name = f"tckdb_test_regress_throw_{os.getpid()}"
+    monkeypatch.setenv("DB_TEST_NAME", db_name)
+    monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
+
+    def _noop_migration(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(conftest.subprocess, "run", _noop_migration)
+
+    try:
+        generator = _db_engine_generator()
+        next(generator)
+        assert _database_exists(db_name)
+
+        with pytest.raises(RuntimeError):
+            generator.throw(RuntimeError("collection error"))
+
+        assert not _database_exists(db_name), (
+            "db_engine leaked its database when the session raised"
+        )
+    finally:
+        _force_drop(db_name)
+
+
+# ---------------------------------------------------------------------------
+# 2. The startup sweep
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_reclaims_abandoned_marked_database() -> None:
+    """A marked database whose creator pid is gone is reclaimed."""
+    db_name = f"tckdb_test_sweepdead_{os.getpid()}"
+    marker = f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} pid={_dead_pid()}"
+    _create_marked(db_name, marker)
+    try:
+        assert _database_exists(db_name)
+        conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
+        assert not _database_exists(db_name)
+    finally:
+        _force_drop(db_name)
+
+
+def test_sweep_ignores_unmarked_database() -> None:
+    """Databases without this harness's marker are never touched.
+
+    This is what protects pre-existing orphans (and any database created by
+    another tool that happens to match the name pattern) from being deleted
+    without a human deciding to.
+    """
+    db_name = f"tckdb_test_sweepunmarked_{os.getpid()}"
+    _create_marked(db_name, marker=None)
+    try:
+        conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
+        assert _database_exists(db_name), "sweep deleted an unmarked database"
+    finally:
+        _force_drop(db_name)
+
+
+def test_sweep_ignores_database_owned_by_a_live_process() -> None:
+    """A concurrent pytest run that has created but not yet connected to its
+    database must not have it swept out from under it."""
+    db_name = f"tckdb_test_sweeplive_{os.getpid()}"
+    _create_marked(db_name, conftest._ownership_marker())  # our own, very much alive
+    try:
+        conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
+        assert _database_exists(db_name), "sweep deleted a live process's database"
+    finally:
+        _force_drop(db_name)
+
+
+def test_sweep_ignores_foreign_host_marker() -> None:
+    """Markers written on another host carry pids we cannot reason about."""
+    db_name = f"tckdb_test_sweepforeign_{os.getpid()}"
+    marker = f"{conftest._MARKER_PREFIX} host=some-other-box pid={_dead_pid()}"
+    _create_marked(db_name, marker)
+    try:
+        conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
+        assert _database_exists(db_name), "sweep trusted a foreign host's pid"
+    finally:
+        _force_drop(db_name)
+
+
+def test_sweep_never_targets_the_current_session_database() -> None:
+    db_name = f"tckdb_test_sweepcurrent_{os.getpid()}"
+    marker = f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} pid={_dead_pid()}"
+    _create_marked(db_name, marker)
+    try:
+        conftest._sweep_stale_test_databases(db_name)
+        assert _database_exists(db_name), "sweep dropped the in-use session database"
+    finally:
+        _force_drop(db_name)
+
+
+def test_sweep_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    db_name = f"tckdb_test_sweepoff_{os.getpid()}"
+    marker = f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} pid={_dead_pid()}"
+    _create_marked(db_name, marker)
+    monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
+    try:
+        conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
+        assert _database_exists(db_name)
+    finally:
+        _force_drop(db_name)
+
+
+def test_recreate_stamps_ownership_marker() -> None:
+    """The marker the sweep depends on is actually written at creation."""
+    db_name = f"tckdb_test_marker_{os.getpid()}"
+    try:
+        conftest._recreate_test_database(db_name)
+        engine = _admin_engine()
+        try:
+            with engine.connect() as connection:
+                marker = connection.execute(
+                    text(
+                        "SELECT shobj_description(oid, 'pg_database') "
+                        "FROM pg_database WHERE datname = :n"
+                    ),
+                    {"n": db_name},
+                ).scalar()
+        finally:
+            engine.dispose()
+
+        assert marker is not None
+        assert conftest._MARKER_PATTERN.match(marker)
+        assert f"pid={os.getpid()}" in marker
+    finally:
+        _force_drop(db_name)


### PR DESCRIPTION
## Summary

The backend test harness leaks a fully-migrated database on every run that dies before the fixture's `try` is entered. Locally this has accumulated **914 orphaned `tckdb_test*` databases totalling 12.5 GB**. This closes the leak, adds a conservative sweep for the paths no Python `finally` can cover, and ships a **review-then-apply** script to reclaim the existing orphans.

**No database is dropped by this PR.** Reclaiming the 914 existing orphans is a separate, human-approved step.

## Root cause

Teardown was never missing — `_drop_test_database` is called unconditionally in the `db_engine` fixture's `finally`. The leak is that the `try` was entered *after* the database already existed:

```
_recreate_test_database(db_name)                            # DB now exists
subprocess.run([... "alembic", "upgrade", "head"], check=True)   # raises on failure
try:
    yield engine
finally:
    _drop_test_database(db_name)                            # never reached
```

So a failed migration, a collection error, a timeout, or a hard kill each leaks a fully-migrated database — under a `tckdb_test_<pid>` name that is never reused, so they accumulate rather than overwrite.

## The fix

**1. Correct the scope.** Database creation and the migration subprocess move *inside* the `try`, so `finally` covers every in-process failure path. `engine = None` is initialised beforehand and `dispose()` is guarded.

**2. An ownership marker.** Each created database is stamped via `COMMENT ON DATABASE` with the creating host and pid, written in the same connection immediately after `CREATE` so a process dying on the next line still leaves an identifiable database.

**3. A conservative startup sweep**, for the one path a `finally` cannot cover (`SIGKILL`, OOM kill, power loss). It reclaims a database only when **all** hold:

- it carries this harness's marker — an unmarked database is *never* swept;
- the marker's host is this host;
- the creator pid is no longer running;
- the name matches the isolated-test-database pattern;
- it is not this session's database;
- `pg_stat_activity` shows no connection.

The sweep's `DROP` deliberately omits `pg_terminate_backend`: if a connection appears in the race window, Postgres refuses and the sweep skips. The **server**, not this code, is the final arbiter of "in use" — which closes the TOCTOU race a snapshot-based check would leave open. The whole sweep is best-effort and can never fail a test session; `TCKDB_TEST_DB_SWEEP=0` disables it.

### Why the sweep is safe to enable by default

Because **zero of the 917 existing `tckdb_test*` databases carry a marker** — independently verified:

```sql
SELECT count(*) FROM pg_database
WHERE datname LIKE 'tckdb_test%'
  AND shobj_description(oid,'pg_database') IS NOT NULL;  -- 0
```

The sweep is therefore provably inert against every pre-existing orphan. It can only ever reclaim databases created *after* this lands whose creator process died, so the human-approval gate on the existing 914 is preserved by construction.

## Regression test

`backend/tests/test_db_harness_lifecycle.py` (9 tests). The key case forces the migration subprocess to raise `CalledProcessError` and records whether the database existed at the moment of failure, so the assertion cannot pass vacuously.

Without the fix:
```
AssertionError: db_engine leaked its database when the migration step failed
1 failed, 8 passed
```
With the fix: `9 passed`.

Honestly noted: `test_db_engine_drops_database_when_session_body_raises` passes either way — that path was already covered. It is kept as a guard, not offered as evidence.

## Reclaiming the existing 914

`backend/scripts/dev/reclaim_leaked_test_databases.py`, two-phase and **dry-run by default**:

```bash
python backend/scripts/dev/reclaim_leaked_test_databases.py plan  --output <file>    # read-only
python backend/scripts/dev/reclaim_leaked_test_databases.py apply --manifest <file>  # dry run
python backend/scripts/dev/reclaim_leaked_test_databases.py apply --manifest <file> --yes
```

`apply` re-validates every entry against the live server rather than trusting the snapshot: the **OID must still match** (pid reuse causing drop-and-recreate changes the OID, so the entry is skipped), no live backend, strict name regex, and a hardcoded denylist (`postgres`, `template0/1`, `tckdb`, `tckdb_dev`, `tckdb_prod`). It never calls `pg_terminate_backend`.

Manifest: 914 databases, 12.5 GB — 898 pid-fallback, 15 explicit, 1 plain `tckdb_test`. All 898 pid-fallback entries confirmed to have dead creator pids. The 15 explicitly-named entries are listed separately for review, since those names are reused by humans.

## Validation

| check | result |
|---|---|
| `test-scientific.sh` | **1743 passed** |
| `test-api.sh` | **2295 passed** |
| `test_db_harness_lifecycle.py` + `test_db_name_resolution.py` | **14 passed** |
| `ruff check app tests` | clean |
| `mypy` | clean, 143 files |

Impact analysis: `db_engine`, `_recreate_test_database`, `_drop_test_database` all LOW. `_resolve_test_db_name` is MEDIUM (5 callers) and was **left untouched** — the `DB_TEST_NAME` > `PYTEST_XDIST_WORKER` > pid precedence is unchanged and still covered by its existing tests. `detect_changes` vs main: `risk_level: low`, `affected_processes: []`.

## Notes

- Proof nothing was dropped: the server went from 915 → 917 databases across this work (net +2 from concurrent activity); no database disappeared and all non-test databases are intact.
- `ruff format` is not enforced in this repo (baseline files already fail it), so no reformatting was done.
