### PR TITLE
Split imaginary-frequency validation four ways

### DIFF
--- a/backend/app/api/routes/uploads.py
+++ b/backend/app/api/routes/uploads.py
@@ -50,6 +50,7 @@ from app.services.provenance_warnings import (
 from app.services.upload_reconciliation import (
     reconcile_species_entry,
     reconcile_species_entry_full,
+    stationary_point_warnings,
 )
 from app.services.upload_submission import (
     audit_sync_upload_failure,
@@ -192,6 +193,13 @@ def upload_conformer(
 ):
     if (replay := idem.maybe_replay()) is not None:
         return replay
+    # ``reconcile_species_entry_full`` already runs the stationary-point
+    # check as part of its Layer-1 pass, so this route deliberately does
+    # *not* also call ``request.stationary_point_findings()`` — that would
+    # emit each finding twice under two different ``field`` paths. The
+    # other species routes do call it, because their
+    # ``reconcile_species_entry`` call has no frequency evidence to work
+    # from.
     warnings = reconcile_species_entry_full(
         request.species_entry,
         primary_calc=request.calculation,
@@ -359,7 +367,9 @@ def upload_network_pdep(
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.network_pdep
     )
-    pdep_warnings: list[UploadWarning] = []
+    pdep_warnings: list[UploadWarning] = stationary_point_warnings(
+        request.stationary_point_findings()
+    )
     network = persist_network_pdep_upload(
         session,
         request,
@@ -402,6 +412,7 @@ def upload_statmech(
     if (replay := idem.maybe_replay()) is not None:
         return replay
     warnings = reconcile_species_entry(request.species_entry)
+    warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
     warnings.extend(collect_statmech_provenance_warnings(request))
     warnings.extend(
         collect_statmech_content_warnings(
@@ -444,6 +455,7 @@ def upload_thermo(
     if (replay := idem.maybe_replay()) is not None:
         return replay
     warnings = reconcile_species_entry(request.species_entry)
+    warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
     warnings.extend(collect_thermo_provenance_warnings(request))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.thermo
@@ -485,6 +497,7 @@ def upload_transition_state(
         ws = reconcile_species_entry(p.species_entry)
         for w in ws:
             warnings.append(w.model_copy(update={"field": f"reaction.products[{i}].{w.field}"}))
+    warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.transition_state
     )
@@ -529,6 +542,7 @@ def upload_transport(
     if (replay := idem.maybe_replay()) is not None:
         return replay
     warnings = reconcile_species_entry(request.species_entry)
+    warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
     warnings.extend(collect_transport_provenance_warnings(request))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.transport
@@ -564,6 +578,7 @@ def upload_computed_species(
     if (replay := idem.maybe_replay()) is not None:
         return replay
     warnings = reconcile_species_entry(request.species_entry)
+    warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.computed_species
     )
@@ -642,6 +657,13 @@ def upload_computed_reaction(
     result_dict = persist_computed_reaction_upload(
         session, request, created_by=current_user.id, review_policy=sub.policy
     )
+    # Stationary-point warnings are derived from the request, not the
+    # persisted rows, so they are merged on top of whatever the workflow
+    # reported rather than being produced inside it.
+    result_dict["warnings"] = [
+        *stationary_point_warnings(request.stationary_point_findings()),
+        *result_dict.get("warnings", []),
+    ]
     result = ComputedReactionUploadResult(
         **result_dict, submission_id=sub.submission_id
     )

--- a/backend/app/schemas/workflows/conformer_upload.py
+++ b/backend/app/schemas/workflows/conformer_upload.py
@@ -1,6 +1,11 @@
 from typing import Self
 
 from pydantic import Field, model_validator
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    evaluate_species_entry_frequency,
+    raise_for_blocking_findings,
+)
 
 from app.db.models.common import (
     CalculationType,
@@ -173,4 +178,41 @@ class ConformerUploadRequest(SchemaBase):
                     f"allowed. Expected one of: "
                     f"{', '.join(t.value for t in sorted(_ALLOWED_ADDITIONAL_TYPES, key=lambda t: t.value))}."
                 )
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge the declared kind against this upload's frequency evidence.
+
+        Every calculation here is scoped to the one species entry named
+        by ``species_entry``, so this payload is the earliest point at
+        which the declaration and the evidence are both in hand.
+        """
+        kind = self.species_entry.species_entry_kind
+        findings: list[StationaryPointFinding] = []
+        for label, calc in [
+            ("calculation", self.calculation),
+            *(
+                (f"additional_calculations[{i}]", c)
+                for i, c in enumerate(self.additional_calculations)
+            ),
+        ]:
+            if calc.freq_result is None:
+                continue
+            findings.extend(
+                evaluate_species_entry_frequency(
+                    kind,
+                    calc.freq_result.n_imag,
+                    calc.freq_result.imag_freq_cm1,
+                    location=f"{label}.freq_result",
+                )
+            )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008).
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self

--- a/backend/app/schemas/workflows/network_pdep_upload.py
+++ b/backend/app/schemas/workflows/network_pdep_upload.py
@@ -59,6 +59,13 @@ from tckdb_schemas.shared.calculation_in import (
     CalculationIn,
     GeometryIn,
     calculation_in_to_with_results_payload,
+    freq_evidence,
+)
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    evaluate_species_entry_frequency,
+    evaluate_transition_state_frequency,
+    raise_for_blocking_findings,
 )
 from tckdb_schemas.workflows.computed_species_upload import StatmechInBundle
 
@@ -165,6 +172,51 @@ class NetworkSpeciesIn(SchemaBase):
                 )
         return self
 
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge this well's declared kind against its own frequency evidence.
+
+        A network well is a species entry like any other. Its transition
+        states live in separate ``TransitionStateIn`` blocks and are
+        judged there, which is why this sits on the species model rather
+        than on the request: a request-level scan would count the TS's
+        single imaginary mode against a well.
+        """
+        kind = self.species_entry.species_entry_kind
+        findings: list[StationaryPointFinding] = []
+        for conformer in self.conformers:
+            n_imag, imag_freq_cm1 = freq_evidence(conformer.calculation)
+            findings.extend(
+                evaluate_species_entry_frequency(
+                    kind,
+                    n_imag,
+                    imag_freq_cm1,
+                    location=(
+                        f"species['{self.key}'].conformers['{conformer.key}']"
+                        f".calculation['{conformer.calculation.key}']"
+                    ),
+                )
+            )
+        for calc in self.calculations:
+            n_imag, imag_freq_cm1 = freq_evidence(calc)
+            findings.extend(
+                evaluate_species_entry_frequency(
+                    kind,
+                    n_imag,
+                    imag_freq_cm1,
+                    location=f"species['{self.key}'].calculations['{calc.key}']",
+                )
+            )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008).
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
+        return self
+
 
 # ---------------------------------------------------------------------------
 # Transition states
@@ -219,6 +271,32 @@ class TransitionStateIn(SchemaBase):
                 f"Transition state '{self.key}' primary calculation must be "
                 f"type 'opt', got '{self.calculation.type.value}'."
             )
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge this saddle point against its own frequency evidence."""
+        findings: list[StationaryPointFinding] = []
+        for calc in (self.calculation, *self.calculations):
+            n_imag, imag_freq_cm1 = freq_evidence(calc)
+            findings.extend(
+                evaluate_transition_state_frequency(
+                    n_imag,
+                    imag_freq_cm1,
+                    location=(
+                        f"transition_states['{self.key}'].calculations"
+                        f"['{calc.key}']"
+                    ),
+                )
+            )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_is_one(self) -> Self:
+        """Refuse frequency evidence that is not a first-order saddle point.
+
+        Definitional, therefore blocking (ADR 0008).
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self
 
 
@@ -926,6 +1004,22 @@ class NetworkPDepUploadRequest(SchemaBase):
     states: list[NetworkStateIn] = Field(min_length=1)
     channels: list[NetworkChannelIn] = Field(default_factory=list)
     solve: NetworkSolveIn | None = None
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Collect every entity's stationary-point findings in this network.
+
+        Each well judges its own frequency evidence against its own
+        declared kind, and each transition state judges its own, so a
+        saddle point's single imaginary mode is never counted against a
+        well. The blocking half already fired from the nested models'
+        validators; the route layer calls this to harvest the warnings.
+        """
+        findings: list[StationaryPointFinding] = []
+        for species in self.species:
+            findings.extend(species.stationary_point_findings())
+        for ts in self.transition_states:
+            findings.extend(ts.stationary_point_findings())
+        return findings
 
     @model_validator(mode="after")
     def normalize_text(self) -> Self:

--- a/backend/app/schemas/workflows/stationary_point_seam.py
+++ b/backend/app/schemas/workflows/stationary_point_seam.py
@@ -1,0 +1,61 @@
+"""Shared traversal for the standalone product uploads' inline calculations.
+
+``StatmechUploadRequest``, ``ThermoUploadRequest`` and
+``TransportUploadRequest`` all have the same shape at the seam that
+matters here: one ``species_entry`` declaring a stationary-point kind,
+plus a list of locally-keyed inline calculations scoped to that entry.
+Three copies of the same walk would be three places for the tiers to
+drift apart, so the walk lives here and each request calls it.
+
+The physics itself is owned by :mod:`tckdb_schemas.stationary_point`;
+this module only knows payload shapes.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from tckdb_schemas.enums import StationaryPointKind
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    evaluate_species_entry_frequency,
+)
+
+from app.schemas.fragments.calculation import CalculationWithResultsPayload
+
+
+class KeyedCalculation(Protocol):
+    """An inline calculation carrying a payload-local string key."""
+
+    key: str
+    calculation: CalculationWithResultsPayload
+
+
+def inline_calculation_findings(
+    kind: StationaryPointKind,
+    calculations: list[KeyedCalculation],
+) -> list[StationaryPointFinding]:
+    """Judge ``kind`` against every inline calculation's frequency evidence.
+
+    :param kind: The stationary-point kind declared on the request's
+        ``species_entry``.
+    :param calculations: The request's locally-keyed inline calculations.
+    :returns: Findings across all of them, possibly empty.
+    """
+    findings: list[StationaryPointFinding] = []
+    for item in calculations:
+        freq_result = item.calculation.freq_result
+        if freq_result is None:
+            continue
+        findings.extend(
+            evaluate_species_entry_frequency(
+                kind,
+                freq_result.n_imag,
+                freq_result.imag_freq_cm1,
+                location=f"calculations['{item.key}'].freq_result",
+            )
+        )
+    return findings
+
+
+__all__ = ["KeyedCalculation", "inline_calculation_findings"]

--- a/backend/app/schemas/workflows/statmech_upload.py
+++ b/backend/app/schemas/workflows/statmech_upload.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 from typing import Self
 
 from pydantic import Field, model_validator
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    raise_for_blocking_findings,
+)
 from tckdb_schemas.statmech_bits import (
     StatmechTorsionCoordinateIn,
 )
@@ -38,6 +42,7 @@ from app.schemas.fragments.refs import (
 from app.schemas.utils import normalize_optional_text
 from app.schemas.workflows.conformer_upload import ElectronicLevelIn
 from app.schemas.workflows.literature_upload import LiteratureUploadRequest
+from app.schemas.workflows.stationary_point_seam import inline_calculation_findings
 
 
 class StatmechCalculationIn(SchemaBase):
@@ -198,6 +203,23 @@ class StatmechUploadRequest(SchemaBase):
         keys = [c.key for c in self.calculations]
         if len(set(keys)) != len(keys):
             raise ValueError("Statmech calculations must have unique keys.")
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge the declared kind against this upload's inline frequency evidence."""
+        return inline_calculation_findings(
+            self.species_entry.species_entry_kind, list(self.calculations)
+        )
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse inline frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008). The inline
+        calculations are scoped to this upload's species entry, so the
+        declared kind and the parsed ``n_imag`` are both present here.
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self
 
     @model_validator(mode="after")

--- a/backend/app/schemas/workflows/thermo_upload.py
+++ b/backend/app/schemas/workflows/thermo_upload.py
@@ -8,6 +8,10 @@ NASA polynomials), and attaches it to the resolved species entry.
 from typing import Self
 
 from pydantic import Field, model_validator
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    raise_for_blocking_findings,
+)
 
 from app.db.models.common import (
     PhaseKind,
@@ -33,6 +37,7 @@ from app.schemas.workflows.group_additivity_upload import (
     AppliedGroupAdditivityUploadPayload,
 )
 from app.schemas.workflows.literature_upload import LiteratureUploadRequest
+from app.schemas.workflows.stationary_point_seam import inline_calculation_findings
 
 
 class ThermoCalculationIn(SchemaBase):
@@ -232,6 +237,23 @@ class ThermoUploadRequest(SchemaBase):
         keys = [c.key for c in self.calculations]
         if len(set(keys)) != len(keys):
             raise ValueError("Thermo calculations must have unique keys.")
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge the declared kind against this upload's inline frequency evidence."""
+        return inline_calculation_findings(
+            self.species_entry.species_entry_kind, list(self.calculations)
+        )
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse inline frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008). The inline
+        calculations are scoped to this upload's species entry, so the
+        declared kind and the parsed ``n_imag`` are both present here.
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self
 
     @model_validator(mode="after")

--- a/backend/app/schemas/workflows/transition_state_upload.py
+++ b/backend/app/schemas/workflows/transition_state_upload.py
@@ -15,6 +15,11 @@ from tckdb_schemas.fragments.ts_validation_evidence import (
     TransitionStateValidationEvidenceIn,
     validate_ts_evidence_set,
 )
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    evaluate_transition_state_frequency,
+    raise_for_blocking_findings,
+)
 
 from app.db.models.common import CalculationType
 from app.schemas.common import SchemaBase
@@ -215,4 +220,40 @@ class TransitionStateUploadRequest(SchemaBase):
                     f"allowed. Expected one of: "
                     f"{', '.join(t.value for t in sorted(_ALLOWED_ADDITIONAL_TYPES, key=lambda t: t.value))}."
                 )
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge this saddle point against its own frequency evidence.
+
+        The whole payload is one transition state, so every frequency
+        result in it describes that saddle point — there is no species
+        entry here whose zero-imaginary-mode expectation could be
+        confused with the TS's one.
+        """
+        findings: list[StationaryPointFinding] = []
+        for label, calc in [
+            ("primary_opt", self.primary_opt),
+            *(
+                (f"additional_calculations[{i}]", c)
+                for i, c in enumerate(self.additional_calculations)
+            ),
+        ]:
+            if calc.freq_result is None:
+                continue
+            findings.extend(
+                evaluate_transition_state_frequency(
+                    calc.freq_result.n_imag,
+                    calc.freq_result.imag_freq_cm1,
+                    location=f"{label}.freq_result",
+                )
+            )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_is_one(self) -> Self:
+        """Refuse frequency evidence that is not a first-order saddle point.
+
+        Definitional, therefore blocking (ADR 0008).
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self

--- a/backend/app/schemas/workflows/transport_upload.py
+++ b/backend/app/schemas/workflows/transport_upload.py
@@ -9,6 +9,10 @@ is the standalone upload payload accepted by
 from typing import Self
 
 from pydantic import Field, model_validator
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    raise_for_blocking_findings,
+)
 
 from app.db.models.common import ScientificOriginKind, TransportCalculationRole
 from app.schemas.common import SchemaBase
