### PR TITLE
Conserve mass and charge, and let a reaction name the electron it releases

### DIFF
--- a/backend/alembic/versions/b8f3d6a1c9e4_molecule_kind_electron.py
+++ b/backend/alembic/versions/b8f3d6a1c9e4_molecule_kind_electron.py
@@ -1,0 +1,159 @@
+"""Let a reaction name the electron it releases.
+
+``validate_reaction_charge_conservation`` refuses ``[OH-] + [H] -> H2O``. That
+reaction is associative detachment — ``OH⁻ + H → H₂O + e⁻`` — real, measured
+gas-phase chemistry and the sibling of ``H⁻ + H → H₂ + e⁻``. Dissociative
+attachment, photoionization and photodetachment are the same family. All of
+them balance perfectly well; they simply have an electron on one side, and
+there was no way to say so.
+
+That is not merely an inconvenience. Under ADR 0008 a check may block only when
+it asserts a **definition**. Charge conservation is definitional only if the
+participant list can be complete — and with no way to name the electron, the
+rule was in fact asserting "every participant of this reaction was declared",
+which is an expectation about the depositor, not a definition of a reaction.
+The error message offered ``molecule_kind: pseudo`` as the escape, but nothing
+in the codebase creates a pseudo species: ``canonical_species_identity``
+refuses every non-``molecule`` kind outright, so both pseudo exemptions in
+``reaction_resolution`` were unreachable. The advertised door did not exist.
+
+This revision makes it exist, by adding ``electron`` to the ``molecule_kind``
+enum.
+
+Why an enum member rather than a seeded row or a column on the reaction
+-----------------------------------------------------------------------
+An electron *is* a participant. It appears on one side of the arrow, it can
+appear with a coefficient (a two-electron process releases two), and it has to
+be part of the reaction's stoichiometry hash or ``A -> B`` and ``A -> B + e⁻``
+would collide on one identity. Every one of those properties already belongs to
+``reaction_participant``, so the electron is carried there like anything else,
+and the enum member is what tells the conservation checks how to count it.
+
+The alternatives were weighed and rejected. A signed ``electrons`` column on
+``chem_reaction`` would duplicate stoichiometry machinery, need its own sign
+convention to say which side the electron is on, and be invisible to every
+reader that iterates participants. A reserved row with no enum member would
+have to be recognised by its SMILES string, which makes a sentinel string
+load-bearing in comparisons rather than in one lookup.
+
+No row is seeded here. The electron's ``species`` row is resolved or created on
+first use by ``resolve_species``, exactly like every other species, and
+converges on one row because its identity ``("[e-]", -1, 2)`` is fixed. Seeding
+would have meant minting a ``public_ref`` inside a migration for a row that may
+never be referenced.
+
+Why ``electron`` is not a flavour of ``pseudo``
+-----------------------------------------------
+``validate_reaction_elemental_balance`` and
+``validate_reaction_charge_conservation`` both return early and skip entirely
+when any participant is ``pseudo``. Had the electron been routed through that
+exemption, a depositor could switch mass-balance checking off on any reaction
+by adding an electron to it — a considerably worse hole than the one being
+closed.
+
+An electron is not "pseudo, therefore unknowable". It is precisely known: zero
+atoms, charge -1. So ``_element_counts_for_species`` returns an empty count for
+it and ``_load_participant_species`` tests for ``pseudo`` specifically rather
+than for "not a molecule". Both conservation checks stay live on a reaction
+carrying an electron, and both must still pass.
+
+Storage
+-------
+``species.smiles`` holds the reserved token ``[e-]``, which RDKit cannot parse
+and which is never handed to it; the payload schema binds that token and
+``molecule_kind: electron`` to each other in both directions, so a structure
+can never hide behind the token and the token can never reach RDKit.
+``species.inchi_key`` is ``CHAR(27) NOT NULL`` and an electron has no InChI, so
+it holds ``ELECTRON-NO-INCHIKEY-EXISTS`` — deliberately not a plausible
+InChIKey (a real one is ``[A-Z]{14}-[A-Z]{10}-[A-Z]``), so it can neither
+collide with a real key nor be mistaken for one. Relaxing the column to
+nullable is the more honest schema and was rejected for reach: half a dozen
+read schemas type it ``str``.
+
+The corresponding ``species_entry`` carries ``NULL`` in every graph-derived
+column — ``mol``, ``unmapped_smiles``, ``isotope_key`` — all of which are
+already nullable, so no table is altered here. Any geometry deposited under an
+electron is refused by
+``assert_geometry_composition_matches_identity``: an electron has no atoms, and
+a structure with atoms contradicts that.
+
+Backfill: none. The enum gains a member; no stored row's value changes, and no
+existing row can be an electron because there was no way to write one.
+
+``downgrade()`` rebuilds the enum without ``electron``. PostgreSQL cannot drop
+a value from an enum in place, so the type is renamed, recreated and the column
+cast across. It will fail — correctly and loudly — if any ``species`` row is an
+electron by then: removing the member would otherwise silently destroy the only
+record that a deposited reaction released one.
+
+Revision ID: b8f3d6a1c9e4
+Revises: e7d1c4b8a3f5
+Create Date: 2026-08-08
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b8f3d6a1c9e4"
+down_revision: Union[str, Sequence[str], None] = "e7d1c4b8a3f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ENUM_NAME = "molecule_kind"
+NEW_VALUE = "electron"
+PRIOR_VALUES = ("molecule", "pseudo")
+
+
+def upgrade() -> None:
+    """Add ``electron`` to the ``molecule_kind`` enum.
+
+    ``ADD VALUE`` is safe inside Alembic's transaction on PostgreSQL 12+ so
+    long as the new value is not *used* in the same transaction, which it is
+    not: nothing here writes a row.
+    """
+
+    op.execute(f"ALTER TYPE {ENUM_NAME} ADD VALUE IF NOT EXISTS '{NEW_VALUE}'")
+
+
+def downgrade() -> None:
+    """Rebuild ``molecule_kind`` without ``electron``.
+
+    Refuses to run while any ``species`` row still uses the value, rather than
+    losing the fact that a deposited reaction released a free electron.
+    """
+
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+            offending bigint;
+        BEGIN
+            SELECT count(*) INTO offending
+            FROM species
+            WHERE kind = '{NEW_VALUE}';
+
+            IF offending > 0 THEN
+                RAISE EXCEPTION
+                    'Cannot remove molecule_kind=''{NEW_VALUE}'': % species '
+                    'row(s) still declare one. Removing the value would '
+                    'silently discard the record that those reactions '
+                    'released or consumed a free electron. Re-deposit or '
+                    'delete those reactions first.',
+                    offending
+                    USING ERRCODE = '23514';
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    prior = ", ".join(f"'{value}'" for value in PRIOR_VALUES)
+    op.execute(f"ALTER TYPE {ENUM_NAME} RENAME TO {ENUM_NAME}_old")
+    op.execute(f"CREATE TYPE {ENUM_NAME} AS ENUM ({prior})")
+    op.execute(
+        f"ALTER TABLE species ALTER COLUMN kind TYPE {ENUM_NAME} "
+        f"USING kind::text::{ENUM_NAME}"
+    )
+    op.execute(f"DROP TYPE {ENUM_NAME}_old")

--- a/backend/app/chemistry/geometry.py
+++ b/backend/app/chemistry/geometry.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from app.chemistry.isotopes import normalize_isotope, validate_isotope
+from app.chemistry.isotopes import (
+    HYDROGEN_ISOTOPE_SYMBOLS,
+    normalize_isotope,
+    validate_isotope,
+)
 from app.schemas.fragments.geometry import GeometryPayload
 
 
@@ -32,6 +36,39 @@ def normalize_element_symbol(symbol: str) -> str:
     """
 
     return symbol.strip().capitalize()
+
+
+def resolve_element_symbol(symbol: str) -> str:
+    """Return the *element* an XYZ symbol names, not the nuclide it names.
+
+    :func:`normalize_element_symbol` settles capitalisation. This settles the
+    other way an XYZ can spell an element that a comparison must not trip over:
+    ``D`` and ``T`` are hydrogen. Both are legal, common tokens — Gaussian,
+    ORCA, Molpro and CFOUR all emit or accept them — and
+    ``geometry_atom.element`` stores them verbatim by design, so a check that
+    compares raw symbols reads a perfectly ordinary deuterated geometry as
+    containing an element its SMILES never mentions. That refuses correct
+    chemistry, which ADR 0008 disqualifies a blocking check from doing.
+
+    Use this wherever elements are **counted or matched** — composition checks,
+    graph-isomorphism element groups. Do not use it where the deposited symbol
+    itself is the subject (round-tripping ``geometry_atom.element``, rendering
+    an XYZ back to a depositor): ``D`` is what they wrote and what they should
+    read back.
+
+    Isotope *identity* is unaffected: it is carried atom-resolved by
+    ``geometry.isotopes`` and by SMILES isotope notation, and compared by
+    :func:`app.services.species_resolution.assert_geometry_isotopes_match_identity`.
+    Writing ``D`` in the element column is therefore composition-neutral and
+    isotope-silent, exactly as it was before any composition check existed.
+
+    :param symbol: Element symbol as deposited.
+    :returns: The normalised symbol of the element, with ``D`` and ``T``
+        resolved to ``H``.
+    """
+
+    normalized = normalize_element_symbol(symbol)
+    return "H" if normalized in HYDROGEN_ISOTOPE_SYMBOLS else normalized
 
 
 @dataclass(frozen=True)

--- a/backend/app/chemistry/isotopes.py
+++ b/backend/app/chemistry/isotopes.py
@@ -22,11 +22,31 @@ from __future__ import annotations
 from rdkit import Chem
 
 __all__ = [
+    "HYDROGEN_ISOTOPE_SYMBOLS",
     "isotope_mass",
     "most_common_isotope",
     "normalize_isotope",
     "validate_isotope",
 ]
+
+#: Element symbols that name a *nuclide* rather than an element, mapped to the
+#: mass number they stand for. Only hydrogen has them, and only these two:
+#: ``D`` is deuterium and ``T`` is tritium.
+#:
+#: They are legal, common XYZ tokens — Gaussian, ORCA, Molpro and CFOUR all
+#: emit or accept them — and ``geometry_atom.element`` stores whatever the
+#: depositor's XYZ said, verbatim (see :func:`app.chemistry.geometry.parse_xyz`).
+#: Anything that *counts elements* must therefore resolve them to ``H`` first
+#: (:func:`app.chemistry.geometry.resolve_element_symbol`), or it refuses a
+#: correctly deposited isotopologue for spelling its hydrogens the way its ESS
+#: did — which ADR 0008 puts out of bounds for a blocking check.
+#:
+#: This mapping is deliberately *not* wired into :func:`validate_isotope` or
+#: :func:`parse_xyz`. Isotope **identity** is carried atom-resolved by
+#: ``geometry.isotopes`` and by SMILES isotope notation, never by the element
+#: column; resolving ``D`` to ``H`` here answers "which element is this atom",
+#: which is the only question composition counting asks.
+HYDROGEN_ISOTOPE_SYMBOLS: dict[str, int] = {"D": 2, "T": 3}
 
 
 def _periodic_table() -> Chem.PeriodicTable:

--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -2,17 +2,48 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from typing import Mapping
+from collections.abc import Mapping
 
 from rdkit import Chem
 from rdkit.Chem import AllChem, inchi, rdDetermineBonds
+from tckdb_schemas.fragments.identity import ELECTRON_SMILES
 
-from app.chemistry.geometry import normalize_element_symbol
+from app.chemistry.geometry import resolve_element_symbol
 from app.chemistry.isotopes import normalize_isotope, validate_isotope
 from app.db.models.common import MoleculeKind, StereoKind
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 
 logger = logging.getLogger(__name__)
+
+#: The value stored in ``species.inchi_key`` for the free electron.
+#:
+#: ``species.inchi_key`` is ``CHAR(27) NOT NULL`` and an electron has no
+#: InChI, so the row needs *something*. This is deliberately **not** a
+#: plausible InChIKey: a real one is ``[A-Z]{14}-[A-Z]{10}-[A-Z]``, and this
+#: fails that shape in its first block, so it can never collide with a real
+#: key, can never be returned by an InChIKey lookup, and cannot be mistaken
+#: for a chemical identifier by a reader. Exactly 27 characters, because the
+#: column is ``CHAR`` and would otherwise pad.
+#:
+#: The alternative — relaxing ``inchi_key`` to nullable — is the more honest
+#: schema and was rejected for reach: half a dozen read schemas type it
+#: ``str``, and widening all of them to admit one row that no structure search
+#: can return is a larger, more disruptive change than a sentinel that is
+#: self-describing at every point it can be read.
+ELECTRON_INCHI_KEY = "ELECTRON-NO-INCHIKEY-EXISTS"
+
+
+def is_electron(payload: SpeciesEntryIdentityPayload) -> bool:
+    """Return whether an identity payload declares a free electron.
+
+    One predicate for every caller that has to branch, so no two of them can
+    disagree about what an electron looks like. The payload schema has already
+    pinned ``smiles``, ``charge`` and ``multiplicity`` to each other by the
+    time this is asked (``SpeciesIdentityPayload.check_electron_identity``), so
+    the kind alone is sufficient and authoritative.
+    """
+
+    return payload.molecule_kind == MoleculeKind.electron
 
 
 def formal_charge(mol: Chem.Mol) -> int:
@@ -157,13 +188,17 @@ def element_counts_from_smiles(smiles: str) -> Counter[str]:
       correctly, lists the same elements as the ordinary compound. Isotope
       agreement is a separate check with its own multiset comparison
       (:func:`app.services.species_resolution.assert_geometry_isotopes_match_identity`).
-    * **Symbols are normalised** through
-      :func:`~app.chemistry.geometry.normalize_element_symbol`, because the
-      other side of every comparison is an XYZ element stored verbatim and
-      electronic-structure codes disagree about capitalisation.
+    * **Symbols are resolved to elements** through
+      :func:`~app.chemistry.geometry.resolve_element_symbol`, because the other
+      side of every comparison is an XYZ element stored verbatim: ESS codes
+      disagree about capitalisation (``CL``, ``cl``) and write hydrogen's
+      isotopes as elements (``D``, ``T``). RDKit's ``GetSymbol()`` produces
+      neither spelling, so this call is a no-op on this side — it is here so
+      that both sides of every comparison are counted by one rule rather than
+      two that must be remembered to agree.
 
     :param smiles: SMILES string to count.
-    :returns: Mapping of normalised element symbol to atom count.
+    :returns: Mapping of element symbol to atom count.
     :raises ValueError: If RDKit cannot parse the SMILES string.
     """
 
@@ -173,16 +208,36 @@ def element_counts_from_smiles(smiles: str) -> Counter[str]:
     mol = Chem.AddHs(mol)
     counts: Counter[str] = Counter()
     for atom in mol.GetAtoms():
-        counts[normalize_element_symbol(atom.GetSymbol())] += 1
+        counts[resolve_element_symbol(atom.GetSymbol())] += 1
     return counts
 
 
 def format_element_counts(counts: Mapping[str, int]) -> str:
-    """Render an element count as a formula, for an error a human can read."""
+    """Render an element count as a formula, for an error a human can read.
+
+    **Hill notation**, which is what a chemist reads: carbon first, hydrogen
+    second, then every other element alphabetically — and, when there is no
+    carbon, everything alphabetically including hydrogen. Plain alphabetical
+    ordering renders chloromethane as ``CClH3``, a string nobody recognises as
+    the molecule they deposited, in an error message whose whole job is to be
+    recognised.
+
+    :param counts: Element symbol to atom count. Elements counted zero times
+        are omitted rather than rendered with no subscript.
+    :returns: The molecular formula, e.g. ``CH3Cl`` or ``H2O``.
+    """
+
+    present = {element: count for element, count in counts.items() if count}
+    ordered: list[str] = []
+    if "C" in present:
+        ordered.append("C")
+        if "H" in present:
+            ordered.append("H")
+    ordered.extend(sorted(element for element in present if element not in ordered))
 
     return "".join(
-        f"{element}{count if count > 1 else ''}"
-        for element, count in sorted(counts.items())
+        f"{element}{present[element] if present[element] > 1 else ''}"
+        for element in ordered
     )
 
 
@@ -477,8 +532,14 @@ def canonical_species_identity(
     :param payload: Upload-facing species-entry identity payload.
     :returns: ``(canonical_smiles, inchi_key)`` for the graph identity.
     :raises ValueError:
-        If the payload is not a supported molecule upload or if the stated
-        charge disagrees with the parsed SMILES identity.
+        If the payload is not a supported molecule or electron upload or if
+        the stated charge disagrees with the parsed SMILES identity.
+
+    A free electron short-circuits every step below: it has no molecular
+    graph to canonicalize and no InChI, so it resolves to the reserved
+    identity pair (see :data:`ELECTRON_INCHI_KEY`). Its charge is pinned by
+    the payload schema rather than reconciled against a structure, because
+    there is no structure to reconcile it against.
 
     Multiplicity is NOT validated against the SMILES: standard SMILES does
     not encode spin state, so the radical count RDKit infers is only a
@@ -494,6 +555,9 @@ def canonical_species_identity(
     ``inchi_key`` isotope-blind, so an InChIKey lookup finds every
     isotopologue of a compound rather than only the ordinary one.
     """
+
+    if payload.molecule_kind == MoleculeKind.electron:
+        return ELECTRON_SMILES, ELECTRON_INCHI_KEY
 
     if payload.molecule_kind != MoleculeKind.molecule:
         raise ValueError("Conformer upload currently supports only molecule species")

--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
+from typing import Mapping
 
 from rdkit import Chem
 from rdkit.Chem import AllChem, inchi, rdDetermineBonds
 
+from app.chemistry.geometry import normalize_element_symbol
 from app.chemistry.isotopes import normalize_isotope, validate_isotope
 from app.db.models.common import MoleculeKind, StereoKind
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
@@ -134,6 +137,53 @@ def isotope_substitutions(smiles: str) -> dict[tuple[str, int], int]:
             key = (atom.GetSymbol(), mass_number)
             counts[key] = counts.get(key, 0) + 1
     return counts
