### PR TITLE
Unpin starlette from the vulnerable 0.52.1

### DIFF
--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -62,10 +62,18 @@ dependencies:
 
   # Web framework + ASGI server. `uvicorn-standard` pulls in
   # httptools / uvloop / websockets / watchfiles. `starlette` is pinned
-  # explicitly (fastapi depends on it) because a minor bump changed
+  # explicitly because fastapi depends on it and only floors it
+  # (`starlette>=0.46.0`, no upper bound), so an unpinned solve would drift.
+  #
+  # Was held at 0.52.1 because a minor bump changed
   # `request.scope["route"].path` semantics and broke idempotency scoping.
+  # That blocker is resolved: `app/api/idempotency.py` now derives its scope
+  # key from `request.url.path` precisely to be version-robust. Holding it
+  # was a live exposure -- on 0.52.1 routing matches `scope["path"]` while
+  # idempotency and rate-limit classification read `request.url.path`, so a
+  # `Host` header makes them disagree.
   - fastapi=0.135.1
-  - starlette=0.52.1
+  - starlette=1.3.1
   - uvicorn-standard=0.42.0
 
   # ORM + driver + migrations. `psycopg-c` is the optional C accelerator
@@ -77,7 +85,7 @@ dependencies:
 
   # Validation / settings.
   - pydantic=2.12.5
-  - pydantic-settings=2.13.1
+  - pydantic-settings=2.14.2
   - python-dotenv=1.2.1
 
   # Chemistry.


### PR DESCRIPTION
## Summary

Bumps `starlette` 0.52.1 → 1.3.1 and `pydantic-settings` 2.13.1 → 2.14.2 in `backend/environment.yml`. Two lines.

This is the only change that hardens the **running** service. #70 closed 42 Dependabot alerts without affecting anything that executes.

## Why this and not the lockfile

All 20 pip alerts are on `backend/uv.lock`. Nothing installs from it:

- `backend/Dockerfile:26-27` builds the published image from `backend/environment.yml` via micromamba — its own comment calls that file *"the single source of truth"*
- `.github/workflows/backend-ci.yml:105` builds the CI env from `backend/environment.yml`

Dependabot cannot scan conda manifests, so the deployed exposure is **invisible to the alert count** and would have stayed that way.

## The reachable issue

Not one of the nine high-severity Pillow advisories — a *medium* starlette one, alert #2.

Routing matches `scope["path"]`, but `idempotency.py:125` and `rate_limit.py:291` both read `request.url.path`. On 0.52.1 those disagree:

```
starlette 0.52.1:  Host: testserver/x  ->  url.path='/x/api/v1/auth/login'
                   routed_path still '/api/v1/auth/login'
                   _classify bucket: 'login' (limit 10) -> 'anon_other' (limit 20)
starlette 1.3.1:   Host: testserver/x  ->  rejected
```

So a `Host` header can:
1. move login attempts out of the strict login rate-limit bucket, and
2. forge **unbounded distinct idempotency scope keys** against one real endpoint, defeating duplicate-write protection on the upload endpoints.

## The pin's stated blocker no longer applies

`environment.yml:65` held starlette because *"a minor bump changed `request.scope["route"].path` semantics and broke idempotency scoping"*. That is no longer true — `idempotency.py:106-125` was since rewritten to derive its scope key from `request.url.path` **precisely to be version-robust**. The comment outlived the constraint.

## Validation

Not just a solve — a real environment was built from this file and the suite run against it.

| check | result |
|---|---|
| conda-forge solve against existing `fastapi=0.135.1` / `pydantic=2.12.5` | resolves, **0 conflicts**, neither package changed |
| built env reports | `starlette 1.3.1`, `fastapi 0.135.1`, `pydantic 2.12.5` |
| **idempotency + rate-limit suites** (what the pin guarded) | **42 passed** |
| `test-scientific.sh` under the bumped env | **1745 passed** |
| `test-api.sh` under the bumped env | **2295 passed** |

`fastapi` requires only `starlette>=0.46.0` with no upper bound, which is why the existing FastAPI/Pydantic pins are untouched.

## Deployment note

This needs a Pi redeploy to take effect — a conda env rebuild, not just a code pull. Worth batching with the pending Stage 2/3 migration deploy rather than rebuilding the environment twice.