### PR TITLE
Delete the tautological charge/multiplicity deduction

### DIFF
--- a/backend/app/services/ess_species_deduction.py
+++ b/backend/app/services/ess_species_deduction.py
@@ -162,34 +162,22 @@ def deduce_term_symbol(result: ESSResult) -> Deduction | None:
     )
 
 
-def deduce_charge_multiplicity(
-    result: ESSResult,
-) -> list[Deduction]:
-    """Cross-check charge/multiplicity from ESS output."""
-    deductions = []
-    if result.meta.charge is not None:
-        deductions.append(
-            Deduction(
-                field="charge",
-                value=result.meta.charge,
-                source=f"{result.meta.software_name}.header",
-                confidence="definitive",
-            )
-        )
-    if result.meta.multiplicity is not None:
-        deductions.append(
-            Deduction(
-                field="multiplicity",
-                value=result.meta.multiplicity,
-                source=f"{result.meta.software_name}.header",
-                confidence="definitive",
-            )
-        )
-    return deductions
-
-
 def deduce_all(result: ESSResult) -> list[Deduction]:
-    """Run all deductions and return the full list."""
+    """Run all deductions and return the full list.
+
+    Charge and multiplicity are deliberately *not* deduced here. On the
+    upload path ``ESSJobMeta.charge`` / ``.multiplicity`` are populated
+    from the very payload a deduction would be compared against (see
+    ``build_ess_result_from_upload``), so any such "deduction" would
+    restate the declaration while labelling its provenance as the ESS
+    header. The genuine declaration-versus-log check lives in
+    :mod:`app.services.charge_multiplicity_reconciliation`, which reads
+    the charge and multiplicity actually parsed from the uploaded output
+    log. ``deduce_term_symbol`` still reads ``meta.multiplicity``, and
+    that is sound: it derives a term symbol from the declared
+    multiplicity and symmetry and compares it against the *declared*
+    term symbol, which are two independent fields.
+    """
     deductions: list[Deduction] = []
 
     for fn in (
@@ -201,5 +189,4 @@ def deduce_all(result: ESSResult) -> list[Deduction]:
         if d is not None:
             deductions.append(d)
 
-    deductions.extend(deduce_charge_multiplicity(result))
     return deductions

--- a/backend/app/services/upload_reconciliation.py
+++ b/backend/app/services/upload_reconciliation.py
@@ -15,10 +15,6 @@ from app.schemas.fragments.calculation import CalculationWithResultsPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.upload_warning import UploadWarning
 from app.schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
-from app.services.charge_multiplicity_reconciliation import (
-    W_CHARGE_MISMATCH,
-    W_MULTIPLICITY_MISMATCH,
-)
 from app.services.ess_result import (
     ESSFreqResult,
     ESSJobMeta,
@@ -48,18 +44,15 @@ W_ELECTRONIC_STATE_CONTRADICTS_METHOD = "electronic_state_contradicts_method"
 W_TERM_SYMBOL_MISMATCH = "term_symbol_mismatch"
 
 # Charge / multiplicity contradictions are detected against the *output log*
-# by :mod:`app.services.charge_multiplicity_reconciliation`, which owns
-# ``W_CHARGE_MISMATCH`` / ``W_MULTIPLICITY_MISMATCH`` (imported above so
-# there is one definition rather than a drifting copy).
+# by :mod:`app.services.charge_multiplicity_reconciliation`, which is their
+# sole owner (``W_CHARGE_MISMATCH`` / ``W_MULTIPLICITY_MISMATCH``).
 #
-# The Layer-2 deduction pass cannot detect these itself:
+# The Layer-2 deduction pass deliberately does not touch them:
 # ``build_ess_result_from_upload`` populates ``ESSJobMeta.charge`` and
-# ``.multiplicity`` from the same payload that ``_reconcile_deduction`` then
-# compares them against, so the comparison is payload-versus-payload and is
+# ``.multiplicity`` from the same payload ``_reconcile_deduction`` would
+# compare them against, so the comparison would be payload-versus-payload and
 # always equal by construction. The meta fields are kept because
-# ``deduce_term_symbol`` genuinely needs the multiplicity; the charge and
-# multiplicity entries in the table below are therefore inert here, and the
-# log-based hook is what actually fires.
+# ``deduce_term_symbol`` genuinely needs the multiplicity.
 
 
 # ---------------------------------------------------------------------------
@@ -168,8 +161,6 @@ _DEDUCTION_FIELD_MAP: dict[str, tuple[str, str]] = {
     "stationary_point_kind": ("species_entry_kind", "value"),
     "electronic_state_kind": ("electronic_state_kind", "value"),
     "term_symbol": ("term_symbol", None),
-    "charge": ("charge", None),
-    "multiplicity": ("multiplicity", None),
 }
 
 # Maps Deduction.field → warning code for contradictions
@@ -177,8 +168,6 @@ _DEDUCTION_WARNING_CODES: dict[str, str] = {
     "stationary_point_kind": W_N_IMAG_CONTRADICTS_MINIMUM,
     "electronic_state_kind": W_ELECTRONIC_STATE_CONTRADICTS_METHOD,
     "term_symbol": W_TERM_SYMBOL_MISMATCH,
-    "charge": W_CHARGE_MISMATCH,
-    "multiplicity": W_MULTIPLICITY_MISMATCH,
 }
 
 


### PR DESCRIPTION
## Summary

Removes `deduce_charge_multiplicity`, which could never detect anything and asserted a false provenance while failing to. #77 replaced it with a real check.

Two files, +21/−45. No schema change, no migration.

## Why it had to go

```python
"""Cross-check charge/multiplicity from ESS output."""
...
source=f"{result.meta.software_name}.header",
confidence="definitive",
```

It read `result.meta.charge` / `result.meta.multiplicity`, which `build_ess_result_from_upload` sets to `payload.charge` / `payload.multiplicity`. So it took the **payload's own values**, stamped their provenance as the ESS program's header, marked them `definitive`, and emitted them for comparison against the payload they came from.

The comparison could never be unequal — proven empirically before any change:

```
declared=(0,1)   deduced=(0,1)   equal=True
declared=(-2,5)  deduced=(-2,5)  equal=True
declared=(7,9)   deduced=(7,9)   equal=True
```

The dead comparison is the lesser problem. The **false provenance claim** is the real one: anything reading `Deduction.source` would believe a user assertion had been independently confirmed by Gaussian or ORCA. For a database whose premise is that provenance is honest and separable from the value, that is the same failure mode as manufactured evidence (ADR 0005) and fabricated PDep attribution (#73) — not a wrong number, but a false claim about where a number came from.

It could not be salvaged in place either: the conformer-upload path carries **zero artifact bytes**, so there is no log there to compare against and it could never emit truthfully.

## What replaces it

`charge_multiplicity_reconciliation.py` (#77) compares the declaration against values genuinely parsed from an uploaded output log, at the artifact seams where logs actually arrive, and returns unknown rather than guessing when it cannot parse. It is now the sole owner of `W_CHARGE_MISMATCH` / `W_MULTIPLICITY_MISMATCH`.

## What deliberately did not change

- **`deduce_term_symbol`** — also reads `meta.multiplicity`, and correctly so: deriving a term symbol from the *declared* multiplicity and symmetry, then comparing it against the *declared* term symbol, is a genuine consistency check.
- **`deduce_stationary_point_kind`** — derives from `n_imag`, which is real evidence.
- **`build_ess_result_from_upload`** — still sets `meta.charge`/`meta.multiplicity`; `deduce_term_symbol` needs it.

Only the charge/multiplicity pair was tautological.

## Removed

`deduce_charge_multiplicity`, its `deduce_all` call, the `"charge"`/`"multiplicity"` entries in `_DEDUCTION_FIELD_MAP` and `_DEDUCTION_WARNING_CODES`, and the now-unused warning-code import into `upload_reconciliation`.

## Validation

| check | result |
|---|---|
| `test_upload_reconciliation.py` + `test_api_uploads.py` | **48 passed** |
| remaining callers of `deduce_charge_multiplicity` | **0** |
| surviving deductions | `deduce_all`, `deduce_electronic_state`, `deduce_stationary_point_kind`, `deduce_term_symbol` |
| `W_N_IMAG_SUGGESTS_TS` still emitted | ✅ unchanged |
| ruff / mypy | clean / clean (143 files) |

Impact analysis before deletion: **LOW** — one direct caller (`deduce_all`), reaching only `upload_conformer`.

## Split from a larger branch — and why

This was originally committed alongside a second change promoting `W_N_IMAG_CONTRADICTS_MINIMUM` and `W_N_IMAG_HIGHER_ORDER_SADDLE` to blocking. **That half was dropped**, because implementing it surfaced a fact that invalidates the premise:

`StationaryPointKind` has exactly two members — `minimum` and `vdw_complex` — and `_MINIMUM_KINDS` contains both. There is no transition-state member; TS lives on a separate `TransitionStateEntry`. So `W_N_IMAG_CONTRADICTS_MINIMUM` and `W_N_IMAG_SUGGESTS_TS` fire on **identical payload sets**, and promoting the former would refuse exactly the payloads the latter exists to flag as possibly legitimate.

The chemistry agrees. A floppy molecule with a shallow torsional mode routinely reports one small imaginary frequency (−5 to −30 cm⁻¹) on a coarse integration grid — a numerical artifact, not evidence the structure is not a minimum. Blocking on `n_imag >= 1` would refuse correct science, which is exactly the test ADR 0008 says a blocking check must pass.

The underlying principle, worth adding to ADR 0008: **a definitional rule evaluated against numerically-uncertain evidence degrades to an expectation.** "A minimum has no imaginary modes" is definitional on the exact PES; deciding whether a *computed* imaginary mode contradicts the declaration requires a magnitude convention, and magnitude thresholds are expectations.