+
+
+def element_counts_from_smiles(smiles: str) -> Counter[str]:
+    """Count the elements a SMILES declares, the way a geometry counts them.
+
+    Three normalisations make the result comparable against
+    ``geometry_atom.element`` and against another SMILES:
+
+    * **Hydrogens are made explicit.** A SMILES carries most of its hydrogens
+      implicitly (``C`` is methane, one atom in the graph and five in the
+      molecule), while an XYZ lists every nucleus. Without
+      :func:`rdkit.Chem.AddHs` every organic species would appear to be
+      missing its hydrogens.
+    * **Isotopes collapse to their element.** ``[2H]`` counts as ``H``. The
+      canonical form stores the element, not the nuclide, and isotopic
+      substitution changes masses rather than composition — counting
+      isotope-resolved would refuse every isotopologue whose geometry, quite
+      correctly, lists the same elements as the ordinary compound. Isotope
+      agreement is a separate check with its own multiset comparison
+      (:func:`app.services.species_resolution.assert_geometry_isotopes_match_identity`).
+    * **Symbols are normalised** through
+      :func:`~app.chemistry.geometry.normalize_element_symbol`, because the
+      other side of every comparison is an XYZ element stored verbatim and
+      electronic-structure codes disagree about capitalisation.
+
+    :param smiles: SMILES string to count.
+    :returns: Mapping of normalised element symbol to atom count.
+    :raises ValueError: If RDKit cannot parse the SMILES string.
+    """
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"RDKit failed to parse SMILES: {smiles}")
+    mol = Chem.AddHs(mol)
+    counts: Counter[str] = Counter()
+    for atom in mol.GetAtoms():
+        counts[normalize_element_symbol(atom.GetSymbol())] += 1
+    return counts
+
+
+def format_element_counts(counts: Mapping[str, int]) -> str:
+    """Render an element count as a formula, for an error a human can read."""
+
+    return "".join(
+        f"{element}{count if count > 1 else ''}"
+        for element, count in sorted(counts.items())
+    )
 
 
 def derive_unmapped_smiles(smiles: str) -> str:

--- a/backend/app/chemistry/torsion_fingerprint.py
+++ b/backend/app/chemistry/torsion_fingerprint.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from rdkit import Chem
 from rdkit.Chem import rdMolTransforms
 
