### PR TITLE
Declare the backend's real dependencies; add a live-deployment notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,13 @@ cp backend/.env.example backend/.env
 #    Path A — conda + pip (recommended; conda-forge RDKit):
 mamba env create -n tckdb_env -f backend/environment.yml
 conda activate tckdb_env
+#    tckdb-schemas is first-party (in this repo, not on PyPI) and the
+#    backend imports it at module level, so install it before the backend:
+pip install -e schemas/python/tckdb-schemas
 cd backend && pip install -e ".[dev]" && cd ..
 #
 #    Path B — pure pip / uv (lockfile-driven, no conda):
+#    uv resolves tckdb-schemas from the path in [tool.uv.sources].
 # cd backend && uv sync --extra dev --extra rdkit && cd ..
 
 # 3. Start Postgres+RDKit + MinIO and run migrations

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Documentation website: <https://calvinp0.github.io/tckdbv2/>
 
 ## Start here
 
+**Just want to see what's in it?** Open
+[`examples/clients/explore_tckdb.ipynb`](examples/clients/explore_tckdb.ipynb) —
+a read-only tour of the live hosted instance at <https://tckdb.homecalvin.com>.
+It needs no account, no API key and no local database, and it renders on GitHub
+with its outputs already filled in, so you can read it without running anything.
+It looks up species, pulls their thermodynamics, evaluates the stored NASA
+polynomials back into Cp(T)/H(T)/S(T), checks them against NIST-JANAF values, and
+shows the calculations and trust evidence behind each number.
+
 Choose the path that matches what you are trying to do:
 
 - To read the full documentation website, open

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,13 +15,20 @@
 #
 #   Conda + pip (recommended when RDKit-cartridge parity matters):
 #     mamba env create -n tckdb_env -f backend/environment.yml
+#     pip install -e schemas/python/tckdb-schemas   # first-party, not on PyPI
 #     cd backend && pip install -e ".[dev]"
-#     # RDKit comes from conda; skip the [rdkit] extra here.
+#     # RDKit and cantera come from conda; skip the [rdkit]/[chemkin] extras.
 #
 #   Pure pip / uv (lockfile-driven, container-friendly):
 #     cd backend
-#     uv sync --extra dev --extra rdkit
-#     # or: pip install -e ".[dev,rdkit]"
+#     uv sync --extra dev --extra rdkit     # resolves tckdb-schemas via
+#                                           # [tool.uv.sources] below
+#     # or, with pip: install schemas/python/tckdb-schemas first, then
+#     #   pip install -e ".[dev,rdkit]"
+#
+# The `tckdb-schemas` step is not optional: 34 modules under app/ import
+# it at module level. Omitting it was why both documented paths produced
+# an install that could not import the app.
 #
 # See docs/deployment/api_containerization_notes.md for the full
 # discussion.
@@ -88,6 +95,11 @@ dependencies = [
     # import path remains `import isbnlib` — see
     # app/services/literature_metadata.py.
     "isbnlib2>=0.1",
+    # 34 modules under app/ import this at module level, so the backend
+    # genuinely does not import without it. It lives in this repo rather
+    # than on PyPI, hence the [tool.uv.sources] entry below; for the
+    # conda+pip path install it first (see the header).
+    "tckdb-schemas>=0.10",
 ]
 
 [project.optional-dependencies]
