### PR TITLE
Recognise Psi4 logs and read their charge/multiplicity

### DIFF
--- a/backend/app/services/calculation_parameter_extraction.py
+++ b/backend/app/services/calculation_parameter_extraction.py
@@ -75,6 +75,12 @@ def _resolve_software(
 
     DB-linked software identity wins; text sniffing is the fallback for
     calculations created without a ``software_release`` row.
+
+    Resolving a program is not a promise that a parser exists for it —
+    ``_run_parser`` is the single place that decides that, and raises for a
+    program it cannot parse. The allow-list below stays at the three
+    programs with a wired parameter parser so a mislabelled
+    ``software_release`` cannot override what the log itself says.
     """
 
     release = calculation.software_release
@@ -90,7 +96,7 @@ def _resolve_software(
     raise ParameterExtractionError(
         "Cannot determine ESS software for parameter extraction: "
         "calculation has no software_release and the artifact text "
-        "contains no recognised Gaussian/ORCA/Molpro markers."
+        "contains no recognised electronic-structure program banner."
     )
 
 
@@ -127,6 +133,14 @@ def _run_parser(software: SoftwareName, artifact_text: str) -> dict:
 
     Wraps any parser exception in :class:`ParameterExtractionError` so
     callers have a single failure mode to catch.
+
+    Dispatch is exhaustive on purpose. A recognised program with no wired
+    parameter parser raises rather than falling through to another
+    program's parser: feeding a Psi4 log to the ORCA parser would emit
+    parameter rows attributed to a run that never happened. The
+    opportunistic callers funnel through :func:`_extract_safe`, which
+    downgrades the raise to a logged skip, so the artifact upload still
+    succeeds.
     """
 
     try:
@@ -137,7 +151,14 @@ def _run_parser(software: SoftwareName, artifact_text: str) -> dict:
             return _parse_gaussian_text(artifact_text)
         if software == "molpro":
             return molpro_parameter_parser.parse_molpro_log(text=artifact_text)
-        return orca_parameter_parser.parse_orca_log(text=artifact_text)
+        if software == "orca":
+            return orca_parameter_parser.parse_orca_log(text=artifact_text)
+        raise ParameterExtractionError(
+            f"No parameter parser is wired for {software}; parameters were "
+            "not extracted. The artifact itself is stored unchanged."
+        )
+    except ParameterExtractionError:
+        raise
     except Exception as exc:
         raise ParameterExtractionError(
             f"{software} parser failed: {type(exc).__name__}: {exc}"

--- a/backend/app/services/charge_multiplicity_reconciliation.py
+++ b/backend/app/services/charge_multiplicity_reconciliation.py
@@ -123,6 +123,23 @@ def _parse_orca(text: str) -> tuple[int | None, int | None]:
     return _unanimous(charges), _unanimous(mults)
 
 
+def _parse_psi4(text: str) -> tuple[int | None, int | None]:
+    """Psi4 declares the pair twice per geometry, in two different shapes.
+
+    Both are collected by the parser, and both must agree. A counterpoise
+    or SAPT job activates each fragment as its own molecule and prints a
+    header per fragment, so the first pair need not describe the whole
+    system — the unanimity check is what stops a fragment's values being
+    compared against the entry's.
+    """
+    from app.services.psi4_parameter_parser import parse_all_charge_multiplicity
+
+    found = parse_all_charge_multiplicity(text)
+    charges: list[int | None] = [c for c, _ in found]
+    mults: list[int | None] = [m for _, m in found]
+    return _unanimous(charges), _unanimous(mults)
+
+
 def _parse_molpro(text: str) -> tuple[int | None, int | None]:
     """Molpro states the spin, but never declares the charge outright.
 
@@ -153,7 +170,7 @@ def parse_charge_multiplicity_from_log(
     Picks the parser by sniffing the program banner in the log's *content*
     (not its filename), the same dispatch the single-point-energy path uses,
     so the two can never disagree about which program produced a given file.
-    Gaussian, ORCA and Molpro are wired.
+    Gaussian, ORCA, Molpro and Psi4 are wired.
 
     Returns ``None`` when the program is unrecognised or neither quantity
     could be read, so the caller treats the log as *unverifiable* rather
@@ -165,10 +182,19 @@ def parse_charge_multiplicity_from_log(
     if software is None:
         return None
 
+    # Exhaustive on purpose. A program without a wired parser must not fall
+    # through to another program's: Gaussian's charge/multiplicity pattern
+    # spans newlines and so coincidentally matches Psi4's SCF block, which
+    # would look like it worked while missing Psi4's geometry-header form
+    # entirely — and would report one confident pair for a log whose two
+    # forms disagree, the exact fabricated mismatch this module exists to
+    # avoid.
     if software == "molpro":
         charge, multiplicity = _parse_molpro(text)
     elif software == "orca":
         charge, multiplicity = _parse_orca(text)
+    elif software == "psi4":
+        charge, multiplicity = _parse_psi4(text)
     else:  # gaussian
         charge, multiplicity = _parse_gaussian(text)
 

--- a/backend/app/services/ess_software_detection.py
+++ b/backend/app/services/ess_software_detection.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-SoftwareName = Literal["gaussian", "orca", "molpro"]
+SoftwareName = Literal["gaussian", "orca", "molpro", "psi4"]
 
 _GAUSSIAN_MARKERS = re.compile(
     r"Gaussian\s+\d+:|Entering Gaussian System", re.IGNORECASE
@@ -32,20 +32,42 @@ _ORCA_MARKERS = re.compile(
     re.IGNORECASE,
 )
 _MOLPRO_MARKERS = re.compile(r"PROGRAM SYSTEM MOLPRO", re.IGNORECASE)
+# Both alternatives are anchored on the literal program name. The banner
+# title is Psi4's own tagline and the start line is the run header it prints
+# immediately below it; no other program emits either string. Deliberately
+# *not* anchored on a version line: Psi4 writes ``Psi4 1.9.1 release`` for a
+# tagged build but only ``Psi4 1.4a1.dev75`` for a development build, so a
+# ``release``-bearing pattern would silently miss dev builds (see
+# ``tests/fixtures/psi4/io_error_truncated.out``).
+_PSI4_MARKERS = re.compile(
+    r"Psi4:\s*An Open-Source Ab Initio Electronic Structure Package"
+    r"|Psi4 started on:",
+    re.IGNORECASE,
+)
 
 
 def detect_software_from_text(text: str) -> SoftwareName | None:
-    """Best-effort sniff for ``"gaussian"``, ``"orca"`` or ``"molpro"``.
+    """Best-effort sniff for ``"gaussian"``, ``"orca"``, ``"molpro"`` or ``"psi4"``.
 
     Returns ``None`` when no recognised marker is found. Molpro's banner
-    (``***  PROGRAM SYSTEM MOLPRO  ***``) is unambiguous and checked before
-    the ORCA fallback so it can never be mistaken for another program.
+    (``***  PROGRAM SYSTEM MOLPRO  ***``) and Psi4's are unambiguous and
+    checked before the ORCA fallback so they can never be mistaken for
+    another program: ORCA is matched partly by a generic
+    ``Program Version X.Y.Z`` line, so anything with a distinctive banner
+    must be ruled out first.
+
+    Identifying a program here does **not** imply every extraction path
+    supports it. Psi4 is wired for charge/multiplicity only; the
+    single-point-energy, Hessian and parameter-extraction paths each decline
+    it explicitly rather than falling through to another program's parser.
     """
     head = text[:8000]
     if _GAUSSIAN_MARKERS.search(head):
         return "gaussian"
     if _MOLPRO_MARKERS.search(head):
         return "molpro"
+    if _PSI4_MARKERS.search(head):
+        return "psi4"
     if _ORCA_MARKERS.search(head):
         return "orca"
     return None

--- a/backend/app/services/ess_software_detection.py
+++ b/backend/app/services/ess_software_detection.py
@@ -28,7 +28,12 @@ _GAUSSIAN_MARKERS = re.compile(
 # wrong answer. Reject, don't guess.
 _ORCA_MARKERS = re.compile(
     r"\*\s*O\s+R\s+C\s+A\s*\*"  # the ASCII-art banner, asterisk-anchored
-    r"|\bORCA\b",  # any header line naming ORCA (version, citation, footer)
+    r"|\bORCA\b"  # any header line naming ORCA (version, citation, footer)
+    # ORCA's version line carries a ``-  RELEASE  -`` suffix. That pairing is an
+    # ORCA convention and is kept, unlike the bare ``Program Version X.Y.Z`` it
+    # replaced -- a phrase many programs print, which made ORCA (the last
+    # branch) a catch-all for every unrecognised log.
+    r"|Program\s+Version\s+[\d.]+\s*-+\s*RELEASE",
     re.IGNORECASE,
 )
 _MOLPRO_MARKERS = re.compile(r"PROGRAM SYSTEM MOLPRO", re.IGNORECASE)

--- a/backend/app/services/hessian_parsing.py
+++ b/backend/app/services/hessian_parsing.py
@@ -455,7 +455,10 @@ def parse_hessian_from_artifact(
         from app.services.gaussian_parameter_parser import parse_hessian
     elif software == "molpro":
         from app.services.molpro_parameter_parser import parse_hessian
-    else:  # orca output logs do not carry the matrix; it is in the .hess
+    else:
+        # ORCA output logs do not carry the matrix (it lives in the .hess,
+        # handled above), and Psi4 Hessian extraction is not wired. Either
+        # way there is nothing to parse, and nothing is guessed.
         return None
 
     result = parse_hessian(text)

--- a/backend/app/services/psi4_parameter_parser.py
+++ b/backend/app/services/psi4_parameter_parser.py
@@ -1,0 +1,96 @@
+"""Psi4 output-log parsing.
+
+Deliberately narrow: only the charge and spin multiplicity a Psi4 log
+declares are read here. That is what
+:mod:`app.services.charge_multiplicity_reconciliation` needs in order to
+cross-check an uploader's declared values against the log the run actually
+produced.
+
+**Single-point energy is not extracted, on purpose.** A Psi4 log prints many
+``Total Energy`` lines — one per SCF, one per post-HF correction, several more
+for a composite or MRCC-driven job — and which one is "the" energy depends on
+the method that was run. Guessing wrong would silently record a wrong number
+into ``calc_sp_result``, which is worse than recording nothing, so the
+single-point path declines Psi4 rather than picking a line. Frequencies and
+geometries are likewise not wired.
+
+DB-free — pure text in, values out.
+"""
+
+from __future__ import annotations
+
+import re
+
+PARSER_VERSION = "psi4-0.1.0"
+
+# ---------------------------------------------------------------------------
+# Charge / multiplicity
+# ---------------------------------------------------------------------------
+
+# Psi4 states the pair twice per geometry, in two different shapes.
+#
+# The geometry header, printed once per molecule Psi4 activates:
+#
+#     Geometry (in Angstrom), charge = 0, multiplicity = 3:
+#
+# and the SCF module's own summary block a few lines further down:
+#
+#       Charge       = 0
+#       Multiplicity = 3
+#
+# Leading indentation varies between builds (the 1.4 dev build in the
+# fixtures writes the geometry header flush-left, 1.9 indents it four
+# spaces), so neither pattern anchors on column position.
+_GEOMETRY_HEADER_RE = re.compile(
+    r"Geometry\s*\([^)]*\)\s*,\s*charge\s*=\s*(-?\d+)\s*,\s*multiplicity\s*=\s*(-?\d+)",
+    re.IGNORECASE,
+)
+
+# Anchored to line starts so the two values must be adjacent lines of the
+# same block. Without ``^``/``$`` the ``\s+`` between them would happily
+# span unrelated intervening output and pair a charge with a multiplicity
+# from somewhere else entirely.
+_SCF_BLOCK_RE = re.compile(
+    r"^[ \t]*Charge[ \t]*=[ \t]*(-?\d+)[ \t]*\r?$\n"
+    r"^[ \t]*Multiplicity[ \t]*=[ \t]*(-?\d+)[ \t]*\r?$",
+    re.MULTILINE,
+)
+
+
+def parse_all_charge_multiplicity(text: str) -> list[tuple[int, int]]:
+    """Return *every* charge/multiplicity pair the log declares.
+
+    Mirrors the Gaussian and ORCA functions of the same name: it reports
+    what the log says, without reducing or choosing. A Psi4 log states the
+    pair at least twice for a single ordinary job (geometry header plus SCF
+    block) and repeats both on every step of an optimisation, so a long run
+    yields dozens of entries. Repetition is expected and harmless — the
+    entries agree.
+
+    They do not always agree, which is the point of returning all of them.
+    A counterpoise or SAPT job activates each fragment as its own molecule
+    and prints a header per fragment, so the first pair describes a
+    *fragment* rather than the whole system. Callers cross-checking a
+    declared value against the log therefore require unanimity before
+    trusting anything — see
+    :mod:`app.services.charge_multiplicity_reconciliation`, whose
+    ``_unanimous`` helper yields *unknown* on disagreement rather than
+    fabricating a mismatch against whichever pair happened to come first.
+
+    Values are reported exactly as written, including an unphysical
+    multiplicity below 1 (2S+1 >= 1). Discarding it is the reconciler's job,
+    not the parser's: it drops the offending *multiplicity* while keeping
+    the charge from the same line, which this function could not express by
+    dropping the pair. Parsers report what the log said; the reconciliation
+    decides what may be compared. Same division as Gaussian and ORCA.
+
+    Returns an empty list for a log that is truncated before the header, is
+    not Psi4 at all, or is otherwise unreadable. Absence is not a
+    contradiction.
+    """
+    found: list[tuple[int, int]] = []
+    for match in _GEOMETRY_HEADER_RE.finditer(text):
+        found.append((int(match.group(1)), int(match.group(2))))
+    for match in _SCF_BLOCK_RE.finditer(text):
+        found.append((int(match.group(1)), int(match.group(2))))
+    return found

--- a/backend/app/services/sp_energy_reconciliation.py
+++ b/backend/app/services/sp_energy_reconciliation.py
@@ -86,6 +86,12 @@ def parse_sp_energy_from_log(text: str | None) -> float | None:
     energy (e.g. an unsupported Molpro MRCI-F12 or a Gaussian composite
     method), returns ``None`` so the caller treats it as *unverifiable*
     rather than guessing.
+
+    Psi4 is recognised by the sniffer but deliberately declines here. Its
+    logs carry many ``Total Energy`` lines and which one is the job's answer
+    is method-dependent, so there is no safe rule to apply; returning
+    ``None`` records nothing rather than risking a wrong number in
+    ``calc_sp_result``.
     """
     if not text:
         return None
@@ -95,12 +101,18 @@ def parse_sp_energy_from_log(text: str | None) -> float | None:
 
     # Local imports keep this module's own import surface to the dataclasses;
     # each parser is pure-text and free of DB dependencies.
+    #
+    # Dispatch is exhaustive on purpose: a program without a wired
+    # single-point parser must return ``None`` here, never fall through to
+    # another program's parser.
     if software == "molpro":
         from app.services.molpro_parameter_parser import parse_sp_energy
     elif software == "orca":
         from app.services.orca_parameter_parser import parse_sp_energy
-    else:  # gaussian
+    elif software == "gaussian":
         from app.services.gaussian_parameter_parser import parse_sp_energy
+    else:  # psi4 — no single-point energy extraction (see docstring)
+        return None
 
     energy = parse_sp_energy(text)
     # A non-finite parse (NaN/inf from a garbage or overflowed energy line)

--- a/backend/tests/fixtures/psi4/README.md
+++ b/backend/tests/fixtures/psi4/README.md
@@ -1,0 +1,51 @@
+# Psi4 fixtures
+
+Real Psi4 output logs, **truncated to the header region the parser reads**.
+
+Everything TCKDB extracts from a Psi4 log today — the banner used by
+`detect_software_from_text` and the charge/multiplicity declarations read by
+`app.services.psi4_parameter_parser` — lives in the first ~170 lines. The
+original files are 26 KB – 972 KB, almost all of it SCF iterations and
+gradients that no wired parser touches, so each fixture is the source file cut
+with `head -N` at a line chosen to sit just past the `Charge` / `Multiplicity`
+block. No other edit was made (the one exception is noted below), so every byte
+kept is a byte Psi4 actually wrote.
+
+| Fixture | Source | Truncation | Charge / multiplicity |
+|---|---|---|---|
+| `sp_mrcc_triplet.dat` | `ARC/arc/testing/sp/psi4_mrcc.dat` (ARC test data, `ReactionMechanismGenerator/ARC`) | `head -170` | 0 / **3** |
+| `sp_nh2_doublet.dat` | `MRCC-Zeus/NH2/output.dat` (M. Keslin, hydrazine study, Zeus cluster) | `head -155` | 0 / **2** |
+| `opt_freq_singlet.out` | `RMG-Py/arkane/data/psi4/opt_freq.out` | `head -112` | 0 / **1** |
+| `opt_freq_dft_ts_singlet.out` | `RMG-Py/arkane/data/psi4/opt_freq_dft_ts.out` | `head -120` | 0 / **1** |
+| `io_error_truncated.out` | `RMG-Py/arkane/data/psi4/IO_error.out` | `head -100` | **none — deliberately cut short** |
+
+## Why each one is here
+
+- **`sp_mrcc_triplet.dat`** — an MRCC-driven single point, the only readily
+  available real triplet. Also the reason Psi4 single-point *energy* extraction
+  is not wired: the full log carries many `Total Energy` lines and picking the
+  right one is method-dependent.
+- **`sp_nh2_doublet.dat`** — an open-shell doublet (UHF reference). Covers the
+  odd-electron case.
+- **`opt_freq_singlet.out`** / **`opt_freq_dft_ts_singlet.out`** — an opt+freq
+  minimum and a DFT transition-state search. Psi4 prints the same
+  charge/multiplicity block regardless of method or stationary-point type; the
+  full sources repeat it 23 and 62 times respectively, always in agreement.
+- **`io_error_truncated.out`** — two jobs in one. Its source is a run that died
+  with a `Fatal Error: PSIO Error`, and its banner is a **development build**
+  (`Psi4 1.4a1.dev75`) with no `release` suffix, which is why the detection
+  marker is anchored on the banner title rather than on a version line. It is
+  cut at line 100, *before* the first declaration at line 115, so it also
+  exercises the truncated-log path: the program is still identified as `psi4`,
+  but no charge or multiplicity can be read and the reconciliation must report
+  *unknown* rather than guess.
+
+## Redaction
+
+`sp_nh2_doublet.dat` is the only fixture sourced from unpublished data. Its
+`PSIDATADIR:` line originally held a collaborator's cluster account path; that
+one path was rewritten to `/home/user/`, the same placeholder the Molpro
+fixtures already carry. Psi4 prints it as a runtime banner detail and no parser
+reads it, so the substitution cannot change any parse result. The other four
+sources are already public (ARC and RMG-Py test data) and are byte-identical to
+`head -N` of their upstream files.

--- a/backend/tests/fixtures/psi4/io_error_truncated.out
+++ b/backend/tests/fixtures/psi4/io_error_truncated.out
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------
+      Psi4: An Open-Source Ab Initio Electronic Structure Package
+                           Psi4 1.4a1.dev75 
+
+                     Git: Rev {master} 73351f5 
+
+
+R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+(doi: 10.1021/acs.jctc.7b00174)
+
+
+                     Additional Contributions by
+P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+
+-----------------------------------------------------------------------
+
+
+Psi4 started on: Wednesday, 10 April 2019 02:48PM
+
+Process ID: 7130
+Host:       r11n32.lisa.surfsara.nl
+PSIDATADIR: /home/mparadiz/opt/psi4/share/psi4
+Memory:     500.0 MiB
+Threads:    15
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! ADC/def-2SVP on BODIPY-Phe  
+
+molecule bodphe {
+0 1       
+N          0.07895        0.63049        2.21156
+N          0.40701       -1.77253        2.18386
+C          0.85975       -1.61894        0.87368
+C          1.93462       -2.51476        0.66009
+C          0.25153       -0.54266        0.07529
+C          0.60747        0.60802        0.92030
+C          1.47746        1.72071        0.77028
+C          1.38234        2.45311        1.95195
+C          2.07438       -3.24863        1.84094
+C          0.53652        1.71840        2.84134
+C          1.13424       -2.73093        2.77791
+H          2.76916       -4.06657        2.02914
+H          0.98002       -2.99119        3.82431
+H          2.46553       -2.64393       -0.28198
+H         -0.76107        1.52726       -1.36025
+C         -0.87740        0.55157       -1.84231
+C         -0.42668       -0.61486       -1.17553
+C         -0.59367       -1.86931       -1.81442
+H         -0.24902       -2.77578       -1.30769
+C         -1.18278       -1.94632       -3.07591
+H         -1.30041       -2.92327       -3.55316
+C         -1.60723       -0.78659       -3.74115
+H         -2.04665       -0.85123       -4.73942
+C         -1.45720        0.45654       -3.10859
+H         -1.78685        1.36634       -3.61791
+B         -0.55985       -0.69534        2.82439
+F         -0.40573       -0.68314        4.19154
+H          0.27433        1.92595        3.87885
+H          1.84952        3.41187        2.17639
+H          2.03049        1.96835       -0.13399
+F         -1.84936       -0.86321        2.39539
+symmetry c1    
+}
+
+
+set {
+reference rhf
+basis def2-svp
+freeze_core true
+guess auto 
+roots_per_irrep [2]   
+}
+
+ref_energy = -906.2735763050857258 
+adc_energy = energy('adc')
+--------------------------------------------------------------------------
+
+*** tstart() called on r11n32.lisa.surfsara.nl
+*** at Wed Apr 10 14:48:14 2019
+
+   => Loading Basis Set <=
+
+Name: DEF2-SVP
+Role: ORBITAL
+Keyword: BASIS
+atoms 1-2                          entry N          line   110 file /home/mparadiz/opt/psi4/share/psi4/basis/def2-svp.gbs 
+atoms 3-11, 16-18, 20, 22, 24      entry C          line    90 file /home/mparadiz/opt/psi4/share/psi4/basis/def2-svp.gbs 
+atoms 12-15, 19, 21, 23, 25, 28-30 entry H          line    15 file /home/mparadiz/opt/psi4/share/psi4/basis/def2-svp.gbs 
+atoms 26                           entry B          line    70 file /home/mparadiz/opt/psi4/share/psi4/basis/def2-svp.gbs 
+atoms 27, 31                       entry F          line   150 file /home/mparadiz/opt/psi4/share/psi4/basis/def2-svp.gbs 
+

--- a/backend/tests/fixtures/psi4/opt_freq_dft_ts_singlet.out
+++ b/backend/tests/fixtures/psi4/opt_freq_dft_ts_singlet.out
@@ -1,0 +1,120 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.3.2 release
+
+                         Git: Rev {HEAD} ecbda83 
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Sunday, 06 September 2020 04:01PM
+
+    Process ID: 10086
+    Host:       X1-ubuntu
+    PSIDATADIR: /home/dranasinghe/anaconda2/envs/rmgpy3_env/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+memory 1024 mb
+
+molecule mol {
+0 1
+O 0.00000000 0.00000000 0.00000000
+H 0.00000000 0.28053300 -0.90381100
+O 0.00000000 -1.39778000 0.00000000
+H 0.00000000 -1.67831300 -0.90381100
+
+}
+set {
+  scf_type DIRECT
+  basis 6-31G(d_p)
+  reference uks
+  opt_type ts
+  full_hess_every 0
+  geom_maxiter 50
+  print 3
+}
+
+optimize('b3lyp')
+scf_e, wfn=frequencies('b3lyp', return_wfn=True, dertype=1)
+wfn.hessian().print_out()
+
+--------------------------------------------------------------------------
+
+  Memory set to 976.562 MiB by Python driver.
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on X1-ubuntu
+*** at Sun Sep  6 16:01:45 2020
+
+   => Loading Basis Set <=
+
+    Name: 6-31G(D_P)
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 3 entry O          line   149 file /home/dranasinghe/anaconda2/envs/rmgpy3_env/share/psi4/basis/6-31g_d_p_.gbs 
+    atoms 2, 4 entry H          line    44 file /home/dranasinghe/anaconda2/envs/rmgpy3_env/share/psi4/basis/6-31g_d_p_.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    976 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -0.000000000000     0.698890000000     0.053572739974    15.994914619570
+         H           -0.000000000000     0.979423000000    -0.850238260026     1.007825032230
+         O            0.000000000000    -0.698890000000     0.053572739974    15.994914619570
+         H            0.000000000000    -0.979423000000    -0.850238260026     1.007825032230
+
+           O
+              BASIS           6-31G(D_P)           ec2d227169b1af6c6a69bc8715bab79dbd7bb644
+           H
+              BASIS           6-31G(D_P)           902186d0f3205710946c2c15d2c68458d6f6cc2a
+           O
+              BASIS           6-31G(D_P)           ec2d227169b1af6c6a69bc8715bab79dbd7bb644
+           H
+              BASIS           6-31G(D_P)           902186d0f3205710946c2c15d2c68458d6f6cc2a
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     10.88336  B =      0.96006  C =      0.88224 [cm^-1]
+  Rotational constants: A = 326274.99817  B =  28781.93695  C =  26448.79031 [MHz]
+  Nuclear repulsion =   37.888114307181077
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 18
+  Nalpha       = 9
+  Nbeta        = 9
+

--- a/backend/tests/fixtures/psi4/opt_freq_singlet.out
+++ b/backend/tests/fixtures/psi4/opt_freq_singlet.out
@@ -1,0 +1,112 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.3.2 release
+
+                         Git: Rev {HEAD} ecbda83 
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Sunday, 06 September 2020 04:11PM
+
+    Process ID: 10137
+    Host:       X1-ubuntu
+    PSIDATADIR: /home/dranasinghe/anaconda2/envs/rmgpy3_env/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+memory 1024 mb
+
+molecule mol {
+0 1
+O                 -1.02870815   -0.00797448    0.00000000
+H                 -0.06870815   -0.00797448    0.00000000
+H                 -1.34916274    0.89696135    0.00000000
+}
+set {
+  basis 6-31G(d_p)
+  geom_maxiter 50
+  print 3
+}
+
+e, wfn = optimize('scf', return_wfn=True)
+scf_e, wfn=frequencies('scf', return_wfn=True, dertype=1)
+wfn.hessian().print_out()
+
+--------------------------------------------------------------------------
+
+  Memory set to 976.562 MiB by Python driver.
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on X1-ubuntu
+*** at Sun Sep  6 16:11:55 2020
+
+   => Loading Basis Set <=
+
+    Name: 6-31G(D_P)
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   149 file /home/dranasinghe/anaconda2/envs/rmgpy3_env/share/psi4/basis/6-31g_d_p_.gbs 
+    atoms 2-3 entry H          line    44 file /home/dranasinghe/anaconda2/envs/rmgpy3_env/share/psi4/basis/6-31g_d_p_.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    976 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -0.000000000000     0.000000000000    -0.062007485347    15.994914619570
+         H            0.783975894634     0.000000000000     0.492051895015     1.007825032230
+         H           -0.783975894634    -0.000000000000     0.492051895015     1.007825032230
+
+           O
+              BASIS           6-31G(D_P)           ec2d227169b1af6c6a69bc8715bab79dbd7bb644
+           H
+              BASIS           6-31G(D_P)           902186d0f3205710946c2c15d2c68458d6f6cc2a
+           H
+              BASIS           6-31G(D_P)           902186d0f3205710946c2c15d2c68458d6f6cc2a
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     30.67709  B =     13.60742  C =      9.42623 [cm^-1]
+  Rotational constants: A = 919675.97593  B = 407940.33087  C = 282591.37824 [MHz]
+  Nuclear repulsion =    9.157116019082448
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==

--- a/backend/tests/fixtures/psi4/sp_mrcc_triplet.dat
+++ b/backend/tests/fixtures/psi4/sp_mrcc_triplet.dat
@@ -1,0 +1,170 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.9.1 release
+
+                         Git: Rev {} zzzzzzz 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 07 January 2025 12:57AM
+
+    Process ID: 414528
+    Host:       n173.zeus.technion.ac.il
+    PSIDATADIR: /home/kaplan.kfir/psi4conda/share/psi4
+    Memory:     500.0 MiB
+    Threads:    30
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+memory 295000 mb
+
+molecule TS_4 {
+0 3
+O       0.00000000   -1.38863500    0.17427700
+O       0.00000000   -0.95108900   -1.03197800
+H       0.00000000   -0.39177700    0.77372600
+N      -0.00000000    0.93429900    0.92886100
+O      -0.00000000    1.38114400   -0.31935600
+H       0.84302700    1.18576200    1.44701800
+H      -0.84302700    1.18576200    1.44701800
+units angstrom
+}
+set {
+    basis aug-cc-pvtz
+    qc_module mrcc
+    reference uhf
+    freeze_core false
+    mrcc_restart 2
+}
+energy('ccsd(t)_l')--------------------------------------------------------------------------
+
+Parsed Psithon:
+import psi4
+from psi4 import *
+from psi4.core import *
+from psi4.driver.diatomic import anharmonicity
+from psi4.driver.gaussian_n import *
+from psi4.driver.frac import ip_fitting, frac_traverse
+from psi4.driver.aliases import *
+from psi4.driver.driver_cbs import *
+from psi4.driver.wrapper_database import database, db, DB_RGT, DB_RXN
+from psi4.driver.wrapper_autofrag import auto_fragments
+psi4_io = core.IOManager.shared_object()
+geometry("""
+0 1
+H 0 0 0
+H 0.74 0 0
+""","blank_molecule_psi4_yo")
+core.set_memory_bytes(295000000000)
+
+TS_4 = geometry("""
+0 3
+O       0.00000000   -1.38863500    0.17427700
+O       0.00000000   -0.95108900   -1.03197800
+H       0.00000000   -0.39177700    0.77372600
+N      -0.00000000    0.93429900    0.92886100
+O      -0.00000000    1.38114400   -0.31935600
+H       0.84302700    1.18576200    1.44701800
+H      -0.84302700    1.18576200    1.44701800
+units angstrom
+""","TS_4")
+core.IO.set_default_namespace("TS_4")
+core.set_global_option("BASIS", "aug-cc-pvtz")
+core.set_global_option("QC_MODULE", "mrcc")
+core.set_global_option("REFERENCE", "uhf")
+core.set_global_option("FREEZE_CORE", "false")
+core.set_global_option("MRCC_RESTART", 2)
+energy('ccsd(t)_l')
+---------------------------------------------------------------------------
+  Memory set to 274.740 GiB by Python driver.
+
+Scratch directory: /gtmp/897425.zeus-master/
+
+Method "ccsd(t)_l" has been regularized to "a-ccsd(t)" for QCVariables.
+Method "ccsd(t)_l" has been regularized to "a-ccsd(t)" for QCVariables.   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on n173.zeus.technion.ac.il
+*** at Tue Jan  7 00:57:42 2025
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2, 5 entry O          line   331 file /home/kaplan.kfir/psi4conda/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 3, 6-7 entry H          line    40 file /home/kaplan.kfir/psi4conda/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 4      entry N          line   285 file /home/kaplan.kfir/psi4conda/share/psi4/basis/aug-cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                       30 Threads, 281333 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            1.384726315507    -0.206941394784     0.000000000000    15.994914619570
+         O            0.947180315507     0.999313605216     0.000000000000    15.994914619570
+         H            0.387868315507    -0.806390394784     0.000000000000     1.007825032230
+         N           -0.938207684493    -0.961525394784     0.000000000000    14.003074004430
+         O           -1.385052684493     0.286691605216     0.000000000000    15.994914619570
+         H           -1.189670684493    -1.479682394784     0.843027000000     1.007825032230
+         H           -1.189670684493    -1.479682394784    -0.843027000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      0.54592  B =      0.17027  C =      0.13271 [cm^-1]
+  Rotational constants: A =  16366.22560  B =   5104.46852  C =   3978.68750 [MHz]
+  Nuclear repulsion =  126.146330605449961
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 34
+  Nalpha       = 18
+  Nbeta        = 16
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.

--- a/backend/tests/fixtures/psi4/sp_nh2_doublet.dat
+++ b/backend/tests/fixtures/psi4/sp_nh2_doublet.dat
@@ -1,0 +1,155 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.9.1 release
+
+                         Git: Rev {} zzzzzzz 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 04 September 2024 02:00PM
+
+    Process ID: 2885695
+    Host:       n137
+    PSIDATADIR: /home/user/mambaforge/share/psi4
+    Memory:     500.0 MiB
+    Threads:    8
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+
+memory 300000 mb
+
+molecule NH2 {
+0 2
+N       0.00024300    0.42354500    0.00000000
+H      -0.80358900   -0.21131100   -0.00000000
+H       0.80334600   -0.21223300    0.00000000
+units angstrom
+}
+set {
+    basis cc-pvtz
+    mrcc_restart 2
+    qc_module mrcc
+    reference uhf
+}
+energy('ccsdt(q)')
+--------------------------------------------------------------------------
+
+Parsed Psithon:
+import psi4
+from psi4 import *
+from psi4.core import *
+from psi4.driver.diatomic import anharmonicity
+from psi4.driver.gaussian_n import *
+from psi4.driver.frac import ip_fitting, frac_traverse
+from psi4.driver.aliases import *
+from psi4.driver.driver_cbs import *
+from psi4.driver.wrapper_database import database, db, DB_RGT, DB_RXN
+from psi4.driver.wrapper_autofrag import auto_fragments
+psi4_io = core.IOManager.shared_object()
+geometry("""
+0 1
+H 0 0 0
+H 0.74 0 0
+""","blank_molecule_psi4_yo")
+
+core.set_memory_bytes(300000000000)
+
+NH2 = geometry("""
+0 2
+N       0.00024300    0.42354500    0.00000000
+H      -0.80358900   -0.21131100   -0.00000000
+H       0.80334600   -0.21223300    0.00000000
+units angstrom
+""","NH2")
+core.IO.set_default_namespace("NH2")
+core.set_global_option("BASIS", "cc-pvtz")
+core.set_global_option("MRCC_RESTART", 2)
+core.set_global_option("QC_MODULE", "mrcc")
+core.set_global_option("REFERENCE", "uhf")
+energy('ccsdt(q)')
+---------------------------------------------------------------------------
+  Memory set to 279.397 GiB by Python driver.
+
+Scratch directory: /gtmp/610247.zeus-master/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  6, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on n137
+*** at Wed Sep  4 14:00:35 2024
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry N          line   224 file /home/user/mambaforge/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/user/mambaforge/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        8 Threads, 286102 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         N            0.000045865354     0.079942493952     0.000000000000    14.003074004430
+         H           -0.803786134646    -0.554913506048     0.000000000000     1.007825032230
+         H            0.803148865354    -0.555835506048     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     23.70308  B =     12.95521  C =      8.37678 [cm^-1]
+  Rotational constants: A = 710600.49087  B = 388387.54190  C = 251129.55709 [MHz]
+  Nuclear repulsion =    7.562042448584871
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.

--- a/backend/tests/parsers/test_psi4_parameter_parser.py
+++ b/backend/tests/parsers/test_psi4_parameter_parser.py
@@ -1,0 +1,172 @@
+"""Tests for Psi4 charge / spin-multiplicity parsing.
+
+Exercised against real Psi4 logs truncated to their header region — see
+``tests/fixtures/psi4/README.md`` for provenance. Psi4 support is
+deliberately narrow: charge and multiplicity only, no single-point energy
+(the choice of which ``Total Energy`` line is the answer is
+method-dependent), no frequencies, no geometries.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services.psi4_parameter_parser import parse_all_charge_multiplicity
+
+_FIX = os.path.join(os.path.dirname(__file__), "..", "fixtures", "psi4")
+
+
+def _read(name: str) -> str:
+    with open(os.path.join(_FIX, name), encoding="utf-8", errors="replace") as fh:
+        return fh.read()
+
+
+# ---------------------------------------------------------------------------
+# Real logs, multiplicity 1 / 2 / 3
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fixture", "charge", "multiplicity"),
+    [
+        pytest.param("opt_freq_singlet.out", 0, 1, id="singlet_opt_freq"),
+        pytest.param("opt_freq_dft_ts_singlet.out", 0, 1, id="singlet_dft_ts"),
+        pytest.param("sp_nh2_doublet.dat", 0, 2, id="doublet_nh2"),
+        pytest.param("sp_mrcc_triplet.dat", 0, 3, id="triplet_mrcc"),
+    ],
+)
+def test_reads_charge_and_multiplicity(fixture, charge, multiplicity):
+    found = parse_all_charge_multiplicity(_read(fixture))
+    assert found, "expected at least one declaration"
+    # Every declaration in a single-molecule job agrees.
+    assert set(found) == {(charge, multiplicity)}
+
+
+def test_both_declaration_forms_are_read():
+    """Psi4 states the pair twice: a geometry header and an SCF block.
+
+    Both must be picked up — the geometry header alone would miss a log
+    whose header line was clipped, and the SCF block alone would miss a
+    job that never reached SCF.
+    """
+    text = _read("sp_mrcc_triplet.dat")
+    assert "charge = 0, multiplicity = 3" in text
+    assert "Charge       = 0" in text
+    # One geometry header + one SCF block in this truncated fixture.
+    assert parse_all_charge_multiplicity(text) == [(0, 3), (0, 3)]
+
+
+# ---------------------------------------------------------------------------
+# Reject-don't-guess
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_log_yields_nothing():
+    """A log cut short before any declaration emits nothing at all.
+
+    The fixture is a real Psi4 run that later died with a PSIO error, cut
+    before its first charge/multiplicity block. Absence is not a
+    contradiction: nothing is inferred, so nothing can be contradicted.
+    """
+    assert parse_all_charge_multiplicity(_read("io_error_truncated.out")) == []
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("not an output log at all\n", id="not_a_log"),
+        pytest.param("\x00\x01\x02 binary garbage \xff", id="binary_garbage"),
+    ],
+)
+def test_unparseable_text_yields_nothing(text):
+    assert parse_all_charge_multiplicity(text) == []
+
+
+def test_disagreeing_declarations_are_all_reported():
+    """A counterpoise/SAPT job prints one header per fragment.
+
+    The parser reports every declaration rather than silently returning the
+    first, which is what lets the reconciliation see the disagreement and
+    report *unknown* instead of fabricating a mismatch against whichever
+    fragment happened to be printed first.
+    """
+    log = (
+        "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+        "    Geometry (in Angstrom), charge = 0, multiplicity = 1:\n"
+        "    Geometry (in Angstrom), charge = 1, multiplicity = 2:\n"
+    )
+    found = parse_all_charge_multiplicity(log)
+    assert found == [(0, 1), (1, 2)]
+    # No single agreed value exists in either column.
+    assert len({c for c, _ in found}) > 1
+    assert len({m for _, m in found}) > 1
+
+
+def test_repeated_agreeing_declarations_are_all_reported():
+    """An optimisation repeats the pair every step; agreement is expected."""
+    text = _read("opt_freq_dft_ts_singlet.out")
+    found = parse_all_charge_multiplicity(text)
+    assert len(found) > 1
+    assert set(found) == {(0, 1)}
+
+
+def test_unphysical_multiplicity_is_reported_not_silently_dropped():
+    """``Multiplicity = 0`` is impossible (2S+1 >= 1).
+
+    The parser reports it verbatim, mirroring Gaussian and ORCA. Discarding
+    it is the reconciliation's job, which drops the multiplicity while
+    keeping the charge from the same block — a distinction this function
+    could not express by dropping the pair.
+    """
+    log = (
+        "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+        "  Charge       = 0\n"
+        "  Multiplicity = 0\n"
+    )
+    assert parse_all_charge_multiplicity(log) == [(0, 0)]
+
+
+def test_negative_charge_is_read():
+    log = (
+        "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+        "    Geometry (in Angstrom), charge = -1, multiplicity = 2:\n"
+    )
+    assert parse_all_charge_multiplicity(log) == [(-1, 2)]
+
+
+def test_crlf_and_tab_separated_blocks_are_read():
+    """Line anchoring must not depend on LF or on space-padded alignment.
+
+    A log fetched through a Windows share arrives CRLF-terminated, and the
+    SCF block's padding is alignment, not syntax.
+    """
+    lf = (
+        "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+        "    Geometry (in Angstrom), charge = 0, multiplicity = 3:\n"
+        "  Charge       = 0\n"
+        "  Multiplicity = 3\n"
+    )
+    assert parse_all_charge_multiplicity(lf) == [(0, 3), (0, 3)]
+    assert parse_all_charge_multiplicity(lf.replace("\n", "\r\n")) == [(0, 3), (0, 3)]
+    tabbed = lf.replace("  Charge       =", "\tCharge\t=").replace(
+        "  Multiplicity =", "\tMultiplicity\t="
+    )
+    assert parse_all_charge_multiplicity(tabbed) == [(0, 3), (0, 3)]
+
+
+def test_scf_block_pair_must_be_adjacent_lines():
+    """A stray ``Charge =`` far from a ``Multiplicity =`` is not a pair.
+
+    Without line anchoring the whitespace between the two would span
+    arbitrary intervening output and marry unrelated values.
+    """
+    log = (
+        "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+        "  Charge       = 0\n"
+        "  Electrons    = 9\n"
+        "  Multiplicity = 2\n"
+    )
+    assert parse_all_charge_multiplicity(log) == []

--- a/backend/tests/services/test_calculation_parameter_extraction.py
+++ b/backend/tests/services/test_calculation_parameter_extraction.py
@@ -33,6 +33,7 @@ from app.schemas.fragments.calculation import (
 )
 from app.services.calculation_parameter_extraction import (
     ParameterExtractionError,
+    _extract_safe,
     extract_and_store_calculation_parameters,
 )
 from app.services.calculation_resolution import (
@@ -48,6 +49,7 @@ GAUSSIAN_LOG = FIXTURES_DIR / "gaussian" / "opt_g09.log"
 ORCA_LOG = FIXTURES_DIR / "orca" / "opt_orca.out"
 MOLPRO_LOG = FIXTURES_DIR / "molpro" / "ch4_closed_shell" / "input.out"
 MOLPRO_MRCI_LOG = FIXTURES_DIR / "molpro" / "mrci" / "hydrazine_closed" / "input.out"
+PSI4_LOG = FIXTURES_DIR / "psi4" / "opt_freq_singlet.out"
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +221,34 @@ def test_extraction_raises_when_software_unknown(db_engine) -> None:
             extract_and_store_calculation_parameters(
                 session, calc, "this text contains no recognised ESS markers"
             )
+
+
+def test_psi4_raises_instead_of_falling_through_to_orca(db_engine) -> None:
+    """Psi4 is sniffed, but has no parameter parser — so nothing is emitted.
+
+    ``_run_parser`` used to treat ORCA as its catch-all, so a newly
+    recognised program would have had its log fed to the ORCA parser and
+    stored parameter rows describing a run that never happened. The
+    dispatch is now exhaustive and raises instead.
+    """
+    text_data = PSI4_LOG.read_text(errors="replace")
+    with Session(db_engine) as session, session.begin():
+        calc = _make_calculation(session, software_name=None)
+        with pytest.raises(ParameterExtractionError, match="psi4"):
+            extract_and_store_calculation_parameters(session, calc, text_data)
+
+
+def test_psi4_extraction_failure_never_aborts_an_upload(db_engine) -> None:
+    """The opportunistic wrapper downgrades the raise to a logged skip.
+
+    An unsupported program must never fail an artifact upload.
+    """
+    text_data = PSI4_LOG.read_text(errors="replace")
+    with Session(db_engine) as session, session.begin():
+        calc = _make_calculation(session, software_name=None)
+        assert (
+            _extract_safe(session, calc, text_data, source="psi4 fixture") is None
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_charge_multiplicity_reconciliation.py
+++ b/backend/tests/services/test_charge_multiplicity_reconciliation.py
@@ -274,3 +274,102 @@ class TestRejectRatherThanGuess:
             log_text=GAUSSIAN_TRIPLET,
         )
         assert _codes(outcome) == [W_MULTIPLICITY_MISMATCH]
+
+
+# ---------------------------------------------------------------------------
+# Psi4
+# ---------------------------------------------------------------------------
+
+
+class TestPsi4:
+    """Psi4 logs are re-read like any other wired program.
+
+    Real Psi4 output, truncated to the header region — see
+    ``tests/fixtures/psi4/README.md``. Psi4 declares the pair twice per
+    geometry (a ``Geometry (in Angstrom), charge = q, multiplicity = m:``
+    header and an indented ``Charge =`` / ``Multiplicity =`` SCF block) and
+    both are read.
+    """
+
+    @pytest.mark.parametrize(
+        ("fixture", "charge", "multiplicity"),
+        [
+            pytest.param("opt_freq_singlet.out", 0, 1, id="singlet"),
+            pytest.param("opt_freq_dft_ts_singlet.out", 0, 1, id="singlet_dft_ts"),
+            pytest.param("sp_nh2_doublet.dat", 0, 2, id="doublet"),
+            pytest.param("sp_mrcc_triplet.dat", 0, 3, id="triplet"),
+        ],
+    )
+    def test_reads_declared_values(self, fixture, charge, multiplicity):
+        parsed = parse_charge_multiplicity_from_log(_read("psi4", fixture))
+        assert parsed is not None
+        assert parsed.software == "psi4"
+        assert (parsed.charge, parsed.multiplicity) == (charge, multiplicity)
+
+    def test_agreement_is_silent(self):
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0,
+            declared_multiplicity=3,
+            log_text=_read("psi4", "sp_mrcc_triplet.dat"),
+        )
+        assert outcome.action is ChargeMultiplicityAction.confirmed
+        assert outcome.warnings == []
+
+    def test_genuine_mismatch_fires(self):
+        """Log says triplet, uploader declared a singlet."""
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0,
+            declared_multiplicity=1,
+            log_text=_read("psi4", "sp_mrcc_triplet.dat"),
+        )
+        assert outcome.action is ChargeMultiplicityAction.mismatch
+        assert _codes(outcome) == [W_MULTIPLICITY_MISMATCH]
+        assert outcome.log_multiplicity == 3
+        assert outcome.software == "psi4"
+
+    def test_truncated_log_is_unverifiable_not_a_mismatch(self):
+        """A run that died before printing the block tells us nothing.
+
+        Absence is not a contradiction: no warning may be emitted, however
+        wrong the declared values look.
+        """
+        log = _read("psi4", "io_error_truncated.out")
+        assert parse_charge_multiplicity_from_log(log) is None
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=7, declared_multiplicity=9, log_text=log
+        )
+        assert outcome.action is ChargeMultiplicityAction.unverifiable
+        assert outcome.warnings == []
+        assert outcome.log_charge is None
+        assert outcome.log_multiplicity is None
+
+    def test_disagreeing_declarations_are_unknown(self):
+        """A counterpoise/SAPT job prints one header per fragment.
+
+        Psi4 must not inherit Gaussian's coincidental behaviour here: the
+        Gaussian pattern spans newlines and so matches Psi4's SCF block,
+        and on a self-contradictory log it would return a single confident
+        pair rather than declining.
+        """
+        log = (
+            "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+            "    Geometry (in Angstrom), charge = 0, multiplicity = 1:\n"
+            "    Geometry (in Angstrom), charge = 1, multiplicity = 2:\n"
+        )
+        assert parse_charge_multiplicity_from_log(log) is None
+        outcome = reconcile_charge_multiplicity(
+            declared_charge=0, declared_multiplicity=1, log_text=log
+        )
+        assert outcome.action is ChargeMultiplicityAction.unverifiable
+        assert outcome.warnings == []
+
+    def test_unphysical_multiplicity_discarded_charge_kept(self):
+        log = (
+            "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+            "  Charge       = 0\n"
+            "  Multiplicity = 0\n"
+        )
+        parsed = parse_charge_multiplicity_from_log(log)
+        assert parsed is not None
+        assert parsed.charge == 0
+        assert parsed.multiplicity is None

