### PR TITLE
Bring backend/scripts under the lint gate

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Lint (ruff)
         if: matrix.gate == 'api'
         working-directory: backend
-        run: conda run -n tckdb_env ruff check app tests
+        run: conda run -n tckdb_env ruff check app tests scripts
 
       - name: Type check (mypy, scoped)
         if: matrix.gate == 'api'

--- a/backend/scripts/arc_ingestion/arkane_conformer_parser.py
+++ b/backend/scripts/arc_ingestion/arkane_conformer_parser.py
@@ -71,7 +71,7 @@ def _extract_e0_kj_mol(block: str) -> float:
     )
     m = pattern.search(block)
     if not m:
-        raise ValueError(f"Could not parse E0 from conformer block.")
+        raise ValueError("Could not parse E0 from conformer block.")
 
     value = float(m.group(1))
     units = m.group(2).strip()

--- a/backend/scripts/arc_ingestion/cli.py
+++ b/backend/scripts/arc_ingestion/cli.py
@@ -55,8 +55,8 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(1)
 
     # Import here to keep the CLI lightweight for --help
-    from .extractor import ARCRunExtractor
     from .builder import build_payload
+    from .extractor import ARCRunExtractor
 
     print(f"Extracting ARC run from: {arc_dir}", file=sys.stderr)
     extractor = ARCRunExtractor(arc_dir)

--- a/backend/scripts/arc_ingestion/extractor.py
+++ b/backend/scripts/arc_ingestion/extractor.py
@@ -10,7 +10,7 @@ remaps them to the actual local directory by replacing the common prefix.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml

--- a/backend/scripts/arc_ingestion/species_yaml.py
+++ b/backend/scripts/arc_ingestion/species_yaml.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import yaml
 
-
 # ---- Unit conversion constants ----
 KCAL_TO_KJ = 4.184
 CAL_TO_J = 4.184
@@ -145,7 +144,10 @@ def _parse_thermo(data: dict) -> SpeciesThermo | None:
             t_values = _get_array_values(thermo_data_node["Tdata"])
             cp_units = thermo_data_node["Cpdata"].get("units", "cal/(mol*K)")
 
-            for t, cp in zip(t_values, cp_values):
+            # strict: Arkane serialises ThermoData's Tdata/Cpdata as parallel
+            # arrays, so a length mismatch means a corrupt file — raise rather
+            # than silently drop the tail of the Cp table.
+            for t, cp in zip(t_values, cp_values, strict=True):
                 if "cal" in cp_units and "kcal" not in cp_units:
                     cp_j = cp * CAL_TO_J
                 else:

--- a/backend/scripts/bootstrap_admin.py
+++ b/backend/scripts/bootstrap_admin.py
@@ -32,18 +32,22 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
 # Ensure repo root is on sys.path so `app` is importable without
 # requiring the caller to export PYTHONPATH.
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
-
-from app.api.config import settings
-from app.db.models.common import AppUserRole
-from app.services.auth import RoleChangeRefused, bootstrap_user
+# E402: the `app` imports must follow the sys.path bootstrap above. This
+# script is run directly (`python scripts/bootstrap_admin.py`) with no
+# PYTHONPATH exported, so `app` is not importable until REPO_ROOT is on
+# sys.path.
+from app.api.config import settings  # noqa: E402
+from app.db.models.common import AppUserRole  # noqa: E402
+from app.services.auth import RoleChangeRefused, bootstrap_user  # noqa: E402
 
 
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:

