### PR TITLE
Reuse one connection for the deployment tour

### DIFF
--- a/examples/clients/explore_tckdb.ipynb
+++ b/examples/clients/explore_tckdb.ipynb
@@ -44,10 +44,10 @@
    "id": "88ab9fa8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:13:34.610414Z",
-     "iopub.status.busy": "2026-08-02T10:13:34.610330Z",
-     "iopub.status.idle": "2026-08-02T10:13:34.874547Z",
-     "shell.execute_reply": "2026-08-02T10:13:34.874130Z"
+     "iopub.execute_input": "2026-08-08T07:59:36.879545Z",
+     "iopub.status.busy": "2026-08-08T07:59:36.879449Z",
+     "iopub.status.idle": "2026-08-08T08:00:07.310994Z",
+     "shell.execute_reply": "2026-08-08T08:00:07.310693Z"
     }
    },
    "outputs": [
@@ -76,10 +76,20 @@
     "BASE_URL = os.environ.get(\"TCKDB_BASE_URL\", \"https://tckdb.homecalvin.com/api/v1\").rstrip(\"/\")\n",
     "TIMEOUT_S = 30\n",
     "\n",
+    "# One connection, reused for every call below.\n",
+    "#\n",
+    "# Not a micro-optimisation. This host resolves to both A and AAAA records, and\n",
+    "# urllib3 tries resolved addresses *serially* -- so on a network where IPv6 is\n",
+    "# advertised but blackholed, every new connection waits for the IPv6 attempt to\n",
+    "# time out before falling back to IPv4. Measured from such a network: 18.4 s per\n",
+    "# call with a fresh connection, 144 ms with this session. curl does not show the\n",
+    "# problem because it races both stacks and abandons IPv6 in milliseconds.\n",
+    "SESSION = requests.Session()\n",
+    "\n",
     "\n",
     "def get(path, **params):\n",
     "    \"\"\"One anonymous GET, surfacing TCKDB's typed error envelope when present.\"\"\"\n",
-    "    r = requests.get(f\"{BASE_URL}/{path.lstrip('/')}\", params=params, timeout=TIMEOUT_S)\n",
+    "    r = SESSION.get(f\"{BASE_URL}/{path.lstrip('/')}\", params=params, timeout=TIMEOUT_S)\n",
     "    if not r.ok:\n",
     "        try:\n",
     "            e = r.json()\n",
@@ -115,10 +125,10 @@
    "id": "c47e1422",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:13:34.875636Z",
-     "iopub.status.busy": "2026-08-02T10:13:34.875547Z",
-     "iopub.status.idle": "2026-08-02T10:13:35.128500Z",
-     "shell.execute_reply": "2026-08-02T10:13:35.128125Z"
+     "iopub.execute_input": "2026-08-08T08:00:07.311950Z",
+     "iopub.status.busy": "2026-08-08T08:00:07.311863Z",
+     "iopub.status.idle": "2026-08-08T08:00:07.460237Z",
+     "shell.execute_reply": "2026-08-08T08:00:07.459884Z"
     }
    },
    "outputs": [
@@ -192,10 +202,10 @@
    "id": "fbeb7e6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:13:35.129524Z",
-     "iopub.status.busy": "2026-08-02T10:13:35.129425Z",
-     "iopub.status.idle": "2026-08-02T10:13:35.398268Z",
-     "shell.execute_reply": "2026-08-02T10:13:35.397704Z"
+     "iopub.execute_input": "2026-08-08T08:00:07.461305Z",
+     "iopub.status.busy": "2026-08-08T08:00:07.461193Z",
+     "iopub.status.idle": "2026-08-08T08:00:07.633205Z",
+     "shell.execute_reply": "2026-08-08T08:00:07.632912Z"
     }
    },
    "outputs": [
@@ -250,10 +260,10 @@
    "id": "dc3e237d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:13:35.399428Z",
-     "iopub.status.busy": "2026-08-02T10:13:35.399280Z",
-     "iopub.status.idle": "2026-08-02T10:13:35.404206Z",
-     "shell.execute_reply": "2026-08-02T10:13:35.403761Z"
+     "iopub.execute_input": "2026-08-08T08:00:07.634113Z",
+     "iopub.status.busy": "2026-08-08T08:00:07.634024Z",
+     "iopub.status.idle": "2026-08-08T08:00:07.637254Z",
+     "shell.execute_reply": "2026-08-08T08:00:07.636977Z"
     }
    },
    "outputs": [
@@ -316,10 +326,10 @@
    "id": "41e6bab1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:13:35.405361Z",
-     "iopub.status.busy": "2026-08-02T10:13:35.405208Z",
-     "iopub.status.idle": "2026-08-02T10:14:07.512040Z",
-     "shell.execute_reply": "2026-08-02T10:14:07.511673Z"
+     "iopub.execute_input": "2026-08-08T08:00:07.638057Z",
+     "iopub.status.busy": "2026-08-08T08:00:07.637970Z",
+     "iopub.status.idle": "2026-08-08T08:00:08.865604Z",
+     "shell.execute_reply": "2026-08-08T08:00:08.865146Z"
     }
    },
    "outputs": [
@@ -391,10 +401,10 @@
    "id": "f58b2ef4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:14:07.513068Z",
-     "iopub.status.busy": "2026-08-02T10:14:07.512972Z",
-     "iopub.status.idle": "2026-08-02T10:14:07.894779Z",
-     "shell.execute_reply": "2026-08-02T10:14:07.894476Z"
+     "iopub.execute_input": "2026-08-08T08:00:08.866786Z",
+     "iopub.status.busy": "2026-08-08T08:00:08.866674Z",
+     "iopub.status.idle": "2026-08-08T08:00:09.307516Z",
+     "shell.execute_reply": "2026-08-08T08:00:09.307180Z"
     }
    },
    "outputs": [
@@ -443,10 +453,10 @@
    "id": "bec77ed6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:14:07.895975Z",
-     "iopub.status.busy": "2026-08-02T10:14:07.895837Z",
-     "iopub.status.idle": "2026-08-02T10:14:08.578708Z",
-     "shell.execute_reply": "2026-08-02T10:14:08.578314Z"
+     "iopub.execute_input": "2026-08-08T08:00:09.308853Z",
+     "iopub.status.busy": "2026-08-08T08:00:09.308700Z",
+     "iopub.status.idle": "2026-08-08T08:00:09.687867Z",
+     "shell.execute_reply": "2026-08-08T08:00:09.687320Z"
     }
    },
    "outputs": [
@@ -508,10 +518,10 @@
    "id": "c62f016a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:14:08.579781Z",
-     "iopub.status.busy": "2026-08-02T10:14:08.579687Z",
-     "iopub.status.idle": "2026-08-02T10:14:08.876670Z",
-     "shell.execute_reply": "2026-08-02T10:14:08.876341Z"
+     "iopub.execute_input": "2026-08-08T08:00:09.688819Z",
+     "iopub.status.busy": "2026-08-08T08:00:09.688714Z",
+     "iopub.status.idle": "2026-08-08T08:00:09.897953Z",
+     "shell.execute_reply": "2026-08-08T08:00:09.897442Z"
     }
    },
    "outputs": [
@@ -580,10 +590,10 @@
    "id": "e2f198e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:14:08.877811Z",
-     "iopub.status.busy": "2026-08-02T10:14:08.877721Z",
-     "iopub.status.idle": "2026-08-02T10:14:09.391926Z",
-     "shell.execute_reply": "2026-08-02T10:14:09.391581Z"
+     "iopub.execute_input": "2026-08-08T08:00:09.898882Z",
+     "iopub.status.busy": "2026-08-08T08:00:09.898782Z",
+     "iopub.status.idle": "2026-08-08T08:00:10.210058Z",
+     "shell.execute_reply": "2026-08-08T08:00:10.209678Z"
     }
    },
    "outputs": [
@@ -634,10 +644,10 @@
    "id": "33440c96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-02T10:14:09.392750Z",
-     "iopub.status.busy": "2026-08-02T10:14:09.392662Z",
-     "iopub.status.idle": "2026-08-02T10:14:09.670367Z",
-     "shell.execute_reply": "2026-08-02T10:14:09.669946Z"
+     "iopub.execute_input": "2026-08-08T08:00:10.211063Z",
+     "iopub.status.busy": "2026-08-08T08:00:10.210972Z",
+     "iopub.status.idle": "2026-08-08T08:00:10.368710Z",
+     "shell.execute_reply": "2026-08-08T08:00:10.368299Z"
     }
    },
    "outputs": [
@@ -720,7 +730,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tckdb_env",
    "language": "python",
    "name": "python3"
   },