--- a/backend/tests/services/test_ess_software_detection.py
+++ b/backend/tests/services/test_ess_software_detection.py
@@ -38,6 +38,85 @@ def test_detects_molpro() -> None:
     ) == "molpro"
 
 
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "sp_mrcc_triplet.dat",
+        "sp_nh2_doublet.dat",
+        "opt_freq_singlet.out",
+        "opt_freq_dft_ts_singlet.out",
+        # A development build: its banner reads ``Psi4 1.4a1.dev75`` with no
+        # ``release`` suffix, so a version-anchored marker would miss it.
+        "io_error_truncated.out",
+    ],
+)
+def test_detects_psi4(fixture: str) -> None:
+    assert detect_software_from_text(_read("psi4", fixture)) == "psi4"
+
+
+def test_psi4_passes_the_upload_signature_gate_it_is_detected_by() -> None:
+    """The artifact gate already admitted Psi4 logs; now they are named too.
+
+    ``OUTPUT_LOG_SIGNATURES`` accepts an output log if ``b"Psi4"`` appears
+    in the first 4 KB, while detection reads the first 8000 characters. The
+    two windows differ, so a log could in principle be storable yet
+    unidentifiable; pin that it is not.
+    """
+    from app.services.artifact_storage import (
+        _SIGNATURE_WINDOW,
+        OUTPUT_LOG_SIGNATURES,
+    )
+
+    for fixture in (
+        "sp_mrcc_triplet.dat",
+        "sp_nh2_doublet.dat",
+        "opt_freq_singlet.out",
+        "opt_freq_dft_ts_singlet.out",
+        "io_error_truncated.out",
+    ):
+        raw = _read("psi4", fixture).encode()
+        assert OUTPUT_LOG_SIGNATURES["psi4"] in raw[:_SIGNATURE_WINDOW], fixture
+        assert detect_software_from_text(raw.decode()) == "psi4", fixture
+
+
+def test_psi4_marker_does_not_claim_other_programs() -> None:
+    """Adding Psi4 must not reclassify any previously-supported log.
+
+    ``detect_software_from_text`` is shared with the single-point-energy
+    path, whose contract is that the two never disagree on the same bytes,
+    so a marker that over-matched would silently reroute real Gaussian,
+    ORCA or Molpro logs to the wrong parser.
+    """
+    assert detect_software_from_text(
+        _read("gaussian", "sp_ub3lyp_g16.log")
+    ) == "gaussian"
+    assert detect_software_from_text(
+        _read("orca", "sp_dlpno_ccsdt_orca.out")
+    ) == "orca"
+    assert detect_software_from_text(
+        _read("orca", "sp_orca_minimal.txt")
+    ) == "orca"
+    assert detect_software_from_text(
+        _read("molpro", "ch4_closed_shell", "input.out")
+    ) == "molpro"
+    assert detect_software_from_text(
+        _read("molpro", "ch3_radical", "input.out")
+    ) == "molpro"
+
+
+def test_psi4_is_checked_before_the_generic_orca_fallback() -> None:
+    """ORCA is matched partly by a generic ``Program Version X.Y.Z`` line.
+
+    A Psi4 log that happened to contain that string must still be called
+    Psi4, because Psi4's own marker is anchored on the program name.
+    """
+    log = (
+        "    Psi4: An Open-Source Ab Initio Electronic Structure Package\n"
+        "    Program Version 1.9.1\n"
+    )
+    assert detect_software_from_text(log) == "psi4"
+
+
 def test_unknown_returns_none() -> None:
     assert detect_software_from_text("just some text, no ESS banner") is None
     assert detect_software_from_text("") is None
