### PR TITLE
Split the temperature predicate; anchor ORCA detection on the name

### DIFF
--- a/backend/app/services/ess_software_detection.py
+++ b/backend/app/services/ess_software_detection.py
@@ -18,8 +18,18 @@ SoftwareName = Literal["gaussian", "orca", "molpro"]
 _GAUSSIAN_MARKERS = re.compile(
     r"Gaussian\s+\d+:|Entering Gaussian System", re.IGNORECASE
 )
+# Every alternative must name ORCA. A bare ``Program Version X.Y.Z`` was
+# previously accepted here, which is not an ORCA fingerprint at all -- it is a
+# phrase many programs print. Because ORCA is the last branch, any non-Gaussian,
+# non-Molpro log containing that phrase anywhere in its first 8 kB was dispatched
+# to the ORCA parser, which would then read charge, multiplicity and energies out
+# of a foreign format. Misattribution is worse than silence: returning ``None``
+# means the caller records nothing, while a wrong program yields a confident
+# wrong answer. Reject, don't guess.
 _ORCA_MARKERS = re.compile(
-    r"\* O   R   C   A \*|Program Version\s+\d+\.\d+\.\d+", re.IGNORECASE
+    r"\*\s*O\s+R\s+C\s+A\s*\*"  # the ASCII-art banner, asterisk-anchored
+    r"|\bORCA\b",  # any header line naming ORCA (version, citation, footer)
+    re.IGNORECASE,
 )
 _MOLPRO_MARKERS = re.compile(r"PROGRAM SYSTEM MOLPRO", re.IGNORECASE)
 

--- a/backend/app/services/trust/evaluator.py
+++ b/backend/app/services/trust/evaluator.py
@@ -97,42 +97,48 @@ def _detect_calculation_hard_fail(calc: Calculation) -> Optional[HardFailReason]
     return None
 
 
-def temperature_range_is_definitionally_invalid(
-    tmin_k: float, tmax_k: float
-) -> bool:
-    """Return True when a temperature range is *definitionally* invalid.
+# Temperature bounds are checked by two predicates, not one, because ``tmin ==
+# tmax`` means different things depending on what the pair describes. See ADR 0008
+# (docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md).
+#
+# Neither predicate carries an upper bound. ``invalid_temperature_range`` used to
+# fuse three claims into one condition -- ``0 < tmin`` and the ordering (both
+# definitional) plus ``tmax <= 10_000`` (an expectation, and a wrong one).
+# Shock-tube, detonation, plasma and re-entry chemistry legitimately exceed any cap
+# we could name, and ``hard_failed`` is a public quality signal, so the cap marked
+# correct high-temperature science as structurally broken. The cap is *demoted*,
+# not deleted: it survives as the graded ``temperature_range_valid`` check in
+# :mod:`app.services.trust.rubrics` (``EvidenceCheckKind.optional``), which lowers
+# completeness and explains itself under ``missing_checks`` without ever labelling
+# a record ``hard_failed``.
 
-    Definitional means the range contradicts itself and no correct calculation
-    could produce it: a temperature must be positive, and ``tmin`` must precede
-    ``tmax``. Nothing else. In particular there is **no upper bound** here.
+def validity_range_is_definitionally_invalid(tmin_k: float, tmax_k: float) -> bool:
+    """Return True when a *validity range* is definitionally invalid.
 
-    Why no cap (ADR 0008,
-    ``docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md``):
-    ``HardFailReason.invalid_temperature_range`` used to fuse three separate
-    claims into one condition — ``0 < tmin`` and ``tmin < tmax`` (both
-    definitional) plus ``tmax <= 10_000`` (an *expectation*, and a wrong one).
-    Shock-tube, detonation, plasma, and atmospheric-re-entry chemistry
-    legitimately exceed any cap we could name, and ``hard_failed`` is a public
-    quality signal, so the cap publicly marked correct high-temperature science
-    as structurally broken. An ordered, positive range is not wrong merely
-    because it is hot.
+    A validity range says where a datum applies. ``tmin == tmax`` is legitimate
+    and common: a rate coefficient measured or computed at a single temperature
+    (``k(298 K)``) has a one-point range, and TCKDB accepts experimental records
+    (:class:`ScientificOriginKind.experimental`) where that is the normal shape.
 
