### PR TITLE
Fix four validation-tier defects found by the ADR 0008 audit

### DIFF
--- a/backend/app/schemas/workflows/transport_upload.py
+++ b/backend/app/schemas/workflows/transport_upload.py
@@ -58,6 +58,39 @@ class TransportUploadPayload(SchemaBase):
         return self
 
     @model_validator(mode="after")
+    def validate_has_scientific_content(self) -> Self:
+        """Reject uploads that carry only identity/provenance and no transport data.
+
+        At least one of ``sigma_angstrom``, ``epsilon_over_k_k``,
+        ``dipole_debye``, ``polarizability_angstrom3``, or
+        ``rotational_relaxation`` must be present. Provenance-only fields such
+        as ``literature``, ``software_release``, ``workflow_tool_release``, and
+        ``note`` do not count.
+
+        A transport row carrying none of these is definitionally empty — it
+        claims to be transport data while carrying no transport property — so
+        this is a contract violation and blocks at upload, per ADR 0008
+        (``docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md``).
+        The read-time counterpart is
+        :attr:`~app.services.trust.models.HardFailReason.no_transport_property_present`,
+        which this check owns as the blocking tier; the trust label remains as a
+        backstop for rows that entered by a non-upload path.
+        """
+        if not (
+            self.sigma_angstrom is not None
+            or self.epsilon_over_k_k is not None
+            or self.dipole_debye is not None
+            or self.polarizability_angstrom3 is not None
+            or self.rotational_relaxation is not None
+        ):
+            raise ValueError(
+                "Transport upload must include at least one transport "
+                "property: sigma_angstrom, epsilon_over_k_k, dipole_debye, "
+                "polarizability_angstrom3, or rotational_relaxation."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_lj_pair(self) -> Self:
         """Require Lennard-Jones sigma and epsilon/k to be provided together."""
         if (self.sigma_angstrom is None) != (self.epsilon_over_k_k is None):

--- a/backend/app/services/trust/evaluator.py
+++ b/backend/app/services/trust/evaluator.py
@@ -97,6 +97,44 @@ def _detect_calculation_hard_fail(calc: Calculation) -> Optional[HardFailReason]
     return None
 
 
+def temperature_range_is_definitionally_invalid(
+    tmin_k: float, tmax_k: float
+) -> bool:
+    """Return True when a temperature range is *definitionally* invalid.
+
+    Definitional means the range contradicts itself and no correct calculation
+    could produce it: a temperature must be positive, and ``tmin`` must precede
+    ``tmax``. Nothing else. In particular there is **no upper bound** here.
+
+    Why no cap (ADR 0008,
+    ``docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md``):
+    ``HardFailReason.invalid_temperature_range`` used to fuse three separate
+    claims into one condition — ``0 < tmin`` and ``tmin < tmax`` (both
+    definitional) plus ``tmax <= 10_000`` (an *expectation*, and a wrong one).
+    Shock-tube, detonation, plasma, and atmospheric-re-entry chemistry
+    legitimately exceed any cap we could name, and ``hard_failed`` is a public
+    quality signal, so the cap publicly marked correct high-temperature science
+    as structurally broken. An ordered, positive range is not wrong merely
+    because it is hot.
+
+    The cap is *demoted*, not deleted: it survives as the graded
+    ``temperature_range_valid`` check in :mod:`app.services.trust.rubrics`
+    (``EvidenceCheckKind.optional``), where an implausibly hot range — usually a
+    unit error or a typo — lowers evidence completeness and is explained under
+    ``missing_checks`` without ever labelling the record ``hard_failed``. That
+    is ADR 0008's "expectations warn" tier.
+
+    This also stops the read tier from contradicting the upload tier and the
+    database, both of which already assert exactly these definitional bounds
+    and no cap: ``kinetics_upload.py`` / ``thermo_upload.py`` use
+    ``Field(gt=0)`` plus a ``tmin_k <= tmax_k`` model validator, and
+    ``kinetics``/``thermo`` carry ``ck_*_tmin_k_gt_0`` / ``ck_*_tmin_le_tmax``
+    CHECK constraints. The surviving reachable violation is ``tmin == tmax``,
+    which the CHECK constraints permit and this predicate rejects.
+    """
+    return not (0 < tmin_k < tmax_k)
+
+
 _KINETICS_REQUIRED_SOURCE_ROLES: frozenset[KineticsCalculationRole] = frozenset(
     {
         KineticsCalculationRole.reactant_energy,
@@ -125,7 +163,9 @@ def _detect_kinetics_hard_fail(kinetics: Kinetics) -> Optional[HardFailReason]:
         return HardFailReason.missing_required_identity
 
     if kinetics.tmin_k is not None and kinetics.tmax_k is not None:
-        if not (0 < kinetics.tmin_k < kinetics.tmax_k <= 10_000):
+        if temperature_range_is_definitionally_invalid(
+            kinetics.tmin_k, kinetics.tmax_k
+        ):
             return HardFailReason.invalid_temperature_range
 
     for link in kinetics.source_calculations:
@@ -188,15 +228,12 @@ def _thermo_has_representation(thermo: Thermo) -> bool:
     )
 
 
-# Upper sanity bound for thermochemical temperature ranges (NASA Glenn maximum,
-# 20,000 K). Canonical NASA-9 fits use a 6,000-20,000 K high-temperature
-# interval; a tighter cap would hard-fail valid high-T data. Mirrors the same
-# constant in ``rubrics.py``.
-_MAX_THERMO_TEMPERATURE_K = 20_000
-
-
 def _thermo_temperature_range_invalid(thermo: Thermo) -> bool:
     """Return True when any populated thermo temperature range is invalid.
+
+    "Invalid" means *definitionally* invalid — non-positive, or out of order.
+    A hot range is not invalid; the upper bound is a graded expectation, not a
+    hard fail. See :func:`temperature_range_is_definitionally_invalid`.
 
     NASA-9 interval bounds (NOT NULL) are validated alongside the top-level and
     NASA-7 ranges. Wilhoit has no intrinsic piecewise range, so it only
@@ -205,12 +242,12 @@ def _thermo_temperature_range_invalid(thermo: Thermo) -> bool:
     if thermo.tmin_k is not None or thermo.tmax_k is not None:
         if thermo.tmin_k is None or thermo.tmax_k is None:
             return True
-        if not (0 < thermo.tmin_k < thermo.tmax_k <= _MAX_THERMO_TEMPERATURE_K):
+        if temperature_range_is_definitionally_invalid(thermo.tmin_k, thermo.tmax_k):
             return True
 
     for interval in thermo.nasa9_intervals:
-        if not (
-            0 < interval.t_min_k < interval.t_max_k <= _MAX_THERMO_TEMPERATURE_K
+        if temperature_range_is_definitionally_invalid(
+            interval.t_min_k, interval.t_max_k
         ):
             return True
 
@@ -221,9 +258,10 @@ def _thermo_temperature_range_invalid(thermo: Thermo) -> bool:
         return False
     if nasa.t_low is None or nasa.t_mid is None or nasa.t_high is None:
         return True
-    return not (
-        0 < nasa.t_low < nasa.t_mid < nasa.t_high <= _MAX_THERMO_TEMPERATURE_K
-    )
+    # NASA-7 additionally requires the mid-point to lie strictly inside.
+    return temperature_range_is_definitionally_invalid(
+        nasa.t_low, nasa.t_mid
+    ) or temperature_range_is_definitionally_invalid(nasa.t_mid, nasa.t_high)
 
 
 def _detect_thermo_hard_fail(thermo: Thermo) -> Optional[HardFailReason]:

--- a/backend/app/services/trust/models.py
+++ b/backend/app/services/trust/models.py
@@ -91,6 +91,42 @@ class HardFailReason(str, Enum):
     rubric output into the ``hard_failed`` family. Names are stable
     identifiers; ``explain`` strings in
     :class:`EvidenceEvaluation.hard_fail_reason` may be richer.
+
+    **Backstop reasons — do not delete these as "duplication."**
+
+    Six of these reasons re-derive a rule the upload tier already refuses:
+
+    =============================================  ==========================================================
+    Reason                                          Already refused at upload by
+    =============================================  ==========================================================
+    ``invalid_lj_pair``                             ``transport_upload.validate_lj_pair``
+    ``no_transport_property_present``               ``transport_upload.validate_has_scientific_content``
+    ``no_thermo_representation_present``            ``thermo_upload.validate_has_scientific_content``
+    ``invalid_external_symmetry``                   ``statmech_upload``: ``external_symmetry: Field(ge=1)``
+    ``invalid_torsion_dimension``                   ``statmech_upload``: ``dimension: Field(ge=1)``
+    ``multiplicity_invalid``                        ``transition_state_upload``: ``multiplicity: Field(ge=1)``
+    =============================================  ==========================================================
+
+    That looks like pointless duplication, and reading it that way invites
+    someone to delete the read-time half. It is not duplication. Under ADR 0008
+    the upload tier *owns* each of these rules; these reasons exist to catch
+    records that never went through the upload tier at all — archive restore,
+    data migrations, bulk importers, and direct SQL. That path is real: an
+    archive-restore defect was found in this repository recently, and a record
+    that entered that way has been validated by nothing.
+
+    The practical consequence for whoever reads a report: when one of these six
+    fires, it is **not a routine grading outcome**. Every path that can create
+    such a record through the API already rejects it, so the record is evidence
+    of a data-integrity problem — a restore, migration, or importer that wrote
+    a row the upload schema would have refused. Treat it as an incident to
+    trace back to its ingestion path, not as a record that merely scored badly.
+    (Contrast ``sparse``/``unsupported``, which mean exactly "incomplete but
+    true" and are expected in normal operation.)
+
+    Do not "reconcile" these away by deleting either half. If a rule here ever
+    diverges from its upload-tier owner, the upload tier is authoritative and
+    this one is the copy that must be corrected.
     """
 
     calculation_missing = "calculation_missing"
@@ -100,12 +136,12 @@ class HardFailReason(str, Enum):
     thermo_missing = "thermo_missing"
     transport_missing = "transport_missing"
     species_entry_missing = "species_entry_missing"
-    no_thermo_representation_present = "no_thermo_representation_present"
-    no_transport_property_present = "no_transport_property_present"
-    invalid_lj_pair = "invalid_lj_pair"
+    no_thermo_representation_present = "no_thermo_representation_present"  # backstop
+    no_transport_property_present = "no_transport_property_present"  # backstop
+    invalid_lj_pair = "invalid_lj_pair"  # backstop
     invalid_temperature_range = "invalid_temperature_range"
-    invalid_external_symmetry = "invalid_external_symmetry"
-    invalid_torsion_dimension = "invalid_torsion_dimension"
+    invalid_external_symmetry = "invalid_external_symmetry"  # backstop
+    invalid_torsion_dimension = "invalid_torsion_dimension"  # backstop
     geometry_validation_failed = "geometry_validation_failed"
     missing_required_identity = "missing_required_identity"
     source_calculation_hard_failed_for_required_role = (
@@ -115,7 +151,7 @@ class HardFailReason(str, Enum):
     transition_state_parent_missing = "transition_state_parent_missing"
     reaction_entry_missing = "reaction_entry_missing"
     ts_entry_status_rejected = "ts_entry_status_rejected"
-    multiplicity_invalid = "multiplicity_invalid"
+    multiplicity_invalid = "multiplicity_invalid"  # backstop
     all_source_calculations_hard_failed = "all_source_calculations_hard_failed"
     geometry_validation_failed_for_source_calculation = (
         "geometry_validation_failed_for_source_calculation"

--- a/backend/app/services/trust/models.py
+++ b/backend/app/services/trust/models.py
@@ -108,7 +108,6 @@ class HardFailReason(str, Enum):
     invalid_torsion_dimension = "invalid_torsion_dimension"
     geometry_validation_failed = "geometry_validation_failed"
     missing_required_identity = "missing_required_identity"
-    result_block_missing_when_successful = "result_block_missing_when_successful"
     source_calculation_hard_failed_for_required_role = (
         "source_calculation_hard_failed_for_required_role"
     )

--- a/backend/app/services/trust/rubrics.py
+++ b/backend/app/services/trust/rubrics.py
@@ -363,7 +363,16 @@ def _check_temperature_range_present(kinetics: Kinetics) -> EvidenceOutcome:
 
 
 def _check_temperature_range_valid(kinetics: Kinetics) -> EvidenceOutcome:
-    """Return passed when the populated temperature range is physically plausible."""
+    """Return passed when the populated temperature range is physically plausible.
+
+    This graded (``optional``) check is the *only* owner of the upper
+    temperature bound. Per ADR 0008 the cap is an expectation, not a
+    definition: shock-tube, detonation, plasma, and re-entry chemistry
+    legitimately exceed it, so exceeding it lowers evidence completeness and is
+    explained in ``missing_checks`` — it never hard-fails the record. The
+    evaluator's ``invalid_temperature_range`` hard fail asserts only the
+    definitional ``0 < tmin_k < tmax_k``.
+    """
     if kinetics.tmin_k is None or kinetics.tmax_k is None:
         return EvidenceOutcome.not_applicable
     return _bool_outcome(0 < kinetics.tmin_k < kinetics.tmax_k <= 10_000)
@@ -655,13 +664,21 @@ def _thermo_range_is_present(thermo: Thermo) -> bool:
 
 # Upper sanity bound for thermochemical temperature ranges. Set at the NASA
 # Glenn (Gordon & McBride) maximum of 20,000 K: canonical NASA-9 fits use a
-# 6,000-20,000 K high-temperature interval, and NASA-7 / top-level ranges never
-# legitimately exceed this. A tighter cap would hard-fail valid high-T data.
+# 6,000-20,000 K high-temperature interval.
+#
+# This bound is an *expectation*, not a definition (ADR 0008), so it lives only
+# in this graded rubric. Exceeding it lowers evidence completeness; it never
+# hard-fails. The evaluator asserts only the definitional 0 < low < high.
 _MAX_THERMO_TEMPERATURE_K = 20_000
 
 
 def _thermo_range_is_valid(thermo: Thermo) -> bool:
-    """Return True when all populated thermo temperature ranges are plausible."""
+    """Return True when all populated thermo temperature ranges are plausible.
+
+    "Plausible" includes the graded upper bound; see
+    ``_MAX_THERMO_TEMPERATURE_K``. Definitional validity (positive, ordered) is
+    asserted separately by the evaluator's hard-fail path.
+    """
     if thermo.tmin_k is not None or thermo.tmax_k is not None:
         if thermo.tmin_k is None or thermo.tmax_k is None:
             return False
@@ -1724,6 +1741,8 @@ COMPUTED_KINETICS_V1: EvidenceRubric = EvidenceRubric(
         EvidenceCheckSpec(
             name="temperature_range_valid",
             kind=EvidenceCheckKind.optional,
+            # Sole owner of the upper-bound *expectation* for kinetics: the
+            # evaluator hard-fails only the definitional 0 < tmin_k < tmax_k.
             explain="Temperature range should satisfy 0 < tmin_k < tmax_k <= 10000.",
             runner=_check_temperature_range_valid,
         ),
@@ -1889,7 +1908,9 @@ COMPUTED_THERMO_V1: EvidenceRubric = EvidenceRubric(
         EvidenceCheckSpec(
             name="temperature_range_valid",
             kind=EvidenceCheckKind.optional,
-            explain="Temperature ranges should satisfy 0 < low < high <= 10000.",
+            # Sole owner of the upper-bound *expectation* for thermo: the
+            # evaluator hard-fails only the definitional 0 < low < high.
+            explain="Temperature ranges should satisfy 0 < low < high <= 20000.",
             runner=_check_thermo_temperature_range_valid,
         ),
         EvidenceCheckSpec(

--- a/backend/tests/api/test_api_transport_upload.py
+++ b/backend/tests/api/test_api_transport_upload.py
@@ -88,6 +88,36 @@ class TestTransportUpload:
 
 
 class TestTransportUploadValidation:
+    def test_empty_transport_returns_422(self, client):
+        """A transport row with no transport property at all is definitionally
+        empty and must be refused at upload (ADR 0008: definitions block)."""
+        payload = _transport_payload()
+        for field in (
+            "sigma_angstrom",
+            "epsilon_over_k_k",
+            "dipole_debye",
+            "polarizability_angstrom3",
+            "rotational_relaxation",
+        ):
+            payload[field] = None
+        resp = client.post("/api/v1/uploads/transport", json=payload)
+        assert resp.status_code == 422
+        assert "at least one transport property" in resp.text
+
+    def test_single_property_transport_still_succeeds(self, client):
+        """Exactly one non-LJ property is enough content; the row is not empty."""
+        payload = _transport_payload(
+            species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+            sigma_angstrom=None,
+            epsilon_over_k_k=None,
+            polarizability_angstrom3=None,
+            rotational_relaxation=None,
+            dipole_debye=1.85,
+        )
+        resp = client.post("/api/v1/uploads/transport", json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["type"] == "transport"
+
     def test_partial_lj_pair_returns_422(self, client):
         payload = _transport_payload()
         payload["epsilon_over_k_k"] = None

--- a/backend/tests/services/test_trust_evaluator.py
+++ b/backend/tests/services/test_trust_evaluator.py
@@ -106,6 +106,7 @@ from app.services.trust import (
     label_from_completeness,
     select_rubric,
 )
+from app.services.trust.evaluator import temperature_range_is_definitionally_invalid
 
 # ---------------------------------------------------------------------------
 # Local ORM helpers — direct inserts; rolled back at end of test
@@ -1149,6 +1150,20 @@ class TestComputedKineticsEvaluator:
         assert result.hard_fail_reason is HardFailReason.invalid_temperature_range
         assert "temperature_range_valid" in result.missing_checks
 
+    def test_hot_but_ordered_temperature_range_is_not_hard_failed(self, db_session):
+        """Shock-tube / detonation / plasma ranges are correct science.
+
+        Per ADR 0008 the upper bound is an expectation, not a definition: it is
+        demoted to the graded ``temperature_range_valid`` check, which lowers
+        completeness without labelling the record ``hard_failed``.
+        """
+        kinetics = _make_kinetics(db_session, tmin_k=300.0, tmax_k=15_000.0)
+        result = evaluate_computed_kinetics(db_session, kinetics.id)
+        assert result.hard_fail_reason is None
+        assert result.label is not EvidenceBadge.hard_failed
+        # The expectation still fires, at the graded tier only.
+        assert "temperature_range_valid" in result.missing_checks
+
     def test_source_calculations_raise_evidence_completeness(self, db_session):
         sparse = _make_kinetics(db_session)
         rich = _make_kinetics(db_session)
@@ -1453,6 +1468,19 @@ class TestComputedThermoEvaluator:
         result = evaluate_computed_thermo(db_session, thermo.id)
         assert result.label is EvidenceBadge.hard_failed
         assert result.hard_fail_reason is HardFailReason.invalid_temperature_range
+        assert "temperature_range_valid" in result.missing_checks
+
+    def test_hot_but_ordered_temperature_range_is_not_hard_failed(self, db_session):
+        """A range above the graded NASA-Glenn cap is hot, not wrong.
+
+        Per ADR 0008 the upper bound is an expectation, not a definition; it is
+        demoted to the graded ``temperature_range_valid`` check.
+        """
+        thermo = _make_thermo(db_session, scalar=True, tmin_k=300.0, tmax_k=25_000.0)
+        result = evaluate_computed_thermo(db_session, thermo.id)
+        assert result.hard_fail_reason is None
+        assert result.label is not EvidenceBadge.hard_failed
+        # The expectation still fires, at the graded tier only.
         assert "temperature_range_valid" in result.missing_checks
 
     def test_source_calculations_raise_evidence_completeness(self, db_session):
@@ -2103,3 +2131,51 @@ class TestComputedTransportEvaluator:
         assert result.rubric == "computed_transport"
         assert result.evidence_completeness >= 0.0
         assert result.is_certified is False
+
+
+# ---------------------------------------------------------------------------
+# 14. Temperature-range definitional predicate (ADR 0008)
+# ---------------------------------------------------------------------------
+
+
+class TestTemperatureRangeDefinitionalPredicate:
+    """The hard-fail tier asserts a definition, never an expectation.
+
+    These are pure-function tests on purpose. The ``thermo`` and ``kinetics``
+    tables carry ``ck_*_tmin_k_gt_0`` and ``ck_*_tmin_le_tmax`` CHECK
+    constraints, so a non-positive or inverted range cannot be inserted through
+    Postgres at all; ``tmin == tmax`` is the only definitional violation
+    reachable end-to-end (covered by
+    ``test_invalid_temperature_range_hard_fails`` above). The predicate is
+    tested directly so the definitional rule stays pinned regardless.
+    """
+
+    @pytest.mark.parametrize(
+        "tmin_k, tmax_k",
+        [
+            (2000.0, 300.0),  # inverted
+            (500.0, 500.0),  # degenerate (reachable through the DB)
+            (0.0, 2000.0),  # non-positive lower bound
+            (-10.0, 2000.0),  # negative lower bound
+            (300.0, 0.0),  # non-positive upper bound
+        ],
+    )
+    def test_definitionally_invalid_ranges_are_rejected(self, tmin_k, tmax_k):
+        assert temperature_range_is_definitionally_invalid(tmin_k, tmax_k) is True
+
+    @pytest.mark.parametrize(
+        "tmin_k, tmax_k",
+        [
+            (300.0, 2000.0),  # ordinary combustion range
+            (300.0, 15_000.0),  # shock tube / detonation
+            (300.0, 25_000.0),  # above the graded NASA-Glenn cap
+            (1000.0, 1.0e6),  # plasma
+        ],
+    )
+    def test_hot_but_ordered_ranges_are_accepted(self, tmin_k, tmax_k):
+        """An ordered, positive range is not wrong merely because it is hot.
+
+        The upper bound is an expectation and lives in the graded rubric; it
+        must not appear in the hard-fail predicate at any magnitude.
+        """
+        assert temperature_range_is_definitionally_invalid(tmin_k, tmax_k) is False


### PR DESCRIPTION
## Summary

Four independent fixes, one commit each, applying [ADR 0008](docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md).

## 1. `6f27d65` — Transport had no upload-tier emptiness check

`no_transport_property_present` existed only as a **read-time label**: an empty transport row could be created and would only discover its problem on read. Thermo has had `validate_has_scientific_content` at upload all along; transport never got the equivalent.

Added, mirroring thermo's shape — and placed on the shared **base** class rather than the request subclass, so the nested paths (conformer bundle, network PDep) are covered too. An empty transport row is equally empty whichever door it comes through.

Zero migration risk: the production database currently holds **no transport rows**.

## 2. `82e742a` — `invalid_temperature_range` fused a definition with an expectation

```python
if not (0 < kinetics.tmin_k < kinetics.tmax_k <= 10_000):
```

Three claims in one condition. `0 < tmin` and `tmin < tmax` are definitional; **`tmax <= 10_000` is an expectation** — shock-tube, detonation, plasma and re-entry chemistry legitimately exceed it. Because this is a read-time label, the consequence was that **correct high-temperature science was publicly marked `hard_failed`**, with nothing ever warning the depositor.

**Chose demotion over deletion**, and the reason is better than expected: the graded carrier already existed *and already applied the cap*. `rubrics._check_temperature_range_valid` and `_thermo_range_is_valid` are both `EvidenceCheckKind.optional`, so they lower completeness and appear in `missing_checks` but can never force `hard_failed`. Demotion therefore needed **zero rubric behaviour change** — a hot range failed the graded check before and still does. Deleting outright would have thrown away a real signal, since a 0.001–1e9 K range is almost always a unit error. Raising the number was rejected: any replacement would be equally arbitrary.

The definitional rule is now one predicate, `temperature_range_is_definitionally_invalid`, shared by the kinetics range, thermo range, NASA-9 intervals and the NASA-7 `t_low/t_mid/t_high` chain, so the four sites cannot drift. Thermo's 20 000 K cap was treated identically. Also corrected the thermo rubric's `explain` string, which advertised `<= 10000` while the code used 20 000.

## 3. `cb9e98d` — Deleted `result_block_missing_when_successful`

Declared and never referenced. Deleted rather than wired up, because as named it cannot distinguish a calculation that genuinely produced nothing (a contradiction) from one whose type TCKDB does not yet model a typed result table for (an absence) — wiring it would risk hard-failing records whose result type simply is not parsed. If wanted later, it should be rebuilt type-aware.

Verified safe as an API change: `hard_fail` is `str | None` (`scientific_assessment.py:19`), `TrustFragment.evidence` is an untyped `dict`, and `HardFailReason` appears **0 times** in the golden OpenAPI.

## 4. `f081ab9` — Documented the backstops

The hard-fails that re-derive upload-tier rules are not duplication: they are the only thing catching records that entered by a **non-upload path** — archive restore, migrations, direct SQL. An archive-restore defect was found in this repository recently, so the path is real. Documented as such, with the note that one firing indicates a **data-integrity problem, not a routine grading outcome**.

It is **six**, not five — `no_transport_property_present` joins the set as of fix 1. Before that it had no upload-tier owner at all.

## Validation

| check | result |
|---|---|
| transport upload (empty rejected, populated accepted) | **4 passed** |
| temperature range | **17 passed** |
| `test-scientific.sh` | **1743 passed** |
| `test-api.sh` | **2297 passed** |
| ruff / mypy | clean / clean (143 files) |

Temperature coverage includes a hot-but-ordered range (kinetics 300→15 000 K, thermo 300→25 000 K) no longer hard-failing, the unchanged inverted/non-positive hard fails, and a predicate suite over `(2000,300)`, `(500,500)`, `(0,2000)`, `(-10,2000)`, `(300,0)` invalid versus `(300,15 000)`, `(300,25 000)`, `(1000,1e6)` valid.

Test files are `+30/-0` and `+76/-0` — nothing weakened or deleted.

⚠️ Impact flagged `HardFailReason` as **CRITICAL** (436 impacted). That is the blast radius of the *type*, which the whole trust layer imports — not of removing one member with zero references. The three independent API checks above plus 4040 green tests are the actual evidence.

## Two findings worth noting

**The database already enforces most of the definitional rule.** `ck_thermo_tmin_k_gt_0`, `ck_kinetics_tmin_le_tmax` and siblings mean Postgres refuses non-positive and inverted ranges outright — so `tmin == tmax` is the only definitional violation reachable end-to-end. That strengthens fix 2: the read tier was disagreeing with both the upload schema *and* the database, which agree with each other and impose no cap.

**A cross-tier inconsistency left deliberately alone:** upload allows `tmin_k == tmax_k` and the DB permits it, but the hard fail rejects it (strict `<`). A single-temperature record passes upload and is then labelled `hard_failed` on read. Changing that alters grading outcomes beyond this PR's permitted exception, so it is flagged for the next pass rather than folded in.