@@ -47,6 +126,10 @@ def test_detection_is_extension_independent() -> None:
     # Same ORCA bytes; the (ignored) filename does not affect the result.
     orca_text = _read("orca", "sp_dlpno_ccsdt_orca.out")
     assert detect_software_from_text(orca_text) == "orca"
+    # A Psi4 single point named ``.dat`` and one named ``.out`` classify
+    # identically; only the banner matters.
+    assert detect_software_from_text(_read("psi4", "sp_mrcc_triplet.dat")) == "psi4"
+    assert detect_software_from_text(_read("psi4", "opt_freq_singlet.out")) == "psi4"
 
 
 class TestOrcaMarkerIsAnchoredOnTheName:
@@ -84,9 +167,19 @@ class TestOrcaMarkerIsAnchoredOnTheName:
         "text",
         [
             "Some Code\nProgram Version 1.2.3\nnothing else",
-            "Psi4: An Open-Source Ab Initio Package\nProgram Version 1.9.1",
             "Northwest Computational Chemistry\nProgram Version 7.0.2",
         ],
     )
     def test_a_bare_version_line_is_not_orca(self, text: str) -> None:
         assert detect_software_from_text(text) is None
+
+    def test_a_psi4_banner_is_psi4_not_orca(self) -> None:
+        """Psi4 is now recognised in its own right.
+
+        Before Psi4 support this asserted ``None`` -- the point being only that
+        a foreign log must not be claimed by ORCA. That intent is preserved and
+        strengthened: it is now positively identified rather than merely not
+        misattributed.
+        """
+        text = "Psi4: An Open-Source Ab Initio Electronic Structure Package\nProgram Version 1.9.1"
+        assert detect_software_from_text(text) == "psi4"