-    The cap is *demoted*, not deleted: it survives as the graded
-    ``temperature_range_valid`` check in :mod:`app.services.trust.rubrics`
-    (``EvidenceCheckKind.optional``), where an implausibly hot range — usually a
-    unit error or a typo — lowers evidence completeness and is explained under
-    ``missing_checks`` without ever labelling the record ``hard_failed``. That
-    is ADR 0008's "expectations warn" tier.
-
-    This also stops the read tier from contradicting the upload tier and the
-    database, both of which already assert exactly these definitional bounds
-    and no cap: ``kinetics_upload.py`` / ``thermo_upload.py`` use
-    ``Field(gt=0)`` plus a ``tmin_k <= tmax_k`` model validator, and
-    ``kinetics``/``thermo`` carry ``ck_*_tmin_k_gt_0`` / ``ck_*_tmin_le_tmax``
-    CHECK constraints. The surviving reachable violation is ``tmin == tmax``,
-    which the CHECK constraints permit and this predicate rejects.
+    So the only definitional violations are a non-positive temperature and an
+    inverted range. This matches the upload schema (``tmin_k <= tmax_k``) and the
+    database (``ck_*_tmin_le_tmax``), which both already permit equality — before
+    this split the read tier was the sole dissenter and would have labelled a
+    single-temperature datum ``hard_failed``.
     """
-    return not (0 < tmin_k < tmax_k)
+    return not (0 < tmin_k <= tmax_k)
+
+
+def fitting_interval_is_definitionally_invalid(t_low: float, t_high: float) -> bool:
+    """Return True when a *polynomial fitting interval* is definitionally invalid.
+
+    A fitting interval is the domain a polynomial piece is fitted over, so it
+    must have width: a NASA-7 segment or NASA-9 interval spanning ``[T, T]``
+    covers no temperatures and cannot be evaluated as a piece. Equality is
+    degenerate here, which is exactly why it is legitimate for a validity range
+    and not for this.
+    """
+    return not (0 < t_low < t_high)
 
 
 _KINETICS_REQUIRED_SOURCE_ROLES: frozenset[KineticsCalculationRole] = frozenset(
@@ -163,7 +169,7 @@ def _detect_kinetics_hard_fail(kinetics: Kinetics) -> Optional[HardFailReason]:
         return HardFailReason.missing_required_identity
 
     if kinetics.tmin_k is not None and kinetics.tmax_k is not None:
-        if temperature_range_is_definitionally_invalid(
+        if validity_range_is_definitionally_invalid(
             kinetics.tmin_k, kinetics.tmax_k
         ):
             return HardFailReason.invalid_temperature_range
@@ -233,7 +239,8 @@ def _thermo_temperature_range_invalid(thermo: Thermo) -> bool:
 
     "Invalid" means *definitionally* invalid — non-positive, or out of order.
     A hot range is not invalid; the upper bound is a graded expectation, not a
-    hard fail. See :func:`temperature_range_is_definitionally_invalid`.
+    hard fail. See :func:`validity_range_is_definitionally_invalid` and
+    :func:`fitting_interval_is_definitionally_invalid`.
 
     NASA-9 interval bounds (NOT NULL) are validated alongside the top-level and
     NASA-7 ranges. Wilhoit has no intrinsic piecewise range, so it only
@@ -242,11 +249,11 @@ def _thermo_temperature_range_invalid(thermo: Thermo) -> bool:
     if thermo.tmin_k is not None or thermo.tmax_k is not None:
         if thermo.tmin_k is None or thermo.tmax_k is None:
             return True
-        if temperature_range_is_definitionally_invalid(thermo.tmin_k, thermo.tmax_k):
+        if validity_range_is_definitionally_invalid(thermo.tmin_k, thermo.tmax_k):
             return True
 
     for interval in thermo.nasa9_intervals:
-        if temperature_range_is_definitionally_invalid(
+        if fitting_interval_is_definitionally_invalid(
             interval.t_min_k, interval.t_max_k
         ):
             return True
@@ -259,9 +266,9 @@ def _thermo_temperature_range_invalid(thermo: Thermo) -> bool:
     if nasa.t_low is None or nasa.t_mid is None or nasa.t_high is None:
         return True
     # NASA-7 additionally requires the mid-point to lie strictly inside.
-    return temperature_range_is_definitionally_invalid(
+    return fitting_interval_is_definitionally_invalid(
         nasa.t_low, nasa.t_mid
-    ) or temperature_range_is_definitionally_invalid(nasa.t_mid, nasa.t_high)
+    ) or fitting_interval_is_definitionally_invalid(nasa.t_mid, nasa.t_high)
 
 
 def _detect_thermo_hard_fail(thermo: Thermo) -> Optional[HardFailReason]:

--- a/backend/tests/api/scientific/test_api_reaction_kinetics.py
+++ b/backend/tests/api/scientific/test_api_reaction_kinetics.py
@@ -311,7 +311,17 @@ def test_include_trust_source_calculations_score_higher(client, db_session):
     assert rich_score > sparse_score
 
 
-def test_include_trust_invalid_temperature_range_hard_failed(client, db_session):
+def test_include_trust_single_temperature_range_is_not_hard_failed(client, db_session):
+    """A one-point validity range is a datum reported at a single temperature.
+
+    This previously asserted ``hard_failed``. ``tmin == tmax`` is the only
+    definitional violation reachable through the database (``ck_*_tmin_le_tmax``
+    and ``ck_*_tmin_k_gt_0`` refuse inverted and non-positive ranges outright),
+    and it is not a violation at all: a rate constant measured at 298 K has a
+    one-point range, which the upload schema and the database already permit.
+    The definitional rule stays pinned by the DB-free predicate tests in
+    ``tests/services/test_trust_evaluator.py``.
+    """
     entry = _entry(db_session)
     make_kinetics(
         db_session,
@@ -326,8 +336,8 @@ def test_include_trust_invalid_temperature_range_hard_failed(client, db_session)
     ).json()
     evidence = body["records"][0]["trust"]["evidence"]
 
-    assert evidence["label"] == "hard_failed"
-    assert evidence["hard_fail_reason"] == "invalid_temperature_range"
+    assert evidence["label"] != "hard_failed"
+    assert evidence["hard_fail_reason"] != "invalid_temperature_range"
 
 
 def test_include_all_does_not_include_trust(client, db_session):

--- a/backend/tests/api/scientific/test_api_species_thermo.py
+++ b/backend/tests/api/scientific/test_api_species_thermo.py
@@ -348,7 +348,17 @@ def test_include_trust_no_representation_hard_failed(client, db_session):
     assert evidence["hard_fail_reason"] == "no_thermo_representation_present"
 
 
-def test_include_trust_invalid_temperature_range_hard_failed(client, db_session):
+def test_include_trust_single_temperature_range_is_not_hard_failed(client, db_session):
+    """A one-point validity range is a datum reported at a single temperature.
+
+    This previously asserted ``hard_failed``. ``tmin == tmax`` is the only
+    definitional violation reachable through the database (``ck_*_tmin_le_tmax``
+    and ``ck_*_tmin_k_gt_0`` refuse inverted and non-positive ranges outright),
+    and it is not a violation at all: a rate constant measured at 298 K has a
+    one-point range, which the upload schema and the database already permit.
+    The definitional rule stays pinned by the DB-free predicate tests in
+    ``tests/services/test_trust_evaluator.py``.
+    """
     entry = _entry(db_session)
     make_thermo_scalar(
         db_session,
@@ -362,8 +372,8 @@ def test_include_trust_invalid_temperature_range_hard_failed(client, db_session)
     ).json()
 
     evidence = body["records"][0]["trust"]["evidence"]
-    assert evidence["label"] == "hard_failed"
-    assert evidence["hard_fail_reason"] == "invalid_temperature_range"
+    assert evidence["label"] != "hard_failed"
+    assert evidence["hard_fail_reason"] != "invalid_temperature_range"
 
 
 def test_include_trust_does_not_mutate_thermo(client, db_session):

--- a/backend/tests/services/test_ess_software_detection.py
+++ b/backend/tests/services/test_ess_software_detection.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 from app.services.ess_software_detection import detect_software_from_text
 
 _FIX = os.path.join(os.path.dirname(__file__), "..", "fixtures")
@@ -45,3 +47,40 @@ def test_detection_is_extension_independent() -> None:
     # Same ORCA bytes; the (ignored) filename does not affect the result.
     orca_text = _read("orca", "sp_dlpno_ccsdt_orca.out")
     assert detect_software_from_text(orca_text) == "orca"
+
+
+class TestOrcaMarkerIsAnchoredOnTheName:
+    """Every ORCA alternative must name ORCA; none may be a generic phrase.
+
+    ``Program Version X.Y.Z`` was previously an accepted ORCA marker. It is not
+    an ORCA fingerprint -- many programs print it -- and because ORCA is the
+    last branch, any non-Gaussian, non-Molpro log containing that phrase in its
+    first 8 kB was dispatched to the ORCA parser, which would then read charge,
+    multiplicity and energies out of a foreign format.
+
+    Misattribution is worse than silence: ``None`` makes the caller record
+    nothing, while the wrong program yields a confident wrong answer.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "                 * O   R   C   A *",
+            "Program Version 5.0.3 -  RELEASE  -\nORCA",
+            "ORCA 6.0.0",
+            "****ORCA TERMINATED NORMALLY****",
+        ],
+    )
+    def test_genuine_orca_logs_are_still_detected(self, text: str) -> None:
+        assert detect_software_from_text(text) == "orca"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Some Code\nProgram Version 1.2.3\nnothing else",
+            "Psi4: An Open-Source Ab Initio Package\nProgram Version 1.9.1",
+            "Northwest Computational Chemistry\nProgram Version 7.0.2",
+        ],
+    )
+    def test_a_bare_version_line_is_not_orca(self, text: str) -> None:
+        assert detect_software_from_text(text) is None

