### PR TITLE
Detect charge and multiplicity mismatches against the actual ESS log

### DIFF
--- a/backend/app/api/routes/calculations.py
+++ b/backend/app/api/routes/calculations.py
@@ -80,6 +80,9 @@ from app.services.artifact_persistence import persist_artifact_batch
 from app.services.calculation_parameter_extraction import (
     try_extract_parameters_from_input_upload,
 )
+from app.services.charge_multiplicity_extraction import (
+    try_reconcile_charge_multiplicity_from_output_upload,
+)
 from app.services.hessian_extraction import (
     try_extract_hessian_from_artifact_upload,
 )
@@ -675,6 +678,13 @@ def upload_calculation_artifacts(
         )
         if sp_warning is not None:
             warnings.append(sp_warning)
+        # Output logs also state the charge and spin multiplicity the run
+        # actually used; contradicting the declared identity is flagged.
+        warnings.extend(
+            try_reconcile_charge_multiplicity_from_output_upload(
+                calculation, art_in
+            )
+        )
         # Fill-when-absent: a freq log / ORCA .hess yields the Cartesian
         # force-constant matrix, bound to the calc's input geometry.
         try_extract_hessian_from_artifact_upload(session, calculation, art_in)

--- a/backend/app/services/README.md
+++ b/backend/app/services/README.md
@@ -16,6 +16,14 @@ these; services never call routes. ~39 top-level modules + 4 subpackages.
   `species_resolution.py`) to understand the pattern.
 - **`upload_submission.py`** — opens/closes submissions around every
   write; `upload_reconciliation.py` — non-blocking upload warnings.
+- **`*_extraction.py`** — best-effort hooks that re-read an uploaded ESS
+  artifact and cross-check it against what the submitter declared:
+  `sp_energy_extraction` (single-point energy),
+  `charge_multiplicity_extraction` (charge / spin multiplicity),
+  `hessian_extraction`, `calculation_parameter_extraction`. All are
+  banner-sniff dispatched per program, never fail an upload, and stay
+  silent when the log cannot be parsed — an absence is not a
+  contradiction (ADR 0008).
 - **`record_review.py`** — the human review state machine + `apply_review_policy()`.
 
 ## Subpackages (curation & reads)