@@ -17,6 +21,7 @@ from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.fragments.refs import SoftwareReleaseRef, WorkflowToolReleaseRef
 from app.schemas.utils import normalize_optional_text
 from app.schemas.workflows.literature_upload import LiteratureUploadRequest
+from app.schemas.workflows.stationary_point_seam import inline_calculation_findings
 
 
 class TransportUploadPayload(SchemaBase):
@@ -162,6 +167,23 @@ class TransportUploadRequest(TransportUploadPayload):
         keys = [c.key for c in self.calculations]
         if len(set(keys)) != len(keys):
             raise ValueError("Transport calculations must have unique keys.")
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge the declared kind against this upload's inline frequency evidence."""
+        return inline_calculation_findings(
+            self.species_entry.species_entry_kind, list(self.calculations)
+        )
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse inline frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008). The inline
+        calculations are scoped to this upload's species entry, so the
+        declared kind and the parsed ``n_imag`` are both present here.
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self
 
     @model_validator(mode="after")

--- a/backend/app/services/upload_reconciliation.py
+++ b/backend/app/services/upload_reconciliation.py
@@ -10,8 +10,23 @@ No database dependencies — pure functions only.
 
 from __future__ import annotations
 
+from tckdb_schemas.stationary_point import (
+    TS_IMAGINARY_FREQUENCY_MIN_CM1,
+    W_N_IMAG_CONTRADICTS_MINIMUM,
+    W_N_IMAG_HIGHER_ORDER_SADDLE,
+    W_N_IMAG_SUGGESTS_TS,
+    W_TS_IMAG_FREQ_TOO_SMALL,
+    W_TS_N_IMAG_NOT_ONE,
+    StationaryPointFinding,
+    evaluate_species_entry_frequency,
+    warning_findings,
+)
+
 from app.db.models.common import StationaryPointKind
-from app.schemas.fragments.calculation import CalculationWithResultsPayload
+from app.schemas.fragments.calculation import (
+    CalculationWithResultsPayload,
+    FreqResultPayload,
+)
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.upload_warning import UploadWarning
 from app.schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
@@ -27,10 +42,33 @@ from app.services.ess_species_deduction import Deduction, deduce_all
 # Warning codes
 # ---------------------------------------------------------------------------
 
-# Layer 1: freq-based
-W_N_IMAG_CONTRADICTS_MINIMUM = "n_imag_contradicts_minimum"
-W_N_IMAG_SUGGESTS_TS = "n_imag_suggests_transition_state"
-W_N_IMAG_HIGHER_ORDER_SADDLE = "n_imag_higher_order_saddle"
+# Layer 1: freq-based.
+#
+# The physics, the tier assignment, and the code strings are all owned by
+# :mod:`tckdb_schemas.stationary_point` (ADR 0008). They are re-exported
+# here so the warning tier and the blocking tier speak one vocabulary
+# rather than two drifting copies.
+#
+# Which of these can actually reach *this* module depends on the declared
+# kind, because the four rules split by kind:
+#
+# * ``minimum`` with any imaginary mode is refused at the schema tier, so
+#   ``W_N_IMAG_CONTRADICTS_MINIMUM`` never arrives here for a minimum.
+# * ``vdw_complex`` is formally a minimum too, but its intermolecular
+#   modes sit low enough that a small imaginary mode is usually Hessian
+#   grid noise rather than evidence. Refusing it would force an expensive
+#   re-run for a physically meaningless mode, so it is recorded and
+#   flagged — that is the only kind that reaches this module with an
+#   imaginary mode, carrying ``W_N_IMAG_CONTRADICTS_MINIMUM`` (one mode)
+#   or ``W_N_IMAG_HIGHER_ORDER_SADDLE`` (two or more).
+# * ``W_N_IMAG_SUGGESTS_TS`` is narrowed to the van der Waals case where
+#   the mode is too stiff to be noise — see its docstring in the owning
+#   module.
+# * The two transition-state codes are re-exported only; transition
+#   states are not species entries and never pass through
+#   ``reconcile_species_entry``.
+#
+# See ``__all__`` at the foot of this module for the re-exported set.
 
 # Layer 1b: parser fidelity. A freq calculation that declares a parser
 # (``parameters_parser_version`` is set) but provides no per-mode
@@ -60,6 +98,25 @@ W_TERM_SYMBOL_MISMATCH = "term_symbol_mismatch"
 # ---------------------------------------------------------------------------
 
 