--- a/backend/tests/services/test_ess_software_detection.py
+++ b/backend/tests/services/test_ess_software_detection.py
@@ -66,7 +66,13 @@ class TestOrcaMarkerIsAnchoredOnTheName:
         "text",
         [
             "                 * O   R   C   A *",
+            # Version-independent by construction: the marker is the name, not
+            # the number, so any release matches and future ones will too.
+            "Program Version 4.2.1 -  RELEASE  -\nORCA",
             "Program Version 5.0.3 -  RELEASE  -\nORCA",
+            "Program Version 6.1.0 -  RELEASE  -\nORCA",
+            "ORCA 4.0.1",
+            "ORCA 5.0.4",
             "ORCA 6.0.0",
             "****ORCA TERMINATED NORMALLY****",
         ],

--- a/backend/tests/services/test_trust_evaluator.py
+++ b/backend/tests/services/test_trust_evaluator.py
@@ -106,7 +106,10 @@ from app.services.trust import (
     label_from_completeness,
     select_rubric,
 )
-from app.services.trust.evaluator import temperature_range_is_definitionally_invalid
+from app.services.trust.evaluator import (
+    fitting_interval_is_definitionally_invalid,
+    validity_range_is_definitionally_invalid,
+)
 
 # ---------------------------------------------------------------------------
 # Local ORM helpers — direct inserts; rolled back at end of test