--- a/backend/app/services/charge_multiplicity_extraction.py
+++ b/backend/app/services/charge_multiplicity_extraction.py
@@ -1,0 +1,122 @@
+"""Upload-side hook: cross-check declared charge / multiplicity against the log.
+
+Sibling to :mod:`app.services.sp_energy_extraction`. That hook reconciles the
+single-point energy an uploading tool reported against the value re-derived
+from the output log; this one does the same for the charge and spin
+multiplicity declared on the species entry (or transition-state entry) the
+calculation belongs to:
+
+* the log states a different charge or multiplicity -> return a warning
+* they agree, or the log cannot be re-read           -> no action
+
+Nothing is ever written. The declared charge and multiplicity are part of
+the entry's *identity* (``uq_species_identity`` is SMILES + charge +
+multiplicity), so silently correcting them would silently repoint the upload
+at a different species. TCKDB flags the contradiction and leaves the record
+exactly as submitted, the same policy the single-point-energy hook applies
+on a mismatch.
+
+**Where it runs:** every path that persists an output-log artifact — the
+dedicated artifacts route (``POST /calculations/{id}/artifacts``) and output
+logs attached *inline* through the contribution-bundle workflows
+(``computed_species`` / ``computed_reaction``, which ARC uses in bundle
+mode), matching the coverage of the sibling hooks.
+
+Best-effort and never raises: artifact upload is canonical and must not be
+aborted by a reconciliation failure.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+
+from tckdb_schemas.upload_warning import UploadWarning
+
+from app.db.models.calculation import Calculation
+from app.db.models.common import ArtifactKind
+from app.schemas.fragments.artifact import ArtifactIn
+from app.services.charge_multiplicity_reconciliation import (
+    reconcile_charge_multiplicity,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def try_reconcile_charge_multiplicity_from_output_upload(
+    calculation: Calculation,
+    artifact_in: ArtifactIn,
+) -> list[UploadWarning]:
+    """Cross-check the owning entry's charge/multiplicity against a log.
+
+    Runs immediately after the matching ``CalculationArtifact`` row has been
+    persisted, decoding bytes from the in-memory base64 payload so no
+    object-storage round-trip is needed.
+
+    Returns the warnings the reconciliation produced (at most one for
+    charge and one for multiplicity), otherwise an empty list. Returns an
+    empty list for non-output-log artifacts, calculations with no owning
+    entry, and any failure — a broad safety net guarantees the canonical
+    artifact upload is never aborted by a reconciliation error, matching
+    the sibling extraction hooks.
+    """
+    # ``artifact_in.kind`` is typed against ``tckdb_schemas.enums.ArtifactKind``
+    # while ``ArtifactKind`` here is the parallel ORM enum; both are
+    # ``(str, Enum)`` with identical members, so a value comparison works
+    # across the boundary (an identity check would always fail).
+    if artifact_in.kind != ArtifactKind.output_log:
+        return []
+
+    try:
+        return _reconcile(calculation, artifact_in)
+    except Exception:
+        # Artifact upload is canonical and must never be aborted by a
+        # reconciliation failure — swallow anything and log it.
+        logger.warning(
+            "charge/multiplicity reconciliation failed for artifact '%s'",
+            artifact_in.filename,
+            exc_info=True,
+        )
+        return []
+
+
+def _reconcile(
+    calculation: Calculation,
+    artifact_in: ArtifactIn,
+) -> list[UploadWarning]:
+    # A calculation is owned by exactly one of the two entry kinds (enforced
+    # by a table check constraint). Where the declared charge/multiplicity
+    # lives differs between them: for a species they are identity columns on
+    # ``species`` (``uq_species_identity`` is SMILES + charge + multiplicity,
+    # DR-0031) reached through the entry, whereas a transition-state entry
+    # carries them directly. Both are non-null.
+    if calculation.species_entry is not None:
+        owner = calculation.species_entry.species
+        field_prefix = "species_entry"
+    elif calculation.transition_state_entry is not None:
+        owner = calculation.transition_state_entry
+        field_prefix = "transition_state_entry"
+    else:
+        return []
+
+    try:
+        content = base64.b64decode(artifact_in.content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        # Should not happen — pass-1 validation already decoded successfully.
+        logger.warning(
+            "charge/multiplicity reconciliation skipped: artifact '%s' could "
+            "not be base64-decoded",
+            artifact_in.filename,
+        )
+        return []
+
+    text = content.decode("utf-8", errors="replace")
+
+    outcome = reconcile_charge_multiplicity(
+        declared_charge=owner.charge,
+        declared_multiplicity=owner.multiplicity,
+        log_text=text,
+        field_prefix=field_prefix,
+    )
+    return outcome.warnings

--- a/backend/app/services/charge_multiplicity_reconciliation.py
+++ b/backend/app/services/charge_multiplicity_reconciliation.py
@@ -1,0 +1,286 @@
+"""Reconcile a declared charge / spin multiplicity against the ESS output log.
+
+The uploader declares the charge and spin multiplicity of the species (or
+transition state) a calculation belongs to. Where the output log is *also*
+uploaded, TCKDB independently re-reads what the electronic-structure run
+actually did and reconciles the two:
+
+======================  ==============================================
+Situation               Outcome
+======================  ==============================================
+declared, log agree     ``confirmed``    — no action
+declared, log differs   ``mismatch``     — non-blocking warning, flag for review
+log un-parseable        ``unverifiable`` — the declaration stands, unchecked
+nothing declared        ``absent``       — nothing to do
+======================  ==============================================
+
+This is the check that makes ``W_CHARGE_MISMATCH`` / ``W_MULTIPLICITY_MISMATCH``
+able to fire at all. The Layer-2 deduction pass in
+:mod:`app.services.upload_reconciliation` builds its ``ESSJobMeta`` from the
+very payload it then compares against, so its charge/multiplicity comparison
+is payload-versus-payload and cannot detect a contradiction by construction.
+Here the second opinion comes from the log bytes, which is a genuinely
+independent source.
+
+**Absence is not a contradiction.** If the producing program is not one of
+the wired parsers, the artifact is missing, the log is truncated, or the
+declarations inside a single log disagree with each other, the value is left
+*unknown* and no warning is emitted. Emitting a mismatch because parsing
+failed would fabricate a contradiction out of ignorance, which
+``docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md``
+forbids. Only a value genuinely read from the log may contradict a
+declaration.
+
+Both findings stay at the :class:`UploadWarning` tier. ADR 0008 argues they
+are definitional and ultimately belong at the blocking tier, but explicitly
+defers that promotion: these checks have never fired on real data, so their
+false-positive rate is unknown and promoting them first would be unsafe.
+
+Pure functions over text and ints; no database dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from tckdb_schemas.upload_warning import UploadWarning
+
+from app.services.ess_software_detection import SoftwareName, detect_software_from_text
+
+#: Emitted when the declared charge and the log's charge disagree.
+W_CHARGE_MISMATCH = "charge_mismatch"
+#: Emitted when the declared multiplicity and the log's multiplicity disagree.
+W_MULTIPLICITY_MISMATCH = "multiplicity_mismatch"
+
+
+class ChargeMultiplicityAction(str, Enum):
+    """What the reconciliation concluded about charge / multiplicity."""
+
+    confirmed = "confirmed"
+    mismatch = "mismatch"
+    unverifiable = "unverifiable"
+    absent = "absent"
+
+
+@dataclass(frozen=True)
+class ParsedChargeMultiplicity:
+    """Charge / multiplicity as actually stated by an output log.
+
+    Either field may be ``None`` independently: a Molpro deck states the
+    spin outright but never declares the charge, so its multiplicity is
+    usable while its charge is not.
+    """
+
+    charge: int | None
+    multiplicity: int | None
+    software: SoftwareName
+
+
+@dataclass(frozen=True)
+class ChargeMultiplicityReconciliation:
+    """Outcome of comparing declared values against the output log."""
+
+    action: ChargeMultiplicityAction
+    declared_charge: int | None
+    declared_multiplicity: int | None
+    log_charge: int | None
+    log_multiplicity: int | None
+    software: SoftwareName | None
+    warnings: list[UploadWarning]
+
+
+def _unanimous(values: list[int | None]) -> int | None:
+    """Return the single agreed value, or ``None`` if there isn't one.
+
+    A log that declares a quantity more than once with conflicting values
+    (Gaussian counterpoise fragments, ORCA compound jobs, multi-state MRCI
+    decks) has not told us what the *system's* value is. Reject rather than
+    pick one and risk a fabricated mismatch.
+    """
+    known = [v for v in values if v is not None]
+    if not known:
+        return None
+    first = known[0]
+    return first if all(v == first for v in known) else None
+
+
+def _parse_gaussian(text: str) -> tuple[int | None, int | None]:
+    from app.services.gaussian_parameter_parser import parse_all_charge_multiplicity
+
+    found = parse_all_charge_multiplicity(text)
+    charges: list[int | None] = [c for c, _ in found]
+    mults: list[int | None] = [m for _, m in found]
+    return _unanimous(charges), _unanimous(mults)
+
+
+def _parse_orca(text: str) -> tuple[int | None, int | None]:
+    from app.services.orca_parameter_parser import parse_all_charge_multiplicity
+
+    found = parse_all_charge_multiplicity(text)
+    charges: list[int | None] = [c for c, _ in found]
+    mults: list[int | None] = [m for _, m in found]
+    return _unanimous(charges), _unanimous(mults)
+
+
+def _parse_molpro(text: str) -> tuple[int | None, int | None]:
+    """Molpro states the spin, but never declares the charge outright.
+
+    In the keyword form (``wf,spin=..,charge=..``) an omitted ``charge=``
+    falls back to Molpro's neutral default, and in the positional MRCI form
+    (``wf,<nelec>,<sym>,<2S>``) the charge is *derived* by subtracting the
+    electron count from a sum of atomic numbers read out of the echoed
+    geometry. A defaulted or derived value is an inference, not something
+    the log declared, so a disagreement with it is not evidence of a
+    contradiction. Only an explicitly written ``charge=`` is trusted here.
+    """
+    from app.services.molpro_parameter_parser import parse_all_charge_multiplicity
+
+    found = parse_all_charge_multiplicity(text)
+    charges: list[int | None] = [
+        entry["charge"] if entry.get("charge_is_declared") else None
+        for entry in found
+    ]
+    mults: list[int | None] = [entry["multiplicity"] for entry in found]
+    return _unanimous(charges), _unanimous(mults)
+
+
+def parse_charge_multiplicity_from_log(
+    text: str | None,
+) -> ParsedChargeMultiplicity | None:
+    """Re-read the charge and spin multiplicity stated by an output log.
+
+    Picks the parser by sniffing the program banner in the log's *content*
+    (not its filename), the same dispatch the single-point-energy path uses,
+    so the two can never disagree about which program produced a given file.
+    Gaussian, ORCA and Molpro are wired.
+
+    Returns ``None`` when the program is unrecognised or neither quantity
+    could be read, so the caller treats the log as *unverifiable* rather
+    than guessing. A returned object may still carry ``None`` in one field.
+    """
+    if not text:
+        return None
+    software = detect_software_from_text(text)
+    if software is None:
+        return None
+
+    if software == "molpro":
+        charge, multiplicity = _parse_molpro(text)
+    elif software == "orca":
+        charge, multiplicity = _parse_orca(text)
+    else:  # gaussian
+        charge, multiplicity = _parse_gaussian(text)
+
+    # A multiplicity below 1 is unphysical (2S+1 >= 1, mirrored by the
+    # ``multiplicity_ge_1`` check constraint on the entry tables): a parse
+    # that produced one has misread the log, so discard it rather than
+    # compare against it.
+    if multiplicity is not None and multiplicity < 1:
+        multiplicity = None
+
+    if charge is None and multiplicity is None:
+        return None
+
+    return ParsedChargeMultiplicity(
+        charge=charge, multiplicity=multiplicity, software=software
+    )
+
+
+def reconcile_charge_multiplicity(
+    *,
+    declared_charge: int | None,
+    declared_multiplicity: int | None,
+    log_text: str | None,
+    field_prefix: str = "species_entry",
+) -> ChargeMultiplicityReconciliation:
+    """Reconcile declared charge/multiplicity against the uploaded log.
+
+    :param declared_charge: Charge recorded on the owning entry.
+    :param declared_multiplicity: Multiplicity recorded on the owning entry.
+    :param log_text: Decoded output-log text, or ``None`` when no output
+        artifact accompanies the calculation.
+    :param field_prefix: Dot-path prefix for any emitted
+        :class:`UploadWarning` (``"species_entry"`` or
+        ``"transition_state_entry"``).
+    """
+    parsed = parse_charge_multiplicity_from_log(log_text)
+
+    if declared_charge is None and declared_multiplicity is None:
+        return ChargeMultiplicityReconciliation(
+            action=ChargeMultiplicityAction.absent,
+            declared_charge=None,
+            declared_multiplicity=None,
+            log_charge=parsed.charge if parsed else None,
+            log_multiplicity=parsed.multiplicity if parsed else None,
+            software=parsed.software if parsed else None,
+            warnings=[],
+        )
+
+    if parsed is None:
+        # Unsupported program, absent artifact, truncated or malformed log,
+        # or self-contradictory declarations. Nothing was learned, so
+        # nothing is contradicted.
+        return ChargeMultiplicityReconciliation(
+            action=ChargeMultiplicityAction.unverifiable,
+            declared_charge=declared_charge,
+            declared_multiplicity=declared_multiplicity,
+            log_charge=None,
+            log_multiplicity=None,
+            software=None,
+            warnings=[],
+        )
+
+    warnings: list[UploadWarning] = []
+    compared = False
+
+    if declared_charge is not None and parsed.charge is not None:
+        compared = True
+        if declared_charge != parsed.charge:
+            warnings.append(
+                UploadWarning(
+                    field=f"{field_prefix}.charge",
+                    code=W_CHARGE_MISMATCH,
+                    message=(
+                        f"Declared charge {declared_charge:+d} disagrees with "
+                        f"the charge stated by the uploaded {parsed.software} "
+                        f"output log ({parsed.charge:+d}). The declared value "
+                        "is kept unchanged and flagged for reviewer attention."
+                    ),
+                )
+            )
+
+    if declared_multiplicity is not None and parsed.multiplicity is not None:
+        compared = True
+        if declared_multiplicity != parsed.multiplicity:
+            warnings.append(
+                UploadWarning(
+                    field=f"{field_prefix}.multiplicity",
+                    code=W_MULTIPLICITY_MISMATCH,
+                    message=(
+                        f"Declared spin multiplicity {declared_multiplicity} "
+                        f"disagrees with the multiplicity stated by the "
+                        f"uploaded {parsed.software} output log "
+                        f"({parsed.multiplicity}). The declared value is kept "
+                        "unchanged and flagged for reviewer attention."
+                    ),
+                )
+            )
+
+    if not compared:
+        # The log yielded only a quantity the caller did not declare.
+        action = ChargeMultiplicityAction.unverifiable
+    elif warnings:
+        action = ChargeMultiplicityAction.mismatch
+    else:
+        action = ChargeMultiplicityAction.confirmed
+
+    return ChargeMultiplicityReconciliation(
+        action=action,
+        declared_charge=declared_charge,
+        declared_multiplicity=declared_multiplicity,
+        log_charge=parsed.charge,
+        log_multiplicity=parsed.multiplicity,
+        software=parsed.software,
+        warnings=warnings,
+    )

