### PR TITLE
Filter and rank the hot searches by review in SQL

### DIFF
--- a/backend/alembic/versions/94daa2c345fb_add_species_formula_expression_index.py
+++ b/backend/alembic/versions/94daa2c345fb_add_species_formula_expression_index.py
@@ -5,7 +5,7 @@ formula on the fly via the RDKit cartridge:
 
     mol_formula(mol_from_smiles(species.smiles))::text = :formula
 
-(see ``app/services/scientific_read/species.py::_query_matching_species``).
+(see ``app/services/scientific_read/species.py::_candidate_species_stmt``).
 Since ``species`` has no stored ``formula`` column, every ``formula=``
 request was a full sequential scan that re-parsed every row's SMILES. This
 revision adds a matching expression (functional) index so the planner can

--- a/backend/app/services/scientific_read/analytics.py
+++ b/backend/app/services/scientific_read/analytics.py
@@ -125,6 +125,8 @@ from app.services.scientific_read.sql_review import (
     join_review,
     review_rank_expr,
     review_status_expr,
+    status_from_sql,
+    summary_from_sql,
     visible_review_filter,
 )
 
@@ -310,7 +312,7 @@ def _run_page(
             watermark=watermark_echo,
         )
 
-    summary = _summary_from_sql(session, ranked)
+    summary = summary_from_sql(session, ranked)
 
     page_stmt = select(
         ranked.c.id, ranked.c.review_rank, ranked.c.review_status
@@ -328,7 +330,7 @@ def _run_page(
 
     ids = [int(row.id) for row in rows]
     statuses = {
-        int(row.id): _as_status(row.review_status) for row in rows
+        int(row.id): status_from_sql(row.review_status) for row in rows
     }
 
     next_cursor: str | None = None
@@ -353,35 +355,6 @@ def _run_page(
         next_cursor=next_cursor,
         watermark=watermark_echo,
     )
-
-
-def _as_status(value: Any) -> RecordReviewStatus:
-    """Coerce the SQL-side review status back to the enum."""
-    if isinstance(value, RecordReviewStatus):
-        return value
-    return RecordReviewStatus(str(value))
-
-
-def _summary_from_sql(session: Session, ranked) -> ReviewStatusSummary:
-    """Count review statuses over the *whole* filtered set in one aggregate.
-
-    The summary describes everything the filters matched, not the page, so it
-    cannot be derived from the page rows — and materializing the candidate set
-    to count it would give back exactly the property this surface exists to
-    have.
-    """
-    rows = session.execute(
-        select(ranked.c.review_status, func.count())
-        .select_from(ranked)
-        .group_by(ranked.c.review_status)
-    ).all()
-    summary = ReviewStatusSummary()
-    for status, count in rows:
-        key = status.value if hasattr(status, "value") else str(status)
-        if hasattr(summary, key):
-            setattr(summary, key, getattr(summary, key) + count)
-        summary.total += count
-    return summary
 
 
 def _echo(

--- a/backend/app/services/scientific_read/calculations_search.py
+++ b/backend/app/services/scientific_read/calculations_search.py
@@ -9,16 +9,28 @@ Composition:
    refs; empty-result short-circuit when an unknown ref is supplied
    on a filter, matching Phase C semantics elsewhere).
 4. Build a SQL query joining ``calculation`` to its provenance tables
-   for the supplied scalar filters; emit only ``calculation.id`` so the
-   filter pass stays cheap.
-5. Bulk-load review badges for the candidate set; apply the visible-
-   statuses gate (default trust posture). Build the ``review_summary``
-   on this filtered, pre-pagination set.
-6. Sort deterministically in Python (review rank → quality rank →
-   created_at desc → id desc — ``evidence_completeness`` is deferred).
-7. Slice for pagination, then materialize each page row via the shared
-   :func:`build_record` helper so search and detail produce identical
-   record shapes for the same include set.
+   for the supplied scalar filters; emit only the columns the ranking
+   needs so the filter pass stays cheap.
+5. Gate, rank, order and slice **in SQL**, over that query as a
+   subquery: LEFT JOIN ``record_review``, apply the visible-statuses
+   gate (default trust posture), order by review rank → quality rank →
+   created_at desc → id desc (``evidence_completeness`` is deferred),
+   and take one page. The ``review_summary`` comes from a single
+   aggregate over the same filtered, pre-pagination set.
+6. Materialize each page row via the shared :func:`build_record` helper
+   so search and detail produce identical record shapes for the same
+   include set.
+
+Why steps 5 is SQL and not Python
+---------------------------------
+It used to load every candidate id and filter/sort them in Python. That
+is not merely slower at catalog scale, it is a hard failure: the badge
+bulk-load renders one bind parameter per candidate and PostgreSQL's wire
+protocol caps a statement at 65,535 parameters, so
+``calculation_type=sp`` over a large corpus returned ``503
+database_unavailable`` rather than a page. See
+:mod:`app.services.scientific_read.sql_review`, whose helpers this module
+uses, and ``backend/docs/benchmarks/README.md`` for the measurement.
 
 See ``backend/docs/specs/scientific_calculation_reads.md``.
 """
@@ -28,7 +40,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import and_, exists, or_, select
+from sqlalchemy import and_, case, exists, or_, select
 from sqlalchemy.orm import Session
 
 from app.db.models.calculation import (
@@ -68,9 +80,6 @@ from app.schemas.reads.scientific_calculation_search import (
     RequestEcho,
     ScientificCalculationsSearchResponse,
 )
-from app.schemas.reads.scientific_common import (
-    REVIEW_RANK,
-)
 from app.services.scientific_read.calculations import (
     _INTERNAL_INCLUDE_TOKENS,
     _LEGAL_INCLUDE_TOKENS,
@@ -91,6 +100,13 @@ from app.services.scientific_read.handles import (
 )
 from app.services.scientific_read.internal_ids import (
     filter_internal_ids_from_resolved,
+)
+from app.services.scientific_read.sql_review import (
+    join_review,
+    review_rank_expr,
+    review_status_expr,
+    summary_from_sql,
+    visible_review_filter,
 )
 
 # Filter knobs that count as "meaningful" for the at-least-one-filter rule.
@@ -135,6 +151,23 @@ _QUALITY_RANK: dict[CalculationQuality, int] = {
     CalculationQuality.raw: 1,
     CalculationQuality.rejected: 2,
 }
+
+#: Rank for a quality value the mapping above does not name. Only reachable
+#: if a new ``CalculationQuality`` member is added without being ranked; it
+#: sorts last rather than raising, which is what the Python dict lookup
+#: could not do.
+_UNRANKED_QUALITY = max(_QUALITY_RANK.values()) + 1
+
+
+def _quality_rank_expr(quality_column):
+    """SQL ``quality_rank`` (lower is better) mirroring :data:`_QUALITY_RANK`."""
+    return case(
+        *(
+            (quality_column == quality, rank)
+            for quality, rank in _QUALITY_RANK.items()
+        ),
+        else_=_UNRANKED_QUALITY,
+    )
 
 
 # Per-calc-type primary result table — drives the ``has_result`` filter.
@@ -240,8 +273,10 @@ def search_calculations(
     if short_circuit:
         return _empty_response(request, includes, offset, limit)
 
-    # Build the filter query.
-    stmt = select(Calculation.id, Calculation.created_at)
+    # Build the filter query. ``quality`` rides along because the ranking
+    # needs it; carrying it here rather than re-reading it per page keeps
+    # the whole ordering expressible over one subquery.
+    stmt = select(Calculation.id, Calculation.created_at, Calculation.quality)
     stmt = _apply_owner_filters(
         stmt,
         species_entry_id=species_entry_id,
@@ -273,55 +308,65 @@ def search_calculations(
         # Caller asked for rejected-quality but didn't opt in — empty result.
         return _empty_response(request, includes, offset, limit)
 
-    rows = session.execute(stmt).all()
-    candidate_ids = [row.id for row in rows]
-    created_at_by_id = {row.id: row.created_at for row in rows}
-
-    if not candidate_ids:
-        return _empty_response(request, includes, offset, limit)
-
-    # Apply review-status visibility gate. Default trust posture excludes
+    # Apply the review-status visibility gate. Default trust posture excludes
     # rejected/deprecated unless explicitly opted in; min_review_status
     # narrows further (D5/D7).
-    badges = fetch_review_badges(
-        session,
-        record_type=SubmissionRecordType.calculation,
-        record_ids=candidate_ids,
-    )
     visible = visible_statuses(
         min_review_status=request.min_review_status,
         include_rejected=request.include_rejected,
         include_deprecated=request.include_deprecated,
     )
-    visible_ids = [
-        cid for cid in candidate_ids if badges[cid].status in visible
-    ]
-    if not visible_ids:
-        return _empty_response(request, includes, offset, limit)
+
+    # Everything from here to the page slice happens in the database. The
+    # LEFT JOIN is load-bearing: a calculation with no ``record_review`` row
+    # is ``not_reviewed`` and visible by default, and an inner join would
+    # drop every one of them.
+    candidates = stmt.subquery("candidates")
+    ranked_base = select(candidates.c.id, candidates.c.created_at)
+    ranked_base, review = join_review(
+        ranked_base, candidates.c.id, SubmissionRecordType.calculation
+    )
+    ranked = (
+        ranked_base.add_columns(
+            review_rank_expr(review).label("review_rank"),
+            review_status_expr(review).label("review_status"),
+            _quality_rank_expr(candidates.c.quality).label("quality_rank"),
+        )
+        .where(visible_review_filter(review, visible))
+        .subquery("visible_candidates")
+    )
 
     # Pre-pagination review summary (Phase 2.1: counts on the candidate set
-    # *after* filtering, before pagination).
-    summary = review_summary(badges[cid] for cid in visible_ids)
+    # *after* filtering, before pagination). Its ``total`` is the count of
+    # that same set, so no second aggregate is needed.
+    summary = summary_from_sql(session, ranked)
+    total = summary.total
+    if total == 0:
+        return _empty_response(request, includes, offset, limit)
 
-    # Load quality + created_at per visible id in one shot for sorting.
-    quality_rows = session.execute(
-        select(Calculation.id, Calculation.quality).where(
-            Calculation.id.in_(visible_ids)
-        )
-    ).all()
-    quality_by_id = {row.id: row.quality for row in quality_rows}
-
-    visible_ids.sort(
-        key=lambda cid: (
-            REVIEW_RANK[badges[cid].status],
-            _QUALITY_RANK[quality_by_id[cid]],
-            -created_at_by_id[cid].timestamp(),
-            -cid,
+    # ``id`` desc is the tiebreak that makes this a total order — without it
+    # two rows equal on rank, quality and created_at (every row inserted in
+    # one transaction shares ``created_at``) would page non-deterministically.
+    page_ids = list(
+        session.scalars(
+            select(ranked.c.id)
+            .order_by(
+                ranked.c.review_rank.asc(),
+                ranked.c.quality_rank.asc(),
+                ranked.c.created_at.desc(),
+                ranked.c.id.desc(),
+            )
+            .offset(offset)
+            .limit(limit)
         )
     )
 
-    total = len(visible_ids)
-    page_ids = visible_ids[offset : offset + limit]
+    # Badges for the page only — bounded by ``limit``, never by the match.
+    badges = fetch_review_badges(
+        session,
+        record_type=SubmissionRecordType.calculation,
+        record_ids=page_ids,
+    )
 
     # Materialize each page row via the shared record builder so search
     # records and detail records have identical shape.

--- a/backend/app/services/scientific_read/species.py
+++ b/backend/app/services/scientific_read/species.py
@@ -1,11 +1,29 @@
 """Service implementation for /api/v1/scientific/species/search.
 
 See docs/specs/read_api_mvp.md §Endpoint 1 for the contract.
+
+Where the work happens
+----------------------
+A species record is ranked by its *best visible entry*, so review
+visibility and ranking are properties of the ``species_entry`` set, not of
+``species``. Both are expressed in SQL (see
+:mod:`app.services.scientific_read.sql_review`) over one candidate-species
+subquery, and only the page is materialized: the per-entry badges,
+availability counts and ``include=`` section id lists are fetched for the
+species on the page, never for every match.
+
+The previous shape loaded every matching species, every one of their
+entries, and a review badge for each, before it could sort or slice. That
+is not just wasted work at catalog scale — the entry and badge loads render
+one bind parameter per id, and PostgreSQL's wire protocol caps a statement
+at 65,535 parameters, so a broad enough identifier match returned ``503
+database_unavailable`` instead of a page. ``backend/docs/benchmarks/README.md``
+has the measurement.
 """
 
 from __future__ import annotations
 
-from sqlalchemy import Text, func, select
+from sqlalchemy import Text, and_, case, func, select
 from sqlalchemy.orm import Session
 
 from app.api.error_contract import reject_unsupported_filters
@@ -39,7 +57,6 @@ from app.services.scientific_read.common import (
     fetch_review_badges,
     reject_client_sort,
     review_summary,
-    slice_for_pagination,
     validate_includes,
     validate_pagination,
     visible_statuses,
@@ -51,6 +68,13 @@ from app.services.scientific_read.handles import (
 )
 from app.services.scientific_read.internal_ids import (
     filter_internal_ids_from_resolved,
+)
+from app.services.scientific_read.sql_review import (
+    join_review,
+    review_rank_expr,
+    review_status_expr,
+    summary_from_sql,
+    visible_review_filter,
 )
 
 _LEGAL_INCLUDE_TOKENS: set[str] = {
@@ -65,6 +89,11 @@ _LEGAL_INCLUDE_TOKENS: set[str] = {
 _INTERNAL_INCLUDE_TOKENS: set[str] = {"internal_ids"}
 
 _DEFAULT_SORT_ECHO = "review_rank,has_entries,created_at,id"
+
+#: The rank a species with no *visible* entry sorts at. Deliberately worse
+#: than every real review rank, so "has entries the caller may see" beats
+#: "has none" without needing a second sort key ahead of it.
+_NO_VISIBLE_ENTRY_RANK = max(REVIEW_RANK.values()) + 1
 
 
 def search_species(
@@ -133,141 +162,65 @@ def search_species(
             "formula, species_ref, species_entry_ref} is required."
         )
 
-    species_rows = _query_matching_species(
-        session,
-        request,
-        species_ref_id=species_ref_id,
-        species_entry_ref_id=species_entry_ref_id,
-    )
-    if not species_rows:
-        return _empty_response(request, includes, offset, limit)
-
-    species_id_to_entries = _query_filtered_entries(
-        session,
-        species_rows,
-        request,
-        species_entry_ref_id=species_entry_ref_id,
-    )
-
-    # Bulk badge fetch across all surviving entries.
-    all_entry_ids = [
-        entry.id
-        for entries in species_id_to_entries.values()
-        for entry in entries
-    ]
-    badges = fetch_review_badges(
-        session,
-        record_type=SubmissionRecordType.species_entry,
-        record_ids=all_entry_ids,
-    )
-
     visible = visible_statuses(
         min_review_status=request.min_review_status,
         include_rejected=request.include_rejected,
         include_deprecated=request.include_deprecated,
     )
 
-    # Apply review-status filter to entries; species drops out only if it has
-    # no surviving entries OR if min_review_status is set and no entry passes.
-    filtered_entries_per_species: dict[int, list[SpeciesEntry]] = {}
-    for species_id, entries in species_id_to_entries.items():
-        survivors = [e for e in entries if badges[e.id].status in visible]
-        if request.min_review_status is None and not survivors:
-            # No entries survived the default visibility filter — drop species
-            # only if min_review_status was unspecified and no entries exist.
-            # We still keep the species if it has entries (for has_entries=False).
-            survivors = []
-        filtered_entries_per_species[species_id] = survivors
+    # The identity filter, as a subquery rather than a materialized id list —
+    # the entry, count and ranking queries below all re-derive it in SQL, so
+    # a match of any size stays a match rather than becoming bind parameters.
+    candidates = _candidate_species_stmt(
+        request,
+        species_ref_id=species_ref_id,
+        species_entry_ref_id=species_entry_ref_id,
+    ).subquery("candidate_species")
 
-    # Drop species whose every entry was filtered out by min_review_status.
-    if request.min_review_status is not None:
-        filtered_entries_per_species = {
-            sid: entries
-            for sid, entries in filtered_entries_per_species.items()
-            if entries
-        }
+    # Pre-collapse total is the number of *species* matched, whether or not
+    # any of their entries survived the trust gate: a species with none is
+    # still a record, with an empty ``entries`` list.
+    pre_collapse_total = (
+        session.scalar(select(func.count()).select_from(candidates)) or 0
+    )
+    if pre_collapse_total == 0:
+        return _empty_response(request, includes, offset, limit)
 
-    # Build per-record availability counts and section payloads.
-    availability_per_entry = _compute_availability(
+    # Pre-collapse review summary across every surviving entry, not just the
+    # page's — one aggregate rather than one badge per candidate.
+    summary = summary_from_sql(
         session,
-        [e for entries in filtered_entries_per_species.values() for e in entries],
+        _visible_entry_rows(
+            candidates,
+            request,
+            visible,
+            species_entry_ref_id=species_entry_ref_id,
+        ),
     )
 
-    # Section ID payloads when include flags are set.
-    section_ids = _compute_section_ids(
-        session,
-        [e for entries in filtered_entries_per_species.values() for e in entries],
-        includes,
-    )
-
-    # Build response records.
-    records: list[SpeciesScientificRecord] = []
-    for species in species_rows:
-        entries = filtered_entries_per_species.get(species.id, [])
-        entry_records = [
-            _build_entry_record(entry, badges[entry.id], availability_per_entry[entry.id], section_ids.get(entry.id, {}))
-            for entry in entries
-        ]
-        records.append(
-            SpeciesScientificRecord(
-                species_id=species.id,
-                species_ref=species.public_ref,
-                canonical_smiles=species.smiles,
-                inchi_key=species.inchi_key,
-                formula=None,  # not stored on Species; future addition
-                charge=species.charge,
-                multiplicity=species.multiplicity,
-                entries=entry_records,
-            )
-        )
-
-    # Pre-collapse review summary across all surviving entries.
-    summary = review_summary(
-        badges[entry.id]
-        for entries in filtered_entries_per_species.values()
-        for entry in entries
-    )
-
-    # Sort: review_rank ASC (best entry's rank), has_entries DESC, created_at DESC, id DESC
-    def sort_key(rec: SpeciesScientificRecord) -> tuple:
-        if rec.entries:
-            best_rank = min(REVIEW_RANK[e.review.status] for e in rec.entries)
-            has_entries = 1
-        else:
-            best_rank = max(REVIEW_RANK.values()) + 1
-            has_entries = 0
-        return (best_rank, -has_entries, _negate_id(rec.species_id))
-
-    # Sort with created_at DESC handled separately by retrieving created_at.
-    species_created_at = {sp.id: sp.created_at for sp in species_rows}
-
-    def full_sort_key(rec: SpeciesScientificRecord) -> tuple:
-        if rec.entries:
-            best_rank = min(REVIEW_RANK[e.review.status] for e in rec.entries)
-            has_entries_int = 1
-        else:
-            best_rank = max(REVIEW_RANK.values()) + 1
-            has_entries_int = 0
-        # Negate descending fields by negation; for datetime, sort ascending
-        # by negated timestamp via tuple inversion.
-        created_at = species_created_at[rec.species_id]
-        return (
-            best_rank,
-            -has_entries_int,
-            -created_at.timestamp(),
-            -rec.species_id,
-        )
-
-    records.sort(key=full_sort_key)
-
-    pre_collapse_total = len(records)
     collapse_first = request.collapse.value == "first"
+    page_species_ids = _rank_and_slice_species(
+        session,
+        candidates,
+        request,
+        visible,
+        species_entry_ref_id=species_entry_ref_id,
+        offset=0 if collapse_first else offset,
+        limit=1 if collapse_first else limit,
+    )
+    if collapse_first:
+        # ``collapse=first`` keeps the single best record and *then* applies
+        # offset/limit to that one-element list, so any offset past it is
+        # an empty page. Mirrored here rather than folded into the SQL.
+        page_species_ids = page_species_ids[offset : offset + limit]
 
-    returned_records = slice_for_pagination(
-        records,
-        offset=offset,
-        limit=limit,
-        collapse_first=collapse_first,
+    returned_records = _build_page_records(
+        session,
+        page_species_ids,
+        request,
+        visible,
+        species_entry_ref_id=species_entry_ref_id,
+        includes=includes,
     )
 
     pagination = build_pagination(
@@ -297,18 +250,19 @@ def search_species(
 # ---------------------------------------------------------------------------
 
 
-def _negate_id(value: int) -> int:
-    return -value
-
-
-def _query_matching_species(
-    session: Session,
+def _candidate_species_stmt(
     request: SpeciesSearchRequest,
     *,
     species_ref_id: int | None = None,
     species_entry_ref_id: int | None = None,
-) -> list[Species]:
-    stmt = select(Species)
+):
+    """The identity filter as a ``SELECT id, created_at`` over ``species``.
+
+    Returns a statement, not rows: it is used as a subquery by the count,
+    the summary and the ranking, so the caller never holds the matching id
+    set in Python.
+    """
+    stmt = select(Species.id, Species.created_at)
     if request.smiles is not None:
         stmt = stmt.where(Species.smiles == request.smiles)
     if request.inchi_key is not None:
@@ -343,30 +297,268 @@ def _query_matching_species(
         # surrounding whitespace from client input.
         formula_expr = func.mol_formula(func.mol_from_smiles(Species.smiles)).cast(Text)
         stmt = stmt.where(formula_expr == request.formula.strip())
-    return session.scalars(stmt).all()
+    return stmt
 
 
-def _query_filtered_entries(
-    session: Session,
-    species_rows: list[Species],
+def _entry_filter_predicates(
+    request: SpeciesSearchRequest, species_entry_ref_id: int | None
+) -> list:
+    """The per-entry ``where`` terms, in one place for all three uses."""
+    predicates = []
+    if request.electronic_state_kind is not None:
+        predicates.append(
+            SpeciesEntry.electronic_state_kind == request.electronic_state_kind
+        )
+    if request.species_entry_kind is not None:
+        predicates.append(SpeciesEntry.kind == request.species_entry_kind)
+    if species_entry_ref_id is not None:
+        predicates.append(SpeciesEntry.id == species_entry_ref_id)
+    return predicates
+
+
+def _join_entries_and_reviews(
+    stmt,
+    candidates,
     request: SpeciesSearchRequest,
     *,
-    species_entry_ref_id: int | None = None,
-) -> dict[int, list[SpeciesEntry]]:
-    species_ids = [sp.id for sp in species_rows]
-    stmt = select(SpeciesEntry).where(SpeciesEntry.species_id.in_(species_ids))
-    if request.electronic_state_kind is not None:
-        stmt = stmt.where(SpeciesEntry.electronic_state_kind == request.electronic_state_kind)
-    if request.species_entry_kind is not None:
-        stmt = stmt.where(SpeciesEntry.kind == request.species_entry_kind)
-    if species_entry_ref_id is not None:
-        stmt = stmt.where(SpeciesEntry.id == species_entry_ref_id)
+    species_entry_ref_id: int | None,
+    outer: bool,
+):
+    """Join candidate species → their entries → each entry's review row.
 
-    entries = session.scalars(stmt).all()
-    grouped: dict[int, list[SpeciesEntry]] = {sid: [] for sid in species_ids}
+    The chain is deliberately **flat**: ``species`` joined to
+    ``species_entry`` joined to ``record_review``, with the per-entry filters
+    as join conditions, rather than a pre-filtered entry *subquery* joined to
+    the species set.
+
+    That is not a cosmetic preference. With the entry filters and the review
+    LEFT JOIN wrapped in a subquery, the planner is free to compile
+    ``species_entry.species_id = species.id`` into a join *filter* rather
+    than an index condition — the review outer join and its ``status IS
+    NULL`` branch block the pushdown — and then the inner side is re-scanned
+    in full once per candidate species. That plan was observed on a
+    statistics-free database (65,599 candidate species: over 15 minutes,
+    ``Join Filter: (species_entry.species_id = species.id)`` above a
+    full ``ix_species_entry_species_id`` scan). Keeping the chain flat leaves
+    the join key on a plain indexed column where the planner can reach it.
+
+    Statistics still matter more than shape — no formulation of this query
+    survives a table that has tens of thousands of rows and no ``ANALYZE``.
+    What the flat chain buys unconditionally is that the identity predicate
+    is evaluated once per statement instead of twice, which is what the
+    RDKit-backed ``formula=`` filter cares about: on the Stage 4 benchmark
+    corpus the broad formula search is 21.7 ms flat against 28.3 ms wrapped.
+
+    :param outer: ``True`` keeps species with no matching entry (the ranking
+        needs them — they are still records); ``False`` drops them (the
+        summary counts entries, not species).
+    :returns: ``(statement, review_alias)``.
+    """
+    entry_on = and_(
+        SpeciesEntry.species_id == candidates.c.id,
+        *_entry_filter_predicates(request, species_entry_ref_id),
+    )
+    from_clause = (
+        candidates.outerjoin(SpeciesEntry, entry_on)
+        if outer
+        else candidates.join(SpeciesEntry, entry_on)
+    )
+    return join_review(
+        stmt.select_from(from_clause),
+        SpeciesEntry.id,
+        SubmissionRecordType.species_entry,
+    )
+
+
+def _rank_and_slice_species(
+    session: Session,
+    candidates,
+    request: SpeciesSearchRequest,
+    visible: set,
+    *,
+    species_entry_ref_id: int | None,
+    offset: int,
+    limit: int,
+) -> list[int]:
+    """Order the candidate species and return one page of ids.
+
+    ``review_rank ASC, has_entries DESC, created_at DESC, id DESC``, where
+    ``review_rank`` is the best rank among a species' *visible* entries and
+    :data:`_NO_VISIBLE_ENTRY_RANK` when it has none.
+
+    Visibility is a ``CASE`` inside the aggregate rather than a ``WHERE``.
+    A ``WHERE`` would drop species whose every entry is invisible, and those
+    species are still records — with an empty ``entries`` list. ``MIN``
+    ignores NULLs, so an invisible entry contributes nothing and a species
+    with no visible entry aggregates to NULL, which the ``COALESCE`` turns
+    into the sorts-last rank.
+
+    The ``SpeciesEntry.id IS NOT NULL`` guard is load-bearing: without it the
+    outer join's all-NULL row for an entry-less species would satisfy the
+    "no review row means not_reviewed" branch of the visibility predicate and
+    the species would rank as if it had a never-reviewed entry.
+
+    ``id`` desc is the tiebreak that makes this a total order; without it,
+    species sharing a ``created_at`` (every row inserted in one transaction
+    does) would page non-deterministically.
+    """
+    stmt, review = _join_entries_and_reviews(
+        select(candidates.c.id),
+        candidates,
+        request,
+        species_entry_ref_id=species_entry_ref_id,
+        outer=True,
+    )
+    visible_rank = case(
+        (
+            and_(
+                SpeciesEntry.id.is_not(None),
+                visible_review_filter(review, visible),
+            ),
+            review_rank_expr(review),
+        ),
+        else_=None,
+    )
+    best_rank = func.coalesce(func.min(visible_rank), _NO_VISIBLE_ENTRY_RANK)
+    has_entries = func.count(visible_rank) > 0
+    stmt = (
+        stmt.group_by(candidates.c.id, candidates.c.created_at)
+        .order_by(
+            best_rank.asc(),
+            has_entries.desc(),
+            candidates.c.created_at.desc(),
+            candidates.c.id.desc(),
+        )
+        .offset(offset)
+        .limit(limit)
+    )
+    return list(session.scalars(stmt))
+
+
+def _visible_entry_rows(
+    candidates,
+    request: SpeciesSearchRequest,
+    visible: set,
+    *,
+    species_entry_ref_id: int | None,
+):
+    """Subquery of every visible entry of every candidate species.
+
+    Feeds the pre-pagination :func:`summary_from_sql` aggregate. Referenced
+    exactly once, so PostgreSQL inlines it into the aggregate rather than
+    treating it as an optimization fence.
+    """
+    stmt, review = _join_entries_and_reviews(
+        select(SpeciesEntry.id),
+        candidates,
+        request,
+        species_entry_ref_id=species_entry_ref_id,
+        outer=False,
+    )
+    return (
+        stmt.add_columns(review_status_expr(review).label("review_status"))
+        .where(visible_review_filter(review, visible))
+        .subquery("visible_entries")
+    )
+
+
+def _load_page_entries(
+    session: Session,
+    page_species_ids: list[int],
+    request: SpeciesSearchRequest,
+    visible: set,
+    *,
+    species_entry_ref_id: int | None,
+) -> list[SpeciesEntry]:
+    """The visible entries of the page's species, in a stable order.
+
+    Scoped by the page's species ids — at most ``limit`` of them — so this is
+    the one place an ``IN`` list of ids is safe.
+    """
+    stmt = select(SpeciesEntry).where(
+        SpeciesEntry.species_id.in_(page_species_ids),
+        *_entry_filter_predicates(request, species_entry_ref_id),
+    )
+    stmt, review = join_review(
+        stmt, SpeciesEntry.id, SubmissionRecordType.species_entry
+    )
+    return list(
+        session.scalars(
+            stmt.where(visible_review_filter(review, visible)).order_by(
+                SpeciesEntry.id
+            )
+        )
+    )
+
+
+def _build_page_records(
+    session: Session,
+    page_species_ids: list[int],
+    request: SpeciesSearchRequest,
+    visible: set,
+    *,
+    species_entry_ref_id: int | None,
+    includes: set[str],
+) -> list[SpeciesScientificRecord]:
+    """Materialize one page: species, their visible entries, and the extras.
+
+    Every load below is bounded by the page — at most ``limit`` species and
+    their entries — which is the whole point of ranking in SQL first.
+    """
+    if not page_species_ids:
+        return []
+
+    species_by_id = {
+        species.id: species
+        for species in session.scalars(
+            select(Species).where(Species.id.in_(page_species_ids))
+        )
+    }
+    entries = _load_page_entries(
+        session,
+        page_species_ids,
+        request,
+        visible,
+        species_entry_ref_id=species_entry_ref_id,
+    )
+    entries_by_species: dict[int, list[SpeciesEntry]] = {
+        species_id: [] for species_id in page_species_ids
+    }
     for entry in entries:
-        grouped[entry.species_id].append(entry)
-    return grouped
+        entries_by_species[entry.species_id].append(entry)
+
+    badges = fetch_review_badges(
+        session,
+        record_type=SubmissionRecordType.species_entry,
+        record_ids=[entry.id for entry in entries],
+    )
+    availability_per_entry = _compute_availability(session, entries)
+    section_ids = _compute_section_ids(session, entries, includes)
+
+    records: list[SpeciesScientificRecord] = []
+    for species_id in page_species_ids:
+        species = species_by_id[species_id]
+        records.append(
+            SpeciesScientificRecord(
+                species_id=species.id,
+                species_ref=species.public_ref,
+                canonical_smiles=species.smiles,
+                inchi_key=species.inchi_key,
+                formula=None,  # not stored on Species; future addition
+                charge=species.charge,
+                multiplicity=species.multiplicity,
+                entries=[
+                    _build_entry_record(
+                        entry,
+                        badges[entry.id],
+                        availability_per_entry[entry.id],
+                        section_ids.get(entry.id, {}),
+                    )
+                    for entry in entries_by_species[species_id]
+                ],
+            )
+        )
+    return records
 
 
 def _compute_availability(

--- a/backend/app/services/scientific_read/sql_review.py
+++ b/backend/app/services/scientific_read/sql_review.py
@@ -37,12 +37,12 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
-from sqlalchemy import Select, and_, case, func, literal, or_
-from sqlalchemy.orm import aliased
+from sqlalchemy import Select, and_, case, func, literal, or_, select
+from sqlalchemy.orm import Session, aliased
 
 from app.db.models.common import RecordReviewStatus, SubmissionRecordType
 from app.db.models.record_review import RecordReview
-from app.schemas.reads.scientific_common import REVIEW_RANK
+from app.schemas.reads.scientific_common import REVIEW_RANK, ReviewStatusSummary
 
 #: Rank used for a record with no ``record_review`` row at all. It must agree
 #: with how the Python path treats a missing row — as ``not_reviewed`` — or a
@@ -130,10 +130,50 @@ def visible_review_filter(review, visible: Iterable[RecordReviewStatus]):
     return predicate
 
 
+def status_from_sql(value: Any) -> RecordReviewStatus:
+    """Coerce a SQL-side review status back to the enum.
+
+    ``review_status_expr`` may come back as the enum (psycopg resolves the
+    PostgreSQL enum) or as its string value, depending on whether the
+    ``COALESCE`` fell through to the literal. Callers want one type.
+    """
+    if isinstance(value, RecordReviewStatus):
+        return value
+    return RecordReviewStatus(str(value))
+
+
+def summary_from_sql(session: Session, ranked) -> ReviewStatusSummary:
+    """Count review statuses over the *whole* filtered set in one aggregate.
+
+    ``ranked`` is a subquery carrying a ``review_status`` column — normally
+    the one :func:`review_status_expr` produced.
+
+    The summary describes everything the filters matched, not the page, so it
+    cannot be derived from the page rows — and materializing the candidate set
+    to count it would give back exactly the property this module exists to
+    remove. ``total`` is the count of the filtered set, so a caller that needs
+    both can take it from here rather than issuing a second aggregate.
+    """
+    rows = session.execute(
+        select(ranked.c.review_status, func.count())
+        .select_from(ranked)
+        .group_by(ranked.c.review_status)
+    ).all()
+    summary = ReviewStatusSummary()
+    for status, count in rows:
+        key = status.value if hasattr(status, "value") else str(status)
+        if hasattr(summary, key):
+            setattr(summary, key, getattr(summary, key) + count)
+        summary.total += count
+    return summary
+
+
 __all__ = [
     "join_review",
     "review_alias",
     "review_rank_expr",
     "review_status_expr",
+    "status_from_sql",
+    "summary_from_sql",
     "visible_review_filter",
 ]

--- a/backend/tests/services/scientific_read/test_sql_review_search_paths.py
+++ b/backend/tests/services/scientific_read/test_sql_review_search_paths.py
@@ -11,7 +11,7 @@ whose candidate set crosses that boundary does not merely slow down: psycopg
 refuses to send the statement and the API answers ``503
 database_unavailable``. :func:`test_bind_parameter_cap_is_the_wire_protocol_limit`
 pins that boundary as a measured fact rather than a remembered constant, and
-the ``…_above_the_bind_parameter_cap`` test drives the search past it.
+the two ``…_above_the_bind_parameter_cap`` tests drive each search past it.
 
 **Equivalence.** Moving the filter into SQL is easy to get subtly wrong in
 ways no small fixture notices — an inner join silently drops every record
@@ -26,6 +26,7 @@ records, not merely the set.
 from __future__ import annotations
 
 import itertools
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 import pytest
@@ -37,12 +38,15 @@ from app.db.models.common import (
     CalculationQuality,
     CalculationType,
     RecordReviewStatus,
+    SpeciesEntryStateKind,
     SubmissionRecordType,
 )
+from app.db.models.species import Species, SpeciesEntry
 from app.schemas.reads.scientific_calculation_search import (
     CalculationsSearchRequest,
 )
 from app.schemas.reads.scientific_common import REVIEW_RANK
+from app.schemas.reads.scientific_species import SpeciesSearchRequest
 from app.services.scientific_read.calculations_search import (
     _QUALITY_RANK,
     search_calculations,
@@ -51,11 +55,13 @@ from app.services.scientific_read.common import (
     fetch_review_badges,
     visible_statuses,
 )
+from app.services.scientific_read.species import search_species
 from tests.services.scientific_read._factories import (
     make_calculation,
     make_lot,
     make_species,
     make_species_entry,
+    next_inchi_key,
     set_review,
 )
 
@@ -72,6 +78,9 @@ MAX_BADGE_IDS = MAX_BIND_PARAMETERS - 1
 #: below insert this many rows per search path.
 OVER_CAP = MAX_BADGE_IDS + 65
 
+#: The rank a record with no visible entry sorts at in ``search_species``.
+_NO_ENTRY_RANK = max(REVIEW_RANK.values()) + 1
+
 #: Every review flavour a record can be in, including "no ``record_review``
 #: row at all" — the one an inner join would drop.
 _REVIEW_FLAVOURS: tuple[RecordReviewStatus | None, ...] = (
@@ -83,7 +92,7 @@ _REVIEW_FLAVOURS: tuple[RecordReviewStatus | None, ...] = (
     None,
 )
 
-#: The trust knobs the endpoint exposes, as a full cross product. The
+#: The trust knobs the two endpoints expose, as a full cross product. The
 #: sort is server-fixed (client ``sort=`` is rejected), so the axes that can
 #: change which records come back, and in what order, are exactly these.
 _TRUST_COMBINATIONS = tuple(
@@ -177,6 +186,44 @@ def test_calculations_search_above_the_bind_parameter_cap(db_session):
     assert response.review_summary.total == len(expected)
 
 
+def test_species_search_above_the_bind_parameter_cap(db_session):
+    """A species search matching more candidates than the cap must work.
+
+    ``inchi_key`` is not unique on ``species`` (only ``(smiles, charge,
+    multiplicity)`` is), so one key legitimately fans out across many
+    species rows — protomers, tautomer assignments, isotopologue parents.
+    """
+    inchi_key = next_inchi_key("CAPSPC")
+    _bulk_insert_species_with_entries(
+        db_session, inchi_key=inchi_key, count=OVER_CAP
+    )
+
+    response = search_species(
+        db_session, SpeciesSearchRequest(inchi_key=inchi_key, limit=50)
+    )
+
+    expected = _reference_species_order(
+        db_session,
+        inchi_key=inchi_key,
+        visible=visible_statuses(
+            min_review_status=None,
+            include_rejected=False,
+            include_deprecated=False,
+        ),
+    )
+    assert response.pagination.total == len(expected) == OVER_CAP
+    assert [r.species_id for r in response.records] == expected[:50]
+    assert response.review_summary.not_reviewed == OVER_CAP
+    # Every species still carries its entry — an inner join would have
+    # returned the species with an empty ``entries`` list instead.
+    assert all(len(r.entries) == 1 for r in response.records)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence with the Python semantics being replaced
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.parametrize(
     ("min_review_status", "include_rejected", "include_deprecated"),
     _TRUST_COMBINATIONS,
@@ -214,6 +261,38 @@ def test_calculations_search_equals_python_reference(
     assert response.review_summary.total == len(expected)
 
 
+@pytest.mark.parametrize(
+    ("min_review_status", "include_rejected", "include_deprecated"),
+    _TRUST_COMBINATIONS,
+)
+def test_species_search_equals_python_reference(
+    db_session, min_review_status, include_rejected, include_deprecated
+):
+    inchi_key = _mixed_species_corpus(db_session)
+    visible = visible_statuses(
+        min_review_status=min_review_status,
+        include_rejected=include_rejected,
+        include_deprecated=include_deprecated,
+    )
+    expected = _reference_species_order(
+        db_session, inchi_key=inchi_key, visible=visible
+    )
+
+    response = search_species(
+        db_session,
+        SpeciesSearchRequest(
+            inchi_key=inchi_key,
+            min_review_status=min_review_status,
+            include_rejected=include_rejected,
+            include_deprecated=include_deprecated,
+            limit=100,
+        ),
+    )
+
+    assert [r.species_id for r in response.records] == expected
+    assert response.pagination.total == len(expected)
+
+
 @pytest.mark.parametrize("offset", [0, 1, 3, 7, 100])
 def test_calculations_search_paginates_the_same_ordering(db_session, offset):
     lot = _mixed_calculation_corpus(db_session)
@@ -241,6 +320,36 @@ def test_calculations_search_paginates_the_same_ordering(db_session, offset):
     )
 
     assert [r.calculation.calculation_id for r in response.records] == expected[
+        offset : offset + 4
+    ]
+    assert response.pagination.total == len(expected)
+
+
+@pytest.mark.parametrize("offset", [0, 1, 3, 7, 100])
+def test_species_search_paginates_the_same_ordering(db_session, offset):
+    inchi_key = _mixed_species_corpus(db_session)
+    expected = _reference_species_order(
+        db_session,
+        inchi_key=inchi_key,
+        visible=visible_statuses(
+            min_review_status=None,
+            include_rejected=True,
+            include_deprecated=True,
+        ),
+    )
+
+    response = search_species(
+        db_session,
+        SpeciesSearchRequest(
+            inchi_key=inchi_key,
+            include_rejected=True,
+            include_deprecated=True,
+            offset=offset,
+            limit=4,
+        ),
+    )
+
+    assert [r.species_id for r in response.records] == expected[
         offset : offset + 4
     ]
     assert response.pagination.total == len(expected)
@@ -310,6 +419,45 @@ def test_calculations_with_no_review_row_are_kept_and_ranked_not_reviewed(
     )
 
 
+def test_species_with_no_review_row_are_kept_and_ranked_not_reviewed(
+    db_session,
+):
+    inchi_key = next_inchi_key("NOJOIN")
+    approved_sp = make_species(db_session, smiles="[CH4:3]", inchi_key=inchi_key)
+    approved_entry = make_species_entry(db_session, approved_sp)
+    set_review(
+        db_session,
+        record_type=SubmissionRecordType.species_entry,
+        record_id=approved_entry.id,
+        status=RecordReviewStatus.approved,
+    )
+    no_row_sp = make_species(db_session, smiles="[CH4:4]", inchi_key=inchi_key)
+    no_row_entry = make_species_entry(db_session, no_row_sp)
+    entryless_sp = make_species(
+        db_session, smiles="[CH4:5]", inchi_key=inchi_key
+    )
+
+    response = search_species(
+        db_session, SpeciesSearchRequest(inchi_key=inchi_key)
+    )
+
+    assert [r.species_id for r in response.records] == [
+        approved_sp.id,
+        no_row_sp.id,
+        entryless_sp.id,  # no entries at all — sorts last, still returned
+    ]
+    assert [e.species_entry_id for e in response.records[1].entries] == [
+        no_row_entry.id
+    ]
+    assert (
+        response.records[1].entries[0].review.status
+        is RecordReviewStatus.not_reviewed
+    )
+    assert response.records[2].entries == []
+    assert response.review_summary.not_reviewed == 1
+    assert response.review_summary.approved == 1
+
+
 def test_calculations_search_tiebreak_is_id_descending(db_session):
     """Equal rank, equal quality, equal ``created_at`` — ``id`` decides.
 
@@ -374,6 +522,15 @@ def _badges_in_chunks(session, *, record_type: SubmissionRecordType, ids):
     return badges
 
 
+def _rows_in_chunks(session, stmt_for, ids):
+    """Run ``stmt_for(chunk)`` over ``ids`` in cap-safe chunks."""
+    ids = list(ids)
+    rows: list = []
+    for start in range(0, len(ids), 10_000):
+        rows.extend(session.execute(stmt_for(ids[start : start + 10_000])).all())
+    return rows
+
+
 def _reference_calculation_order(
     session,
     *,
@@ -415,6 +572,64 @@ def _reference_calculation_order(
     return [row.id for row in survivors]
 
 
+def _reference_species_order(
+    session, *, inchi_key: str, visible: set[RecordReviewStatus]
+) -> list[int]:
+    """Order species exactly as the Python path did.
+
+    A species is ranked by its *best visible* entry; one with no visible
+    entry keeps its place in the result and sorts after every species that
+    has one.
+    """
+    species_rows = session.execute(
+        select(Species.id, Species.created_at).where(
+            Species.inchi_key == inchi_key
+        )
+    ).all()
+    species_ids = [row.id for row in species_rows]
+    entry_rows = _rows_in_chunks(
+        session,
+        lambda chunk: select(
+            SpeciesEntry.id, SpeciesEntry.species_id
+        ).where(SpeciesEntry.species_id.in_(chunk)),
+        species_ids,
+    )
+    badges = _badges_in_chunks(
+        session,
+        record_type=SubmissionRecordType.species_entry,
+        ids=[row.id for row in entry_rows],
+    )
+
+    visible_entries: dict[int, list[int]] = defaultdict(list)
+    for row in entry_rows:
+        if badges[row.id].status in visible:
+            visible_entries[row.species_id].append(row.id)
+
+    keyed = []
+    for row in species_rows:
+        entries = visible_entries.get(row.id, [])
+        best_rank = min(
+            (REVIEW_RANK[badges[eid].status] for eid in entries),
+            default=_NO_ENTRY_RANK,
+        )
+        keyed.append(
+            (
+                best_rank,
+                -(1 if entries else 0),
+                -row.created_at.timestamp(),
+                -row.id,
+                row.id,
+            )
+        )
+    keyed.sort()
+    return [item[-1] for item in keyed]
+
+
+# ---------------------------------------------------------------------------
+# Corpus builders
+# ---------------------------------------------------------------------------
+
+
 def _mixed_calculation_corpus(session):
     """One ``sp`` calculation per (review flavour x quality), plus ties.
 
@@ -449,6 +664,62 @@ def _mixed_calculation_corpus(session):
                 status=flavour,
             )
     return lot
+
+
+def _mixed_species_corpus(session) -> str:
+    """Species sharing an InChIKey, one per (review flavour + entryless).
+
+    Includes species with two entries of different statuses, so the
+    "rank by best visible entry" rule is exercised rather than assumed.
+    """
+    inchi_key = next_inchi_key("MIXSPC")
+    base = datetime(2026, 3, 1, 12, 0, 0)
+    smiles_counter = itertools.count(100)
+
+    def _new_species(day_offset: int) -> Species:
+        species = make_species(
+            session,
+            smiles=f"[CH4:{next(smiles_counter)}]",
+            inchi_key=inchi_key,
+        )
+        species.created_at = base + timedelta(days=day_offset)
+        session.flush()
+        return species
+
+    for index, flavour in enumerate(_REVIEW_FLAVOURS):
+        species = _new_species(index % 3)
+        entry = make_species_entry(session, species)
+        if flavour is not None:
+            set_review(
+                session,
+                record_type=SubmissionRecordType.species_entry,
+                record_id=entry.id,
+                status=flavour,
+            )
+
+    # A species whose best entry is approved but which also carries a
+    # rejected one — the two must not be conflated.
+    pair = _new_species(1)
+    first = make_species_entry(session, pair)
+    second = make_species_entry(
+        session, pair, electronic_state_kind=SpeciesEntryStateKind.excited
+    )
+    set_review(
+        session,
+        record_type=SubmissionRecordType.species_entry,
+        record_id=first.id,
+        status=RecordReviewStatus.approved,
+    )
+    set_review(
+        session,
+        record_type=SubmissionRecordType.species_entry,
+        record_id=second.id,
+        status=RecordReviewStatus.rejected,
+    )
+
+    # A species with no entries at all.
+    _new_species(2)
+    return inchi_key
 
 
 def _analyze(session, *tables: str) -> None:
@@ -486,3 +757,29 @@ def _bulk_insert_calculations(session, *, species_entry_id: int, count: int):
     _analyze(session, "calculation", "record_review")
 
 
+def _bulk_insert_species_with_entries(session, *, inchi_key: str, count: int):
+    """Insert ``count`` species sharing ``inchi_key``, one entry each.
+
+    The SMILES are atom-mapped methanes: distinct (so ``uq_species_identity``
+    holds), and RDKit-parseable, so the ``mol_formula`` expression index on
+    ``species`` builds without emitting one warning per row.
+    """
+    session.execute(
+        text(
+            "INSERT INTO species "
+            "(kind, smiles, inchi_key, charge, multiplicity, stereo_kind) "
+            "SELECT 'molecule', '[CH4:' || (g + 1000000) || ']', :inchi_key, "
+            "0, 1, 'achiral' FROM generate_series(1, :count) g"
+        ),
+        {"inchi_key": inchi_key, "count": count},
+    )
+    session.execute(
+        text(
+            "INSERT INTO species_entry "
+            "(species_id, kind, electronic_state_kind) "
+            "SELECT id, 'minimum', 'ground' FROM species "
+            "WHERE inchi_key = :inchi_key"
+        ),
+        {"inchi_key": inchi_key},
+    )
+    _analyze(session, "species", "species_entry", "record_review")

--- a/backend/tests/services/scientific_read/test_sql_review_search_paths.py
+++ b/backend/tests/services/scientific_read/test_sql_review_search_paths.py
@@ -1,0 +1,488 @@
+"""Review visibility/ranking must be SQL-side on the two hot search paths.
+
+Two properties are tested here, and both are needed: one of them is a
+correctness bug and the other is what a wrong fix for it looks like.
+
+**The cap.** The Python path bulk-loads review badges with
+``RecordReview.record_id.in_(candidate_ids)``, which SQLAlchemy renders as
+one bind parameter per candidate. PostgreSQL's *wire protocol* — not any
+server setting — caps a single statement at 65,535 parameters, so a search
+whose candidate set crosses that boundary does not merely slow down: psycopg
+refuses to send the statement and the API answers ``503
+database_unavailable``. :func:`test_bind_parameter_cap_is_the_wire_protocol_limit`
+pins that boundary as a measured fact rather than a remembered constant, and
+the ``…_above_the_bind_parameter_cap`` test drives the search past it.
+
+**Equivalence.** Moving the filter into SQL is easy to get subtly wrong in
+ways no small fixture notices — an inner join silently drops every record
+with no ``record_review`` row (on this corpus, most of them), and a missing
+tiebreak makes the page order depend on the plan. So the same corpus is
+answered twice: once by the service and once by a reference implementation
+that reproduces the pre-SQL Python semantics directly, over every trust
+combination the endpoints expose. The two must agree on the *sequence* of
+records, not merely the set.
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import OperationalError
+
+from app.db.models.calculation import Calculation
+from app.db.models.common import (
+    CalculationQuality,
+    CalculationType,
+    RecordReviewStatus,
+    SubmissionRecordType,
+)
+from app.schemas.reads.scientific_calculation_search import (
+    CalculationsSearchRequest,
+)
+from app.schemas.reads.scientific_common import REVIEW_RANK
+from app.services.scientific_read.calculations_search import (
+    _QUALITY_RANK,
+    search_calculations,
+)
+from app.services.scientific_read.common import (
+    fetch_review_badges,
+    visible_statuses,
+)
+from tests.services.scientific_read._factories import (
+    make_calculation,
+    make_lot,
+    make_species,
+    make_species_entry,
+    set_review,
+)
+
+#: Measured in :func:`test_bind_parameter_cap_is_the_wire_protocol_limit`.
+#: The number of bind parameters PostgreSQL's extended-query protocol
+#: accepts in one statement.
+MAX_BIND_PARAMETERS = 65_535
+
+#: ``fetch_review_badges`` spends one parameter on ``record_type`` and one
+#: per candidate id, so this many candidates is the last set it can load.
+MAX_BADGE_IDS = MAX_BIND_PARAMETERS - 1
+
+#: Comfortably past the cap without being gratuitous — the corpus builders
+#: below insert this many rows per search path.
+OVER_CAP = MAX_BADGE_IDS + 65
+
+#: Every review flavour a record can be in, including "no ``record_review``
+#: row at all" — the one an inner join would drop.
+_REVIEW_FLAVOURS: tuple[RecordReviewStatus | None, ...] = (
+    RecordReviewStatus.approved,
+    RecordReviewStatus.under_review,
+    RecordReviewStatus.not_reviewed,
+    RecordReviewStatus.deprecated,
+    RecordReviewStatus.rejected,
+    None,
+)
+
+#: The trust knobs the endpoint exposes, as a full cross product. The
+#: sort is server-fixed (client ``sort=`` is rejected), so the axes that can
+#: change which records come back, and in what order, are exactly these.
+_TRUST_COMBINATIONS = tuple(
+    itertools.product(
+        (None, *_REVIEW_FLAVOURS[:5]),  # min_review_status
+        (False, True),  # include_rejected
+        (False, True),  # include_deprecated
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# The cap
+# ---------------------------------------------------------------------------
+
+
+def test_bind_parameter_cap_is_the_wire_protocol_limit(db_session):
+    """Establish the real boundary, and that it is the wire protocol's.
+
+    ``max_locks_per_transaction`` and friends are server settings that can be
+    raised; this one cannot. It is a 16-bit field in the Bind message, so no
+    amount of tuning moves it, which is why the fix has to be "do not send
+    the ids" rather than "send them differently".
+    """
+    # Not a server GUC — there is no setting to read, and asking for one is
+    # the mistake this assertion exists to rule out.
+    assert (
+        db_session.execute(
+            text(
+                "SELECT count(*) FROM pg_settings "
+                "WHERE name LIKE '%%parameter%%' AND setting = '65535'"
+            )
+        ).scalar()
+        == 0
+    )
+
+    # One parameter for ``record_type`` plus one per id: the last size that
+    # fits exactly fills the message.
+    badges = fetch_review_badges(
+        db_session,
+        record_type=SubmissionRecordType.calculation,
+        record_ids=range(1, MAX_BADGE_IDS + 1),
+    )
+    assert len(badges) == MAX_BADGE_IDS
+
+    with pytest.raises(OperationalError) as excinfo:
+        fetch_review_badges(
+            db_session,
+            record_type=SubmissionRecordType.calculation,
+            record_ids=range(1, MAX_BADGE_IDS + 2),
+        )
+    assert "number of parameters must be between 0 and 65535" in str(
+        excinfo.value
+    )
+
+
+def test_calculations_search_above_the_bind_parameter_cap(db_session):
+    """A calculation search matching more candidates than the cap must work.
+
+    ``calculation_type=sp`` matches 119,701 rows on the Stage 4 benchmark
+    corpus. Whatever the page size, the candidate set must never become bind
+    parameters.
+    """
+    species_entry = make_species_entry(
+        db_session, make_species(db_session, smiles="[CH4:1]")
+    )
+    _bulk_insert_calculations(
+        db_session, species_entry_id=species_entry.id, count=OVER_CAP
+    )
+
+    response = search_calculations(
+        db_session,
+        CalculationsSearchRequest(
+            calculation_type=CalculationType.sp, limit=50
+        ),
+    )
+
+    expected = _reference_calculation_order(
+        db_session,
+        calculation_type=CalculationType.sp,
+        visible=visible_statuses(
+            min_review_status=None,
+            include_rejected=False,
+            include_deprecated=False,
+        ),
+    )
+    assert response.pagination.total == len(expected) >= OVER_CAP
+    assert [r.calculation.calculation_id for r in response.records] == expected[:50]
+    # Nothing is reviewed, and nothing was dropped for lacking a review row.
+    assert response.review_summary.not_reviewed == len(expected)
+    assert response.review_summary.total == len(expected)
+
+
+@pytest.mark.parametrize(
+    ("min_review_status", "include_rejected", "include_deprecated"),
+    _TRUST_COMBINATIONS,
+)
+def test_calculations_search_equals_python_reference(
+    db_session, min_review_status, include_rejected, include_deprecated
+):
+    lot = _mixed_calculation_corpus(db_session)
+    visible = visible_statuses(
+        min_review_status=min_review_status,
+        include_rejected=include_rejected,
+        include_deprecated=include_deprecated,
+    )
+    expected = _reference_calculation_order(
+        db_session,
+        calculation_type=CalculationType.sp,
+        visible=visible,
+        method=lot.method,
+    )
+
+    response = search_calculations(
+        db_session,
+        CalculationsSearchRequest(
+            calculation_type=CalculationType.sp,
+            method=lot.method,
+            min_review_status=min_review_status,
+            include_rejected=include_rejected,
+            include_deprecated=include_deprecated,
+            limit=100,
+        ),
+    )
+
+    assert [r.calculation.calculation_id for r in response.records] == expected
+    assert response.pagination.total == len(expected)
+    assert response.review_summary.total == len(expected)
+
+
+@pytest.mark.parametrize("offset", [0, 1, 3, 7, 100])
+def test_calculations_search_paginates_the_same_ordering(db_session, offset):
+    lot = _mixed_calculation_corpus(db_session)
+    expected = _reference_calculation_order(
+        db_session,
+        calculation_type=CalculationType.sp,
+        visible=visible_statuses(
+            min_review_status=None,
+            include_rejected=True,
+            include_deprecated=True,
+        ),
+        method=lot.method,
+    )
+
+    response = search_calculations(
+        db_session,
+        CalculationsSearchRequest(
+            calculation_type=CalculationType.sp,
+            method=lot.method,
+            include_rejected=True,
+            include_deprecated=True,
+            offset=offset,
+            limit=4,
+        ),
+    )
+
+    assert [r.calculation.calculation_id for r in response.records] == expected[
+        offset : offset + 4
+    ]
+    assert response.pagination.total == len(expected)
+
+
+def test_calculations_with_no_review_row_are_kept_and_ranked_not_reviewed(
+    db_session,
+):
+    """The inner-join trap, stated as its own assertion.
+
+    A record with no ``record_review`` row is ``not_reviewed``: visible by
+    default, ranked between ``under_review`` and ``deprecated``, and counted
+    in the summary. It must not disappear, and it must not sort last.
+    """
+    lot = make_lot(db_session, method="sqlreview-nojoin", basis="def2tzvp")
+    entry = make_species_entry(
+        db_session, make_species(db_session, smiles="[CH4:2]")
+    )
+    approved = make_calculation(
+        db_session,
+        type=CalculationType.sp,
+        species_entry_id=entry.id,
+        lot_id=lot.id,
+    )
+    set_review(
+        db_session,
+        record_type=SubmissionRecordType.calculation,
+        record_id=approved.id,
+        status=RecordReviewStatus.approved,
+    )
+    no_row = make_calculation(
+        db_session,
+        type=CalculationType.sp,
+        species_entry_id=entry.id,
+        lot_id=lot.id,
+    )
+    deprecated = make_calculation(
+        db_session,
+        type=CalculationType.sp,
+        species_entry_id=entry.id,
+        lot_id=lot.id,
+    )
+    set_review(
+        db_session,
+        record_type=SubmissionRecordType.calculation,
+        record_id=deprecated.id,
+        status=RecordReviewStatus.deprecated,
+    )
+
+    response = search_calculations(
+        db_session,
+        CalculationsSearchRequest(
+            calculation_type=CalculationType.sp,
+            method=lot.method,
+            include_deprecated=True,
+        ),
+    )
+
+    assert [r.calculation.calculation_id for r in response.records] == [
+        approved.id,
+        no_row.id,
+        deprecated.id,
+    ]
+    assert response.review_summary.not_reviewed == 1
+    assert (
+        response.records[1].calculation.review.status is RecordReviewStatus.not_reviewed
+    )
+
+
+def test_calculations_search_tiebreak_is_id_descending(db_session):
+    """Equal rank, equal quality, equal ``created_at`` — ``id`` decides.
+
+    Every row inserted in one transaction shares ``now()``, so this is the
+    common case rather than a contrived one, and it is the axis a SQL
+    ``ORDER BY`` will silently leave to the plan if the tiebreak is dropped.
+    """
+    lot = make_lot(db_session, method="sqlreview-tiebreak", basis="def2tzvp")
+    entry = make_species_entry(
+        db_session, make_species(db_session, smiles="[CH4:6]")
+    )
+    ids = [
+        make_calculation(
+            db_session,
+            type=CalculationType.sp,
+            species_entry_id=entry.id,
+            lot_id=lot.id,
+        ).id
+        for _ in range(6)
+    ]
+    created = db_session.scalars(
+        select(Calculation.created_at).where(Calculation.id.in_(ids))
+    ).all()
+    assert len(set(created)) == 1, "fixture must produce a genuine tie"
+
+    response = search_calculations(
+        db_session,
+        CalculationsSearchRequest(
+            calculation_type=CalculationType.sp, method=lot.method
+        ),
+    )
+
+    assert [r.calculation.calculation_id for r in response.records] == sorted(
+        ids, reverse=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reference implementations — the Python semantics being replaced
+# ---------------------------------------------------------------------------
+
+
+def _badges_in_chunks(session, *, record_type: SubmissionRecordType, ids):
+    """``fetch_review_badges`` over an id list of any size.
+
+    The reference has to answer the same over-cap corpus the service does,
+    so it cannot itself issue a single over-cap statement. Chunking changes
+    nothing about the semantics being compared — the badge for a record does
+    not depend on which other records were asked for — it only lets the
+    oracle survive the defect it exists to detect.
+    """
+    ids = list(ids)
+    badges: dict[int, object] = {}
+    for start in range(0, len(ids), 10_000):
+        badges.update(
+            fetch_review_badges(
+                session,
+                record_type=record_type,
+                record_ids=ids[start : start + 10_000],
+            )
+        )
+    return badges
+
+
+def _reference_calculation_order(
+    session,
+    *,
+    calculation_type: CalculationType,
+    visible: set[RecordReviewStatus],
+    method: str | None = None,
+) -> list[int]:
+    """Filter and order calculations exactly as the Python path did.
+
+    Deliberately a transcription of the pre-SQL implementation rather than a
+    tidier equivalent: its value is that it shares no code with the SQL one.
+    """
+    stmt = select(
+        Calculation.id, Calculation.created_at, Calculation.quality
+    ).where(Calculation.type == calculation_type)
+    if method is not None:
+        from app.db.models.level_of_theory import LevelOfTheory
+
+        stmt = stmt.join(
+            LevelOfTheory, LevelOfTheory.id == Calculation.lot_id
+        ).where(LevelOfTheory.method == method)
+    stmt = stmt.where(Calculation.quality != CalculationQuality.rejected)
+
+    rows = session.execute(stmt).all()
+    badges = _badges_in_chunks(
+        session,
+        record_type=SubmissionRecordType.calculation,
+        ids=[row.id for row in rows],
+    )
+    survivors = [row for row in rows if badges[row.id].status in visible]
+    survivors.sort(
+        key=lambda row: (
+            REVIEW_RANK[badges[row.id].status],
+            _QUALITY_RANK[row.quality],
+            -row.created_at.timestamp(),
+            -row.id,
+        )
+    )
+    return [row.id for row in survivors]
+
+
+def _mixed_calculation_corpus(session):
+    """One ``sp`` calculation per (review flavour x quality), plus ties.
+
+    ``created_at`` is spread over three distinct values so the ordering is
+    exercised on that axis too, with duplicates so the ``id`` tiebreak still
+    has to do work.
+    """
+    lot = make_lot(session, method="sqlreview-mixed", basis="def2tzvp")
+    entry = make_species_entry(
+        session, make_species(session, smiles="[CH4:10]")
+    )
+    base = datetime(2026, 3, 1, 12, 0, 0)
+    qualities = (CalculationQuality.curated, CalculationQuality.raw)
+
+    for index, (flavour, quality) in enumerate(
+        itertools.product(_REVIEW_FLAVOURS, qualities)
+    ):
+        calc = make_calculation(
+            session,
+            type=CalculationType.sp,
+            species_entry_id=entry.id,
+            lot_id=lot.id,
+        )
+        calc.quality = quality
+        calc.created_at = base + timedelta(days=index % 3)
+        session.flush()
+        if flavour is not None:
+            set_review(
+                session,
+                record_type=SubmissionRecordType.calculation,
+                record_id=calc.id,
+                status=flavour,
+            )
+    return lot
+
+
+def _analyze(session, *tables: str) -> None:
+    """Give the planner statistics for the rows this test just inserted.
+
+    Rows written inside the test's own uncommitted transaction are invisible
+    to autovacuum, so without this the planner sees empty tables, estimates
+    one row everywhere, and picks nested loops that turn a 65,599-row join
+    into a 65,599 x 65,599 one. That is a property of the fixture, not of the
+    code under test, and every deployed database has statistics.
+
+    It cannot mask what these tests are for: the bind-parameter overflow
+    happens in psycopg while encoding the Bind message, before the statement
+    reaches the planner at all, so no amount of statistics makes the Python
+    path pass.
+    """
+    for table in tables:
+        session.execute(text(f"ANALYZE {table}"))
+
+
+def _bulk_insert_calculations(session, *, species_entry_id: int, count: int):
+    """Insert ``count`` ``sp`` calculations in one server-side statement.
+
+    ``INSERT … SELECT generate_series`` rather than an ORM loop: the point of
+    the test is the candidate *count*, and it must not cost more than a
+    second to reach it.
+    """
+    session.execute(
+        text(
+            "INSERT INTO calculation (type, species_entry_id) "
+            "SELECT 'sp', :species_entry_id FROM generate_series(1, :count)"
+        ),
+        {"species_entry_id": species_entry_id, "count": count},
+    )
+    _analyze(session, "calculation", "record_review")
+
+


### PR DESCRIPTION
Moves the review-badge filter and sort for the calculation and species searches into SQL, via the existing `sql_review.py`. Reconstructs the half of the Stage 4 work that was lost with the working tree (#84 recovered only `analytics.py`'s use of it).

**This fixes a correctness bug, not just latency.** `fetch_review_badges` renders one bind parameter per candidate id, so a large result set exceeds PostgreSQL's wire-protocol cap and the request dies:

```
psycopg.OperationalError: sending query and params failed:
number of parameters must be between 0 and 65535
```

`calculation_search_by_lot` on the 50k-species / 418k-calculation benchmark corpus matches 116,940 rows and needed **119,702** parameters — it could not succeed at all.

### Evidence first

The previous attempt at this stopped deliberately, because no existing test distinguishes a correct rewrite from a wrong one — they pass either way on small fixtures. So the test came first, and it fails on unmodified `main`:

```
2 failed, 62 passed in 57.53s
FAILED ...::test_calculations_search_above_the_bind_parameter_cap
FAILED ...::test_species_search_above_the_bind_parameter_cap
```
and passes here: `64 passed`. **Independently reproduced on a clean `origin/main` worktree**, not just reported.

`test_bind_parameter_cap_is_the_wire_protocol_limit` establishes the threshold by measurement rather than assumption — 65,534 ids succeed, 65,535 fail — and asserts no `pg_settings` row carries that number, pinning it as the wire protocol rather than a tunable GUC.

Equivalence is covered by a 24-way trust cross-product (`min_review_status` × `include_rejected` × `include_deprecated`) per endpoint against a reference implementation transcribed from the Python semantics being replaced, plus offset sweeps and a genuine `created_at` tie proving the `id DESC` tiebreak. Critically, each endpoint has an explicit **"a record with no `record_review` row survives and ranks `not_reviewed`"** test — the inner-join mistake that would otherwise look correct on small fixtures.

### Measurements

| shape | before | after |
|---|---|---|
| `calculation_search_by_lot` (116,940 match) | **OperationalError** after 651 ms, 119,702 params | p50 281 ms, max 51 params |
| `species_search_by_formula_broad` | p50 22.3 ms, 165 params | p50 21.7 ms, 54 params |
| at 65,599 candidates | OperationalError (both paths) | 232 ms / 156 ms |

The emitted calculation SQL matches `docs/benchmarks/README.md`'s recorded statement verbatim, including the `candidates` / `visible_candidates` aliases, and the species statement counts reproduce its recorded 11 / 15 exactly — so this recovers the lost work's shape rather than something merely equivalent. The README needed no edit: it was written against the fixed state and served as the spec.

### Judgement calls, flagged rather than buried

- **The species join shape is new design, not recovered.** The first version passed all 64 tests in isolation but hung the scientific gate for 15+ minutes: on a statistics-free database the planner compiles `species_entry.species_id = species.id` as a join filter over a full inner scan per candidate species. Rewritten as a flat `species → species_entry → record_review` chain with visibility as a `CASE` inside `MIN()`.
- **A behaviour change no test noticed.** Entry order within a species record was previously whatever the database returned (no `ORDER BY`); it is now `species_entry.id`. Non-deterministic → deterministic.
- **`summary_from_sql`'s `total`** now supplies `calculations_search`'s `total` instead of a separate `COUNT`. Equal by construction (every row has a coalesced status), not by test.
- The species path breaks one query *earlier* than the badge fetch — `_query_filtered_entries`'s `species_id.in_(...)` — so the original bug report was incomplete.
- `calculation_search_by_lot` still issues ~1059 statements per page: the `build_record` N+1 the README already records as a known, page-bounded defect. Unchanged here.

### Gates

`test-scientific.sh` **1903 passed**; `test-api.sh` **2395 passed** (the 1 warning is a pre-existing pydantic `alias` warning in `test_api_jobs.py`); `ruff check app tests` clean. Re-verified after rebasing onto current `main`: **134 passed**.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