@@ -1143,12 +1146,21 @@ class TestComputedKineticsEvaluator:
         assert "temperature_range_valid" in result.not_applicable_checks
         assert result.hard_fail_reason is None
 
-    def test_invalid_temperature_range_hard_fails(self, db_session):
+    def test_single_temperature_range_is_not_hard_failed(self, db_session):
+        """A one-point validity range is a datum reported at a single temperature.
+
+        This test previously asserted the opposite. ``tmin == tmax`` is the only
+        definitionally-invalid range reachable end-to-end -- ``ck_*_tmin_le_tmax``
+        and ``ck_*_tmin_k_gt_0`` refuse inverted and non-positive ranges at the
+        database -- and it turns out not to be invalid at all: a rate constant
+        measured at 298 K has a one-point range, and both the upload schema and
+        the database already permit it. The definitional rule itself stays pinned
+        by ``TestTemperatureRangeDefinitionalPredicate``, which needs no database.
+        """
         kinetics = _make_kinetics(db_session, tmin_k=500.0, tmax_k=500.0)
         result = evaluate_computed_kinetics(db_session, kinetics.id)
-        assert result.label is EvidenceBadge.hard_failed
-        assert result.hard_fail_reason is HardFailReason.invalid_temperature_range
-        assert "temperature_range_valid" in result.missing_checks
+        assert result.label is not EvidenceBadge.hard_failed
+        assert result.hard_fail_reason is not HardFailReason.invalid_temperature_range
 
     def test_hot_but_ordered_temperature_range_is_not_hard_failed(self, db_session):
         """Shock-tube / detonation / plasma ranges are correct science.
@@ -1463,12 +1475,21 @@ class TestComputedThermoEvaluator:
         assert "temperature_range_valid" in result.not_applicable_checks
         assert result.hard_fail_reason is None
 
-    def test_invalid_temperature_range_hard_fails(self, db_session):
+    def test_single_temperature_range_is_not_hard_failed(self, db_session):
+        """A one-point validity range is a datum reported at a single temperature.
+
+        This test previously asserted the opposite. ``tmin == tmax`` is the only
+        definitionally-invalid range reachable end-to-end -- ``ck_*_tmin_le_tmax``
+        and ``ck_*_tmin_k_gt_0`` refuse inverted and non-positive ranges at the
+        database -- and it turns out not to be invalid at all: a rate constant
+        measured at 298 K has a one-point range, and both the upload schema and
+        the database already permit it. The definitional rule itself stays pinned
+        by ``TestTemperatureRangeDefinitionalPredicate``, which needs no database.
+        """
         thermo = _make_thermo(db_session, scalar=True, tmin_k=500.0, tmax_k=500.0)
         result = evaluate_computed_thermo(db_session, thermo.id)
-        assert result.label is EvidenceBadge.hard_failed
-        assert result.hard_fail_reason is HardFailReason.invalid_temperature_range
-        assert "temperature_range_valid" in result.missing_checks
+        assert result.label is not EvidenceBadge.hard_failed
+        assert result.hard_fail_reason is not HardFailReason.invalid_temperature_range
 
     def test_hot_but_ordered_temperature_range_is_not_hard_failed(self, db_session):
         """A range above the graded NASA-Glenn cap is hot, not wrong.