--- a/backend/tests/services/test_hessian_parsing.py
+++ b/backend/tests/services/test_hessian_parsing.py
@@ -148,6 +148,17 @@ class TestArtifactDispatch:
     def test_unknown_banner_returns_none(self):
         assert parse_hessian_from_artifact("random text\n", from_hess_file=False) is None
 
+    def test_psi4_log_returns_none(self):
+        """Psi4 is sniffed but has no wired Hessian parser.
+
+        The dispatch must decline it rather than hand a Psi4 log to the
+        Gaussian or Molpro matrix reader, which shares this module's
+        detection with the single-point-energy path.
+        """
+        for name in ("opt_freq_singlet.out", "opt_freq_dft_ts_singlet.out"):
+            text = (FIXTURES / "psi4" / name).read_text(errors="replace")
+            assert parse_hessian_from_artifact(text, from_hess_file=False) is None
+
     def test_empty_or_none_returns_none(self):
         assert parse_hessian_from_artifact("", from_hess_file=False) is None
         assert parse_hessian_from_artifact(None, from_hess_file=True) is None

--- a/backend/tests/services/test_sp_energy_reconciliation.py
+++ b/backend/tests/services/test_sp_energy_reconciliation.py
@@ -248,3 +248,58 @@ def test_gaussian_dft_mentioning_composite_in_title_still_extracts() -> None:
         " SCF Done:  E(UB3LYP) =  -76.123400  A.U. after 10 cycles\n"
     )
     assert parse_sp_energy_from_log(log) == -76.1234