+def extract_freq_result(
+    primary: CalculationWithResultsPayload,
+    additional: list[CalculationWithResultsPayload],
+) -> FreqResultPayload | None:
+    """Return the first freq result that actually reports ``n_imag``.
+
+    Both the imaginary-mode count and its magnitude are read off the same
+    result block, so they are extracted together — reading them from two
+    separate scans could pair a count from one calculation with a
+    magnitude from another.
+    """
+    if primary.freq_result is not None and primary.freq_result.n_imag is not None:
+        return primary.freq_result
+    for calc in additional:
+        if calc.freq_result is not None and calc.freq_result.n_imag is not None:
+            return calc.freq_result
+    return None
+
+
 def extract_freq_n_imag(
     primary: CalculationWithResultsPayload,
     additional: list[CalculationWithResultsPayload],
@@ -69,12 +126,8 @@ def extract_freq_n_imag(
     Returns the first non-None ``n_imag`` found, or ``None`` if no
     frequency result is present in any calculation.
     """
-    if primary.freq_result is not None and primary.freq_result.n_imag is not None:
-        return primary.freq_result.n_imag
-    for calc in additional:
-        if calc.freq_result is not None and calc.freq_result.n_imag is not None:
-            return calc.freq_result.n_imag
-    return None
+    freq_result = extract_freq_result(primary, additional)
+    return None if freq_result is None else freq_result.n_imag
 
 
 # ---------------------------------------------------------------------------
@@ -191,8 +244,14 @@ def _get_payload_value(
 # ---------------------------------------------------------------------------
 # Layer 1: direct n_imag checks (structural warnings)
 # ---------------------------------------------------------------------------
-
-_MINIMUM_KINDS = frozenset({StationaryPointKind.minimum, StationaryPointKind.vdw_complex})
+#
+# The local ``_MINIMUM_KINDS`` frozenset that used to live here is gone.
+# It held both ``minimum`` and ``vdw_complex``, which made the
+# ``if kind in _MINIMUM_KINDS`` guard vestigial — those were the only two
+# members of the enum, so it was always true. The two kinds now differ in
+# tier, and that split is expressed by dispatching on the kind in
+# :mod:`tckdb_schemas.stationary_point` rather than by a set that cannot
+# tell them apart.
 
 
 def check_freq_parser_fidelity(
@@ -234,49 +293,45 @@ def check_freq_parser_fidelity(
     return warnings
 
 
+def stationary_point_warnings(
+    findings: list[StationaryPointFinding],
+) -> list[UploadWarning]:
+    """Convert stationary-point findings into upload warnings.
+
+    Only the warning tier survives the conversion. Blocking findings are
+    dropped rather than reported twice: ADR 0008 gives the blocking tier
+    sole ownership of a fact it refuses, and the upload schemas already
+    turned those into a 422 before any route body ran. A blocking finding
+    reaching here would mean a payload got past its own validator, which
+    is a bug in the seam wiring, not something to annotate.
+    """
+    return [
+        UploadWarning(field=f.location, code=f.code, message=f.message)
+        for f in warning_findings(findings)
+    ]
+
+
 def _check_n_imag(
     kind: StationaryPointKind,
     n_imag: int,
+    imag_freq_cm1: float | None = None,
 ) -> list[UploadWarning]:
-    """Check consistency between stationary point kind and n_imag."""
-    warnings: list[UploadWarning] = []
+    """Warn where the declared kind and ``n_imag`` disagree non-fatally.
 
-    if n_imag == 0:
-        return warnings
+    Delegates the physics and the tier split to
+    :mod:`tckdb_schemas.stationary_point` so this path and the schema
+    tier cannot disagree about the same record. In practice that means
+    only ``vdw_complex`` produces anything here: a declared ``minimum``
+    with an imaginary mode was already refused.
 
-    if n_imag == 1:
-        if kind in _MINIMUM_KINDS:
-            warnings.append(UploadWarning(
-                field="species_entry_kind",
-                code=W_N_IMAG_CONTRADICTS_MINIMUM,
-                message=(
-                    f"Frequency analysis shows 1 imaginary frequency, "
-                    f"but species_entry_kind is '{kind.value}'. "
-                    f"A minimum should have 0 imaginary frequencies."
-                ),
-            ))
-        warnings.append(UploadWarning(
-            field="species_entry_kind",
-            code=W_N_IMAG_SUGGESTS_TS,
-            message=(
-                "Frequency analysis shows exactly 1 imaginary frequency, "
-                "which is the signature of a transition state. "
-                "If this is a TS, use the transition-state upload endpoint instead."
-            ),
-        ))
-        return warnings
-
-    # n_imag >= 2
-    warnings.append(UploadWarning(
-        field="species_entry_kind",
-        code=W_N_IMAG_HIGHER_ORDER_SADDLE,
-        message=(
-            f"Frequency analysis shows {n_imag} imaginary frequencies. "
-            f"This is a higher-order saddle point, not a valid minimum "
-            f"or transition state. The geometry may need re-optimization."
-        ),
-    ))
-    return warnings
+    ``field`` stays ``species_entry_kind`` because this entry point is
+    reached from routes that hand over a bare identity payload with no
+    per-calculation path to point at.
+    """
+    findings = evaluate_species_entry_frequency(
+        kind, n_imag, imag_freq_cm1, location="species_entry_kind"
+    )
+    return stationary_point_warnings(findings)
 
 
 # ---------------------------------------------------------------------------
@@ -325,15 +380,25 @@ def reconcile_species_entry(
     payload: SpeciesEntryIdentityPayload,
     *,
     freq_n_imag: int | None = None,
+    freq_imag_freq_cm1: float | None = None,
 ) -> list[UploadWarning]:
     """Layer 1: reconcile using only freq n_imag (no calculation context).
 
     Use :func:`reconcile_species_entry_full` when calculation and
     statmech data are available for richer deduction-based checks.
+
+    :param freq_imag_freq_cm1: Magnitude of the imaginary mode in cm⁻¹,
+        when the evidence reports one. Only consulted for
+        ``vdw_complex``, to tell a soft intermolecular artifact from a
+        mode too stiff to be anything but a reaction coordinate.
     """
     warnings: list[UploadWarning] = []
     if freq_n_imag is not None:
-        warnings.extend(_check_n_imag(payload.species_entry_kind, freq_n_imag))
+        warnings.extend(
+            _check_n_imag(
+                payload.species_entry_kind, freq_n_imag, freq_imag_freq_cm1
+            )
+        )
     return warnings
 
 
@@ -360,11 +425,17 @@ def reconcile_species_entry_full(
     additional = additional_calcs or []
 
     # Layer 1: structural n_imag checks
-    freq_n_imag = None
+    freq_result = None
     if primary_calc is not None:
-        freq_n_imag = extract_freq_n_imag(primary_calc, additional)
-    if freq_n_imag is not None:
-        warnings.extend(_check_n_imag(payload.species_entry_kind, freq_n_imag))
+        freq_result = extract_freq_result(primary_calc, additional)
+    if freq_result is not None and freq_result.n_imag is not None:
+        warnings.extend(
+            _check_n_imag(
+                payload.species_entry_kind,
+                freq_result.n_imag,
+                freq_result.imag_freq_cm1,
+            )
+        )
 
     # Layer 1b: parser-fidelity check across all freq-bearing calcs.
     if primary_calc is not None:
@@ -391,3 +462,26 @@ def reconcile_species_entry_full(
             warnings.append(w)
 
     return warnings
+
+
+# ``W_CHARGE_MISMATCH`` / ``W_MULTIPLICITY_MISMATCH`` are deliberately
+# absent: ``charge_multiplicity_reconciliation`` is their sole owner and
+# this module no longer imports them (#81).
+__all__ = [
+    "TS_IMAGINARY_FREQUENCY_MIN_CM1",
+    "W_ELECTRONIC_STATE_CONTRADICTS_METHOD",
+    "W_FREQ_PARSED_NO_MODES",
+    "W_N_IMAG_CONTRADICTS_MINIMUM",
+    "W_N_IMAG_HIGHER_ORDER_SADDLE",
+    "W_N_IMAG_SUGGESTS_TS",
+    "W_TERM_SYMBOL_MISMATCH",
+    "W_TS_IMAG_FREQ_TOO_SMALL",
+    "W_TS_N_IMAG_NOT_ONE",
+    "build_ess_result_from_upload",
+    "check_freq_parser_fidelity",
+    "extract_freq_n_imag",
+    "extract_freq_result",
+    "reconcile_species_entry",
+    "reconcile_species_entry_full",
+    "stationary_point_warnings",
+]

--- a/backend/tests/api/test_api_uploads.py
+++ b/backend/tests/api/test_api_uploads.py
@@ -23,6 +23,60 @@ def _hydrogen_conformer_payload(label: str = "conf-a") -> dict:
     }
 
 
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+
+def _freq_calc(*, n_imag: int, imag_freq_cm1: float | None = None) -> dict:
+    return {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "freq_result": {"n_imag": n_imag, "imag_freq_cm1": imag_freq_cm1},
+    }
+
+
+def _transition_state_payload(
+    *,
+    n_imag: int | None = 1,
+    imag_freq_cm1: float | None = -1500.0,
+    label: str = "ts-a",
+) -> dict:
+    payload: dict = {
+        "reaction": {
+            "reversible": True,
+            "reactants": [
+                {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+                {"species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1}},
+            ],
+            "products": [
+                {"species_entry": {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}},
+                {"species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}},
+            ],
+        },
+        "charge": 0,
+        "multiplicity": 2,
+        "geometry": {
+            "xyz_text": (
+                "3\nH-CH3 abstraction TS\n"
+                "H 0.0 0.0 0.0\nC 0.0 0.0 1.4\nH 0.0 0.0 -0.9"
+            ),
+        },
+        "primary_opt": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [],
+        "label": label,
+    }
+    if n_imag is not None:
+        payload["additional_calculations"] = [
+            _freq_calc(n_imag=n_imag, imag_freq_cm1=imag_freq_cm1)
+        ]
+    return payload
+
+
 def _reaction_payload() -> dict:
     return {
         "reversible": True,
@@ -64,6 +118,144 @@ class TestConformerUpload:
         del payload["geometry"]
         resp = client.post("/api/v1/uploads/conformers", json=payload)
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Imaginary-frequency validation tiers (ADR 0008)
+#
+# minimum + n_imag >= 1     -> block   (definition)
+# vdw_complex + n_imag >= 1 -> warn    (expectation: Hessian grid noise)
+# TS + n_imag != 1          -> block   (definition)
+# TS + |imag| < threshold   -> warn    (expectation: flat/variational)
+# ---------------------------------------------------------------------------
+
+
+class TestMinimumImaginaryModeBlocks:
+    def test_minimum_with_one_imaginary_mode_returns_422(self, client):
+        payload = _hydrogen_conformer_payload(label="conf-imag")
+        payload["additional_calculations"] = [_freq_calc(n_imag=1)]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 422
+        assert "n_imag_contradicts_minimum" in resp.text
+
+    def test_minimum_with_higher_order_saddle_returns_422(self, client):
+        payload = _hydrogen_conformer_payload(label="conf-saddle")
+        payload["additional_calculations"] = [_freq_calc(n_imag=2)]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 422
+        assert "n_imag_higher_order_saddle" in resp.text
+
+    def test_minimum_blocking_ignores_magnitude(self, client):
+        """ADR 0008 forbids a magnitude threshold on a blocking check, so a
+        tiny imaginary mode on a declared minimum is refused just the same."""
+        payload = _hydrogen_conformer_payload(label="conf-tiny-imag")
+        payload["additional_calculations"] = [
+            _freq_calc(n_imag=1, imag_freq_cm1=-3.0)
+        ]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 422
+
+    def test_zero_imaginary_modes_still_uploads(self, client):
+        payload = _hydrogen_conformer_payload(label="conf-real-min")
+        payload["additional_calculations"] = [_freq_calc(n_imag=0)]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["warnings"] == []
+
+    def test_no_frequency_evidence_is_unaffected(self, client):
+        """Absence is not contradiction — the base payload has no freq data."""
+        resp = client.post(
+            "/api/v1/uploads/conformers",
+            json=_hydrogen_conformer_payload(label="conf-no-freq"),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["warnings"] == []
+
+
+class TestVdwComplexImaginaryModeWarns:
+    def test_vdw_complex_with_one_imaginary_mode_is_accepted(self, client):
+        payload = _hydrogen_conformer_payload(label="vdw-imag")
+        payload["species_entry"]["species_entry_kind"] = "vdw_complex"
+        payload["additional_calculations"] = [
+            _freq_calc(n_imag=1, imag_freq_cm1=-22.0)
+        ]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "n_imag_contradicts_minimum" in codes
+        assert "n_imag_suggests_transition_state" not in codes
+
+    def test_vdw_complex_with_higher_order_saddle_is_accepted(self, client):
+        payload = _hydrogen_conformer_payload(label="vdw-saddle")
+        payload["species_entry"]["species_entry_kind"] = "vdw_complex"
+        payload["additional_calculations"] = [_freq_calc(n_imag=3)]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "n_imag_higher_order_saddle" in codes
+
+    def test_stiff_vdw_mode_also_suggests_a_transition_state(self, client):
+        payload = _hydrogen_conformer_payload(label="vdw-stiff")
+        payload["species_entry"]["species_entry_kind"] = "vdw_complex"
+        payload["additional_calculations"] = [
+            _freq_calc(n_imag=1, imag_freq_cm1=-1200.0)
+        ]
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "n_imag_suggests_transition_state" in codes
+
+
+class TestTransitionStateImaginaryModeTiers:
+    def test_one_imaginary_mode_uploads_cleanly(self, client):
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(label="ts-ok"),
+        )
+        assert resp.status_code == 201, resp.text
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "transition_state_imaginary_frequency_too_small" not in codes
+
+    def test_zero_imaginary_modes_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                n_imag=0, imag_freq_cm1=None, label="ts-min"
+            ),
+        )
+        assert resp.status_code == 422
+        assert "transition_state_n_imag_not_one" in resp.text
+
+    def test_two_imaginary_modes_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                n_imag=2, imag_freq_cm1=-900.0, label="ts-saddle"
+            ),
+        )
+        assert resp.status_code == 422
+        assert "transition_state_n_imag_not_one" in resp.text
+
+    def test_small_imaginary_mode_is_accepted_with_a_warning(self, client):
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                n_imag=1, imag_freq_cm1=-30.0, label="ts-soft"
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "transition_state_imaginary_frequency_too_small" in codes
+
+    def test_no_frequency_evidence_is_unaffected(self, client):
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(n_imag=None, label="ts-no-freq"),
+        )
+        assert resp.status_code == 201, resp.text
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "transition_state_n_imag_not_one" not in codes
+        assert "transition_state_imaginary_frequency_too_small" not in codes
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/schemas/test_stationary_point_validation_tiers.py
+++ b/backend/tests/schemas/test_stationary_point_validation_tiers.py
@@ -1,0 +1,598 @@
+"""The four-way split of imaginary-frequency validation (ADR 0008).
+
+======================  ====================================  ======
+declared                rule                                  tier
+======================  ====================================  ======
+``minimum``             ``n_imag == 0``                       block
+``vdw_complex``         ``n_imag == 0`` *expected*            warn
+transition state        ``n_imag == 1``                       block
+transition state        ``|imag_freq_cm1| >= 100 cm⁻¹``       warn
+======================  ====================================  ======
+
+The two blocking rules are definitions: no correct calculation produces a
+covalently bound minimum with an imaginary mode, or a "transition state"
+that is really a well or a higher-order saddle. The two warning rules are
+expectations: a van der Waals complex's intermolecular modes sit low
+enough that Hessian grid noise can fake a small imaginary mode, and a
+genuinely flat or variational barrier can have a soft reaction
+coordinate. Refusing either would reject correct science.
+
+Absence is never contradiction — an upload carrying no frequency evidence
+is unaffected in every case.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from tckdb_schemas.enums import StationaryPointKind as SchemasStationaryPointKind
+from tckdb_schemas.stationary_point import (
+    TS_IMAGINARY_FREQUENCY_MIN_CM1,
+    W_N_IMAG_CONTRADICTS_MINIMUM,
+    W_N_IMAG_HIGHER_ORDER_SADDLE,
+    W_N_IMAG_SUGGESTS_TS,
+    W_TS_IMAG_FREQ_TOO_SMALL,
+    W_TS_N_IMAG_NOT_ONE,
+    ValidationTier,
+    evaluate_species_entry_frequency,
+    evaluate_transition_state_frequency,
+)
+from tckdb_schemas.workflows.computed_reaction_upload import (
+    BundleSpeciesIn,
+    BundleTransitionStateIn,
+)
+from tckdb_schemas.workflows.computed_species_upload import (
+    ComputedSpeciesUploadRequest,
+)
+
+from app.schemas.workflows.conformer_upload import ConformerUploadRequest
+from app.schemas.workflows.network_pdep_upload import (
+    NetworkSpeciesIn,
+    TransitionStateIn,
+)
+from app.schemas.workflows.statmech_upload import StatmechUploadRequest
+from app.schemas.workflows.thermo_upload import ThermoUploadRequest
+from app.schemas.workflows.transition_state_upload import (
+    TransitionStateUploadRequest,
+)
+from app.schemas.workflows.transport_upload import TransportUploadRequest
+
+_XYZ = "1\ncomment\nH 0.0 0.0 0.0"
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+_SPECIES_ENTRY = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+
+#: Comfortably below the threshold — a soft mode.
+_SOFT_CM1 = -30.0
+#: Comfortably above it — a real reaction coordinate.
+_STIFF_CM1 = -1500.0
+
+
+def _codes(findings) -> set[str]:
+    return {f.code for f in findings}
+
+
+def _tiers(findings) -> set[ValidationTier]:
+    return {f.tier for f in findings}
+
+
+# ---------------------------------------------------------------------------
+# The pure evaluators
+# ---------------------------------------------------------------------------
+
+
+class TestSpeciesEntryEvaluator:
+    @pytest.mark.parametrize("kind", list(SchemasStationaryPointKind))
+    def test_absence_is_not_contradiction(
+        self, kind: SchemasStationaryPointKind
+    ) -> None:
+        assert evaluate_species_entry_frequency(kind, None, location="x") == []
+
+    @pytest.mark.parametrize("kind", list(SchemasStationaryPointKind))
+    def test_zero_imaginary_modes_is_consistent(
+        self, kind: SchemasStationaryPointKind
+    ) -> None:
+        assert evaluate_species_entry_frequency(kind, 0, location="x") == []
+
+    @pytest.mark.parametrize("n_imag", [1, 2, 7])
+    def test_minimum_with_any_imaginary_mode_blocks(self, n_imag: int) -> None:
+        findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.minimum, n_imag, location="calc"
+        )
+        assert _tiers(findings) == {ValidationTier.block}
+        assert _codes(findings) == {W_N_IMAG_CONTRADICTS_MINIMUM}
+        assert "calc" in findings[0].message
+
+    def test_minimum_blocking_is_magnitude_blind(self) -> None:
+        """ADR 0008 forbids a magnitude threshold on a blocking check."""
+        soft = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.minimum, 1, _SOFT_CM1, location="c"
+        )
+        stiff = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.minimum, 1, _STIFF_CM1, location="c"
+        )
+        assert _tiers(soft) == _tiers(stiff) == {ValidationTier.block}
+
+    @pytest.mark.parametrize("n_imag", [1, 2, 7])
+    def test_vdw_complex_never_blocks(self, n_imag: int) -> None:
+        findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex, n_imag, location="calc"
+        )
+        assert findings
+        assert _tiers(findings) == {ValidationTier.warn}
+
+    def test_vdw_complex_one_mode_reports_the_minimum_contradiction(self) -> None:
+        findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex, 1, _SOFT_CM1, location="c"
+        )
+        assert _codes(findings) == {W_N_IMAG_CONTRADICTS_MINIMUM}
+
+    def test_vdw_complex_two_modes_report_a_higher_order_saddle(self) -> None:
+        findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex, 2, location="c"
+        )
+        assert _codes(findings) == {W_N_IMAG_HIGHER_ORDER_SADDLE}
+
+    def test_stiff_vdw_mode_additionally_suggests_a_transition_state(self) -> None:
+        """A mode this stiff cannot be an intermolecular vdW mode, so it is
+        not the grid noise the vdW carve-out exists to tolerate."""
+        findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex, 1, _STIFF_CM1, location="c"
+        )
+        assert W_N_IMAG_SUGGESTS_TS in _codes(findings)
+        assert _tiers(findings) == {ValidationTier.warn}
+
+    def test_unknown_magnitude_does_not_suggest_a_transition_state(self) -> None:
+        findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex, 1, None, location="c"
+        )
+        assert W_N_IMAG_SUGGESTS_TS not in _codes(findings)
+
+    def test_suggests_ts_boundary_is_inclusive(self) -> None:
+        at = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex,
+            1,
+            -TS_IMAGINARY_FREQUENCY_MIN_CM1,
+            location="c",
+        )
+        just_below = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.vdw_complex,
+            1,
+            -(TS_IMAGINARY_FREQUENCY_MIN_CM1 - 0.1),
+            location="c",
+        )
+        assert W_N_IMAG_SUGGESTS_TS in _codes(at)
+        assert W_N_IMAG_SUGGESTS_TS not in _codes(just_below)
+
+
+class TestTransitionStateEvaluator:
+    def test_absence_is_not_contradiction(self) -> None:
+        assert evaluate_transition_state_frequency(None, location="x") == []
+
+    def test_zero_imaginary_modes_blocks(self) -> None:
+        findings = evaluate_transition_state_frequency(0, location="ts")
+        assert _tiers(findings) == {ValidationTier.block}
+        assert _codes(findings) == {W_TS_N_IMAG_NOT_ONE}
+
+    @pytest.mark.parametrize("n_imag", [2, 3, 9])
+    def test_higher_order_saddle_blocks(self, n_imag: int) -> None:
+        findings = evaluate_transition_state_frequency(n_imag, location="ts")
+        assert _tiers(findings) == {ValidationTier.block}
+        assert W_N_IMAG_HIGHER_ORDER_SADDLE in findings[0].message
+
+    def test_one_stiff_mode_is_clean(self) -> None:
+        assert evaluate_transition_state_frequency(1, _STIFF_CM1, location="ts") == []
+
+    def test_one_soft_mode_warns_but_never_blocks(self) -> None:
+        findings = evaluate_transition_state_frequency(1, _SOFT_CM1, location="ts")
+        assert _tiers(findings) == {ValidationTier.warn}
+        assert _codes(findings) == {W_TS_IMAG_FREQ_TOO_SMALL}
+
+    def test_one_mode_of_unknown_magnitude_is_clean(self) -> None:
+        assert evaluate_transition_state_frequency(1, None, location="ts") == []
+
+    def test_magnitude_threshold_boundary_is_exclusive(self) -> None:
+        at = evaluate_transition_state_frequency(
+            1, -TS_IMAGINARY_FREQUENCY_MIN_CM1, location="ts"
+        )
+        just_below = evaluate_transition_state_frequency(
+            1, -(TS_IMAGINARY_FREQUENCY_MIN_CM1 - 0.1), location="ts"
+        )
+        assert at == []
+        assert _codes(just_below) == {W_TS_IMAG_FREQ_TOO_SMALL}
+
+    def test_sign_convention_is_irrelevant(self) -> None:
+        """Producers write the imaginary mode as a negative magnitude, but a
+        positive one means the same thing."""
+        negative = evaluate_transition_state_frequency(1, -50.0, location="ts")
+        positive = evaluate_transition_state_frequency(1, 50.0, location="ts")
+        assert _codes(negative) == _codes(positive) == {W_TS_IMAG_FREQ_TOO_SMALL}
+
+
+# ---------------------------------------------------------------------------
+# Seam 1 — conformer upload
+# ---------------------------------------------------------------------------
+
+
+def _conformer_payload(
+    n_imag: int | None,
+    *,
+    kind: str = "minimum",
+    imag_freq_cm1: float | None = None,
+) -> dict:
+    freq: dict = {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+    }
+    if n_imag is not None:
+        freq["freq_result"] = {"n_imag": n_imag, "imag_freq_cm1": imag_freq_cm1}
+    return {
+        "species_entry": {**_SPECIES_ENTRY, "species_entry_kind": kind},
+        "geometry": {"xyz_text": _XYZ},
+        "calculation": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [freq],
+    }
+
+
+class TestConformerUploadRequest:
+    @pytest.mark.parametrize("n_imag", [1, 2, 5])
+    def test_minimum_with_imaginary_modes_is_rejected(self, n_imag: int) -> None:
+        with pytest.raises(ValidationError) as exc:
+            ConformerUploadRequest(**_conformer_payload(n_imag))
+        assert W_N_IMAG_CONTRADICTS_MINIMUM in str(exc.value)
+
+    @pytest.mark.parametrize("n_imag", [1, 2, 5])
+    def test_vdw_complex_with_imaginary_modes_is_accepted(self, n_imag: int) -> None:
+        request = ConformerUploadRequest(
+            **_conformer_payload(n_imag, kind="vdw_complex")
+        )
+        findings = request.stationary_point_findings()
+        assert findings
+        assert _tiers(findings) == {ValidationTier.warn}
+
+    def test_zero_imaginary_modes_is_accepted(self) -> None:
+        request = ConformerUploadRequest(**_conformer_payload(0))
+        assert request.stationary_point_findings() == []
+
+    @pytest.mark.parametrize("kind", ["minimum", "vdw_complex"])
+    def test_no_frequency_evidence_is_unaffected(self, kind: str) -> None:
+        request = ConformerUploadRequest(**_conformer_payload(None, kind=kind))
+        assert request.additional_calculations[0].freq_result is None
+        assert request.stationary_point_findings() == []
+
+    def test_primary_calculation_is_checked_too(self) -> None:
+        payload = _conformer_payload(0)
+        payload["calculation"] = {
+            "type": "freq",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "freq_result": {"n_imag": 2},
+        }
+        with pytest.raises(ValidationError) as exc:
+            ConformerUploadRequest(**payload)
+        assert W_N_IMAG_CONTRADICTS_MINIMUM in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Seams 2-4 — standalone product uploads with inline species calculations
+# ---------------------------------------------------------------------------
+
+
+def _keyed_calc(n_imag: int, imag_freq_cm1: float | None = None) -> dict:
+    return {
+        "key": "f1",
+        "calculation": {
+            "type": "freq",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "freq_result": {"n_imag": n_imag, "imag_freq_cm1": imag_freq_cm1},
+        },
+    }
+
+
+def _statmech(kind: str, n_imag: int) -> StatmechUploadRequest:
+    return StatmechUploadRequest(
+        species_entry={**_SPECIES_ENTRY, "species_entry_kind": kind},
+        calculations=[_keyed_calc(n_imag)],
+    )
+
+
+def _thermo(kind: str, n_imag: int) -> ThermoUploadRequest:
+    return ThermoUploadRequest(
+        species_entry={**_SPECIES_ENTRY, "species_entry_kind": kind},
+        h298_kj_mol=1.0,
+        calculations=[_keyed_calc(n_imag)],
+    )
+
+
+def _transport(kind: str, n_imag: int) -> TransportUploadRequest:
+    return TransportUploadRequest(
+        species_entry={**_SPECIES_ENTRY, "species_entry_kind": kind},
+        sigma_angstrom=3.0,
+        epsilon_over_k_k=100.0,
+        calculations=[_keyed_calc(n_imag)],
+    )
+
+
+_PRODUCT_BUILDERS = [_statmech, _thermo, _transport]
+
+
+class TestStandaloneProductUploads:
+    @pytest.mark.parametrize("build", _PRODUCT_BUILDERS)
+    @pytest.mark.parametrize("n_imag", [1, 2])
+    def test_minimum_is_rejected(self, build, n_imag: int) -> None:
+        with pytest.raises(ValidationError) as exc:
+            build("minimum", n_imag)
+        assert W_N_IMAG_CONTRADICTS_MINIMUM in str(exc.value)
+
+    @pytest.mark.parametrize("build", _PRODUCT_BUILDERS)
+    @pytest.mark.parametrize("n_imag", [1, 2])
+    def test_vdw_complex_is_accepted_and_warns(self, build, n_imag: int) -> None:
+        request = build("vdw_complex", n_imag)
+        assert _tiers(request.stationary_point_findings()) == {ValidationTier.warn}
+
+    @pytest.mark.parametrize("build", _PRODUCT_BUILDERS)
+    def test_zero_imaginary_modes_is_accepted(self, build) -> None:
+        assert build("minimum", 0).stationary_point_findings() == []
+
+    def test_no_inline_calculations_is_unaffected(self) -> None:
+        request = StatmechUploadRequest(species_entry=_SPECIES_ENTRY)
+        assert request.calculations == []
+        assert request.stationary_point_findings() == []
+
+
+# ---------------------------------------------------------------------------
+# Seam 5 — computed-species bundle
+# ---------------------------------------------------------------------------
+
+
+def _bundle_conformer(n_imag: int, imag_freq_cm1: float | None = None) -> dict:
+    return {
+        "key": "c1",
+        "geometry": {"xyz_text": _XYZ},
+        "primary_calculation": {
+            "key": "c1_opt",
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [
+            {
+                "key": "c1_freq",
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_result": {"n_imag": n_imag, "imag_freq_cm1": imag_freq_cm1},
+            }
+        ],
+    }
+
+
+class TestComputedSpeciesBundle:
+    @pytest.mark.parametrize("n_imag", [1, 3])
+    def test_minimum_is_rejected(self, n_imag: int) -> None:
+        with pytest.raises(ValidationError) as exc:
+            ComputedSpeciesUploadRequest(
+                species_entry=_SPECIES_ENTRY,
+                conformers=[_bundle_conformer(n_imag)],
+            )
+        assert W_N_IMAG_CONTRADICTS_MINIMUM in str(exc.value)
+
+    @pytest.mark.parametrize("n_imag", [1, 3])
+    def test_vdw_complex_is_accepted_and_warns(self, n_imag: int) -> None:
+        request = ComputedSpeciesUploadRequest(
+            species_entry={**_SPECIES_ENTRY, "species_entry_kind": "vdw_complex"},
+            conformers=[_bundle_conformer(n_imag)],
+        )
+        assert _tiers(request.stationary_point_findings()) == {ValidationTier.warn}
+
+    def test_zero_imaginary_modes_is_accepted(self) -> None:
+        request = ComputedSpeciesUploadRequest(
+            species_entry=_SPECIES_ENTRY,
+            conformers=[_bundle_conformer(0)],
+        )
+        assert request.stationary_point_findings() == []
+
+
+# ---------------------------------------------------------------------------
+# Seams 6-7 — bundle species blocks (computed reaction, network PDep)
+# ---------------------------------------------------------------------------
+
+
+def _bundle_species(
+    n_imag: int,
+    *,
+    kind: str = "minimum",
+    imag_freq_cm1: float | None = None,
+) -> dict:
+    return {
+        "key": "s1",
+        "species_entry": {**_SPECIES_ENTRY, "species_entry_kind": kind},
+        "conformers": [
+            {
+                "key": "s1_c1",
+                "geometry": {"key": "s1_geom", "xyz_text": _XYZ},
+                "calculation": {
+                    "key": "s1_opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                },
+            }
+        ],
+        "calculations": [
+            {
+                "key": "s1_freq",
+                "type": "freq",
+                "geometry_key": "s1_geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": n_imag,
+                "freq_imag_freq_cm1": imag_freq_cm1,
+            }
+        ],
+    }
+
+
+_SPECIES_BLOCKS = [BundleSpeciesIn, NetworkSpeciesIn]
+
+
+class TestBundleSpeciesBlocks:
+    @pytest.mark.parametrize("model", _SPECIES_BLOCKS)
+    @pytest.mark.parametrize("n_imag", [1, 2])
+    def test_minimum_is_rejected(self, model, n_imag: int) -> None:
+        with pytest.raises(ValidationError) as exc:
+            model(**_bundle_species(n_imag))
+        assert W_N_IMAG_CONTRADICTS_MINIMUM in str(exc.value)
+
+    @pytest.mark.parametrize("model", _SPECIES_BLOCKS)
+    @pytest.mark.parametrize("n_imag", [1, 2])
+    def test_vdw_complex_is_accepted_and_warns(self, model, n_imag: int) -> None:
+        species = model(**_bundle_species(n_imag, kind="vdw_complex"))
+        assert _tiers(species.stationary_point_findings()) == {ValidationTier.warn}
+
+    @pytest.mark.parametrize("model", _SPECIES_BLOCKS)
+    def test_zero_imaginary_modes_is_accepted(self, model) -> None:
+        assert model(**_bundle_species(0)).stationary_point_findings() == []
+
+    @pytest.mark.parametrize("model", _SPECIES_BLOCKS)
+    def test_non_freq_calculation_carrying_freq_fields_is_ignored(
+        self, model
+    ) -> None:
+        """The bundle adapter only persists ``freq_*`` off a freq-type calc,
+        so the check must read the same way or it would refuse a payload
+        over a value the database never stores."""
+        payload = _bundle_species(0)
+        payload["calculations"][0]["type"] = "sp"
+        payload["calculations"][0]["freq_n_imag"] = 3
+        assert model(**payload).stationary_point_findings() == []
+
+
+# ---------------------------------------------------------------------------
+# Seams 8-10 — transition states
+# ---------------------------------------------------------------------------
+
+
+def _ts_reaction() -> dict:
+    return {
+        "reversible": True,
+        "reactants": [{"species_entry": {**_SPECIES_ENTRY, "smiles": "[H]"}}],
+        "products": [{"species_entry": {**_SPECIES_ENTRY, "smiles": "[H]"}}],
+    }
+
+
+def _standalone_ts(
+    n_imag: int | None, imag_freq_cm1: float | None = None
+) -> TransitionStateUploadRequest:
+    freq: dict = {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+    }
+    if n_imag is not None:
+        freq["freq_result"] = {"n_imag": n_imag, "imag_freq_cm1": imag_freq_cm1}
+    return TransitionStateUploadRequest(
+        reaction=_ts_reaction(),
+        charge=0,
+        multiplicity=2,
+        geometry={"xyz_text": _XYZ},
+        primary_opt={
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        additional_calculations=[freq],
+    )
+
+
+def _bundle_ts_payload(
+    n_imag: int | None, imag_freq_cm1: float | None = None
+) -> dict:
+    calcs = []
+    if n_imag is not None:
+        calcs.append(
+            {
+                "key": "ts_freq",
+                "type": "freq",
+                "geometry_key": "ts_geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": n_imag,
+                "freq_imag_freq_cm1": imag_freq_cm1,
+            }
+        )
+    return {
+        "charge": 0,
+        "multiplicity": 2,
+        "geometry": {"key": "ts_geom", "xyz_text": _XYZ},
+        "calculation": {
+            "key": "ts_opt",
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "calculations": calcs,
+    }
+
+
+def _bundle_ts(
+    n_imag: int | None, imag_freq_cm1: float | None = None
+) -> BundleTransitionStateIn:
+    return BundleTransitionStateIn(**_bundle_ts_payload(n_imag, imag_freq_cm1))
+
+
+def _network_ts(
+    n_imag: int | None, imag_freq_cm1: float | None = None
+) -> TransitionStateIn:
+    return TransitionStateIn(
+        key="ts1",
+        micro_reaction_key="mr1",
+        **_bundle_ts_payload(n_imag, imag_freq_cm1),
+    )
+
+
+_TS_BUILDERS = [_standalone_ts, _bundle_ts, _network_ts]
+
+
+class TestTransitionStateSeams:
+    @pytest.mark.parametrize("build", _TS_BUILDERS)
+    def test_zero_imaginary_modes_is_rejected(self, build) -> None:
+        with pytest.raises(ValidationError) as exc:
+            build(0)
+        assert W_TS_N_IMAG_NOT_ONE in str(exc.value)
+
+    @pytest.mark.parametrize("build", _TS_BUILDERS)
+    @pytest.mark.parametrize("n_imag", [2, 4])
+    def test_higher_order_saddle_is_rejected(self, build, n_imag: int) -> None:
+        with pytest.raises(ValidationError) as exc:
+            build(n_imag)
+        assert W_TS_N_IMAG_NOT_ONE in str(exc.value)
+
+    @pytest.mark.parametrize("build", _TS_BUILDERS)
+    def test_one_imaginary_mode_is_accepted(self, build) -> None:
+        assert build(1, _STIFF_CM1).stationary_point_findings() == []
+
+    @pytest.mark.parametrize("build", _TS_BUILDERS)
+    def test_one_soft_imaginary_mode_is_accepted_and_warns(self, build) -> None:
+        findings = build(1, _SOFT_CM1).stationary_point_findings()
+        assert _codes(findings) == {W_TS_IMAG_FREQ_TOO_SMALL}
+        assert _tiers(findings) == {ValidationTier.warn}
+
+    @pytest.mark.parametrize("build", _TS_BUILDERS)
+    def test_no_frequency_evidence_is_unaffected(self, build) -> None:
+        assert build(None).stationary_point_findings() == []
+
+    def test_a_transition_state_is_never_judged_as_a_minimum(self) -> None:
+        """The species rule and the TS rule are mutually exclusive: what
+        refuses a minimum is exactly what a transition state requires."""
+        ts_findings = _bundle_ts(1, _STIFF_CM1).stationary_point_findings()
+        species_findings = evaluate_species_entry_frequency(
+            SchemasStationaryPointKind.minimum, 1, _STIFF_CM1, location="c"
+        )
+        assert ts_findings == []
+        assert _tiers(species_findings) == {ValidationTier.block}

--- a/backend/tests/services/test_upload_reconciliation.py
+++ b/backend/tests/services/test_upload_reconciliation.py
@@ -48,12 +48,14 @@ def _identity(
     )
 
 
-def _freq_calc(n_imag: int) -> CalculationWithResultsPayload:
+def _freq_calc(
+    n_imag: int, imag_freq_cm1: float | None = None
+) -> CalculationWithResultsPayload:
     return CalculationWithResultsPayload(
         type=CalculationType.freq,
         level_of_theory={"method": "b3lyp", "basis": "def2-svp"},
         software_release={"name": "gaussian", "version": "16"},
-        freq_result=FreqResultPayload(n_imag=n_imag),
+        freq_result=FreqResultPayload(n_imag=n_imag, imag_freq_cm1=imag_freq_cm1),
     )
 
 
@@ -114,39 +116,75 @@ class TestReconcileSpeciesEntry:
         )
         assert warnings == []
 
-    def test_n_imag_one_minimum_produces_two_warnings(self) -> None:
-        warnings = reconcile_species_entry(_identity(), freq_n_imag=1)
-        codes = {w.code for w in warnings}
-        assert W_N_IMAG_CONTRADICTS_MINIMUM in codes
-        assert W_N_IMAG_SUGGESTS_TS in codes
-        assert len(warnings) == 2
+    def test_n_imag_one_minimum_produces_no_warning(self) -> None:
+        """A declared minimum with an imaginary mode blocks, so it is not
+        re-derived here: ADR 0008 gives the blocking tier sole ownership
+        of a fact it refuses, and the schema tier already rejected the
+        payload with a 422 before any route body ran."""
+        assert reconcile_species_entry(_identity(), freq_n_imag=1) == []
 
-    def test_n_imag_one_vdw_complex_produces_two_warnings(self) -> None:
+    def test_n_imag_two_minimum_produces_no_warning(self) -> None:
+        assert reconcile_species_entry(_identity(), freq_n_imag=2) == []
+
+    def test_n_imag_one_vdw_complex_warns(self) -> None:
+        """A van der Waals complex is formally a minimum but its soft
+        intermolecular modes make a small imaginary mode a plausible
+        Hessian artifact, so it is recorded and flagged, not refused."""
         warnings = reconcile_species_entry(
             _identity(kind=StationaryPointKind.vdw_complex),
             freq_n_imag=1,
         )
         codes = {w.code for w in warnings}
+        assert codes == {W_N_IMAG_CONTRADICTS_MINIMUM}
+
+    def test_n_imag_one_stiff_vdw_complex_also_suggests_ts(self) -> None:
+        """An imaginary mode at or above the threshold is far too stiff to
+        be an intermolecular mode, so it is unlikely to be grid noise."""
+        warnings = reconcile_species_entry(
+            _identity(kind=StationaryPointKind.vdw_complex),
+            freq_n_imag=1,
+            freq_imag_freq_cm1=-1200.0,
+        )
+        codes = {w.code for w in warnings}
         assert W_N_IMAG_CONTRADICTS_MINIMUM in codes
         assert W_N_IMAG_SUGGESTS_TS in codes
 
-    def test_n_imag_two_produces_higher_order_warning(self) -> None:
-        warnings = reconcile_species_entry(_identity(), freq_n_imag=2)
+    def test_n_imag_one_soft_vdw_complex_does_not_suggest_ts(self) -> None:
+        warnings = reconcile_species_entry(
+            _identity(kind=StationaryPointKind.vdw_complex),
+            freq_n_imag=1,
+            freq_imag_freq_cm1=-30.0,
+        )
+        codes = {w.code for w in warnings}
+        assert W_N_IMAG_SUGGESTS_TS not in codes
+
+    def test_n_imag_two_vdw_complex_produces_higher_order_warning(self) -> None:
+        warnings = reconcile_species_entry(
+            _identity(kind=StationaryPointKind.vdw_complex), freq_n_imag=2
+        )
         assert len(warnings) == 1
         assert warnings[0].code == W_N_IMAG_HIGHER_ORDER_SADDLE
-        assert "2 imaginary frequencies" in warnings[0].message
+        assert "2 imaginary modes" in warnings[0].message
 
-    def test_n_imag_three_produces_higher_order_warning(self) -> None:
-        warnings = reconcile_species_entry(_identity(), freq_n_imag=3)
+    def test_n_imag_three_vdw_complex_produces_higher_order_warning(self) -> None:
+        warnings = reconcile_species_entry(
+            _identity(kind=StationaryPointKind.vdw_complex), freq_n_imag=3
+        )
         assert len(warnings) == 1
         assert warnings[0].code == W_N_IMAG_HIGHER_ORDER_SADDLE
 
     def test_warning_field_is_species_entry_kind(self) -> None:
-        warnings = reconcile_species_entry(_identity(), freq_n_imag=1)
+        warnings = reconcile_species_entry(
+            _identity(kind=StationaryPointKind.vdw_complex), freq_n_imag=1
+        )
+        assert warnings
         assert all(w.field == "species_entry_kind" for w in warnings)
 
     def test_warning_messages_are_nonempty(self) -> None:
-        warnings = reconcile_species_entry(_identity(), freq_n_imag=1)
+        warnings = reconcile_species_entry(
+            _identity(kind=StationaryPointKind.vdw_complex), freq_n_imag=1
+        )
+        assert warnings
         assert all(w.message for w in warnings)
 
 
@@ -247,14 +285,34 @@ class TestReconcileSpeciesEntryFull:
         codes = {w.code for w in warnings}
         assert W_ELECTRONIC_STATE_CONTRADICTS_METHOD in codes
 
-    def test_n_imag_one_still_produces_layer1_warnings(self) -> None:
+    def test_n_imag_one_vdw_complex_still_produces_layer1_warnings(self) -> None:
         """Layer 1 n_imag warnings fire even in full reconciliation."""
+        warnings = reconcile_species_entry_full(
+            _identity(kind=StationaryPointKind.vdw_complex),
+            primary_calc=_freq_calc(1),
+        )
+        codes = {w.code for w in warnings}
+        assert W_N_IMAG_CONTRADICTS_MINIMUM in codes
+
+    def test_n_imag_one_minimum_produces_no_layer1_warning(self) -> None:
+        """The blocking tier owns this contradiction; the warning tier
+        does not re-derive it."""
         warnings = reconcile_species_entry_full(
             _identity(),
             primary_calc=_freq_calc(1),
         )
         codes = {w.code for w in warnings}
-        assert W_N_IMAG_CONTRADICTS_MINIMUM in codes
+        assert W_N_IMAG_CONTRADICTS_MINIMUM not in codes
+        assert W_N_IMAG_SUGGESTS_TS not in codes
+
+    def test_layer1_reads_magnitude_off_the_same_freq_result(self) -> None:
+        """The count and the magnitude must come from one calculation."""
+        warnings = reconcile_species_entry_full(
+            _identity(kind=StationaryPointKind.vdw_complex),
+            primary_calc=_opt_calc(),
+            additional_calcs=[_freq_calc(1, imag_freq_cm1=-1200.0)],
+        )
+        codes = {w.code for w in warnings}
         assert W_N_IMAG_SUGGESTS_TS in codes
 
     def test_term_symbol_not_derived_without_closed_shell_evidence(self) -> None:

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.14.0"
+version = "0.15.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
@@ -107,6 +107,21 @@ class CalculationIn(SchemaBase):
     artifacts: list[ArtifactIn] = Field(default_factory=list)
 
 
+def freq_evidence(calc_in: "CalculationIn") -> tuple[int | None, float | None]:
+    """Return the ``(n_imag, imag_freq_cm1)`` this calculation will persist.
+
+    The flat ``freq_*`` fields are only translated into a result block by
+    :func:`calculation_in_to_with_results_payload` when ``type`` is
+    ``freq``; on any other type they are silently dropped. Consistency
+    checks must therefore read frequency evidence through this helper
+    rather than off the fields directly, so they judge exactly what the
+    database will hold.
+    """
+    if calc_in.type != CalculationType.freq:
+        return (None, None)
+    return (calc_in.freq_n_imag, calc_in.freq_imag_freq_cm1)
+
+
 def calculation_in_to_with_results_payload(
     calc_in: "CalculationIn",
 ) -> CalculationWithResultsPayload:

--- a/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
@@ -1,0 +1,424 @@
+"""Consistency between a declared stationary point and its frequency evidence.
+
+The Hessian eigenvalue spectrum *is* the definition of a stationary point:
+zero imaginary modes is a minimum, exactly one is a first-order saddle
+point, two or more is a higher-order saddle. A payload that declares one
+thing and carries frequency evidence for another is internally
+contradictory.
+
+ADR 0008 (*definitions block, expectations warn*) sorts the four possible
+findings into two tiers, and this module is their single owner:
+
+======================  ====================================  ======
+declared                rule                                  tier
+======================  ====================================  ======
+``minimum``             ``n_imag == 0``                       block
+``vdw_complex``         ``n_imag == 0`` *expected*            warn
+transition state        ``n_imag == 1``                       block
+transition state        ``|imag_freq_cm1| >= 100 cm⁻¹``       warn
+======================  ====================================  ======
+
+Why the two minima split, given that a van der Waals complex is formally
+also a minimum:
+
+* A covalently bound **minimum** whose own frequency evidence reports an
+  imaginary mode is mislabelled. The correct response is to re-optimise
+  on a tighter integration grid or to declare it as something else, so
+  refusing the deposit is right — no correct calculation produces the
+  record as submitted.
+* A **van der Waals complex** is held together by intermolecular forces,
+  and its intermolecular stretch, bends and hindered internal rotations
+  sit below roughly 50 cm⁻¹. That is the region where numerical noise in
+  a finite-difference or quadrature-grid Hessian is comparable to the
+  true curvature, so a small imaginary mode there is usually a grid
+  artifact rather than evidence of a saddle point. Refusing it would
+  force an expensive re-run for a physically meaningless mode, so it is
+  recorded and flagged instead. This is what makes ``vdw_complex`` earn
+  its separate enum member: it is the only place the two kinds behave
+  differently.
+* A **transition state** with zero imaginary modes is a minimum, and one
+  with two or more is a higher-order saddle. Either way it is not the
+  first-order saddle point it claims to be, so that blocks.
+* A transition state whose imaginary mode is very small is *suspicious*
+  but can be perfectly real — flat barriers and variational transition
+  states genuinely produce them. Magnitude is therefore a quality
+  expectation, never a definition, and ADR 0008 names it explicitly as a
+  check that must not block.
+
+Absence is never contradiction: a payload with no frequency evidence
+produces no findings at all, in every case.
+
+Pure functions only — no Pydantic, no backend imports, no payload
+shapes. Callers extract ``(n_imag, imag_freq_cm1)`` from whatever shape
+they hold and pass scalars in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from tckdb_schemas.enums import StationaryPointKind
+
+# ---------------------------------------------------------------------------
+# The tunable expectation
+# ---------------------------------------------------------------------------
+
+#: Magnitude below which a transition state's single imaginary mode is
+#: reported as suspiciously soft (cm⁻¹). This is an expectation, not a
+#: definition — it never blocks. The value is a starting point rather
+#: than a physical constant: reaction coordinates for hydrogen transfers
+#: run to thousands of cm⁻¹, while genuinely flat or variational barriers
+#: can fall well under 100, so the threshold trades false positives on
+#: loose saddle points against silence on under-converged ones. It is
+#: also the scale that separates a van der Waals complex's soft
+#: intermolecular modes from a real reaction coordinate, and is reused
+#: for that judgement below.
+TS_IMAGINARY_FREQUENCY_MIN_CM1: float = 100.0
+
+
+# ---------------------------------------------------------------------------
+# Machine-readable codes
+# ---------------------------------------------------------------------------
+
+#: Frequency evidence reports an imaginary mode on an entry declared a
+#: minimum. Blocking for ``minimum``; reported as a warning for
+#: ``vdw_complex``, where the same fact is usually Hessian noise. The
+#: code names the *finding*; the declared kind decides the tier.
+W_N_IMAG_CONTRADICTS_MINIMUM = "n_imag_contradicts_minimum"
+
+#: Two or more imaginary modes. Folded into the blocking message for
+#: ``minimum`` and for transition states; reported as a warning for
+#: ``vdw_complex``.
+W_N_IMAG_HIGHER_ORDER_SADDLE = "n_imag_higher_order_saddle"
+
+#: Narrowed by ADR 0008's tier split. Before the split this fired on
+#: every species entry with one imaginary mode, alongside
+#: ``W_N_IMAG_CONTRADICTS_MINIMUM``, and said "if this is a TS, use the
+#: transition-state endpoint". That advice now lives inside the blocking
+#: message for ``minimum``, and the only declared kind that still reaches
+#: the warning tier with an imaginary mode is ``vdw_complex`` — where
+#: suggesting a transition state would usually be wrong, because the mode
+#: is intermolecular noise.
+#:
+#: So the code keeps its name and gains a precise, reachable subject: a
+#: van der Waals complex whose imaginary mode is *too stiff* to be
+#: intermolecular noise (at or above
+#: :data:`TS_IMAGINARY_FREQUENCY_MIN_CM1`) is not showing a grid
+#: artifact, and really does look like a first-order saddle point.
+W_N_IMAG_SUGGESTS_TS = "n_imag_suggests_transition_state"
+
+#: A transition state whose frequency evidence does not report exactly
+#: one imaginary mode. Definitional, therefore blocking.
+W_TS_N_IMAG_NOT_ONE = "transition_state_n_imag_not_one"
+
+#: A transition state's single imaginary mode is below
+#: :data:`TS_IMAGINARY_FREQUENCY_MIN_CM1` in magnitude. An expectation,
+#: therefore a warning.
+W_TS_IMAG_FREQ_TOO_SMALL = "transition_state_imaginary_frequency_too_small"
+
+
+#: Stationary-point kinds that are, by definition, minima on the
+#: potential energy surface: every one of them *expects* zero imaginary
+#: modes. Membership says nothing about the tier — ``minimum`` and
+#: ``vdw_complex`` share the expectation and differ in the consequence.
+MINIMUM_KINDS = frozenset({StationaryPointKind.minimum, StationaryPointKind.vdw_complex})
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+class ValidationTier(str, Enum):
+    """Consequence of a finding, in ADR 0008's vocabulary."""
+
+    #: Refuse the payload. Reserved for definitions and contracts.
+    block = "block"
+    #: Accept the payload and record a machine-readable annotation.
+    warn = "warn"
+
+
+@dataclass(frozen=True)
+class StationaryPointFinding:
+    """One consistency finding about one piece of frequency evidence.
+
+    :param tier: Whether the finding refuses the payload or annotates it.
+    :param code: Stable machine-readable code, shared across tiers so
+        blocking messages and upload warnings speak one vocabulary.
+    :param location: Human-readable path to the payload element that
+        produced the finding, used verbatim so a depositor can find it.
+    :param message: Producer-facing explanation, including the remedy.
+    """
+
+    tier: ValidationTier
+    code: str
+    location: str
+    message: str
+
+
+def expects_zero_imaginary_modes(kind: StationaryPointKind) -> bool:
+    """Whether ``kind`` is formally a minimum on the potential surface."""
+    return kind in MINIMUM_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Species entries
+# ---------------------------------------------------------------------------
+
+
+def evaluate_species_entry_frequency(
+    kind: StationaryPointKind,
+    n_imag: int | None,
+    imag_freq_cm1: float | None = None,
+    *,
+    location: str,
+) -> list[StationaryPointFinding]:
+    """Judge one species entry's declared kind against its own frequency evidence.
+
+    :param kind: The stationary-point kind the uploader declared.
+    :param n_imag: Imaginary-mode count parsed from the frequency evidence
+        deposited with that same entry. ``None`` means no evidence was
+        supplied — absence is not contradiction, so nothing is reported.
+    :param imag_freq_cm1: Magnitude of the imaginary mode, if reported.
+        Only consulted for ``vdw_complex``, to tell a soft intermolecular
+        artifact from a genuine reaction coordinate.
+    :param location: Path to the offending payload element.
+    :returns: Findings, possibly empty. Never raises.
+    """
+    if n_imag is None or n_imag <= 0:
+        return []
+
+    if kind == StationaryPointKind.minimum:
+        return [_minimum_contradiction(n_imag, location=location)]
+
+    if kind == StationaryPointKind.vdw_complex:
+        return _vdw_complex_findings(n_imag, imag_freq_cm1, location=location)
+
+    # A kind this module has not been taught about. Say nothing rather
+    # than guess a tier for it; adding an enum member must be a
+    # deliberate decision here, not a default.
+    return []
+
+
+def _minimum_contradiction(
+    n_imag: int, *, location: str
+) -> StationaryPointFinding:
+    if n_imag == 1:
+        detail = (
+            "One imaginary mode is a first-order saddle point, which belongs "
+            "on a transition-state entry — deposit it through a "
+            "transition-state or computed-reaction payload instead."
+        )
+    else:
+        detail = (
+            f"{n_imag} imaginary modes is a higher-order saddle point "
+            f"({W_N_IMAG_HIGHER_ORDER_SADDLE}) — neither a minimum nor a "
+            f"transition state."
+        )
+    return StationaryPointFinding(
+        tier=ValidationTier.block,
+        code=W_N_IMAG_CONTRADICTS_MINIMUM,
+        location=location,
+        message=(
+            f"{location}: species_entry_kind is 'minimum' but the frequency "
+            f"analysis reports {n_imag} imaginary mode"
+            f"{'s' if n_imag != 1 else ''} "
+            f"({W_N_IMAG_CONTRADICTS_MINIMUM}). A minimum has zero imaginary "
+            f"modes by definition. {detail} Re-optimise on a tighter "
+            f"integration grid, or declare the entry as what it actually is. "
+            f"If the soft mode is intermolecular and this is a van der Waals "
+            f"complex, declare species_entry_kind='vdw_complex', which "
+            f"records the mode with a warning instead."
+        ),
+    )
+
+
+def _vdw_complex_findings(
+    n_imag: int,
+    imag_freq_cm1: float | None,
+    *,
+    location: str,
+) -> list[StationaryPointFinding]:
+    if n_imag == 1:
+        code = W_N_IMAG_CONTRADICTS_MINIMUM
+        count_phrase = "1 imaginary mode"
+    else:
+        code = W_N_IMAG_HIGHER_ORDER_SADDLE
+        count_phrase = f"{n_imag} imaginary modes"
+
+    findings = [
+        StationaryPointFinding(
+            tier=ValidationTier.warn,
+            code=code,
+            location=location,
+            message=(
+                f"{location}: species_entry_kind is 'vdw_complex' but the "
+                f"frequency analysis reports {count_phrase}. A van der Waals "
+                f"complex is formally a minimum, so zero is expected; its "
+                f"intermolecular modes sit low enough that Hessian grid noise "
+                f"is comparable to the true curvature, so the record is "
+                f"accepted and flagged rather than refused. Re-run the "
+                f"frequency job on a tighter integration grid if the mode "
+                f"matters downstream."
+            ),
+        )
+    ]
+
+    if (
+        imag_freq_cm1 is not None
+        and abs(imag_freq_cm1) >= TS_IMAGINARY_FREQUENCY_MIN_CM1
+    ):
+        findings.append(
+            StationaryPointFinding(
+                tier=ValidationTier.warn,
+                code=W_N_IMAG_SUGGESTS_TS,
+                location=location,
+                message=(
+                    f"{location}: the imaginary mode is "
+                    f"{abs(imag_freq_cm1):.1f} cm⁻¹, at or above "
+                    f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm⁻¹. That is far "
+                    f"too stiff to be an intermolecular mode of a van der "
+                    f"Waals complex, so it is unlikely to be Hessian grid "
+                    f"noise and looks instead like a genuine reaction "
+                    f"coordinate. If this really is a saddle point, deposit "
+                    f"it as a transition state."
+                ),
+            )
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Transition states
+# ---------------------------------------------------------------------------
+
+
+def evaluate_transition_state_frequency(
+    n_imag: int | None,
+    imag_freq_cm1: float | None = None,
+    *,
+    location: str,
+) -> list[StationaryPointFinding]:
+    """Judge a transition state against its own frequency evidence.
+
+    A transition state is a first-order saddle point by declaration —
+    there is no ``stationary_point_kind`` column on a transition-state
+    entry, the entity *is* the claim — so the count check needs no kind
+    argument.
+
+    :param n_imag: Imaginary-mode count parsed from the frequency
+        evidence deposited with this transition state. ``None`` means no
+        evidence was supplied, and nothing is reported.
+    :param imag_freq_cm1: Magnitude of the imaginary mode, if reported.
+    :param location: Path to the offending payload element.
+    :returns: Findings, possibly empty. Never raises.
+    """
+    if n_imag is None:
+        return []
+
+    if n_imag != 1:
+        if n_imag <= 0:
+            detail = (
+                "Zero imaginary modes is a minimum, not a saddle point: the "
+                "geometry did not converge onto a barrier top. Re-run the "
+                "saddle-point search, or deposit the structure as a species "
+                "entry."
+            )
+        else:
+            detail = (
+                f"{n_imag} imaginary modes is a higher-order saddle point "
+                f"({W_N_IMAG_HIGHER_ORDER_SADDLE}), not the first-order "
+                f"saddle a transition state is defined to be. Re-optimise "
+                f"the geometry, following the spurious modes down if they "
+                f"are real rather than grid artifacts."
+            )
+        return [
+            StationaryPointFinding(
+                tier=ValidationTier.block,
+                code=W_TS_N_IMAG_NOT_ONE,
+                location=location,
+                message=(
+                    f"{location}: a transition state has exactly one "
+                    f"imaginary mode by definition, but the frequency "
+                    f"analysis reports {n_imag} "
+                    f"({W_TS_N_IMAG_NOT_ONE}). {detail}"
+                ),
+            )
+        ]
+
+    if (
+        imag_freq_cm1 is not None
+        and abs(imag_freq_cm1) < TS_IMAGINARY_FREQUENCY_MIN_CM1
+    ):
+        return [
+            StationaryPointFinding(
+                tier=ValidationTier.warn,
+                code=W_TS_IMAG_FREQ_TOO_SMALL,
+                location=location,
+                message=(
+                    f"{location}: the transition state's imaginary mode is "
+                    f"{abs(imag_freq_cm1):.1f} cm⁻¹, below "
+                    f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm⁻¹. The saddle "
+                    f"point count is correct, so the record is accepted; a "
+                    f"mode this soft is nevertheless often an "
+                    f"under-converged geometry or a coarse integration grid. "
+                    f"It can also be real — flat and variational barriers "
+                    f"genuinely produce one — which is why this is a quality "
+                    f"expectation and not a refusal."
+                ),
+            )
+        ]
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Tier helpers
+# ---------------------------------------------------------------------------
+
+
+def blocking_findings(
+    findings: list[StationaryPointFinding],
+) -> list[StationaryPointFinding]:
+    """Return only the findings that refuse the payload."""
+    return [f for f in findings if f.tier is ValidationTier.block]
+
+
+def warning_findings(
+    findings: list[StationaryPointFinding],
+) -> list[StationaryPointFinding]:
+    """Return only the findings that annotate an accepted payload."""
+    return [f for f in findings if f.tier is ValidationTier.warn]
+
+
+def raise_for_blocking_findings(findings: list[StationaryPointFinding]) -> None:
+    """Raise ``ValueError`` if any finding is at the blocking tier.
+
+    Upload schemas call this from a ``model_validator`` so a definitional
+    contradiction becomes a 422 naming the contradiction, before the
+    route body opens a submission.
+    """
+    blocked = blocking_findings(findings)
+    if blocked:
+        raise ValueError(" ".join(f.message for f in blocked))
+
+
+__all__ = [
+    "MINIMUM_KINDS",
+    "TS_IMAGINARY_FREQUENCY_MIN_CM1",
+    "StationaryPointFinding",
+    "ValidationTier",
+    "W_N_IMAG_CONTRADICTS_MINIMUM",
+    "W_N_IMAG_HIGHER_ORDER_SADDLE",
+    "W_N_IMAG_SUGGESTS_TS",
+    "W_TS_IMAG_FREQ_TOO_SMALL",
+    "W_TS_N_IMAG_NOT_ONE",
+    "blocking_findings",
+    "evaluate_species_entry_frequency",
+    "evaluate_transition_state_frequency",
+    "expects_zero_imaginary_modes",
+    "raise_for_blocking_findings",
+    "warning_findings",
+]

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -58,6 +58,13 @@ from tckdb_schemas.shared.calculation_in import (
     CalculationIn as _BaseCalculationIn,
     GeometryIn,
     calculation_in_to_with_results_payload as _base_calc_to_payload,
+    freq_evidence,
+)
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    evaluate_species_entry_frequency,
+    evaluate_transition_state_frequency,
+    raise_for_blocking_findings,
 )
 from tckdb_schemas.statmech_bits import StatmechTorsionCoordinateIn
 from tckdb_schemas.thermo import ThermoNASACreate, ThermoPointCreate
@@ -509,6 +516,53 @@ class BundleSpeciesIn(SchemaBase):
                 )
         return self
 
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge this species's declared kind against its own frequency evidence.
+
+        This sits on the *species* model rather than on the request
+        because the bundle also carries a transition state, whose single
+        imaginary mode is correct science; a request-level scan that
+        ignored which entity owns the frequency would wrongly reject it.
+        """
+        kind = self.species_entry.species_entry_kind
+        findings: list[StationaryPointFinding] = []
+        for conformer in self.conformers:
+            n_imag, imag_freq_cm1 = freq_evidence(conformer.calculation)
+            findings.extend(
+                evaluate_species_entry_frequency(
+                    kind,
+                    n_imag,
+                    imag_freq_cm1,
+                    location=(
+                        f"species['{self.key}'].conformers['{conformer.key}']"
+                        f".calculation"
+                    ),
+                )
+            )
+        for calc in self.calculations:
+            n_imag, imag_freq_cm1 = freq_evidence(calc)
+            findings.extend(
+                evaluate_species_entry_frequency(
+                    kind,
+                    n_imag,
+                    imag_freq_cm1,
+                    location=f"species['{self.key}'].calculations['{calc.key}']",
+                )
+            )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008). This model is the
+        earliest point at which one species entry's declared
+        stationary-point kind and that same entry's own frequency
+        evidence are both in hand.
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
+        return self
+
 
 # ---------------------------------------------------------------------------
 # Reaction participants
@@ -595,6 +649,32 @@ class BundleTransitionStateIn(SchemaBase):
                 f"TS primary calculation must be type 'opt', "
                 f"got '{self.calculation.type.value}'."
             )
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge this transition state against its own frequency evidence."""
+        findings: list[StationaryPointFinding] = []
+        for calc in (self.calculation, *self.calculations):
+            n_imag, imag_freq_cm1 = freq_evidence(calc)
+            findings.extend(
+                evaluate_transition_state_frequency(
+                    n_imag,
+                    imag_freq_cm1,
+                    location=f"transition_state.calculations['{calc.key}']",
+                )
+            )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_is_one(self) -> Self:
+        """Refuse frequency evidence that is not a first-order saddle point.
+
+        Definitional, therefore blocking (ADR 0008). A transition state
+        does not carry a ``stationary_point_kind`` — the entity is the
+        claim — so this model is where the declaration and the evidence
+        meet.
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self
 
     @model_validator(mode="after")
@@ -868,6 +948,23 @@ class ComputedReactionUploadRequest(SchemaBase):
 
     # Kinetics fits (empty when Arkane fitting didn't complete)
     kinetics: list[BundleKineticsIn] = Field(default_factory=list)
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Collect every entity's stationary-point findings in this bundle.
+
+        Each species judges its own frequency evidence against its own
+        declared kind, and the transition state judges its own — so the
+        transition state's single imaginary mode never counts against a
+        species and vice versa. The blocking half already fired from the
+        nested models' validators by the time this is callable; the route
+        layer calls it to harvest the warning half.
+        """
+        findings: list[StationaryPointFinding] = []
+        for species in self.species:
+            findings.extend(species.stationary_point_findings())
+        if self.transition_state is not None:
+            findings.extend(self.transition_state.stationary_point_findings())
+        return findings
 
     @model_validator(mode="after")
     def validate_ts_validation_evidence(self) -> Self:

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -52,6 +52,11 @@ from tckdb_schemas.fragments.refs import (
 from tckdb_schemas.fragments.scan import CalculationScanResultCreate
 from tckdb_schemas.literature import LiteratureUploadRequest
 from tckdb_schemas.statmech_bits import StatmechTorsionCoordinateIn
+from tckdb_schemas.stationary_point import (
+    StationaryPointFinding,
+    evaluate_species_entry_frequency,
+    raise_for_blocking_findings,
+)
 from tckdb_schemas.thermo import ThermoNASACreate, ThermoPointCreate
 from tckdb_schemas.upload_warning import UploadWarning
 
@@ -641,6 +646,42 @@ class ComputedSpeciesUploadRequest(SchemaBase):
                             f"calculation '{calc.key}' depends_on undefined "
                             f"calculation_key '{dep.parent_calculation_key}'."
                         )
+        return self
+
+    def stationary_point_findings(self) -> list[StationaryPointFinding]:
+        """Judge the bundle's declared kind against its own frequency evidence.
+
+        One bundle is one species entry, and every calculation in it is
+        scoped to that entry, so the request is the right owner here —
+        unlike the computed-reaction bundle, which also carries a
+        transition state and therefore judges per entity.
+        """
+        kind = self.species_entry.species_entry_kind
+        findings: list[StationaryPointFinding] = []
+        for conf in self.conformers:
+            for calc in (conf.primary_calculation, *conf.additional_calculations):
+                if calc.freq_result is None:
+                    continue
+                findings.extend(
+                    evaluate_species_entry_frequency(
+                        kind,
+                        calc.freq_result.n_imag,
+                        calc.freq_result.imag_freq_cm1,
+                        location=(
+                            f"conformers['{conf.key}'].calculations"
+                            f"['{calc.key}'].freq_result"
+                        ),
+                    )
+                )
+        return findings
+
+    @model_validator(mode="after")
+    def validate_n_imag_matches_species_entry_kind(self) -> Self:
+        """Refuse frequency evidence that contradicts the declared kind.
+
+        Definitional, therefore blocking (ADR 0008).
+        """
+        raise_for_blocking_findings(self.stationary_point_findings())
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
Applies the audit that [ADR 0008](docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md) deliberately deferred. That ADR sorts a check by whether it asserts a **definition** (may block) or an **expectation** (must only warn). Applied to imaginary frequencies, that is not one rule but four, and they disagree on both tier and entity:

| declared kind | rule | tier |
|---|---|---|
| `minimum` | `n_imag == 0` | **block** |
| `vdw_complex` | `n_imag == 0` expected | warn |
| transition state | `n_imag == 1` | **block** |
| transition state | `abs(imag_freq_cm1) >= 100` | warn |

Before this, `W_N_IMAG_CONTRADICTS_MINIMUM` and `W_N_IMAG_SUGGESTS_TS` fired on identical sets and both were advisory, so a species entry contradicting its own frequency evidence was accepted.

### Why `vdw_complex` does not block

A van der Waals complex is formally a minimum, but its intermolecular modes sit below ~50 cm⁻¹, where numerical noise in a quadrature-grid Hessian is comparable to the true curvature. A small imaginary mode there is usually a grid artifact. Refusing it would force an expensive re-run for a physically meaningless mode, so it is recorded and flagged. This is what makes `vdw_complex` earn its separate enum member — it previously sat in `_MINIMUM_KINDS` beside `minimum` and behaved identically everywhere.

No blocking check reads a magnitude (pinned by `test_minimum_blocking_is_magnitude_blind`); only the two warn-tier checks use the 100 cm⁻¹ threshold.

### Scope

Ten seams: 7 species (`ConformerUploadRequest`, `StatmechUploadRequest`, `ThermoUploadRequest`, `TransportUploadRequest`, `ComputedSpeciesUploadRequest`, `BundleSpeciesIn`, `NetworkSpeciesIn`) and 3 TS (`TransitionStateUploadRequest`, `BundleTransitionStateIn`, `TransitionStateIn`). Bundle checks sit on the **nested** models, not the request — those payloads carry both entity kinds, and a request-level scan would reject every real TS.

The physics and code strings live in one owner, `tckdb_schemas/stationary_point.py`, which returns tiered findings rather than raising, so a single traversal serves both tiers: schemas raise on blocking findings, routes convert warning findings to `UploadWarning`s.

### Verification

- Four rules probed independently of the suite's own assertions — 17/17, including the boundary (−99.9 warns, −100.0 accepts) and magnitude-blindness on `minimum`.
- **All 13 real ARC payloads still upload** (`14 passed`) — their species are `minimum`/`n_imag=0` and every imaginary mode is TS-owned at `n_imag=1`, −1090.6 to −1896.2 cm⁻¹, so no new warnings. This was the regression risk: a request-level scan would have rejected all of them.
- Targeted suites `154 passed`; full gates SCI `1743 passed`, API `2321 passed`.
- `ruff` clean in both packages; golden `openapi.json` **unchanged** (the seam methods are invisible to the schema).
- `tckdb-schemas` bumped 0.14.0 → 0.15.0.

### Follow-ups, not in this PR

- The read-time labels (`frequency_source_has_zero/multiple_imaginary_modes_for_validated_ts`) are untouched. They now grade a strictly narrower population — status-gated and reading a stored row's representative freq result — so going forward they can only fire on rows deposited before this commit. Collapsing them onto the single owner is the ADR-0008 duplication cleanup.
- No ADR 0009 recording the promotion and the narrowing of `W_N_IMAG_SUGGESTS_TS`.
- The client builder is unchanged; it never sees the declared kind at calc-build time and will surface a server 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
