### PR TITLE
Reconcile species labels across a dual-form PDep pair

### DIFF
--- a/backend/scripts/pdep_ingestion/builder.py
+++ b/backend/scripts/pdep_ingestion/builder.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import base64
 import hashlib
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1108,11 +1109,61 @@ def _plog_channel_kinetics_entry(
     return entry
 
 
+def _validate_species_aliases(
+    aliases: Mapping[str, str],
+    *,
+    cheb_labels: set[str],
+    plog_labels: set[str],
+) -> None:
+    """Reject an alias map that cannot mean what the caller intended.
+
+    An alias merges two species labels, so a wrong one silently attaches a PLOG
+    fit to the wrong channel -- the exact failure the topology check exists to
+    prevent. Each rule below turns a silent misattachment into an error naming
+    the offending label:
+
+    * a target absent from the Chebyshev run is a typo that would otherwise
+      surface as a confusing topology mismatch;
+    * a source absent from the PLOG run means the caller's assumption about
+      that run is wrong (already renamed, or the wrong directory);
+    * an identity alias is a no-op and signals confusion about direction;
+    * two sources sharing one target would merge two distinct species into one
+      state, which no relabelling can justify.
+    """
+    # Checked first: an identity alias is a caller mistake whatever else is
+    # wrong with it, and "this is a no-op" diagnoses it better than the
+    # unknown-target error it would otherwise trip on.
+    identity = sorted(s for s, t in aliases.items() if s == t)
+    if identity:
+        raise ValueError(f"species_aliases maps these labels to themselves: {identity}.")
+    bad_targets = sorted({t for t in aliases.values() if t not in cheb_labels})
+    if bad_targets:
+        raise ValueError(
+            f"species_aliases targets absent from the Chebyshev run: {bad_targets}. "
+            f"Known Chebyshev species labels: {sorted(cheb_labels)}."
+        )
+    unused = sorted({s for s in aliases if s not in plog_labels})
+    if unused:
+        raise ValueError(
+            f"species_aliases sources absent from the PLOG run: {unused}. "
+            f"Known PLOG species labels: {sorted(plog_labels)}."
+        )
+    collisions = sorted(
+        t for t, n in Counter(aliases.values()).items() if n > 1
+    )
+    if collisions:
+        raise ValueError(
+            f"species_aliases maps several PLOG labels onto one Chebyshev label: "
+            f"{collisions}. That would merge distinct species into one state."
+        )
+
+
 def build_dual_form_payload(
     cheb_run_dir: Path,
     plog_run_dir: Path,
     *,
     include_artifacts: bool = False,
+    species_aliases: Mapping[str, str] | None = None,
 ) -> tuple[dict, GapReport]:
     """Build a dual-form request dict (Chebyshev + PLOG) from two Arkane runs.
 
@@ -1129,6 +1180,18 @@ def build_dual_form_payload(
     mapping the Chebyshev build uses) to a channel that the Chebyshev build
     produced, and the two channel sets must be identical. Any mismatch raises
     ``ValueError`` rather than silently dropping or misaligning a channel.
+
+    ``species_aliases`` reconciles the case where the two Arkane inputs name the
+    same species differently -- the hydrazine network labels isodiazene ``H2NN``
+    in its Chebyshev run and ``NH2N`` in its PLOG run while both point at the
+    same ``Data/NH2N.py`` and SMILES ``[N-]=[NH2+]``, which leaves 6 of 21
+    channels unmapped. Pass ``{"NH2N": "H2NN"}`` (PLOG label -> Chebyshev label)
+    instead of hand-editing the run directory, so the build stays reproducible
+    from the untouched sources.
+
+    This is a *label* reconciliation only. It asserts that two names denote the
+    same species; establishing that they do is the caller's responsibility, and
+    :func:`_validate_species_aliases` rejects the maps that cannot be right.
     """
     request_dict, gap = build_network_pdep_payload(
         cheb_run_dir, include_artifacts=include_artifacts
@@ -1146,22 +1209,34 @@ def build_dual_form_payload(
     # State lookup keyed by the multiset of participant species labels, rebuilt
     # from the Chebyshev payload's states so PLOG fits attach to the same keys.
     state_lookup: dict[tuple, str] = {}
+    cheb_labels: set[str] = set()
     for st in request_dict["states"]:
         labels: list[str] = []
         for p in st["participants"]:
             labels.extend([p["species_key"]] * int(p.get("stoichiometry", 1)))
+        cheb_labels.update(labels)
         state_lookup[_multiset_key(labels)] = st["key"]
 
     plog_fits = parse_pdep_arrhenius_reactions(
         (Path(plog_run_dir) / "output.py").read_text()
     )
 
+    aliases = dict(species_aliases or {})
+    if aliases:
+        plog_labels = {s for fit in plog_fits for s in fit.reactants + fit.products}
+        _validate_species_aliases(
+            aliases, cheb_labels=cheb_labels, plog_labels=plog_labels
+        )
+
+    def _aliased(labels: list[str]) -> tuple[tuple[str, int], ...]:
+        return _multiset_key([aliases.get(label, label) for label in labels])
+
     plog_kinetics: list[dict] = []
     plog_pairs: set[tuple[str, str]] = set()
     unmapped: list[tuple[str, str]] = []
     for fit in plog_fits:
-        src = state_lookup.get(_multiset_key(fit.reactants))
-        snk = state_lookup.get(_multiset_key(fit.products))
+        src = state_lookup.get(_aliased(fit.reactants))
+        snk = state_lookup.get(_aliased(fit.products))
         if src is None or snk is None or src == snk:
             unmapped.append(("+".join(fit.reactants), "+".join(fit.products)))
             continue
@@ -1210,16 +1285,21 @@ def build_dual_form_request(
     plog_run_dir: Path,
     *,
     include_artifacts: bool = False,
+    species_aliases: Mapping[str, str] | None = None,
 ):
     """Build a validated dual-form ``NetworkPDepUploadRequest`` from two runs.
 
-    See :func:`build_dual_form_payload`. The result carries both a Chebyshev
-    and a PLOG ``channel_kinetics`` entry per channel (2N total for N channels)
-    and validates against the relaxed
+    See :func:`build_dual_form_payload`, including the ``species_aliases``
+    contract. The result carries both a Chebyshev and a PLOG
+    ``channel_kinetics`` entry per channel (2N total for N channels) and
+    validates against the relaxed
     ``(source_state_key, sink_state_key, model_kind)`` uniqueness rule.
     """
     request_dict, _ = build_dual_form_payload(
-        cheb_run_dir, plog_run_dir, include_artifacts=include_artifacts
+        cheb_run_dir,
+        plog_run_dir,
+        include_artifacts=include_artifacts,
+        species_aliases=species_aliases,
     )
     from app.schemas.workflows.network_pdep_upload import NetworkPDepUploadRequest
 

--- a/backend/tests/scripts/test_pdep_ingestion.py
+++ b/backend/tests/scripts/test_pdep_ingestion.py
@@ -9,6 +9,7 @@ scientific evidence back.
 
 from __future__ import annotations
 
+import re
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
@@ -273,6 +274,77 @@ def test_dual_form_build_rejects_topology_mismatch(tmp_path) -> None:
     )
     with pytest.raises(ValueError, match="topology does not match"):
         build_dual_form_payload(FIXTURE_DIR, tmp_path)
+
+
+def _relabelled_plog_run(tmp_path: Path, old: str, new: str) -> Path:
+    """Copy the PLOG fixture with one species label renamed.
+
+    Reproduces the real hydrazine case: the two Arkane inputs name isodiazene
+    ``H2NN`` and ``NH2N`` while pointing at the same data file and SMILES.
+    """
+    run_dir = tmp_path / "plog_relabelled"
+    run_dir.mkdir()
+    text = (PLOG_FIXTURE_DIR / "output.py").read_text()
+    assert old in text, f"fixture does not contain {old!r}"
+    (run_dir / "output.py").write_text(re.sub(rf"\b{re.escape(old)}\b", new, text))
+    return run_dir
+
+
+def _plog_fingerprint(request) -> list[tuple]:
+    return sorted(
+        (nk.source_state_key, nk.sink_state_key, round(e.pressure_bar, 9),
+         float(e.a), round(e.n, 9), round(e.ea_kj_mol, 9))
+        for nk in request.solve.channel_kinetics
+        if nk.model_kind.value == "plog"
+        for e in nk.plog.entries
+    )
+
+
+def test_species_alias_recovers_a_relabelled_plog_run(tmp_path) -> None:
+    """A PLOG run that only *names* a species differently still maps.
+
+    The alias must be equivalent to having relabelled the run by hand: the
+    resulting PLOG fits are identical to those built from the unaltered
+    fixture, so nothing about the kinetics depends on the rename.
+    """
+    run_dir = _relabelled_plog_run(tmp_path, "H2NN", "NH2N")
+    aliased = build_dual_form_request(
+        FIXTURE_DIR, run_dir, species_aliases={"NH2N": "H2NN"}
+    )
+    baseline = build_dual_form_request(FIXTURE_DIR, PLOG_FIXTURE_DIR)
+    assert _plog_fingerprint(aliased) == _plog_fingerprint(baseline)
+    assert len(aliased.solve.channel_kinetics) == 2
+
+
+def test_a_relabelled_plog_run_without_an_alias_is_rejected(tmp_path) -> None:
+    """Without the alias the same run fails the topology check rather than
+    silently dropping the channel."""
+    run_dir = _relabelled_plog_run(tmp_path, "H2NN", "NH2N")
+    with pytest.raises(ValueError, match="topology does not match"):
+        build_dual_form_payload(FIXTURE_DIR, run_dir)
+
+
+@pytest.mark.parametrize(
+    "aliases, message",
+    [
+        ({"NH2N": "NOT_A_SPECIES"}, "targets absent from the Chebyshev run"),
+        ({"NEVER_APPEARS": "H2NN"}, "sources absent from the PLOG run"),
+        ({"NH2N": "NH2N"}, "maps these labels to themselves"),
+        ({"NH2N": "H2NN", "H2": "H2NN"}, "merge distinct species"),
+    ],
+)
+def test_species_alias_rejects_maps_that_cannot_be_right(
+    tmp_path, aliases, message
+) -> None:
+    """An alias merges labels, so a wrong one misattaches a fit silently.
+
+    Each rejected map is a distinct way of being wrong: a typo'd target, a
+    source the PLOG run never uses, a no-op, and two labels collapsed onto one
+    species.
+    """
+    run_dir = _relabelled_plog_run(tmp_path, "H2NN", "NH2N")
+    with pytest.raises(ValueError, match=message):
+        build_dual_form_payload(FIXTURE_DIR, run_dir, species_aliases=aliases)
 
 
 def test_dual_form_persist_two_kinetics_rows_per_channel(db_engine) -> None:


### PR DESCRIPTION
`build_dual_form_payload` attaches a PLOG run's fits to a Chebyshev run's channels by matching the multiset of participant species labels. That assumes both Arkane inputs spell every species the same way — and they need not.

The hydrazine network labels isodiazene **`H2NN`** in `Final_MRCI_PDep` and **`NH2N`** in `MRCI_davidson_Plog`, while both point at the same `Data/NH2N.py` and SMILES `[N-]=[NH2+]`. Six of twenty-one channels then fail to map and the topology check rejects the pair — correctly, since it cannot tell a renamed species from a different one.

The only way to build that network was to hand-edit a copy of the run directory. That puts the upload's provenance in a shell command nobody records, which is the same class of problem as an unreproducible fit. `species_aliases={"NH2N": "H2NN"}` (PLOG label → Chebyshev label) states it as data instead:

```python
build_dual_form_request(
    hydrazine / "Final_MRCI_PDep",
    hydrazine / "MRCI_davidson_Plog",
    species_aliases={"NH2N": "H2NN"},
)
```

### Guardrails

An alias merges two labels, so a wrong one misattaches a fit **silently** — exactly the failure the topology check exists to prevent. Four maps are refused, each a distinct way of being wrong:

| map | why it is refused |
|---|---|
| `{"X": "X"}` | a no-op; signals confusion about direction. Checked **first**, because it diagnoses the mistake better than the unknown-target error it would otherwise trip on |
| target not in the Chebyshev run | a typo, which would otherwise surface as a confusing topology mismatch |
| source not in the PLOG run | the caller's assumption about that run is wrong (already renamed, or wrong directory) |
| two sources → one target | would collapse distinct species into one state |

Establishing that two names denote the same species remains the caller's job. This reconciles *labels*; it does not verify chemistry, and the docstring says so.

### Verification

- **On the real pair**: with the alias, the payload built from the untouched Dropbox directories is **identical** to the previously hand-edited one — 21 channels, 42 `channel_kinetics` (21 chebyshev + 21 plog), 105 PLOG entries, matching `(channel, pressure, A, n, Ea)` for every entry.
- **Fixture test**: a relabelled PLOG run plus its alias yields byte-identical PLOG fits to the unaltered fixture (`test_species_alias_recovers_a_relabelled_plog_run`), and the same run *without* the alias is still rejected (`test_a_relabelled_plog_run_without_an_alias_is_rejected`).
- All four rejection paths parametrised.
- `tests/scripts/test_pdep_ingestion.py`: **28 passed**. `ruff check app tests` clean. The two pre-existing `B007`s in `builder.py` are on `main` too and sit in `scripts/`, which CI does not lint.

No schema, migration, or wire-contract change; default `None` preserves existing behaviour exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