+
+
+# ---------------------------------------------------------------------------
+# Psi4 is recognised by the sniffer but has no wired single-point parser
+# ---------------------------------------------------------------------------
+
+
+def _read_psi4(name: str) -> str:
+    path = os.path.join(_FIX, "psi4", name)
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def test_psi4_log_yields_no_energy() -> None:
+    """A Psi4 log must return ``None``, not another program's answer.
+
+    ``detect_software_from_text`` now classifies Psi4, so this dispatch
+    could have let it fall through to the Gaussian branch. Choosing which
+    of a Psi4 log's many ``Total Energy`` lines is the job's answer is
+    method-dependent, so nothing is extracted at all.
+    """
+    for fixture in (
+        "sp_mrcc_triplet.dat",
+        "sp_nh2_doublet.dat",
+        "opt_freq_singlet.out",
+        "opt_freq_dft_ts_singlet.out",
+        "io_error_truncated.out",
+    ):
+        assert parse_sp_energy_from_log(_read_psi4(fixture)) is None, fixture
+
+
+def test_psi4_energy_is_unverifiable_never_a_mismatch() -> None:
+    """No energy read means the payload value stands, unchecked.
+
+    It must not be contradicted, and it must not be overwritten: absence of
+    a second opinion is not evidence against the first.
+    """
+    outcome = reconcile_sp_energy(
+        payload_energy_hartree=-123.456,
+        log_text=_read_psi4("sp_mrcc_triplet.dat"),
+    )
+    assert outcome.action is SpEnergyAction.unverifiable
+    assert outcome.warning is None
+    assert outcome.log_energy_hartree is None
+    assert outcome.resolved_energy_hartree == -123.456
+
+
+def test_psi4_log_never_fills_an_absent_energy() -> None:
+    """Nothing may be filled into ``calc_sp_result`` from a Psi4 log."""
+    outcome = reconcile_sp_energy(
+        payload_energy_hartree=None,
+        log_text=_read_psi4("sp_mrcc_triplet.dat"),
+    )
+    assert outcome.action is not SpEnergyAction.filled
+    assert outcome.resolved_energy_hartree is None


