### PR TITLE
Represent well-skipping channels in the PDep upload contract

### DIFF
--- a/backend/alembic/versions/d5b1a7c3e9f4_network_channel_mechanism.py
+++ b/backend/alembic/versions/d5b1a7c3e9f4_network_channel_mechanism.py
@@ -1,0 +1,85 @@
+"""Declare whether a network channel is elementary or well-skipping.
+
+Adds ``network_channel.mechanism``, a non-null machine token with two members:
+
+``elementary``
+    The channel is one elementary step (or several parallel elementary steps),
+    each named on ``network_channel_microreaction``.
+
+``well_skipping``
+    A chemically-activated / well-skipping channel. Reactants form an energized
+    intermediate that reacts onward before collisional stabilization, so the
+    phenomenological k(T,P) comes out of the master equation and there is no
+    single elementary step or saddle point behind it. Such a channel carries
+    zero ``network_channel_microreaction`` rows *by declaration*.
+
+Why a stored column rather than inferring it from an empty child collection:
+"this rate is a multi-step ME channel" is a scientific claim about the channel,
+not an absence of data, and a reader must be able to tell it apart from "the
+producer forgot to supply the paths". ``network_channel_microreaction`` already
+permits zero rows, so without this column the two cases are indistinguishable
+in the database and on the read surface.
+
+Backfill design
+---------------
+``server_default='elementary'`` is correct and unambiguous rather than a guess.
+Revision ``c1d2e3f4a5b6`` refuses to run at all unless ``network_channel`` is
+empty (pre-v2 channels have no producer-visible identity and must be exported,
+deleted, and re-uploaded). Any ``network_channel`` row reachable by this
+revision was therefore written under the v2 contract, which required at least
+one ``microreaction_paths`` entry per channel — i.e. every existing row is
+genuinely elementary. No legacy row is mislabelled.
+
+The default is kept on the column so that a client of the ORM which does not
+know about this axis still writes the conservative, evidence-bearing value.
+
+Downgrade drops the column and the enum type; the mechanistic declaration is
+lost, and well-skipping channels become indistinguishable from channels whose
+paths were omitted. That is inherent to removing the axis.
+
+Revision ID: d5b1a7c3e9f4
+Revises: e3f4a5b6c7d8
+Create Date: 2026-08-02
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d5b1a7c3e9f4"
+down_revision: Union[str, Sequence[str], None] = "e3f4a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+network_channel_mechanism = postgresql.ENUM(
+    "elementary",
+    "well_skipping",
+    name="network_channel_mechanism",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    """Add the mechanistic-attribution token to ``network_channel``."""
+    bind = op.get_bind()
+    network_channel_mechanism.create(bind, checkfirst=True)
+    op.add_column(
+        "network_channel",
+        sa.Column(
+            "mechanism",
+            network_channel_mechanism,
+            nullable=False,
+            server_default="elementary",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove the mechanism column and its enum type."""
+    op.drop_column("network_channel", "mechanism")
+    bind = op.get_bind()
+    network_channel_mechanism.drop(bind, checkfirst=True)

--- a/backend/app/db/models/common.py
+++ b/backend/app/db/models/common.py
@@ -516,6 +516,37 @@ class NetworkChannelKind(str, Enum):
     exchange = "exchange"
 
 
+class NetworkChannelMechanism(str, Enum):
+    """How a phenomenological channel is mechanistically attributed.
+
+    Orthogonal to :class:`NetworkChannelKind`, which classifies the channel's
+    *macroscopic* reaction type (association, isomerization, ...). This axis
+    says what scientific evidence stands behind the channel.
+
+    ``elementary``
+        The channel is one elementary step, or several parallel elementary
+        steps, each named on ``network_channel_microreaction``. Every
+        saddle-point path carries a barrier.
+
+    ``well_skipping``
+        A chemically-activated / well-skipping channel: the reactants form an
+        energized intermediate that reacts onward before collisional
+        stabilization, so the phenomenological k(T,P) is produced by the
+        master equation and there is no single elementary step or saddle point
+        to attribute it to. Its backing is the network topology plus the ME
+        solve, and it therefore carries **zero**
+        ``network_channel_microreaction`` rows *by declaration*, never by
+        omission.
+
+    There is deliberately no ``unknown``/``other`` member. An escape hatch here
+    would be indistinguishable from "the producer did not supply the paths",
+    which is exactly the silent gap this discriminator exists to close.
+    """
+
+    elementary = "elementary"
+    well_skipping = "well_skipping"
+
+
 class NetworkKineticsModelKind(str, Enum):
     chebyshev = "chebyshev"
     plog = "plog"