--- a/backend/app/services/gaussian_parameter_parser.py
+++ b/backend/app/services/gaussian_parameter_parser.py
@@ -517,6 +517,26 @@ def parse_charge_multiplicity(text: str) -> tuple[int, int] | None:
     return None
 
 
+def parse_all_charge_multiplicity(text: str) -> list[tuple[int, int]]:
+    """Return *every* ``Charge = q Multiplicity = m`` declaration in the log.
+
+    :func:`parse_charge_multiplicity` deliberately returns only the first
+    match, which is the right answer for parameter extraction. Gaussian
+    however prints the pair once per fragment in a counterpoise job and
+    once per layer in an ONIOM job, so on those logs the first match
+    describes a *fragment* rather than the whole system.
+
+    Callers that cross-check the declared charge/multiplicity against the
+    log use this function instead and require the declarations to agree
+    before trusting them — see
+    :mod:`app.services.charge_multiplicity_reconciliation`.
+    """
+    return [
+        (int(m.group(1)), int(m.group(2)))
+        for m in _CHARGE_MULT_RE.finditer(text)
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Method / basis extraction from route line
 # ---------------------------------------------------------------------------

--- a/backend/app/services/molpro_parameter_parser.py
+++ b/backend/app/services/molpro_parameter_parser.py
@@ -249,7 +249,37 @@ def parse_charge_multiplicity(text: str) -> dict | None:
     In both cases Molpro ``spin`` is ``2S`` (unpaired electrons), so
     ``multiplicity = spin + 1``.  Returns ``None`` if no ``wf`` line found.
     """
+    found = parse_all_charge_multiplicity(text)
+    if not found:
+        return None
+    # Return the historical two-key shape: ``charge_is_declared`` is an
+    # extra signal for the reconciliation path only and must not leak into
+    # the parameter-extraction payload this function has always produced.
+    first = found[0]
+    return {"charge": first["charge"], "multiplicity": first["multiplicity"]}
+
+
+def parse_all_charge_multiplicity(text: str) -> list[dict]:
+    """Return one entry per ``wf`` directive in the deck, in deck order.
+
+    :func:`parse_charge_multiplicity` reports only the first directive,
+    which is the right answer for parameter extraction. A multi-state MRCI
+    deck carries several ``wf`` lines that may declare different spins, so
+    a caller cross-checking the declared multiplicity against the log needs
+    all of them and requires agreement before trusting the value — see
+    :mod:`app.services.charge_multiplicity_reconciliation`.
+
+    Each entry additionally carries ``charge_is_declared``: ``True`` only
+    when the deck stated the charge outright. In the keyword form an
+    omitted ``charge=`` falls back to Molpro's neutral default and in the
+    positional form the charge is *derived* from the echoed geometry, so
+    neither is a value the log actually declared. The reconciliation path
+    treats those as unknown rather than inferring, while
+    ``parse_charge_multiplicity``'s long-standing ``charge`` value is
+    unchanged for parameter extraction.
+    """
     deck_lines = _extract_deck_lines(text)
+    found: list[dict] = []
 
     for line in deck_lines:
         if not _WF_KEYWORD_RE.search(line):
@@ -261,7 +291,12 @@ def parse_charge_multiplicity(text: str) -> dict | None:
             # Keyword form
             spin = int(spin_m.group(1))
             charge = int(charge_m.group(1)) if charge_m else 0
-            return {"charge": charge, "multiplicity": spin + 1}
+            found.append({
+                "charge": charge,
+                "multiplicity": spin + 1,
+                "charge_is_declared": charge_m is not None,
+            })
+            continue
 
         pos_m = _WF_POSITIONAL_RE.search(line)
         if pos_m is not None:
@@ -270,9 +305,13 @@ def parse_charge_multiplicity(text: str) -> dict | None:
             spin = int(pos_m.group(3))
             z_sum = _sum_atomic_numbers(deck_lines)
             charge = (z_sum - nelec) if z_sum is not None else None
-            return {"charge": charge, "multiplicity": spin + 1}
+            found.append({
+                "charge": charge,
+                "multiplicity": spin + 1,
+                "charge_is_declared": False,
+            })
 
-    return None
+    return found
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/orca_parameter_parser.py
+++ b/backend/app/services/orca_parameter_parser.py
@@ -961,6 +961,32 @@ def parse_charge_multiplicity(text: str) -> dict | None:
     return None
 
 
+def parse_all_charge_multiplicity(text: str) -> list[tuple[int, int]]:
+    """Return *every* ``* xyz <charge> <mult>`` coordinate header in the input.
+
+    :func:`parse_charge_multiplicity` returns only the first header, which
+    is the right answer for parameter extraction. A compound job echoes one
+    header per ``$new_job`` step, and those steps may legitimately describe
+    different species, so a caller cross-checking the declared
+    charge/multiplicity against the log needs to see all of them and require
+    agreement before trusting the value — see
+    :mod:`app.services.charge_multiplicity_reconciliation`.
+    """
+    found: list[tuple[int, int]] = []
+    for line in _extract_input_block(text):
+        stripped = line.strip()
+        if stripped.startswith("*") and (
+            "xyz" in stripped.lower() or "int" in stripped.lower()
+        ):
+            parts = stripped.split()
+            if len(parts) >= 4:
+                try:
+                    found.append((int(parts[2]), int(parts[3])))
+                except ValueError:
+                    continue
+    return found
+
+
 # ---------------------------------------------------------------------------
 # Software version extraction
 # ---------------------------------------------------------------------------

--- a/backend/app/services/upload_reconciliation.py
+++ b/backend/app/services/upload_reconciliation.py
@@ -15,6 +15,10 @@ from app.schemas.fragments.calculation import CalculationWithResultsPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.upload_warning import UploadWarning
 from app.schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
+from app.services.charge_multiplicity_reconciliation import (
+    W_CHARGE_MISMATCH,
+    W_MULTIPLICITY_MISMATCH,
+)
 from app.services.ess_result import (
     ESSFreqResult,
     ESSJobMeta,
@@ -42,8 +46,20 @@ W_FREQ_PARSED_NO_MODES = "freq_parser_extracted_but_modes_missing"
 # Layer 2: deduction-based
 W_ELECTRONIC_STATE_CONTRADICTS_METHOD = "electronic_state_contradicts_method"
 W_TERM_SYMBOL_MISMATCH = "term_symbol_mismatch"
-W_CHARGE_MISMATCH = "charge_mismatch"
-W_MULTIPLICITY_MISMATCH = "multiplicity_mismatch"
+
+# Charge / multiplicity contradictions are detected against the *output log*
+# by :mod:`app.services.charge_multiplicity_reconciliation`, which owns
+# ``W_CHARGE_MISMATCH`` / ``W_MULTIPLICITY_MISMATCH`` (imported above so
+# there is one definition rather than a drifting copy).
+#
+# The Layer-2 deduction pass cannot detect these itself:
+# ``build_ess_result_from_upload`` populates ``ESSJobMeta.charge`` and
+# ``.multiplicity`` from the same payload that ``_reconcile_deduction`` then
+# compares them against, so the comparison is payload-versus-payload and is
+# always equal by construction. The meta fields are kept because
+# ``deduce_term_symbol`` genuinely needs the multiplicity; the charge and
+# multiplicity entries in the table below are therefore inert here, and the
+# log-based hook is what actually fires.
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -53,6 +53,9 @@ from app.services.calculation_resolution import (
     resolve_workflow_tool_release_ref,
 )
 from app.services.calculation_scan_resolution import persist_calculation_scan
+from app.services.charge_multiplicity_extraction import (
+    try_reconcile_charge_multiplicity_from_output_upload,
+)
 from app.services.conformer_resolution import resolve_conformer_group
 from app.services.energy_correction_resolution import (
     create_applied_energy_correction,
@@ -146,6 +149,16 @@ def _persist_calculation(
         )
         if sp_warning is not None and sp_energy_warnings is not None:
             sp_energy_warnings.append(sp_warning)
+        # Output logs also state the charge and spin multiplicity the run
+        # actually used; a contradiction with the declared identity is
+        # flagged for review. (``sp_energy_warnings`` is the shared
+        # per-artifact warning accumulator, not single-point-energy only.)
+        if sp_energy_warnings is not None:
+            sp_energy_warnings.extend(
+                try_reconcile_charge_multiplicity_from_output_upload(
+                    calculation, artifact_in
+                )
+            )
 
     resolved_geom_id = geometry_id
     if calc_in.geometry_key is not None:

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -60,6 +60,9 @@ from app.services.calculation_resolution import (
     resolve_workflow_tool_release_ref,
 )
 from app.services.calculation_scan_resolution import persist_calculation_scan
+from app.services.charge_multiplicity_extraction import (
+    try_reconcile_charge_multiplicity_from_output_upload,
+)
 from app.services.conformer_resolution import resolve_conformer_group
 from app.services.energy_correction_resolution import (
     create_applied_energy_correction,
@@ -575,6 +578,14 @@ def persist_computed_species_upload(
                     )
                     if sp_warning is not None:
                         upload_warnings.append(sp_warning)
+                    # Output logs also state the charge and spin
+                    # multiplicity the run actually used; a contradiction
+                    # with the declared identity is flagged for review.
+                    upload_warnings.extend(
+                        try_reconcile_charge_multiplicity_from_output_upload(
+                            calc_row, art_in
+                        )
+                    )
                     # Input geometries for this calc were attached in an
                     # earlier pass, so the Hessian can bind to them here.
                     try_extract_hessian_from_artifact_upload(

--- a/backend/tests/api/test_api_artifact_charge_multiplicity_hook.py
+++ b/backend/tests/api/test_api_artifact_charge_multiplicity_hook.py
@@ -1,0 +1,290 @@
+"""End-to-end tests for the charge / multiplicity artifact hook.
+
+Proves the contradiction check fires on the paths where an output log is
+actually uploaded: the dedicated artifacts route and inline bundle uploads.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+# A real Gaussian UB3LYP log whose header states ``Charge = 0 Multiplicity = 3``.
+GAUSSIAN_TRIPLET_LOG = (FIXTURES / "gaussian" / "sp_ub3lyp_g16.log").read_bytes()
+LOG_CHARGE = 0
+LOG_MULTIPLICITY = 3
+
+# A real Molpro CH4 log: ``wf,spin=0,charge=0`` -> charge 0, multiplicity 1.
+MOLPRO_CH4_LOG = (
+    FIXTURES / "molpro" / "ch4_closed_shell" / "input.out"
+).read_bytes()
+
+W_CHARGE = "charge_mismatch"
+W_MULT = "multiplicity_mismatch"
+
+
+@pytest.fixture
+def stub_store_artifact(monkeypatch) -> list[tuple[str, str]]:
+    written: list[tuple[str, str]] = []
+
+    def _fake_store(content: bytes, sha256: str) -> str:
+        uri = f"s3://test-bucket/{sha256[:2]}/{sha256}"
+        written.append((uri, sha256))
+        return uri
+
+    monkeypatch.setattr(
+        "app.services.artifact_persistence.store_artifact", _fake_store
+    )
+    return written
+
+
+def _b64(content: bytes) -> str:
+    return base64.b64encode(content).decode("ascii")
+
+
+def _output_log(content: bytes = GAUSSIAN_TRIPLET_LOG, filename: str = "job.log") -> dict:
+    return {
+        "kind": "output_log",
+        "filename": filename,
+        "content_base64": _b64(content),
+    }
+
+
+def _conformer_payload(*, smiles: str, charge: int, multiplicity: int) -> dict:
+    return {
+        "species_entry": {
+            "smiles": smiles,
+            "charge": charge,
+            "multiplicity": multiplicity,
+        },
+        "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+        # An ``opt`` calculation keeps the single-point-energy hook out of the
+        # way so the warnings under test are unambiguous.
+        "calculation": {
+            "type": "opt",
+            "software_release": {"name": "Gaussian", "version": "16"},
+            "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+            "opt_result": {"converged": True},
+        },
+        "label": "charge-mult-hook",
+    }
+
+
+def _create_calc(client, *, smiles: str, charge: int, multiplicity: int) -> int:
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_conformer_payload(
+            smiles=smiles, charge=charge, multiplicity=multiplicity
+        ),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["primary_calculation"]["calculation_id"]
+
+
+def _post_artifact(client, calc_id: int, artifact: dict):
+    return client.post(
+        f"/api/v1/calculations/{calc_id}/artifacts",
+        json={"artifacts": [artifact]},
+    )
+
+
+def _codes(resp) -> list[str]:
+    return [w["code"] for w in resp.json().get("warnings", [])]
+
+
+def _relevant(resp) -> list[str]:
+    return [c for c in _codes(resp) if c in {W_CHARGE, W_MULT}]
+
+
+class TestChargeMultiplicityArtifactHook:
+    def test_genuine_multiplicity_mismatch_is_detected(
+        self, client, stub_store_artifact
+    ):
+        """The whole point: log says triplet, uploader declared a doublet."""
+        calc_id = _create_calc(client, smiles="[CH3]", charge=0, multiplicity=2)
+        resp = _post_artifact(client, calc_id, _output_log())
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == [W_MULT]
+
+        warning = next(
+            w for w in resp.json()["warnings"] if w["code"] == W_MULT
+        )
+        assert warning["field"] == "species_entry.multiplicity"
+        assert str(LOG_MULTIPLICITY) in warning["message"]
+
+    def test_genuine_charge_mismatch_is_detected(
+        self, client, stub_store_artifact
+    ):
+        calc_id = _create_calc(client, smiles="[CH2+]", charge=1, multiplicity=3)
+        resp = _post_artifact(client, calc_id, _output_log())
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == [W_CHARGE]
+
+    def test_matching_values_emit_nothing(self, client, stub_store_artifact):
+        calc_id = _create_calc(
+            client,
+            smiles="[CH2]",
+            charge=LOG_CHARGE,
+            multiplicity=LOG_MULTIPLICITY,
+        )
+        resp = _post_artifact(client, calc_id, _output_log())
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == []
+
+    def test_program_without_a_wired_parser_emits_nothing(
+        self, client, stub_store_artifact
+    ):
+        """Psi4 is accepted by the route but has no charge/multiplicity parser.
+
+        The log plainly states values that differ from the declared ones,
+        but TCKDB cannot read them for this program, so it must stay silent
+        rather than invent a contradiction.
+        """
+        calc_id = _create_calc(client, smiles="[CH3]", charge=0, multiplicity=2)
+        psi4_log = (
+            b"    Psi4: An Open-Source Quantum Chemistry Package\n"
+            b"    Molecular charge  = 1\n"
+            b"    Spin multiplicity = 3\n"
+        )
+        resp = _post_artifact(
+            client, calc_id, _output_log(content=psi4_log, filename="psi4.out")
+        )
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == []
+
+    def test_log_with_no_ess_signature_never_reaches_the_hook(
+        self, client, stub_store_artifact
+    ):
+        """The route rejects unrecognised output logs before the hook runs."""
+        calc_id = _create_calc(client, smiles="[CH3]", charge=0, multiplicity=2)
+        resp = _post_artifact(
+            client,
+            calc_id,
+            _output_log(
+                content=b"SOME UNSUPPORTED QC CODE v1.0\nCHARGE 7 SPIN 9\n",
+                filename="mystery.out",
+            ),
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_absent_artifact_emits_nothing(self, client):
+        """A conformer upload with no log at all must not warn."""
+        resp = client.post(
+            "/api/v1/uploads/conformers",
+            json=_conformer_payload(smiles="[CH3]", charge=0, multiplicity=2),
+        )
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == []
+
+    def test_truncated_log_emits_nothing(self, client, stub_store_artifact):
+        """A recognised banner with the header cut off is still unknown."""
+        calc_id = _create_calc(client, smiles="[CH3]", charge=0, multiplicity=2)
+        resp = _post_artifact(
+            client,
+            calc_id,
+            _output_log(
+                content=GAUSSIAN_TRIPLET_LOG[:200], filename="truncated.log"
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == []
+
+    def test_input_artifact_kind_is_not_checked(
+        self, client, stub_store_artifact
+    ):
+        """Only output logs describe what the run actually did."""
+        calc_id = _create_calc(client, smiles="[CH3]", charge=0, multiplicity=2)
+        resp = _post_artifact(
+            client,
+            calc_id,
+            {
+                "kind": "input",
+                "filename": "job.gjf",
+                "content_base64": _b64(GAUSSIAN_TRIPLET_LOG),
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == []
+
+    def test_declared_values_are_never_overwritten(
+        self, client, db_session, stub_store_artifact
+    ):
+        """A mismatch flags for review; identity fields stay as submitted."""
+        from app.db.models.calculation import Calculation
+
+        calc_id = _create_calc(client, smiles="[CH3]", charge=0, multiplicity=2)
+        resp = _post_artifact(client, calc_id, _output_log())
+        assert resp.status_code == 201, resp.text
+        assert _relevant(resp) == [W_MULT]
+
+        # Charge/multiplicity are identity columns on ``species`` (DR-0031),
+        # reached through the entry. A mismatch must never rewrite them:
+        # doing so would silently repoint the upload at a different species.
+        calc = db_session.get(Calculation, calc_id)
+        assert calc.species_entry.species.multiplicity == 2
+        assert calc.species_entry.species.charge == 0
+
+
+def _computed_species_bundle(*, charge: int, multiplicity: int) -> dict:
+    """A bundle whose calc carries its output log INLINE (ARC bundle mode)."""
+    return {
+        "species_entry": {
+            "smiles": "C",
+            "charge": charge,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "software_release": {"name": "Molpro", "version": "2022.1"},
+                    "level_of_theory": {
+                        "method": "CCSD(T)-F12",
+                        "basis": "cc-pVTZ-F12",
+                    },
+                    "opt_result": {"converged": True},
+                    "artifacts": [
+                        {
+                            "kind": "output_log",
+                            "filename": "opt0.out",
+                            "content_base64": _b64(MOLPRO_CH4_LOG),
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+
+class TestChargeMultiplicityBundleHook:
+    """The check must also fire on logs uploaded inline in a bundle."""
+
+    def test_bundle_inline_log_detects_mismatch(
+        self, client, stub_store_artifact
+    ):
+        # The Molpro CH4 deck declares a closed-shell singlet; declare a triplet.
+        resp = client.post(
+            "/api/v1/uploads/computed-species",
+            json=_computed_species_bundle(charge=0, multiplicity=3),
+        )
+        assert resp.status_code == 201, resp.text
+        assert W_MULT in [w["code"] for w in resp.json().get("warnings", [])]
+
+    def test_bundle_inline_log_agreement_is_silent(
+        self, client, stub_store_artifact
+    ):
+        resp = client.post(
+            "/api/v1/uploads/computed-species",
+            json=_computed_species_bundle(charge=0, multiplicity=1),
+        )
+        assert resp.status_code == 201, resp.text
+        codes = [w["code"] for w in resp.json().get("warnings", [])]
+        assert W_MULT not in codes
+        assert W_CHARGE not in codes

--- a/backend/tests/services/test_charge_multiplicity_reconciliation.py
+++ b/backend/tests/services/test_charge_multiplicity_reconciliation.py
@@ -1,0 +1,276 @@
+"""Tests for charge / spin-multiplicity reconciliation against ESS output logs.
+
+These exercise the check that makes ``charge_mismatch`` and
+``multiplicity_mismatch`` able to fire at all. Before the log-derived source
+existed, the Layer-2 deduction pass compared the upload payload against an
+``ESSJobMeta`` it had just built *from that same payload*, so no input could
+make the comparison unequal and no test of a genuine mismatch was possible.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services.charge_multiplicity_reconciliation import (
+    W_CHARGE_MISMATCH,
+    W_MULTIPLICITY_MISMATCH,
+    ChargeMultiplicityAction,
+    parse_charge_multiplicity_from_log,
+    reconcile_charge_multiplicity,
+)
+
+_FIX = os.path.join(os.path.dirname(__file__), "..", "fixtures")
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_FIX, *parts), encoding="utf-8", errors="replace") as fh:
+        return fh.read()
+
+
+# A real Gaussian UB3LYP single-point log: ``Charge =  0 Multiplicity = 3``.
+GAUSSIAN_TRIPLET = _read("gaussian", "sp_ub3lyp_g16.log")
+# A real ORCA input echo: ``* xyz 0 2``.
+ORCA_DOUBLET = _read("orca", "sp_orca_minimal.txt")
+# A real Molpro CCSD(T)-F12 deck: ``wf,spin=1,charge=0`` -> charge 0, mult 2.
+MOLPRO_DOUBLET = _read("molpro", "ch3_radical", "input.out")
+# A real Molpro MRCI deck in positional form: ``wf,9,2,1`` -> mult 2, and a
+# charge that is *derived*, never declared.
+MOLPRO_MRCI_DOUBLET = _read("molpro", "mrci", "nh2_radical", "input.out")
+
+
+def _codes(outcome) -> list[str]:
+    return [w.code for w in outcome.warnings]
+
+
+# ---------------------------------------------------------------------------
+# The point of the change: a genuine contradiction is now detected
+# ---------------------------------------------------------------------------
+
+
+class TestGenuineMismatchIsDetected:
+    def test_multiplicity_mismatch_fires(self):
+        """Log says triplet, uploader declared a singlet."""
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0,
+            declared_multiplicity=1,
+            log_text=GAUSSIAN_TRIPLET,
+        )
+        assert outcome.action is ChargeMultiplicityAction.mismatch
+        assert _codes(outcome) == [W_MULTIPLICITY_MISMATCH]
+        assert outcome.log_multiplicity == 3
+        assert outcome.declared_multiplicity == 1
+        assert outcome.warnings[0].field == "species_entry.multiplicity"
+        assert "3" in outcome.warnings[0].message
+
+    def test_charge_mismatch_fires(self):
+        """Log says neutral, uploader declared a cation."""
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=1,
+            declared_multiplicity=3,
+            log_text=GAUSSIAN_TRIPLET,
+        )
+        assert outcome.action is ChargeMultiplicityAction.mismatch
+        assert _codes(outcome) == [W_CHARGE_MISMATCH]
+        assert outcome.log_charge == 0
+        assert outcome.warnings[0].field == "species_entry.charge"
+
+    def test_both_mismatch_together(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=-1,
+            declared_multiplicity=1,
+            log_text=GAUSSIAN_TRIPLET,
+        )
+        assert outcome.action is ChargeMultiplicityAction.mismatch
+        assert _codes(outcome) == [W_CHARGE_MISMATCH, W_MULTIPLICITY_MISMATCH]
+
+    def test_mismatch_on_orca(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0, declared_multiplicity=1, log_text=ORCA_DOUBLET
+        )
+        assert _codes(outcome) == [W_MULTIPLICITY_MISMATCH]
+        assert outcome.software == "orca"
+
+    def test_mismatch_on_molpro(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0, declared_multiplicity=1, log_text=MOLPRO_DOUBLET
+        )
+        assert _codes(outcome) == [W_MULTIPLICITY_MISMATCH]
+        assert outcome.software == "molpro"
+
+    def test_transition_state_owner_field_prefix(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0,
+            declared_multiplicity=1,
+            log_text=GAUSSIAN_TRIPLET,
+            field_prefix="transition_state_entry",
+        )
+        assert outcome.warnings[0].field == "transition_state_entry.multiplicity"
+
+
+# ---------------------------------------------------------------------------
+# Agreement is silent
+# ---------------------------------------------------------------------------
+
+
+class TestMatchingValuesEmitNothing:
+    @pytest.mark.parametrize(
+        ("log", "charge", "multiplicity"),
+        [
+            (GAUSSIAN_TRIPLET, 0, 3),
+            (ORCA_DOUBLET, 0, 2),
+            (MOLPRO_DOUBLET, 0, 2),
+        ],
+    )
+    def test_agreement_is_confirmed_and_silent(self, log, charge, multiplicity):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=charge,
+            declared_multiplicity=multiplicity,
+            log_text=log,
+        )
+        assert outcome.action is ChargeMultiplicityAction.confirmed
+        assert outcome.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Absence is not a contradiction (ADR 0008)
+# ---------------------------------------------------------------------------
+
+
+class TestUnparseableEmitsNothing:
+    @pytest.mark.parametrize(
+        "log_text",
+        [
+            pytest.param(None, id="no_artifact"),
+            pytest.param("", id="empty"),
+            pytest.param("   \n\n ", id="whitespace"),
+            pytest.param(
+                "GAMESS VERSION = 30 JUN 2020\n CHARGE OF MOLECULE = 0\n",
+                id="unsupported_program",
+            ),
+            pytest.param(
+                "\x00\x01\x02 binary garbage \xff",
+                id="binary_garbage",
+            ),
+            pytest.param(
+                " Entering Gaussian System, Link 0=g16\n",
+                id="gaussian_truncated_before_charge_line",
+            ),
+            pytest.param(
+                "***  PROGRAM SYSTEM MOLPRO  ***\n memory,100,m;\n",
+                id="molpro_no_wf_directive",
+            ),
+        ],
+    )
+    def test_no_warning_when_nothing_could_be_parsed(self, log_text):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=1,
+            declared_multiplicity=7,
+            log_text=log_text,
+        )
+        assert outcome.action is ChargeMultiplicityAction.unverifiable
+        assert outcome.warnings == []
+        assert outcome.log_charge is None
+        assert outcome.log_multiplicity is None
+
+    def test_nothing_declared_is_absent_not_mismatch(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=None,
+            declared_multiplicity=None,
+            log_text=GAUSSIAN_TRIPLET,
+        )
+        assert outcome.action is ChargeMultiplicityAction.absent
+        assert outcome.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Reject-don't-guess: ambiguous or inferred values are never compared
+# ---------------------------------------------------------------------------
+
+
+class TestRejectRatherThanGuess:
+    def test_conflicting_gaussian_declarations_are_unknown(self):
+        """A counterpoise/ONIOM log declares the pair once per fragment.
+
+        The first match describes a fragment, not the system, so a
+        disagreement between declarations must yield *unknown* rather than
+        a fabricated mismatch against whichever one came first.
+        """
+        log = (
+            " Entering Gaussian System, Link 0=g16\n"
+            " Charge =  0 Multiplicity = 1\n"
+            " Charge =  1 Multiplicity = 2\n"
+        )
+        assert parse_charge_multiplicity_from_log(log) is None
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0, declared_multiplicity=1, log_text=log
+        )
+        assert outcome.action is ChargeMultiplicityAction.unverifiable
+        assert outcome.warnings == []
+
+    def test_repeated_agreeing_declarations_are_trusted(self):
+        """Multi-step (``--Link1--``) logs repeat the same pair; that is fine."""
+        log = (
+            " Entering Gaussian System, Link 0=g16\n"
+            " Charge =  0 Multiplicity = 2\n"
+            " Charge =  0 Multiplicity = 2\n"
+        )
+        parsed = parse_charge_multiplicity_from_log(log)
+        assert parsed is not None
+        assert (parsed.charge, parsed.multiplicity) == (0, 2)
+
+    def test_molpro_positional_charge_is_never_compared(self):
+        """MRCI decks derive the charge from the geometry; that is an inference.
+
+        The multiplicity, which the deck states outright, is still checked.
+        """
+        parsed = parse_charge_multiplicity_from_log(MOLPRO_MRCI_DOUBLET)
+        assert parsed is not None
+        assert parsed.charge is None
+        assert parsed.multiplicity == 2
+
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=99,  # would mismatch a derived charge
+            declared_multiplicity=2,
+            log_text=MOLPRO_MRCI_DOUBLET,
+        )
+        assert outcome.action is ChargeMultiplicityAction.confirmed
+        assert outcome.warnings == []
+
+    def test_molpro_omitted_charge_keyword_is_not_assumed_neutral(self):
+        """``wf,spin=0`` without ``charge=`` means unknown, not neutral."""
+        log = "***  PROGRAM SYSTEM MOLPRO  ***\n basis=cc-pvtz\n wf,spin=0;\n"
+        parsed = parse_charge_multiplicity_from_log(log)
+        assert parsed is not None
+        assert parsed.charge is None
+        assert parsed.multiplicity == 1
+
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=1, declared_multiplicity=1, log_text=log
+        )
+        assert outcome.action is ChargeMultiplicityAction.confirmed
+        assert outcome.warnings == []
+
+    def test_unphysical_multiplicity_is_discarded(self):
+        log = (
+            " Entering Gaussian System, Link 0=g16\n"
+            " Charge =  0 Multiplicity = 0\n"
+        )
+        parsed = parse_charge_multiplicity_from_log(log)
+        assert parsed is not None
+        assert parsed.multiplicity is None
+        assert parsed.charge == 0
+
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0, declared_multiplicity=1, log_text=log
+        )
+        assert outcome.warnings == []
+
+    def test_declared_field_absent_is_not_compared(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=None,
+            declared_multiplicity=1,
+            log_text=GAUSSIAN_TRIPLET,
+        )
+        assert _codes(outcome) == [W_MULTIPLICITY_MISMATCH]


### PR DESCRIPTION
## Summary

`W_CHARGE_MISMATCH` and `W_MULTIPLICITY_MISMATCH` were **structurally incapable of firing**. They now compare the declared values against what the electronic-structure log actually states.

Kept at the `UploadWarning` tier deliberately — see below.

## The defect

`build_ess_result_from_upload` set `meta.charge = payload.charge` and `meta.multiplicity = payload.multiplicity`, `deduce_charge_multiplicity` echoed them back, and `_reconcile_deduction` compared the payload against itself. Empirically confirmed before changing anything:

```
declared=(0,1)   deduced=(0,1)   equal=True
declared=(1,2)   deduced=(1,2)   equal=True
declared=(-2,5)  deduced=(-2,5)  equal=True
declared=(7,9)   deduced=(7,9)   equal=True
```

Equal for every input. **No payload could make the comparison unequal**, which is why no regression test for this could have existed.

## One planned assumption was wrong

The brief said to fix this inside `build_ess_result_from_upload` on the conformer upload path. **There is no ESS log there** — `ConformerUploadRequest` and `CalculationWithResultsPayload` carry zero artifact bytes (`grep -i artifact` on the calculation fragment returns nothing). Feeding a parsed log in at that point is impossible.

Output logs arrive at the three seams the existing SP-energy and Hessian hooks already use, so the check lives there instead: `routes/calculations.py:673`, `workflows/computed_species.py:573`, `workflows/computed_reaction.py:144`. Same established pattern, correct seam.

`build_ess_result_from_upload` is left alone — `deduce_term_symbol` genuinely needs `meta.multiplicity`, so nulling it would break term-symbol derivation. The inert comparison is documented in place rather than removed.

A second correction found during the work: charge and multiplicity are **not** on `SpeciesEntry`. They are identity columns on `Species` (`uq_species_identity` = SMILES + charge + multiplicity, DR-0031), reached via `species_entry.species` — but sit *directly* on `TransitionStateEntry`. The hook handles both.

## Reject-don't-guess, applied per field

Program is identified by banner sniff on log **content** via the shared `detect_software_from_text`, so this can never disagree with the SP-energy path about the same bytes. Supported: **Gaussian, ORCA, Molpro**.

- **Gaussian / ORCA** — declarations must be **unanimous**. Counterpoise fragments, ONIOM layers and ORCA compound jobs each print their own, so a first-match would describe a *fragment*, not the system. Disagreement → unknown.
- **Molpro charge is never compared.** It is either defaulted to neutral when `charge=` is omitted, or *derived* as `sum(Z) − nelec` from the echoed geometry in positional MRCI decks. Both are inferences, not statements. Multiplicity (explicit `spin`) is still checked.
- Multiplicity < 1 is discarded as unphysical.

Every failure mode is silent — unsupported program, missing artifact, truncated log, self-contradictory declarations, or any exception. Nothing is ever written: a mismatch flags for review and leaves identity untouched. An absence is not a contradiction (ADR 0008).

## Why this stays a warning

These have **never fired on real data**, so the false-positive rate is unknown. Promoting a check to blocking before you know how often it fires is how you start rejecting valid uploads. Make it work, observe it, then decide — the promotion is a separate, informed call.

## Validation

| check | result |
|---|---|
| `test_charge_multiplicity_reconciliation.py` | **23 passed** |
| `test_api_artifact_charge_multiplicity_hook.py` | **11 passed** |
| `test-api.sh` | **2306 passed** |
| `test-scientific.sh` | **1743 passed** |
| ruff / mypy | clean / clean (143 files) |

Covers a genuine mismatch being detected, matching values staying silent, and unparseable/absent artifacts staying silent — including a Psi4 log stating *different* values, which is correctly ignored rather than reported.

⚠️ Impact analysis flagged `_persist_calculation` (computed_reaction) as **HIGH** (7 impacted, 1 process). The edit there is append-only into an existing warnings list. `detect_changes` against the branch point: 14 changed symbols, 0 affected processes, risk low.

## Follow-up found, not fixed

`detect_software_from_text` treats a bare `Program Version X.Y.Z` line as an ORCA marker, so a Psi4 or similar log carrying that string could be misrouted to the ORCA parser. **Pre-existing and shared with the SP-energy path** — changing detection would alter SP-energy behaviour, which was out of scope here. Worth its own pass.