### PR DESCRIPTION
## Summary

Adds Psi4 to ESS detection and charge/multiplicity extraction. Supported programs were Gaussian, ORCA and Molpro; a Psi4 log classified as `None` and nothing was read from it.

**SP-energy, frequency and geometry extraction for Psi4 are deliberately out of scope** — see below.

## The finding that matters more than the feature

Three dispatch sites used a bare `else` catch-all:

```python
else:  # gaussian
    return gaussian_parser(...)
```

So adding **any** new `SoftwareName` member would silently route its logs to Gaussian's SP-energy parser, ORCA's parameter parser, and Gaussian's charge/multiplicity parser. The bug would have been *introduced by* this change — a trap laid for exactly the work being done.

It is not theoretical. Gaussian's `Charge\s*=...\s+Multiplicity\s*=` spans newlines, so it **coincidentally matches Psi4's SCF block**. Verified independently:

```
Gaussian parser on a Psi4 log : [(0, 2)]        <- one confident pair
Psi4 parser on the same log   : [(0, 2), (0, 2)] <- both declarations
```

They agree on that file. The danger is the disagreement case — Psi4 states the pair twice, and the two forms can differ:

| case | gaussian fallthrough | psi4 parser |
|---|---|---|
| cross-form disagreement | `[(1, 2)]` | `[(0, 1), (1, 2)]` |
| geometry-header only | `[]` | `[(-1, 2)]` |