@@ -2154,14 +2175,33 @@ class TestTemperatureRangeDefinitionalPredicate:
         "tmin_k, tmax_k",
         [
             (2000.0, 300.0),  # inverted
-            (500.0, 500.0),  # degenerate (reachable through the DB)
             (0.0, 2000.0),  # non-positive lower bound
             (-10.0, 2000.0),  # negative lower bound
             (300.0, 0.0),  # non-positive upper bound
         ],
     )
     def test_definitionally_invalid_ranges_are_rejected(self, tmin_k, tmax_k):
-        assert temperature_range_is_definitionally_invalid(tmin_k, tmax_k) is True
+        assert validity_range_is_definitionally_invalid(tmin_k, tmax_k) is True
+        assert fitting_interval_is_definitionally_invalid(tmin_k, tmax_k) is True
+
+    def test_single_temperature_validity_range_is_accepted(self):
+        """``tmin == tmax`` is a datum reported at one temperature.
+
+        A rate constant measured at 298 K has a one-point validity range. The
+        upload schema (``tmin_k <= tmax_k``) and the database
+        (``ck_*_tmin_le_tmax``) both already permit it; before the split the
+        read tier was the sole dissenter and would have labelled such a record
+        ``hard_failed``.
+        """
+        assert validity_range_is_definitionally_invalid(298.15, 298.15) is False
+
+    def test_zero_width_fitting_interval_is_rejected(self):
+        """The same equality is degenerate for a polynomial piece.
+
+        A NASA segment spanning ``[T, T]`` covers no temperatures and cannot be
+        evaluated as a piece, which is precisely why the two predicates differ.
+        """
+        assert fitting_interval_is_definitionally_invalid(500.0, 500.0) is True
 
     @pytest.mark.parametrize(
         "tmin_k, tmax_k",
@@ -2178,4 +2218,5 @@ class TestTemperatureRangeDefinitionalPredicate:
         The upper bound is an expectation and lives in the graded rubric; it
         must not appear in the hard-fail predicate at any magnitude.
         """
-        assert temperature_range_is_definitionally_invalid(tmin_k, tmax_k) is False
+        assert validity_range_is_definitionally_invalid(tmin_k, tmax_k) is False
+        assert fitting_interval_is_definitionally_invalid(tmin_k, tmax_k) is False


### PR DESCRIPTION
## Summary

Two fixes that were reviewed and verified alongside #78 but **did not make it into that merge** — they were committed locally and never pushed, so #78 landed with only its original four commits. Both are follow-ups to code #78 introduced.

## 1. The unified temperature predicate conflates two meanings

#78 extracted `temperature_range_is_definitionally_invalid` — `not (0 < tmin < tmax)` — and shared it across four call sites. Those sites do not mean the same thing:

| site | what `tmin == tmax` means |
|---|---|
| `kinetics.tmin_k` / `tmax_k` | a rate reported **at a single temperature** |
| `thermo.tmin_k` / `tmax_k` | a datum valid at one temperature |
| NASA-7 `t_low` / `t_mid` / `t_high` | a **zero-width polynomial interval** — degenerate |
| NASA-9 intervals | same |

A rate constant measured at 298 K has a one-point validity range, and TCKDB accepts experimental records where that is the normal shape. Both the upload schema (`tmin_k <= tmax_k`) and the database (`ck_*_tmin_le_tmax`) already permit equality — **the read tier is the sole dissenter**, so such a record is accepted and then publicly labelled `hard_failed`.

This is the same fusion mistake ADR 0008 describes, one level down: a rule derived from polynomial fitting applied to a statement about where a rate is valid.

Split into two predicates:

```python
validity_range_is_definitionally_invalid(tmin, tmax)    ->  not (0 < tmin <= tmax)
fitting_interval_is_definitionally_invalid(t_lo, t_hi)  ->  not (0 < t_lo <  t_hi)
```

The old name is **deleted** rather than kept as a raising stub, so any missed call site fails at lint time rather than runtime.

### Four tests encoded the old behaviour

Two unit-level and two API-level, all using `tmin_k == tmax_k == 500`. They are **repurposed, not deleted**: since the CHECK constraints refuse inverted and non-positive ranges outright, equality is the *only* definitional violation reachable end-to-end — so once equality is valid, those tests cannot test invalidity at all. They now pin the corrected behaviour, and the definitional rule stays pinned by DB-free predicate tests.

The two API-level ones were only caught by a full gate run, after the unit-level pass looked clean.

## 2. The ORCA marker fingerprints on a generic phrase

```python
_ORCA_MARKERS = re.compile(r"\* O   R   C   A \*|Program Version\s+\d+\.\d+\.\d+", re.IGNORECASE)
```

`Program Version X.Y.Z` is not an ORCA fingerprint — many programs print it. ORCA is the **last** branch, so any non-Gaussian, non-Molpro log containing that phrase in its first 8 kB is dispatched to the ORCA parser, which then reads charge, multiplicity and energies out of a foreign format. Misattribution is worse than silence: `None` makes the caller record nothing, while the wrong program yields a confident wrong answer.

Every alternative now names ORCA. Verified against real logs: the ASCII banner, a version line naming ORCA, a truncated `ORCA 6.0.0`, and the termination footer all still detect; a bare `Program Version`, Psi4 and NWChem-shaped headers return `None`.

**Correcting my own earlier justification:** I originally said a Psi4 log could be misrouted by this. With real Psi4 files now to hand (Psi4 1.9.1, from ARC and RMG-Py fixtures), the old pattern **does not match them** — Psi4 prints `Psi4 1.9.1 release`, not `Program Version 1.9.1`. This is principled hardening against generic fingerprinting, **not** a fix for a demonstrated misrouting. The change stands; the stated reason was wrong.

The detection test is parametrised across ORCA 4.2.1 / 5.0.3 / 6.1.0 / 4.0.1 / 5.0.4 / 6.0.0 so version-independence is asserted rather than implied.

## Validation

Both gate scripts were run on these changes while they sat on the #78 branch:

| check | result |
|---|---|
| `test-api.sh` | **2295 passed** (after the API test repurposing) |
| `test-scientific.sh` | green |
| trust + detection + kinetics + thermo read tests, post-rebase onto current `main` | **171 passed** |
| ruff | clean |

`ess_software_detection` is shared with the SP-energy path — its docstring requires the two never disagree on the same bytes — so the SP-energy and Hessian suites were run as evidence too (93 passed).