+from app.chemistry.geometry import resolve_element_symbol
+
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
@@ -460,15 +462,27 @@ def _find_matches_using_smiles_graph(
     inference for radicals, TSs, and stretched bonds.
 
     Returns a list of valid (xyz_idx → ref_idx) mappings.
+
+    Both sides go through
+    :func:`~app.chemistry.geometry.resolve_element_symbol` before they are
+    grouped, because they come from sources that spell elements differently by
+    construction: the XYZ side holds whatever the depositor's file said
+    (``CL``, ``c``, ``D``), the reference side holds RDKit's title-case
+    ``GetSymbol()``. Grouping the raw strings makes a correct geometry look
+    like it has no atoms in common with its own SMILES, and the caller records
+    that as ``is_isomorphic=False`` / ``validation_status='fail'`` — a false
+    ``fail`` on correct chemistry, and one that disagreed with
+    :func:`app.services.species_resolution.assert_geometry_composition_matches_identity`,
+    which normalises, about the very same deposit.
     """
     # Build element→indices maps for XYZ atoms
     xyz_by_elem: dict[str, list[int]] = {}
     for i, (elem, _x, _y, _z) in enumerate(xyz_atoms):
-        xyz_by_elem.setdefault(elem, []).append(i)
+        xyz_by_elem.setdefault(resolve_element_symbol(elem), []).append(i)
 
     ref_by_elem: dict[str, list[int]] = {}
     for i in range(ref_mol.GetNumAtoms()):
-        elem = ref_mol.GetAtomWithIdx(i).GetSymbol()
+        elem = resolve_element_symbol(ref_mol.GetAtomWithIdx(i).GetSymbol())
         ref_by_elem.setdefault(elem, []).append(i)
 
     # Check element counts match
@@ -571,15 +585,25 @@ def resolve_atom_mapping(
         if not matches:
             return AtomMappingResult(status="no_match")
 
+        # Everything below indexes the *uploaded* atom list, never ``xyz_mol``.
+        # ``xyz_mol`` is unbound whenever ``_build_mol_from_xyz`` raised, which
+        # is precisely when the SMILES-graph fallback was supposed to rescue
+        # the mapping; reading it here turned that rescue into a ``NameError``,
+        # caught by the blanket handler below and reported as
+        # ``status="error"`` — so the fallback could only ever be reached when
+        # bond perception had already succeeded.
+        heavy_xyz_indices = [
+            index
+            for index, (element, _x, _y, _z) in enumerate(xyz_atoms)
+            if resolve_element_symbol(element) != "H"
+        ]
+
         # Deduplicate: only care about heavy-atom-distinct mappings
         # (H permutations within the same heavy-atom mapping are equivalent
         # for torsion purposes since we use canonical terminal atom selection)
         seen_heavy_maps: dict[tuple, tuple] = {}
         for match in matches:
-            heavy_key = tuple(
-                match[i] for i in range(xyz_mol.GetNumAtoms())
-                if xyz_mol.GetAtomWithIdx(i).GetAtomicNum() > 1
-            )
+            heavy_key = tuple(match[i] for i in heavy_xyz_indices)
             if heavy_key not in seen_heavy_maps:
                 seen_heavy_maps[heavy_key] = match
 
@@ -595,7 +619,7 @@ def resolve_atom_mapping(
             # Build conformer on ref_mol with mapped coordinates
             conf = Chem.Conformer(ref_mol.GetNumAtoms())
             mapped_coords: list[tuple[float, float, float]] = [(0.0, 0.0, 0.0)] * ref_mol.GetNumAtoms()
-            for xyz_idx in range(xyz_mol.GetNumAtoms()):
+            for xyz_idx in range(len(xyz_atoms)):
                 ref_idx = match[xyz_idx]
                 _, x, y, z = xyz_atoms[xyz_idx]
                 conf.SetAtomPosition(ref_idx, (x, y, z))
@@ -615,7 +639,9 @@ def resolve_atom_mapping(
 
             fingerprints.append(fp)
             if chosen_mapping is None:
-                chosen_mapping = {xyz_idx: match[xyz_idx] for xyz_idx in range(xyz_mol.GetNumAtoms())}
+                chosen_mapping = {
+                    xyz_idx: match[xyz_idx] for xyz_idx in range(len(xyz_atoms))
+                }
                 chosen_mapped_coords = mapped_coords
 
         # Check if all fingerprints agree

--- a/backend/app/db/models/common.py
+++ b/backend/app/db/models/common.py
@@ -4,8 +4,37 @@ from enum import Enum
 
 
 class MoleculeKind(str, Enum):
+    # What sort of thing a reaction participant is.
+    #
+    # ``molecule`` is an atom-resolved structure with a SMILES, which is nearly
+    # everything. ``pseudo`` is a lumped or phenomenological construct whose
+    # composition and charge are not atom-resolved facts, so
+    # ``validate_reaction_elemental_balance`` and
+    # ``validate_reaction_charge_conservation`` decline to judge a reaction
+    # containing one.
+    #
+    # ``electron`` is deliberately **not** a flavour of ``pseudo``. A free
+    # electron has no SMILES and no atoms, but it is precisely known — zero
+    # atoms, charge -1 — where a pseudo-species is unknowable by construction.
+    # It therefore exempts a reaction from nothing: it contributes 0 to every
+    # element count and -1 to the charge sum, and both conservation checks stay
+    # live. Routing it through the ``pseudo`` exemption would have let any
+    # depositor switch mass balance off by adding an electron, which is a worse
+    # hole than the one the electron exists to close. See
+    # ``app.services.reaction_resolution._load_participant_species`` and
+    # revision ``b8f3d6a1c9e4``.
+    #
+    # Deliberately a comment rather than a docstring: this enum is mirrored as
+    # ``tckdb_schemas.enums.MoleculeKind``, and the two JSON schemas merge into
+    # one ``MoleculeKind`` component only while they are byte-identical. A
+    # docstring on one side alone splits it into ``MoleculeKind-Output`` and
+    # ``tckdb_schemas__enums__MoleculeKind`` and renames a published component.
+    # The two enums are kept in lockstep by
+    # ``tests/schemas/test_tckdb_schemas_enum_drift.py``.
+
     molecule = "molecule"
     pseudo = "pseudo"
+    electron = "electron"
 
 
 class StationaryPointKind(str, Enum):

--- a/backend/app/services/geometry_validation.py
+++ b/backend/app/services/geometry_validation.py
@@ -1,10 +1,45 @@
-"""Validate calculation output geometry against species identity.
+"""Compare a calculation's output geometry against its species' formula.
 
-This is a *structure-consistency* check: does the output geometry still
-represent the molecule we claimed it does? It is intended to catch
-optimizations that rearranged the molecule, broke/formed bonds,
-dissociated, transferred a proton, or otherwise drifted to a different
-chemical identity.
+**What this actually checks is the molecular formula, not the molecular
+graph.** The field is named ``is_isomorphic`` and the policy below is worded
+as graph isomorphism, but the code beneath it does not test that.
+:func:`app.chemistry.torsion_fingerprint.resolve_atom_mapping` falls back to
+:func:`~app.chemistry.torsion_fingerprint._find_matches_using_smiles_graph`
+whenever bond perception from XYZ fails or produces no substructure match,
+which is the common case for the radicals, ions and stretched geometries this
+service mostly sees — and that fallback rejects a candidate on one condition
+only: the per-element atom counts disagree. Anything with the right formula is
+reported as isomorphic.
+
+Verified consequences, by direct call:
+
+- Ethanol declared, dimethyl ether deposited — constitutional isomers, both
+  C2H6O — **passes**.
+- Methane with one hydrogen pulled out to 5 Å, i.e. a dissociated fragment
+  pair — **passes**.
+
+So the rearrangement, bond-breaking, dissociation and proton-transfer cases
+this module was written to catch are **not** caught. A ``pass`` here means
+"the output has the same atoms as the declared species", nothing more, and a
+``fail`` here has only ever meant "the atom counts disagree".
+
+Connectivity validation is not implemented. Implementing it needs a bond
+perception step that is trustworthy on exactly the strained, radical and
+stretched structures where a rearrangement would matter, which
+``rdDetermineBonds`` is not — it fails silently rather than loudly, so a naive
+version would trade a visible gap for an invisible one.
+
+Where the formula rule blocks
+-----------------------------
+Per ADR 0008 §9, where the same fact is checked in more than one tier the
+blocking tier owns it and the others cite it. Formula agreement between a
+structure and the identity it is deposited under is owned by
+:func:`app.services.species_resolution.assert_geometry_composition_matches_identity`,
+which refuses the upload outright — but only for **conformer** geometries. A
+calculation's input and output geometries reach no composition check on any
+upload path, so for those this service's advisory row is the only place the
+comparison happens at all. That is deliberate for an *output* geometry: an
+optimisation that drifted is science to record, not a payload to refuse.
 
 Not in scope here:
 
@@ -15,12 +50,13 @@ Not in scope here:
   Hessian character, etc. — lives on the frequency result surfaces.
 
 Policy (species-entry optimizations):
-- Not graph-isomorphic → fail (hard gate)
-- Isomorphic + RMSD above threshold → warning (advisory)
+- Formula disagrees (recorded as ``is_isomorphic=False``) → fail
+- Formula agrees + RMSD above threshold → warning (advisory)
 - Otherwise → pass
 
-Graph isomorphism is the identity criterion.
-RMSD is a suspicion signal, not an identity criterion.
+Neither outcome refuses an upload; see
+:func:`run_and_persist_geometry_validation`. RMSD is a suspicion signal, not
+an identity criterion.
 
 Two layers:
 
@@ -99,7 +135,9 @@ def validate_calculation_geometry(
     :param rmsd_warning_threshold: RMSD above this triggers warning.
     :returns: GeometryValidationResult (caller persists).
     """
-    # --- Step 1: Graph isomorphism check on output geometry ---
+    # --- Step 1: Identity check on output geometry. Named for graph
+    # isomorphism; in practice a formula comparison — see the module
+    # docstring. ---
     output_mapping = resolve_atom_mapping(species_smiles, output_atoms)
 
     if output_mapping.status in ("no_match", "error"):

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.chemistry.geometry import normalize_element_symbol
+from app.chemistry.species import element_counts_from_smiles, format_element_counts
 from app.db.models.common import MoleculeKind, ReactionRole
 from app.db.models.geometry import GeometryAtom
 from app.db.models.reaction import (
@@ -65,17 +66,47 @@ def _element_counts_for_species(species: Species) -> Counter[str]:
     :raises ValueError: If the stored SMILES cannot be parsed by RDKit.
     """
 
-    mol = Chem.MolFromSmiles(species.smiles)
-    if mol is None:
+    try:
+        return element_counts_from_smiles(species.smiles)
+    except ValueError as exc:
         raise ValueError(
             f"Cannot parse stored SMILES for species_id={species.id} "
             "while validating reaction elemental balance."
-        )
-    mol = Chem.AddHs(mol)
-    counts: Counter[str] = Counter()
-    for atom in mol.GetAtoms():
-        counts[normalize_element_symbol(atom.GetSymbol())] += 1
-    return counts
+        ) from exc
+
+
+def _load_participant_species(
+    session: Session,
+    *,
+    reactant_stoichiometry: Mapping[int, int],
+    product_stoichiometry: Mapping[int, int],
+) -> dict[int, Species] | None:
+    """Fetch the participant species rows, or ``None`` if the check is exempt.
+
+    ``None`` means "do not judge this reaction": either it has no participants
+    at all, or one of them is a pseudo-species. Pseudo-species are lumped or
+    phenomenological constructs rather than atom-resolved chemistry, so neither
+    their elements nor their charge is a quantity a conservation law applies
+    to. Shared by both conservation checks so the two can never drift into
+    exempting different reactions.
+    """
+
+    species_ids = set(reactant_stoichiometry) | set(product_stoichiometry)
+    if not species_ids:
+        return None
+
+    species_rows = session.scalars(
+        select(Species).where(Species.id.in_(species_ids))
+    ).all()
+    species_by_id = {species.id: species for species in species_rows}
+
+    if any(
+        species_by_id[species_id].kind == MoleculeKind.pseudo
+        for species_id in species_ids
+    ):
+        return None
+
+    return species_by_id
 
 
 def validate_reaction_elemental_balance(
@@ -92,23 +123,19 @@ def validate_reaction_elemental_balance(
     may represent lumped or phenomenological constructs rather than
     atom-resolved chemistry).
 
+    Charge is the other conserved quantity and is checked separately by
+    :func:`validate_reaction_charge_conservation`.
+
     :raises ValueError: If all participants are ordinary molecule species
         and the reactant/product element totals disagree.
     """
 
-    species_ids = set(reactant_stoichiometry) | set(product_stoichiometry)
-    if not species_ids:
-        return
-
-    species_rows = session.scalars(
-        select(Species).where(Species.id.in_(species_ids))
-    ).all()
-    species_by_id = {species.id: species for species in species_rows}
-
-    if any(
-        species_by_id[species_id].kind == MoleculeKind.pseudo
-        for species_id in species_ids
-    ):
+    species_by_id = _load_participant_species(
+        session,
+        reactant_stoichiometry=reactant_stoichiometry,
+        product_stoichiometry=product_stoichiometry,
+    )
+    if species_by_id is None:
         return
 
     reactant_totals: Counter[str] = Counter()
@@ -131,13 +158,93 @@ def validate_reaction_elemental_balance(
         )
 
 
+def validate_reaction_charge_conservation(
+    session: Session,
+    *,
+    reactant_stoichiometry: Mapping[int, int],
+    product_stoichiometry: Mapping[int, int],
+) -> None:
+    """Enforce charge conservation for ordinary reactions.
+
+    Charge is conserved by every elementary and overall chemical reaction, in
+    exactly the sense that atoms are: electrons are neither created nor
+    destroyed by rearranging bonds, so the summed formal charge of the
+    reactants equals that of the products. ``[OH-] + [H] -> H2O`` is not a
+    reaction that is hard to compute — it is not a reaction, because it loses
+    an electron on the way across. Under ADR 0008 that is a **definition**, not
+    an expectation: no correct calculation can produce it, so the check blocks
+    rather than warns, and it sits beside
+    :func:`validate_reaction_elemental_balance` because it is the same
+    conservation argument applied to the other conserved quantity.
+
+    Nothing checked this before. Elemental balance compared element totals and
+    said nothing about charge, so a charge-losing reaction deposited with no
+    error and no warning at all. That gap reached further than itself:
+    :func:`validate_transition_state_composition` checks a saddle point's
+    charge against its *reactants*, and until now the reactant side carried no
+    conservation guarantee of its own for that rule to be anchored to.
+
+    Per-species charge is trustworthy input: ``Species.charge`` is compared
+    against the formal charge of its own SMILES by
+    :func:`app.chemistry.species.canonical_species_identity`, which blocks, so
+    this function sums values that have already been reconciled with the
+    structures they label.
+
+    The stoichiometric coefficients and the pseudo-species exemption are the
+    same as elemental balance's, by construction — both read
+    :func:`_load_participant_species`.
+
+    **Conservation, not neutrality.** A reaction may carry any net charge as
+    long as both sides carry the same one. Requiring neutrality would refuse
+    every ion-molecule reaction in the literature, which is exactly the false
+    positive ADR 0008 disqualifies a blocking check for.
+
+    **What this cannot express.** A free electron is not a species TCKDB can
+    represent — there is no SMILES for one — so genuinely electron-transferring
+    processes (dissociative attachment, photoionization) have no way to balance
+    here. Elemental balance has the same limitation for the same reason and
+    offers the same escape: declare a participant as a ``pseudo`` species,
+    which exempts the reaction from both rules and records that its
+    bookkeeping is phenomenological.
+
+    :raises ValueError: If all participants are ordinary molecule species and
+        the reactant/product charge totals disagree.
+    """
+
+    species_by_id = _load_participant_species(
+        session,
+        reactant_stoichiometry=reactant_stoichiometry,
+        product_stoichiometry=product_stoichiometry,
+    )
+    if species_by_id is None:
+        return
+
+    reactant_charge = sum(
+        coefficient * species_by_id[species_id].charge
+        for species_id, coefficient in reactant_stoichiometry.items()
+    )
+    product_charge = sum(
+        coefficient * species_by_id[species_id].charge
+        for species_id, coefficient in product_stoichiometry.items()
+    )
+
+    if reactant_charge != product_charge:
+        raise ValueError(
+            f"Reaction reactants total charge {reactant_charge:+d} but products "
+            f"total {product_charge:+d} (reaction_charge_not_conserved). Charge "
+            "is conserved across a reaction, so the two sides describe "
+            "different numbers of electrons and cannot be the same reaction. "
+            "A net charge is fine as long as both sides carry the same one; if "
+            "the process genuinely transfers an electron to or from somewhere "
+            "outside the reaction, declare that participant as a pseudo "
+            "species."
+        )
+
+
 def _format_formula(counts: Mapping[str, int]) -> str:
     """Render an element count as a formula, for an error a human can read."""
 
-    return "".join(
-        f"{element}{count if count > 1 else ''}"
-        for element, count in sorted(counts.items())
-    )
+    return format_element_counts(counts)
 
 
 def validate_transition_state_composition(
@@ -330,6 +437,11 @@ def resolve_chem_reaction(
     """
 
     validate_reaction_elemental_balance(
+        session,
+        reactant_stoichiometry=reactant_stoichiometry,
+        product_stoichiometry=product_stoichiometry,
+    )
+    validate_reaction_charge_conservation(
         session,
         reactant_stoichiometry=reactant_stoichiometry,
         product_stoichiometry=product_stoichiometry,

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.chemistry.geometry import normalize_element_symbol
+from app.chemistry.geometry import resolve_element_symbol
 from app.chemistry.species import element_counts_from_smiles, format_element_counts
 from app.db.models.common import MoleculeKind, ReactionRole
 from app.db.models.geometry import GeometryAtom
@@ -61,10 +61,19 @@ def reaction_stoichiometry_hash(
 
 
 def _element_counts_for_species(species: Species) -> Counter[str]:
-    """Count element occurrences for one ordinary (molecule-kind) species.
+    """Count element occurrences for one reaction participant.
+
+    A free electron contributes an empty count — not because its composition
+    is unknown, but because it is known to be nothing. That is the whole
+    difference between it and a pseudo-species, which is skipped by
+    :func:`_load_participant_species` before it ever gets here: an electron
+    still has to balance, it simply has no atoms to bring to the balance.
 
     :raises ValueError: If the stored SMILES cannot be parsed by RDKit.
     """
+
+    if species.kind == MoleculeKind.electron:
+        return Counter()
 
     try:
         return element_counts_from_smiles(species.smiles)
@@ -89,6 +98,15 @@ def _load_participant_species(
     their elements nor their charge is a quantity a conservation law applies
     to. Shared by both conservation checks so the two can never drift into
     exempting different reactions.
+
+    **A declared electron does not land here.** ``MoleculeKind.electron`` is
+    checked against ``pseudo`` specifically, not against "anything that is not
+    a molecule", and that is load-bearing rather than incidental. An electron
+    is exactly known — zero atoms, charge -1 — so it participates in both
+    conservation laws instead of suspending them. Were it routed through this
+    exemption, adding an electron to any reaction would switch its mass
+    balance off, which is a larger hole than the one the electron exists to
+    close.
     """
 
     species_ids = set(reactant_stoichiometry) | set(product_stoichiometry)
@@ -123,11 +141,16 @@ def validate_reaction_elemental_balance(
     may represent lumped or phenomenological constructs rather than
     atom-resolved chemistry).
 
+    A declared free electron is **not** exempted — it contributes an empty
+    element count, so a reaction carrying one still has to balance atom for
+    atom. See :func:`_load_participant_species` for why that separation
+    matters.
+
     Charge is the other conserved quantity and is checked separately by
     :func:`validate_reaction_charge_conservation`.
 
-    :raises ValueError: If all participants are ordinary molecule species
-        and the reactant/product element totals disagree.
+    :raises ValueError: If no participant is a pseudo-species and the
+        reactant/product element totals disagree.
     """
 
     species_by_id = _load_participant_species(
@@ -199,16 +222,30 @@ def validate_reaction_charge_conservation(
     every ion-molecule reaction in the literature, which is exactly the false
     positive ADR 0008 disqualifies a blocking check for.
 
-    **What this cannot express.** A free electron is not a species TCKDB can
-    represent — there is no SMILES for one — so genuinely electron-transferring
-    processes (dissociative attachment, photoionization) have no way to balance
-    here. Elemental balance has the same limitation for the same reason and
-    offers the same escape: declare a participant as a ``pseudo`` species,
-    which exempts the reaction from both rules and records that its
-    bookkeeping is phenomenological.
+    **Electron-transferring processes balance here too.** Associative
+    detachment (``OH- + H -> H2O + e-``), dissociative attachment,
+    photoionization and photodetachment all release or consume a free
+    electron, and all are real measured gas-phase chemistry. They are
+    deposited by declaring the electron as a participant —
+    ``{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1,
+    "multiplicity": 2}`` — which contributes -1 to the side it sits on and
+    lets the reaction balance as written.
 
-    :raises ValueError: If all participants are ordinary molecule species and
-        the reactant/product charge totals disagree.
+    That door has to exist for this check to be allowed to block at all.
+    Charge conservation is definitional only if the participant list can be
+    *complete*; with no way to name the electron, the rule would in fact be
+    asserting "every participant was declared", which is an expectation about
+    the depositor rather than a definition of a reaction, and ADR 0008
+    disqualifies an expectation from blocking. The electron is what makes the
+    stated claim the claim actually enforced.
+
+    Declaring one exempts nothing. Unlike a ``pseudo`` participant, an
+    electron is precisely known, so it contributes 0 atoms to elemental
+    balance and -1 to this sum, and both checks still have to pass. See
+    :func:`_load_participant_species`.
+
+    :raises ValueError: If no participant is a pseudo-species and the
+        reactant/product charge totals disagree.
     """
 
     species_by_id = _load_participant_species(
@@ -234,17 +271,14 @@ def validate_reaction_charge_conservation(
             f"total {product_charge:+d} (reaction_charge_not_conserved). Charge "
             "is conserved across a reaction, so the two sides describe "
             "different numbers of electrons and cannot be the same reaction. "
-            "A net charge is fine as long as both sides carry the same one; if "
-            "the process genuinely transfers an electron to or from somewhere "
-            "outside the reaction, declare that participant as a pseudo "
-            "species."
+            "A net charge is fine as long as both sides carry the same one. If "
+            "the process genuinely releases or consumes a free electron — "
+            "associative or dissociative attachment, photoionization, "
+            "photodetachment — declare the electron as a participant: "
+            '{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, '
+            '"multiplicity": 2}. It balances the charge and still leaves the '
+            "elemental balance to be satisfied on its own terms."
         )
-
-
-def _format_formula(counts: Mapping[str, int]) -> str:
-    """Render an element count as a formula, for an error a human can read."""
-
-    return format_element_counts(counts)
 
 
 def validate_transition_state_composition(
@@ -326,8 +360,8 @@ def validate_transition_state_composition(
         if ts_counts != reactant_totals:
             raise ValueError(
                 f"Transition state '{subject_label}' is "
-                f"{_format_formula(ts_counts)}, but the reaction it sits in is "
-                f"{_format_formula(reactant_totals)} "
+                f"{format_element_counts(ts_counts)}, but the reaction it sits "
+                f"in is {format_element_counts(reactant_totals)} "
                 "(transition_state_composition_mismatch). A transition state is "
                 "a stationary point on the potential energy surface of its "
                 "reaction's atoms, so a saddle point made of different atoms "
@@ -364,15 +398,15 @@ def _transition_state_element_counts(
     SMILES is a lossy description of a structure that is, by construction, not
     a stable molecule.
 
-    Both branches are normalised through
-    :func:`~app.chemistry.geometry.normalize_element_symbol` before they are
-    counted, and so is the reactant side, because the two sources disagree
-    about capitalisation by construction: ``geometry_atom.element`` holds
+    Both branches are resolved through
+    :func:`~app.chemistry.geometry.resolve_element_symbol` before they are
+    counted, and so is the reactant side, because the two sources spell
+    elements differently by construction: ``geometry_atom.element`` holds
     whatever the depositor's XYZ said, while ``_element_counts_for_species``
     reads RDKit's title-case ``GetSymbol()``. Comparing them raw makes a saddle
-    point written ``CL`` or ``c`` contradict a reaction it is in fact made of,
-    which refuses correct chemistry over a string — the failure ADR 0008 puts
-    out of bounds for a blocking check.
+    point written ``CL``, ``c`` or ``D`` contradict a reaction it is in fact
+    made of, which refuses correct chemistry over a string — the failure ADR
+    0008 puts out of bounds for a blocking check.
     """
 
     if transition_state_geometry_id is not None:
@@ -382,14 +416,14 @@ def _transition_state_element_counts(
             )
         ).all()
         if elements:
-            return Counter(normalize_element_symbol(element) for element in elements)
+            return Counter(resolve_element_symbol(element) for element in elements)
 
     if transition_state_smiles is not None:
         mol = Chem.MolFromSmiles(transition_state_smiles)
         if mol is not None:
             mol = Chem.AddHs(mol)
             return Counter(
-                normalize_element_symbol(atom.GetSymbol()) for atom in mol.GetAtoms()
+                resolve_element_symbol(atom.GetSymbol()) for atom in mol.GetAtoms()
             )
 
     return None

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import ColumnElement
 
-from app.chemistry.geometry import normalize_element_symbol, parse_xyz
+from app.chemistry.geometry import parse_xyz, resolve_element_symbol
 from app.chemistry.species import (
     canonical_isotope_key,
     canonical_species_identity,
@@ -19,6 +19,7 @@ from app.chemistry.species import (
     element_counts_from_smiles,
     format_element_counts,
     identity_mol_from_smiles,
+    is_electron,
     isotope_substitutions,
 )
 from app.db.models.common import MoleculeKind, StereoKind
@@ -44,6 +45,12 @@ def resolve_species(
 ) -> Species:
     """Resolve or create a species row from upload identity data.
 
+    A free electron resolves like anything else — one row, deduped on the same
+    ``(smiles, charge, multiplicity)`` identity as every other species — but
+    with the graph-derived steps skipped, because it has no graph. There is
+    exactly one electron, so every deposit that declares one converges on that
+    single row.
+
     :param session: Active SQLAlchemy session.
     :param payload: Upload-facing species-entry identity payload.
     :returns: Existing or newly created ``Species`` row.
@@ -55,8 +62,13 @@ def resolve_species(
     # Derive stereo_kind from molecular graph if not explicitly provided
     stereo_kind = payload.stereo_kind
     if stereo_kind == StereoKind.unspecified:
-        ident_mol = identity_mol_from_smiles(payload.smiles)
-        stereo_kind, _auto_label = classify_stereo_kind(ident_mol)
+        if is_electron(payload):
+            # No graph, no stereocentres, and nothing that could ever acquire
+            # one — not "unspecified pending better data".
+            stereo_kind = StereoKind.achiral
+        else:
+            ident_mol = identity_mol_from_smiles(payload.smiles)
+            stereo_kind, _auto_label = classify_stereo_kind(ident_mol)
 
     # Identity is (canonical_smiles, charge, multiplicity) — see DR-0031.
     # inchi_key is stored for cross-notation search but is NOT the dedup
@@ -132,6 +144,12 @@ def assert_geometry_isotopes_match_identity(
     :raises ValueError: If the isotope substitutions disagree.
     """
 
+    if is_electron(payload):
+        # ``[e-]`` is a sentinel, not a SMILES; there are no nuclei to label.
+        # The composition check has already refused any geometry attached to
+        # an electron, so reaching here with one is not possible.
+        return
+
     from_smiles = isotope_substitutions(payload.smiles)
     from_geometry = parse_xyz(geometry).isotope_substitutions()
     if from_smiles == from_geometry:
@@ -158,15 +176,15 @@ def assert_geometry_composition_matches_identity(
     payload: SpeciesEntryIdentityPayload,
     geometry: GeometryPayload,
 ) -> None:
-    """Refuse a deposit whose structure is not made of the atoms it declares.
+    """Refuse a conformer geometry not made of the atoms its entry declares.
 
     Nothing checked this before. A species entry declares what it is in
-    ``smiles``; the geometry deposited under it is the structure that every
-    downstream number — energies, frequencies, partition functions, thermo —
-    is computed from. If the two name different molecules, the record is
-    internally contradictory: the identity says methane and the coordinates
-    describe methyl, and every consumer that trusts the label gets numbers for
-    a molecule nobody deposited.
+    ``smiles``; the conformer geometry deposited under it is the structure that
+    the numbers hanging off that conformer — energies, frequencies, partition
+    functions, thermo — are computed from. If the two name different molecules,
+    the record is internally contradictory: the identity says methane and the
+    coordinates describe methyl, and every consumer that trusts the label gets
+    numbers for a molecule nobody deposited.
 
     Formula agreement between a structure and its own identifier is
     **definitional** under ADR 0008 — no correct calculation can produce a
@@ -182,11 +200,39 @@ def assert_geometry_composition_matches_identity(
     composition check in the codebase compared a reaction's two *sides*
     against each other and never a structure against its own label.
 
+    Which geometries this reaches, and which it does not
+    ---------------------------------------------------
+    **Conformer geometries only.** This function is called from
+    :func:`resolve_species_entry` and its coverage is exactly that of the
+    isotope check beside it: the geometry deposited with a species entry and
+    the further conformer geometries deposited under the same entry. That
+    reaches the computed-species bundle, ``/uploads/conformers``, the
+    computed-reaction bundle and the PDep bundle, because all four resolve
+    their conformer geometries through this one seam.
+
+    **Calculation geometries are not reached, on any path.**
+    ``CalculationIn.input_geometries`` and ``output_geometries`` are attached
+    to a ``calculation`` row, never resolved through
+    :func:`resolve_species_entry`, and no composition check runs on them
+    anywhere: benzene coordinates can be attached as a calculation geometry
+    under a ``smiles: "C"`` species entry and the deposit is accepted. The
+    only comparison they get is
+    :mod:`app.services.geometry_validation`, which is advisory rather than
+    blocking, runs only for ``opt`` calculations, and — despite its
+    ``is_isomorphic`` field name — compares formulas too (see that module's
+    docstring). Closing that gap for *output* geometries would be wrong: an
+    optimisation that dissociated is science to record. Closing it for *input*
+    geometries is a genuine open gap and is not attempted here.
+
     What is compared, and what deliberately is not
     ----------------------------------------------
     **Elements, not nuclides.** ``[2H]`` is stored as element ``H`` in the
     canonical form, so counting isotope-resolved would refuse every
-    isotopologue. Isotope agreement is checked separately and exactly by
+    isotopologue. The XYZ element column gets the same treatment from the
+    other direction: ``D`` and ``T`` are legal tokens that every major ESS
+    emits or accepts, and they are counted as the hydrogen they are (see
+    :func:`app.chemistry.geometry.resolve_element_symbol`). Isotope agreement
+    is checked separately and exactly by
     :func:`assert_geometry_isotopes_match_identity`.
 
     **Counts, not positions.** Two structures with the same formula pass, even
@@ -215,6 +261,12 @@ def assert_geometry_composition_matches_identity(
     a lumped or phenomenological construct has no atom-resolved composition
     for a geometry to agree with.
 
+    A free electron is **not** exempt, and this is the point of separating the
+    two kinds. Its composition is not unknown, it is empty: zero atoms. Any
+    geometry deposited under an electron therefore contradicts it and is
+    refused here, which is what keeps ``molecule_kind: electron`` from becoming
+    a second, quieter way to smuggle a structure past this check.
+
     :param payload: Upload-facing resolved identity payload.
     :param geometry: Upload-facing geometry payload deposited alongside it.
     :raises ValueError: If the geometry's element counts contradict the
@@ -224,27 +276,36 @@ def assert_geometry_composition_matches_identity(
     if payload.molecule_kind == MoleculeKind.pseudo:
         return
 
-    try:
-        from_smiles = element_counts_from_smiles(payload.smiles)
-    except ValueError:
-        return
+    if is_electron(payload):
+        from_smiles: Counter[str] = Counter()
+    else:
+        try:
+            from_smiles = element_counts_from_smiles(payload.smiles)
+        except ValueError:
+            return
 
     from_geometry: Counter[str] = Counter(
-        normalize_element_symbol(element)
+        resolve_element_symbol(element)
         for element, _x, _y, _z in parse_xyz(geometry).atoms
     )
     if from_smiles == from_geometry:
         return
 
+    geometry_formula = format_element_counts(from_geometry) or "empty"
+    identity_formula = (
+        format_element_counts(from_smiles)
+        or "nothing at all — a free electron has no atoms"
+    )
     raise ValueError(
-        f"Species geometry is {format_element_counts(from_geometry)}, but "
+        f"Species geometry is {geometry_formula}, but "
         f"species_entry.smiles={payload.smiles!r} is "
-        f"{format_element_counts(from_smiles)} "
+        f"{identity_formula} "
         "(species_geometry_composition_mismatch). A deposited structure must "
         "be made of the atoms its own identifier declares, or every number "
         "computed from it describes a different molecule. Hydrogens are "
         "counted explicitly on both sides, and isotope labels are counted as "
-        "their element, so an isotopologue is not a mismatch."
+        "their element — SMILES [2H] and the XYZ symbols D and T all count as "
+        "H — so an isotopologue is not a mismatch."
     )
 
 
@@ -264,6 +325,12 @@ def resolve_species_entry(
     :func:`app.chemistry.species.canonical_isotope_key`). Two deposits that
     differ only in deuteration therefore resolve to different entries under
     one shared species, and two all-standard deposits dedupe onto one entry.
+
+    A free electron (``molecule_kind: electron``) resolves through here too,
+    so a reaction can declare one as a participant, but every graph-derived
+    column of its entry stays ``NULL`` — it has no molecular graph — and any
+    geometry deposited under it is refused, because an electron has no atoms
+    for a structure to be made of.
 
     :param session: Active SQLAlchemy session.
     :param payload: Upload-facing resolved identity payload.
@@ -300,7 +367,11 @@ def resolve_species_entry(
     if stereo_label is None and species.stereo_kind != StereoKind.achiral and xyz_text:
         stereo_label = derive_stereo_label_from_3d(payload.smiles, xyz_text)
 
-    isotope_key = canonical_isotope_key(payload.smiles)
+    # A free electron has no molecular graph, so every graph-derived column
+    # stays NULL: no isotope key (no nuclei to label), no ``mol`` and no
+    # ``unmapped_smiles`` (nothing for the RDKit cartridge to hold, and nothing
+    # a structure search should ever return).
+    isotope_key = None if is_electron(payload) else canonical_isotope_key(payload.smiles)
 
     species_entry = session.scalar(
         select(SpeciesEntry).where(
@@ -319,12 +390,17 @@ def resolve_species_entry(
     if species_entry is None:
         # Auto-derive unmapped_smiles and mol SMILES for the RDKit cartridge
         unmapped = payload.unmapped_smiles
-        if unmapped is None:
-            unmapped = derive_unmapped_smiles(payload.smiles)
+        mol_smiles: str | None
+        if is_electron(payload):
+            unmapped = None
+            mol_smiles = None
+        else:
+            if unmapped is None:
+                unmapped = derive_unmapped_smiles(payload.smiles)
 
-        mol_smiles = Chem.MolToSmiles(
-            identity_mol_from_smiles(payload.smiles), canonical=True
-        )
+            mol_smiles = Chem.MolToSmiles(
+                identity_mol_from_smiles(payload.smiles), canonical=True
+            )
 
         try:
             with session.begin_nested():

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Sequence
 
 from rdkit import Chem
@@ -8,17 +9,19 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import ColumnElement
 
-from app.chemistry.geometry import parse_xyz
+from app.chemistry.geometry import normalize_element_symbol, parse_xyz
 from app.chemistry.species import (
     canonical_isotope_key,
     canonical_species_identity,
     classify_stereo_kind,
     derive_stereo_label_from_3d,
     derive_unmapped_smiles,
+    element_counts_from_smiles,
+    format_element_counts,
     identity_mol_from_smiles,
     isotope_substitutions,
 )
-from app.db.models.common import StereoKind
+from app.db.models.common import MoleculeKind, StereoKind
 from app.db.models.species import Species, SpeciesEntry
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
@@ -151,6 +154,100 @@ def assert_geometry_isotopes_match_identity(
     )
 
 
+def assert_geometry_composition_matches_identity(
+    payload: SpeciesEntryIdentityPayload,
+    geometry: GeometryPayload,
+) -> None:
+    """Refuse a deposit whose structure is not made of the atoms it declares.
+
+    Nothing checked this before. A species entry declares what it is in
+    ``smiles``; the geometry deposited under it is the structure that every
+    downstream number — energies, frequencies, partition functions, thermo —
+    is computed from. If the two name different molecules, the record is
+    internally contradictory: the identity says methane and the coordinates
+    describe methyl, and every consumer that trusts the label gets numbers for
+    a molecule nobody deposited.
+
+    Formula agreement between a structure and its own identifier is
+    **definitional** under ADR 0008 — no correct calculation can produce a
+    geometry that is not made of its own molecule's atoms — so it blocks,
+    exactly as :func:`app.services.reaction_resolution.validate_reaction_elemental_balance`
+    blocks the same class of contradiction one layer up and
+    :func:`~app.services.reaction_resolution.validate_transition_state_composition`
+    blocks it for a saddle point.
+
+    This is not a hypothetical. The pressure-dependent test fixtures stored
+    geometries with hydrogen omitted entirely — ethyl as three atoms, HO2 as
+    two — for as long as they existed, and nothing looked, because the only
+    composition check in the codebase compared a reaction's two *sides*
+    against each other and never a structure against its own label.
+
+    What is compared, and what deliberately is not
+    ----------------------------------------------
+    **Elements, not nuclides.** ``[2H]`` is stored as element ``H`` in the
+    canonical form, so counting isotope-resolved would refuse every
+    isotopologue. Isotope agreement is checked separately and exactly by
+    :func:`assert_geometry_isotopes_match_identity`.
+
+    **Counts, not positions.** Two structures with the same formula pass, even
+    if the connectivity differs — an isomer deposited under the wrong
+    identity is not caught here. Catching that needs 3D bond perception, which
+    fails silently on strained and radical systems, i.e. exactly where it
+    would matter; the same reasoning that stops
+    :func:`assert_geometry_isotopes_match_identity` from distinguishing
+    isotopomers.
+
+    **Charge is already owned elsewhere.** The SMILES formal charge is
+    compared against the declared ``charge`` by
+    :func:`app.chemistry.species.canonical_species_identity`, which blocks. Per
+    ADR 0008 the blocking tier owns a rule and the others cite it rather than
+    re-deriving it, so this function does not re-check charge — a second copy
+    could only disagree with the first.
+
+    **Absence does not block.** No geometry, or a SMILES RDKit will not parse,
+    is incompleteness rather than contradiction, and gets the tier an absent
+    atom map gets. (In practice an unparseable SMILES is already refused
+    upstream by the identity canonicalisation; the branch here exists so this
+    function is safe to call from anywhere.)
+
+    Pseudo-species are exempt, mirroring
+    :func:`~app.services.reaction_resolution.validate_reaction_elemental_balance`:
+    a lumped or phenomenological construct has no atom-resolved composition
+    for a geometry to agree with.
+
+    :param payload: Upload-facing resolved identity payload.
+    :param geometry: Upload-facing geometry payload deposited alongside it.
+    :raises ValueError: If the geometry's element counts contradict the
+        identity's own SMILES.
+    """
+
+    if payload.molecule_kind == MoleculeKind.pseudo:
+        return
+
+    try:
+        from_smiles = element_counts_from_smiles(payload.smiles)
+    except ValueError:
+        return
+
+    from_geometry: Counter[str] = Counter(
+        normalize_element_symbol(element)
+        for element, _x, _y, _z in parse_xyz(geometry).atoms
+    )
+    if from_smiles == from_geometry:
+        return
+
+    raise ValueError(
+        f"Species geometry is {format_element_counts(from_geometry)}, but "
+        f"species_entry.smiles={payload.smiles!r} is "
+        f"{format_element_counts(from_smiles)} "
+        "(species_geometry_composition_mismatch). A deposited structure must "
+        "be made of the atoms its own identifier declares, or every number "
+        "computed from it describes a different molecule. Hydrogens are "
+        "counted explicitly on both sides, and isotope labels are counted as "
+        "their element, so an isotopologue is not a mismatch."
+    )
+
+
 def resolve_species_entry(
     session: Session,
     payload: SpeciesEntryIdentityPayload,
@@ -173,21 +270,27 @@ def resolve_species_entry(
     :param created_by: Optional application user id for new rows.
     :param geometry: Optional geometry deposited with this entry. When given,
         it supplies 3D stereo perception and is cross-checked against the
-        identity's isotope labels.
+        identity's element composition and isotope labels.
     :param additional_geometries: Any further geometries deposited under this
-        same entry (the second and later conformers). They are isotope-checked
-        too but never used for stereo perception. Checking only the first
-        conformer let a deuterated entry store all-protium geometries for
-        every other conformer.
+        same entry (the second and later conformers). They are composition- and
+        isotope-checked too but never used for stereo perception. Checking only
+        the first conformer let a deuterated entry store all-protium geometries
+        for every other conformer.
     :returns: Existing or newly created ``SpeciesEntry`` row.
     :raises ValueError: If the underlying species identity cannot be
-        canonicalized, or the geometry contradicts the declared isotopes.
+        canonicalized, or a geometry contradicts the declared composition or
+        isotopes.
     """
 
-    if geometry is not None:
-        assert_geometry_isotopes_match_identity(payload, geometry)
-    for extra_geometry in additional_geometries:
-        assert_geometry_isotopes_match_identity(payload, extra_geometry)
+    # Composition first: a geometry made of the wrong atoms is the larger
+    # contradiction, and reporting "this is CH3, not CH4" reads better than an
+    # isotope-multiset complaint derived from the same broken structure.
+    for candidate_geometry in (
+        *(() if geometry is None else (geometry,)),
+        *additional_geometries,
+    ):
+        assert_geometry_composition_matches_identity(payload, candidate_geometry)
+        assert_geometry_isotopes_match_identity(payload, candidate_geometry)
 
     species = resolve_species(session, payload)
 

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -308,6 +308,7 @@ enum MolecularPropertyKind {
 enum MoleculeKind {
   molecule
   pseudo
+  electron
 }
 
 enum NetworkChannelKind {

--- a/backend/schema_spec.md
+++ b/backend/schema_spec.md
@@ -61,6 +61,17 @@ Notes:
 - `inchi_key` is unique
 - `multiplicity` must be at least 1
 - `stereo_kind` is stored on the graph-level identity row, not on `species_entry`
+- `kind` (`molecule_kind` enum) is `molecule`, `pseudo`, or `electron`.
+  `pseudo` is a lumped or phenomenological construct whose composition and
+  charge are not atom-resolved facts, so `validate_reaction_elemental_balance`
+  and `validate_reaction_charge_conservation` decline to judge a reaction
+  containing one. `electron` is a free electron: it has no SMILES (the row
+  carries the reserved token `[e-]`) and no InChI (the row carries a sentinel
+  that is deliberately not InChIKey-shaped), and it exists so that associative
+  detachment, dissociative attachment, photoionization and photodetachment can
+  be deposited as balanced reactions. An electron exempts a reaction from
+  **nothing** — it contributes zero atoms and charge −1, and both conservation
+  checks still have to pass. See revision `b8f3d6a1c9e4`.
 
 ### 3.2 Species Entry
 
@@ -853,21 +864,40 @@ exactly as before.
 - `rmsd_warning_threshold`
 - `created_at`
 
-`calc_geometry_validation` is a *structure-consistency* check: does the
-calculation's output geometry still represent the declared species
-identity (graph isomorphism, with RMSD as a suspicion signal)? It exists
-to catch optimizations that rearranged the molecule, broke or formed
-bonds, dissociated, or transferred a proton.
+`calc_geometry_validation` compares the calculation's output geometry
+against the declared species identity, with RMSD as a suspicion signal.
 
-A `validation_status=fail` row means "the automated identity validator
-found a mismatch," **not** "the calculation is scientifically invalid."
-Connectivity perception from XYZ is imperfect for weak complexes,
-stretched or partially broken bonds, radicals, charged species, loose
-conformers, and proton-transfer-like geometries — these can produce
-false-positive `fail` rows even when the calculation is fine. These
-rows are curator-attention signals, not inputs to automatic rejection
-or quality gating. Phase-1 wiring records evidence; it never blocks an
-upload.
+**What it compares is the molecular formula, not the molecular graph.**
+The column is named `is_isomorphic` and the check was written intending
+graph isomorphism, but `resolve_atom_mapping` falls back to
+`_find_matches_using_smiles_graph` whenever bond perception from XYZ
+fails or finds no substructure match — the common case for radicals,
+ions and stretched geometries — and that fallback rejects a candidate
+only on a per-element atom-count mismatch. Verified by direct call:
+ethanol declared with dimethyl ether deposited (constitutional isomers,
+both C2H6O) **passes**, and methane with one hydrogen pulled to 5 Å
+**passes**. The rearrangement, bond-breaking, dissociation and
+proton-transfer cases this table was introduced for are therefore *not*
+caught, and connectivity validation is not implemented. Doing it
+properly needs bond perception that is trustworthy on exactly the
+strained, radical and stretched structures where it would matter, which
+`rdDetermineBonds` is not.
+
+A `validation_status=fail` row means "the atom counts disagree," **not**
+"the calculation is scientifically invalid." These rows are
+curator-attention signals, not inputs to automatic rejection or quality
+gating. Phase-1 wiring records evidence; it never blocks an upload.
+
+Per ADR 0008 §9 the blocking tier owns a rule and the others cite it:
+formula agreement between a structure and the identity it is deposited
+under is owned by
+`app.services.species_resolution.assert_geometry_composition_matches_identity`,
+which refuses the upload — but only for **conformer** geometries. A
+calculation's input and output geometries reach no blocking composition
+check on any path, so for those this advisory row is the only place the
+comparison happens at all. For an *output* geometry that is deliberate:
+an optimisation that drifted is science to record, not a payload to
+refuse.
 
 Three closely related but distinct calculation-quality surfaces must not
 be conflated:

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -19974,7 +19974,8 @@
       "MoleculeKind": {
         "enum": [
           "molecule",
-          "pseudo"
+          "pseudo",
+          "electron"
         ],
         "title": "MoleculeKind",
         "type": "string"

--- a/backend/tests/api/test_api_artifact_charge_multiplicity_hook.py
+++ b/backend/tests/api/test_api_artifact_charge_multiplicity_hook.py
@@ -26,6 +26,53 @@ MOLPRO_CH4_LOG = (
 W_CHARGE = "charge_mismatch"
 W_MULT = "multiplicity_mismatch"
 
+# Every payload below used to carry the same one-atom geometry,
+# ``1\nC atom\nC 0.0 0.0 0.0``, whatever species it declared -- a lone carbon
+# under methyl, methylene, methylene cation and methane alike. The geometry is
+# incidental to what these tests assert (charge and multiplicity read out of a
+# log header), which is exactly why nobody looked, and
+# ``assert_geometry_composition_matches_identity`` now refuses it: a structure
+# has to be made of the atoms its own identifier declares.
+#
+# Coordinates are schematic but the atoms are the molecules', per species:
+_GEOMETRY_BY_SMILES = {
+    # Methyl radical, CH3. Planar D3h: C at the origin (index 1), three H in
+    # the z = 0 plane at 1.079 A (indices 2-4).
+    "[CH3]": (
+        "4\nmethyl\n"
+        "C  0.0000  0.0000  0.0000\n"
+        "H  1.0790  0.0000  0.0000\n"
+        "H -0.5395  0.9345  0.0000\n"
+        "H -0.5395 -0.9345  0.0000"
+    ),
+    # Methylene cation, CH2+. C at the origin (index 1), two H at 1.09 A
+    # (indices 2-3); CH2+ is quasi-linear, so they sit opposite each other.
+    "[CH2+]": (
+        "3\nmethylene cation\n"
+        "C  0.0000  0.0000  0.0000\n"
+        "H  1.0900  0.0000  0.0000\n"
+        "H -1.0900  0.0000  0.0000"
+    ),
+    # Methylene, CH2. C at the origin (index 1), two H at 1.03 A (indices 2-3)
+    # with the ~134 degree H-C-H angle of the triplet ground state.
+    "[CH2]": (
+        "3\nmethylene\n"
+        "C  0.0000  0.0000  0.0000\n"
+        "H  0.4020  0.9480  0.0000\n"
+        "H  0.4020 -0.9480  0.0000"
+    ),
+    # Methane, CH4. C at the origin (index 1), four H at the tetrahedral
+    # vertices (indices 2-5).
+    "C": (
+        "5\nmethane\n"
+        "C  0.000  0.000  0.000\n"
+        "H  0.629  0.629  0.629\n"
+        "H -0.629 -0.629  0.629\n"
+        "H -0.629  0.629 -0.629\n"
+        "H  0.629 -0.629 -0.629"
+    ),
+}
+
 
 @pytest.fixture
 def stub_store_artifact(monkeypatch) -> list[tuple[str, str]]:
@@ -61,7 +108,7 @@ def _conformer_payload(*, smiles: str, charge: int, multiplicity: int) -> dict:
             "charge": charge,
             "multiplicity": multiplicity,
         },
-        "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+        "geometry": {"xyz_text": _GEOMETRY_BY_SMILES[smiles]},
         # An ``opt`` calculation keeps the single-point-energy hook out of the
         # way so the warnings under test are unambiguous.
         "calculation": {
@@ -240,7 +287,7 @@ def _computed_species_bundle(*, charge: int, multiplicity: int) -> dict:
         "conformers": [
             {
                 "key": "c0",
-                "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+                "geometry": {"xyz_text": _GEOMETRY_BY_SMILES["C"]},
                 "primary_calculation": {
                     "key": "opt0",
                     "type": "opt",

--- a/backend/tests/api/test_api_artifact_hessian_hook.py
+++ b/backend/tests/api/test_api_artifact_hessian_hook.py
@@ -90,6 +90,27 @@ def _artifact(content: bytes, *, kind: str, filename: str) -> dict:
     return {"kind": kind, "filename": filename, "content_base64": _b64(content)}
 
 
+def _smiles_for(xyz: str) -> str:
+    """Name the collection of separated atoms that ``xyz`` actually is.
+
+    These geometries are deliberately not molecules. ``_xyz`` spaces its atoms
+    five Angstrom apart precisely so no bonds are perceived, and
+    ``_orca_frame_xyz`` reproduces a saddle-point frame; only the atom count
+    and the elements matter for binding a Hessian to a geometry.
+
+    The species entry nevertheless declared ``C`` -- methane -- for every one
+    of them, so a twelve-atom deposit claimed to be a five-atom molecule.
+    ``assert_geometry_composition_matches_identity`` refuses that, and rightly:
+    the identity has to be made of the atoms the structure has. A
+    dot-separated set of bare atoms is the honest identity here, it is exactly
+    what the coordinates describe, and it stays correct for any ``natoms`` a
+    later test asks for rather than needing a hand-picked molecule per count.
+    """
+
+    elements = [line.split()[0] for line in xyz.strip().splitlines()[2:]]
+    return ".".join(f"[{element}]" for element in elements)
+
+
 def _conformer_payload(
     *,
     natoms: int,
@@ -110,9 +131,14 @@ def _conformer_payload(
         calc["opt_result"] = {"converged": True}
     if input_geometries is not None:
         calc["input_geometries"] = [{"xyz_text": g} for g in input_geometries]
+    geometry_xyz = xyz if xyz is not None else _xyz(natoms)
     return {
-        "species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1},
-        "geometry": {"xyz_text": xyz if xyz is not None else _xyz(natoms)},
+        "species_entry": {
+            "smiles": _smiles_for(geometry_xyz),
+            "charge": 0,
+            "multiplicity": 1,
+        },
+        "geometry": {"xyz_text": geometry_xyz},
         "calculation": calc,
         "label": "hessian-hook",
     }
@@ -330,7 +356,11 @@ def _computed_species_bundle(*, natoms: int) -> dict:
     The freq calc links the conformer geometry as its input geometry (via the
     freq/sp fallback), so the inline Hessian binds to it."""
     return {
-        "species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1},
+        "species_entry": {
+            "smiles": _smiles_for(_xyz(natoms)),
+            "charge": 0,
+            "multiplicity": 1,
+        },
         "conformers": [
             {
                 "key": "c0",

--- a/backend/tests/api/test_api_artifact_sp_energy_hook.py
+++ b/backend/tests/api/test_api_artifact_sp_energy_hook.py
@@ -29,6 +29,21 @@ FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
 CH4_LOG = (FIXTURES / "molpro" / "ch4_closed_shell" / "input.out").read_bytes()
 CH4_ENERGY = -40.457885930635
 
+# Methane, CH4: C at the origin (index 1) and four H at the tetrahedral
+# vertices (indices 2-5). The species entry has always declared ``C``, which is
+# methane, and the log is a closed-shell CH4 single point, but the geometry
+# said "1\nC atom\nC 0.0 0.0 0.0" -- a lone carbon, four hydrogens missing.
+# Nothing compared a deposited structure against its own SMILES until
+# ``assert_geometry_composition_matches_identity``.
+XYZ_CH4 = (
+    "5\nmethane\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
+)
+
 
 @pytest.fixture
 def stub_store_artifact(monkeypatch) -> list[tuple[str, str]]:
@@ -106,7 +121,7 @@ def _sp_conformer_payload(
         calc["opt_result"] = {"converged": True}
     return {
         "species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1},
-        "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+        "geometry": {"xyz_text": XYZ_CH4},
         "calculation": calc,
         "label": "ch4-sp-energy-hook",
     }
@@ -300,7 +315,7 @@ def _computed_species_bundle(*, sp_energy: float | None) -> dict:
         "conformers": [
             {
                 "key": "c0",
-                "geometry": {"xyz_text": "1\nC atom\nC 0.0 0.0 0.0"},
+                "geometry": {"xyz_text": XYZ_CH4},
                 "primary_calculation": {
                     "key": "opt0",
                     "type": "opt",

--- a/backend/tests/api/test_api_lookup_expansion.py
+++ b/backend/tests/api/test_api_lookup_expansion.py
@@ -55,10 +55,35 @@ def _transport_payload(smiles: str = "[H]", mult: int = 2,
 
 
 def _pdep_payload(name: str = "net-lookup") -> dict:
-    xyz_ethyl = "3\n\nC 0.0 0.0 0.0\nC 1.54 0.0 0.0\nH 2.0 1.0 0.0"
-    xyz_o2 = "2\n\nO 0.0 0.0 0.0\nO 1.21 0.0 0.0"
-    xyz_etoo = "4\n\nC 0.0 0.0 0.0\nC 1.54 0.0 0.0\nO 2.5 0.0 0.0\nO 3.7 0.0 0.0"
-    xyz_ar = "1\n\nAr 0.0 0.0 0.0"
+    # Composition matches the SMILES each geometry is deposited under: ethyl
+    # (``C[CH2]``) is C2H5, seven atoms, and ethylperoxy (``CCO[O]``) is
+    # C2H5O2, nine. They used to be "C C H" and "C C O O", hydrogens simply
+    # absent, which nothing compared against the identity. Coordinates are
+    # schematic; the atoms are not.
+    xyz_ethyl = (
+        "7\nC2H5\n"
+        "C  0.00  0.00  0.00\n"
+        "C  1.49  0.00  0.00\n"
+        "H -0.38  1.01  0.00\n"
+        "H -0.38 -0.51  0.88\n"
+        "H -0.38 -0.51 -0.88\n"
+        "H  1.99  0.94  0.00\n"
+        "H  1.99 -0.94  0.00"
+    )
+    xyz_o2 = "2\nO2\nO 0.0 0.0 0.0\nO 1.21 0.0 0.0"
+    xyz_etoo = (
+        "9\nC2H5OO\n"
+        "C  0.00  0.00  0.00\n"
+        "C  1.51  0.00  0.00\n"
+        "O  2.05  1.28  0.00\n"
+        "O  3.44  1.30  0.00\n"
+        "H -0.38  1.01  0.00\n"
+        "H -0.38 -0.51  0.88\n"
+        "H -0.38 -0.51 -0.88\n"
+        "H  1.88 -0.53  0.88\n"
+        "H  1.88 -0.53 -0.88"
+    )
+    xyz_ar = "1\nAr\nAr 0.0 0.0 0.0"
     software = {"name": "Gaussian", "version": "16"}
     lot = {"method": "B3LYP", "basis": "6-31G(d)"}
 

--- a/backend/tests/api/test_api_network_reads.py
+++ b/backend/tests/api/test_api_network_reads.py
@@ -33,11 +33,41 @@ from app.db.models.network_pdep import (
 # ---------------------------------------------------------------------------
 
 
-_XYZ_ETHYL = "3\n\nC 0.0 0.0 0.0\nC 1.54 0.0 0.0\nH 2.0 1.0 0.0"
-_XYZ_O2 = "2\n\nO 0.0 0.0 0.0\nO 1.21 0.0 0.0"
-_XYZ_ETOO = "4\n\nC 0.0 0.0 0.0\nC 1.54 0.0 0.0\nO 2.5 0.0 0.0\nO 3.7 0.0 0.0"
-_XYZ_TS = "4\n\nC 0.0 0.0 0.0\nC 1.54 0.0 0.0\nO 2.2 0.0 0.0\nO 3.4 0.0 0.0"
-_XYZ_AR = "1\n\nAr 0.0 0.0 0.0"
+# Every geometry below carries the atoms its species actually has. Ethyl used
+# to be "C C H" and ethylperoxy "C C O O" -- three and four atoms for species
+# that have seven and nine -- because nothing compared a deposited structure
+# against its own SMILES. The same rot was corrected in the PDep workflow
+# fixture when ``validate_transition_state_composition`` landed; these API
+# copies were missed. Coordinates stay schematic; composition does not.
+#
+# A ``_XYZ_TS`` constant sat here too, four atoms for a saddle point that this
+# payload never declares -- C2H5 + O2 -> C2H5OO is a barrierless association,
+# as the comment on ``micro_reactions`` says. It was dead, and dead fixture
+# chemistry that looks meaningful is worse than none, so it is gone.
+_XYZ_ETHYL = (
+    "7\nC2H5\n"
+    "C  0.00  0.00  0.00\n"
+    "C  1.49  0.00  0.00\n"
+    "H -0.38  1.01  0.00\n"
+    "H -0.38 -0.51  0.88\n"
+    "H -0.38 -0.51 -0.88\n"
+    "H  1.99  0.94  0.00\n"
+    "H  1.99 -0.94  0.00"
+)
+_XYZ_O2 = "2\nO2\nO 0.0 0.0 0.0\nO 1.21 0.0 0.0"
+_XYZ_ETOO = (
+    "9\nC2H5OO\n"
+    "C  0.00  0.00  0.00\n"
+    "C  1.51  0.00  0.00\n"
+    "O  2.05  1.28  0.00\n"
+    "O  3.44  1.30  0.00\n"
+    "H -0.38  1.01  0.00\n"
+    "H -0.38 -0.51  0.88\n"
+    "H -0.38 -0.51 -0.88\n"
+    "H  1.88 -0.53  0.88\n"
+    "H  1.88 -0.53 -0.88"
+)
+_XYZ_AR = "1\nAr\nAr 0.0 0.0 0.0"
 
 _SOFTWARE = {"name": "Gaussian", "version": "16"}
 _LOT_DFT = {"method": "B3LYP", "basis": "6-31G(d)"}

--- a/backend/tests/client_builder_contract/test_computed_reaction_calculation_keys_response.py
+++ b/backend/tests/client_builder_contract/test_computed_reaction_calculation_keys_response.py
@@ -51,14 +51,24 @@ _XYZ_CH4 = (
     "H -0.629  0.629 -0.629\n"
     "H  0.629 -0.629 -0.629"
 )
+# The ``CH3 + H -> CH4`` saddle point: CH4, five atoms. C at the origin
+# (index 1), the three methyl hydrogens flattened towards planarity in the
+# z = 0 plane (indices 2-4), and the incoming hydrogen on the C3 axis at a
+# stretched 1.500 A (index 5).
+#
+# This fixture used to list six atoms — a whole methane plus a sixth hydrogen —
+# which is CH5 for a CH4 reaction. ``validate_transition_state_composition``
+# refuses that, and has since it was introduced; this suite is in neither the
+# ``test-api`` nor the ``test-scientific`` gate, so the two tests below were
+# already failing on ``origin/main`` before the composition and charge work in
+# this branch touched anything.
 _XYZ_TS = (
-    "6\nts\n"
+    "5\nts for CH3 + H -> CH4\n"
     "C  0.000  0.000  0.000\n"
-    "H  0.629  0.629  0.629\n"
-    "H -0.629 -0.629  0.629\n"
-    "H -0.629  0.629 -0.629\n"
-    "H  0.629 -0.629 -0.629\n"
-    "H  1.500  0.000  0.000"
+    "H  1.080  0.000  0.000\n"
+    "H -0.540  0.935  0.000\n"
+    "H -0.540 -0.935  0.000\n"
+    "H  0.000  0.000  1.500"
 )
 _SOFTWARE = {"name": "Gaussian", "version": "16"}
 _LOT = {"method": "wb97xd", "basis": "def2tzvp"}

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -3037,7 +3037,13 @@ def test_computed_species_applied_correction_behavior_unchanged(db_engine) -> No
                 {
                     "key": "c0",
                     "geometry": {
-                        "xyz_text": "1\nHCl\nCl 0.0 0.0 0.0",
+                        # HCl, two atoms: Cl (index 1) and H (index 2), at the
+                        # experimental 1.2746 A bond length. The identity here
+                        # has always been HCl — SMILES ``Cl`` is hydrogen
+                        # chloride, not the chlorine atom, and multiplicity 1
+                        # agrees — but the geometry listed the chlorine alone
+                        # and dropped the hydrogen.
+                        "xyz_text": "2\nHCl\nCl 0.0 0.0 0.0\nH 0.0 0.0 1.2746",
                     },
                     "primary_calculation": {
                         "key": "opt0",

--- a/backend/tests/workflows/test_computed_species_upload.py
+++ b/backend/tests/workflows/test_computed_species_upload.py
@@ -7,7 +7,11 @@ through HTTP.
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -2362,16 +2366,40 @@ def _bac_melius_scheme_ref(**overrides) -> dict:
     return base
 
 
-_METHANE_GEOM = {
-    "xyz_text": (
-        "5\nmethane\n"
-        "C 0.0 0.0 0.0\n"
-        "H 0.629 0.629 0.629\n"
-        "H -0.629 -0.629 0.629\n"
-        "H -0.629 0.629 -0.629\n"
-        "H 0.629 -0.629 -0.629"
-    )
-}
+@lru_cache(maxsize=None)
+def _geom_for_smiles(smiles: str) -> str:
+    """Build an XYZ that is genuinely the molecule ``smiles`` names.
+
+    These bundles used to hand every species the same methane geometry, which
+    was accepted because nothing compared a deposited structure against its
+    own identifier. ``assert_geometry_composition_matches_identity`` now does,
+    and it is right to: a bundle claiming ``BrCCCCCCCCCCCCCCCO`` while storing
+    five atoms of methane is not a record of that molecule.
+
+    Generating from the SMILES rather than hand-writing coordinates makes
+    per-atom correctness structural instead of asserted: ``AddHs`` puts in
+    exactly the hydrogens the graph implies and ETKDG only assigns positions
+    to atoms that are already there, so the element multiset of the result is
+    the molecule's by construction and cannot drift as SMILES are added.
+    ``randomSeed`` is fixed so a rerun deposits the same geometry.
+
+    The coordinates are an embedded conformer, not an optimised structure —
+    these tests are about energy-correction bookkeeping and never read them.
+    """
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    params = AllChem.ETKDGv3()
+    params.randomSeed = 0xC0FFEE
+    if AllChem.EmbedMolecule(mol, params) != 0:
+        raise AssertionError(f"RDKit could not embed a 3D structure for {smiles!r}")
+    conformer = mol.GetConformer()
+    lines = [str(mol.GetNumAtoms()), smiles]
+    for atom in mol.GetAtoms():
+        position = conformer.GetAtomPosition(atom.GetIdx())
+        lines.append(
+            f"{atom.GetSymbol()} {position.x:.4f} {position.y:.4f} {position.z:.4f}"
+        )
+    return "\n".join(lines)
 
 
 def _bundle_with_sp_calc(*, smiles: str, **overrides) -> dict:
@@ -2387,7 +2415,7 @@ def _bundle_with_sp_calc(*, smiles: str, **overrides) -> dict:
         "conformers": [
             {
                 "key": "c0",
-                "geometry": dict(_METHANE_GEOM),
+                "geometry": {"xyz_text": _geom_for_smiles(smiles)},
                 "primary_calculation": _calc("opt0", calc_type="opt"),
                 "additional_calculations": [
                     _calc("sp0", calc_type="sp"),

--- a/backend/tests/workflows/test_computed_species_upload.py
+++ b/backend/tests/workflows/test_computed_species_upload.py
@@ -2385,13 +2385,27 @@ def _geom_for_smiles(smiles: str) -> str:
 
     The coordinates are an embedded conformer, not an optimised structure —
     these tests are about energy-correction bookkeeping and never read them.
+
+    Distance-geometry embedding fails on a minority of structures — long
+    flexible chains and strained rings are the usual culprits, and this helper
+    is handed a C16 chain — so a failure falls back to ``useRandomCoords``,
+    which seeds the optimisation from random positions instead of from the
+    distance bounds and succeeds where the default gives up. The fallback
+    changes only *where* the atoms are, never *which* atoms there are, so the
+    composition guarantee above survives it intact. Failing outright would turn
+    a future SMILES addition into an unrelated-looking test error.
     """
 
     mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
     params = AllChem.ETKDGv3()
     params.randomSeed = 0xC0FFEE
     if AllChem.EmbedMolecule(mol, params) != 0:
-        raise AssertionError(f"RDKit could not embed a 3D structure for {smiles!r}")
+        params.useRandomCoords = True
+        if AllChem.EmbedMolecule(mol, params) != 0:
+            raise AssertionError(
+                f"RDKit could not embed a 3D structure for {smiles!r}, with or "
+                "without random starting coordinates."
+            )
     conformer = mol.GetConformer()
     lines = [str(mol.GetNumAtoms()), smiles]
     for atom in mol.GetAtoms():

--- a/backend/tests/workflows/test_geometry_validation_wiring.py
+++ b/backend/tests/workflows/test_geometry_validation_wiring.py
@@ -12,6 +12,16 @@ calculations only. These tests verify the wiring contract:
 
 The pure chemistry seam is exercised separately in
 ``tests/services/test_geometry_validation.py``.
+
+**How narrow ``is_isomorphic=False`` really is.** ``resolve_atom_mapping``
+falls back to ``_find_matches_using_smiles_graph`` whenever bond perception
+from coordinates yields no substructure match, and that fallback bails out
+only on an element-count mismatch. So the ``fail`` branch here fires on a
+*formula* disagreement, not on a connectivity one: ethanol and dimethyl ether,
+constitutional isomers with identical element counts, are reported isomorphic.
+Since ``assert_geometry_composition_matches_identity`` now blocks a formula
+disagreement on the species entry's own geometry, an explicitly declared
+output geometry is the last place this row's ``fail`` status is reachable.
 """
 
 from __future__ import annotations
@@ -65,6 +75,21 @@ _XYZ_METHANE = (
     "H -0.629  0.629 -0.629\n"
     "H  0.629 -0.629 -0.629"
 )
+# Ethanol, CH3-CH2-OH. C2H6O, nine atoms: C1 (methyl carbon), C2 (methylene
+# carbon), O3 (hydroxyl oxygen), H4-H6 on C1, H7-H8 on C2, H9 on O3 — 1-based
+# file indices, matching the line order below.
+_XYZ_ETHANOL = (
+    "9\nethanol\n"
+    "C -0.8364 -0.3141 -0.1395\n"
+    "C  0.3591  0.5831  0.1051\n"
+    "O  1.4337 -0.1755  0.6405\n"
+    "H -1.6790  0.2587 -0.5368\n"
+    "H -0.5850 -1.1091 -0.8492\n"
+    "H -1.1474 -0.8033  0.7894\n"
+    "H  0.6916  1.0559 -0.8240\n"
+    "H  0.1068  1.3701  0.8217\n"
+    "H  1.6566 -0.8657 -0.0073"
+)
 
 
 _SOFTWARE = {"name": "Gaussian", "version": "16"}
@@ -95,9 +120,31 @@ def _isolated_session(db_engine) -> Iterator[Session]:
 
 
 def _species_bundle(
-    *, smiles: str, xyz: str, multiplicity: int = 1
+    *,
+    smiles: str,
+    xyz: str,
+    multiplicity: int = 1,
+    output_xyz: str | None = None,
 ) -> ComputedSpeciesUploadRequest:
-    """Minimal one-conformer opt bundle for the wiring tests."""
+    """Minimal one-conformer opt bundle for the wiring tests.
+
+    ``output_xyz`` declares the opt calculation's output geometry explicitly
+    instead of letting it fall back to the conformer geometry. That is the
+    seam the identity-mismatch test needs: the conformer geometry is what the
+    *species entry* is checked against, and the output geometry is what
+    *geometry validation* is run against, so they can be made to disagree.
+    """
+    primary_calculation: dict = {
+        "key": "opt0",
+        "type": "opt",
+        "level_of_theory": _LOT,
+        "software_release": _SOFTWARE,
+        "opt_result": {"converged": True},
+    }
+    if output_xyz is not None:
+        primary_calculation["output_geometries"] = [
+            {"geometry": {"xyz_text": output_xyz}, "role": "final"}
+        ]
     return ComputedSpeciesUploadRequest(
         **{
             "species_entry": {
@@ -109,13 +156,7 @@ def _species_bundle(
                 {
                     "key": "c0",
                     "geometry": {"xyz_text": xyz},
-                    "primary_calculation": {
-                        "key": "opt0",
-                        "type": "opt",
-                        "level_of_theory": _LOT,
-                        "software_release": _SOFTWARE,
-                        "opt_result": {"converged": True},
-                    },
+                    "primary_calculation": primary_calculation,
                 }
             ],
         }
@@ -218,12 +259,30 @@ def test_computed_species_opt_persists_passed_row(db_engine) -> None:
 def test_computed_species_opt_records_fail_when_identity_mismatch(
     db_engine,
 ) -> None:
-    """Geometry is methane but the declared species is water — the
-    chemistry layer must reject isomorphism, and the wiring layer must
-    persist that as evidence (validation_status=fail) rather than abort
-    the upload. This is the policy: phase-1 is non-blocking."""
+    """The declared species is ethanol and the opt calculation reports a
+    methane output geometry — the chemistry layer must reject isomorphism, and
+    the wiring layer must persist that as evidence (validation_status=fail)
+    rather than abort the upload. This is the policy: phase-1 is non-blocking.
+
+    The mismatch is on the *output* geometry, not the conformer geometry.
+    This test used to declare water and deposit methane as the conformer
+    geometry, which is now refused outright by
+    ``assert_geometry_composition_matches_identity``: a species entry's own
+    structure must be made of the atoms its own identifier declares, and H2O
+    is not CH4. That blocking rule owns the species entry's geometry, so the
+    non-blocking evidence rule is exercised where it still applies — an output
+    geometry, which the species entry is deliberately *not* checked against
+    because an optimisation that rearranged or dissociated the molecule is
+    exactly the science this row exists to record rather than refuse.
+
+    Ethanol is nine atoms (C2H6O); methane is five (CH4). The atom counts
+    differ, which is what ``resolve_atom_mapping`` actually detects — see the
+    note in this module's docstring about how narrow ``is_isomorphic=False``
+    has become."""
     with _isolated_session(db_engine) as session:
-        bundle = _species_bundle(smiles="O", xyz=_XYZ_METHANE)
+        bundle = _species_bundle(
+            smiles="CCO", xyz=_XYZ_ETHANOL, output_xyz=_XYZ_METHANE
+        )
         outcome = persist_computed_species_upload(session, bundle)
         primary_id = outcome.conformers[0].primary_calculation.id
         row = session.scalar(

--- a/backend/tests/workflows/test_reaction_charge_conservation.py
+++ b/backend/tests/workflows/test_reaction_charge_conservation.py
@@ -1,0 +1,226 @@
+"""Charge must be conserved across a reaction.
+
+``validate_reaction_elemental_balance`` has always compared element totals and
+has never mentioned charge, so ``[OH-] + [H] -> H2O`` — which loses an electron
+on the way across — deposited with no error and no warning at all. It is
+element-balanced and it is not a reaction.
+
+The gap reached further than itself. ``validate_transition_state_composition``
+checks a saddle point's charge against its *reactants*, so that rule was
+anchored to a side which carried no conservation guarantee of its own.
+
+Charge conservation is the same argument as elemental balance applied to the
+other conserved quantity: electrons are neither created nor destroyed by
+rearranging bonds. Definitional under ADR 0008, therefore blocking, with the
+same stoichiometric-coefficient handling and the same pseudo-species exemption.
+
+The accepting half of this file is the load-bearing half. Ionic chemistry is
+real chemistry, and a check that refused it would be worse than no check at
+all: a reaction may carry any net charge it likes, as long as both sides carry
+the same one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.db.models.common import (
+    MoleculeKind,
+    SpeciesEntryStateKind,
+    StationaryPointKind,
+    StereoKind,
+)
+from app.db.models.reaction import ChemReaction
+from app.db.models.species import Species, SpeciesEntry
+from app.schemas.workflows.reaction_upload import ReactionUploadRequest
+from app.workflows.reaction import persist_reaction_upload
+
+#: ``smiles`` / ``charge`` / ``multiplicity`` for the ions and molecules below.
+_HYDROXIDE = {"smiles": "[OH-]", "charge": -1, "multiplicity": 1}
+_PROTON = {"smiles": "[H+]", "charge": 1, "multiplicity": 1}
+_H_ATOM = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+_WATER = {"smiles": "O", "charge": 0, "multiplicity": 1}
+_OXIDE = {"smiles": "[O-2]", "charge": -2, "multiplicity": 1}
+_O_ATOM = {"smiles": "[O]", "charge": 0, "multiplicity": 3}
+_METHANE = {"smiles": "C", "charge": 0, "multiplicity": 1}
+_METHANIDE = {"smiles": "[CH3-]", "charge": -1, "multiplicity": 1}
+
+
+def _request(*, reactants: list[dict], products: list[dict]) -> ReactionUploadRequest:
+    return ReactionUploadRequest(
+        reversible=False,
+        reactants=[{"species_entry": dict(item)} for item in reactants],
+        products=[{"species_entry": dict(item)} for item in products],
+    )
+
+
+# ---------------------------------------------------------------------------
+# It fires
+# ---------------------------------------------------------------------------
+
+
+def test_a_reaction_that_loses_an_electron_is_refused(db_engine) -> None:
+    """``[OH-] + [H] -> H2O``: element-balanced (OH2 both sides), charge -1 -> 0.
+
+    The exact deposit that used to succeed silently.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            before = session.scalar(select(func.count()).select_from(ChemReaction))
+            with pytest.raises(ValueError) as excinfo:
+                persist_reaction_upload(
+                    session,
+                    _request(reactants=[_HYDROXIDE, _H_ATOM], products=[_WATER]),
+                )
+            message = str(excinfo.value)
+            assert "reaction_charge_not_conserved" in message
+            assert "reactants total charge -1" in message
+            assert "products total +0" in message
+            after = session.scalar(select(func.count()).select_from(ChemReaction))
+            assert after == before
+
+
+def test_stoichiometric_coefficients_are_multiplied_in(db_engine) -> None:
+    """``2 [OH-] -> H2O + O``: two hydroxides carry -2, not -1.
+
+    A per-participant comparison that ignored the coefficient would read this
+    as -1 against 0 and still refuse it, for the wrong reason and with the
+    wrong number in the message. The repeated participant is compressed to a
+    coefficient by ``compress_species_stoichiometry`` before the check ever
+    sees it, exactly as elemental balance receives it.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            with pytest.raises(ValueError) as excinfo:
+                persist_reaction_upload(
+                    session,
+                    _request(
+                        reactants=[_HYDROXIDE, _HYDROXIDE],
+                        products=[_WATER, _O_ATOM],
+                    ),
+                )
+            assert "reactants total charge -2" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# It does not fire on correct chemistry
+# ---------------------------------------------------------------------------
+
+
+def test_a_neutral_reaction_is_accepted(db_engine) -> None:
+    """The overwhelming majority of the database: 0 on both sides."""
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(reactants=[_H_ATOM, _H_ATOM], products=[
+                    {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}
+                ]),
+            )
+            assert entry.id is not None
+
+
+def test_ion_recombination_to_a_neutral_product_is_accepted(db_engine) -> None:
+    """``[OH-] + [H+] -> H2O``. Charge -1 and +1 sum to the product's 0."""
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(reactants=[_HYDROXIDE, _PROTON], products=[_WATER]),
+            )
+            assert entry.id is not None
+
+
+def test_a_reaction_with_a_conserved_nonzero_charge_is_accepted(db_engine) -> None:
+    """``[OH-] + CH4 -> [CH3-] + H2O``, a proton transfer that stays at -1.
+
+    Conservation, not neutrality, is the rule. Requiring both sides to be
+    neutral would refuse every ion-molecule reaction in the literature, which
+    is the false-positive ADR 0008 disqualifies a blocking check for.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(
+                    reactants=[_HYDROXIDE, _METHANE],
+                    products=[_METHANIDE, _WATER],
+                ),
+            )
+            assert entry.id is not None
+
+
+def test_a_reaction_conserving_a_charge_of_minus_two_is_accepted(db_engine) -> None:
+    """``2 [OH-] -> H2O + [O-2]``. -2 on both sides, with a coefficient of 2."""
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(
+                    reactants=[_HYDROXIDE, _HYDROXIDE],
+                    products=[_WATER, _OXIDE],
+                ),
+            )
+            assert entry.id is not None
+
+
+def test_a_pseudo_species_participant_is_exempt(db_engine) -> None:
+    """Mirrors the elemental-balance exemption, and shares its implementation.
+
+    A lumped or phenomenological construct is not atom-resolved, so neither its
+    elements nor its charge is a quantity a conservation law applies to.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            # An anion on one side and a neutral pseudo-species on the other:
+            # -1 against 0, which would be refused were the reaction judged.
+            # The ordinary participant's smiles is a unique placeholder — the
+            # check reads ``Species.charge`` and never parses it, and the
+            # exemption returns before even that.
+            ordinary = Species(
+                kind=MoleculeKind.molecule,
+                smiles="pseudo-charged-anion-0001",
+                inchi_key="CHARGECONSERVE00000000001",
+                charge=-1,
+                multiplicity=1,
+                stereo_kind=StereoKind.achiral,
+            )
+            pseudo = Species(
+                kind=MoleculeKind.pseudo,
+                smiles="lumped_charge_sink",
+                inchi_key="CHARGECONSERVE00000000002",
+                charge=0,
+                multiplicity=1,
+                stereo_kind=StereoKind.achiral,
+            )
+            session.add_all([ordinary, pseudo])
+            session.flush()
+            entries = []
+            for species in (ordinary, pseudo):
+                entry = SpeciesEntry(
+                    species_id=species.id,
+                    kind=StationaryPointKind.minimum,
+                    electronic_state_kind=SpeciesEntryStateKind.ground,
+                )
+                session.add(entry)
+                entries.append(entry)
+            session.flush()
+
+            reaction_entry = persist_reaction_upload(
+                session,
+                ReactionUploadRequest(
+                    reversible=False,
+                    reactants=[{"species_entry_id": entries[0].id}],
+                    products=[{"species_entry_id": entries[1].id}],
+                ),
+            )
+            assert reaction_entry.id is not None

--- a/backend/tests/workflows/test_reaction_electron_participant.py
+++ b/backend/tests/workflows/test_reaction_electron_participant.py
@@ -1,0 +1,413 @@
+"""A reaction may name the electron it releases — and gains nothing by it.
+
+``validate_reaction_charge_conservation`` refuses ``[OH-] + [H] -> H2O``. That
+reaction is associative detachment, ``OH⁻ + H → H₂O + e⁻``: real, measured
+gas-phase chemistry, sibling of ``H⁻ + H → H₂ + e⁻``, and balanced once its
+electron is written down. Dissociative attachment, photoionization and
+photodetachment are the same family.
+
+Until this door existed the refusal was not merely inconvenient, it was
+**out of tier**. Under ADR 0008 a check may block only when it asserts a
+definition. Charge conservation is definitional only if the participant list
+can be *complete*; with no way to name an electron, the rule was in fact
+asserting "every participant was declared", which is an expectation about the
+depositor. The error message pointed at ``molecule_kind: pseudo`` as the
+escape, but nothing in the codebase can create a pseudo species —
+``canonical_species_identity`` refused every non-``molecule`` kind — so the
+advertised door did not exist and both pseudo exemptions were unreachable.
+
+The load-bearing half of this file is the second half. ``pseudo`` participants
+switch *both* conservation checks off entirely; if an electron did the same,
+any depositor could disable mass balance on any reaction by adding one, which
+is a larger hole than the one being closed. An electron is not "unknowable" —
+it is exactly known: zero atoms, charge -1 — so it exempts nothing, and the
+tests below pin that from both directions.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+from tckdb_schemas.fragments.identity import ELECTRON_SMILES
+
+from app.chemistry.species import ELECTRON_INCHI_KEY
+from app.db.models.common import (
+    MoleculeKind,
+    SpeciesEntryStateKind,
+    StationaryPointKind,
+    StereoKind,
+)
+from app.db.models.reaction import ChemReaction, ReactionParticipant
+from app.db.models.species import Species, SpeciesEntry
+from app.schemas.fragments.geometry import GeometryPayload
+from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
+from app.schemas.workflows.reaction_upload import ReactionUploadRequest
+from app.services.species_resolution import (
+    assert_geometry_composition_matches_identity,
+)
+from app.workflows.reaction import persist_reaction_upload
+
+#: The whole depositor-facing interface for a free electron. No database id;
+#: the identity row is resolved server-side like every other participant's.
+_ELECTRON = {
+    "molecule_kind": "electron",
+    "smiles": ELECTRON_SMILES,
+    "charge": -1,
+    "multiplicity": 2,
+}
+_HYDROXIDE = {"smiles": "[OH-]", "charge": -1, "multiplicity": 1}
+_H_ATOM = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+_H2 = {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}
+_HYDRIDE = {"smiles": "[H-]", "charge": -1, "multiplicity": 1}
+_WATER = {"smiles": "O", "charge": 0, "multiplicity": 1}
+_METHANE = {"smiles": "C", "charge": 0, "multiplicity": 1}
+_OXIDE = {"smiles": "[O-2]", "charge": -2, "multiplicity": 1}
+_O_ATOM = {"smiles": "[O]", "charge": 0, "multiplicity": 3}
+
+
+def _request(*, reactants: list[dict], products: list[dict]) -> ReactionUploadRequest:
+    return ReactionUploadRequest(
+        reversible=False,
+        reactants=[{"species_entry": dict(item)} for item in reactants],
+        products=[{"species_entry": dict(item)} for item in products],
+    )
+
+
+# ---------------------------------------------------------------------------
+# The door is real
+# ---------------------------------------------------------------------------
+
+
+def test_associative_detachment_deposits(db_engine) -> None:
+    """``OH- + H -> H2O + e-``. The reaction the refusal was really about.
+
+    Atoms: OH2 on both sides, the electron contributing none. Charge: -1 on
+    the left, ``0 + (-1)`` on the right. Both conservation checks run and both
+    pass, which is the point — the electron did not switch either off, it made
+    the second one true.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(reactants=[_HYDROXIDE, _H_ATOM], products=[_WATER, _ELECTRON]),
+            )
+            assert entry.id is not None
+
+
+def test_the_same_reaction_without_its_electron_is_still_refused(db_engine) -> None:
+    """The check did not go soft. Omit the electron and the deposit still fails.
+
+    This is the pairing that makes the tier claim honest: the rule now refuses
+    exactly what it says it refuses — a reaction whose two sides describe
+    different numbers of electrons — rather than refusing a reaction whose
+    participant list happened to be inexpressible.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            with pytest.raises(ValueError) as excinfo:
+                persist_reaction_upload(
+                    session,
+                    _request(reactants=[_HYDROXIDE, _H_ATOM], products=[_WATER]),
+                )
+    message = str(excinfo.value)
+    assert "reaction_charge_not_conserved" in message
+    # The message must name the escape that exists, not one that does not.
+    assert '"molecule_kind": "electron"' in message
+    assert "pseudo" not in message
+
+
+def test_an_electron_may_be_a_reactant(db_engine) -> None:
+    """Dissociative attachment: ``e- + H2 -> H- + H``.
+
+    Charge -1 both sides; atoms H2 both sides. Nothing about the electron's
+    handling depends on which side of the arrow it sits on.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(reactants=[_ELECTRON, _H2], products=[_HYDRIDE, _H_ATOM]),
+            )
+            assert entry.id is not None
+
+
+def test_two_electrons_carry_a_stoichiometric_coefficient(db_engine) -> None:
+    """``[O-2] -> O + 2 e-``. A two-electron process needs two electrons.
+
+    Both electrons resolve to the same species row and are compressed into a
+    coefficient of 2 by ``compress_species_stoichiometry`` before either check
+    sees them, so the charge sum is ``0 + 2 x (-1) = -2`` and matches the
+    oxide's -2. A per-participant comparison would read this as -1 and refuse
+    correct chemistry.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            entry = persist_reaction_upload(
+                session,
+                _request(reactants=[_OXIDE], products=[_O_ATOM, _ELECTRON, _ELECTRON]),
+            )
+            session.flush()
+            reaction = session.get(ChemReaction, entry.reaction_id)
+            electron_rows = [
+                participant
+                for participant in reaction.participants
+                if participant.species.kind == MoleculeKind.electron
+            ]
+            assert len(electron_rows) == 1
+            assert electron_rows[0].stoichiometry == 2
+
+
+def test_the_electron_is_part_of_the_reaction_identity(db_engine) -> None:
+    """It is a participant row, so it is inside the stoichiometry hash.
+
+    ``A -> B`` and ``A -> B + e-`` are different reactions and must not dedupe
+    onto one ``chem_reaction``. Carrying the electron in
+    ``reaction_participant`` rather than as a scalar on the reaction is what
+    makes that automatic.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            with_electron = persist_reaction_upload(
+                session,
+                _request(reactants=[_OXIDE], products=[_O_ATOM, _ELECTRON, _ELECTRON]),
+            )
+            # Same heavy atoms, no electron declared, and charge-balanced on
+            # its own terms so it is accepted for its own reasons.
+            without_electron = persist_reaction_upload(
+                session,
+                _request(reactants=[_OXIDE], products=[_OXIDE]),
+            )
+            assert with_electron.reaction_id != without_electron.reaction_id
+
+
+# ---------------------------------------------------------------------------
+# The door is not a back door
+# ---------------------------------------------------------------------------
+
+
+def test_an_electron_does_not_switch_off_elemental_balance(db_engine) -> None:
+    """The whole risk of this feature, pinned.
+
+    ``OH- + H + CH4 -> H2O + e-`` has a carbon and four hydrogens that simply
+    vanish. Its charge balances (-1 against -1), so charge conservation has
+    nothing to say — and if the electron had been routed through the
+    ``pseudo`` exemption, elemental balance would have had nothing to say
+    either, and a depositor could disable mass balance on any reaction by
+    adding an electron to it.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            before = session.scalar(select(func.count()).select_from(ChemReaction))
+            with pytest.raises(ValueError) as excinfo:
+                persist_reaction_upload(
+                    session,
+                    _request(
+                        reactants=[_HYDROXIDE, _H_ATOM, _METHANE],
+                        products=[_WATER, _ELECTRON],
+                    ),
+                )
+            assert "reaction_mass_balance_failed" in str(excinfo.value)
+            after = session.scalar(select(func.count()).select_from(ChemReaction))
+            assert after == before
+
+
+def test_an_electron_does_not_switch_off_charge_conservation(db_engine) -> None:
+    """``OH- + H -> H2O + 2 e-`` releases one electron too many.
+
+    Atoms balance, so only the charge rule can catch it: -1 on the left
+    against -2 on the right. Declaring an electron makes the charge sum
+    expressible, never optional.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            with pytest.raises(ValueError) as excinfo:
+                persist_reaction_upload(
+                    session,
+                    _request(
+                        reactants=[_HYDROXIDE, _H_ATOM],
+                        products=[_WATER, _ELECTRON, _ELECTRON],
+                    ),
+                )
+    message = str(excinfo.value)
+    assert "reaction_charge_not_conserved" in message
+    assert "reactants total charge -1" in message
+    assert "products total -2" in message
+
+
+def test_a_pseudo_participant_still_exempts_and_an_electron_still_does_not(
+    db_engine,
+) -> None:
+    """The contrast, in one place, on the same unbalanced reaction.
+
+    ``pseudo`` means "this participant is not atom-resolved, do not judge this
+    reaction". ``electron`` means "this participant is exactly nothing, judge
+    the reaction as usual". Two kinds, two consequences, deliberately not one.
+    """
+
+    unbalanced = {
+        "reactants": [_HYDROXIDE, _H_ATOM, _METHANE],
+        "products": [_WATER, _ELECTRON],
+    }
+
+    with Session(db_engine) as session:
+        with session.begin():
+            with pytest.raises(ValueError):
+                persist_reaction_upload(session, _request(**unbalanced))
+
+    with Session(db_engine) as session:
+        with session.begin():
+            # Same reaction, with a lumped construct standing in for the
+            # electron. The composition is now declared unknowable, so nothing
+            # is judged and the deposit goes through.
+            lumped = Species(
+                kind=MoleculeKind.pseudo,
+                smiles="lumped_electron_sink_0001",
+                inchi_key="ELECTRONCONTRAST0000000001",
+                charge=-1,
+                multiplicity=2,
+                stereo_kind=StereoKind.achiral,
+            )
+            session.add(lumped)
+            session.flush()
+            lumped_entry = SpeciesEntry(
+                species_id=lumped.id,
+                kind=StationaryPointKind.minimum,
+                electronic_state_kind=SpeciesEntryStateKind.ground,
+            )
+            session.add(lumped_entry)
+            session.flush()
+
+            entry = persist_reaction_upload(
+                session,
+                ReactionUploadRequest(
+                    reversible=False,
+                    reactants=[
+                        {"species_entry": dict(item)}
+                        for item in (_HYDROXIDE, _H_ATOM, _METHANE)
+                    ],
+                    products=[
+                        {"species_entry": dict(_WATER)},
+                        {"species_entry_id": lumped_entry.id},
+                    ],
+                ),
+            )
+            assert entry.id is not None
+
+
+def test_a_geometry_deposited_under_an_electron_is_refused() -> None:
+    """An electron has no atoms, so any structure contradicts it.
+
+    Without this, ``molecule_kind: electron`` would be a second, quieter way to
+    attach coordinates that no composition check would look at.
+    """
+
+    with pytest.raises(ValueError) as excinfo:
+        assert_geometry_composition_matches_identity(
+            SpeciesEntryIdentityPayload(**_ELECTRON),
+            GeometryPayload(xyz_text="1\nnot an electron\nH 0.0 0.0 0.0"),
+        )
+    message = str(excinfo.value)
+    assert "species_geometry_composition_mismatch" in message
+    assert "a free electron has no atoms" in message
+
+
+# ---------------------------------------------------------------------------
+# The identity is pinned, not trusted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (
+            {**_ELECTRON, "charge": 0},
+            "a neutral electron would silently satisfy any charge sum",
+        ),
+        (
+            {**_ELECTRON, "multiplicity": 1},
+            "an electron is a doublet",
+        ),
+        (
+            {**_ELECTRON, "smiles": "C"},
+            "an electron declared with a structure would hide that structure "
+            "from elemental balance",
+        ),
+        (
+            {**_ELECTRON, "molecule_kind": "molecule"},
+            "the token would be handed to RDKit, which cannot parse it",
+        ),
+    ],
+)
+def test_an_electron_payload_may_not_contradict_itself(payload, reason) -> None:
+    """``electron``, ``[e-]``, -1 and 2 are declared together or not at all."""
+
+    with pytest.raises(ValidationError):
+        SpeciesEntryIdentityPayload(**payload)
+
+
+def test_every_electron_deposit_resolves_to_the_one_electron(db_engine) -> None:
+    """There is one electron, so there is one row, with no molecular graph.
+
+    ``smiles`` holds the reserved token and ``inchi_key`` a sentinel that
+    cannot be mistaken for an InChIKey (a real one is 14-10-1 letters). Every
+    graph-derived column of the entry is NULL, because there is no graph.
+    """
+
+    with Session(db_engine) as session:
+        with session.begin():
+            detachment = persist_reaction_upload(
+                session,
+                _request(reactants=[_HYDROXIDE, _H_ATOM], products=[_WATER, _ELECTRON]),
+            )
+            attachment = persist_reaction_upload(
+                session,
+                _request(reactants=[_ELECTRON, _H2], products=[_HYDRIDE, _H_ATOM]),
+            )
+            session.flush()
+
+            electrons = list(
+                session.scalars(
+                    select(Species).where(Species.kind == MoleculeKind.electron)
+                )
+            )
+            assert len(electrons) == 1
+            electron = electrons[0]
+            assert electron.smiles == ELECTRON_SMILES
+            assert electron.inchi_key.strip() == ELECTRON_INCHI_KEY
+            assert (electron.charge, electron.multiplicity) == (-1, 2)
+            assert electron.stereo_kind == StereoKind.achiral
+
+            entries = list(
+                session.scalars(
+                    select(SpeciesEntry).where(
+                        SpeciesEntry.species_id == electron.id
+                    )
+                )
+            )
+            assert len(entries) == 1
+            assert entries[0].mol is None
+            assert entries[0].unmapped_smiles is None
+            assert entries[0].isotope_key is None
+
+            # It is a participant of both reactions, not a decoration on one.
+            # Asserted per reaction rather than as a total: ``db_engine`` is
+            # session-scoped and these tests commit, so other reactions in
+            # this file share the one electron row.
+            participating = set(
+                session.scalars(
+                    select(ReactionParticipant.reaction_id).where(
+                        ReactionParticipant.species_id == electron.id
+                    )
+                )
+            )
+            assert {detachment.reaction_id, attachment.reaction_id} <= participating

--- a/backend/tests/workflows/test_species_geometry_composition.py
+++ b/backend/tests/workflows/test_species_geometry_composition.py
@@ -1,0 +1,375 @@
+"""A species' geometry must be made of the atoms its own SMILES declares.
+
+Nothing compared the two before. A species entry declaring methane could store
+the coordinates of methyl and deposit successfully, and every number computed
+downstream from that structure — energies, frequencies, partition functions,
+thermo — would then describe a molecule nobody deposited, under a label saying
+otherwise.
+
+This is not a hypothetical failure mode. The pressure-dependent fixtures stored
+geometries with hydrogen omitted entirely (ethyl as ``C C H``, ethylperoxy as
+``C C O O``, HO2 as ``O O``) for as long as they existed, and nothing looked,
+because the only composition check in the codebase compared a reaction's two
+*sides* against each other and never a structure against its own label.
+
+Formula agreement between a structure and its own identifier is definitional
+under ADR 0008 — no correct calculation can produce a geometry that is not made
+of its own molecule's atoms — so it blocks.
+
+The interesting half of this file is the accepting half. A blocking check that
+refuses correct science is worse than no check, so isotopologues, charged
+species, two-letter element symbols written in whatever case an ESS felt like,
+and deposits with no geometry at all must all still go through.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.db.models.app_user import AppUser
+from app.schemas.fragments.geometry import GeometryPayload
+from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
+from app.schemas.workflows.computed_species_upload import (
+    ComputedSpeciesUploadRequest,
+)
+from app.services.species_resolution import (
+    assert_geometry_composition_matches_identity,
+    resolve_species_entry,
+)
+from app.workflows.computed_species import persist_computed_species_upload
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+_USER_ID = 50_711
+
+#: Methane, CH4. Five atoms: C at the origin, four H at the tetrahedral
+#: vertices.
+_XYZ_CH4 = (
+    "5\nmethane\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
+)
+#: Methyl, CH3. Four atoms: C at the origin and three H in the plane. One
+#: hydrogen short of the methane it will be deposited against.
+_XYZ_CH3 = (
+    "4\nmethyl\n"
+    "C  0.000  0.000  0.000\n"
+    "H  1.080  0.000  0.000\n"
+    "H -0.540  0.935  0.000\n"
+    "H -0.540 -0.935  0.000"
+)
+#: Chloromethane, CH3Cl. Five atoms: C (index 1), Cl (index 2), three H
+#: (indices 3-5). Written the way plenty of electronic-structure output writes
+#: it — chlorine shouted, carbon and hydrogen whispered — because
+#: ``geometry_atom.element`` stores whatever the XYZ said, verbatim.
+_XYZ_CH3CL_MIXED_CASE = (
+    "5\nchloromethane, elements as an ESS wrote them\n"
+    "c  0.000  0.000  0.000\n"
+    "CL 1.781  0.000  0.000\n"
+    "h -0.372  1.028  0.000\n"
+    "h -0.372 -0.514  0.890\n"
+    "h -0.372 -0.514 -0.890"
+)
+#: Hydroxide, OH-. Two atoms: O (index 1) and H (index 2) at 0.964 A.
+_XYZ_OH = "2\nhydroxide\nO 0.000 0.000 0.000\nH 0.000 0.000 0.964"
+#: Ammonium, NH4+. Five atoms: N (index 1) and four H at the tetrahedral
+#: vertices, N-H 1.02 A.
+_XYZ_NH4 = (
+    "5\nammonium\n"
+    "N  0.000  0.000  0.000\n"
+    "H  0.589  0.589  0.589\n"
+    "H -0.589 -0.589  0.589\n"
+    "H -0.589  0.589 -0.589\n"
+    "H  0.589 -0.589 -0.589"
+)
+
+
+@contextmanager
+def _isolated_session(db_engine) -> Iterator[Session]:
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection, expire_on_commit=False)
+    try:
+        session.add(AppUser(id=_USER_ID, username="species_composition_tests"))
+        session.flush()
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+def _bundle(
+    *,
+    smiles: str,
+    xyz: str,
+    charge: int = 0,
+    multiplicity: int = 1,
+    isotopes: dict[int, int] | None = None,
+) -> dict:
+    geometry: dict = {"xyz_text": xyz}
+    if isotopes is not None:
+        geometry["isotopes"] = isotopes
+    return {
+        "species_entry": {
+            "smiles": smiles,
+            "charge": charge,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": geometry,
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_result": {"converged": True},
+                },
+            }
+        ],
+    }
+
+
+def _upload(session: Session, payload: dict):
+    return persist_computed_species_upload(
+        session,
+        ComputedSpeciesUploadRequest(**payload),
+        created_by=_USER_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# It fires
+# ---------------------------------------------------------------------------
+
+
+def test_methane_declared_with_a_methyl_geometry_is_refused(db_engine) -> None:
+    """The exact deposit that used to succeed: CH4's entry given CH3's XYZ."""
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(session, _bundle(smiles="C", xyz=_XYZ_CH3))
+    message = str(excinfo.value)
+    assert "species_geometry_composition_mismatch" in message
+    assert "geometry is CH3" in message
+    assert "is CH4" in message
+
+
+def test_a_geometry_that_omits_hydrogen_entirely_is_refused(db_engine) -> None:
+    """The fixture-rot shape: heavy atoms listed, hydrogens simply absent.
+
+    Ethyl deposited as ``C C H``. Three atoms where C2H5 has seven, which is
+    what went unnoticed for as long as those fixtures existed.
+    """
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(
+                session,
+                _bundle(
+                    smiles="[CH2]C",
+                    multiplicity=2,
+                    xyz=(
+                        "3\nethyl with its hydrogens missing\n"
+                        "C 0.00 0.00 0.00\n"
+                        "C 1.49 0.00 0.00\n"
+                        "H -0.38 1.01 0.00"
+                    ),
+                ),
+            )
+    message = str(excinfo.value)
+    assert "species_geometry_composition_mismatch" in message
+    assert "geometry is C2H" in message
+    assert "is C2H5" in message
+
+
+def test_a_later_conformer_with_the_wrong_atoms_is_refused(db_engine) -> None:
+    """Every conformer is checked, not only the first.
+
+    The first conformer is the one that drives stereo perception, and checking
+    only that one would let a bundle deposit one correct structure and any
+    number of wrong ones behind it.
+    """
+
+    payload = _bundle(smiles="C", xyz=_XYZ_CH4)
+    second = {
+        "key": "c1",
+        "geometry": {"xyz_text": _XYZ_CH3},
+        "primary_calculation": {
+            "key": "opt1",
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "opt_result": {"converged": True},
+        },
+    }
+    payload["conformers"].append(second)
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(session, payload)
+    assert "species_geometry_composition_mismatch" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# It does not fire on correct chemistry
+# ---------------------------------------------------------------------------
+
+
+def test_a_geometry_that_matches_its_smiles_is_accepted(db_engine) -> None:
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(session, _bundle(smiles="C", xyz=_XYZ_CH4))
+    assert outcome.species_entry_id is not None
+
+
+def test_a_deuterated_isotopologue_is_accepted(db_engine) -> None:
+    """CD4 declares four ``[2H]``; its geometry declares four H at mass 2.
+
+    The canonical form stores element ``H`` for ``[2H]``, and the XYZ writes
+    ``H`` too — the mass number rides in ``geometry.isotopes``, not in the
+    element column. Counting isotope-resolved would refuse every isotopologue
+    in the database, so the comparison is on elements. Isotope agreement is a
+    separate check with its own multiset comparison, and it runs on this
+    deposit as well.
+    """
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(
+            session,
+            _bundle(
+                smiles="[2H]C([2H])([2H])[2H]",
+                xyz=_XYZ_CH4,
+                isotopes={2: 2, 3: 2, 4: 2, 5: 2},
+            ),
+        )
+    assert outcome.species_entry_id is not None
+
+
+def test_a_partially_deuterated_isotopologue_is_accepted(db_engine) -> None:
+    """CH3D: one deuterium, three protium, still C1H4 by element."""
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(
+            session,
+            _bundle(smiles="[2H]C", xyz=_XYZ_CH4, isotopes={2: 2}),
+        )
+    assert outcome.species_entry_id is not None
+
+
+def test_an_anion_is_accepted(db_engine) -> None:
+    """Hydroxide. RDKit's implicit-H handling on a charged heteroatom is the
+    thing most likely to be got wrong here: ``[OH-]`` carries one hydrogen,
+    not zero and not two."""
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(
+            session, _bundle(smiles="[OH-]", xyz=_XYZ_OH, charge=-1)
+        )
+    assert outcome.species_entry_id is not None
+
+
+def test_a_cation_is_accepted(db_engine) -> None:
+    """Ammonium. Four hydrogens on a positively charged nitrogen."""
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(
+            session, _bundle(smiles="[NH4+]", xyz=_XYZ_NH4, charge=1)
+        )
+    assert outcome.species_entry_id is not None
+
+
+def test_a_radical_is_accepted(db_engine) -> None:
+    """Methyl, where the implicit-H count depends on reading the radical."""
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(
+            session, _bundle(smiles="[CH3]", xyz=_XYZ_CH3, multiplicity=2)
+        )
+    assert outcome.species_entry_id is not None
+
+
+def test_element_symbols_in_any_case_are_accepted(db_engine) -> None:
+    """``CL`` is chlorine and ``c`` is carbon.
+
+    ``geometry_atom.element`` holds whatever the depositor's XYZ said, and
+    electronic-structure codes are not consistent about capitalisation.
+    Refusing correct chemistry over a string is what ADR 0008 puts out of
+    bounds for a blocking check; this exact bug shipped once already.
+    """
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(
+            session, _bundle(smiles="CCl", xyz=_XYZ_CH3CL_MIXED_CASE)
+        )
+    assert outcome.species_entry_id is not None
+
+
+def test_a_deposit_with_no_geometry_is_accepted(db_engine) -> None:
+    """Absence is incompleteness, not contradiction.
+
+    A thermo or transport record uploaded from a paper has an identity and no
+    structure — those workflows call ``resolve_species_entry`` with no geometry
+    at all. There is nothing to disagree with, so there is nothing to refuse.
+    """
+
+    with _isolated_session(db_engine) as session:
+        entry = resolve_species_entry(
+            session, _identity("C"), created_by=_USER_ID
+        )
+    assert entry.id is not None
+
+
+# ---------------------------------------------------------------------------
+# The pure seam
+# ---------------------------------------------------------------------------
+
+
+def _identity(smiles: str, **overrides) -> SpeciesEntryIdentityPayload:
+    return SpeciesEntryIdentityPayload(
+        **{"smiles": smiles, "charge": 0, "multiplicity": 1, **overrides}
+    )
+
+
+def test_an_unparseable_smiles_does_not_block() -> None:
+    """A SMILES RDKit cannot read says nothing, so it contradicts nothing.
+
+    In the upload path such a payload is already refused upstream by identity
+    canonicalisation. The branch exists so this function is safe to call from
+    anywhere, and asserting it keeps a future caller from discovering that
+    "cannot parse" was quietly treated as "does not match".
+    """
+
+    payload = _identity("C").model_copy(update={"smiles": "not a smiles"})
+    assert_geometry_composition_matches_identity(
+        payload, GeometryPayload(xyz_text=_XYZ_CH3)
+    )
+
+
+def test_a_pseudo_species_is_exempt() -> None:
+    """Mirrors ``validate_reaction_elemental_balance``.
+
+    A lumped or phenomenological construct has no atom-resolved composition
+    for a geometry to agree with.
+    """
+
+    payload = _identity("C", molecule_kind="pseudo")
+    assert_geometry_composition_matches_identity(
+        payload, GeometryPayload(xyz_text=_XYZ_CH3)
+    )
+
+
+def test_the_pure_seam_refuses_a_mismatch() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        assert_geometry_composition_matches_identity(
+            _identity("C"), GeometryPayload(xyz_text=_XYZ_CH3)
+        )
+    assert "species_geometry_composition_mismatch" in str(excinfo.value)

--- a/backend/tests/workflows/test_species_geometry_composition.py
+++ b/backend/tests/workflows/test_species_geometry_composition.py
@@ -16,10 +16,23 @@ Formula agreement between a structure and its own identifier is definitional
 under ADR 0008 — no correct calculation can produce a geometry that is not made
 of its own molecule's atoms — so it blocks.
 
+**Scope: conformer geometries, and only those.** The check runs from
+``resolve_species_entry``, so it reaches every conformer geometry on the
+computed-species bundle, ``/uploads/conformers``, the computed-reaction bundle
+and the PDep bundle. It does **not** reach ``CalculationIn.input_geometries``
+or ``output_geometries`` on any path: benzene coordinates can still be attached
+as a calculation geometry under a ``smiles: "C"`` species entry and the deposit
+is accepted. That gap is stated rather than closed here — for an *output*
+geometry, an optimisation that drifted is science to record, not a payload to
+refuse; for an *input* geometry it is simply open. The only comparison those
+geometries get is the advisory ``calc_geometry_validation`` row, which is
+formula-based too (see ``app.services.geometry_validation``).
+
 The interesting half of this file is the accepting half. A blocking check that
 refuses correct science is worse than no check, so isotopologues, charged
-species, two-letter element symbols written in whatever case an ESS felt like,
-and deposits with no geometry at all must all still go through.
+species, hydrogens written ``D`` or ``T``, two-letter element symbols written
+in whatever case an ESS felt like, and deposits with no geometry at all must
+all still go through.
 """
 
 from __future__ import annotations
@@ -28,9 +41,12 @@ from contextlib import contextmanager
 from typing import Iterator
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db.models.app_user import AppUser
+from app.db.models.calculation import Calculation, CalculationGeometryValidation
+from app.db.models.common import ValidationStatus
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.workflows.computed_species_upload import (
@@ -77,6 +93,24 @@ _XYZ_CH3CL_MIXED_CASE = (
     "h -0.372  1.028  0.000\n"
     "h -0.372 -0.514  0.890\n"
     "h -0.372 -0.514 -0.890"
+)
+#: Heavy water, written the way an ESS is entitled to write it: ``D`` in the
+#: element column. Gaussian, ORCA, Molpro and CFOUR all emit or accept the
+#: token, and ``geometry_atom.element`` stores it verbatim by design.
+_XYZ_D2O = (
+    "3\nheavy water, hydrogens written as D\n"
+    "O  0.000  0.000  0.117\n"
+    "D  0.000  0.757 -0.469\n"
+    "D  0.000 -0.757 -0.469"
+)
+#: Tritiated methane, CH3T, with the tritium written ``T``.
+_XYZ_CH3T = (
+    "5\nmethane with one tritium\n"
+    "C  0.000  0.000  0.000\n"
+    "T  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
 )
 #: Hydroxide, OH-. Two atoms: O (index 1) and H (index 2) at 0.964 A.
 _XYZ_OH = "2\nhydroxide\nO 0.000 0.000 0.000\nH 0.000 0.000 0.964"
@@ -297,6 +331,62 @@ def test_a_radical_is_accepted(db_engine) -> None:
     assert outcome.species_entry_id is not None
 
 
+def test_deuterium_written_as_the_element_D_is_accepted(db_engine) -> None:
+    """``D`` is hydrogen, and this check must know it.
+
+    ``D`` is a legal, common XYZ token — Gaussian, ORCA, Molpro and CFOUR all
+    emit or accept it — and ``geometry_atom.element`` stores it verbatim. A raw
+    comparison reads this geometry as containing an element water's SMILES
+    never mentions and refuses a deposit that was accepted before any
+    composition check existed. That is a regression on correct chemistry, and
+    the error message it produced ended by promising that "isotope labels are
+    counted as their element, so an isotopologue is not a mismatch" — while
+    refusing the depositor for an isotope label.
+
+    Note what the ``D`` does *not* do: it carries no isotope identity. Isotope
+    identity lives in ``geometry.isotopes`` and in SMILES isotope notation, so
+    this deposit is the ordinary H2O it declares itself to be. That is
+    unchanged from before the composition check, and deliberately not widened
+    here.
+    """
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(session, _bundle(smiles="O", xyz=_XYZ_D2O))
+    assert outcome.species_entry_id is not None
+
+
+def test_tritium_written_as_the_element_T_is_accepted(db_engine) -> None:
+    """``T`` is hydrogen too, and for exactly the same reason."""
+
+    with _isolated_session(db_engine) as session:
+        outcome = _upload(session, _bundle(smiles="C", xyz=_XYZ_CH3T))
+    assert outcome.species_entry_id is not None
+
+
+def test_a_D_geometry_with_the_wrong_atom_count_is_still_refused(
+    db_engine,
+) -> None:
+    """Resolving ``D`` to ``H`` must not blunt the check.
+
+    Otherwise the fix for the deuterium regression would have bought
+    acceptance by making the rule stop counting hydrogens at all.
+    """
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(
+                session,
+                _bundle(
+                    smiles="O",
+                    xyz="2\nhydroxyl written with a D\nO 0.0 0.0 0.0\nD 0.0 0.0 0.96",
+                ),
+            )
+    message = str(excinfo.value)
+    assert "species_geometry_composition_mismatch" in message
+    assert "geometry is HO" in message
+    assert "is H2O" in message
+
+
 def test_element_symbols_in_any_case_are_accepted(db_engine) -> None:
     """``CL`` is chlorine and ``c`` is carbon.
 
@@ -304,13 +394,40 @@ def test_element_symbols_in_any_case_are_accepted(db_engine) -> None:
     electronic-structure codes are not consistent about capitalisation.
     Refusing correct chemistry over a string is what ADR 0008 puts out of
     bounds for a blocking check; this exact bug shipped once already.
+
+    The upload succeeding is only half of it. ``validate_calculation_geometry``
+    compares the very same symbols on the very same deposit, and it compared
+    them raw — so this bundle was accepted at the blocking tier and
+    simultaneously recorded ``is_isomorphic=False`` /
+    ``validation_status='fail'`` in ``calc_geometry_validation``, a false
+    ``fail`` on correct chemistry with two checks in one tree disagreeing about
+    one deposit. Per ADR 0008 §9 a fact gets one owner; asserting the persisted
+    row here is what keeps the advisory tier from contradicting the blocking
+    one.
     """
 
     with _isolated_session(db_engine) as session:
         outcome = _upload(
             session, _bundle(smiles="CCl", xyz=_XYZ_CH3CL_MIXED_CASE)
         )
-    assert outcome.species_entry_id is not None
+        assert outcome.species_entry_id is not None
+
+        session.flush()
+        # Scoped to this deposit's own calculation: ``db_engine`` is
+        # session-scoped and other test modules commit, so an unfiltered
+        # count would depend on what else ran first.
+        validation = session.scalar(
+            select(CalculationGeometryValidation).where(
+                CalculationGeometryValidation.calculation_id.in_(
+                    select(Calculation.id).where(
+                        Calculation.species_entry_id == outcome.species_entry_id
+                    )
+                )
+            )
+        )
+        assert validation is not None
+        assert validation.is_isomorphic is True
+        assert validation.validation_status == ValidationStatus.passed
 
 
 def test_a_deposit_with_no_geometry_is_accepted(db_engine) -> None:
@@ -373,3 +490,35 @@ def test_the_pure_seam_refuses_a_mismatch() -> None:
             _identity("C"), GeometryPayload(xyz_text=_XYZ_CH3)
         )
     assert "species_geometry_composition_mismatch" in str(excinfo.value)
+
+
+def test_the_formula_is_rendered_in_hill_notation() -> None:
+    """A chemist must recognise the formula in the error, or it is noise.
+
+    Ordering the elements alphabetically renders chloromethane ``CClH3``, which
+    nobody reads as the molecule they deposited. Hill notation — carbon, then
+    hydrogen, then the rest alphabetically — renders it ``CH3Cl``, and is what
+    every formula in the literature uses.
+    """
+
+    with pytest.raises(ValueError) as excinfo:
+        assert_geometry_composition_matches_identity(
+            _identity("CCl"), GeometryPayload(xyz_text=_XYZ_CH3)
+        )
+    message = str(excinfo.value)
+    assert "is CH3Cl" in message
+    assert "CClH3" not in message
+
+
+def test_a_carbon_free_formula_stays_alphabetical() -> None:
+    """Hill notation only privileges C and H when there is a carbon.
+
+    Water is ``H2O``, not ``OH2``: with no carbon, hydrogen takes its
+    alphabetical place like everything else.
+    """
+
+    with pytest.raises(ValueError) as excinfo:
+        assert_geometry_composition_matches_identity(
+            _identity("O"), GeometryPayload(xyz_text=_XYZ_CH3)
+        )
+    assert "is H2O" in str(excinfo.value)

--- a/backend/tests/workflows/test_transition_state_composition.py
+++ b/backend/tests/workflows/test_transition_state_composition.py
@@ -297,7 +297,7 @@ def test_a_saddle_point_whose_xyz_shouts_its_elements_is_accepted(
     ``geometry_atom.element`` holds the depositor's XYZ symbol verbatim, while
     the reactant side of the comparison comes from RDKit's title-case
     ``GetSymbol()``. Comparing the two raw makes a correct saddle point read as
-    ``CCLHHH`` against a reaction of ``CClH3`` and refuses it — rejecting
+    ``CCLHHH`` against a reaction of ``CH3Cl`` and refuses it — rejecting
     correct chemistry over capitalisation, which ADR 0008 disqualifies a
     blocking check from doing.
     """
@@ -320,9 +320,9 @@ def test_normalising_case_does_not_blunt_the_check(db_engine) -> None:
             )
     message = str(excinfo.value)
     assert "transition_state_composition_mismatch" in message
-    # Reported in the normalised spelling, so the formula reads as chemistry
-    # rather than as whatever the file happened to shout.
-    assert "is CH3, but the reaction it sits in is CClH3" in message
+    # Reported in the normalised spelling and in Hill notation, so the formula
+    # reads as chemistry rather than as whatever the file happened to shout.
+    assert "is CH3, but the reaction it sits in is CH3Cl" in message
 
 
 def test_multiplicity_is_deliberately_not_checked(db_engine) -> None:

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.18.0"
+version = "0.19.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/enums.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/enums.py
@@ -17,8 +17,33 @@ from enum import Enum
 
 
 class MoleculeKind(str, Enum):
+    # What sort of thing a reaction participant is.
+    #
+    # ``molecule`` is an atom-resolved structure with a SMILES, which is nearly
+    # everything. ``pseudo`` is a lumped or phenomenological construct whose
+    # composition and charge are not atom-resolved facts, so the conservation
+    # laws are not applied to a reaction containing one.
+    #
+    # ``electron`` is neither. A free electron has no SMILES and no atoms, but
+    # it is not *unknown* the way a pseudo-species is — it is exactly known:
+    # zero atoms, charge -1. It exists so that associative detachment
+    # (``OH- + H -> H2O + e-``), dissociative attachment, photoionization and
+    # photodetachment can be deposited as the balanced reactions they are.
+    # Declaring one therefore does **not** exempt a reaction from elemental
+    # balance or charge conservation; it contributes 0 to every element count
+    # and -1 to the charge sum, and both checks stay live. How to declare one
+    # is documented on ``SpeciesIdentityPayload``, which is where a depositor
+    # will be reading.
+    #
+    # Deliberately a comment rather than a docstring: this enum is mirrored by
+    # the backend's ``app.db.models.common.MoleculeKind``, and the two JSON
+    # schemas merge into one ``MoleculeKind`` component only while they are
+    # byte-identical. A docstring on one side alone renames the published
+    # component.
+
     molecule = "molecule"
     pseudo = "pseudo"
+    electron = "electron"
 
 
 class StationaryPointKind(str, Enum):

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
@@ -52,10 +52,29 @@ class SpeciesEntryIdentityValidatorMixin:
         return self
 
 
+#: The reserved token that declares a free electron as a reaction participant.
+#:
+#: An electron has no SMILES — RDKit does not parse ``[e-]`` and no
+#: standard notation names one — so this string is a *sentinel*, never parsed
+#: as chemistry. It is spelled the way plasma- and ion-chemistry mechanisms
+#: write it so a depositor recognises it, and it is the only ``smiles`` value
+#: ``MoleculeKind.electron`` accepts, so a payload can never claim to be an
+#: electron while carrying a structure or claim a structure while marked an
+#: electron.
+ELECTRON_SMILES = "[e-]"
+
+#: An electron's charge and spin multiplicity, which are not opinions. Stating
+#: anything else is a contradiction in the payload, not an unusual deposit.
+ELECTRON_CHARGE = -1
+ELECTRON_MULTIPLICITY = 2
+
+
 class SpeciesIdentityPayload(SchemaBase):
     """Reusable upload fragment for graph identity resolution.
 
-    :param molecule_kind: High-level species kind. Current workflows assume molecules.
+    :param molecule_kind: What sort of participant this is — see
+        :class:`~tckdb_schemas.enums.MoleculeKind`. Nearly every deposit is a
+        ``molecule``.
     :param smiles: Input graph identity SMILES string. Isotopic substitution is
         expressed with standard SMILES isotope notation (``[2H]``, ``[13C]``,
         ``[18O]``) and is atom-resolved: ``[2H]CO`` and ``[2H]OC`` are
@@ -64,6 +83,27 @@ class SpeciesIdentityPayload(SchemaBase):
         shared ``species``.
     :param charge: Expected formal charge for the uploaded identity.
     :param multiplicity: Expected spin multiplicity for the uploaded identity.
+
+    Declaring a free electron
+    -------------------------
+    Set ``molecule_kind`` to ``electron`` with ``smiles="[e-]"``,
+    ``charge=-1``, ``multiplicity=2``::
+
+        {"molecule_kind": "electron", "smiles": "[e-]",
+         "charge": -1, "multiplicity": 2}
+
+    That is the whole interface — no database id, and the electron's identity
+    row is resolved server-side like any other participant's. It exists so
+    that ``OH- + H -> H2O + e-`` (associative detachment) and its siblings —
+    dissociative attachment, photoionization, photodetachment — can be
+    deposited as balanced reactions rather than being refused for the electron
+    they legitimately release. An electron is exactly known, so declaring one
+    exempts a reaction from nothing: it adds no atoms to the elemental balance
+    and -1 to the charge sum, and both conservation checks still have to pass.
+
+    The three values are pinned rather than trusted. An electron carrying
+    charge 0 would silently switch charge conservation off, which is the whole
+    property this participant exists to preserve.
     """
 
     molecule_kind: MoleculeKind = MoleculeKind.molecule
@@ -75,6 +115,41 @@ class SpeciesIdentityPayload(SchemaBase):
     @classmethod
     def normalize_smiles(cls, value: str) -> str:
         return normalize_required_text(value)
+
+    @model_validator(mode="after")
+    def check_electron_identity(self) -> Self:
+        """Bind ``electron`` and ``[e-]`` to each other, and to -1 / 2.
+
+        Both directions matter. An ``electron`` carrying a real SMILES would
+        make a structure invisible to elemental balance; a ``molecule``
+        carrying ``[e-]`` would be handed to RDKit, which cannot parse it.
+        """
+
+        is_electron_kind = self.molecule_kind == MoleculeKind.electron
+        is_electron_smiles = self.smiles == ELECTRON_SMILES
+
+        if is_electron_kind != is_electron_smiles:
+            raise ValueError(
+                f"molecule_kind={MoleculeKind.electron.value!r} and "
+                f"smiles={ELECTRON_SMILES!r} must be declared together: a free "
+                "electron has no structure, and no structure is a free "
+                "electron."
+            )
+
+        if not is_electron_kind:
+            return self
+
+        if self.charge != ELECTRON_CHARGE or self.multiplicity != ELECTRON_MULTIPLICITY:
+            raise ValueError(
+                "A free electron carries charge "
+                f"{ELECTRON_CHARGE} and multiplicity {ELECTRON_MULTIPLICITY}; "
+                f"got charge={self.charge}, multiplicity={self.multiplicity}. "
+                "These are not deposit-specific values, and an electron "
+                "declared neutral would switch off the charge conservation "
+                "this participant exists to preserve."
+            )
+
+        return self
 
 
 class SpeciesEntryIdentityPayload(


### PR DESCRIPTION
Two blocking checks that close confirmed holes, and the participant needed to make one of them honest. Governed by [ADR 0008](docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md).

## The two checks

**A species' geometry must have the atoms its own SMILES declares.** Giving CH₄'s entry the XYZ of CH₃ used to deposit clean. This is the root cause of a long-standing fixture rot: PDep fixtures stored geometries that **omitted hydrogen entirely** — HO₂ as `O O`, ethylperoxy as `C C O O` — for years, because nothing compared a structure to its own identifier.

**Charge must be conserved across a reaction.** `[OH-] + [H] → H2O` (−1 vs 0) used to deposit with no error *and no warning*.

Both are definitional, so both block. Both exempt lumped/phenomenological `pseudo` species, sharing one loader so the exemptions cannot drift apart.

## Why the electron exists

Adversarial review found the charge check refuses **associative detachment** — `OH⁻ + H → H₂O + e⁻`, real measured gas-phase chemistry, sibling of `H⁻ + H → H₂ + e⁻`. Dissociative attachment, photoionization and photodetachment are the same family.

Worse, both docstrings told depositors to "declare that participant as a pseudo species", and **that route did not exist**: `species.py` refuses every non-`molecule` kind, and `MoleculeKind.pseudo` appeared in the whole backend *only* as an exemption predicate — nothing ever created one.

The real defect was tier, not wording: charge conservation is definitional only if the participant list can be **complete**. With no way to declare an electron, the check asserted "all participants were declared" — an expectation, which ADR 0008 disqualifies from blocking.

So the electron became declarable:

```json
{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, "multiplicity": 2}
```

It is carried as an ordinary `reaction_participant` because it *is* one — it takes a coefficient (a two-electron process releases two) and must sit inside the stoichiometry hash, or `A → B` and `A → B + e⁻` collide on one identity. A signed `electrons` column on `chem_reaction` was rejected: duplicate stoichiometry machinery, a sign convention to get wrong, and invisible to every reader that iterates participants.

### The electron is not exempt from anything

This is the part that would have been a bigger hole than the one being closed. The pseudo exemption **skips both balance checks entirely**, so an electron routed through it would let anyone disable mass balance on any reaction by adding one.

`_load_participant_species` tests for `pseudo` **specifically**, not "anything that is not a molecule". An electron contributes an empty element count and −1 charge, and both checks stay live.

Pinned by `test_an_electron_does_not_switch_off_elemental_balance`: `OH- + H + CH4 → H2O + e-` **balances charge** at −1/−1, so charge conservation has nothing to say and only mass balance can catch the vanishing CH₄. It is refused and writes no row.

## A latent bug this surfaced

`resolve_atom_mapping`'s SMILES-graph fallback was **dead in the only case it existed for**. After the fallback it read `xyz_mol`, which is unbound whenever `_build_mol_from_xyz` raised — precisely when the fallback is supposed to rescue the mapping — and a blanket `except Exception` swallowed the `NameError` as `status="error"`. It only ever ran when bond perception had already succeeded. Everything after the match now indexes the uploaded atom list.

## Other review findings fixed

- **`D` and `T` as element symbols** were refused. Every major ESS emits or accepts them, and the error message ended by saying isotope labels are fine while refusing the depositor for one. Now resolved to `H` for counting, composition-neutral and isotope-silent as before.
- **A false coverage claim** — only *conformer* geometries reach the check. `CalculationIn.input_geometries`/`output_geometries` reach no composition check on any path; benzene under `smiles: "C"` still deposits. Claim narrowed and the gap named rather than papered over.
- **`geometry_validation.py`'s module docstring was false** — it claimed to catch rearrangement, bond breaking, dissociation and proton transfer, and asserted "graph isomorphism is the identity criterion". It passes ethanol vs dimethyl ether, and methane with one H pulled to 5 Å. It is a **formula** check; now documented as one, citing the blocking owner per ADR 0008 §9.
- **Mixed-case elements wrote a false `fail`** — two checks in the same tree disagreed about the same geometry. Fixed; the deposit now records `passed`.
- Hill notation, so a formula reads `CH3Cl` rather than `CClH3`.

## Seven fixture files were wrong

Every corrected geometry was audited per atom and per bond with RDKit connectivity perception — no repeat of the earlier correction that got atom counts right and identities wrong. `test_computed_species_upload.py` had used **one methane geometry for 36 species** including `BrCCCCCCCCCCCCCCCO`; each is now generated from its own SMILES, correct by construction.

## Gates

scientific **1975 passed**, API **2424 passed** (both exactly baseline); `workflows scripts importers cli client_builder_contract invariants schemas` **1807 passed, 5 skipped**; `ruff check app tests scripts` clean; `alembic check` on a fresh DB reports no new operations; `schema.dbml` regenerated; `tckdb_schemas` 0.18.0 → 0.19.0.

## Worth knowing

Documenting a **mirrored** enum splits its published OpenAPI component — the two schemas merge only while byte-identical, so prose on one side produced ``MoleculeKind-Output`` plus a namespaced twin. Both sides now carry the prose as comments. Relevant to any other mirrored enum someone wants to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