The fallthrough reports **confident certainty** where the dedicated parser correctly declines as unverifiable. That is a fabricated mismatch — precisely what reject-don't-guess exists to prevent, in the very path built to enforce it. All three dispatches are now exhaustive.

## Detection

```python
_PSI4_MARKERS = re.compile(
    r"Psi4:\s*An Open-Source Ab Initio Electronic Structure Package"
    r"|Psi4 started on:", re.IGNORECASE)
```

Both alternatives contain the literal program name — no generic phrase, unlike the ORCA marker being fixed in #79. Psi4 is checked **before** the ORCA fallback.

**A correction to my brief:** I stated Psi4's banner is `Psi4 <version> release`. That is not universal — `IO_error.out` is a dev build printing `Psi4 1.4a1.dev75` with no `release` suffix. A version-anchored marker would silently miss dev builds, so the agent correctly declined to anchor on one.

## Fixtures — 23.2 KB, copied into the repo and truncated

| fixture | source | charge/mult |
|---|---|---|
| `sp_mrcc_triplet.dat` | ARC `psi4_mrcc.dat` (50 KB) | 0 / **3** |
| `sp_nh2_doublet.dat` | `MRCC-Zeus/NH2/output.dat` (39 KB) | 0 / **2** |
| `opt_freq_singlet.out` | RMG-Py `opt_freq.out` (281 KB) | 0 / **1** |
| `opt_freq_dft_ts_singlet.out` | RMG-Py `opt_freq_dft_ts.out` (969 KB) | 0 / **1** |
| `io_error_truncated.out` | RMG-Py `IO_error.out` (26 KB) | **none** |

