### PR TITLE
Stop schema guarantees vanishing from generated artefacts

### DIFF
--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -2520,6 +2520,7 @@ Table record_review {
     (record_type, record_id) [name: 'ix_record_review_record_lookup']
     (status, record_type) [name: 'ix_record_review_status_record_type']
     submission_id [name: 'ix_record_review_submission_id']
+    (record_type, record_id) [unique, name: 'uq_record_review_record']
   }
 
   checks {

--- a/backend/scripts/generate_dbml.py
+++ b/backend/scripts/generate_dbml.py
@@ -247,11 +247,19 @@ def _render_indexes(table, pk_col_names: set[str]) -> list[str]:
         col_names = [c.name for c in constraint.columns]
         if set(col_names) == pk_col_names:
             continue
-        # Check if already covered by an index
-        existing_index_cols = {
-            frozenset(c.name for c in idx.columns) for idx in table.indexes
+        # Skip only if a *unique* index already renders this exact column set.
+        # Matching on columns alone loses the constraint: a non-unique index
+        # over the same columns is a lookup aid, not a uniqueness guarantee, so
+        # suppressing against one drops the guarantee from the document without
+        # dropping it from the database. That is what happened to
+        # ``uq_record_review_record`` once ``ix_record_review_record_lookup``
+        # was added over ``(record_type, record_id)``.
+        unique_index_cols = {
+            frozenset(c.name for c in idx.columns)
+            for idx in table.indexes
+            if idx.unique
         }
-        if frozenset(col_names) in existing_index_cols:
+        if frozenset(col_names) in unique_index_cols:
             continue
         if len(col_names) == 1:
             expr = col_names[0]

--- a/backend/tests/schemas/test_tckdb_schemas_enum_drift.py
+++ b/backend/tests/schemas/test_tckdb_schemas_enum_drift.py
@@ -30,11 +30,15 @@ ENUM_PAIRS: list[tuple[type[Enum], type[Enum]]] = [
     (db_enums.ConstraintKind, wire_enums.ConstraintKind),
     (db_enums.CoordinateUnit, wire_enums.CoordinateUnit),
     (db_enums.EnergyCorrectionApplicationRole, wire_enums.EnergyCorrectionApplicationRole),
+    (db_enums.EnergyCorrectionConvention, wire_enums.EnergyCorrectionConvention),
     (db_enums.EnergyCorrectionSchemeKind, wire_enums.EnergyCorrectionSchemeKind),
     (db_enums.EnergyUnit, wire_enums.EnergyUnit),
+    (db_enums.EnergyZeroConvention, wire_enums.EnergyZeroConvention),
     (db_enums.FrequencyScaleKind, wire_enums.FrequencyScaleKind),
+    (db_enums.HessianSource, wire_enums.HessianSource),
     (db_enums.IRCDirection, wire_enums.IRCDirection),
     (db_enums.KineticsCalculationRole, wire_enums.KineticsCalculationRole),
+    (db_enums.KineticsDegeneracyConvention, wire_enums.KineticsDegeneracyConvention),
     (db_enums.KineticsDirection, wire_enums.KineticsDirection),
     (db_enums.KineticsModelKind, wire_enums.KineticsModelKind),
     (db_enums.KineticsUncertaintyKind, wire_enums.KineticsUncertaintyKind),
@@ -42,19 +46,48 @@ ENUM_PAIRS: list[tuple[type[Enum], type[Enum]]] = [
     (db_enums.MeliusBacComponentKind, wire_enums.MeliusBacComponentKind),
     (db_enums.MoleculeKind, wire_enums.MoleculeKind),
     (db_enums.NetworkChannelKind, wire_enums.NetworkChannelKind),
+    (db_enums.NetworkKineticsModelKind, wire_enums.NetworkKineticsModelKind),
     (db_enums.NetworkSolveCalculationRole, wire_enums.NetworkSolveCalculationRole),
     (db_enums.PathSearchMethod, wire_enums.PathSearchMethod),
+    (db_enums.PressureContext, wire_enums.PressureContext),
+    (db_enums.PressureUnit, wire_enums.PressureUnit),
     (db_enums.RigidRotorKind, wire_enums.RigidRotorKind),
     (db_enums.SCFStabilityStatus, wire_enums.SCFStabilityStatus),
     (db_enums.ScientificOriginKind, wire_enums.ScientificOriginKind),
     (db_enums.SpeciesEntryStateKind, wire_enums.SpeciesEntryStateKind),
+    (db_enums.SpinTreatment, wire_enums.SpinTreatment),
     (db_enums.StatmechCalculationRole, wire_enums.StatmechCalculationRole),
     (db_enums.StatmechTreatmentKind, wire_enums.StatmechTreatmentKind),
     (db_enums.StationaryPointKind, wire_enums.StationaryPointKind),
     (db_enums.StereoKind, wire_enums.StereoKind),
+    (db_enums.TemperatureUnit, wire_enums.TemperatureUnit),
     (db_enums.ThermoCalculationRole, wire_enums.ThermoCalculationRole),
     (db_enums.TorsionTreatmentKind, wire_enums.TorsionTreatmentKind),
+    (db_enums.TunnelingModel, wire_enums.TunnelingModel),
 ]
+
+
+def test_every_mirrored_wire_enum_is_paired() -> None:
+    """No wire enum may sit outside ``ENUM_PAIRS``.
+
+    The pairs above are hand-maintained, so a newly mirrored enum drifts
+    silently until someone remembers to add it -- which is exactly what
+    happened to ten of them, five arriving with the Stage 4 restore and five
+    older. This closes the loop: mirroring an enum without pairing it now
+    fails here rather than at the first serialization mismatch in production.
+    """
+    paired = {wire_enum.__name__ for _backend, wire_enum in ENUM_PAIRS}
+    mirrored = {
+        name
+        for name in dir(wire_enums)
+        if isinstance(getattr(wire_enums, name), type)
+        and issubclass(getattr(wire_enums, name), Enum)
+        and getattr(wire_enums, name) is not Enum
+    }
+    assert mirrored - paired == set(), (
+        f"wire enums missing from ENUM_PAIRS: {sorted(mirrored - paired)}. "
+        "Add each alongside its app.db.models.common counterpart."
+    )
 
 
 @pytest.mark.parametrize("backend_enum,wire_enum", ENUM_PAIRS, ids=lambda e: e.__name__)

--- a/backend/tests/scripts/test_generate_dbml.py
+++ b/backend/tests/scripts/test_generate_dbml.py
@@ -1,0 +1,83 @@
+"""Tests for the DBML generator's constraint rendering.
+
+``schema.dbml`` is the document people read to understand the schema, so a
+guarantee the database enforces but the document omits is worse than a missing
+file -- it is a confident wrong answer.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from sqlalchemy import Column, Index, Integer, MetaData, String, Table, UniqueConstraint
+
+_GENERATOR = Path(__file__).parents[2] / "scripts" / "generate_dbml.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("generate_dbml", _GENERATOR)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _render(table: Table) -> list[str]:
+    generator = _load_generator()
+    return generator._render_indexes(table, pk_col_names={"id"})
+
+
+def test_a_non_unique_index_does_not_suppress_a_unique_constraint() -> None:
+    """A lookup index over the same columns is not the constraint.
+
+    Regression: ``uq_record_review_record`` vanished from ``schema.dbml`` when
+    ``ix_record_review_record_lookup`` was added over the same
+    ``(record_type, record_id)`` pair. The constraint was untouched in the
+    database, so the document silently under-reported what the schema
+    guarantees. Matching on the column set alone cannot tell a uniqueness
+    guarantee from a lookup aid.
+    """
+    metadata = MetaData()
+    table = Table(
+        "record_review_like",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("record_type", String),
+        Column("record_id", Integer),
+        UniqueConstraint("record_type", "record_id", name="uq_pair"),
+        Index("ix_pair_lookup", "record_type", "record_id"),  # NOT unique
+    )
+
+    rendered = "\n".join(_render(table))
+
+    assert "uq_pair" in rendered, (
+        "a unique constraint covered only by a non-unique index must still be "
+        f"rendered; got:\n{rendered}"
+    )
+
+
+def test_a_unique_index_does_suppress_the_duplicate_constraint() -> None:
+    """The original de-duplication still holds where it is actually true.
+
+    When the covering index is itself unique it already renders ``unique`` for
+    that column set, so emitting the constraint too would double-report one
+    guarantee.
+    """
+    metadata = MetaData()
+    table = Table(
+        "unique_index_table",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("a", String),
+        Column("b", Integer),
+        UniqueConstraint("a", "b", name="uq_ab"),
+        Index("ix_ab", "a", "b", unique=True),
+    )
+
+    rendered = "\n".join(_render(table))
+
+    assert "uq_ab" not in rendered, (
+        f"a unique index already conveys this constraint; got:\n{rendered}"
+    )
+    assert "unique" in rendered


### PR DESCRIPTION
Two schema-hygiene fixes surfaced while verifying the Stage 4 restore (#84). Both are cases where a guarantee existed in the database but not in the artefact people read.

### 1. A non-unique index was erasing a unique constraint from `schema.dbml`

`generate_dbml.py` skipped a `UniqueConstraint` whenever *any* index covered the same column set. A column set alone cannot distinguish a uniqueness guarantee from a lookup aid, so a plain index over the same columns silently suppressed the constraint — removing it from the document while leaving it in the database.

`uq_record_review_record` vanished exactly this way when `ix_record_review_record_lookup` was added over `(record_type, record_id)`. The constraint is still enforced — verified `contype='u'` on the deployed Pi. For a file whose only job is to describe the schema, silently under-reporting is worse than an omission: it reads as authoritative.

Suppression now requires the covering index to be **unique**, which is the case where the original de-duplication is actually true (a unique index already renders `unique` for those columns, so emitting both would double-report one guarantee). Both directions are tested.

Regenerating adds **exactly one line** across all 30 tables, so this was the only constraint affected.

### 2. Ten mirrored wire enums had no drift coverage

`ENUM_PAIRS` is hand-maintained, so a newly mirrored enum is unguarded until someone remembers to add it. Ten had slipped through — five arrived with the Stage 4 restore, five predate it: `EnergyCorrectionConvention`, `EnergyZeroConvention`, `HessianSource`, `KineticsDegeneracyConvention`, `NetworkKineticsModelKind`, `PressureContext`, `PressureUnit`, `SpinTreatment`, `TemperatureUnit`, `TunnelingModel`.

All ten already agreed with `app.db.models.common`, so this adds coverage **without changing a single value** — it closes the window in which they could have diverged unnoticed rather than fixing a divergence.

Adding the ten alone would leave the same trap for the eleventh, so `test_every_mirrored_wire_enum_is_paired` now derives the mirrored set by reflection and fails on anything unpaired, naming it. Verified non-vacuous by removing a pair: it fails with `wire enums missing from ENUM_PAIRS: ['TunnelingModel']`.

### Verification

`tests/schemas/test_tckdb_schemas_enum_drift.py` **91 passed**; `tests/scripts/test_generate_dbml.py` **2 passed**; `ruff` clean on all changed files. The three `E402`s in `generate_dbml.py` are pre-existing — the diff touches no import line, and `scripts/` is outside CI's `ruff check app tests` scope.

Closes the enum half of #15 and all of #13 from the post-restore follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