--- a/examples/clients/explore_tckdb.py
+++ b/examples/clients/explore_tckdb.py
@@ -28,6 +28,21 @@ import requests
 DEFAULT_BASE_URL = "https://tckdb.homecalvin.com/api/v1"
 TIMEOUT_S = 30
 
+#: One connection, reused for every call.
+#:
+#: This is not a micro-optimisation. The hosted deployment resolves to both A
+#: and AAAA records, and ``urllib3`` tries resolved addresses **serially** --
+#: so on a network where IPv6 is advertised but blackholed, every new
+#: connection waits for the IPv6 attempt to time out before falling back to
+#: IPv4. Measured against the hosted instance from such a network: 18.4 s per
+#: call with a fresh connection each time, 144 ms with this session. ``curl``
+#: does not show the problem because it races both stacks (Happy Eyeballs)
+#: and gives up on IPv6 in milliseconds.
+#:
+#: Reusing the connection pays that cost once instead of per request. It is
+#: also simply correct for repeated calls to one host.
+SESSION = requests.Session()
+
 
 def base_url() -> str:
     """The deployment to talk to; override with ``TCKDB_BASE_URL``."""
@@ -41,7 +56,7 @@ def get(path: str, **params: Any) -> dict:
     returns a typed ``{"code", "detail", "context"}`` body, which says far
     more than a bare status line.
     """
-    response = requests.get(f"{base_url()}/{path.lstrip('/')}", params=params, timeout=TIMEOUT_S)
+    response = SESSION.get(f"{base_url()}/{path.lstrip('/')}", params=params, timeout=TIMEOUT_S)
     if not response.ok:
         try:
             envelope = response.json()


### PR DESCRIPTION
`examples/clients/explore_tckdb.{ipynb,py}` opened a fresh HTTP connection per call. Harmless on most networks, catastrophic on some.

The hosted deployment resolves to both A and AAAA records, and `urllib3` tries resolved addresses **serially**. On a network where IPv6 is advertised but blackholed, every new connection waits for the IPv6 attempt to time out before falling back to IPv4.

Measured against the live instance from such a network:

| | per call |
|---|---|
| fresh connection each time | **18.4 s** |
| reused session | **144 ms** |

The failure is worth a comment rather than a silent one-word fix, because it presents exactly like a slow server — and the obvious cross-check exonerates the wrong component. `curl` never reproduces it: it races both stacks (Happy Eyeballs) and abandons IPv6 in milliseconds.

For the record, the server was never implicated. On the deployment host: `/health` 3 ms, species search 19 ms, thermo search 44 ms.

The notebook was re-executed end to end against the live deployment, so its stored outputs match the code that produced them.