Each verified byte-identical to `head -N` of its source, with provenance in a README. One redaction: a collaborator's cluster account path in `PSIDATADIR` → `/home/user/`; no parser reads it.

## Reject-don't-guess

Psi4 states charge/multiplicity twice per geometry, in two shapes. The parser returns **all** pairs without reducing — mirroring Gaussian and ORCA — and the reconciler's existing unanimity rule yields **unknown** on disagreement. The `multiplicity < 1` rule was deliberately not duplicated in the parser: the reconciler drops the offending multiplicity while keeping the charge from the same block, which a pre-filtered list could not express.

## Why no SP-energy

Choosing *which* energy is the answer for a Psi4 job is a real scientific judgement. In `MRCC-Zeus/c-N2H2`, Psi4 drives MRCC (`qc_module mrcc`, `energy('ccsdt(q)')`) and the output offers:

| variable | value | error vs. the requested answer |
|---|---|---|
| `HF TOTAL ENERGY` | −110.029229393 | **+294.5 kcal/mol** |
| `MP2 TOTAL ENERGY` | −110.465257996 | **+20.9 kcal/mol** |
| `CURRENT ENERGY` | −110.498505072 | correct |

Chemical accuracy is ~1 kcal/mol, and the correct value lives inside the embedded MRCC section, not Psi4's own format. A parser that pattern-matched "total energy" would confidently record a number wrong by 20–300×. The SP-energy path now **explicitly declines Psi4** with that reasoning recorded, rather than falling through.

## Validation

| check | result |
|---|---|
| all 5 Psi4 fixtures detect as `psi4` | ✅ |
| Gaussian / ORCA / Molpro detection unchanged | ✅ (9 fixtures) |
| charge/mult for multiplicity 1, 2, 3 | ✅ |
| truncated/error log → unknown, no warning | ✅ |
| disagreeing declarations → unknown, no warning | ✅ |
| `test-api.sh` | **2306 passed** |
| `test-scientific.sh` | **1743 passed** |
| ruff / mypy | clean / clean (143 files) |

⚠️ Impact flagged `detect_software_from_text` as **CRITICAL** (634 symbols, 76 processes) — it is imported across the parsing layer. The change is purely additive; existing branches are untouched, and the exhaustiveness fixes make the previously-implicit routing explicit.

## Scope note

The brief said "add the parser so the reconciliation can use it"; #77 merged mid-task, so the psi4 arm was wired into the real reconciler rather than left unwired — otherwise the Gaussian fallthrough would have taken Psi4 logs anyway. `psi4` was **not** added to the DB-linked allow-list in `_resolve_software`, since no Psi4 parameter parser is wired.