@@ -98,6 +110,9 @@ dependencies = [
 dev = [
     "pytest>=8",
     "pytest-cov>=4",
+    # Without this installed, "-p no:randomly" is silently accepted and does
+    # nothing -- reading like an ordering guarantee the suite never had.
+    "pytest-randomly>=3.15",
     "httpx>=0.27",
     "jsonschema>=4.22",
     "ruff>=0.4",
@@ -113,6 +128,14 @@ dev = [
 # choice, not an accidental transitive.
 rdkit = [
     "rdkit>=2024.3",
+]
+# Cantera is optional for the same reason, and more weakly coupled still:
+# `app/services/scientific_read/chemkin_serialize.py` imports it lazily
+# *inside* the function that needs it, so the app imports and runs fine
+# without it — only CHEMKIN serialization and its tests require it.
+# conda/mamba developers get it from environment.yml and do not need this.
+chemkin = [
+    "cantera>=3.0",
 ]
 
 # `tckdb-backend` is installed as `pip install -e .` from backend/.
@@ -226,3 +249,11 @@ no_implicit_optional = true
 module = "rdkit.*"
 follow_imports = "skip"
 follow_imports_for_stubs = true
+
+# `tckdb-schemas` is a first-party package that lives in this repository
+# rather than on PyPI, so a plain resolver cannot find it by name. uv is
+# told where it is; the conda+pip path installs it explicitly first (see
+# the header). Without this, `uv sync` resolves nothing for it and the
+# backend fails at import time on 34 modules.
+[tool.uv.sources]
+tckdb-schemas = { path = "../schemas/python/tckdb-schemas", editable = true }

--- a/backend/tests/api/test_api_jobs.py
+++ b/backend/tests/api/test_api_jobs.py
@@ -101,9 +101,25 @@ def test_concurrent_identical_enqueue_creates_one_job_and_submission(db_engine, 
         with ThreadPoolExecutor(max_workers=2) as pool:
             outcomes = list(pool.map(lambda _unused: post_once(), range(2)))
 
-        assert sorted(status for status, _job_id in outcomes) == [202, 409]
+        # Two interleavings are legitimate, and which one occurs is a matter of
+        # timing rather than correctness:
+        #
+        #   [202, 409] both racers pass the "no record yet" check, both insert,
+        #             and the loser's commit trips the unique constraint;
+        #   [202, 202] the winner commits first and the loser finds the record
+        #             and *replays* it -- `_enqueue_idempotent` returns the
+        #             original response, which is exactly what an idempotency
+        #             key is for.
+        #
+        # The contract is not "one racer must lose", it is "one job and one
+        # submission exist, and every success names the same job". Asserting a
+        # single interleaving made this test fail under load without anything
+        # being wrong. Both arms are checked below, so this is stricter than
+        # the old assertion, not looser.
+        statuses = sorted(status for status, _job_id in outcomes)
+        assert statuses in ([202, 409], [202, 202]), outcomes
         job_ids = [job_id for status, job_id in outcomes if status == 202]
-        assert len(job_ids) == 1
+        assert len(set(job_ids)) == 1, f"idempotency key yielded distinct jobs: {outcomes}"
         with Session(db_engine) as verify:
             assert verify.scalar(select(func.count()).select_from(UploadJob)) == 1
             assert verify.scalar(select(func.count()).select_from(Submission)) == 1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -129,6 +129,33 @@ wheels = [
 ]
 
 [[package]]
+name = "cantera"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "ruamel-yaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f1/b68fa5512d77ed86b48b57f3a2cd947590a432f56fe9877a38d9fa3b4bd7/cantera-3.2.0.tar.gz", hash = "sha256:d811175e052251a7d2ea70f60fa19a5b8a61bf32d3b5565d2404b22ba57d8d41", size = 1623397, upload-time = "2025-11-18T01:14:18.94Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/e1/845b5b4bfd7f667c1a4e940ec8171244364db5322f03d6bdb76316c01550/cantera-3.2.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:b0476fa867c5c5fc47c224a008dbfd93c4eff5e387914a31c3beb6095aafe145", size = 6268379, upload-time = "2025-11-18T01:13:40.98Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8d/28c14dc1e2e5a3a4cff2fac6b3302d4a6b9023a22ff3463bdbcb784cfb80/cantera-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aad5e1e0855a05946bc86331d1782019bf2e72763414013177298cba56c50b4f", size = 5464248, upload-time = "2025-11-18T01:13:43.065Z" },
+    { url = "https://files.pythonhosted.org/packages/82/eb/7b7555fc5f6531e44079e0ba36e1b550f48689134878e4fbc7908e953ada/cantera-3.2.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2678c9b9ac83b6ede7ebd7a5cc953abfd9702f9f6d5224cbde686954222fb198", size = 11835930, upload-time = "2025-11-18T01:13:45.233Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4a/763ad5c301a552e7bd533ed25cc70150f6adfe67c6e73541ce8b8d7b00b0/cantera-3.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:52335f69b9fc6fe88d56ee5a11797c25798714f6ce1373597a3d8a26e1db4365", size = 19299408, upload-time = "2025-11-18T01:13:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c4/2eb7115cb1a9a3e8d8f9f931e9c3031ebe6d43a2ee1a3bc454f5eacefa0c/cantera-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a16dcb6873b402e56e763d2017a86125ccc2f60f7234beddd5ec9c797ae8f768", size = 5294332, upload-time = "2025-11-18T01:13:51.871Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9f/44c8315ef53fdfc03b4a4244fd3759b447790d1cd4c9345f7fd254b27e9b/cantera-3.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0fcd3d62d8b1fd740ba149ae6a0b5a2673061336d31c60d526d0349826cd2793", size = 6270332, upload-time = "2025-11-18T01:13:54.368Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/50/daec99f5a09f1f61696816fb42c8128b6ebf515855138a0e3f06cc6b59f5/cantera-3.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63c2a3fb5856796eef1fe9b9b65ac688863e805ccdb0c9dee0ee6410d63c896b", size = 5471960, upload-time = "2025-11-18T01:13:56.322Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c8/50d5a7489f10782aaaacdff147154fc6e445889c93609f4c936a0ceb8c38/cantera-3.2.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:fb9a60319b1a090a107fe7cdaa9ef235bad5a8fc6780f83176605de2ec2c09ba", size = 11856620, upload-time = "2025-11-18T01:13:58.773Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bf/5a267a658e528f112fdc120bcdefb1692c12134454819c7bb6d5fc342cf8/cantera-3.2.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:01a92b2aa3db4b239ff4380c229283baf34f557afbb0409dc863d4204b88d0ff", size = 19307436, upload-time = "2025-11-18T01:14:02.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/07/da23437993f06e6251dddf2e3fa8cb8b12ded3955d034b25c925a74ad47e/cantera-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab7743909ee95ae46b46c36c96f029a32b2f28f8528d175495ce4ecb76d34314", size = 5283229, upload-time = "2025-11-18T01:14:04.807Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/28/6c69120f444f8a06077fe74c6f1e64bc7c5952100fb81c9cc03bda9d42a0/cantera-3.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9125e99d93c1810341ae9389dd0bb5ae41f0e7d3a6d7392634d872914d3980a", size = 6354783, upload-time = "2025-11-18T01:14:07.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/eddaa256814c74b1ee14b3a5c6189db22e9a6d7856e4223584faac82e6fe/cantera-3.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e11a218359b6b21123f5f2701f72bacc17581f2acbbbdff121e723499d9cf591", size = 5594649, upload-time = "2025-11-18T01:14:10.028Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ff/ea9e4a7e09ede234b1f8f987003cde62a9fa242f0157d1343a7ced3e37ca/cantera-3.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fbdca971caa5df204cf077523fc6d7d9bbfed1cb40d7b3f2e48958088d9853c0", size = 11844365, upload-time = "2025-11-18T01:14:12.868Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e9/9a44ca1002e2f5cf7432b8fda05c6721f4b6ca696ac76b8f37f8bc4d1ee6/cantera-3.2.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:45b13e4232efde00e279b56ef09225d88d54b06260afec27bac2631caa4c5786", size = 19290981, upload-time = "2025-11-18T01:14:16.474Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -282,6 +309,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
     { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
     { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -923,6 +972,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1108,6 +1169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,16 +1291,21 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlalchemy" },
+    { name = "tckdb-schemas" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
+chemkin = [
+    { name = "cantera" },
+]
 dev = [
     { name = "httpx" },
     { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "ruff" },
 ]
 rdkit = [
@@ -1241,6 +1316,7 @@ rdkit = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "boto3", specifier = ">=1.34" },
+    { name = "cantera", marker = "extra == 'chemkin'", specifier = ">=3.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "isbnlib2", specifier = ">=0.1" },
@@ -1252,15 +1328,34 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4" },
+    { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rdkit", marker = "extra == 'rdkit'", specifier = ">=2024.3" },
     { name = "requests", specifier = ">=2.31" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "tckdb-schemas", editable = "../schemas/python/tckdb-schemas" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
 ]
-provides-extras = ["dev", "rdkit"]
+provides-extras = ["dev", "rdkit", "chemkin"]
+
+[[package]]
+name = "tckdb-schemas"
+version = "0.14.0"
+source = { editable = "../schemas/python/tckdb-schemas" }
+dependencies = [
+    { name = "email-validator" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "email-validator", specifier = ">=2" },
+    { name = "pydantic", specifier = ">=2.6" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "typing-extensions"

--- a/examples/clients/explore_tckdb.ipynb
+++ b/examples/clients/explore_tckdb.ipynb
@@ -1,0 +1,742 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "00d27a16",
+   "metadata": {},
+   "source": [
+    "# Exploring TCKDB\n",
+    "\n",
+    "**A guided tour of a live Thermochemical & Kinetics Database deployment.**\n",
+    "\n",
+    "TCKDB stores computational-chemistry results — species, thermodynamics, kinetics,\n",
+    "and the quantum-chemistry calculations behind them — together with the provenance\n",
+    "needed to judge how much to trust each number.\n",
+    "\n",
+    "This notebook queries a running deployment and reconstructs real thermodynamic\n",
+    "functions from it.\n",
+    "\n",
+    "> **Read-only.** Every call here is an anonymous `GET`. Nothing in this notebook\n",
+    "> can modify the database. You do not need an account or an API key.\n",
+    "\n",
+    "### The deployment this talks to\n",
+    "\n",
+    "```\n",
+    "https://tckdb.homecalvin.com\n",
+    "```\n",
+    "\n",
+    "That is Calvin's live TCKDB instance. The notebook points there by default, so you can\n",
+    "run it as-is — no signup, no key, no local database. Set `TCKDB_BASE_URL` if you want to\n",
+    "aim it somewhere else (your own local instance, say).\n",
+    "\n",
+    "### What you need\n",
+    "\n",
+    "Only `requests` and `matplotlib`. There *is* a proper Python client\n",
+    "(`pip install tckdb-client`) which is the better choice for programmatic work —\n",
+    "but it pins a contract version, so a client newer than the server it talks to will\n",
+    "fail on endpoints that server doesn't have yet. Plain HTTP keeps this tour working\n",
+    "against any deployment, which matters when you're handing it to someone else."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "88ab9fa8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:13:34.610414Z",
+     "iopub.status.busy": "2026-08-02T10:13:34.610330Z",
+     "iopub.status.idle": "2026-08-02T10:13:34.874547Z",
+     "shell.execute_reply": "2026-08-02T10:13:34.874130Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deployment: https://tckdb.homecalvin.com/api/v1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "health    : {'status': 'ok'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "import os\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "# Point this anywhere: a colleague's server, or your own localhost instance.\n",
+    "BASE_URL = os.environ.get(\"TCKDB_BASE_URL\", \"https://tckdb.homecalvin.com/api/v1\").rstrip(\"/\")\n",
+    "TIMEOUT_S = 30\n",
+    "\n",
+    "\n",
+    "def get(path, **params):\n",
+    "    \"\"\"One anonymous GET, surfacing TCKDB's typed error envelope when present.\"\"\"\n",
+    "    r = requests.get(f\"{BASE_URL}/{path.lstrip('/')}\", params=params, timeout=TIMEOUT_S)\n",
+    "    if not r.ok:\n",
+    "        try:\n",
+    "            e = r.json()\n",
+    "            raise RuntimeError(f\"{r.status_code} {e.get('code','?')}: {e.get('detail', r.text[:200])}\")\n",
+    "        except ValueError:\n",
+    "            r.raise_for_status()\n",
+    "    return r.json()\n",
+    "\n",
+    "\n",
+    "print(\"deployment:\", BASE_URL)\n",
+    "print(\"health    :\", get(\"health\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75d971dd",
+   "metadata": {},
+   "source": [
+    "## 1. Finding a species\n",
+    "\n",
+    "The search endpoints are **lookup-by-identity**, not list-everything. You must supply\n",
+    "at least one of `smiles`, `inchi`, `inchi_key`, `formula`, `species_ref`, or\n",
+    "`species_entry_ref`.\n",
+    "\n",
+    "That's deliberate for a scientific database: you ask for a molecule, not a page of rows.\n",
+    "Asking without an identifier returns a helpful `422` rather than dumping the table —\n",
+    "try it by deleting the `smiles=` argument below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c47e1422",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:13:34.875636Z",
+     "iopub.status.busy": "2026-08-02T10:13:34.875547Z",
+     "iopub.status.idle": "2026-08-02T10:13:35.128500Z",
+     "shell.execute_reply": "2026-08-02T10:13:35.128125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matched 1 species\n",
+      "\n",
+      "species_ref     : spc_bzlnvjru7in32c2gz7peczhlwi\n",
+      "canonical SMILES: C=C\n",
+      "InChIKey        : VGGSQFUCUMXWEO-UHFFFAOYSA-N\n",
+      "charge / mult   : 0 / 1\n",
+      "entries         : 1\n",
+      "   spe_5nr24y2ssxokxlhsvymdwbpwmm  kind=minimum  state=ground  review=under_review\n"
+     ]
+    }
+   ],
+   "source": [
+    "species = get(\"scientific/species/search\", smiles=\"C=C\")[\"records\"]\n",
+    "print(f\"matched {len(species)} species\\n\")\n",
+    "\n",
+    "sp = species[0]\n",
+    "print(\"species_ref     :\", sp[\"species_ref\"])\n",
+    "print(\"canonical SMILES:\", sp[\"canonical_smiles\"])\n",
+    "print(\"InChIKey        :\", sp[\"inchi_key\"])\n",
+    "print(\"charge / mult   :\", sp[\"charge\"], \"/\", sp[\"multiplicity\"])\n",
+    "print(\"entries         :\", len(sp[\"entries\"]))\n",
+    "\n",
+    "# A \"species\" is the chemical identity; each \"entry\" is one physical\n",
+    "# interpretation of it (a minimum, a particular electronic state, ...).\n",
+    "for e in sp[\"entries\"]:\n",
+    "    print(f\"   {e['species_entry_ref']}  kind={e['species_entry_kind']}  \"\n",
+    "          f\"state={e['electronic_state_kind']}  review={e['review']['status']}\")\n",
+    "\n",
+    "SPECIES_REF = sp[\"species_ref\"]\n",
+    "SPECIES_SMILES = sp[\"canonical_smiles\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3666b6ed",
+   "metadata": {},
+   "source": [
+    "### Species vs. species *entry* — the distinction that matters\n",
+    "\n",
+    "TCKDB separates **identity** from **interpretation**:\n",
+    "\n",
+    "- a **species** is *what the molecule is* (deduplicated by InChIKey),\n",
+    "- a **species entry** is *one physical reading of it* — a particular minimum, a\n",
+    "  specific electronic state.\n",
+    "\n",
+    "Thermo, kinetics and calculations attach to an **entry**, never to the bare identity.\n",
+    "So two conformers, or a ground and excited state, never silently blur into one number."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ddfc228",
+   "metadata": {},
+   "source": [
+    "## 2. Thermodynamics\n",
+    "\n",
+    "Each thermo record carries its model (`nasa`, `nasa9`, `wilhoit`), the standard-state\n",
+    "values, and its review status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fbeb7e6a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:13:35.129524Z",
+     "iopub.status.busy": "2026-08-02T10:13:35.129425Z",
+     "iopub.status.idle": "2026-08-02T10:13:35.398268Z",
+     "shell.execute_reply": "2026-08-02T10:13:35.397704Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 thermo record(s) for C=C\n",
+      "\n",
+      "  thm_kehnhu3mmaxhm55xrjreryphhy  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
+      "  thm_gk74mw4vyergttszkxgtjnyfwe  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
+      "  thm_3xldk7zoo7fgqpfeydev2e4q5y  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
+      "  thm_ry3rnspliwtmueeth7pitbinpy  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
+      "  thm_nqtvuodj6trobe6rmv4ixtmxva  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
+      "  thm_opilwohiutrg26h5xx6g5ib3r4  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
+      "  thm_lzteqmvad6fzdz2cdejssxdlgu  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n"
+     ]
+    }
+   ],
+   "source": [
+    "thermo = get(\"scientific/thermo/search\", species_ref=SPECIES_REF)[\"records\"]\n",
+    "print(f\"{len(thermo)} thermo record(s) for {SPECIES_SMILES}\\n\")\n",
+    "\n",
+    "for t in thermo:\n",
+    "    th = t[\"thermo\"]\n",
+    "    h, s298 = th.get(\"h298_kj_mol\"), th.get(\"s298_j_mol_k\")\n",
+    "    print(f\"  {th['thermo_ref']}  model={th['model_kind']:6s} origin={th['scientific_origin']:9s} \"\n",
+    "          f\"H298={h if h is None else round(h, 2)!s:>9s} kJ/mol   \"\n",
+    "          f\"S298={s298 if s298 is None else round(s298, 2)!s:>7s} J/mol/K   \"\n",
+    "          f\"[{th['review']['status']}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a14ba84",
+   "metadata": {},
+   "source": [
+    "### Reconstructing Cp(T), H(T), S(T)\n",
+    "\n",
+    "A NASA-7 fit stores two coefficient sets meeting at `t_mid`. Evaluating them is what\n",
+    "turns a stored record back into thermodynamic functions — and it's the reason to query\n",
+    "thermo at all rather than just read a summary table.\n",
+    "\n",
+    "$$\\frac{C_p}{R} = a_1 + a_2T + a_3T^2 + a_4T^3 + a_5T^4$$\n",
+    "$$\\frac{H}{RT} = a_1 + \\frac{a_2T}{2} + \\frac{a_3T^2}{3} + \\frac{a_4T^3}{4} + \\frac{a_5T^4}{5} + \\frac{a_6}{T}$$\n",
+    "$$\\frac{S}{R} = a_1\\ln T + a_2T + \\frac{a_3T^2}{2} + \\frac{a_4T^3}{3} + \\frac{a_5T^4}{4} + a_7$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dc3e237d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:13:35.399428Z",
+     "iopub.status.busy": "2026-08-02T10:13:35.399280Z",
+     "iopub.status.idle": "2026-08-02T10:13:35.404206Z",
+     "shell.execute_reply": "2026-08-02T10:13:35.403761Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "valid 10-3000 K, switching at 770.8 K\n",
+      "\n",
+      "Cp(300 K) = 42.93 J/mol/K\n",
+      "H (300 K) = 62.92 kJ/mol\n",
+      "S (300 K) = 219.06 J/mol/K\n"
+     ]
+    }
+   ],
+   "source": [
+    "R = 8.31446261815324  # J/mol/K\n",
+    "\n",
+    "\n",
+    "def _coeffs(nasa, T):\n",
+    "    return nasa[\"low_temperature_coefficients\"] if T <= nasa[\"t_mid\"] else nasa[\"high_temperature_coefficients\"]\n",
+    "\n",
+    "\n",
+    "def cp(nasa, T):\n",
+    "    a = _coeffs(nasa, T)\n",
+    "    return R * (a[0] + a[1]*T + a[2]*T**2 + a[3]*T**3 + a[4]*T**4)\n",
+    "\n",
+    "\n",
+    "def h(nasa, T):\n",
+    "    a = _coeffs(nasa, T)\n",
+    "    return R * T * (a[0] + a[1]*T/2 + a[2]*T**2/3 + a[3]*T**3/4 + a[4]*T**4/5 + a[5]/T) / 1000.0\n",
+    "\n",
+    "\n",
+    "def s(nasa, T):\n",
+    "    a = _coeffs(nasa, T)\n",
+    "    return R * (a[0]*math.log(T) + a[1]*T + a[2]*T**2/2 + a[3]*T**3/3 + a[4]*T**4/4 + a[6])\n",
+    "\n",
+    "\n",
+    "nasa = next(t[\"thermo\"][\"nasa\"] for t in thermo if t[\"thermo\"].get(\"nasa\"))\n",
+    "print(f\"valid {nasa['t_low']:.0f}-{nasa['t_high']:.0f} K, switching at {nasa['t_mid']:.1f} K\")\n",
+    "print(f\"\\nCp(300 K) = {cp(nasa, 300):.2f} J/mol/K\")\n",
+    "print(f\"H (300 K) = {h(nasa, 300):.2f} kJ/mol\")\n",
+    "print(f\"S (300 K) = {s(nasa, 300):.2f} J/mol/K\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a61f6b11",
+   "metadata": {},
+   "source": [
+    "### Sanity-checking against literature\n",
+    "\n",
+    "Recomputed values are only worth anything if they agree with known ones. This is the\n",
+    "check to run before trusting anything else in the database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "41e6bab1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:13:35.405361Z",
+     "iopub.status.busy": "2026-08-02T10:13:35.405208Z",
+     "iopub.status.idle": "2026-08-02T10:14:07.512040Z",
+     "shell.execute_reply": "2026-08-02T10:14:07.511673Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "species    S298 db  S298 lit      Δ%    Cp300 db  Cp300 lit      Δ%\n",
+      "--------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "H2O         188.66     188.8   -0.1%       33.59       33.6   -0.0%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C2H4        218.80     219.3   -0.2%       42.93       43.6   -1.5%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CH3         194.40     194.2    0.1%       38.93       38.7    0.6%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OH          178.19     183.7   -3.0%       29.10       29.9   -2.7%\n"
+     ]
+    }
+   ],
+   "source": [
+    "REFERENCE = {  # NIST-JANAF / standard tables, 298-300 K\n",
+    "    \"O\":     {\"name\": \"H2O\",  \"S298\": 188.8, \"Cp300\": 33.6},\n",
+    "    \"C=C\":   {\"name\": \"C2H4\", \"S298\": 219.3, \"Cp300\": 43.6},\n",
+    "    \"[CH3]\": {\"name\": \"CH3\",  \"S298\": 194.2, \"Cp300\": 38.7},\n",
+    "    \"[OH]\":  {\"name\": \"OH\",   \"S298\": 183.7, \"Cp300\": 29.9},\n",
+    "}\n",
+    "\n",
+    "print(f\"{'species':8s} {'S298 db':>9s} {'S298 lit':>9s} {'Δ%':>7s}   {'Cp300 db':>9s} {'Cp300 lit':>10s} {'Δ%':>7s}\")\n",
+    "print(\"-\" * 68)\n",
+    "for smi, ref in REFERENCE.items():\n",
+    "    recs = get(\"scientific/species/search\", smiles=smi)[\"records\"]\n",
+    "    if not recs:\n",
+    "        print(f\"{ref['name']:8s} not present in this deployment\")\n",
+    "        continue\n",
+    "    ts = get(\"scientific/thermo/search\", species_ref=recs[0][\"species_ref\"])[\"records\"]\n",
+    "    n = next((t[\"thermo\"][\"nasa\"] for t in ts if t[\"thermo\"].get(\"nasa\")), None)\n",
+    "    if n is None:\n",
+    "        print(f\"{ref['name']:8s} no NASA polynomial stored\")\n",
+    "        continue\n",
+    "    s_db, cp_db = s(n, 298.15), cp(n, 300)\n",
+    "    print(f\"{ref['name']:8s} {s_db:9.2f} {ref['S298']:9.1f} {100*(s_db-ref['S298'])/ref['S298']:6.1f}%   \"\n",
+    "          f\"{cp_db:9.2f} {ref['Cp300']:10.1f} {100*(cp_db-ref['Cp300'])/ref['Cp300']:6.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f58b2ef4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:14:07.513068Z",
+     "iopub.status.busy": "2026-08-02T10:14:07.512972Z",
+     "iopub.status.idle": "2026-08-02T10:14:07.894779Z",
+     "shell.execute_reply": "2026-08-02T10:14:07.894476Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWoAAAF7CAYAAABLi7JfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtLxJREFUeJzs3Qd0VNXWB/A/6b2HkJAAobdQDF2khqY0QVCxgA+VTxDlARawPPApCBbwoeJTeYAgggqIiFSliAjSIfQSSiAhvffyrX3CDJmQQEgmmfb/rTVrZu7cmbl37mROzr7n7F2jsLCwEERERERERERERERkMFaGe2siIiIiIiIiIiIiEgzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERGR0Tt27BieeeYZBAcHw8HBAS4uLrjvvvswd+5cJCQk6OU9srOz8emnn6Jr167w9PSEnZ0dateujZEjR2Lnzp3Qt3/84x/o37//XdfbsWMHatSooa6rQo8ePdCyZUtUB9mPGTNm3HGdS5cuqfWWLFmiXSa3ZZk8Zspk32U/atasidTU1Nser1evHgYOHFjqc+Pi4mBvb6+ef+DAgVLXKSwsxMqVK/HAAw+o95C/lcDAQPTr1w9ff/11mdslf0vyuh9++GG59+X69etqf44cOQJDkM9qzJgxFfr7eeqppzB06NAq3kIiIiKie8dALRERERm1r776CqGhodi/fz9eeeUVbNq0CWvXrsWIESPwxRdfYOzYsZV+DwmC3X///Zg8ebIKWkpg8LfffsNHH30Ea2tr9O7dG0ePHoW+HD58GEuXLsW7776rt9c0Zw899BD++usv+Pv7wxzExsaqkwz3YtmyZcjJyVG3Fy1aVOo606ZNw+OPP45mzZqpwOzGjRvVd8zPzw/r1q0r9TkSaJXv451et6xA7cyZMw0WqJXfgLfeeqtCz5UA84YNG/D777/rfbuIiIiIKsOmUs8mIiIiqkISnHvhhRfQp08f/PTTT2pEoYYsmzJligrcVtbTTz+tArGbN29Gr169dB577LHHVABXRtnqy/vvv48OHTqgXbt2entNc+br66su5kJGUs+bNw8TJkxArVq1yvWc//3vf2qUbN26dfHdd9/h448/hqOjo/bxzMxMzJ8/X32Xv/zyS53nysjTgoKCUl9XM9JWguESvNyzZw+6dOkCY9e2bdsKP7dBgwbqGMjfYcm/dyIiIiJD4ohaIiIiMlqzZs1S05Yl8FQ8SKsh6QkGDx5cqfc4ePCgGnkoI3PLCtq0b98ederUgT7cuHFDjQaU6dclnT59WgWQnJyc4OPjg//7v/8rdYr81q1bMWTIEDWtXaa3N2zYEOPGjVMjg0uO3Hz++ecRFBSkPj8JdsrI4W3btt32mjJiWabMy3vXr19fBbFKBvdSUlIwdepUlYJCkxpi0qRJSE9Pv2295557Dt7e3ipNhezT2bNnK/yZlZb6QJOyQZ/bXV1klGteXt5d00Bo7Nu3D+Hh4eo7I59rcnIyVq9erbOO7Iuk7yhr1LGV1e3/9mdlZWHFihVqxLoEjjUB4buRNALyNyEkJYkcm/KktSj+fFlf3vu1115T2yzfk0GDBqm/D/nOy/dW/gbkIu+RlpZ219QH5f37EfJZyt/BhQsXyrXNRERERNWBgVoiIiIySvn5+WpqsgSRJNBYHhKgkwDY3S7y2hpbtmxR19WVs1LeLzc3Fz179tRZLgGq7t27q4Dc559/rqa6S3DqxRdfvO01JLjUuXNnLFy4UL3e22+/rYJ5kl9XXrt4MEpGIsvjsp6MngwLC0N8fLzO60VHR+OJJ57Ak08+iZ9//hkDBgxQ0+iXL1+uXScjI0Ntn6RseOmll1RwW4JsEkSVYLnkRxVyLZ+lbL+MeJagdKdOndRr6ps+t1uf36m7kVGx48ePV6kGyhPA1qQkkLzGMsJbApEl0xRIYFIC9vLdkdG2ErS8276tWbMGiYmJ6nUbNWqkvj+rVq26LShaWk7bxYsXq9tvvvmmGvkul2effRb3Yvr06YiJiVHHQtKMSABXUjcMHz4c7u7uauTwq6++qr5Lsu6d3MvfjybQL5/Pr7/+ek/bTERERFSlComIiIiMUHR0tESZCh977LFyP2f06NHqOXe7dO/eXfuc//u//1PLTp8+XVgdXnjhhUJHR8fCgoICneWvvfZaYY0aNQqPHDmis7xPnz5q+7Zv317q68nr5ObmFl6+fFmtt27dOu1jLi4uhZMmTbrj9shnIc/bt2+fzvLmzZsX9uvXT3t/9uzZhVZWVoX79+/XWe/HH39Uz//111/V/Y0bN6r7n3zyic567733nlr+r3/9647bExERodZbvHixdpnclmXyWFVtd1lke8vznapbt+4dX6f4a8XGxhbGxcUVuru7Fw4fPlz7uLzGQw89pPOc9PT0Qjc3t8JOnTrpfM/lu3L+/Hmddf/+++/COnXqaLfJ1dW1cODAgYXffPPNbd830atXr0IHB4fCxMREnc950aJFd90X+TxLHqfyku+yPHfQoEE6y+W7KstfeuklneVDhw4t9PLy0lkmn5V8DpX5+6ldu3bho48+es/bT0RERFRVOKKWiIiIzIZMvZap8He7/Pe//zXYNkoRJklBIFO/i9u+fTtatGiB1q1b6ywfNWrUba8hoxBlWreMNLaxsYGtra0apSlOnTqlXU/y4MpoRZlqv3fvXp3RtsVJnlRZt7hWrVrh8uXL2vu//PKLSjXQpk0bnZGk/fr1U/sioyE1+yFkpOvd9qOy9LndZZEp+OX5Tq1fv/6etl3SQsjIXklhIKOhy/L999+r1A0y6lVDbstoUM2oVg1JR3D+/HmVt1lGoMqoaymKJ3lrS44ejoiIUMdq2LBh8PDwUMukQJ+rq2u50h/ow8CBA3XuSxE0Tb7ckssTEhLuONL3Xv5+NCTn77Vr1yq49URERET6x2JiREREZJRkKrdM8ZaAUnlJHlnJ23o3xYOkmtyz8j5NmjRBVZOiT5JXtiRJRyA5VEsqWWxKpuL37dtXBXyl6n1ISAicnZ3VckkxIK+vIdPYJUgrKQ9kXckD+vDDD2Pu3Lk6rytBw5Ikp23x15Kp5RIElKBwaTT5cWU/JHhc8jXLWzTrXuhzu8si2y0BvbspGXgvD8mT++mnn6rp/Tt37ix1HUlxIN8Xyb2alJSkDUZLjlYJws+cORPW1tba9WU/JQgtF83xeOSRR1TAWtI+PPjgg2q5BGMlcCuPaV5XSED322+/VakTmjZtiqrk5eWlc1/yB99pueTUle9wacr791OcfK7FvytEREREhsZALRERERklCT717t1bBZciIyPLFYCVkYaSi/RuJJelZiSlBLRk9KHkcpVgWHUEoA8dOlRq0FFyrpZUcpnk4Dx69KgK0o0ePVq7XIKRpb3X/Pnz1eXKlSsqj+vrr7+uRuTKqMt73W5HR8cyR1vK45r9kBGrEjgrHkgtbd+qQ3m3uyzvvPOOCobejYxoLl7srDxku2QUuIza3bBhw22PS/7a3bt3q9tlFbPbvHmzNvhaGjkGEhCW77t8d2RdCerL90fIiNrSyOclAX1TUd6/n+JklK4EvImIiIiMBQO1REREZLSkMJQU+5FK9+vWrdOOrNOQqfwScJRq8UKCXmUVDypOpncXL4wkRahk5OLIkSPRq1ev29Y/cOCAGlVZVrDsXsgoRSmSlJycrAomaUhxMQmMSRC2+PTtFStWlDpyU0aOFne3dA6y7fLZyFT4P//8s0LT1GfNmqUCYqWNXCy5HzIqU4p3lbUf1aW8210WCaKWnKJfmpLHo7zk5MK8efNUAF0CqMVpCoZ99dVXqlBYcTISdMiQISqgKsFX+VuQFAmljTLWpMMICAjQBnfl5MeECRPUiNqS5HvyzTffqM9NRkffaX+NZURqef9+NORkwtWrV+8Y5CYiIiKqbgzUEhERkdGSHJsLFy7E+PHjERoaihdeeEHloZSg1OHDh/Hll1+q/KOaQK2MjqvICDkJSsloWgnYSuBMrj09PREVFaVyj0pg9eDBg3oJ1GqqzUteUklhoCGjHiXoJvk5JV2Bn5+fdgp6yUBvgwYNVGBPXkemics2bt26VWc9CQRL8EpydMpzJDgtuVQlsF3WKMo7ke2TfKrdunXDP//5TzX9XgKLMlJ3y5YtmDJlCjp27Kj2SdaR6fzp6elo166dCgwvW7YMhlDe7S6LBDc1Ac6qGjkuAVFJSSFk+zSBRPleSn7WZ599ttTnyvdeRknHxsaqAL589yXPbFhYmMpfLDldZSTtJ598ol5Hc9wlACwBWBlJXtq+jRs3TgXZZZSvBINLI99BGREs31F5bUlJUNWf1Z2U9+9H49ixY8jIyFB/I0RERETGgsXEiIiIyKjJaFoZ0SqB2jlz5qhA4NChQ1XwVIKQEqytLJn+LlPMP/zwQzUi76mnnlIjayWwJ8EcCYaVLFJUUffff78KqMkI4ZK5NCVPafPmzVVA+sknn1Q5NCWHaXGSg1QCs40bN1YBtccff1ylMti2bZvOevJcCUBKgFQKe0nwWXLVSgErGaF5ryQP7h9//IExY8aoz1wCYjIC+T//+Y9KS6EJkFtZWanPS95TRjjKsdqzZ48aGW0I5d1uQ5LPqEuXLjrLJEgq0/blGN9ptK+ctJBj7ObmplI0SE5eCcDK38nw4cNVbloJYsr3W3I+S05e+f7IKOGygqry/ZcgrGZEb2nktSQwKiku5L2kkJk+/hYrqrx/PxqS6kT+7oufLCEiIiIytBqFxcu/EhEREVGV++ijj/Dee++pivMSECOi6pOfn69SSciJHvk7JCIiIjIWHFFLREREVM0kN6jkp/3ss8/42RNVs+XLl6u0EK+88go/eyIiIjIqDNQSERERVTOZki3T1StagIrIGMlEPcmte6eLMUzmkxzFkr/Ww8PD0JtCREREpIOpD4iIiIiIqNKkcNndinMtXrxY5QsmIiIiotsxUEtERERERJWWmpqKM2fO3HGd4OBgeHt789MmIiIiKgUDtUREREREREREREQGxhy1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUElGVycjIQNeuXeHp6Yl69epV+yf93//+F40aNYKNjQ2WLFlS7e9PRERkSe0uERFRVZkxY4Zq26ysrLBjx45q/aAjIiLQoUMHuLq6okePHtX63mR5GKgls3bs2DE888wzCA4OhoODA1xcXHDfffdh7ty5SEhIqLZtqFGjBg4fPnzPDZE8Ly4uDsZCtke2q7zs7OywYMECrFq1qtzPGTNmjDpOJe3fvx8+Pj5o3LgxLl++XK7XCgsLw65du1SnlYiIqo6cDJM24sCBA6U+PnDgwEoHDvPz81GzZk3MmzdPr9tm6e0uERHp1759+/Dwww+jTp06sLe3h5+fHzp37owpU6ZU+rWlL/vyyy/f03MuXbqk2pMPP/wQxkL6fPf6f8Fjjz2GQ4cOqc+1PCSYK/v9448/3nZSc8CAAbC1tcU333xTrteSfujixYsxf/78e9pmoopgoJbM1ldffYXQ0FAV4HvllVewadMmrF27FiNGjMAXX3yBsWPHVst2rF69WgWK27ZtC0sjI1llv6XjWBnbt29H7969ERQUhN27d6Nu3brlel6DBg3g7+9fqfcmIiLjICfeYmNjMWzYMENvitm3u0REVDEbNmxAly5dkJKSogYHbdmyBZ988gnuv//+Sp9Ek1GdMvhn+PDhFnl4mjZtCi8vr0q9RnJyMvr27av6lxLAffrpp8v1PBlJ26JFC1hbW1fq/YnKw6ZcaxGZmL/++gsvvPAC+vTpg59++kmdydSQZXI2UwK31UEaAEttTPVh3bp1ePTRR9G+fXv88ssvcHd3N/QmERGRAUh72q5du3KfrCMiIqpuEpyVQTqbN29WJ8+KjwaVxyrbDsrMEs4WrJiYmBj069cPFy5cwMaNG9GzZ89KHQ+iqsIRtWSWZs2apaY5fPnllzpBWg0ZaTJ48GDtfZl2IdMyZcRtq1atVJqE+vXr4z//+U+ltuP06dM4efJklQZqNVM1JcWCjBaWQKacaZw8eTLy8vJw5swZ9O/fX50FlP0s7R+EK1eu4Mknn1QNv3xezZo1w0cffYSCgoI7vvfEiRNVjp6Sl2effVYv+7Zs2TI88sgj6NWrlzobXTxIe/DgwVLfWy4y6paIiMxHYWGhaqP11Z5GRUWpWTeSx/zcuXP39FxzbneJiKhy4uPj1TT54kFaDcmtWtmZmpJSobKvc7cUCR988AHmzJmj2jBHR0fVzpw9exa5ubl4/fXXERAQoNo+2RYJfhYn7Zi0ezL6Vdo3aedk1GpkZORdRyKX1bc7f/58pfdNUudJgFu24/fff78tSCvteWnv/eabb1b6vYnuFUfUktmRHHby4ysdMJkqX15HjhzBpEmTVAesVq1a+Pbbb1X+n5ycHEydOrXCjWnt2rXRsWNHVLWRI0eqTt+4ceOwdetW1UBKY7pt2zaMHz9e7cOKFSvw2muvoWHDhtqpozKNVKbnyH7++9//Vg2yjFyV9eVs4+eff17me0oevKoiQXI5HjKaVnIHSQ6h4uT4VncSeSIiunsbLMHK0gKtlbFnzx4VXNVHoDY8PBwPPvggAgMD1Qwc6VBXhLm1u0REVHmSi/brr7/GSy+9hCeeeELllC3Zj6kICTD+/fffqt2oap999pkavCTXSUlJajbqoEGDVJ9W9uV///ufCnxKuyUnCn/++Wftc2VWqwyWevHFF9VAKAn+vvXWW6rfJvlly2pzH3roIXWpCqdOncI///lPbRolOTla0g8//FAl701UIYVEZiY6Olp6g4WPPfZYuZ9Tt27dwho1ahQeOXJEZ3mfPn0K3dzcCtPT0yu0LW3atCmcOHFihZ77r3/9S+1HbGxsudb76KOPbntvWb5mzRrtstzc3EJfX9/CYcOGaZe9/vrrar19+/bpPP+FF15Qn8mZM2e0y2Q9eb970bx5c/UZWllZFXp7exe+/fbbd1x/9OjR6n3k0rVr18L8/PzCilqyZIl6Txsbm0IXFxd1Oy0trcKvR0REpVu8eLH2t7usi7S1FTVp0qTCkJCQSm3b/v37C7du3arapEceeaQwMzNTZz1LbXeJiEh/4uLiVB9G0/bZ2toWdunSpXD27NmFqampFX7d+fPnF3p6eqp25V5FRESobfnggw/KtV7r1q11+mDy3rJ88ODBt7XNsjw5OVndP3XqlLo/fvx4nfWkvZPl06dP1+nz3ev/Be+8845q16R9k3aucePGd1x/+/bt2uNgbW1dePLkycKKysrKUu8tfUrpW8rtr7/+usKvR3QnTH1AdJMkB2/durXO5zFq1CiVCF7O/t2rixcvqlG61ZWfVs5YFidnCmXqilS01JApODKqR86Aasjo4+bNm6NDhw63VeKUPqI8XhknTpxQSdtllJVU0p45c+ZdnyNTbCSX8J9//qkKv1XU6NGj1XvKCKfU1FR129nZucKvR0REdyYzIKSIZ8lLZfPprVmzptLt6dKlS9VIWhn98/3336s0R5VhTu0uERHph7e3N/744w/V9r3//vsYMmSIShswbdo0hISEqN/lis7UlNcqLaWCvklbWTy9gmYEaskRr5rlks5HSIEuTXtWnLR3su5vv/1Wqe2Skbny+Un7Ju2cpBoqb3stKRkmTJiAjIyMCr23pHGQ95Y+pfQt5XZ1FScny8NALZkdmU7h5OSkqmLeC0l3UNYyyTVk7MneS1bAlDy88jmU7IjK8qysLO192Td/f//bXk9yD2ker27yj4FMoZFgrTSoMu2GiIiMn3TEpOBXyUtlCkHKVE/pBFY2ULty5Up1IlACtRJQrSxzaneJiEi/pO2T1Dcypf769etq6r2kAahIQbHo6Gg1gKW6BgCV1r7dabmmjdO0X2W1cYZq32TwzldffaXSL0iwOT093SDbQVReDNSS2bG2tkbv3r1Vsam7JS0v2QCWtUzOjFbkrOfQoUPV9hgz2TfJ+1eS/EMhKpq7r7Kko7tu3TpVkEVyHDEvHxGRZZL2tHHjxmjZsmWlXkdyz0txk+7du6sZL4ZirO0uERFVDcnr+q9//UubJ/1eSTFNmRUog1iMmabPXFYbZ8j2TUa/Llq0SOWolRHDDNaSMWOglsySTC2R6YPPPfecKtZRkkxXWL9+/W1TBY8ePaqzTIqASNVmSQJ/L65evaqmu1TXWc/KkKD2yZMnb0vvINNXZcRRyYqY1R2s/emnn9Q0UknI/8knnxhsW4iIyHCBWn20pzISSAp9yahfadv27t0LQzDmdpeIiCqntCClpqBV8dkT99oOyvR9mX5vzHr16qWuly9frrNc+sWy/9L+GdIzzzyjgrW7d+9W/cu0tDSDbg9RWao+wQmRgaptLly4UFVdDg0NVdUnJQetBGgPHz6sKlHKyBypXqkhjebgwYMxY8YMNV1DGhip4jxnzhw1lfFeG1MPDw+9dLb0MT3zTmQajnQOZRrIO++8g7p162LDhg2q6rR8bjKKyZDkHxI5iyyd9EmTJqn8QpqqnUREZN5k5OuFCxf0duJTTr5u2rQJw4YNUyOTJM1Oybba0ttdIiKquH79+iEwMFD1M2UWh/RdpC376KOP4OLigpdffvmeXk/SBezcuVOl76msqm7fmjRpgueff17NhJRUdhIMlXQPkls2KCjIKPpwkj9Xtk2CtrJ9GzduVMeFyJgwUEtmS0bTSuLyefPmqWCrpDGQaSfSAZIiYTKdvrg2bdqoH2yZlnLu3DkVuP34448r1KBIoFaCvvJ+FaVJdF7VZ059fX2xZ88eNQpZLlI8rX79+ip/0uTJk2EM5DOQQjKPPPKI2ib5h2fKlCmG3iwiIqpi0p5KIFNOuuqL5KmV1Dryv4BMf5T3kGu2u0REVFlvvvmmamOkDyqja7Ozs9UgoLCwMNXX0hTgKi+ZXSi5YIsXqrxX1dW+CRks1aBBAzVyVeqMSI56SWU3e/bsCqUTrApPP/20CtZK0FYC63ICV07kEhmLGoUyP5zIwtWrV0+NsP3ll18q/VoSEK5du7ZqVIuP2L1XUtXzr7/+QkxMTKW3iYiIyBQ1b95cdU5lJFJVY7tLRETGRk4kyglGOalYUTI7UWaSyOwNeT0iMm4cUUukZ7Vq1UJ+fn6Fny85c2SE66+//nrbqF8iIiJLIrlcqxrbXSIiMlbSJ6woSR0kaRemT5+u+qiaHLJEZNwYqCUyMt26dVPpCCS/z6xZswy9OURERGaN7S4REZmjf//73/j+++/RsWNHrFq1ShVqJiLjx9QHRERERERERERERAZmZegNICIiIiIiIiIiIrJ0DNQSERERERERERERGRgDtUREREREREREREQGZpLFxAoKCnD9+nW4urqiRo0aht4cIiIyA4WFhUhNTUVAQACsrMzrPCbbTSIi0je2m0RERFXQbhaaoKtXrxbKpvPCz4DfAX4H+B3gd0Df3wFpY/Tl888/LwwJCSl0dXVVl06dOhX++uuv2sdHjx592/t37NhR5zWysrIKX3zxxUJvb+9CJyenwkGDBt3zNrLd5N8Jfyv5HeB3gN8BU2g3jQXbTf698DeT3wF+B/gdgIHaTZMcUSsjacXVq1fh5uZWqRFGsbGx8PX1NbvRU8a+z4mJidixYwd69OgBT09Pi9nv6sb95vG2BPr6nqekpCAoKEjbxuhDYGAg3n//fTRs2FDdX7p0KYYMGYLDhw+jRYsWaln//v2xePFi7XPs7Ox0XmPSpElYv349Vq5cCW9vb0yZMgUDBw7EwYMHYW1tXW3tJn9P2G5aAn7P2W5aAmNuN40F203T/h2t7r6msey3IVjiflviPgvut2+lj3d5202TDNRq0h1IZ7OygdqsrCz1GpbyB2Ys+5yTk4Ps7Gw4OztX6hia2n5XN+43j7cl0Pf3XJ8pdQYNGqRz/7333sPChQuxd+9ebaDW3t4etWrVKvX5ycnJWLRoEZYtW4awsDC1bPny5aqB37ZtG/r161dt7SZ/T9huWgJ+z9luWgJjbjeNBdtN0/4dre6+prHstyFY4n5b4j4L7reb3o733dpNkwzUEhERmZr8/Hz88MMPSE9PR+fOnbXLZcRHzZo14eHhge7du6tgrtwXMmo2NzcXffv21a4vOY1atmyJPXv2lBmolc6JXIqfvdX8gyWXipDnSV6lij7fVBnLfmvevzLH0BT3u7pxv3m8LYG+vueW9vtARERUHRioJSIiqkLHjx9XgVk58+7i4oK1a9eiefPm6rEBAwZgxIgRqFu3LiIiIvDWW2+hV69eKkArI22jo6NVKoSS0/b8/PzUY2WZPXs2Zs6cedtymaYl21HRDrmM8JXOvaWNHjCG/U5KSlLXCQkJ1RaoNYb9rm7cbx5vS6Cv77kURCEiIiL9YqCWiIioCjVp0gRHjhxRgbbVq1dj9OjR2LlzpwrWPvroo9r1ZJRsu3btVNB2w4YNGDZsWJmvKZ3rO02ZmTZtGiZPnnxbPiTJpVWZ1AfynpaYj8sY9lvz3l5eXvDx8bGY/a5u3G8eb0ugr++5g4ODXreLiIiIGKglA5HkyTKV1xyLDxARFScjYjXFxCQQu3//fnzyySf473//e9sH5e/vrwK1586dU/cld63kWZOiGMVH1cbExKBLly5lftAyGlcuJUmHvDKdcunYV/Y1TJEx7Le7u7tqN+W6urbDGPbbELjfPN6WQB/fc0v7bSDTwb4mEZkytq5kEBJAqFevXqmBBCIicyajYYvnjy0uPj4eV69eVQFbERoaCltbW2zdulW7TlRUFMLDw+8YqCXzw3aTiIiIbSYRmT8GaskgMjIycPjwYXVNRHSv8gsKkZiegyvxGTh5PQWHIlORnJlrdB/k9OnT8ccff+DSpUsqV+0bb7yhioc98cQTSEtLw9SpU/HXX3+px2X5oEGD1LT2hx9+WD1fRk+OHTsWU6ZMwW+//aZ+N5988kmEhIQgLCzM0LtH1YjtJhHpq/38fMcFXEsu/YQhkTlgm0lE+pKQnoNdF5JwPiYN1YU5aslgjadM/5WciU5OTjwKRBbeaYxPz0Zsajbi0nIQn5aNxIxcJGfkICkzF0kZuUjMyFGBWLmdlJGDlKy8215n6TPu6N6kJozJjRs38NRTT6lRsBJ0bdWqFTZt2oQ+ffogMzNTBW+/+eYblb9WRtH27NkTq1at0kkLM2/ePNjY2GDkyJHqOb1798aSJUtgbW1t0H2j6sV2k4gqKyY1C/9cdQR/no9Hcz8nrJlQGw52HLdD5odtJhFVdObjpfgMHLiUgAOXEnHgcgIuxKarxyb0AF7pX7FaH/eKgVoiIqoSWbn5iErOQlRyJm6kZGkDsUXXmsBsNuLTc1BYWPn3S80yvhG1ixYtKvMxR0dHbN68uVzFWhYsWKAuREREFbH7XBwmrTqi2l1xOiYD+yISjO4EJxERUXXJySvAievJOHg5EfsvJahr6a+W5sDlxGrbLgZqiYjonmXm5CM6JQtRSZkqGCu3rydlIjo5C9flfnKmGhWrT1Y1AHdHW3g42alrubg62MDV3gZWBTmo5+3MI0lERFRMXn4BPvntHD7dfl57UtTPzR7/6lsXDzTy4WdFREQWIzkzF4euJOLgpaLA7NHIJGTlFpS5vq11DbQIcENzXwf0ahlYbdvJQC0REZV6dvFaUiauJmTgamIGriZkqutIdT9T5eqpLDtrK/i62sPHxQ4+LvY3bxfd93S2UwFZDxWYtYWHo50KylpJtLaEgoICxMTEoGbN6pmKQkREZApkRsvL3x3B35cStMu6N/bFh4+EID8j2aDbRkREVNUiEyWNwa3RsmdupN5xJqf0N0PreqJ9PS913TrQA/Y2NW72NatvBgoDtWQQdnZ2CA4OVtdEZJj8OzGp2bgUl64Cr5qAbOTNgKyMkK1oOgIbqxrwc3NAgIcDark7IsDdQd2v6aYJxBYFZd0cbFCjxu2BVyK6HdtNIroXv5++gSnfH9XObrG2qoGpfZtgXLf68l8AYljPl8wY20wiy+zfRsSl4++IBJXaR65l4NGdBHo6ol1dT7Sr54V29TzRuKbrbQODZFBQdWOglgzCzc1NFdMhoqptrGTk66X4dETEZSAiLg2X1HW6WpaRk3/Prylx1VpuDqjt4Qh/j6IgbC13B/i7O8Jfrj0c4ONsX+rIVyKqOLabRFTeGTEfbD6Nr/6I0C6TtnrBqLYIreul7hcU6CExPJERY5tJZP4KCgpxNia1KDB7sSg4q8nDXhrpnjYPcEO7ukVBWbmWfqwxYqCWDCI/P19VL5diOqxcTlQ56dl5uBCbhgsxaThxJQYxmddxOb4oIJuSlXfPr+flbIcgT0cEejkhyNMJQV6ON6+d1ChZextrHjKiasZ2k4juRmbHvPjdYRy9mqRdFtbMDx+OaKXSCRFZCraZROaZc/1kVIp2xKykM0i6Q00UB1sr3FenKI2BXNrU8YCLvWmEQE1jK8nsJCYmYs2aNRg2bBh8fFjIgKhcfzfpOTgXk4bzNy/nYlJVcFaKd90Lmf4ogdh6Ps6qAFcdCciqiyMCPZ1MpgEjsiRsN4noTjYej8Krq48h9eYJWimAMv3BZhjTpR7TDJHFYZtJZB4zRI5fS8Lei0VpDCTHbFp22YOQpA8rI2U7BHuhY7AXQmp7wM7GCqaIvXEiIiNLVyD5Yc/rBGSLRsvG30MBL0lREODuiGAJxvo4IdjHBcE+TiowK0FZW2vTbLSIiIjolqzcfLy34RSW7b2sXSYnYD8d1RatAj34URERkcm0Z4evJGFfRLxKZXD4aiKycsvODysFp2WkrARlOwZ7o5m/K2zMpI97z4HaXbt24YMPPsDBgwcRFRWFtWvXYujQoeqx3NxcvPnmm/j1119x8eJFuLu7IywsDO+//z4CAgK0r5GdnY2pU6fiu+++U9Pfe/fujc8//xyBgYH63TsiIiOWkpWLM9GpOB2dijPRKTgdlaoqUWpGw5SHFORqWNNFXSQo62WTh9YN/FHPxwUOtkxRQEREZK4uxqZhworDOBWVol32UCt/zB4WAjcHW4NuGxER0Z3k5heoVD1/XYjHXxfj1YjZ7LyyA7NSjFpGy3YK9kKHYG80qulitnVR7jlQm56ejtatW+OZZ57B8OHDdR7LyMjAoUOH8NZbb6l1ZMrBpEmTMHjwYBw4cEC7nixbv349Vq5cCW9vb0yZMgUDBw5UwV/mKyUic5y2cTEurVhQNhWno1LuKWWBNEwNfV3QyK8oKCu35VqW15DhszcrUsbExKCmqlZpHmcTiYiI6HY/Hb6G6WuPawuD2ttY4V+DWuDxDkFMdUBEREYnv6AQ4deSVVB2z4V4HLiUcMfi1rU9HNVoWZXKoL436nk7WUz7ds+B2gEDBqhLaWQE7datW3WWLViwAB06dMCVK1dQp04dJCcnY9GiRVi2bJkabSuWL1+OoKAgbNu2Df369avovhARGVxSRg5OXE9RjZAkO5egrBT6ys0vX4VlqczcuJarOkNYNFLWVQVl3Z04MoaIiMjSZeTk4V/rTuCHg5HaZQ18nfHZE/ehaS03mJPZs2dj+vTpePnllzF//nxtiqiZM2fiyy+/VIOCOnbsiM8++wwtWrTQPo+zN4mIDK+goFANUpLA7F8X4lQBsDvNHJXAbJcG3uhU3xsd63up2imWqspz1EpgVqLeHh5FOZJk1KykSOjbt692HUmL0LJlS+zZs4eBWgshI6nHjh3LUX9ksqSjcCMlGyeuJyP8Woq6lgDttaTMcj3f1d4GTWq5qktTufi7obGfK9wdGZAlotux3SQiOfk7YcUhlb9e45HQQLwzpAWc7Myr9Mj+/ftVMLZVq1Y6y+fOnYuPP/4YS5YsQePGjfHuu++iT58+OHPmDFxdXdU6nL1JbDOJDNM/lgFKMlpW0hnsvRiPxIzcMtf3c7NH5/re6NzAG10a+Kg6KlSkSlv0rKwsvP766xg1ahTc3IrO8EZHR8POzg6enp466/r5+anHSiNnReWikZKSop3mK5eKkufKl6kyr2FqjGmfJYAv2yIXS9rv6sT9LtDb2cAriRk4eV0Csrcu5SnuZWNVA/V9ndHE71ZQVq5l5GxpUzf4m2a4v29L+30g0yK/F0wPRWSZpI1btf8q/vXzCW3+Pic7a7w7tCWG3Wd+NT7S0tLwxBNP4KuvvlKB2OKfg4ysfeONNzBs2DC1bOnSpaofuWLFCowbN46zN0lhm0lUPWSQ0u5zsfjzfFGe2djUW3G7kryc7bSBWbnU93G2mFQGRhOolVGzjz32mOr4SqGwu5GGt6yDJNNeZIpLSbGxsSoYXFGybTLiV97bUvI5Gss+yz9gR48eVbmMXVxcLGa/qxv3u2LHOy49Fyej03EiOh0nb6TjVHQG0u6QP0fDydYKjXyd0KSmExr7Oqrrel4OsC1ZfTInFbGxqdA3Hu/K/X2npur/mBDpS1JSEv744w888MAD2llKRGT+UrNyMX1tONYfva5dJid9JdVBA9+q/x/aECZMmICHHnpIpckrHqiNiIhQA3uKz8y0t7dH9+7d1cxMCdRWdPZmVQwM4oAJw50Al36fps2U9IzVgcfbcgY8WPKxlmLYh8Oj8OeFBPx5IR4Rcel3LHotOWY730xn0LhE8a/qGrRnTMe7vK9RJYFaaRxHjhypGtPff/9dO5pW1KpVCzk5OSqnUPFRtVIAp0uXLqW+3rRp0zB58mSdhlNy2vr6+uq8dkU+JAkOy+tYSvDOWPZZ3js+Pl4dPx8fH4vZ7+rG/b778U7LzlP5ZI9GJquqk3IdVY4iX55OtmgR4IbmAW5oGeCurut5ORm08iSPd+X+vh0cHPR6PIj0KS8vD1FRUeqaiCyD/H8iqQ4ux2dolz3ZqQ7efKg5HGytYY6k2LQUp5bUByVpZl/KCNri5P7ly5crPHuzqgYG8QS64QbIyMlNOd43btzQCcBXJR5vyxkQZUnHOje/AOFR6dh/NRX7Lifj1I0MFBSWPWipTW0XhAa5IjTIDY18HGGt7RtnIi6ufCkCzfl4l3dgkE1VBWnPnTuH7du3q/wwxYWGhsLW1lYVHZP1hHQ8wsPDVc6h0siZUrmUJB9SZT8oCd7p43VMiTHss+a9q3M7jGG/DYH7baVTafLsjVQcvJx4MyibhHMxabjbiTxfV3u0DnRHiwB3tKwt127wLyN1gaHxeFf879vSfhuIiMg4SWdw6Z5LmPXraeTkF2hz278/vBUeauUPc3X16lVVOGzLli13PHla8v+vO83MLO86VTEwiCfQDTdARvO+Xl5e1TIoSPB4W86AKHM+1vJbKf3j3efjsPt8PP6OSEBGGTNLJcVfmyAPdG3ojfsb+qBVoPvtM0nNQIEej3d5BwbZVGTK+vnz57X3ZdTskSNH1I+gTCt55JFH1FnQX375Bfn5+dozl/K4nN2UqQdSRGrKlCkqiCvLp06dipCQEDW9hYhIn5WRj0Wm4MDlRHU5fDkRqdl3Ho3mbGeNVoEeaB3kgTZB7uq6lptxBmWJiIjIvCRn5OKVH49iy8kb2mVysnjB4/ehjrd5F1qRtAUyy1IG9mhIf3LXrl349NNPVcEwIf1Lf/9bAWt5jmaUbUVmb1blwCCeQDdsoLa6B+nweJtfkM4SjvWNlCzsPheHP1VwNg4xd8gzG+zlgO5N/PBAY190rO8NF3vzKmRZ1ce7vM+/50/1wIED6Nmzp/a+5szj6NGjMWPGDPz888/qfps2bXSeJ6Nre/TooW7PmzcPNjY2akRtZmYmevfurSp3skgGEVVGdHIWDlxOwIGIBOy9EItzcZlqFG1Z5CxgU39XtNYGZj1UvrdbUzSIiIiIqofM+Hnpu8OqOIvGs12D8Wr/prCzMf1gwN1In/D48eM6y5555hk0bdoUr732GurXr68CsTIzs23btupxCcru3LkTc+bMqfDsTSIiS5Kdl48DlxKx82wsdp6JxZkbqXecWdq1oY8aMdulvhesslNQs2ZNswhQG7N7DtRKsPVOCX/LkwxYhvsuWLBAXcgySQGxbt26VUshMTJP8lsTmZipqkvuvRiPfRcTdDo2pfFxsUe7up5oV88Tbet4qFQG5prjjYjMC9tNIvNVUFCIL/+4iA82n9GeYPZwssWHj7RGWHPdfKzmzNXVVRX9Ks7Z2VnNwtQsnzRpEmbNmoVGjRqpi9x2cnLCqFGj1OOcvUmCbSaRrsvx6drA7J4L8cjMLT2dgaOtNTrW91LB2a6NfNDEz1U7s1RSAMTEFBVapKplGeOUyehIsF7OjhPdi6sJGfcUmJXKkqH1vLTB2TpeTkxhQEQmie0mkXmKT8vG5O+Pqg60Rvt6nvjksbYI8HA06LYZo1dffVXNyBw/frxKb9CxY0eV01aCvBqcvUlsM8nSSQpA6TNLYFbal0vFilIWJzFYSfv3wM3A7H11PC1iBoexY6CWDEKqp166dAn16tVjpXUq0/WkTJUrZ+/FBNXQ3Ckw6yBVJoM80K6uF+6r44FAx1w0rBPAaRlEZBbYbhKZn78uxOPllYe1+QClwzyhR0NMCmsEGzMsyFIRO3bs0LkvI7sk3Z5cysLZm8Q2kyyNpgiYJjArRcA0xShLm2XavbEvujfxVSNnvZztqn176c4YqCWDkKJ0UhhAqnCWt/IdWcaZPxkpu+tcLP44F4fzMWllrmtvY6VGyXYK9kanBt4qz6zm7F/RtIyYatxyIqKqxXaTyHxIeoMFv5/Df347B00qfR8XO8x7tA0eaORr6M0jMnlsM8kSpGTl4s9zcUUpDc7GIio5q8y6LKF1PVVgVgK0zWq5wYo1WYwaA7VEZNCcbCeup9wMzMaqIhq5+YVlBmalgelcvygw2yrQHfY2zC9LREREplVde9LKIyqVk8b9Db1VkLamKwcvEBFR2aNmL8Sm4/fTN/D76Rjsv5RYZuHs2h6O2sBslwbecHWw5cdqQhioJaJqlZCeg51nY/D76ViV1kDul0ZO8rWt46mtMtk6iIFZIiIiMl0y4mnyqiOIv/m/j/yvM7lPY7zQoyGsObqJiIhKyM7LV2kMfjsVg+1nYnC5jFyzMrO0U33vopQGjX3RwNeZtVlMGAO1RFTlZ/7O3kjDb3Lm71QMDl1J1E7zKynIyxHdGvmqaX+dG3jD3ZFn/oiIiMi05eYX4KMtZ/HFzgvaZbXcHPDJY23Qsb63QbeNiIiMS0xKlgrKyqjZ3efikJ6TX+p69byd0KNJTfRo4ouOwd5wtONsU3PBQC0Z5otnYwN/f391TeYnKzdfFf+SxkXO/pVVBMzV3kYFZB9o7ItujXxQ19u52reViMgUsN0kMk2RiRl46bvDOHQlSbusV9Oa+HBEaxZwIaoibDPJ1NIBhl9PVv1m6T8fv5ZcZq7Z9vW80LtZTdWO1Pd1qfZtperBKBkZhIeHBwYNGsRP34ykZedh++kYbDoRra4zyjjz17CmC3o3LWpc7qvrCVtWNSYiuiu2m0SmZ1N4FF798RhSsvK0nezX+jfF2K7BLORCVIXYZpIpFNHedTbuZr7ZWMSlZZe6npeznRox27upHx5o7AM35pq1CAzUksGmwxcUFMDKyoq5U0xYUkYOtp68gc0norHrXBxy8gpuW8fWuobKlyOBWblw1CxZkoULF6rLpUuX1P0WLVrg7bffxoABA7S/hTNnzsSXX36JxMREdOzYEZ999plaTyM7OxtTp07Fd999h8zMTPTu3Ruff/45AgMDDbZfVP3YbhKZ1syidzecxPK9V7TLAj0dseDxtir/PhFVLbaZZIxiU7Px26kbqv/8x/nS+86iub+bGjXbs2lNtA70YA5zC8RALRlEfHw81qxZg2HDhsHHx4dHwcQaGAnMbgqPVhWLS6s06elki97N/BDWrCa6NvKFiz1/asgySTD1/fffR8OGDdX9pUuXYsiQITh8+LAKxs6dOxcff/wxlixZgsaNG+Pdd99Fnz59cObMGbi6uqrnTJo0CevXr8fKlSvh7e2NKVOmYODAgTh48CCsrZmLylKw3SQyDedupGLid4dxOjpVu+yhEH/MGhbC3PtE1YRtJhmLC7FpKjArF6nVUlhKrRYHWytVQLtXUz/0bOoLf3dHQ2wqGRFGT4jorlKzcrH5xA2sO3INf56PK7UYWE1Xe/RvWQv9W9RCh2Av2DClAdFtKV7ee+89NcJ27969aN68OebPn4833nhDnbTSBHL9/PywYsUKjBs3DsnJyVi0aBGWLVuGsLAwtc7y5csRFBSEbdu2oV+/fvyUiYiMZATfqv1XMWP9CWTlFo2Ssrexwr8GtcDjHYI4g4yIyELyzR6+mnQzOBuNC7Hppa4nfeew5n7o08xP1WxxsOXgC7qFgVoiKnPa3o4zMVh35Dp+Ox1T6tQMmcY3QIKzLf3RNsiD+daI7iA/Px8//PAD0tPT0blzZ0RERCA6Ohp9+/bVrmNvb4/u3btjz549KlAro2Zzc3N11gkICEDLli3VOmUFaiVdglw0UlJS1LWknJFLRcjzNFMJLYmx7Lfm/StzDE1xv6sb95vHuyJSsnLx5toT+OV4lHZZ45ou+M/jbdDYz1X9LcnF3L7nlvb7QERUVr95z4W4m8HZmDLzzTaq6YK+LfzQp3kttKrtzr4zlYmBWiLSkjQGf12IVyNnJbVBanZR8YuSwdnBrQPwYIg/WgS4cYQI0V0cP35cBWazsrLg4uKCtWvXqtG0EmgVMoK2OLl/+fJldVsCuXZ2dvD09LxtHXmsLLNnz1a5b0uKjY1V21HRDrmM8JXOveQXtxTGst9JSUUV4xMSEqotUGsM+13duN883vcqPCodb2+8iOspOdplD4f44OXuQXCokYmYmEyY6/c8NfVWegciIkuSmpWHPYevYeupGOw8G1tqIW2rGkBoXU/0bV4LfZr7oZ6Ps0G2lUwPA7VEhMvx6fjhQCRWH4pEVPLtQRxvZzsMbOWPwW1q4746HgzOEt2DJk2a4MiRIyrQtnr1aowePRo7d+7UPl6jRg2d9aXjXHJZSXdbZ9q0aZg8ebLOiFpJl+Dr6ws3N7cKd+zlPeU1LC1wZwz7rXlvLy+vasntbiz7Xd243zze5f+uFOKr3RH4aMtZ5N3MCeXqYIPZD7dUJ7Mt4Xvu4OCg1+0iIjJmCek52HIiGhvDo/Dn+Xjtb3/JfLMPNPJVgdneTWvC28XeINtKpo2BWjIIGR02atQoODoyUbahZOTk4dfj0fjhwFXsi0i47XEpANavRS0MaROALg28mXOWqIJkRKymmFi7du2wf/9+fPLJJ3jttdfUMhkZ6+9/q1MfExOjHWVbq1Yt5OTkIDExUWdUrazTpUuXMt9TUijIpSTpkFemUy4d+8q+hikyhv2WQnKadrO6tsMY9tsQuN883uUprDr5+yP441ycdpmcyP7ksbYI8nKCpXzPLe23gUwH+5qkLzEpWaqQ9sbwaOy9GF9qrRYvZzv0aloTfZv7qSCtox3zzVLlMFBLBiGVymUKMFUvGYUnyc1X/X0Vvxy7jvQSUzRkekbPJjUx7L5A9G5Wk0nNiaro71DyxwYHB6tA7NatW9G2bVv1mARlZbTtnDlz1P3Q0FDY2tqqdUaOHKmWRUVFITw8HHPnzuXxsSBsN4mMwx/nYvHPVUe1OQhlcsP4Hg0wKawxbFlIlcgosM2kyriWlKnSAG48HoWDVxJRWopxP1dbPNiqtiqk3a6eF6ylI02kJwzUkkHINNx9+/ahY8eOFZ6GS+WXnp2H9ceisXzvZZyMKioqVFx9X2eMbBeEYW1ro6Ybp7ER6cv06dMxYMAAlXZAcvmtXLkSO3bswKZNm9RopkmTJmHWrFlo1KiRushtJycnNXJSuLu7Y+zYsZgyZYoaUSnT3qdOnYqQkBCEhYXxQFkQtptEhpWbX6DSHHyx84J2ma+rPeY/2gb3N6z6dCREVH5sM+leXYpLV6NmN4VH4Whkcqnr1PV2Qn8ppN3cD7XsstUMOM4soKrAQC0ZhIwak4rnmlFkVDXO3UjFVzuuYNPpo0grURhMUhtI3tkR7YKYd5aoity4cQNPPfWUGgUrQddWrVqpIG2fPn3U46+++ioyMzMxfvx4ld5ATl5t2bIFrq6u2teYN28ebGxs1IhaWbd3795YsmSJGi1CloPtJpHhXE3IwMTvDuPI1aKifqJ7Y198NLI1fJh/kMjosM2k8rgYm4YNx6Lwa3g0TpUymEk0rOmCAS1rYUBLfzTzd1UDLSTPt6QhI6oqDNQSmeGID5mqIaNnS8s92zrIA092rIOHWvnDyY4/AURVadGiRXd8XP7ZmzFjhrrcqVjLggUL1IWIiKqXpIqatvo4Um+e8LaxqoHX+jfF2K7BsOJUVyIikzvx9suxKPXbfuJ66cHZZv5ueFCCsyG10LDmrcETRNWFURoiM5GcmYuVf1/Bkj2XEJWcdVv1ySGta+PJTnUREuhusG0kIiIiMgWZOfl455cT+O7vq9pldbycsODxtuqkNxERmYbo5CxsOB6F9Uev68yMKK51oDsGhPirnLP1fJyrfRuJimOglsjEXYnPwP/+jMD3B64io0RxsPo+zhjSwhOjuzWFh/PtFeCJiIiISNeZ6FS8uOIQzsWkaZcNbh2A9x5uCVcHW35cRERGTgo+SjGw9ceisP9SQqkFwVoFumNQqwA1cjbQ08kQm0lUKgZqySCkWE779u3VNVXMwcsJ+PqPCGw+EY2CEg1PWLOa+Mf9wegY7InY2Fi4ObJTQURkythuElW9wsJCfLvvCv79y0lk5xWoZY621pg5pAVGhAaqdDVEZPzYZlqmpIwc1TdefzQKey7E3dZHFk1ruWJQ6wBVq6WuN0fOknFioJYM1niykFjFOhA7zsTi0+3ncfBy4m3pDR4JDVQB2vq+LmqZJDonIiLTx3aTqGolZ+Ti9TXHVNXv4h36T0fdp4rJEJHpYJtpOdKz87DlZFFw9o9zscjNvz06W9/XWY2cHdTanzlnySQwUEsGkZ2draqg+/v7w96eU/LvpqCgUDVAC34/f1vSc19Xe4zpUg+jOtSBp7NdFR41IiIyFLabRFVHTn5PWnUU15IytctGd66LaQ82g4OtNT96IhPDNtO85eUX4I/zcfjp8DVsOXEDmbm66f9EkJejCs4ObBWAZv6unBFBJoWBWjKI1NRUbNmyBcOGDWOg9i6NkFSl/Gz7eZ08aaJRTReM695AnRm0t2EngojInLHdJNK//IJCLPk7Cl/tjVK3hbujLeY+0gr9WtTiR05kothmmufM0qORySo4K0XB4tNzblvH390BD4X4q9QGkn+W6WrIVDFQS2SEcvMLsOZQJD7fcQGX4zN0Hgup7Y4JPRuib3M/WFkxVxoRERHRvYpJycKkVUew50K8dln7ep745LG2CPBw5AdqAAsXLlSXS5cuqfstWrTA22+/jQEDBqj7Y8aMwdKlS3We07FjR+zdu1dnJOXUqVPx3XffITMzE71798bnn3+OwMDAat4bItKHy/Hp+Onwdfx05Boi4tJve1xOrkm+2SFtaqNdXU/2j8ksMFBLZERkNIecIZy37extAVppeF7s1RDdG/vy7CARERFRBW0/E4Op3x/VjsiSGmETezXCS70awsbaip+rgUgw9f3330fDhg3VfQnKDhkyBIcPH1ZBW9G/f38sXrxY+xw7O920X5MmTcL69euxcuVKeHt7Y8qUKRg4cCAOHjwIa2vOQCMyBfFp2dhwPAprD1/D4StJtz1uZ2OlimcPbVMbPZrUVPeJzAkDtURGMpVj84kb+HjrGZy9oZvioGtDHxWg7RjsxQAtERERUQVl5+VjzsYz+N+fEdplvs62+OTxtujS0Jefq4ENGjRI5/57772nRtjKiFlNoFZqW9SqVXpaiuTkZCxatAjLli1DWFiYWrZ8+XIEBQVh27Zt6NevXzXsBRFVRFZuPraduoE1h65h19lY5N1MR6MhJ9Q6BXvj4ba10T+kFtwcbPlBk9lioJYMQs5oe3p6WvyZbQnQ/nEuDh9uOYNjkck6n1GXBt6Y0rcxQut68VtKRGTh2G4SVc75mDS89N1hnIy6VZS1V1NfvNo9AI3revPjNTL5+fn44YcfkJ6ejs6dO2uX79ixAzVr1oSHhwe6d++ugrlyX8io2dzcXPTt21e7fkBAAFq2bIk9e/bcMVArKRPkopGSUvQ9KSgoUJeKkOfJ//oVfb6pMob9ltyk8h2R6+raDmPYb0OozH7L845dS8bqg9ew/lgUkjNzb1unaS1XDGkTgEGt/HXS0hjyc+ax5ne8osr7vWWglgxCgrQjRoyw6E//xPVkzPr1FP48fys3mmhbxwOv9G2CLg19DLZtRERkXNhuElWMBAJW7b+KmetPaiuDyzTZ6QOa4qlOdRAbG8uP1ogcP35cBWazsrLg4uKCtWvXonnz5uoxyVUr/Ye6desiIiICb731Fnr16qUCtDLSNjo6WqVCkN/L4vz8/NRjdzJ79mzMnDnztuXy/ZBtqWiHXEb5ynfQyspypmYby35369ZNBe5jYmIsar+rW0X2Oz49FxtPxWPDyXhEJNz+9+XrYot+TbzQr6kXGvk6FS3MSUVMTCqMAY81v+OVKXRYHgzUElWz6OQsNYJ29aFIFBbqni18pV8T9GpakykOiIiIiCopOSMX09Yew6/HbwXpGtZ0wYLH26KZv5vFjXwzBU2aNMGRI0eQlJSE1atXY/To0di5c6cK1j766KPa9WSUbLt27VTQdsOGDRg2bFiZrykBpLtVf582bRomT56sM6JWUib4+vrCzc2tQvsi3y95X3kNSwvccb95vEtLPfPbqRisltQG5+JUbZbiHGyt0L9FLQy/rzY61/c26qJg/I7zN62iHBwcyrUeA7VkEHFxcSrRv+Si8vGxjJGj6dl5+O/OC/jyj4vIyr3VMQjycsQr/ZpiYIi/UTdIRERkOJbYbhJVxt8RCZi08jCuJ98arfVExzp486HmcLRjUSljJSNiNcXEJBC7f/9+fPLJJ/jvf/9727r+/v4qUHvu3Dl1X3LX5uTkIDExUWdUrYyo7NKlyx3fV0bkyqUkCbBWJsgqAcvKvoYpMvR+G6rNNPR+G0pZ+y0nScKvpeDHg1ex7uh1JGXcntqgfT1PPBIaiAdD/OFqQnlneaz5Ha+I8v42MFBLBiNTUSxBQUEhfjwUibmbziAu7VbuKzcHG1Vh+OkudWFvww4DERHdmaW0m0SVkZdfgP/8fh6f/n4OmgFb7o62mDO8Ffq3LL0IFRkvCfQUzx1bXHx8PK5evaoCtiI0NBS2trbYunUrRo4cqZZFRUUhPDwcc+fOrdbtJsNjm2k48WnZWHv4Gn48GInT0bdP9fZ3d8Dw+wIxPDQQwT7OBtlGImPGQC1RFToemYy3fw7H4StJt/7orGrgqc518VKvRvB0tuPnT0RERKQHVxMyMGnVERy8nKhd1jHYC/MfawN/91tFaMg4TZ8+XeWhlZQDksdv5cqVqnjYpk2bkJaWhhkzZmD48OEqMHvp0iW1voyWfPjhh9Xz3d3dMXbsWEyZMgXe3t7w8vLC1KlTERISgrCwMEPvHpHZD07acyEO3+2/gi0nopGbr5vawN7GSp0sGxEahM4NvGHNmaREZWKglqgKJGXk4IPNZ7Di7ys6eWj7tfDD6wOa8cwhERERkR6tP3od09ceR2pWnrovQYB/hjXCCz0aMiBgIm7cuIGnnnpKjYKVoGurVq1UkLZPnz7IzMxUhca++eYblb9WgrU9e/bEqlWr4Orqqn2NefPmwcbGRo2olef07t0bS5YsgbU1Z68RVcnfbUoWlv4dhQ2nTuJqYuZtj4fWLUpt8FArf7iZUGoDIpMK1O7atQsffPCBqq4pjahU4hw6dKjO9BSpmPnll1+q/EAdO3bEZ599hhYtWmjXkekrcnbzu+++0zagn3/+OQIDA/W3Z0QGIEnRpbLwB5tPI7FYDp4Gvs6YMbgFHmjky+NCREREpMcaADN+PoEfDkZqlwV6OuKTx9qqAAGZjkWLFpX5mKOjIzZv3lyuQi0LFixQFyKquj7vjjMx+O7vq9h+Jua2wmDeznYqODuyfRAa+LrwMBBVdaA2PT0drVu3xjPPPKOmnpQk+X8+/vhjdeaycePGePfdd9VZ0DNnzmjPdk6aNEkl95bpLDItRaanDBw4UAV/ebbTMnh4eKjqrHJtLk5Hp+D11cdx5OqtNAdOdtZ4uXcjPHN/MOxsLCvhNhER6Y85tptElRV+LRkvfXcYF+PStcsGtw7Auw+35MgtIgvGNrNqRCZm4Pv9V/H9gUhEp9wq1Chq1AC6NvTB4x3qIKyZH/u+RNUZqJW8QXIpjYymnT9/Pt544w3VmRBLly6Fn58fVqxYgXHjxiE5OVmdLV22bJk2V9Dy5ctVLqJt27ahX79+ldkfMhEyJclcqlZn5eZjwe/n8N+dF5FX7GyidBSmP9gMtdwdDLp9RERk+syp3STSRy7ERbsjMHfzaW0eRGc7a7wzpCWG3VdbVeMmIsvFNlO/BRp/Ox2Db/ddwR/nYnXS+gk/N3s82NQTz3RvgjreHD1LZHQ5aiMiIhAdHY2+fftql9nb26N79+7Ys2ePCtTKqFmpwFh8nYCAALRs2VKtU1qgVlIlFK/2mZKSoq4LCgrUpaLkuRJcrsxrmBpj2WcpCHD06FE1OtvFxcVk93vfxXhMWxuOS/EZOmkO/j2kBTrV99a+t6Uf7+rG/ebxruj3hshYSbt55MgRtGnTplraTSJjFZOahSnfH8Uf5+K0y1oFuuM/j7VFPVYPJyK2mfr5rU3Jwsr9V/Hd31cQlaw7elbqgPVqWhOPta+Dbo28kRAfh5qeTvzuERljoFaCtEJG0BYn9y9fvqxdx87ODp6enreto3l+SbNnz1Z5b0uKjY1FVpbuj8a9dsplhK8EsqysLGNaurHssxQBOHXqFHx9fatlGqe+9zslKw+f7r6Gn8NvdRJsrGpgdPta6mJnk4+YmBgYmrEc7+rG/ebxrgipME1krOT/nZMnT6Jp06YM1JLF2n46BlN/OIr49BztsnHd62NKnyacZktEWmwzK0b6jPsiErBs72VsDo/WmS0qans44rH2QRjRLkg7a5QDHYiMPFCrUXK6kfzB320K0p3WmTZtGiZPnqwzolZSJUiQz83NrcLbKT8q8p7yOpYSxDKWfda8t5eXV7VM5dTnfkvC9GlrTiMm9dYo7/vqeGDWwy3R2O9W1VljYCzHu7pxv3m8K0IKkBARkfHJzsvH+xtPY/Gfl7TLarra4+ORbdC1EVOCEBFVRkpWLtYeuobley/jXExaqaNnn+hUF90bSR+DqWWITCpQW6tWLXUtI2P9/f21y2VkoWaUrayTk5ODxMREnVG1sk6XLl1KfV1JnyCXkiTwVNngkwSx9PE6psQY9lnz3tW5HZXd77TsPLy34aSqbqkh+dBeG9AUT3asa7SNljEcb0PgfvN43ytL+xshIjIF52NSMfG7IzgVVZT6TPRuWhNzH2kFb5fb+wdERFQ+J6+nYPm+y/jp8DVk5OTrPObtbIfHOgSp4mCBTGtAZLqB2uDgYBWI3bp1K9q2bauWSVB2586dmDNnjrofGhoKW1tbtc7IkSPVsqioKISHh2Pu3Ln63Bwivdl7MV5NtYtMzNQu697YF7OHhSDAw5GfNBEREZEeyWw7yY84c/0JZOUW5RC3s7HCGw82w9Od67JgGBFRBeTkFWBjeBSW/XUZBy4n3vZ4+3qeeLJTXfRvWQv2Ntb8jIlMIVArxSzOnz+vU0BMilvIFPY6depg0qRJmDVrFho1aqQuctvJyQmjRo1S67u7u2Ps2LGYMmUKvL291fOmTp2KkJAQhIWF6XfvyGjJFGM55sY+1TgrNx8fbD6D//0Zoa1w6WRnjTcfao7HOwSxk0BERNXCVNpNIn1IysjBtDXHsTH8Vv2KRjVd8J/H26KZf8XTnhGRZWCbebu4tGys2HdFpTconsJPM0v04ftqqwBt01r8jSUyuUDtgQMH0LNnT+19Te7Y0aNHY8mSJXj11VeRmZmJ8ePHq/QGHTt2xJYtW+Dqeit357x582BjY6NG1Mq6vXv3Vs+1tuYZG0shFas7d+4MY58K8tLKwzhfLE9Ph3pe+HBEa9TxZlVLIiKqPqbQbhLpw76L8Zi06ohOlfEnOtZRJ8kd7dhXIKK7Y5t5y4nrySq/989Hr6vRtMU19nPBU53qYmjb2nB1sOVXi8hUA7U9evRQU5HulBdyxowZ6nKnM1wLFixQF7JMubm5SEhIUCOqJRWGMZHv9zd/XcZ7v57SNmYy1e6Vvk3wj67BsDbSXLREZHxmz56NNWvW4PTp03B0dFS52CUVUJMmTbTrjBkzBkuXLtV5npzk3Lt3r/Z+dna2mn3y3XffaU9wfv755wgMDKzW/SHDMeZ2k0gfcvMLMH/bWXy+44J2FpOHky3mDG+Ffi2K6mAQEZXr98TC28z8gkJsPRmN//15CX9HJOg8Jl3Zvs1rYcz99dAx2IszRImMECunkEEkJydj3bp16trYpto9v+wg/vXzCW2QtkWAGzZM7IrnutVnkJaI7onkaJ8wYYIKukpu9ry8PPTt2xfp6ek66/Xv31/la9dcfv31V53HJa3Q2rVrsXLlSuzevVulIRo4cCDy83ULP5D5MtZ2k0gfLsamYfjCPfhs+60gbaf6Xtj48gMM0hLRPbPUNjM5Ixdf7rqAbnO34/+WH9IJ0ro52OD5bvWx85We+OKpUHSq780gLZElFBMjMmXSkL288rDOVLt/3B+M1wY0YSJ1IqqQTZs26dxfvHgxatasiYMHD6Jbt27a5fb29qoYZ2mkk7Fo0SIsW7ZMm8t9+fLlCAoKwrZt29CvXz8eHSIySTKLaZUqGHYSmblFJ55srGpgSt8mKqDAWUxERHcnqfqW7InA6oPXtL+lGg18nTHm/mAMv682nOwY/iEyBfxLJYsnU0M+/f08PvntLApujuLwdLJVuWh7N/Oz+M+HiPRHM7JDpuIVt2PHDhXA9fDwQPfu3fHee++p+0KCujKFT0biagQEBKBly5bYs2dPqYFaSZUgF42UlBR1XVBQoC4VIc+ToEpFn2+qjGW/Ne9fmWNoivtd3bjf1Xe8E1XBsHBsOXlDuyzYxxnzH22NkNruEsZFgeYfsyrC4125421pvw9ExkTa6L8uxuOrXRex/UzsbY/3aOKLZ+4PxgMNfWDF1H1EJoWBWrJoCek5eOm7w9h9Pk67TKbazX+0LWq5s7I2Een3H2opwNm1a1cVZNUYMGAARowYgbp16yIiIgJvvfUWevXqpQK0MtI2OjoadnZ28PT01Hk9Pz8/9VhZuXFnzpx52/LY2FhkZd2aNXCvHXIJNMt+WFlZTuYkY9nvpKQkdS0596orUGsM+13duN/Vc7z/vpKCf2++hNj0XO2yh0N88FK3QDjaZiMmJgbVgce7csc7NTVVr8eDiO4uL78Av4ZHqwDt8Wu6qR2c7KzxSGggRnephwa+Lvw4iUwUA7VkEFJ0TorKybWhHL2ahPHfHsK1pEx1X040/jOsMcb3bMipdkSkdy+++CKOHTumcswW9+ijj2pvSwC3Xbt2Kmi7YcMGDBs2rMzXkwBaWb+h06ZNU0Hh4iNqJVWCr68v3NzcKhzQkPeT17C0wJ0x7Le1tbVqN729vdXFUva7unG/q/Z4Z+fl46Mt5/D17gjtMpnF9P6wEPRpXv2zmHi8K3e85TeJyBgZQ19T39Ky81SqmP/tjtD2XzVqezjimfvrYUS7ILg7Wl7xNCJzw0AtGYR0Mp9++mmDffor/76Ct9edQE5+0agkHxc7fDrqPpVUnYhI3yZOnIiff/4Zu3btQmBg4B3X9ff3V4Hac+fOqfuSuzYnJweJiYk6o2plxFmXLl1KfQ0ZiSuXkqRDXplOuXR4KvsapsgY9lsCptXdbhrDfhsC97tqjve5G6l4aeURnIoqSsUiHmjko1JN+bkZLuDH413x421pvw1kOgzd19SnGylZWLLnEr7dexkpWXk6j7Ws7YbnuzXAgy1rwcaaf49E5oKBWrIo2bn5mLE+HKsOXNUuu6+OBz5/IpSpDohI72TUqwRp165dq/LQBgcH3/U58fHxuHr1qgrYitDQUNja2mLr1q0YOXKkWhYVFYXw8HDMnTuXR42IjP53cPney3h3wylk5xWdILeztsJrA5rimS71mDuRiKgUZ6JT8dUfF7HuyDXk5uvm6+7ZxBfPdauPzvW9zWrUMBEVYaCWDEJy7G3ZskUVxylZVKeqRKfk4Nkf9iL82q2RHKM718UbDzWHnQ3PQBKR/k2YMAErVqzAunXr4Orqqs0p6+7uDkdHR6SlpWHGjBkYPny4CsxeunQJ06dPh4+PDx5++GHtumPHjsWUKVPUCBH5zZw6dSpCQkIQFhbGw2YhDNFuElVWXFo2Xv3xGH4/fSvnbGM/F3zyWFs0869YGhYiInNuMw9cSsDnOy7o/G5qTnANbRuAZx+oj8Z+rgbbPiKqegzUkkFITjDJmVhd1WIPXUnEcytPITGjaLqIg60VZg8LwcNt7zwFmYioMhYuXKiue/ToobN88eLFGDNmjMo7evz4cXzzzTeqWJQEa3v27IlVq1apwK7GvHnzYGNjo0bUZmZmonfv3liyZIl6PlmG6m43iSpr+5kYvPLDUcSl5WiXjelSD68PaAoHW/52EVHVMbU2U2Ye7DoXh8+2n8ffEQk6j7k52ODJTnXV72dNA6aJIaLqw0Atmb2fDl/Dqz8eRc7NKSN1vJzwxZOhaB7AkRxEVPX/eN+JjKrdvHnzXV9HCmIsWLBAXYiIjFlWbj7e33ha5VTUkFoAHzzSGj2b1jTothERGZP8gkJsPhGtArQnrt+a9akpEDa2azAebR8EZ3uGbYgsCf/iyWwVFBTi461n8en289plnet7YeGTofBwsjPothERERGZGykU9vLKwzh7I027rFfTmpj7SCv4uNxe4JCIyBLl5BXgpyPX8MXOC7gYm67zWANfZ7zQoyGGtAmALQuEEVkkBmrJLGXk5GHyqqPYdKIoH6QY2tIHcx4Nhb0tv/ZERERE+jw5/r8/IzB30xnk5BdNNba3scKbA5vjyY51WOyGiAhAZk4+Vu2/gi93XcT15CydzySktjsm9GyAvs1rscgikYVjxIoMws3NDQMGDFDX+hadnIVnv9mvLRpmVQN486FmGNDAkWcliYjIJFVlu0lUGTdSsjD1h6P441ycdpkUCvvPY23QiAVviMgAjK3NTMvOw9I9l/C/3RGIT7+Vt1t0qu+F8T0a4oFGPjypRUQKS92TQdjZ2SEoKEhd69OZ6FQM/exPbZDW1d4G/xvTXiVfr1Gjhl7fi4iIyNTbTaLKkNyK/efv0gnSPvdAMH6a0IVBWqpQAc5WrVqp4JpcOnfujI0bN+rkfZ8xYwYCAgJUjncp1HnixAmd18jOzsbEiRPh4+MDZ2dnDB48GJGRkTwaFsZY2szUrFyVf7brnN/xweYzOkHa3k1rYvULnbHy+c7o1tiXfVUi0mKglgwiIyMDBw4cUNf6svdiPB75Yg+iU7K0RcPWjO+CHk1YuIKIiExbVbSbRBWVnp2HaWuOY9yyg0jMyFXL/NzssXxsR7zxUHPY21jzw6V7FhgYiPfff1/91smlV69eGDJkiDYYO3fuXHz88cf49NNPsX//ftSqVQt9+vRBamqq9jUmTZqEtWvXYuXKldi9ezfS0tIwcOBA5Ofn84hYEEO3mRKgXfDbOXSds10FaJNu/k7KTM/BrQOw8eUHsGhMe4TW9TLI9hGRcWPqAzIIaTQPHTqEevXqwcnJqdKv9+vxKExaeUSbF611oLsaSevNwhVERGQG9N1uElXUoSuJmLzqCC7F3wqA9Gvhh/eHtYKnM0d8U8UNGjRI5/57772nRtnu3bsXzZs3x/z58/HGG29g2LBh6vGlS5fCz88PK1aswLhx45CcnIxFixZh2bJlCAsLU+ssX75cjazctm0b+vXrx8NjIQzVZqZl52PV7+fxvz8vITmzKDirCdAObVMbL/ZqiPq+LtW2PURkmhioJZO35M8IzPzlJAoLi+73bOKLz564D052/HoTERER6UNufgEW/H5eTePNLyj6p8vJzhpvD2yOR9sHcdou6ZWMgP3hhx+Qnp6uUiBEREQgOjoaffv21a5jb2+P7t27Y8+ePSpQe/DgQeTm5uqsI2kSWrZsqda5U6BWUibIRSMlpSiNWkFBgbpUhDxP0jVU9Pmmyhj2W/PelTl+9yIlMxeL/4xQAdrU7Fujt62tamBomwCM79EAwT7OOttmLozheFc3S9xnwf0u0MtnWB6MZJHJkh/HOZvO4IudF7TLRoQGYtawEBYNIyIiItKTi7Fp+OeqIzgamaxd1raOB+aNbIN6N4MPRPpw/PhxFZjNysqCi4uLSmMgo2kl0CpkBG1xcv/y5cvqtgRyJSepp6fnbevIY3cye/ZszJw587blsbGxalsq2iGXUb7SZ7GyspyMg8aw30lJSeo6ISGhSoNpqVl5WHUkBisPxSAtp1iAtgbQv5k3xnSohSAPB6AgHTEx6TBHxnC8q5sl7rPgfhdW+ngXT9VzJwzUkknKyy/Aq6uPYc2ha9plL/ZsiCl9G3NEBxEREZEeSCf0231X8N6GU8jMzdeOEHu5dyM1QszG2nI6qFQ9mjRpgiNHjqhA2+rVqzF69Gjs3LlT+3jJ4sDyHb1bweDyrDNt2jRMnjxZZ0StpEzw9fVVhc0qGtSQ95XXsLRgjqH3W/O+Xl5eqrBcVeTpXvLXZXy16yJSsvJ0ArQPt62NCT0boK63ZZzEMobjXd0scZ8F99u30sfbwcGhXOsxUEsGIWe7GzZsWKFKnNl5+Zi44jC2nLyh7sv/Xe8MaYmnOtWtgi0lIiIy7XaTqCJiUrPw+urj+P10jHZZfR9nzHu0DVoHefBDpSr9rRPt2rVTRcM++eQTvPbaa2qZjIz19/e/9T2NidGOspXiYjk5OUhMTNQZVSvrdOnS5Y7vK2kU5FKSdMor0zGXYE5lX8MUGXq/JRgi3yO51uc2ZOXmY8W+K/h8x3nEpeVol9tY1cCw+2rj0RAPtG0UxONtAQz9HTcU7rdVpT6/8n5fGKglg5Az01LJ9V5l5uTj+WUH8Me5OHXfztoK/3m8Dfq3vPUPGxERkbmpaLtJVBFbTkTj9TXHkZB+KxDxZKc6mP5gM9YAoGolo2Eld2xwcLAKxG7duhVt27ZVj0lQVkbbzpkzR90PDQ2Fra2tWmfkyJFqWVRUFMLDwzF37lweOQui7zZTcnT/eDAS//ntHKKSs3SKhA2/LxAv9W6E2h4O6qQAEVFlMVBLBpGXl6eKAzg7O8PGpnxfw9SsXIxdcgB/X0pQ9x1trfHl06F4oJFvFW8tERGR6bWbRPcqLTsP7204jVUHrmqX+bjY44NHWqFn05r8QKlKTZ8+HQMGDFApBySP38qVK7Fjxw5s2rRJjeKaNGkSZs2ahUaNGqmL3HZycsKoUaPU893d3TF27FhMmTIF3t7eatr71KlTERISgrCwMB49C6KvNrOgoBDrj13HvK1ncSk+Q+exga388c8+jdHA1+XmupZVWIqIqg7/0yeDkLxTa9aswbBhw8qVNygxPQdjFv+tLWLham+D/z3THu3reVXD1hIREZlWu0l0r45dT8O735zElYRM7bK+zf0we1gIvF1unxJOpG83btzAU089pUbBStC1VatWKkjbp08f9firr76KzMxMjB8/XqU36NixI7Zs2QJXV1fta8ybN08F5mRErazbu3dvLFmyBNbW1jxgFqSybaaM5N568gY+3noWp6N1i//0bloTk/s2RosAdz1uMRHRLQzUktGLT8vGE1/v0zaSnk62+OYfHRESyMaRiIiIqLJTeudvPYuFOy+goLBombOdNf41uAVGhAaySCtVm0WLFt3xcRlVO2PGDHUpi+QkXbBggboQVcSf5+Mwd/MZHL2apLO8U30vvNKvKULr3sp/TERUFRioJZMK0vq62uPbZzuisd+tM+dEREREdO/Ox6Thn6uO4Pi1ohlLol1dT3w8sg3qeDvxIyUii3HiejLe33haWwtFQ4onvtK3Ce5v6M0TV0RULRioJZMJ0tZyc8B3z3dCsI+zoTeNiIiIyGTJtN5ley9j1q+nkJVblFfR2gqYFNYY43s0hLVUyCEisgCRiRn4eMtZrD1yDYU3ZxWIJn6umNqvCcKa1WSAloiqFQO1ZJSkyjCDtERERET6FZOShVd+PIadZ2O1yxr4OuOtsCB0CwmGFYO0RGQBkjNy8fmO81i85xJy8m4VAqvt4Yip/RpjSOva/D0kIoNgoJYMQpK6P//882UGaUd9tVc7ktbPzZ4jaYmIyKLdqd0kKq9N4VGYtuY4EjNytctGd66LV/s1QWpSPD9IIjL7NjMrNx/L/rqMT7efR3Lmrd9Cd0dbTOzVEE92qgsHWxafIyLDYaCWjO7MZvGRtBKkXfl8Z6Y7ICIiIqqg1KxczFx/Ej8ejNQuq+lqjw9GtEb3xr4oKCiAbl1zIiLzUlBQiJ+PXscHm8/gWlKmdrmdjRWeub8exndvCHcnW4NuIxGRYKCWDCIpKQk7duxAjx494OHhoZalZedh9OK/cSoqRd1nkJaIiKjsdpOoPPZejMfUH44iMvFWYOLBkFp4b2gIPJ3t+CESkdm3mfsuxuPfG04i/FpRP1PUqAEMaxuIyX0bq3QHRETGgoFaMoi8vDzExMSoa80UlOeWHsCRq0nqvo+LPb57joXDiIiISms3ie5G/rf6cPMZLPozQlsgx8XeBjMHt8Cw+2qzOA4RmX2beTUuFdN+uYCN4dE6j3dr7IvX+zdF8wA3g20jEVFZGKglg8vNL8D4bw/hr4vx2vxAy8Z2QH1fF0NvGhEREZHJOR6ZjH9+fwTnY9K0yzoEe+GjEa0R5OVk0G0jIqpq6dlFuWdf+PYQIjNvhTya+bvhjQeboWsjHx4EIjJaDNSSQeUXFOKfq47g99Mx6r6znTWW/qODakSJiIiI6N5Ofn+2/Tw+/f088goKtfkXpVjYP+4PZgVzIjL7vuX3B65iye/HMNyr6DdRM1vzlX6N8UhoEKytahh6M4mI7oiBWjIo6Uz8cixB3ba3scLXo9ujTRBz7xERERHdi/MxqZj8/VEci0zWLgup7Y6PR7ZGIz9XfphEZNb2XIjDO+tPqqLUfna5gBdga22FF3o0wPgeDeDqwEJhRGQaGKglg3BxcUGmT1N8fyAOgBVsrWvgiydD0bmBN48IERFRKe1mz5491TVRyUrmi/dcwtxNp5GdVzR6TEaMvdizIV7s1VAFKoiIzNWluHTM+vUUtpy8oV2WnGeDy/bBWDquHRrU8jTo9hER3Surqkjc/eabbyI4OBiOjo6oX78+3nnnHRQUFP3jKAoLCzFjxgwEBASodaQa44kTJ/S9KWTEfjgcjXl/pyKrwEpV3Jz3aBv0bFrT0JtFRERklBwcHNCoUSN1TaRxNSEDo77ei3//clIbpG3g64w1L3TBP/s0ZpCWiMxWRk4ePth8Gn3n7dIJ0spMgm+eux/vje7DIC0RmSS9B2rnzJmDL774Ap9++ilOnTqFuXPn4oMPPsCCBQu068iyjz/+WK2zf/9+1KpVC3369EFqaqq+N4eM0MbjUZj9yzGEuqXBySof/xrYHANbBRh6s4iI9G727Nlo3749XF1dUbNmTQwdOhRnzpzRWac8Jy+zs7MxceJE+Pj4wNnZGYMHD0ZkZCSPmAXJzMxU3wu5JpLfDcnDOOCTP7D3YlEKKTG2azA2vPQAWjONFBGZ8e/fr8ejEPbRTny2/QJybuahrelqjw9HtMa6CfcjpJYj20wiMll6D9T+9ddfGDJkCB566CHUq1cPjzzyCPr27YsDBw5of1jnz5+PN954A8OGDUPLli2xdOlSZGRkYMWKFfreHDIyey/G4+WVR+BqnY9+PskY28kfY+4PNvRmERFViZ07d2LChAnYu3cvtm7dqmadSJuYnp5+TycvJ02ahLVr12LlypXYvXs30tLSMHDgQOTn5/PIWQj5zvz555863x2yTDGpWXjumwN49cdjSMvOU8tqezhixXMd8dbA5nCwtTb0JhIRVVku7qcW/Y3x3x7C9eQstUxS6Eke2u1Te+CR0EBVNJFtJhGZMr3nqO3atasaUXv27Fk0btwYR48eVZ1KCc6KiIgIREdHq46qhr29Pbp37449e/Zg3Lhxt72mjCSSi0ZKSoq6lnQKxVMq3Ct5rgSOK/MapsaQ+yyJ3aVjoc563uxDPNmxTrVsiyUea8H95vG2BPr6nlfF78OmTZt07i9evFiNrD148CC6det228lLIScv/fz81MlLaROTk5OxaNEiLFu2DGFhYWqd5cuXIygoCNu2bUO/fv30vt1EZLyzkqavPY7EjFztspHtAlWAloVyiMhcyUmp//x2Dv/bHYG8gkLt8m6NfTFjUHPU92X+diIyH3oP1L722muqU9m0aVNYW1ur0T7vvfceHn/8cfW4BGmFdEKLk/uXL18uc+rozJkzb1seGxuLrKyiM2kV7ZTLtkpH2crKMgotGGqfY9NyMHblaaRmFY38aBXgLEuRmJiotqWqWeKxFtxvHm9LoK/veXWk35HtFF5eXuU+eSlB3dzcXJ11JE2CzEiRdUoL1FbFCU6e+DHsiR/NcavsSep7eT+e4DQeKZm5mLH+JH46cl27zNvZDu8Pa4nezYr+p+bghXvH77nxneAkKk7aoZ+PXsd7G04hJvXW/zWBno54e2Bz9GnuhxpS8ISIyIzoPVC7atUqNdJHRgK1aNECR44cUVM2pVM5evRo7Xolf1DlR7isH9lp06Zh8uTJOh1OGUnk6+sLNze3Sv1zIe8pr2MpwTtD7LMken/2h32ISSsa/dEq0B1vDWqATRsuqWCF5FysapZ4rAX3m8fbEujre17VRZqknZO2TGaeSJC1vCcvZR07Ozt4enreto7m+dVxgpMnfgx74icpKUldJyQkVFuglic4jeP/hX2XU/Du1kuIvfl/lOjR0AOv9aoDT6caiImJqfR78HjzxG5FsL4IVaUz0al4a104/o64lYfbzsYKL3RvoFIdMM0LEZkrvQdqX3nlFbz++ut47LHH1P2QkBDV2ZROowRqJfeekM6lv7+/9nnyT2bJjmrx0UVyKUk6TJXtNEnnXh+vY0qqc58LCgox+ftjCL+Wos2htmh0e9gVZCEwMFAd1+r67C3xWAvuN4+3JdDH97yqfxtefPFFHDt2TKUDKuleTl4a6gQnT/wY9sSPtJe1a9dW/yu5u7tX+fvxeBv+RJ+c6H5/4xks33dFu8zVwQYzBzXHkDYBeh1FxuNt+ONdnUzlBCdZJvnt++S3c1j0h26ag7BmfmoUbR1vp7u+hq2trepryjURESw9UCtFwUo2+JICQTP6Izg4WAVrpahK27Zt1bKcnBxVcGXOnDn63hwysDmbT2PLyRvqtou9Df43pj18XSXobo8HH3zQ0JtHRFQtJk6ciJ9//hm7du1SHQeN8py8lHWknZRUMcVH1co6Xbp0qdYTnDzxY7hAjhx7KdRanXi8DXe8D15OwJTvj+JSfIZ22QONfDD3kVbwd3eskvfk8bacQK2pnOAky/P76Rt466cTuJaUqV1W19sJMwa1QM+mNcv9OnJCk31NIjJVeg/UDho0SOWkrVOnjkp9cPjwYVXN+h//+If2nwJJhTBr1iw0atRIXeS2k5MTRo0ape/NIQNatf8K/rvzorptbVUDnz1xH5rUclX3JXAv1c9tbGz4Tx4RmS0Z9SpB2rVr12LHjh3qZGVx5Tl5GRoaqkaEyDojR45Uy6KiohAeHo65c+caYK/IENhuWoas3Hx8vPUsvvrjIjQp/B1srfDGg83wZKe6zMVIRGYpOjkLM9efwMbwWymd7KytML5nA/xf93tPc8A2k4hMmd4DtQsWLMBbb72F8ePHq9E+kptWiqG8/fbb2nVeffVVZGZmqnVkhFDHjh2xZcsWuLoWBfHI9O05H4c31oZr70s1zu6NfbX3JcfemjVrVJXz6shRS0RkCBMmTFA529etW6faOE1OWRnp4ejoWK6Tl7Lu2LFjMWXKFHh7e6vc3lOnTlWphcLCwnhgLQTbTfN3+Eoipv5wFBdi07XL2tbxwMcj2yDYR4qwEhGZl/yCQnzz1yV8tOUs0rKLik6LLg288e7Qlqjv61Kh12WbSUSmTO+BWumIzp8/X13KIh3TGTNmqAuZn6sJGRi/4pA2p9CYLvXwVOd6ht4sIqJqt3DhQnXdo0cPneWLFy/GmDFjyn3yct68eWoGgoyolXV79+6NJUuWqNRCRGT6o2jnbzuHL3ddgCYdoxTMmdKnMZ59oL6alUREZG6ORyZj+trjOH4tWbvM29kObw5shqFtanMGARFZLCYWIr3KzMnH88sOIimjqDJxjya+eGtgc37KRGSxqQ9Ku2iCtMVPXko6g6ysLJX2oGXLlrcVbJEZK/Hx8SoX/Pr161VxMCIybccikzBowW58sfNWkLZ1oDs2TOyKcd0bMEhLFkWKT7dv316dqKxZsyaGDh2KM2fO6Kwj7ae0m8UvnTp10lknOztbpR2SWXvOzs4YPHgwIiMjq3lvqCwyclbSHAz5bLdOkPbxDkH4bUp3PNw2kEFaIrJoeh9RS5ZLgg+vrzmGU1Ep6r5M0/vksbbsZBAREREVk52XjwW/ncfCnRfU1F9ha10Dk8IaY1y3+rCx5lgKsjxyolJSBkmwVmpZvPHGG+jbty9OnjypAq4a/fv3VzNTNOzs7HReR1IKyQnNlStXqpRBkjpo4MCBOHjwIGeiGNj20zF4Y+1xXE/O0i5r4ueK9x5uiXb1vAy6bURExoKBWtKbRbsjsO7IdXXb2c4aXz4VCndHW37CRERERDeFX0tWuWhPR6dqP5OWtd3w4YjWaFrLjZ8TWaxNmzbp3JdgrIyslQBrt27dtMvt7e1VIc7SJCcnY9GiRVi2bJk2j/vy5cvVLJRt27ahX79+VbwXVJqE9Bz8+5eTWHv4mnaZFEp8ubekeAmGLU9OERFpMVBLeiseNnvjae39j0a2RiO/sovDSTGcp556Sv2jRURERHfGdtP05eQV4LPt59VFk8ffxqoGXurdCC/0aMBABVEpQVfN719xO3bsUAFcDw8PdO/eHe+99566LySom5ubq0biakhxa0kptGfPnjIDtZIuQS4aKSlFMwQLCgrUpSLkeTLjsKLPN1XF91uuNxyPxsz1JxGfnqNdp2tDb7w3tCWCvJy0z9En+W488cQTqq9ZXZ8/j7flfM95rC3nWOv7eJf3NRiopUqLTMzAi98d1k7de7FnQ/Rv6X/H51hZWamK50RERHR3bDdN28nrKWoU7cmb6aFEM383fDSiNZoHcBQtUUnSKZ48eTK6du2qk7d9wIABGDFiBOrWrYuIiAi89dZb6NWrlwrQSlAuOjpapULw9PTUeT0/Pz/12J3y486cOfO25bGxsSp/fEU75BJsln2R33BLodnvmNRsfLgjEn9cvJWH1tXeGi93C8RDzb1RIy8NMTFpVbotqam3Zi5UNUs/3pa035a4z4L7XVjp413e3yQGaqnSOdbGf3tITWfRFA/7Z5/Gd32enKWWs9pdunSBmxs7KERERGw3zU9ufgEW7riA//x2TjuK1tqqBib0bKhObNvZWE4Hj+hevPjiizh27Bh2796ts/zRRx/V3pYAbrt27VTQdsOGDRg2bFiZrycBFSk8VpZp06apwHDxvoqkS/D19a1wX0WCGvKe8hqWFMzJy8vHuvB4fPbnGVU4TKN/Cz/MHNwCvq5VP6NSjt/evXtVobnq6mta6vG2xP22xH0W3G/fSh9vKRBdHgzUUqW8v/E0jkUWnSWt6+2ETx4tX/GwnJwcXLlyRf1zRURERGw3zc2Z6FRM+eEIwq+l6BTNkfRQLWu7G3TbiIzZxIkT8fPPP2PXrl0IDAy847r+/v4qUHvu3Dl1X3LXSj8jMTFRZ1RtTEyMGiBSFhmNW1pKNumUV6ZjLsGcyr6GKbkUl47XVx/D3ogE7TIfF3v8e0gLDAi584xLfZJidJq+ZnV+9pZ2vC15vy1xnwX326pSn195vy8M1FKFbQqPxuI/L6nbMiLks1H3wd2JxcOIiIjIcuXlF+C/uy7ik23nkJNflItMTmK/0L0BJvZuCHsba0NvIpFRklGvEqRdu3atykMbHBx81+fEx8fj6tWrKmArQkNDYWtri61bt2LkyJFqWVRUFMLDwzF37twq3wdLJSnwFv8ZgQ82n0F23q0cjCNCA/HmQ83ZRyQiugcM1FKFXE3IwKs/HtXef2tgc44OISIiIlj6KFr5/+jozdlGolFNF3w4ojVaB3kYdNuIjN2ECROwYsUKrFu3Dq6urtqcsu7u7qq2RVpaGmbMmIHhw4erwOylS5cwffp0+Pj44OGHH9auO3bsWEyZMgXe3t6qENnUqVMREhKCsLAwA++hebocn65ycO+/lKhd5u9mh/eHt0b3JkVF3oiIqPwYqKUKVS1+ccUhpGQV5Rx6KMQfT3asw0+SiIiILDoX7YLfzyE3vygXrWSCer5bA0wKawQHW46iJbqbhQsXqusePXroLF+8eDHGjBkDa2trHD9+HN988w2SkpJUsLZnz55YtWqVCuxqzJs3DzY2NmpEbWZmJnr37o0lS5ao55P+FBQU4tt9lzHr19PIzM1XyyQN8OhOdfF0W0/UC/Thx01EVAEM1NI9m7PptHakiOSlnT085I7J+Uvj5OSkkrvLNREREbHdNFXh15Lxyo/HcCrqVi7aBr7O+GBEa9xXR7fyPBHdOfXBncio2s2bN5erWMuCBQvUharGtaRMNXvgz/Px2mVBXo748JHWaF/PU+UENiT2NYnIlDFQS/dk68kbWLQ7Qt22sy7KS+vmYFuhxrNVq1b89ImIiNhumqSs3Hw1gvaLnRdVfkZNLtpx3erjpd4cRUtE5hlM/+FAJN755STSsotmV4onOtbB9AebwdneRlWGNzT2NYnIlDFQS+V2IyULrxTLS/vmwGYVzkubnZ2Na9euoXbt2qVWWCUiIiK2m8bq0JVEvPrjMZyPSdMua1rLVeWirej/RkRExt4XfH31MWw/E6td5u/ugDnDW6FbY18YE/Y1iciUWRl6A8h0chBJkvikjFx1v18LPzzVqW6FXy81NRXbtm1T10RERMR20xRk5uTj3V9OYvjCPdogra11DfwzrDF+frErg7REZJZ+OXYdfeft0gnSPhIaiE2TuhldkFawr0lEpowjaqlcvvnrEv44F6du13S1x/vDWt1zXloiIiIiU7X3YjxeW30Ml+MztMtaBbpj7iOt0LSWm0G3jYioKqRm5WLGzyex+lCkdpmv6guGoHczP37oRERVgIFauqtzN1Ixe+Np7X2Z1ufpbMdPjoiIiMye5GF8f+MpLN97RbvMzsYKk/s0xrNdg2FjzQlqRGR+Dl5OwKRVR3A1IVO77KFW/nh3SEv2BYmIqhADtXRHOXkFeHnlEWTnFSWFf+b+ekY5vYWIiIhI33adjcW0NcdVhXON0LqeahRtA18XfuBEZHby8guw4PfzqljizTqJcLG3wTtDWuDhtrU5q5KIqIoxUEt39PHWszgZlaJuN/ZzwWv9m+rlE7O2toa3t7e6JiIiIrabxiQlMxezNp7G9wduTfd1tLXGq/2b4OnO9WBtxfRPRGR+Lsenq1G0h68k6Zycmv9oGwR5OcFUsK9JRKaMgVq6Yy62/+66oG7bWVth/qNt4WCrn8Cqp6cnhg8fzk+fiIiI7aZR2XUhCR/uCEdMarZ2Wef63qqyeR1v0wlUEBHdi9UHI/H2unCk5+Sr+3JC6uXejTC+RwOTS/HCviYRmTIGaqlU6dl5mPrDURTenO4ytV9jNA9goQwiIiIyTzGpWZj58wlsOB6tXSbTfac/2AyPdwjidF8iMksZOXl466cTOgXD6no7qVG0bet4GnTbiIgskWmdGqNqM3vjKUQmFuVj6xjshWe71tfr68fFxeHrr79W10RERMR201AKCwvx/f6rCPtop06QtkcTX2z5ZzeM6liHQVoiMktnolMx+NM/dYK0I0IDseGlB0w6SMu+JhGZMo6opdvsOR+nrWzsZGeNDx5pDasqyMVWUFBUoIyIiIjYbhrCpbh0TF97HHsuxGuXuTtY4+1BLTDsvkAGaInIbE9Qrdp/Ff/6+YS2aLSznTVmDQvBkDa1YQ7Y1yQiU8VALd2W8uDV1ce0918f0JT52IiIiMjsqpp/vTsC87ae1QYpxNA2ARjXwQdN6rGyORGZp7TsPLyx9jjWHbmuXdbM3w2fjWqL+r4uBt02IiJioJbukPKgU30vPNmxLj8jIiIiMhvh15Lx2upjOHE9Rbustocj3nu4Jbo18kFMTIxBt4+IqKqcu5GKccsP4mJsunbZk53q4M2HmuutaDQREVUOR9RSqSkPHG2tMXd41aQ8ICIiIqpumTn5mLftLL7+4yIKbhZLrVEDeKZLMKb0bQxnextOlSUis7XxeJQqFp2ek68tlvj+8BAMbBVg6E0jIqJiGKglg6Q88PDwwCOPPAI3NzceASIiIrabVWr3uTiVi/ZKQoZ2WdNarpg9LMSkC+YQEd1NfkEhPtxyBgt3XND5/fviyVDU83E2yw+QfU0iMmVWht4AMg5zNp3WpjzoGOyFpzpVbcoDGxsbeHl5qWsiInO1a9cuDBo0CAEBAaoo0U8//aTz+JgxY9Ty4pdOnTrprJOdnY2JEyfCx8cHzs7OGDx4MCIjb1VnJsvAdrNiEtNz1AiyJxft0wZp7Wys8Eq/Jlg/sSuDtERk9r+BYxb/rROkHdImAGvH32+2QVrBNpOITBkDtYSDlxOxbO/lWykPHmlV5SkPUlNTsXPnTnVNRGSu0tPT0bp1a3z66adlrtO/f39ERUVpL7/++qvO45MmTcLatWuxcuVK7N69G2lpaRg4cCDy84umLpJlYLt57xXNfz56HX3m7cSPB2+d2OgQ7IWNLz+ACT0bwtaa/wYTkfk6H5OKwZ/txh/n4tR9a6saeHtgc8x/tA0c7cw7Hy3bTCIyZRzOaOFy8gowbc0xFN7M1SY52up6V/3ZVRkhdubMGbRo0QKurq5V/n5ERIYwYMAAdbkTe3t71KpVq9THkpOTsWjRIixbtgxhYWFq2fLlyxEUFIRt27ahX79+VbLdZHzYbpbf1YQMvL0uHNvPxGqXuTrYYPqDzfBouyDm3ycii0j38sK3B5Galafu+7jY4dNR96FTfW9YAraZRGTKOJTAwn256wLO3khTt0Nqu2NMl3qG3iQiIouyY8cO1KxZE40bN8Zzzz2nU3H+4MGDyM3NRd++fbXLJI1Cy5YtsWfPHgNtMZFxys0vwBc7L6hRtMWDtP1b1MK2yd3xeIc6DNISkdn77u8rGL34b22Qtrm/m0r1YilBWiIiU8cRtRbsYmwa/vP7ee1UGCmoYcNpgERE1UZG244YMQJ169ZFREQE3nrrLfTq1UsFaGWkbXR0NOzs7ODpqVvsyM/PTz12p5EkctFISUlR1wUFBRWuai/Pk+nkFX2+qTKW/da8f2WOoSnu972kcXpz3Qmcib6VUsnPzR7/Gtgc/VsWjVgvz76Y2n7rC/ebx7ui3xsyrqJhUnfky10XtcvCmvnhk8fawNme3X4iIlPBX2wLJZ2QaWuOq9QHYmzXYLSs7W7ozSIisiiPPvqo9raMkm3Xrp0K2m7YsAHDhg2742+4FB4ry+zZszFz5szblsfGxiIrK6vCHXJJxSDvbWVlORNyjGW/k5KS1HVCQkK1BWqNYb/vJiUrD5/vvoafwotyMAr5y3ikjS/+r3NtONtb6YxSN5f91jfuN493RbDWhPHIys3HpJVHsOnErZO4z3YNxrQHm6kBOUREZDoYqLVQPxyMxL6IBHU7yMsRk8IaVev7Ozo6ok2bNuqaiIiK+Pv7q0DtuXPn1H3JXZuTk4PExESdUbUSeOrSpUuZH9u0adMwefJknRG1ktfW19cXbm5uFQ7kSHBYXsPSAljGsN/Ozs6qMF3t2rXVbUvZ7zsXC4vCuxtOIT49R7u8ZYAb3h3aEq0C3c1yv6sK95vHuyIcHBz0/l2ke5eWnYfnvzmAPRfi1X0JzL4zpAWe6FjXYj9O9jWJyJQxUGuB4tNzMXvjGe39d4eGwMmuer8K0sns0KFDtb4nEZGxi4+Px9WrV1XAVoSGhsLW1hZbt27FyJEj1bKoqCiEh4dj7ty5Zb6OpE2QS0kSeKpM8EkCWJV9DVNkDPsthTc7duxocftdmktx6Xjzp3DsPn9rFK2znTWm9G2CpzvXrXQaJ2Pd76rG/ebxvleW9jdijBLTczBm8d84Gpms7jvZWWPhk6Ho3tgXlox9TSIyZVXSul67dg1PPvkkvL294eTkpEZOSr694qMgZsyYoQqiyNmuHj164MSJE1WxKVSK+TuvIjkzV90e2ibAIA25jBC7fv26uiYiMldpaWk4cuSIugjJQyu3r1y5oh6bOnUq/vrrL1y6dEkVFRs0aBB8fHzw8MMPq/Xd3d0xduxYTJkyBb/99hsOHz6s2teQkBCEhYUZeO+oOrHdBLLz8vGf386h7/xdOkFaVSxsSnf8o2swc+0TmTBJ29O+fXt1YkqKbA4dOhRnztwaXFLefqTkaJ84caJqTyVgN3jwYERGRsLcRCdnYeR//9IGad0dbbH82Y4WH6QVbDOJyJTpPVAr0zPvv/9+NQJo48aNOHnyJD766CN4eHho15FRQB9//DE+/fRT7N+/X03t7NOnD/McVYPtZ2Kw9Wyiuu3hZIu3BjaHIcg03F9++UVb4IaIyBwdOHAAbdu2VRch6Qjk9ttvvw1ra2scP34cQ4YMQePGjTF69Gh1LYFb6aRqzJs3T3VWZUSttK9yAnT9+vXq+WQ5LL3d3HsxHgM++QMfbz2rza9f28MRi0a3wxdPhcLfnamUiEzdzp07MWHCBOzdu1fNJMnLy0Pfvn2Rnp5+T/3ISZMmYe3atVi5ciV2796tTowOHDgQ+fn5MBcxqVkY9dVenItJU/d9Xe2xalwn3FdHt/iopbL0NpOITJve57vPmTNH5cFbvHixdlm9evV0zoLOnz8fb7zxhrZQytKlS1UF6xUrVmDcuHH63iS6KTMnH//6+aT283jzoebwdrl9aiwREemHjPSRdq8smzdvLlcOwAULFqgLkaWJT8vG7I2n8ePBW6PhJP+iFEGV/PrVnbqJiKrOpk2bdO5Lf1JG1srMzG7dupWrHynFABctWoRly5ZpZ54sX75c9U+3bduGfv36mcXv4hNf7cPFuHRtvZFvx3ZCHW8nQ28aERHpgd7/u/35559VAzhixAh1VlSKXowfPx7PPfecdtpndHS0OjuqIXn0unfvjj179pQaqJXpK3LR0JwZk8IHlal8LM+VBr86qicbg09/P4fIxEx1u3N9Lzzcxt9g+65538oew3t5P0s61hrcbx5vS6Cv77ml/T4QGbP8gkJ89/cVfLD5jDZdk2gT5IFZD4egeUDFiuIRkemQoKvw8vIqdz9Sgrq5ubk660iahJYtW6p1ygrUVkV/syr+D0/KyMFTi/7WjqQN8HDAirEdUdvTwWj+jzGG/kd19zWNZb8NwRL32xL3WXC/C/TyGRokUHvx4kUsXLhQTe+cPn06/v77b7z00kuqEX366adV4yrkzGdxcv/y5ctl5iuaOXPmbctjY2ORlZVVqQ9J/gGQPzJzT4Z/OSEL/911Ud22sQJeut9PfX6GkpSUpK4TEhKqLVBrKce6OO43j7cl0Nf3vPi0SSIynKNXk/DWunAcu5l3Ubg62OC1/k0xqkMdWFnV4OEhMnPSpkt/smvXrirIKsrTj5R17Ozs4Onpeds6mudXV39T3/+Hp+fkY+Lqszh5I0Pd93WxxX+GNoRtbipiYoznfxhj6H9Ud1/TWPbbECxxvy1xnwX3u7DSx7u8/U2bqjh47dq1w6xZs9R9ycUnCd4leCuB2uKVZYuTL3nJZRrTpk1TDXXxM5wyfcXX1xdubm6V2lZ5T3kdc/4DU//orN+PvIKi6bdPhPqhfZM6Bt1nGxsblWdRkvxrzpJXJUs51iVxv3m8LYG+vueSYoDIWMl3W4rimHMbJtXL524+g5X7r6B4xpBhbWvj9QeboqYr/0aJLMWLL76IY8eOqRyzJd1LP7K861RFf1Of/4fn5hfg1W8OaoO0Pi52+O65jqjv6wJjYwz9j+ruaxrLfhuCJe63Je6z4H77Vvp4l7e/qfdArb+/P5o31y1Q1axZM6xevVrdloTvQs5oyroaMTExt50d1ZDRuHIpST6kyn5Q8gemj9cxZuuPXseeC/HawhvPdAgw+D5LoymVy6uTJRzr0nC/ebwtgT6+55b220CmRTqaTzzxBMxRQUEhVh24ijmbTiMp41aagyZ+rnhnSAt0rO9t0O0jouo1ceJElU5v165dCAwM1C4vTz9S1snJyVEFrouPqpV1unTpUuZ7VlV/Ux//n0iQWeqM7DoXp+67O9ri22c7oaHfrcKjxsbQ/Q9D9DWNYb8NxRL32xL3WXC/rSr1+ZX3+6L3b5VUpD5z5ozOsrNnz6Ju3brqdnBwsGpApZKnhjSmks/2To0nVUxqVi7+/cutAmIzBjWDg61l/ZgQERGRcToemYyHF+7BtDXHtUFaF3sbvPlQM/zyUlcGaYksiAQkZSTtmjVr8Pvvv6t+Y3Hl6UeGhobC1tZWZ52oqCiEh4ebbF9z4c4LWLn/qrptZ22Fr55uhya1jDdIS0RElaP3EbX//Oc/VSMoqQ9GjhypctR++eWX6qKJwE+aNEk93qhRI3WR2zI1YdSoUfreHIs3b+s5xKQWJcYPa1YTvZv5qTPKhib5gjZu3IgBAwZU23QUIiIiU2Vu7WZyRi4+2HIa3+7TTXMwuHUA3nioGfzcmOaAyNJMmDABK1aswLp16+Dq6qrNKevu7g5HR8dy9SNl3bFjx2LKlCnw9vZWv5dTp05FSEgIwsLCYGp2nY1VRRU1PhzZGh2CTb8NqGrm1mYSkWXRe6C2ffv2WLt2rcrz884776gzn/Pnz9eZrvfqq68iMzMT48ePV9NSOnbsiC1btqgGmfTn5PUULP3rkroto2j/NaiFUeU3SU9Pt7hKiURERJbcbkqagx8PReL9jaeRkJ6jXd6wpotKc9ClgY9Bt4+IDEdqmogePXroLF+8eDHGjBlT7n7kvHnzVI5SGTQk6/bu3RtLliyBtbU1TElkYgZeXnlYezLrn2GN1cksspw2k4gsk94DtWLgwIHqUhY5Gzpjxgx1oarrCEnF5PybBcQm9mqEIC8nNlZERERkEEevJmHG+hM4fKWoGrdwsrPGpLBGGNMlGHY2TM1EZOmpD+6mPP1IKdayYMECdTFV2Xn5GP/tISTeTAnTu2lNTOzV0NCbRUREphqoJcP78WAkDl5OVLfr+zjj2Qd0czwRERERVYfY1GzM3XQaPxyM1Fn+UCt/lYvW392RB4KIqET6umORyep2HS8nfDyyDaysavAzIiKyAAzUmqHE9BzM3nhKe/+dIS1hb2NaU32IiIjItOXkFWDJngj857fzSMvO0y5v4OuMGYNb4IFGvgbdPiIiY3ToSiK+3HVB3ba1roHPn7gP7k62ht4sIiKqJgzUmqG5m89op8kMbOWPro2ML9+bm5ubSo8h10RERGRe7eb20zH49y8ncTEuXbvM1cEGk8Ia4+nOdWFrzTQHREQlZebkY+r3R3Eze536zWxZ250flJm3mURExTFQa2YOX0nEyv1X1G0Xexu8NbA5jJGdnR0CApgMn4iIyJzazYuxaSpAu/1MrHZZjRrAY+2DMKVvE/i42Bt0+4iIjNlHW85oT3C1DvLAuG71Db1JJslU2kwiotIwUGtGpHDYmz+F36oM2qcx/NwcYIykCueJEyfQokULODs7G3pziIiIjJqxt5upWblY8Pt5LP4zArn5twoCtavrqdIccEQYEdGdnY9JxeI9l9RtexsrfDSiNWw4+8As20wiojthoNaMLN97GSeup6jbTWu5YnTnujBWmZmZOHLkCOrXr8/Gk4iIyETbzYKCQvx4KBJzN51BXFq2dnktNwdMe7ApBrcOUFXaiYjozt7dcEoNvBHjezREw5ou/MjMrM0kIioPBmrNqKLyh1vOaO+/O7Qlz8ASERFRlTlwKUGlOTh6szK5sLOxUlN1X+jRAE52/DeTiKg8tp+JwY6bKWMC3B3wPFMeEBFZLP4HbSZmbzyF1KyiisojQgPRrp6XoTeJiIiIzNDl+HS8v/E0NoZH6yzv36IW3nioGYK8nAy2bUREpiY3vwDv/nJSe/+1AU3haGdt0G0iIiLDYaDWDPwdkYA1h66p224ONnh9QFNDbxIRERGZmeQMyUN7Dkv/uqSTh7aJnyveHtQc9zf0Mej2ERGZojWHInEhtqiA2H11PFTKGCIislwM1JrBGdi3fgrX3n+lf1N4m0BFZXt7ezRp0kRdExERkfG2mzl5BSoP/n9+P4ekjFztch8XO0zu0wQj2wUy3RIRUQXk5Rfgs+0XtPdlVgLzelce+5pEZMoYqDVxS/dcwpkbqep2q0B3jOpQB6bA1dUV3bt3N/RmEBERmQRDtJuFhYXYcvIG5mw6g4i4otFemmrkzz1QH//XowFc7PmvJBFRRf1yLApXEjLU7fsbeiO0LtPX6QP7mkRkyvjftQm7kZKF+dvOqdtSUPnfQ1rC2so0Kivn5eUhJSUFbm5usLHh15CIiMiY2s3j15Ix46ezOHwtTWf5w21r45V+TRDg4Vjl20BEZM7kZNii3RHa+xN7NTLo9pgT9jWJyJRZGXoDqOLe23AKadlFBcQea18HrYM8TObjTEpKwo8//qiuiYiIyDjazWtJmZi86giGfLZHJ0jbIdgLP794P+Y92oZBWiIiPTh0JVGdFBMhtd3RMZijafWFfU0iMmUcymii9pyPw89Hr6vbnk62eLVfE0NvEhEREZmoxPQcfLb9PL7Ze1nlpNWo6+2E6Q82Q9/mfsybSESkR0v2XNbeHtOlHn9jiYhIYaDWBEkH6q11twqIvda/KTyd7Qy6TURERGR6MnLysPjPS/hixwWk3pylI9wdbfGPDn4Y17sFHOz47yIRkT4lZ+Ric3i0uu3lbIeBrf35ARMRkcL/vE3Q//6MwIXYoqIebet4YGS7IENvEhEREZmQ3PwCfH/gqsp1H5uarVMo7Jn7gzGuWzCyUxNhZ8MsWURE+rb+2HXk5BfNXhjapjbsbaz5IRMRkcJArYm5npSJT24WELO6WUDMykQKiJVkZcXOHxERUXW2m1K85tfj0fhwyxlExKXfeu0awKPtg/By78ao5e6AgoICxKTy2BARVYXVhyK1t4eH1uaHXAXY1yQiU8VArYn59y8nkZmbr24/2akuWtZ2hyny8fHBs88+a+jNICIisph2U/Lbz9l0Gkcji4rXaPRvUQtT+zVBw5ouldxKIiK6m8jEDBy+UlQYsmktV7QIMM3+nDFjX5OITBmHNJqQnWdjsfFmLiMfFztM6csCYkRExmzXrl0YNGgQAgICVJGQn3766bbRjTNmzFCPOzo6okePHjhx4oTOOtnZ2Zg4caLqdDg7O2Pw4MGIjLw1Eofobg5eTsCor/Zi1Nf7dIK0UmF8zfgu+OKpUAZpiYiqydaTN7S3B7ZibloiItLFQK2JyM7Lx4yfb3Xepw1opgp9mKrExESsXr1aXRMRmav09HS0bt0an376aamPz507Fx9//LF6fP/+/ahVqxb69OmD1NRbc84nTZqEtWvXYuXKldi9ezfS0tIwcOBA5OcXza4gy1CRdvNYZBLGLP4bwxf+hT0X4rXLZQTX4mfaY+XznXBfHc8q2mIiIirN5hNFA29E3xa1+CFVAfY1iciUMfWBifh8+wVtLrn29Twx7D7TzmUkAYb4+HgGGojIrA0YMEBdSiOjaefPn4833ngDw4YNU8uWLl0KPz8/rFixAuPGjUNycjIWLVqEZcuWISwsTK2zfPlyBAUFYdu2bejXr1+17g+ZRrt5KioFH289qzNqS9TzdsLLYY0wpHVtk81vT0RkyhLTc/B3RIL2N7kRU85UCfY1iciUMVBrAs7HpGHhjgvqto1VDfx7aEs1hZaIiExXREQEoqOj0bdvX+0ye3t7dO/eHXv27FGB2oMHDyI3N1dnHUmT0LJlS7VOWYFaSZcgF42UlBR1LQWi5FIR8jwJLlf0+abKWPZb8/53Ooby/8Inv53DhuO3RmuJ2h6OmNirAYa1rQ0ba5lMJftTaBL7Xd243zzelkBf33NL+33Qhz/Ox0Hz8yujadmnIyKikhioNXLyT9Qba48jJ7/oH6HnutVH01puht4sIiKqJAnSChlBW5zcv3z5snYdOzs7eHp63raO5vmlmT17NmbOnHnb8tjYWGRlZVW4Qy4jfKVdsqRKysay30lJRYVnEhISbguORCZlY9G+69h8OkEbABC+zrYY08Efg1t6w9baCgnxcSa339WN+83jbQn09T0vnqaHyuevYmloujb04cdGRES3YaDWyP1wMBL7bk6PqePlhJd6NTL0JhERkR6VHE0jHee7jbC52zrTpk3D5MmTdUbUSroEX19fuLm5VbhjL+8pr2FpgTtj2G/Ne3t5eanCcuKCzLjZeRHrjl5HfrEIrbezHV7oUR+jOtSBg621Se93deN+83hbAn19zx0cHFAVRTg/+OADNaMkKipK5WgfOnSo9vExY8aoNEHFdezYEXv37tXelxklU6dOxXfffYfMzEz07t0bn3/+OQIDA2Foey8WBWptrWugXT3mCCciotsxUGvE4tOyMevXU9r77w5tCUe7inW4jI2rq6vKtyjXRESWSAqHCRkZ6+9/q+pzTEyMdpStrJOTk6OKYhQfVSvrdOnSpczXlhQKcilJOuSV6ZRLx76yr2GKjGG/3d3dVbsp12dupOHT7efx6/EoFBYbQevhZItx3RpgdJe6cLKzMYv9NgTuN4+3JdDH97wqfhs0RTifeeYZDB8+vNR1+vfvj8WLF2vvy8yT4qQI5/r161URTm9vb0yZMkUV4ZTgr7W14fpS0clZ2pojrQM99PI7TaVjX5OITBlbByP23oZTSMrIVbeHtAlAt8a+MBcSQKhfv76hN4OIyGCCg4NVIHbr1q1o27atWiZB2Z07d2LOnDnqfmhoKGxtbdU6I0eOVMtkhFF4eDjmzp3Lo2dBpN1Ms/PCi6uO31YkTAK0/7g/GM/cXw+uDrYG20Yioqoswln891BzsrMkYy7C+dfFW+lnOjfwNth2WAL2NYnIlDFQa6T+PB+HNYevqdtuDjZ486HmMCcZGRk4f/48GjZsCCcnJ0NvDhFRlUhLS1O/dcULiB05ckRNX69Tp44a9TNr1iw0atRIXeS2/CaOGjVKrS+jJ8eOHatGA8moIHmeTOcMCQnRdkDJ/B28nICF204hJeYqTqRJm1k0IszHxQ7PPlAfT3aqCxd7/ktHRJZhx44dqFmzJjw8PFQBzvfee0/dF8ZchPPQ5UTtY+3reZptMTZjKMoofc0LFy6gQYMG1dbXNIb9NgRL3G9L3GfB/S7Qy2dYHvyv3ghl5earAmIa0x9sBl/X26ewmjJpPCWXlPzjxEAtEZmrAwcOoGfPntr7mryxo0ePxpIlS/Dqq6+q/Hnjx49X6Q0kz96WLVt00sLMmzcPNjY2akStJteePNeQ0zep6kkHQIrOLPj9PP66GA8/uxyMDUzB5Ux7uDo7Y1z3+nisfR2zSYlERFQeMtp2xIgRqFu3rjr5+dZbb6FXr14qQCujKI25COeRy7cKifnb5ag0RubIGIoySgHOffv2qe+EBPQtZb8NwRL32xL3WXC/Cyt9vMtbhJOBWiP08dazuBSfoT3bOrJdkKE3iYiIKqBHjx7qn7g75QicMWOGutypWMuCBQvUhcxfXn4BNoZH48tdF3H8WvJtj0/o2RCPPtAc9jYM0BKR5Xn00Ue1t2WUbLt27VTQdsOGDRg2bJjRFuEsRA2cizusltfxckSDOgEwV8ZQlLG0ApyWsN+GYIn7bYn7LLjfvpU+3uUtwslArZE5fCURX/9xUd22s7HC7GEhsLK6c/VvIiIiMm0ZOXn44UAkvt59EVcTMnUeC/ZxxvMd6iL1dCweDPFnkJaI6CYpximB2nPnzhl1Ec7zsenIyi2a8hpS28PsgzuGLsqoed/q3gZD77ehWOJ+W+I+C+63VaU+v/J+XxioNSLZefl49cdjKLg5+GpSWCM0rHlr+isRERGZl/i0bCz96zKW/XUJiTcLiGq0rO2G57s1wEMh/khMiMea0wbbTCIioxQfH4+rV6+qgK0xF+EMLzZDokXtio3QJSIiy8BArRH5z2/ncC4mTd1uFeiO5x+oD3MluaOkkI5cExERWZqIuHQs2n1RjaLNztMtLNCtsS/GdauPLg28tVN12W4SkaUX4ZSLpAoaPny4CsxeunQJ06dPV1PbH374YaMuwhl+rag4mWgZ4G6w7bAUbDOJyJQxUGskjkcm44udRSkPbK1rYO4jrWBjbb7D6CXXU//+/Q29GURERNWmoKAQf5yPw5I/I7D9TKzOY9ZWNTC4dQCee6A+mgfcPtqK7SYRWXoRzoULF+L48eP45ptvVLEoCdbKuqtWrTL6Ipynom4FaluU8htP+sU2k4hMGQO1RiArNx9TfziK/Js5D17s2QhNa7mZfSLq7OxslQvK0vK6EBGRZUnLzsOaQ5FYsucSLsam6zzmZGeNxzvUwT+6BqO2h2OZr8F2k4gswd2KcG7evPmur2GMRTgvxxf99ns42cLb5fZcuKRfbDOJyJQxUGsEPtx8BmdupKrbzfzdML5nA5i7hIQErFmzRlVnra5KnERERNXdMV+65zJ+OHAVqdl5Oo9JUPbpznXxWPs6cHeyvetrsd0kIjLdOiRRKVnqdl0vJ0NvjkVgm0lEpqzKhzLOnj1b5VebNGmSdpmcJZX8QgEBAXB0dFRnTk+cOAFL9Of5OHy9O0LdtrOxwrxHW8PWjFMeEBERmTOZHbP9dAzGLtmPHh/uwP/+jNAJ0naq74UvngzFzld6YFz3BuUK0hIRkemKTMiEZpBwHW9nQ28OERFZ8oja/fv348svv0SrVq10lkvFzY8//ljlCmrcuDHeffdd9OnTB2fOnNHJL2TukjJyMOX7o9r7r/VvavYpD4iIiMxRdHIWVu2/ilX7r+B6ctHIKQ17Gys83LY2Rnepp2bOEBGR5bickKG9zRG1RERksECtVOx84okn8NVXX6lAbPHRtPPnz8cbb7yhpr2LpUuXws/PDytWrMC4ceNgCeRzeGNtOKJvToPp2tAHz3SpZ+jNIiIionKS0bM7z8Zgxb6r+P30DdxMNa/l7+6Ap26mN/BytuPnSkRkgS7HFwvUejP1ARERGShQO2HCBDz00EMICwvTCdRGREQgOjoaffv21S6TglLdu3fHnj17Sg3UStEpuWikpKRok4TLpaLkuRIwrcxrVNSPByOx4XiUuu3haIu5w0MkfKsqQlclQ+5zye3QXFfHthjLflc37jePtyXQ1/fc0n4fqHK5Z1cfuoYfD1y9bfRsjRpAzyY1VYGwnk18YcN0RkREFu1K8RG1TH1ARESGCNSuXLkShw4dUqkPSpIgrZARtMXJ/cuXL5eZ53bmzJm3LY+NjUVWlm4H6V475cnJyaqDb2VVfXlhz8Vm4K2fTmvvv9orCFbZKYiJKQpAVyVD7XNJ8v4DBgxAfn4+YmJiLGa/qxv3m8fbEujre56aWlTUkag0KVm52BR+A6sPRWL/pcTbHq/l5oCR7YPwaPsgVShM37y8vDBmzBjY2LAOLBGRyaY+4IjaasE2k4hMmd7/27969SpefvllbNmyBQ4ODmWuJwXGipMOdsllGtOmTcPkyZN1RtQGBQXB19cXbm5ulercy3vK61RX8E46em8uO4Xs/KKRs4+3D8Jj9zdBdTHEPhsD7jePtyXg97xy3/M7tVlkuakNdp2NxYo9F7HrYjKy8woMNnpWvtt2dkyfQERkqqkPHGytUNPV3tCbYxHYZhKRKdN7oPbgwYNqhGRoaKh2mYya3LVrFz799FNVMEwzstbf31+7jjyn5Cjb4qkR5FLaD3Blg40StNTH65SHBKNf/fG4trFuWdsN/xrcotoDptW5z2WR0W9//vkn7r//fri7u1vMfhsC95vH2xLo43tuab8NVDpJQXToSiJ+ORaFX49HISb1VuoljYY1XTD8vkBVIKyWu4PZtptERFT5/t+1pEx1O8jTqcyBSaRfbDOJyJTpPVDbu3dvHD9+XGfZM888g6ZNm+K1115D/fr1UatWLWzduhVt27ZVj+fk5GDnzp2YM2cOzNlXf1zElpM31G13R1ssfCIUDrbWsES5ubmIjIxU10RERIbuSB+NTMYvR6+r4GzJvLPC08kWg1sHYHhoIEJqu1d7Z5vtJhGR6cnIKUDOzdkYvhxNW23YZhKRKdN7oNbV1RUtW7bUWebs7Axvb2/t8kmTJmHWrFlo1KiRushtJycnjBo1CuZq97k4zNlUNJpYzHu0NYK8WPWTiIjIUCNnj11LxqbwaGw4fh1XE4pGPBVnZ22FHk180au+M4Z2aAQHO+aHJSKi8kvKytPe9nJm+hoiIro7g/Q4Xn31VWRmZmL8+PFITExEx44dVU5bCfKao3M3UvHCtwdVrjsxoWcD9GpaepoHIiIiqhpZufn460K8mt3y26kbpaY1sLGqgQca+WBgqwD0aeEHFztrlZ7JzoapMYiI6N4kZjBQS0RERhio3bFjh859mS44Y8YMdTF3cWnZ+MfS/Ui9eTY1rJkfJvepvuJhREREliwhPQe/n47BtpM3sOtcLDJy8m9bx9qqBro08MagVgHo28IPHk52OkX6iIiIKiKZI2qJiOgecQ5fFUrNysU/luzXTqdsEeCGTx5rozqElk7SYUhBFLkmIiLSF8kFePhKogrK/nEuDsevJaOwaEKLDnsbKzVyVk6g9mnuB28X467EzXaTiMj0JGVyRK0hsM0kIlPGQG0VyczJx9ilB3AsMlnd93Ozx6LR7eFsz49cODo6okWLFlX18RMRkQUVArscn6ECs7vOxuGvC3FIL2XUrPB2tkOvpjVVYPaBRr5wtDOdgp5sN4mITE9S5q3CyZ7FZmtQ1WKbSUSmjFHDKsqB93/LD+LviARtpehlYzuilrtDVbydScrKysLVq1cRFBQEBwd+LkREVP7A7MW4dOy7mIB9EfHqOjolq8z1m/m7oVtjH/Rp5oe2dTxNdlYL200iItMeUSsnC6l6sM0kIlPGQK2epWTl4rmlB7DvZpDWxd4G3/yjIxr7mWehtIpKS0vD9u3bMWzYMAZqiYioTLn5BTh7IxUHLyeqtlUCs5L/vSzSEZaUBt0a+6JrQx/UdDOPk4FsN4mITDtQ68lAbbVhm0lEpoyBWj2KTc3GmMV/48T1FHXf2c4a/xvTHiGB7vp8GyIiIrOUl1+AczFpOB6ZrHLLHruWjFNRKSrvbFkcba3Rrp4nujTwUQHa5v5usDLRUbNERGReOKKWiIjulcUHao9eT0M3T2842luhMg5dScT45Ye00y8l3cGSZzqgdZBHpV6XiIjIHOUXFOK8BGWvJeN4ZJI2KJuVW3ZQVjNTRQKzHYO90bG+F0Jqu8PWunJtOBERUVUHaj2Yo5aIiMrBogO1RyOT8NLqs2i6JxpfPt0OfhWYHllQUIilf13CrF9PITe/qKy0v7sDlo3tgIY1me6AiIhIgrIRcWmqwKZcwq8lq9kn/9/evQBXVZ0LHP8SCEkISUjCIy8CiFKvQFKKijBU5WGAEZALHSN2esFHb22LUwcYB/VOoXOdan2gjkUdwSqoiJ1CFKS0QIFQBREfXAhSLl4QiQQCMS8gvMy+8y3MMQESojmc/Vj/38yeJOfsJOfba5/znfWtddauPX3hi341dFmnBOmblSy52cmmOPtvGYnSlsIsAMBHhdrE2LbSri2DigCAi2trc6dx2p+3ycmvHfmfkioZ98d35albfyiDL+/U4r+x40CV/NdbxfLJF5Wh267tkSp/vL1/YNbEu1Tatm0rXbp0MV8BAMGhA5h7y4+Fli/Qr8UHquT4qYsXZXuktQ8VZftldZQ+WUmSFBcTkcftdeRNAPCfqm8KtakduJBYJJEzAfiZtVUyverzs7f9UO5esEUO1pySQ9Un5fb5m+Xf+2fJvcMul8s6d2jyatO6zMGf3vtcVm4vlbqzk2iNu4b0lJmjr+QjmC3QsWNHGT9+fNjaEwDgTlF231fHZVtJpZklq7Nldabs0ZPfftSzKd1S4yU3q6NZx12XL+ibmSzJ7SnKNoW8CQD+W3e9+uTZQcoUlj2IKHImAD+ztlCrrspMkj9NulL+e82XsmlPubmt8JMvzXZ19xQZ1CtNeqQlSFxMG6msPSW7Dx2Vdz87YtbUa+iyzgny8Pi+5kImAAB8F7Nnz5bf/e53jW7r2rWrHDx4MDRAqPe/+OKLUlFRIQMHDpS5c+dKnz59Inqg9XGUVJ6ULQdLpfhA9dklDA5USc2JixdlszrGm1my9bNltSjL1a8BAEFWcfx06Pu0BGbUAgBaxupCrUptHyOv3nmNLNqyX+as/l+p/CahfrivwmzN6dShndw5pKeZSRvbtk2EHnEwHDlyRJYuXSoTJkyQTp0ocAOwmxZd16xZE/q5TZtvc8pjjz0mc+bMkVdeeUV69+4tDz/8sNx0002ya9cuSUyM3FroJ8/UScGCYvlmOfYmZSbHhWbJ9svuaL6m0kFtNfImABts2LBBHn/8cfnoo4+ktLRUCgsLG30KryWDlydPnpQZM2bIG2+8IbW1tTJ8+HB57rnnJDs7O6KxVBw/FfqewcnIImcC8DPrC7UqOjpK/mNQD7nlh1ny5pYv5M0t++X/Dh+74AGLjhLpn5Mik67NkbF5GRRoAQCtT8Zt20p6evp5t2uH9Omnn5aHHnrIDGypBQsWmBm3ixYtkl/84hcRO/r66ZKeafHy2ZHa0G3pSXHfrin7TXG2U4fYiD0mAECwHDt2TPLy8uSOO+6QiRMnnnd/SwYv77vvPlm+fLksXrxY0tLSZPr06TJmzBhT/G04EHqpVRz7tlDLgCUAoKUo1DaQHB8j/3l9L7OVVByXTw9Uy4HKWjn1dZ10iI2R7mntpU9mknRkjSEAQBjt3r1bMjMzJTY21swO+v3vfy+XXXaZ7N271yyBkJ+fH9pX97nhhhtk48aNTRZqdTaRbvWqq6vN17q6OrN9H/p7Y/ukyddtYs/OlM1MuuCFM7/v3/cqjUcL5m7HVf//W9OGfow70oib9rZBuM7zS/H6MHr0aLNdSEsGL6uqquSll16SV199VUaMGGH2ee2116Rbt27mkysjR46USMlJay8zhnaTM9GxcnWPtIj9XwCAv1GobUJ2SnuzAQBwKWlhduHChWZm0KFDh8zsoMGDB8uOHTtC69RqJ7Qh/Xnfvn1N/s1HHnnkvHVv1eHDh+XEiRPfu0Oe36OdJCcnSXS0iJyolrITZwvAQaZxa8dfCwTRJnB3VFZWmq9fffVVxAq1Xog70oib9rZBuM7zmpoaiaSWDF7qrNnTp0832kcHQvv27Wv2aapQeykGOLsmxsrE3M7SuXNnc5xtGfjywoBXpAc3vRK3G2yM28aYFXHXheUYtgSFWgAAXNRw5lC/fv1k0KBB0qtXLzNL6LrrrjO3R0VFNfodfXN47m0NPfDAAzJt2rRGHU6dTaSdxaSkpO/9xkL/Z32H0xZeibv+f6empkZkbXevxB1pxE172yBc53lc3PmfqriUWjJ4qfu0a9dOUlJSztun/vcjOcDJgFe0FYObiva2Z6CPtranrcPd3i0d4KRQC1d07NhRCgoKJCEhgRYAgAb0dVELtrocQv0FVLRzmZGREdqnrKzsvI5qQzrDSLdz6ZuL1rzB0I59a/+GH3khbi3Q1ufNSD0OL8TtBuKmvW0QjvPcrdeG7zp42ZJ9GOAM1oCX5kx9n6Q5U68DYEvcbrAxbhtjVsTdudXt3dIBTgq1cIUmzOTkZI4+AJxDP3q5c+dO+fGPfyw9e/Y0FxlbvXq19O/f39x/6tQpKSoqkj/84Q8cO4uQNwHYrv6im80NXuo+micrKioazarVfXRZoaYwwBmsAS+dVa2bbXG7xca4bYxZEXd0q45fS88Xu84qeIZ+DHft2rWh9Z8AwFYzZswwhVdde2/z5s3yk5/8xLw2Tp482bwZ0qtX68XFCgsLpbi4WKZMmSLt27eX22+/3e2HjggibwKwXcPBy3r1g5f1RdgBAwZITExMo31KS0tN/myuUItgIWcC8DNm1MIV+qbqs88+k9zcXFoAgNVKSkpk0qRJcuTIEfMRKl2X9v3335fu3bub+++//36pra2VX/3qV2aGkF58bNWqVZKYmOj2Q0cEkTcB2ODo0aOmj1BPBzG3bt1qPsqek5MTGry84oorzKbfNxy81E/s3XXXXTJ9+nRJS0szv6cDorqk0IgRI1yMDJFEzgTgZxRqAQBw0eLFi5u9X2fVzp4922wAAATZhx9+KEOHDg39XH9hTP2UySuvvNKiwcunnnrKLBdz6623mn2HDx9ufrdNmzauxAQAwHdBoRYAAAAA4Lobb7zRXPirNYOXerGWZ5991mwAAPiNLwu19cm7teub6lXrampqTDK3ZRFor8Ssj0FHuPVrJBZ690rckUbctLcNwnWe1+eU5jqIfhWOvMnrCXnTBpzn5E0bkDcvjrzp/vnlp76mV+J2g41x2xizIu64Vrd3S/ubUY4Pe6S6nl+3bt3cfhgAgADav3+/ZGdnS5CQNwEAlwp5EwCA8OVNXxZqtZJ/4MABsxaRfvylNdVsLfjqQUpKShIb2BizIm7a2wac5607zzUd6uh4ZmZm4EbHw5E3Ob94HbUB5znnuQ3CdZ6TNyNznP2GuGnvoOMc5xy/1HnTl0sfaEDhnO2kidOm5GlrzIq47UJ72yUc7a1Xiw6icOZNnld2ob3tQnvbhbzZNPKmN84vPyJue9DWdkkK02taS/qbwZoyBAAAAAAAAAA+RKEWAAAAAAAAAFxmdaE2NjZWZs2aZb7awsaYFXHT3jbgPLfrPI80zi+7zi/am/a2Aee5Xed5pHF+2XV+0d72tDdtbU9bu9XevryYGAAAAAAAAAAEidUzagEAAAAAAADACyjUAgAAAAAAAIDLKNQCAAAAAAAAgMso1AIAAAAAAACAy6wt1D733HPSs2dPiYuLkwEDBsg///lP8avZs2dLVFRUoy09PT10v14vTvfJzMyU+Ph4ufHGG2XHjh2N/sbJkyfl3nvvlU6dOklCQoKMGzdOSkpKxEs2bNggY8eONXFojG+99Vaj+8MVZ0VFhfzsZz+T5ORks+n3lZWV4tW4p0yZcl77X3fddb6O+5FHHpFrrrlGEhMTpUuXLjJ+/HjZtWtX4Nu7JXEHsb2ff/55yc3NlaSkJLMNGjRIVq5cGei29iPyJnnTL88t8iZ5syHyJnnTDUHKmYr+ZnDfk9qYMxX9TfqbK73c33QstHjxYicmJsaZN2+e8+mnnzq/+c1vnISEBGffvn2OH82aNcvp06ePU1paGtrKyspC9z/66KNOYmKis2TJEmf79u1OQUGBk5GR4VRXV4f2ueeee5ysrCxn9erVzscff+wMHTrUycvLc86cOeN4xV//+lfnoYceMnHoqVtYWNjo/nDFOWrUKKdv377Oxo0bzabfjxkzxvFq3JMnTzaPuWH7l5eXN9rHb3GPHDnSefnll53i4mJn69atzs033+zk5OQ4R48eDXR7tyTuILb3smXLnBUrVji7du0y24MPPmheo/U4BLWt/Ya8Sd7003OLvEneJG+SN90UtJyp6G86gX1PamPOVPQ36W/GeLi/aWWh9tprrzUHuaErr7zSmTlzpuPXxKknyIXU1dU56enp5sSrd+LECSc5Odl54YUXzM+VlZXmJNU3FfW+/PJLJzo62vnb3/7meNG5SSRcceqbKf3b77//fmifTZs2mdv+9a9/OW5rKnnecsstTf5OEOLWgQd9LEVFRVa197lx29LeKiUlxZk/f741be115E3ypl+fW+RN8iZ5k7wZaUHLmYr+ph39D1tzpqK/SX/zUQ89t61b+uDUqVPy0UcfSX5+fqPb9eeNGzeKX+3evdtM09aP2Nx2222yZ88ec/vevXvl4MGDjeKNjY2VG264IRSvHo/Tp0832kf/Vt++fX1zTMIV56ZNm8wU9YEDB4b20Y926G1ePhbr1683H5Xv3bu3/PznP5eysrLQfUGIu6qqynxNTU21qr3PjduG9v76669l8eLFcuzYMbMEgi1t7WXkTfJmEJ9bQX4dVeRN8iZ50x1BzZmK/qa970mDnjMVeZO8me+h57Z1hdojR46YQkDXrl0b3a4/6wuvH+mJsHDhQvn73/8u8+bNM3EMHjxYysvLQzE1F69+bdeunaSkpDS5j9eFK079qknoXHqbV4/F6NGj5fXXX5e1a9fKk08+KVu2bJFhw4aZNVSCELcO7k6bNk2GDBliXghtae8LxR3k9t6+fbt06NDBJMV77rlHCgsL5aqrrrKirb2OvHkWeTM4z62gvo7WI2+SNxV50x1BzJmK/qYd/Q8bc6Yib5I3vfbcbiuW0kWwz31ynnubX+iLZ71+/fqZWWi9evWSBQsWhBb6/j7x+vGYhCPOC+3v5WNRUFAQ+l4LeldffbV0795dVqxYIRMmTPB93FOnTpVt27bJu+++a1V7NxV3UNv7Bz/4gWzdutUstr5kyRKZPHmyFBUVWdHWfkHeJG8G5bkV1NfReuRN8qYib7orSDlT0d8Ua59bQc+ZirxJ3vTac9u6GbV6hbY2bdqcV9HW6fvnVtD9Sq9ApwVb/XhKenq6ua25eHUf/ZiOXqGuqX28Llxx6j6HDh067+8fPnzYN8ciIyPDJE9tf7/HrVdVXLZsmaxbt06ys7Otae+m4g5ye+sI5eWXX27e/OlVWPPy8uSZZ54JfFv7AXnzLPJmcJ9bQXkdVeRN8iZ501025ExFf9Pe96RBypmKvEneTPdgf9O6Qq0WAwYMGCCrV69udLv+rMsFBIF+DGHnzp3mRVTXrNUTpmG8eoLpTLX6ePV4xMTENNqntLRUiouLfXNMwhWnzkbW9Wk++OCD0D6bN282t/nlWOiSF/v37zft79e4ddRJRzaXLl1qPmaj7WtDe18s7qC2d1PHQl/LgtrWfkLeJG8G/bkVhNdR8iZ5k7zpDTbkTEV/0973pEHImYq8Sd50vNzfdCykV2rTK7a99NJL5sps9913n5OQkOB8/vnnjh9Nnz7dWb9+vbNnzx5zhbkxY8Y4iYmJoXj06nV6xbqlS5c627dvdyZNmuRkZGQ41dXVob+hVybNzs521qxZ43z88cfOsGHDnLy8POfMmTOOV9TU1DiffPKJ2fTUnTNnjvl+3759YY1z1KhRTm5urrlCn279+vUzx9SLcet92v4bN2509u7d66xbt84ZNGiQk5WV5eu4f/nLX5q21PO6tLQ0tB0/fjy0TxDb+2JxB7W9H3jgAWfDhg0mpm3btjkPPviguYLmqlWrAtvWfkPeJG/66blF3iRvkjfJm24KWs5U9DeD29+0MWcq+pv0N6M93N+0slCr5s6d63Tv3t1p166d86Mf/cgpKipy/KqgoMCcRPqGIDMz05kwYYKzY8eO0P11dXXOrFmznPT0dCc2Nta5/vrrzcnXUG1trTN16lQnNTXViY+PNyfTF1984XiJJgZNHudukydPDmuc5eXlzk9/+lNT7NZNv6+oqHC8GLd2RPLz853OnTub9s/JyTG3nxuT3+K+ULy6vfzyy6F9gtjeF4s7qO195513hl6PNbbhw4eHkmZQ29qPyJvkTb88t8ib5E3yJnnTbUHKmYr+ZnD7mzbmTEV/k/7mKg/3N6O+OUkBAAAAAAAAAC6xbo1aAAAAAAAAAPAaCrUAAAAAAAAA4DIKtQAAAAAAAADgMgq1AAAAAAAAAOAyCrUAAAAAAAAA4DIKtQAAAAAAAADgMgq1AAAAAAAAAOAyCrUAAAAAAAAA4DIKtQAAAAAAAADgMgq1gA9ERUU1u02ZMqXZ39f7Z86c2eR948ePb3TbX/7yF4mLi5PHHnssrHEAABAJ5E0AAMibgB+1dfsBALi40tLS0Pdvvvmm/Pa3v5Vdu3aFbouPj2/yd+vq6mTFihWybNmyFh3q+fPny69//WuZO3eu3H333TQPAMB3yJsAAJA3AT+iUAv4QHp6euj75ORkM1Oo4W3Nee+99yQ6OloGDhx40X11Bq0WgRctWiQTJ05s1WMGAMAt5E0AAMibgB9RqAUCTmfSjh071hRrm6NLI+gs2nfeeUdGjBgRsccHAICXkDcBACBvAm6hUAtY0OF84oknmt1n5cqV8vbbb8s//vEPGTZsWMQeGwAAXkPeBACAvAm4hYuJAQG2c+dOKSkpuegM2dzcXOnRo4dZ9qCmpiZijw8AAC8hbwIAQN4E3EShFgj4rKCbbrqp2YuNqaysLCkqKjIXXxk1ahTFWgCAlcibAACQNwE3UagFAkyXMxg3blyL9s3JyTHF2rKyMsnPz5fq6upL/vgAAPAS8iYAAORNwE0UaoGA0oLrli1bZMyYMS3+nezsbFm/fr2Ul5ebYm1VVdUlfYwAAHgFeRMAAPIm4DYKtUBALV++XAYOHChdunT5Tr9XvwxCZWWlWTZBvwIAEHTkTQAAyJuA26Icx3HcfhAAwk+XPBgyZIjcf//9HF4AAMibAADQ3wQ8jhm1QEBpkXbSpEluPwwAAHyBvAkAAHkTcBszagEAAAAAAADAZcyoBQAAAAAAAACXUagFAAAAAAAAAJdRqAUAAAAAAAAAl1GoBQAAAAAAAACXUagFAAAAAAAAAJdRqAUAAAAAAAAAl1GoBQAAAAAAAACXUagFAAAAAAAAAJdRqAUAAAAAAAAAcdf/A04oXPGyFn4sAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1400x360 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "T = [t for t in range(int(nasa[\"t_low\"]) or 200, int(nasa[\"t_high\"]) + 1, 10) if t > 0]\n",
+    "fig, ax = plt.subplots(1, 3, figsize=(14, 3.6))\n",
+    "for axis, fn, label in zip(ax, (cp, h, s), (\"Cp  /  J mol⁻¹ K⁻¹\", \"H  /  kJ mol⁻¹\", \"S  /  J mol⁻¹ K⁻¹\")):\n",
+    "    axis.plot(T, [fn(nasa, t) for t in T], lw=2)\n",
+    "    axis.axvline(nasa[\"t_mid\"], ls=\"--\", c=\"0.6\", lw=1)\n",
+    "    axis.set_xlabel(\"T / K\")\n",
+    "    axis.set_title(label)\n",
+    "    axis.grid(alpha=0.3)\n",
+    "fig.suptitle(f\"{SPECIES_SMILES}   (dashed line = NASA t_mid)\", y=1.04)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2c1499c",
+   "metadata": {},
+   "source": [
+    "## 3. The calculations behind the numbers\n",
+    "\n",
+    "This is what distinguishes TCKDB from a table of values: every thermo record traces\n",
+    "back to the quantum-chemistry calculations that produced it, each with its level of\n",
+    "theory and software provenance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bec77ed6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:14:07.895975Z",
+     "iopub.status.busy": "2026-08-02T10:14:07.895837Z",
+     "iopub.status.idle": "2026-08-02T10:14:08.578708Z",
+     "shell.execute_reply": "2026-08-02T10:14:08.578314Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "32 calculation(s) for C=C\n",
+      "\n",
+      "by calculation type: {'sp': 7, 'freq': 7, 'opt': 18}\n",
+      "by level of theory : {'b3lyp/def2tzvp': 32} \n",
+      "\n",
+      "  calc_c3pgshx34sw7uaqfimxe2qeo6e  sp    raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
+      "  calc_uzdtyaspttrufuapeljaibbf54  freq  raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
+      "  calc_mxhadodv3hsdead3rnmofh3xyi  opt   raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
+      "  calc_j4my2yvcqowtzfdaufvpoqu3z4  opt   raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
+      "  calc_u7j7kghz7wxdi7odncrfwml7im  opt   raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
+      "  calc_j2rgfjta4ycv3k3wamogup2t6u  sp    raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n"
+     ]
+    }
+   ],
+   "source": [
+    "calcs = get(\"scientific/calculations/search\", species_ref=SPECIES_REF)[\"records\"]\n",
+    "print(f\"{len(calcs)} calculation(s) for {SPECIES_SMILES}\\n\")\n",
+    "\n",
+    "# level_of_theory and software_release sit alongside `calculation` on the record,\n",
+    "# not inside it -- provenance is a peer of the result, not a detail of it.\n",
+    "by_type, by_lot = {}, {}\n",
+    "for rec in calcs:\n",
+    "    cal, lot = rec[\"calculation\"], (rec.get(\"level_of_theory\") or {})\n",
+    "    by_type[cal[\"type\"]] = by_type.get(cal[\"type\"], 0) + 1\n",
+    "    key = f\"{lot.get('method','?')}/{lot.get('basis','?')}\"\n",
+    "    by_lot[key] = by_lot.get(key, 0) + 1\n",
+    "\n",
+    "print(\"by calculation type:\", by_type)\n",
+    "print(\"by level of theory :\", by_lot, \"\\n\")\n",
+    "\n",
+    "for rec in calcs[:6]:\n",
+    "    cal, lot = rec[\"calculation\"], (rec.get(\"level_of_theory\") or {})\n",
+    "    sw = (rec.get(\"software_release\") or {})\n",
+    "    print(f\"  {cal['calculation_ref']}  {cal['type']:5s} {cal['quality']:4s} \"\n",
+    "          f\"{lot.get('method','?')}/{lot.get('basis','?'):10s} {sw.get('software','?')} {sw.get('version','')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ab23ed9",
+   "metadata": {},
+   "source": [
+    "## 4. Statistical mechanics\n",
+    "\n",
+    "Frequencies, rotors and symmetry — the inputs a partition function is built from.\n",
+    "These are what make a thermo value *recomputable* rather than merely *quoted*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c62f016a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:14:08.579781Z",
+     "iopub.status.busy": "2026-08-02T10:14:08.579687Z",
+     "iopub.status.idle": "2026-08-02T10:14:08.876670Z",
+     "shell.execute_reply": "2026-08-02T10:14:08.876341Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 statmech record(s)\n",
+      "\n",
+      "  sm_ub3tbslev5twt7btwtzcgouckq\n",
+      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
+      "     frequency scale factor: 0.999\n",
+      "  sm_4hxeerk7n4oslcjt4ivgk3rdiq\n",
+      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
+      "     frequency scale factor: 0.999\n",
+      "  sm_df3deeaphwtqeaj5btfsesds7e\n",
+      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
+      "     frequency scale factor: 0.999\n",
+      "  sm_pq5k4zcwhhzpzv7i2anuvnocw4\n",
+      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
+      "     frequency scale factor: 0.999\n"
+     ]
+    }
+   ],
+   "source": [
+    "sm = get(\"scientific/statmech/search\", species_ref=SPECIES_REF)[\"records\"]\n",
+    "print(f\"{len(sm)} statmech record(s)\\n\")\n",
+    "\n",
+    "for rec in sm[:4]:\n",
+    "    b = rec[\"statmech\"]\n",
+    "    print(f\"  {b['statmech_ref']}\")\n",
+    "    print(f\"     treatment={b['statmech_treatment']}  point_group={b['point_group']}  \"\n",
+    "          f\"symmetry={b['external_symmetry']}  linear={b['is_linear']}  \"\n",
+    "          f\"optical_isomers={b['optical_isomers']}\")\n",
+    "    rot = [b[f\"rotational_constant_{x}_cm1\"] for x in (\"a\", \"b\", \"c\")]\n",
+    "    if any(r is not None for r in rot):\n",
+    "        print(f\"     rotational constants /cm-1: {rot}\")\n",
+    "    if b.get(\"frequency_scale_factor_value\") is not None:\n",
+    "        print(f\"     frequency scale factor: {b['frequency_scale_factor_value']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb1178b5",
+   "metadata": {},
+   "source": [
+    "## 5. Review status — how much should you trust this?\n",
+    "\n",
+    "Every scientific record carries a review state. TCKDB deliberately keeps three\n",
+    "*separate* judgements rather than collapsing them into one score:\n",
+    "\n",
+    "| | question it answers |\n",
+    "|---|---|\n",
+    "| **review** | has a human curator signed off? |\n",
+    "| **trust** | is the supporting evidence complete? |\n",
+    "| **reproducibility** | is enough deposited to audit or re-run it? |\n",
+    "\n",
+    "They can legitimately disagree — a well-evidenced record may be unreviewed, and a\n",
+    "reviewed record may still lack the artifacts needed to reproduce it. Collapsing them\n",
+    "would hide exactly the distinction a reader needs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e2f198e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:14:08.877811Z",
+     "iopub.status.busy": "2026-08-02T10:14:08.877721Z",
+     "iopub.status.idle": "2026-08-02T10:14:09.391926Z",
+     "shell.execute_reply": "2026-08-02T10:14:09.391581Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "review summary: {'approved': 0, 'under_review': 7, 'not_reviewed': 0, 'deprecated': 0, 'rejected': 0, 'total': 7}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " 422 unknown_include_token: unknown_include_token: token(s) ['not_a_real_token'] not legal for /scientific/thermo/search. Legal tokens: ['artifacts', 'assessments', 'calculations', 'internal_ids', 'provenance', 'review', 'all']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Every search response carries a review roll-up for free.\n",
+    "print(\"review summary:\", get(\"scientific/thermo/search\", species_ref=SPECIES_REF)[\"review_summary\"])\n",
+    "\n",
+    "# Heavier blocks are opt-in. Ask for an illegal token and the server tells you\n",
+    "# exactly which are legal for that endpoint -- a fast way to explore the API.\n",
+    "try:\n",
+    "    get(\"scientific/thermo/search\", species_ref=SPECIES_REF, include=\"not_a_real_token\")\n",
+    "except RuntimeError as exc:\n",
+    "    print(\"\\n\", exc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ea6aad2",
+   "metadata": {},
+   "source": [
+    "### A worked trust block\n",
+    "\n",
+    "`include=trust` on a calculation returns the deterministic evidence evaluation —\n",
+    "the rubric that ran, the checks it passed, and the label it concluded. This is the\n",
+    "part that lets a reader decide for themselves rather than taking a status word on\n",
+    "faith."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "33440c96",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-02T10:14:09.392750Z",
+     "iopub.status.busy": "2026-08-02T10:14:09.392662Z",
+     "iopub.status.idle": "2026-08-02T10:14:09.670367Z",
+     "shell.execute_reply": "2026-08-02T10:14:09.669946Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "review status: under_review\n",
+      "trust status : well_supported\n",
+      "\n",
+      "rubric: computed_calculation_v1 v1  ->  well_supported\n",
+      "\n",
+      "passed checks:\n",
+      "   + calculation_has_owner\n",
+      "   + calculation_type_present\n",
+      "   + level_of_theory_present\n",
+      "   + software_release_present\n",
+      "   + workflow_tool_release_present\n",
+      "   + input_geometry_present\n",
+      "   + output_geometry_present\n",
+      "   + result_block_present\n",
+      "   + geometry_validation_present\n",
+      "   + artifacts_present\n",
+      "   + parameters_parsed\n",
+      "   - quality_recorded (missing)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A calculation from the real-data validation set.\n",
+    "CALC_REF = \"calc_hh7v4go23xr6drhbb4f4ewuvbq\"\n",
+    "\n",
+    "trust = get(f\"scientific/calculations/{CALC_REF}\", include=\"trust\")[\"record\"][\"trust\"]\n",
+    "print(\"review status:\", trust[\"review_status\"])\n",
+    "print(\"trust status :\", trust[\"trust_status\"])\n",
+    "\n",
+    "ev = trust[\"evidence\"]\n",
+    "print(f\"\\nrubric: {ev['rubric']} v{ev['rubric_version']}  ->  {ev['label']}\")\n",
+    "print(\"\\npassed checks:\")\n",
+    "for check in ev.get(\"passed_checks\", []):\n",
+    "    print(\"   +\", check)\n",
+    "for check in ev.get(\"missing_checks\", []) or []:\n",
+    "    print(\"   -\", check, \"(missing)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bc3f519",
+   "metadata": {},
+   "source": [
+    "## 6. Where to go next\n",
+    "\n",
+    "- `scientific/transport/search` — Lennard-Jones parameters\n",
+    "- `scientific/kinetics/search` and `scientific/reactions/search` — rate coefficients\n",
+    "- `scientific/calculations/{ref}?include=all` — the full record for one calculation,\n",
+    "  including artifacts and geometries\n",
+    "\n",
+    "Every search response carries a `pagination` block; pass `include=` to opt into heavier\n",
+    "sections. Anything omitted by default is omitted on purpose — the default response is\n",
+    "meant to stay small and predictable.\n",
+    "\n",
+    "### Using the typed client instead\n",
+    "\n",
+    "```python\n",
+    "pip install tckdb-client\n",
+    "```\n",
+    "```python\n",
+    "from tckdb_client import TCKDBClient\n",
+    "with TCKDBClient(base_url=\"https://tckdb.homecalvin.com\") as c:\n",
+    "    print(c.health())\n",
+    "```\n",
+    "Match the client version to the deployment: a client built against a newer contract will\n",
+    "404 on endpoints an older server doesn't serve yet.\n",
+    "\n",
+    "---\n",
+    "*Read-only tour. The script form of this notebook is `explore_tckdb.py` in the same\n",
+    "directory, runnable as `python examples/clients/explore_tckdb.py`.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/clients/explore_tckdb.py
+++ b/examples/clients/explore_tckdb.py
@@ -1,0 +1,159 @@
+"""Explore a live TCKDB deployment — the script form of ``explore_tckdb.ipynb``.
+
+Read-only. Every request here is an anonymous GET against the public
+scientific read API; nothing in this file can modify the database.
+
+Run it directly to print a tour of what a deployment holds::
+
+    python examples/clients/explore_tckdb.py
+    TCKDB_BASE_URL=http://localhost:8000 python examples/clients/explore_tckdb.py
+
+The notebook alongside this file is the version to hand to a colleague: it
+carries the same calls with explanation and plots. This module keeps the
+functions importable so the notebook stays thin and both stay in sync.
+
+Only ``requests`` is required. ``tckdb-client`` is the better choice for
+programmatic work, but it pins a contract version, and a client newer than
+the deployment it talks to will 404 on endpoints the server does not have
+yet. Plain HTTP keeps this tour working against any deployment.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+DEFAULT_BASE_URL = "https://tckdb.homecalvin.com/api/v1"
+TIMEOUT_S = 30
+
+
+def base_url() -> str:
+    """The deployment to talk to; override with ``TCKDB_BASE_URL``."""
+    return os.environ.get("TCKDB_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def get(path: str, **params: Any) -> dict:
+    """One anonymous GET against the scientific read API.
+
+    Raises with the server's own error envelope when there is one — TCKDB
+    returns a typed ``{"code", "detail", "context"}`` body, which says far
+    more than a bare status line.
+    """
+    response = requests.get(f"{base_url()}/{path.lstrip('/')}", params=params, timeout=TIMEOUT_S)
+    if not response.ok:
+        try:
+            envelope = response.json()
+            raise RuntimeError(
+                f"{response.status_code} {envelope.get('code', '?')}: {envelope.get('detail', response.text[:200])}"
+            )
+        except ValueError:
+            response.raise_for_status()
+    return response.json()
+
+
+def health() -> dict:
+    """Liveness check. Works without any query parameters."""
+    return get("health")
+
+
+def find_species(**identifier: Any) -> list[dict]:
+    """Look up species by identity.
+
+    The search endpoints are lookup-by-identity, not list-everything: at
+    least one of ``smiles``, ``inchi``, ``inchi_key``, ``formula``,
+    ``species_ref`` or ``species_entry_ref`` is required. That is deliberate
+    for a scientific database — you ask for a molecule, not a page of rows.
+    """
+    return get("scientific/species/search", **identifier)["records"]
+
+
+def thermo_for(species_ref: str) -> list[dict]:
+    """Every thermodynamic record attached to one species."""
+    return get("scientific/thermo/search", species_ref=species_ref)["records"]
+
+
+def calculations_for(species_ref: str) -> list[dict]:
+    """Every quantum-chemistry calculation behind one species."""
+    return get("scientific/calculations/search", species_ref=species_ref)["records"]
+
+
+def statmech_for(species_ref: str) -> list[dict]:
+    """Statistical-mechanics records (frequencies, rotors) for one species."""
+    return get("scientific/statmech/search", species_ref=species_ref)["records"]
+
+
+# ---------------------------------------------------------------------------
+# NASA polynomials
+#
+# A NASA-7 fit stores two coefficient sets meeting at ``t_mid``. Evaluating
+# them is what turns a stored record back into Cp(T), H(T) and S(T), so the
+# functions below are the point of querying thermo at all.
+# ---------------------------------------------------------------------------
+
+R_J_MOL_K = 8.31446261815324
+
+
+def _coefficients(nasa: dict, temperature_k: float) -> list[float]:
+    if temperature_k <= nasa["t_mid"]:
+        return nasa["low_temperature_coefficients"]
+    return nasa["high_temperature_coefficients"]
+
+
+def cp_j_mol_k(nasa: dict, temperature_k: float) -> float:
+    """Cp/R = a1 + a2·T + a3·T² + a4·T³ + a5·T⁴."""
+    a = _coefficients(nasa, temperature_k)
+    t = temperature_k
+    return R_J_MOL_K * (a[0] + a[1] * t + a[2] * t**2 + a[3] * t**3 + a[4] * t**4)
+
+
+def h_kj_mol(nasa: dict, temperature_k: float) -> float:
+    """H/(R·T) = a1 + a2·T/2 + a3·T²/3 + a4·T³/4 + a5·T⁴/5 + a6/T."""
+    a = _coefficients(nasa, temperature_k)
+    t = temperature_k
+    dimensionless = (
+        a[0] + a[1] * t / 2 + a[2] * t**2 / 3 + a[3] * t**3 / 4 + a[4] * t**4 / 5 + a[5] / t
+    )
+    return R_J_MOL_K * t * dimensionless / 1000.0
+
+
+def s_j_mol_k(nasa: dict, temperature_k: float) -> float:
+    """S/R = a1·lnT + a2·T + a3·T²/2 + a4·T³/3 + a5·T⁴/4 + a7."""
+    import math
+
+    a = _coefficients(nasa, temperature_k)
+    t = temperature_k
+    return R_J_MOL_K * (
+        a[0] * math.log(t) + a[1] * t + a[2] * t**2 / 2 + a[3] * t**3 / 3 + a[4] * t**4 / 4 + a[6]
+    )
+
+
+def _tour() -> None:
+    print(f"deployment : {base_url()}")
+    print(f"health     : {health()}\n")
+
+    for smiles in ("C=C", "[CH3]", "[OH]", "O"):
+        species = find_species(smiles=smiles)
+        if not species:
+            print(f"{smiles:8s} not present in this deployment")
+            continue
+        record = species[0]
+        ref = record["species_ref"]
+        thermo = thermo_for(ref)
+        calcs = calculations_for(ref)
+        print(
+            f"{smiles:8s} {record['inchi_key']:29s} "
+            f"thermo={len(thermo):2d} calcs={len(calcs):3d} statmech={len(statmech_for(ref)):2d}"
+        )
+        nasa = next((t["thermo"].get("nasa") for t in thermo if t["thermo"].get("nasa")), None)
+        if nasa:
+            print(
+                f"         Cp(300K)={cp_j_mol_k(nasa, 300):7.2f} J/mol/K   "
+                f"H(300K)={h_kj_mol(nasa, 300):8.2f} kJ/mol   "
+                f"S(300K)={s_j_mol_k(nasa, 300):7.2f} J/mol/K"
+            )
+
+
+if __name__ == "__main__":
+    _tour()

--- a/schemas/python/tckdb-schemas/tckdb_schemas/__init__.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/__init__.py
@@ -1,3 +1,3 @@
 """Pure Pydantic wire-contract schemas for TCKDB upload payloads."""
 
-__version__ = "0.10.0"
+__version__ = "0.14.0"


### PR DESCRIPTION
## Summary

Two related things: the backend's declared dependencies did not match what it actually imports, and there was no way for a colleague to explore a live deployment. Fixes the first; adds a notebook for the second.

## The dependency defect

**Both documented install paths produced an app that could not import.**

- `backend/environment.yml`'s pip section carries only `isbnlib2`
- `backend/uv.lock` contained **no `tckdb-schemas` at all**
- yet **34 modules under `app/`** import `tckdb_schemas` at module level

Only CI and the Dockerfile worked, because they run an extra `pip install -e schemas/python/tckdb-schemas` step the README never mentions. Anyone following `README.md` Path A or Path B got an `ImportError`.

The file's own header calls itself *"the source of truth for the Python package itself, the runtime dependency list"* — so this was a defect by its own definition.

### Changes

| change | why |
|---|---|
| declare `tckdb-schemas>=0.10` + `[tool.uv.sources]` path entry | it's first-party, in this repo, not on PyPI — a plain resolver cannot find it by name |
| `cantera` as a **`[chemkin]` extra**, not a hard dependency | it is imported *lazily inside* `chemkin_serialize.py`, so the app genuinely runs without it. Mirrors the existing `[rdkit]` convention |
| `pytest-randomly>=3.15` in `[dev]` | without it installed, `-p no:randomly` is **silently accepted and does nothing** — reading like an ordering guarantee the suite never had |
| `tckdb_schemas.__version__` 0.10.0 → 0.14.0 | hardcoded literal left behind when `pyproject.toml` was bumped; the package was reporting a version it isn't |
| corrected both documented install paths | in the pyproject header and `README.md` |

**Verified:** `uv sync --extra dev` now succeeds and imports `tckdb_schemas` (it could not before). `uv.lock` regenerated — 70 packages, `starlette 1.3.1` from #70 preserved, `tckdb-schemas` and `pytest-randomly` added.

### On enabling pytest-randomly

Installing it makes randomised ordering the **default**, so CI will now vary test order every run. That is the point — #69 fixed an order-dependent bug that randomised ordering would have caught years earlier — but it is a real change in CI character.

Evidence it is safe: the scientific gate was run twice with explicit seeds, **1743 passed, 0 failures, exit 0 both times**. Failures print their seed, so any future ordering failure is reproducible.

## The notebook

`examples/clients/explore_tckdb.ipynb` — a read-only tour of a live deployment, defaulting to the hosted instance so a colleague can run it with **no account, no key, and no local database**.

It deliberately uses plain `requests` rather than `tckdb-client`: the client pins a contract version, and a client newer than the server it talks to 404s on endpoints that server does not have yet. That was not hypothetical — it happened while writing this.

Contents: species lookup by SMILES; the species-vs-entry distinction; **evaluating the stored NASA-7 polynomials back into Cp(T), H(T), S(T)** with plots; a NIST-JANAF comparison table; the calculations and statmech behind the numbers; and a worked trust block.

The literature check is the part worth showing a reviewer — it validates the database against known values rather than merely displaying it:

| | S(298) db | lit | Cp(300) db | lit |
|---|---|---|---|---|
| H₂O | 188.86 | 188.8 | 33.59 | 33.6 |
| C₂H₄ | 219.06 | 219.3 | 42.93 | 43.6 |
| CH₃ | 194.64 | 194.2 | 38.93 | 38.7 |

`examples/clients/explore_tckdb.py` ships alongside it as the runnable script form, per the repo's script-plus-notebook convention.

**The notebook is committed executed** — 10/10 code cells carry outputs, zero errors, plot embedded — against the live deployment.

Three bugs were caught only by executing it, each of which would have hit a colleague:
1. a species variable shadowing the entropy function `s()`
2. `include=trust` is not legal on thermo search (the token is `assessments`); the server's 422 lists the legal set, which became a teaching cell
3. `level_of_theory` and `software_release` are **peers** of `calculation` on the record, not nested inside it — which is why an earlier draft printed `?` everywhere. That shape encodes the design principle: provenance is a peer of the result, not a detail of it.

## Validation

- `uv sync --extra dev` succeeds; `tckdb_schemas` imports
- scientific gate under randomised ordering: **1743 passed** × 2 seeds
- notebook: 10/10 cells executed, 0 errors, 1 embedded plot
- `explore_tckdb.py` runs clean against the live deployment

No production code changed; no migrations.