--- a/backend/app/db/models/network_pdep.py
+++ b/backend/app/db/models/network_pdep.py
@@ -26,6 +26,7 @@ from app.db.models.common import (
     EnergyCorrectionConvention,
     EnergyZeroConvention,
     NetworkChannelKind,
+    NetworkChannelMechanism,
     NetworkKineticsModelKind,
     NetworkSolveCalculationRole,
     NetworkStateKind,
@@ -143,6 +144,18 @@ class NetworkChannel(Base):
     kind: Mapped[NetworkChannelKind] = mapped_column(
         SAEnum(NetworkChannelKind, name="network_channel_kind"),
         nullable=False,
+    )
+    # Mechanistic attribution, orthogonal to ``kind``. ``elementary`` channels
+    # name their elementary step(s) on ``network_channel_microreaction``;
+    # ``well_skipping`` channels carry none, because a chemically-activated
+    # pathway has no single elementary step behind it. Storing the claim is
+    # what keeps "multi-step ME channel" distinguishable from "the producer
+    # omitted the paths" — a reader must never have to infer it from an empty
+    # child collection.
+    mechanism: Mapped[NetworkChannelMechanism] = mapped_column(
+        SAEnum(NetworkChannelMechanism, name="network_channel_mechanism"),
+        nullable=False,
+        server_default=NetworkChannelMechanism.elementary.value,
     )
     # A stable, producer-visible identity is required because distinct
     # mechanistic pathways may have the same macroscopic source and sink.

--- a/backend/app/schemas/entities/network_pdep.py
+++ b/backend/app/schemas/entities/network_pdep.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field, model_validator
 from app.db.models.common import (
     ArrheniusAUnits,
     NetworkChannelKind,
+    NetworkChannelMechanism,
     NetworkKineticsModelKind,
     NetworkSolveCalculationRole,
     NetworkStateKind,
@@ -124,13 +125,17 @@ class NetworkChannelBase(BaseModel):
     :param network_id: Owning network id.
     :param source_state_id: Source network-state id.
     :param sink_state_id: Sink network-state id.
-    :param kind: Channel classification.
+    :param kind: Macroscopic channel classification.
+    :param mechanism: Mechanistic attribution — ``elementary`` (the default,
+        backed by named ``network_channel_microreaction`` rows) or
+        ``well_skipping`` (chemically activated; no single elementary step).
     """
 
     network_id: int
     source_state_id: int
     sink_state_id: int
     kind: NetworkChannelKind
+    mechanism: NetworkChannelMechanism = NetworkChannelMechanism.elementary
 
     @model_validator(mode="after")
     def validate_source_ne_sink(self) -> Self:
@@ -147,6 +152,7 @@ class NetworkChannelUpdate(SchemaBase):
     """Patch schema for a network channel."""
 
     kind: NetworkChannelKind | None = None
+    mechanism: NetworkChannelMechanism | None = None
 
 
 class NetworkChannelRead(NetworkChannelBase, ORMBaseSchema):

--- a/backend/app/schemas/reads/network.py
+++ b/backend/app/schemas/reads/network.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.db.models.common import (
     ArrheniusAUnits,
     NetworkChannelKind,
+    NetworkChannelMechanism,
     NetworkKineticsModelKind,
     NetworkSolveCalculationRole,
     NetworkSpeciesRole,
@@ -93,6 +94,10 @@ class NetworkChannelRead(ORMBaseSchema):
     source_state_id: int
     sink_state_id: int
     kind: NetworkChannelKind
+    # Always present: says whether this channel is one elementary step or a
+    # chemically-activated well-skipping pathway, so an empty microreaction
+    # set is never ambiguous.
+    mechanism: NetworkChannelMechanism
     channel_key: str | None = None
 
 

--- a/backend/app/schemas/reads/scientific_network.py
+++ b/backend/app/schemas/reads/scientific_network.py
@@ -35,6 +35,7 @@ from app.db.models.common import (
     EnergyCorrectionConvention,
     EnergyZeroConvention,
     NetworkChannelKind,
+    NetworkChannelMechanism,
     NetworkKineticsModelKind,
     NetworkSolveCalculationRole,
     NetworkSpeciesRole,
@@ -154,11 +155,19 @@ class NetworkChannelSummary(BaseModel):
     ``network_state`` has no public_ref. Composition_hash is unique
     per ``(network_id, composition_hash)`` so it's a stable address
     within a network.
+
+    ``mechanism`` is always present and states, as a machine token, why
+    ``microreactions`` looks the way it does: an ``elementary`` channel names
+    its elementary step(s), a ``well_skipping`` one has none because a
+    chemically-activated pathway has no single elementary step behind it. A
+    caller never has to read an empty ``microreactions`` list and guess whether
+    the pathway is multi-step or the deposit was incomplete.
     """
 
     network_channel_id: int | None = None
     channel_key: str | None = None
     kind: NetworkChannelKind
+    mechanism: NetworkChannelMechanism
     source_state_composition_hash: str
     sink_state_composition_hash: str
     source_state_id: int | None = None

--- a/backend/app/schemas/workflows/network_pdep_upload.py
+++ b/backend/app/schemas/workflows/network_pdep_upload.py
@@ -32,6 +32,7 @@ from app.db.models.common import (
     EnergyCorrectionConvention,
     EnergyZeroConvention,
     NetworkChannelKind,
+    NetworkChannelMechanism,
     NetworkKineticsModelKind,
     NetworkSolveCalculationRole,
     PressureUnit,
@@ -344,19 +345,68 @@ class NetworkChannelIn(SchemaBase):
 
     :param source_state_key: Local key of the source state.
     :param sink_state_key: Local key of the sink state.
-    :param kind: Channel classification.
+    :param kind: Macroscopic channel classification (association, ...).
+    :param mechanism: Mechanistic attribution. Defaults to ``elementary``, so
+        an existing payload that names its ``microreaction_paths`` is
+        unaffected.
+    :param microreaction_paths: The elementary step(s) this channel is
+        attributed to.
+
+    The two classification axes are orthogonal. ``kind`` says what the channel
+    does macroscopically; ``mechanism`` says what evidence stands behind it:
+
+    - ``elementary`` (the default) requires at least one ``microreaction_path``.
+      Omitting the paths is an incomplete deposit, not a declaration, and is
+      rejected.
+    - ``well_skipping`` declares a chemically-activated channel whose flux
+      passes *through* one or more energized wells before the products separate
+      — ``NH2 + NH2 → H + N2H3`` proceeding via energized ``N2H4*`` is the
+      canonical case. There is no single elementary step or saddle point to
+      name, so ``microreaction_paths`` must be empty; the channel's backing is
+      the network topology plus the master-equation solve. Declaring it is not
+      taken on trust: ``NetworkPDepUploadRequest`` checks that the endpoints are
+      *not* joined by a single elementary step and *are* joined by a chain of
+      elementary steps whose intermediates are all wells.
     """
 
     key: str = Field(min_length=1)
     source_state_key: str = Field(min_length=1)
     sink_state_key: str = Field(min_length=1)
     kind: NetworkChannelKind
-    microreaction_paths: list["NetworkChannelMicroReactionIn"] = Field(min_length=1)
+    mechanism: NetworkChannelMechanism = NetworkChannelMechanism.elementary
+    microreaction_paths: list["NetworkChannelMicroReactionIn"] = Field(
+        default_factory=list
+    )
 
     @model_validator(mode="after")
     def validate_source_ne_sink(self) -> Self:
         if self.source_state_key == self.sink_state_key:
             raise ValueError("source_state_key and sink_state_key must differ.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_paths_match_mechanism(self) -> Self:
+        """Path cardinality is fixed by the declared mechanism, never optional.
+
+        This is what keeps the relaxation additive and non-silent: a channel
+        that supplies no paths is only ever accepted when it has *said* it is
+        well-skipping.
+        """
+        if self.mechanism == NetworkChannelMechanism.elementary:
+            if not self.microreaction_paths:
+                raise ValueError(
+                    f"channel '{self.key}' supplies no microreaction_paths. An "
+                    "elementary channel (the default) must name at least one "
+                    "elementary step; a channel with no elementary step behind "
+                    "it must declare mechanism='well_skipping' explicitly."
+                )
+        elif self.microreaction_paths:
+            raise ValueError(
+                f"channel '{self.key}' declares mechanism='well_skipping' but "
+                "supplies microreaction_paths. A well-skipping channel has no "
+                "single elementary step; if the endpoints are joined by one, "
+                "declare mechanism='elementary' and name it."
+            )
         return self
 
 
@@ -1206,6 +1256,113 @@ class NetworkPDepUploadRequest(SchemaBase):
             for barrier in self.solve.channel_barriers:
                 if barrier.source_calculation_key is not None and barrier.source_calculation_key not in calc_keys:
                     raise ValueError("channel_barriers references undefined source_calculation_key.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_well_skipping_channels(self) -> Self:
+        """A well-skipping declaration must be supported by the topology.
+
+        The scientific content of ``mechanism='well_skipping'`` is a claim
+        about the network: the endpoints are *not* directly connected by an
+        elementary step, and the flux reaches the sink by traversing one or
+        more energized wells. Both halves are checkable against the
+        ``micro_reactions`` and ``states`` already in this payload, so the
+        declaration is verified rather than trusted — the backend still
+        manufactures no evidence, it only reads the evidence the producer
+        supplied.
+
+        Bimolecular and termolecular configurations are reservoirs in the
+        master equation: flux that reaches one has separated into products.
+        Only a *well* can be an energized intermediate, so intermediates on the
+        path are required to be wells.
+        """
+        well_skipping = [
+            channel
+            for channel in self.channels
+            if channel.mechanism == NetworkChannelMechanism.well_skipping
+        ]
+        if not well_skipping:
+            return self
+
+        state_kind = {state.key: state.kind for state in self.states}
+        composition_to_state: dict[frozenset[tuple[str, int]], str] = {
+            frozenset(
+                (p.species_key, p.stoichiometry) for p in state.participants
+            ): state.key
+            for state in self.states
+        }
+
+        def _state_for(participants: list[MicroReactionParticipantUpload]) -> str | None:
+            counts: dict[str, int] = {}
+            for participant in participants:
+                counts[participant.species_key] = (
+                    counts.get(participant.species_key, 0) + 1
+                )
+            return composition_to_state.get(frozenset(counts.items()))
+
+        # Undirected adjacency of the *elementary* step graph over states. A
+        # micro reaction whose sides do not both name a declared state is not
+        # an edge of the macroscopic network.
+        elementary_edges: set[frozenset[str]] = set()
+        for reaction in self.micro_reactions:
+            reactant_state = _state_for(reaction.reactants)
+            product_state = _state_for(reaction.products)
+            if (
+                reactant_state is None
+                or product_state is None
+                or reactant_state == product_state
+            ):
+                continue
+            elementary_edges.add(frozenset((reactant_state, product_state)))
+
+        neighbours: dict[str, set[str]] = {state.key: set() for state in self.states}
+        for edge in elementary_edges:
+            left, right = tuple(edge)
+            neighbours[left].add(right)
+            neighbours[right].add(left)
+
+        for channel in well_skipping:
+            source = channel.source_state_key
+            sink = channel.sink_state_key
+            if source not in state_kind or sink not in state_kind:
+                # Undefined endpoints are reported by validate_key_references;
+                # do not mask that with a topology error.
+                continue
+            if frozenset((source, sink)) in elementary_edges:
+                raise ValueError(
+                    f"channel '{channel.key}' declares mechanism='well_skipping' "
+                    f"but '{source}' and '{sink}' are directly connected by an "
+                    "elementary micro reaction. Declare mechanism='elementary' "
+                    "and name that step."
+                )
+            # Breadth-first search that may only pass *through* wells; the
+            # source and the sink themselves may be of any kind.
+            seen = {source}
+            frontier = [source]
+            reached = False
+            while frontier and not reached:
+                nxt: list[str] = []
+                for node in frontier:
+                    for neighbour in neighbours[node]:
+                        if neighbour == sink:
+                            reached = True
+                            break
+                        if neighbour in seen or state_kind[neighbour] != "well":
+                            continue
+                        seen.add(neighbour)
+                        nxt.append(neighbour)
+                    if reached:
+                        break
+                frontier = nxt
+            if not reached:
+                raise ValueError(
+                    f"channel '{channel.key}' declares mechanism='well_skipping' "
+                    f"but no chain of elementary micro reactions runs from "
+                    f"'{source}' to '{sink}' through well states. A "
+                    "chemically-activated channel is backed by the network "
+                    "topology; without it there is no evidence for this "
+                    "channel at all."
+                )
         return self
 
     @model_validator(mode="after")

--- a/backend/app/services/scientific_read/networks.py
+++ b/backend/app/services/scientific_read/networks.py
@@ -634,6 +634,7 @@ def _build_channels(
             network_channel_id=r.id,
             channel_key=r.channel_key,
             kind=r.kind,
+            mechanism=r.mechanism,
             source_state_id=r.source_state_id,
             sink_state_id=r.sink_state_id,
             source_state_composition_hash=state_hash_by_id.get(

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -550,6 +550,7 @@ def persist_network_pdep_upload(
             source_state_id=state_key_to_row[ch_in.source_state_key].id,
             sink_state_id=state_key_to_row[ch_in.sink_state_key].id,
             kind=ch_in.kind,
+            mechanism=ch_in.mechanism,
             channel_key=ch_in.key,
         )
         session.add(channel_row)

--- a/backend/docs/deployment/migrations.md
+++ b/backend/docs/deployment/migrations.md
@@ -267,11 +267,12 @@ If both counts are zero, `alembic upgrade head` proceeds normally and nothing be
    ```
    Species, calculations, transition states and statmech rows are **not** deleted — they are shared identity/result rows and the re-upload will resolve to the existing ones.
 4. **Migrate.** `alembic upgrade head` now runs to completion.
-5. **Re-upload** each network through `POST /api/v1/uploads/networks/pdep` with a v2 payload regenerated from its source run (for Arkane runs, `backend/scripts/pdep_ingestion` emits one). Each payload must carry per-channel `microreaction_paths`, per-path `channel_barriers`, and `(state_key, collider_species_key)`-scoped `energy_transfer`.
+5. **Re-upload** each network through `POST /api/v1/uploads/networks/pdep` with a v2 payload regenerated from its source run (for Arkane runs, `backend/scripts/pdep_ingestion` emits one). Each payload must carry per-path `channel_barriers`, `(state_key, collider_species_key)`-scoped `energy_transfer`, and, for every channel that is one elementary step, `microreaction_paths`. A chemically-activated **well-skipping** channel has no elementary step to name and instead declares `mechanism: "well_skipping"` with no paths (see `backend/docs/specs/pdep_upload_contract_v2.md`, "Well-skipping channels"). Omitting the paths *without* that declaration is still rejected.
 6. **Verify** that the re-uploaded network count matches the export, and that `network_channel.channel_key` is non-null everywhere:
    ```sql
    SELECT count(*) FROM network_channel WHERE channel_key IS NULL;  -- expect 0
    ```
+   The per-network **channel** count should match the export too: well-skipping channels are carried across, so a v1 network's phenomenological channels are all representable in v2. A shortfall means the producer dropped chemically-activated pathways rather than declaring them.
 
 **Downgrading** `c1d2e3f4a5b6` refuses symmetrically when either a TS-owned `statmech` row exists (the prior schema has no truthful subject for it) or two channels share `(network_id, source_state_id, sink_state_id)` (the prior schema made that triple unique). Resolve those rows before rolling back.
 

--- a/backend/docs/specs/pdep_upload_contract_v2.md
+++ b/backend/docs/specs/pdep_upload_contract_v2.md
@@ -8,8 +8,12 @@ are rejected; the backend does not manufacture missing scientific evidence.
 
 ## What v2 requires
 
-- Every channel supplies explicit `microreaction_paths`. A path names a
-  `micro_reaction_key` and either the `transition_state_key` of the saddle
+- Every channel declares a `mechanism`, a machine token that says what evidence
+  stands behind it. It defaults to `elementary`, so a payload that names its
+  paths is unaffected. It is orthogonal to `kind`, which classifies the
+  channel's macroscopic reaction type.
+- An `elementary` channel supplies explicit `microreaction_paths`. A path names
+  a `micro_reaction_key` and either the `transition_state_key` of the saddle
   point it goes through, or nothing at all — omitting it declares the path
   **barrierless / variational**, which is the honest description of a
   radical-radical association or a simple bond fission. Distinct pathways may
@@ -17,6 +21,10 @@ are rejected; the backend does not manufacture missing scientific evidence.
   several distinct saddle points (e.g. syn/anti conformers of one TS); that is
   expressed with several paths on **one** micro reaction, never with duplicate
   micro reactions of identical stoichiometry.
+- A `well_skipping` channel supplies **no** paths, and says so. See
+  "Well-skipping channels" below. A channel that omits its paths *without*
+  declaring `mechanism: well_skipping` is still rejected: silence is never a
+  declaration.
 - A solve gives a state energy for every state, and one forward/reverse barrier
   for every *saddle-point* channel path. A barrierless path carries no barrier —
   offering one would be a fabricated number.
@@ -43,6 +51,58 @@ are rejected; the backend does not manufacture missing scientific evidence.
   actually produces.
 - TS partition functions are recorded as TS-owned `statmech` records, never as
   pseudo-species statmech.
+
+## Well-skipping channels
+
+A pressure-dependent network's most characteristic rates are the ones that no
+single elementary step produces. `NH2 + NH2` recombines into energized `N2H4*`,
+which dissociates to `H + N2H3` before collisional stabilization; the master
+equation returns one phenomenological k(T,P) for `NH2 + NH2 → H + N2H3` even
+though the pathway is two elementary steps through a well. These are the
+chemically-activated, or **well-skipping**, channels. They have no saddle point
+of their own, so requiring mechanistic attribution of every channel silently
+discarded them — for the hydrazine network, 15 of 21 channels, leaving only the
+6 that essentially reproduce the high-pressure limit.
+
+The DB never forbade them: `network_channel_microreaction` is a separate table
+and a channel with zero rows there has always been representable. The upload
+contract was the only thing in the way.
+
+v2 therefore accepts them, on three conditions:
+
+1. **Declared, never inferred.** The channel sets
+   `mechanism: "well_skipping"`. There is no `unknown` or `other` member on the
+   enum, because an escape hatch here would be indistinguishable from "the
+   producer omitted the paths".
+2. **No paths.** A well-skipping channel must supply an empty
+   `microreaction_paths`. If a single elementary step does join the endpoints,
+   the channel is elementary and must name it. It carries no `channel_barriers`
+   entry either, for the same reason a barrierless path carries none: there is
+   no barrier to state.
+3. **Verified against the topology.** The declaration is checked, not trusted.
+   `NetworkPDepUploadRequest.validate_well_skipping_channels` requires that the
+   endpoints are *not* directly connected by any declared micro reaction, and
+   *are* connected by a chain of declared micro reactions every intermediate of
+   which is a `well` state. Bimolecular and termolecular configurations are
+   reservoirs in the master equation — flux reaching one has separated into
+   products — so they cannot be intermediates on a single chemically-activated
+   channel. The backend still manufactures no evidence; it reads the network
+   topology the producer already supplied and confirms it supports the claim.
+
+`mechanism` is stored on `network_channel` (revision `d5b1a7c3e9f4`,
+`server_default 'elementary'`) rather than derived from an empty child
+collection, and is always present on the channel read surfaces. "This rate is a
+multi-step ME channel" is a scientific claim about the channel, not an absence
+of data, and a reader must be able to tell it apart from an incomplete deposit
+without consulting the contract version that wrote the row. The backfill is
+unambiguous: `c1d2e3f4a5b6` refuses to run unless `network_channel` is empty, so
+every row this revision can reach was written under v2, which required at least
+one path per channel.
+
+Deliberately **not** recorded: *which* wells a given well-skipping channel
+traverses. The master equation does not attribute its phenomenological flux to
+one route, so naming a route would be a fabricated attribution. The traversal is
+recoverable from the network topology, which is stored in full.
 
 ## Rollout
 

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -313,6 +313,11 @@ enum NetworkChannelKind {
   exchange
 }
 
+enum NetworkChannelMechanism {
+  elementary
+  well_skipping
+}
+
 enum NetworkKineticsModelKind {
   chebyshev
   plog
@@ -2070,6 +2075,7 @@ Table network_channel {
   source_state_id bigint [not null, ref: > network_state.id]
   sink_state_id bigint [not null, ref: > network_state.id]
   kind NetworkChannelKind [not null]
+  mechanism NetworkChannelMechanism [not null, default: 'elementary']
   channel_key text [not null]
 
   indexes {

--- a/backend/scripts/pdep_ingestion/builder.py
+++ b/backend/scripts/pdep_ingestion/builder.py
@@ -120,6 +120,7 @@ class GapReport:
     ts_built: list[str] = field(default_factory=list)
     ts_stub_no_geometry: list[str] = field(default_factory=list)
     channels_built: int = 0
+    channels_well_skipping: list[tuple[str, str]] = field(default_factory=list)
     channels_unmapped: list[tuple[str, str]] = field(default_factory=list)
     channels_duplicate: list[tuple[str, str]] = field(default_factory=list)
     pdep_non_chebyshev: list[tuple[str, str, str]] = field(default_factory=list)
@@ -794,6 +795,40 @@ def build_network_pdep_payload(
                 )
         return paths
 
+    # Undirected adjacency over the elementary steps that were actually parsed.
+    elementary_neighbours: dict[str, set[str]] = {}
+    for _rxn_key, (reactant_state, product_state) in rxn_endpoints.items():
+        if reactant_state is None or product_state is None:
+            continue
+        if reactant_state == product_state:
+            continue
+        elementary_neighbours.setdefault(reactant_state, set()).add(product_state)
+        elementary_neighbours.setdefault(product_state, set()).add(reactant_state)
+
+    def _well_skipping_supported(src: str, snk: str) -> bool:
+        """Is there a multi-step route from src to snk through energized wells?
+
+        Mirrors ``NetworkPDepUploadRequest.validate_well_skipping_channels``. A
+        bimolecular configuration is a reservoir in the master equation — flux
+        that reaches one has separated — so only wells may sit *between* the
+        endpoints. Without such a route the fit has no topological backing in
+        this run and stays unmapped rather than being asserted.
+        """
+        seen = {src}
+        frontier = [src]
+        while frontier:
+            nxt: list[str] = []
+            for node in frontier:
+                for neighbour in elementary_neighbours.get(node, ()):
+                    if neighbour == snk:
+                        return True
+                    if neighbour in seen or state_kind.get(neighbour) != "well":
+                        continue
+                    seen.add(neighbour)
+                    nxt.append(neighbour)
+            frontier = nxt
+        return False
+
     # ------------------------------------------------------------------
     # Channels + channel_kinetics (one per fitted pdepreaction)
     # ------------------------------------------------------------------
@@ -822,12 +857,23 @@ def build_network_pdep_payload(
             continue
         paths = _paths_for_channel(src, snk)
         if not paths:
-            # A phenomenological fit with no elementary step behind it cannot
-            # be attributed; name it instead of emitting an unsupported channel.
-            gap.channels_unmapped.append(
+            # No single elementary step joins these two configurations, yet the
+            # master equation produced a phenomenological k(T,P) for them. That
+            # is the definition of a chemically-activated / well-skipping
+            # channel: the flux runs through one or more energized wells before
+            # the products separate. Emit it as such rather than dropping it —
+            # dropping it discards exactly the rates that distinguish a PDep
+            # treatment from the high-pressure limit. The upload schema
+            # re-derives and checks the traversal, so this is a declaration the
+            # backend verifies, not one it takes on trust.
+            if not _well_skipping_supported(src, snk):
+                gap.channels_unmapped.append(
+                    ("+".join(fit.reactants), "+".join(fit.products))
+                )
+                continue
+            gap.channels_well_skipping.append(
                 ("+".join(fit.reactants), "+".join(fit.products))
             )
-            continue
         seen_channel_pairs.add(pair)
         pmin_bar, pmax_bar = _fit_bounds_bar_kelvin(fit)  # honours atm/bar; K
         kind = _KIND.get((state_kind[src], state_kind[snk]), "isomerization")
@@ -838,6 +884,7 @@ def build_network_pdep_payload(
                 "source_state_key": src,
                 "sink_state_key": snk,
                 "kind": kind,
+                "mechanism": "elementary" if paths else "well_skipping",
                 "microreaction_paths": paths,
             }
         )

--- a/backend/scripts/pdep_ingestion/cli.py
+++ b/backend/scripts/pdep_ingestion/cli.py
@@ -50,6 +50,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"torsions emitted for: {gap.torsions_emitted}", file=sys.stderr)
     print(f"micro_reactions: {gap.micro_reactions}", file=sys.stderr)
     print(f"channels built: {gap.channels_built}", file=sys.stderr)
+    print(
+        f"channels well-skipping ({len(gap.channels_well_skipping)}): "
+        f"{gap.channels_well_skipping}",
+        file=sys.stderr,
+    )
     if gap.channels_unmapped:
         print(f"channels unmapped: {gap.channels_unmapped}", file=sys.stderr)
     if gap.channels_duplicate:

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -19451,7 +19451,7 @@
       },
       "NetworkChannelIn": {
         "additionalProperties": false,
-        "description": "A directed phenomenological channel between two network states.\n\n:param source_state_key: Local key of the source state.\n:param sink_state_key: Local key of the sink state.\n:param kind: Channel classification.",
+        "description": "A directed phenomenological channel between two network states.\n\n:param source_state_key: Local key of the source state.\n:param sink_state_key: Local key of the sink state.\n:param kind: Macroscopic channel classification (association, ...).\n:param mechanism: Mechanistic attribution. Defaults to ``elementary``, so\n    an existing payload that names its ``microreaction_paths`` is\n    unaffected.\n:param microreaction_paths: The elementary step(s) this channel is\n    attributed to.\n\nThe two classification axes are orthogonal. ``kind`` says what the channel\ndoes macroscopically; ``mechanism`` says what evidence stands behind it:\n\n- ``elementary`` (the default) requires at least one ``microreaction_path``.\n  Omitting the paths is an incomplete deposit, not a declaration, and is\n  rejected.\n- ``well_skipping`` declares a chemically-activated channel whose flux\n  passes *through* one or more energized wells before the products separate\n  — ``NH2 + NH2 → H + N2H3`` proceeding via energized ``N2H4*`` is the\n  canonical case. There is no single elementary step or saddle point to\n  name, so ``microreaction_paths`` must be empty; the channel's backing is\n  the network topology plus the master-equation solve. Declaring it is not\n  taken on trust: ``NetworkPDepUploadRequest`` checks that the endpoints are\n  *not* joined by a single elementary step and *are* joined by a chain of\n  elementary steps whose intermediates are all wells.",
         "properties": {
           "key": {
             "minLength": 1,
@@ -19461,11 +19461,14 @@
           "kind": {
             "$ref": "#/components/schemas/NetworkChannelKind"
           },
+          "mechanism": {
+            "$ref": "#/components/schemas/NetworkChannelMechanism",
+            "default": "elementary"
+          },
           "microreaction_paths": {
             "items": {
               "$ref": "#/components/schemas/NetworkChannelMicroReactionIn"
             },
-            "minItems": 1,
             "title": "Microreaction Paths",
             "type": "array"
           },
@@ -19484,8 +19487,7 @@
           "key",
           "source_state_key",
           "sink_state_key",
-          "kind",
-          "microreaction_paths"
+          "kind"
         ],
         "title": "NetworkChannelIn",
         "type": "object"
@@ -19499,6 +19501,15 @@
           "exchange"
         ],
         "title": "NetworkChannelKind",
+        "type": "string"
+      },
+      "NetworkChannelMechanism": {
+        "description": "How a phenomenological channel is mechanistically attributed.\n\nOrthogonal to :class:`NetworkChannelKind`, which classifies the channel's\n*macroscopic* reaction type (association, isomerization, ...). This axis\nsays what scientific evidence stands behind the channel.\n\n``elementary``\n    The channel is one elementary step, or several parallel elementary\n    steps, each named on ``network_channel_microreaction``. Every\n    saddle-point path carries a barrier.\n\n``well_skipping``\n    A chemically-activated / well-skipping channel: the reactants form an\n    energized intermediate that reacts onward before collisional\n    stabilization, so the phenomenological k(T,P) is produced by the\n    master equation and there is no single elementary step or saddle point\n    to attribute it to. Its backing is the network topology plus the ME\n    solve, and it therefore carries **zero**\n    ``network_channel_microreaction`` rows *by declaration*, never by\n    omission.\n\nThere is deliberately no ``unknown``/``other`` member. An escape hatch here\nwould be indistinguishable from \"the producer did not supply the paths\",\nwhich is exactly the silent gap this discriminator exists to close.",
+        "enum": [
+          "elementary",
+          "well_skipping"
+        ],
+        "title": "NetworkChannelMechanism",
         "type": "string"
       },
       "NetworkChannelMicroReactionIn": {
@@ -19584,6 +19595,9 @@
           "kind": {
             "$ref": "#/components/schemas/NetworkChannelKind"
           },
+          "mechanism": {
+            "$ref": "#/components/schemas/NetworkChannelMechanism"
+          },
           "network_id": {
             "title": "Network Id",
             "type": "integer"
@@ -19602,13 +19616,14 @@
           "network_id",
           "source_state_id",
           "sink_state_id",
-          "kind"
+          "kind",
+          "mechanism"
         ],
         "title": "NetworkChannelRead",
         "type": "object"
       },
       "NetworkChannelSummary": {
-        "description": "One ``network_channel`` row projected for ``include=channels``.\n\nSource/sink state pointers use the composition_hash because\n``network_state`` has no public_ref. Composition_hash is unique\nper ``(network_id, composition_hash)`` so it's a stable address\nwithin a network.",
+        "description": "One ``network_channel`` row projected for ``include=channels``.\n\nSource/sink state pointers use the composition_hash because\n``network_state`` has no public_ref. Composition_hash is unique\nper ``(network_id, composition_hash)`` so it's a stable address\nwithin a network.\n\n``mechanism`` is always present and states, as a machine token, why\n``microreactions`` looks the way it does: an ``elementary`` channel names\nits elementary step(s), a ``well_skipping`` one has none because a\nchemically-activated pathway has no single elementary step behind it. A\ncaller never has to read an empty ``microreactions`` list and guess whether\nthe pathway is multi-step or the deposit was incomplete.",
         "properties": {
           "channel_key": {
             "anyOf": [
@@ -19627,6 +19642,9 @@
           },
           "kind": {
             "$ref": "#/components/schemas/NetworkChannelKind"
+          },
+          "mechanism": {
+            "$ref": "#/components/schemas/NetworkChannelMechanism"
           },
           "microreactions": {
             "items": {
@@ -19682,6 +19700,7 @@
         },
         "required": [
           "kind",
+          "mechanism",
           "source_state_composition_hash",
           "sink_state_composition_hash",
           "has_kinetics"

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -2351,3 +2351,187 @@ def test_network_chebyshev_requires_temperature_and_pressure_bounds() -> None:
 
     payload["solve"]["channel_kinetics"][0].update({"pmin_bar": 0.01, "pmax_bar": 100.0})
     assert NetworkPDepUploadRequest(**payload) is not None
+
+
+# ---------------------------------------------------------------------------
+# Well-skipping (chemically-activated) channels
+# ---------------------------------------------------------------------------
+
+
+def _well_skipping_payload() -> dict:
+    """``_full_payload`` plus the chemically-activated entrance -> exit channel.
+
+    ``C2H5 + O2 -> C2H4 + HO2`` is the textbook well-skipping rate: the
+    reactants associate into energized ``C2H5OO*``, which eliminates HO2 before
+    it is collisionally stabilized. No single elementary step joins the
+    entrance and exit configurations, so the master equation's phenomenological
+    k(T,P) is the only thing that describes it.
+    """
+    payload = _full_payload(include_solve=True)
+    payload["channels"].append(
+        {
+            "key": "chemically_activated_path",
+            "source_state_key": "entrance",
+            "sink_state_key": "exit",
+            "kind": "exchange",
+            "mechanism": "well_skipping",
+        }
+    )
+    payload["solve"]["channel_kinetics"] = [
+        {
+            "channel_key": "chemically_activated_path",
+            "model_kind": "chebyshev",
+            "chebyshev": {
+                "n_temperature": 2,
+                "n_pressure": 2,
+                "coefficients": [[7.0, 0.5], [-0.25, 0.125]],
+            },
+            "tmin_k": 300.0,
+            "tmax_k": 2000.0,
+            "pmin_bar": 0.01,
+            "pmax_bar": 100.0,
+            "rate_units": "cm3_mol_s",
+            "pressure_units": "bar",
+            "temperature_units": "kelvin",
+            "stores_log10_k": True,
+            "note": "chemically activated; no single elementary step",
+        }
+    ]
+    return payload
+
+
+def test_pathless_channel_without_a_declaration_is_still_rejected() -> None:
+    """Omitting the paths is an incomplete deposit, never an implicit claim.
+
+    This is the guarantee that keeps the well-skipping relaxation additive:
+    silence still fails, and it fails with a message naming the declaration the
+    producer would have to make.
+    """
+    payload = _full_payload()
+    payload["channels"][2].pop("microreaction_paths")
+    with pytest.raises(ValueError, match="must declare mechanism='well_skipping'"):
+        NetworkPDepUploadRequest(**payload)
+
+    # Explicitly empty is not a loophole either.
+    payload["channels"][2]["microreaction_paths"] = []
+    with pytest.raises(ValueError, match="must declare mechanism='well_skipping'"):
+        NetworkPDepUploadRequest(**payload)
+
+
+def test_well_skipping_channel_must_not_supply_paths() -> None:
+    """If a single elementary step joins the endpoints, it is not well-skipping."""
+    payload = _well_skipping_payload()
+    payload["channels"][-1]["microreaction_paths"] = [
+        {"micro_reaction_key": "rxn_assoc"}
+    ]
+    with pytest.raises(ValueError, match="declares mechanism='well_skipping' but"):
+        NetworkPDepUploadRequest(**payload)
+
+
+def test_well_skipping_rejected_when_an_elementary_step_joins_the_endpoints() -> None:
+    """A directly-connected pair must be attributed, not declared multi-step."""
+    payload = _full_payload()
+    # entrance -> well_RO2 IS rxn_assoc; calling it well-skipping hides evidence.
+    payload["channels"][0] = {
+        "key": "association_path",
+        "source_state_key": "entrance",
+        "sink_state_key": "well_RO2",
+        "kind": "association",
+        "mechanism": "well_skipping",
+    }
+    with pytest.raises(ValueError, match="directly connected by an elementary"):
+        NetworkPDepUploadRequest(**payload)
+
+
+def test_well_skipping_rejected_without_a_well_intermediate() -> None:
+    """The intermediate must be an energized well, not a separated product set.
+
+    Flux that reaches a bimolecular configuration has separated; it is a
+    reservoir in the master equation, not an energized intermediate. Reclassify
+    the RO2 well as bimolecular and the declaration loses its backing.
+    """
+    payload = _well_skipping_payload()
+    payload["states"][1]["kind"] = "bimolecular"
+    # With no well states left, the (well, collider) transfer cross product is
+    # empty, so the transfer rows must go too.
+    payload["solve"]["energy_transfer"] = []
+    with pytest.raises(ValueError, match="through well states"):
+        NetworkPDepUploadRequest(**payload)
+
+
+def test_well_skipping_channel_round_trips(db_engine) -> None:
+    """A declared chemically-activated channel uploads, persists, and reads back.
+
+    It stores zero ``network_channel_microreaction`` rows and zero barriers —
+    correctly, because it has no elementary step and no saddle point — while
+    still carrying the master equation's k(T,P). The stored ``mechanism`` is
+    what keeps that emptiness readable as a claim rather than as a gap.
+    """
+    from app.db.models.common import NetworkChannelMechanism
+    from app.db.models.network_pdep import NetworkKinetics
+
+    with _rolled_back_session(db_engine) as session:
+        request = NetworkPDepUploadRequest(**_well_skipping_payload())
+        network = persist_network_pdep_upload(session, request)
+        session.flush()
+
+        channel = session.scalars(
+            select(NetworkChannel).where(
+                NetworkChannel.network_id == network.id,
+                NetworkChannel.channel_key == "chemically_activated_path",
+            )
+        ).one()
+        assert channel.mechanism is NetworkChannelMechanism.well_skipping
+        assert (
+            session.scalars(
+                select(NetworkChannelMicroReaction).where(
+                    NetworkChannelMicroReaction.channel_id == channel.id
+                )
+            ).all()
+            == []
+        )
+
+        solve = session.scalars(
+            select(NetworkSolve).where(NetworkSolve.network_id == network.id)
+        ).one()
+        assert (
+            session.scalars(
+                select(NetworkSolveChannelBarrier).where(
+                    NetworkSolveChannelBarrier.solve_id == solve.id,
+                    NetworkSolveChannelBarrier.channel_id == channel.id,
+                )
+            ).all()
+            == []
+        )
+        # The rate the master equation produced is what makes it worth storing.
+        kinetics = session.scalars(
+            select(NetworkKinetics).where(NetworkKinetics.channel_id == channel.id)
+        ).all()
+        assert len(kinetics) == 1
+
+        # Every elementary channel in the same payload is untouched.
+        elementary = session.scalars(
+            select(NetworkChannel).where(
+                NetworkChannel.network_id == network.id,
+                NetworkChannel.channel_key != "chemically_activated_path",
+            )
+        ).all()
+        assert len(elementary) == 3
+        assert all(
+            c.mechanism is NetworkChannelMechanism.elementary for c in elementary
+        )
+
+        # The read surface states the mechanism instead of leaving the caller
+        # to infer it from an empty microreaction list.
+        read = get_network(
+            session, network_handle=network.public_ref, include=["channels"]
+        )
+        by_key = {c.channel_key: c for c in read.record.channels or []}
+        activated = by_key["chemically_activated_path"]
+        assert activated.mechanism is NetworkChannelMechanism.well_skipping
+        assert activated.microreactions == []
+        assert activated.has_kinetics is True
+        assert (
+            by_key["elimination_path"].mechanism
+            is NetworkChannelMechanism.elementary
+        )


### PR DESCRIPTION
## Summary

Stage 2's v2 contract silently discarded **well-skipping (chemically activated) channels** — the distinctively pressure-dependent output of a master-equation calculation. On the real hydrazine network that meant storing **6 of 21 channels**. This makes them representable, without weakening v2's "no manufactured evidence" principle.

## The defect

`network_pdep_upload.py` required every channel to be backed by an elementary micro-reaction:

```python
microreaction_paths: list["NetworkChannelMicroReactionIn"] = Field(min_length=1)
```

A well-skipping channel has no single elementary transition state — that is what makes it well-skipping. `NH2+NH2 → H+N2H3` proceeds via *energized* `N2H4*` which dissociates before collisional stabilization: two elementary steps through a well, with a phenomenological k(T,P) only an ME produces.

So the contract forced either fabricating a fake elementary step (which v2 rightly forbids) or dropping the channel. It dropped.

Measured on `Final_MRCI_PDep` (2 wells `N2H4`/`NH3NH`, 5 bimolecular configurations):

| | before | after |
|---|---|---|
| channels built | **6** | **21** |
| channels unmapped | **15** | **0** |

The 15 dropped were 10 bimolecular→bimolecular and 5 bimolecular→far-well — every one a well-skipping path. What survived was direct association/isomerization into a well: essentially the high-pressure-limit picture, obtainable from TST without an ME at all. **The contract kept the part you did not need a master equation for and discarded the part you did.**

21 = C(7,2): Arkane emits one fit per state pair, and all 21 are now representable. This matches the 21 channels per network held in production under v1, so a v1→v2 re-upload is now faithful rather than lossy.

## The fix, and why it is not a loosening

A machine-token discriminator, mirroring how v2 already handles "no TS" via `path_kind`:

```python
class NetworkChannelMechanism(str, Enum):
    elementary = "elementary"      # default -> >=1 path, as before
    well_skipping = "well_skipping"  # zero paths, zero barriers
```

**The declaration is verified, not trusted.** `validate_well_skipping_channels` requires that source and sink are *not* joined by any single declared micro-reaction, *and* **are** joined by a chain of declared micro-reactions whose every intermediate is a `well` state. Bimolecular configurations are reservoirs in the ME — flux reaching one has separated — so they cannot be intermediates on one chemically-activated channel.

A pathless channel that does *not* declare itself is still rejected, covered by an explicit test. Simply relaxing `min_length` to 0 was considered and rejected: silence would become indistinguishable from a claim.

Deliberately **not** recorded: which wells a channel traverses. The ME does not attribute its phenomenological flux to one route, so naming one would be fabricated attribution — the exact thing v2 exists to prevent. The traversal is recoverable from the stored topology, which is what the validator walks.

## Schema

New revision **`d5b1a7c3e9f4`** above `e3f4a5b6c7d8`: `network_channel.mechanism`, NOT NULL, `server_default 'elementary'`, new enum `network_channel_mechanism`. Both `upgrade()`/`downgrade()` implemented and an `upgrade → downgrade → upgrade` cycle verified clean.

The backfill is unambiguous rather than a guess: `c1d2e3f4a5b6` refuses to run unless `network_channel` is empty, so every row this revision can reach was written under v2 — which required ≥1 path — and is genuinely elementary.

## Validation

| check | result |
|---|---|
| hydrazine rebuild | **21 built, 0 unmapped**, `VALIDATION: PASS` |
| persistence into a clean DB at head | 21 channels (6 elementary + 15 well-skipping), 7 states, 21 kinetics, 2 energy-transfer |
| well-skipping channels carrying microreaction rows | **none** |
| every well-skipping channel has a fitted k(T,P) | **true** |
| `test-api.sh` | **2295 passed** |
| `test-scientific.sh` | **1743 passed** |
| `test_network_pdep_upload.py` | **63 passed** |
| ruff / mypy | clean / clean (143 files) |

Four new negative tests guard the declaration itself: pathless-without-declaration, well-skipping-supplying-paths, well-skipping-where-an-elementary-step-joins-the-endpoints, and well-skipping-without-a-well-intermediate. The pre-existing `("missing channel path")` case still raises — the relaxation did not open it.

## Notes

- **Production untouched.** `c1d2e3f4a5b6` and its migration guard are byte-identical to main. The delete-and-re-upload procedure is unchanged; only one now-false sentence in `migrations.md` step 5 was corrected, plus a note that the re-uploaded channel count should now match the v1 export rather than fall short.
- Impact analysis returned CRITICAL for `NetworkChannelIn` / `NetworkChannel` / `NetworkChannelSummary`, but those look file/import-level rather than symbol-precise — the counts are byte-identical across symbols in different files, and the "affected modules" include unrelated areas. The real blast radius is bounded empirically by 4101 green tests, and every schema change is additive with a default.
- **Follow-up for whoever lands the Stage-4 branch:** that branch adds `schemas/python/tckdb-schemas/tckdb_schemas/workflows/network_pdep_upload.py`. It must mirror `mechanism` and the new enum, or the published wire contract will diverge from the backend.