--- a/backend/scripts/bulk_load_arc.py
+++ b/backend/scripts/bulk_load_arc.py
@@ -226,10 +226,10 @@ def _process_one_run(
     Returns ``(run_name, status, error_msg)`` where status is one of
     ``'success'``, ``'skipped'``, or ``'failed'``.
     """
-    from scripts.arc_ingestion.extractor import ARCRunExtractor
-    from scripts.arc_ingestion.builder import build_payload
     from app.schemas.workflows.computed_reaction_upload import ComputedReactionUploadRequest
     from app.workflows.computed_reaction import persist_computed_reaction_upload
+    from scripts.arc_ingestion.builder import build_payload
+    from scripts.arc_ingestion.extractor import ARCRunExtractor
 
     run_name = run_dir.name
 
@@ -479,7 +479,7 @@ def main():
     print(f"  Workers: {workers}  Artifacts: {'yes' if include_artifacts else 'no (--no-artifacts)'}")
     if arc_repo_dir:
         print(f"  ARC repo: {arc_repo_dir} (freq scale factor citations enabled)")
-    print(f"Loading into tckdb_dev...\n")
+    print("Loading into tckdb_dev...\n")
 
     # Create a short-lived session just for user setup and DB stats
     engine, session = create_engine_and_session()
@@ -493,7 +493,7 @@ def main():
     stats = load_arc_runs(run_dirs, user_id, workers=workers, include_artifacts=include_artifacts,
                           arc_repo_dir=arc_repo_dir)
 
-    print(f"\n--- Load Complete ---")
+    print("\n--- Load Complete ---")
     print(f"  Total runs:    {stats['total']}")
     print(f"  Already done:  {stats['already_done']}")
     print(f"  New success:   {stats['success']}")
@@ -502,7 +502,7 @@ def main():
     print(f"  Time:          {stats['elapsed_s']:.1f}s")
 
     if stats["errors"]:
-        print(f"\n--- First 10 Errors ---")
+        print("\n--- First 10 Errors ---")
         for err in stats["errors"][:10]:
             print(f"  {err}")
 
@@ -514,8 +514,8 @@ def main():
         session.close()
         engine.dispose()
 
-    print(f"\nDB is alive at: psql -h 127.0.0.1 -p 5432 -U tckdb -d tckdb_dev")
-    print(f"Start the API with: conda run -n tckdb_env uvicorn main:app --host 127.0.0.1 --port 8010 --reload")
+    print("\nDB is alive at: psql -h 127.0.0.1 -p 5432 -U tckdb -d tckdb_dev")
+    print("Start the API with: conda run -n tckdb_env uvicorn main:app --host 127.0.0.1 --port 8010 --reload")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/bulk_load_reactions.py
+++ b/backend/scripts/bulk_load_reactions.py
@@ -19,17 +19,17 @@ The DB is left alive after loading — connect with:
 
 from __future__ import annotations
 
+import argparse
 import os
+import subprocess
 import sys
 import time
-import subprocess
-import argparse
 from pathlib import Path
 
 # Ensure project root is on sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.parse_sdf_to_bundle import sdf_to_bundle, _SDF_DIR, _CSV_PATH
+from scripts.parse_sdf_to_bundle import _CSV_PATH, _SDF_DIR, sdf_to_bundle
 
 
 def get_all_rxn_ids(sdf_dir: Path = _SDF_DIR) -> list[str]:
@@ -230,7 +230,7 @@ def main():
 
         stats = load_reactions(session, rxn_ids, user_id)
 
-        print(f"\n--- Load Complete ---")
+        print("\n--- Load Complete ---")
         print(f"  Total:   {stats['total']}")
         print(f"  Success: {stats['success']}")
         print(f"  Failed:  {stats['failed']}")
@@ -238,7 +238,7 @@ def main():
         print(f"  Time:    {stats['elapsed_s']:.1f}s")
 
         if stats["errors"]:
-            print(f"\n--- First 10 Errors ---")
+            print("\n--- First 10 Errors ---")
             for err in stats["errors"][:10]:
                 print(f"  {err}")
 
@@ -248,7 +248,7 @@ def main():
         session.close()
         engine.dispose()
 
-    print(f"\nDB is alive at: psql -h 127.0.0.1 -p 5432 -U tckdb -d tckdb_dev")
+    print("\nDB is alive at: psql -h 127.0.0.1 -p 5432 -U tckdb -d tckdb_dev")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/cccbdb_form_payload_dryrun.py
+++ b/backend/scripts/cccbdb_form_payload_dryrun.py
@@ -54,7 +54,6 @@ from app.schemas.entities.molecular_property_observation import (
     MolecularPropertyObservationCreate,
 )
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -226,7 +225,7 @@ def _run_one_target(
                 resolver_strategy=parsed_file.resolver_strategy,
                 species_key=parsed_file.species_key,
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             result.warnings.append(
                 f"{path.name}: builder raised "
                 f"{type(exc).__name__}: {exc}"

--- a/backend/scripts/cccbdb_generate_form_queue.py
+++ b/backend/scripts/cccbdb_generate_form_queue.py
@@ -33,7 +33,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/backend/scripts/cccbdb_import_molecular_property_payloads.py
+++ b/backend/scripts/cccbdb_import_molecular_property_payloads.py
@@ -33,7 +33,6 @@ from app.services.cccbdb_molecular_property_import import (
     import_cccbdb_molecular_property_payloads,
 )
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/backend/scripts/cccbdb_import_saved_species_page.py
+++ b/backend/scripts/cccbdb_import_saved_species_page.py
@@ -23,8 +23,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# E402: must follow the sys.path bootstrap above so `app` resolves when the
+# wrapper is run directly without PYTHONPATH.
 from app.importers.cccbdb.browser_import import main  # noqa: E402
-
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))

--- a/backend/scripts/cccbdb_property_payload_dryrun.py
+++ b/backend/scripts/cccbdb_property_payload_dryrun.py
@@ -22,8 +22,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# E402: must follow the sys.path bootstrap above so `app` resolves when the
+# wrapper is run directly without PYTHONPATH.
 from app.importers.cccbdb.property_payload_dryrun import main  # noqa: E402
-
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))

--- a/backend/scripts/cccbdb_resolver_diagnostics.py
+++ b/backend/scripts/cccbdb_resolver_diagnostics.py
@@ -21,8 +21,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# E402: must follow the sys.path bootstrap above so `app` resolves when the
+# wrapper is run directly without PYTHONPATH.
 from app.importers.cccbdb.diagnostics.runner import main  # noqa: E402
-
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))

--- a/backend/scripts/cccbdb_snapshot.py
+++ b/backend/scripts/cccbdb_snapshot.py
@@ -21,8 +21,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# E402: must follow the sys.path bootstrap above so `app` resolves when the
+# wrapper is run directly without PYTHONPATH.
 from app.importers.cccbdb.snapshot import main  # noqa: E402
-
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))

--- a/backend/scripts/export_contribution_bundle.py
+++ b/backend/scripts/export_contribution_bundle.py
@@ -44,8 +44,8 @@ from app.schemas.workflows.contribution_bundle import (
     ContributionBundleV0,
 )
 from app.services.contribution_bundle_export import (
-    ContributionBundleExportError,
     DEFAULT_INSTANCE_NAME,
+    ContributionBundleExportError,
     export_kinetics_bundle,
     export_thermo_bundle,
 )

--- a/backend/scripts/generate_dbml.py
+++ b/backend/scripts/generate_dbml.py
@@ -12,16 +12,19 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from sqlalchemy import CheckConstraint, UniqueConstraint
+
 # Ensure repo root is on sys.path so `app` is importable
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from sqlalchemy import CheckConstraint, UniqueConstraint
-
+# E402: the `app` imports must follow the sys.path bootstrap above — run
+# directly or as `python -m scripts.generate_dbml` without PYTHONPATH,
+# `app` is only importable once REPO_ROOT is on sys.path.
 # Load all models so metadata is populated
-import app.db.models  # noqa: F401
-from app.db.base import Base
+import app.db.models  # noqa: F401,E402
+from app.db.base import Base  # noqa: E402
 
 OUTPUT = REPO_ROOT / "schema.dbml"
 

--- a/backend/scripts/parse_sdf_to_bundle.py
+++ b/backend/scripts/parse_sdf_to_bundle.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 import re
 import sys
 from pathlib import Path

--- a/backend/scripts/pdep_ingestion/arkane_pdep_parser.py
+++ b/backend/scripts/pdep_ingestion/arkane_pdep_parser.py
@@ -333,7 +333,8 @@ def parse_pdep_arrhenius_reactions(text: str) -> list[PlogFit]:
         entries: list[PlogArrhenius] = []
         tmin_value = tmax_value = None
         temperature_units: str | None = None
-        for pressure, ab in zip(pressures, arr_blocks):
+        # strict: lengths are already enforced by the equality check above.
+        for pressure, ab in zip(pressures, arr_blocks, strict=True):
             a = _extract_value_units(ab, "A")
             ea = _extract_value_units(ab, "Ea")
             n_m = re.search(r"\bn\s*=\s*([-\d.eE+]+)", ab)
@@ -803,6 +804,20 @@ def _parse_csv_xyz(raw: str) -> str | None:
     return f"{len(lines)}\n\n" + "\n".join(lines)
 
 
+def _csv_num(row: dict[str, str], key: str) -> float | None:
+    """Read ``key`` from a supporting-information CSV row as a float."""
+    v = (row.get(key) or "").strip()
+    if not v or v == "-":
+        return None
+    return float(v)
+
+
+def _csv_int(row: dict[str, str], key: str) -> int | None:
+    """Read ``key`` from a supporting-information CSV row as an int."""
+    v = _csv_num(row, key)
+    return int(v) if v is not None else None
+
+
 def parse_supporting_information(path: Path) -> dict[str, SupportingInfo]:
     """Parse ``supporting_information.csv`` into a label -> SupportingInfo map."""
     out: dict[str, SupportingInfo] = {}
@@ -812,16 +827,6 @@ def parse_supporting_information(path: Path) -> dict[str, SupportingInfo]:
             label = (row.get("Label") or "").strip()
             if not label:
                 continue
-
-            def _num(key: str) -> float | None:
-                v = (row.get(key) or "").strip()
-                if not v or v == "-":
-                    return None
-                return float(v)
-
-            def _int(key: str) -> int | None:
-                v = _num(key)
-                return int(v) if v is not None else None
 
             freqs_raw = (
                 row.get("Calculated Frequencies (unscaled and prior to "
@@ -841,21 +846,25 @@ def parse_supporting_information(path: Path) -> dict[str, SupportingInfo]:
 
             out[label] = SupportingInfo(
                 label=label,
-                symmetry_number=_int("Symmetry Number"),
-                optical_isomers=_int("Number of optical isomers"),
+                symmetry_number=_csv_int(row, "Symmetry Number"),
+                optical_isomers=_csv_int(row, "Number of optical isomers"),
                 point_group=((row.get("Symmetry Group") or "").strip() or None),
                 rotational_constants_cm_inv=rot,
                 frequencies_cm_inv=freqs,
                 n_imag=n_imag,
-                electronic_energy_j_mol=_num("Electronic energy (J/mol)"),
-                e0_zpe_j_mol=_num("E0 (electronic energy + ZPE, J/mol)"),
-                e0_corrected_j_mol=_num(
-                    "E0 with atom and bond corrections (J/mol)"
+                electronic_energy_j_mol=_csv_num(
+                    row, "Electronic energy (J/mol)"
+                ),
+                e0_zpe_j_mol=_csv_num(
+                    row, "E0 (electronic energy + ZPE, J/mol)"
+                ),
+                e0_corrected_j_mol=_csv_num(
+                    row, "E0 with atom and bond corrections (J/mol)"
                 ),
                 xyz_text=_parse_csv_xyz(
                     row.get("Atom XYZ coordinates (angstrom)") or ""
                 ),
-                t1_diagnostic=_num("T1 diagnostic"),
-                d1_diagnostic=_num("D1 diagnostic"),
+                t1_diagnostic=_csv_num(row, "T1 diagnostic"),
+                d1_diagnostic=_csv_num(row, "D1 diagnostic"),
             )
     return out

--- a/backend/scripts/pdep_ingestion/builder.py
+++ b/backend/scripts/pdep_ingestion/builder.py
@@ -1001,9 +1001,9 @@ def build_network_pdep_payload(
     # Source calculations: species sp -> well_energy, freq -> well_freq;
     # TS sp -> barrier_energy, freq -> barrier_freq.
     source_calcs: list[dict] = []
-    for label, key in species_sp_key.items():
+    for key in species_sp_key.values():
         source_calcs.append({"calculation_key": key, "role": "well_energy"})
-    for label, key in species_freq_key.items():
+    for key in species_freq_key.values():
         source_calcs.append({"calculation_key": key, "role": "well_freq"})
     for ts in transition_states:
         for calc in ts["calculations"]:

--- a/backend/scripts/pdep_ingestion/cli.py
+++ b/backend/scripts/pdep_ingestion/cli.py
@@ -81,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
             payload = request.model_dump(mode="json", exclude_none=True)
             validated_ok = True
             print("VALIDATION: PASS (schema-valid NetworkPDepUploadRequest)", file=sys.stderr)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             validated_ok = False
             print("VALIDATION: FAIL", file=sys.stderr)
             print(repr(exc), file=sys.stderr)

--- a/backend/scripts/seed_scientific_demo_data.py
+++ b/backend/scripts/seed_scientific_demo_data.py
@@ -423,7 +423,8 @@ def seed(session: Session) -> dict[str, int]:
     # ---- Thermo records (2–3) ----
     # Scalar-only for CH4 + scalar+NASA for C2H6 + a points-shaped one is
     # skipped to keep the script short; the goal is variety, not coverage.
-    thermo_ch4 = _make_thermo_scalar(
+    # Created for its persistence side effect only; nothing references it.
+    _make_thermo_scalar(
         session, entry=entry_by_smiles["C"], h298=-74.6, s298=186.3
     )
     thermo_c2h6 = _make_thermo_scalar(
@@ -569,7 +570,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
 
     db_url = args.database_url or settings.database_url
-    print(f"TCKDB scientific demo seed")
+    print("TCKDB scientific demo seed")
     print(f"  database_url: {db_url}")
     print(f"  marker note : {DEMO_NOTE!r}")
     print(f"  timestamp   : {datetime.now(timezone.utc).isoformat()}")

--- a/backend/scripts/validation/arkane_statmech_roundtrip.py
+++ b/backend/scripts/validation/arkane_statmech_roundtrip.py
@@ -465,7 +465,10 @@ json.dump(out, sys.stdout)
             f"rotor-term computation failed in {RMG_ENV}:\n{proc.stderr[-2000:]}"
         )
     terms = json.loads(proc.stdout)
-    for rotor, term in zip(data["rotors"], terms):
+    # strict: the subprocess emits exactly one term per input rotor, so a
+    # mismatch means truncated output from the RMG env — raise, don't pair up
+    # the wrong rotors.
+    for rotor, term in zip(data["rotors"], terms, strict=True):
         rotor["inertia_amu_a2"] = term["inertia_amu_a2"]
         rotor["fourier_kj_mol"] = term["fourier_kj_mol"]
 
@@ -479,7 +482,9 @@ def principal_moments(symbols, coords) -> np.ndarray:
     com = (m[:, None] * coords).sum(0) / m.sum()
     r = coords - com
     tensor = np.zeros((3, 3))
-    for mi, ri in zip(m, r):
+    # strict: one mass per atom and one displacement row per atom by
+    # construction; a mismatch means symbols and coords disagree.
+    for mi, ri in zip(m, r, strict=True):
         tensor += mi * (np.dot(ri, ri) * np.eye(3) - np.outer(ri, ri))
     return np.linalg.eigvalsh(tensor), m.sum()
 


### PR DESCRIPTION
`.github/workflows/backend-ci.yml` linted `app` and `tests` but not `backend/scripts/` — around 40 modules including deploy helpers, ingestion parsers and bulk loaders. Now `ruff check app tests scripts`, and the 47 findings that surfaced are fixed.

Nothing was deleted. An earlier audit confirmed every "unreferenced" script is a hand-run operator entry point invoked from runbooks, not dead code.

## Dispositions

| rule | n | how |
|---|---|---|
| I001 / F541 / F401 / RUF100 | 27 | autofix — the two `F401` verified genuinely unreferenced, both `RUF100` stale `# noqa: BLE001` for a rule this repo doesn't enable |
| E402 | 12 | reordered where the import had no real dependency on the `sys.path` bootstrap; `# noqa: E402` **with an inline reason** where it does |
| B905 | 4 | `strict=True` at all four |
| B007 | 2 | `.items()` → `.values()` |
| B023 | 1 | closures hoisted to module scope |
| F841 | 1 | binding dropped, call kept for its persistence side effect |

No per-directory ignore was added.

## The one behaviour change

`strict=True` makes a length-mismatched `zip()` raise instead of silently truncating. Each of the four sites was checked individually rather than defaulted; all four pair sequences whose lengths are guaranteed — by an explicit prior length check, by 1:1 construction, or by a parallel-array invariant of the input format.

The site that matters is `arc_ingestion/species_yaml.py`, where Arkane serialises `ThermoData`'s `Tdata`/`Cpdata` as parallel arrays. A mismatch there means a corrupt file, and silently dropping the tail of a Cp table into a scientific database is the worse failure. This follows the same reject-don't-guess rule the ESS artifact extraction path uses.

## B023 was not a bug

`_num`/`_int` in the supporting-information CSV parser closed over the loop variable, but were called eagerly within each iteration and never stored, returned or deferred — the late binding could not manifest. Hoisted to `_csv_num(row, key)` / `_csv_int(row, key)` anyway, to satisfy the linter and stop re-creating two closures per row. Equivalence was verified differentially against the real hydrazine `supporting_information.csv`: exact match on all rows and fields.

## Verification

- `ruff check app tests scripts` clean; `mypy`, `bash -n`, `git diff --check` clean
- Scientific gate **1975 passed**, API gate **2424 passed** — both exactly at baseline
- Plus **638 passed / 5 skipped** across `tests/scripts/`, `tests/importers/cccbdb/`, `tests/cli/` and two `tests/services/` files, which import these scripts but sit outside both named gates
- `--help` actually executed on 15 CLI entry points; `generate_dbml.py` run in full and regenerates `schema.dbml` byte-identical; the rest import-verified

## Gotcha worth recording

`ruff --fix` with a narrowed `--select` **deletes `# noqa` directives for rules outside that select** — a `--select I001,F541,F401,RUF100` run made RUF100 judge four legitimate `# noqa: E402` comments unused and strip them. Caught and restored, with every added or removed `noqa` line in the diff audited.

## Flagged, not fixed

`parse_sdf_to_bundle.py` does real work at import time, so importing it as a library has side effects — a design wart ruff cannot see. And `seed_scientific_demo_data.py` has a discarded call that is load-bearing only via its DB side effect, with the count hardcoded separately; preserved exactly, but fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)