### PR TITLE
Register the scientific positions TCKDB enforces

### DIFF
--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -12,6 +12,7 @@ from app.chemistry.geometry import resolve_element_symbol
 from app.chemistry.isotopes import normalize_isotope, validate_isotope
 from app.db.models.common import MoleculeKind, StereoKind
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 logger = logging.getLogger(__name__)
 
@@ -574,3 +575,48 @@ def canonical_species_identity(
     canonical_smiles = Chem.MolToSmiles(bare, canonical=True)
     inchi_key = inchi.MolToInchiKey(bare)
     return canonical_smiles, inchi_key
+
+
+CHECK_SMILES_CHARGE_MATCHES_DECLARED = ScientificCheck(
+    group="A structure against its own label",
+    sort_key=3,
+    code=None,
+    asserts=(
+        "A species entry's declared charge equals the summed formal charge of "
+        "its own SMILES."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional, and the anchor the reaction-level charge law stands on: "
+        "``validate_reaction_charge_conservation`` sums ``Species.charge`` and "
+        "is only meaningful because each value has already been reconciled "
+        "with the structure it labels. Per ADR 0008 the blocking tier owns the "
+        "rule and the others cite it, which is why "
+        "``assert_geometry_composition_matches_identity`` deliberately does "
+        "not re-check charge."
+    ),
+    adr="0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(
+            canonical_species_identity,
+            note=(
+                "Charge is compared against ``formal_charge`` of the sanitized "
+                "identity molecule — the sum of RDKit per-atom formal charges, "
+                "which is a notation convention rather than an electron count. "
+                "A referee may object that formal-charge assignment on "
+                "hypervalent, zwitterionic or dative-bonded SMILES is "
+                "notation-dependent."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "A free electron short-circuits before the comparison, returning a "
+        "pinned identity pair. Multiplicity is deliberately **not** validated "
+        "against the SMILES at all: standard SMILES does not encode spin "
+        "state, so RDKit's inferred radical count is only a hint and the "
+        "uploaded multiplicity is authoritative — which is what lets singlet "
+        "CH2 (whose SMILES ``[CH2]`` implies a triplet) and the singlet and "
+        "triplet states of O2 be represented."
+    ),
+)

--- a/backend/app/chemistry/units.py
+++ b/backend/app/chemistry/units.py
@@ -1,6 +1,7 @@
 """Unit conversion utilities for scientific quantities."""
 
 from app.db.models.common import ActivationEnergyUnits, ArrheniusAUnits
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 # 1 cal = 4.184 J (thermochemical calorie)
 _CAL_TO_J = 4.184
@@ -69,3 +70,48 @@ def validate_a_units_for_molecularity(
             f"{order_label[molecularity]} reaction (molecularity={molecularity}). "
             f"Expected one of: {allowed_names}."
         )
+
+
+CHECK_ARRHENIUS_A_UNITS_MATCH_MOLECULARITY = ScientificCheck(
+    group="Rate coefficients",
+    sort_key=1,
+    code=None,
+    asserts=(
+        "An Arrhenius pre-exponential factor carries units of the "
+        "dimensionality its reaction order requires — per-second for "
+        "unimolecular, concentration^-1 time^-1 for bimolecular, "
+        "concentration^-2 time^-1 for termolecular."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. The dimensionality of A follows from the rate law, so "
+        "an A in cm3/mol/s on a unimolecular reaction is not an unusual result "
+        "but a number that cannot mean what it says. A mis-declared unit is "
+        "also silently catastrophic downstream, since nothing later in the "
+        "stack can recover the intended order from the value alone."
+    ),
+    adr="0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(
+            validate_a_units_for_molecularity,
+            note=(
+                "Called from the kinetics upload schema, so it refuses at the "
+                "wire boundary. The order is not simply ``len(reactants)``: a "
+                "simple ``+M`` third-body reaction carries a ``[M]`` term on "
+                "the main line and validates one order higher, while a falloff "
+                "reaction's main line is the high-pressure limit k-infinity "
+                "and keeps ``len(reactants)``, its low-pressure limit k0 being "
+                "validated separately one order up."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "None, and the refinements are the reason it can block without firing "
+        "on correct science: PLOG and Chebyshev are refused the "
+        "``is_third_body`` flag outright, because both already encode the full "
+        "pressure dependence and the flag would otherwise inflate the expected "
+        "order by one — rejecting a PLOG entry carrying the *correct* units "
+        "and accepting one carrying the units of the next order up."
+    ),
+)

--- a/backend/app/scientific_checks/__init__.py
+++ b/backend/app/scientific_checks/__init__.py
@@ -1,0 +1,344 @@
+"""Self-declaration for TCKDB's *scientific* checks.
+
+TCKDB runs roughly 326 Pydantic validators and 225 database check
+constraints. Almost all of them enforce plumbing — string lengths, enum
+membership, foreign-key existence, ``multiplicity >= 1``. A small
+minority enforce **theoretical chemistry**: elemental balance, charge
+conservation, the imaginary-mode count that defines a saddle point, the
+bijectivity of an atom map. Those are the ones a referee could disagree
+with, and they are the ones this package makes enumerable.
+
+Why a registry has to exist at all
+----------------------------------
+Nothing in the code distinguishes the two populations. A generator
+cannot tell :func:`validate_reaction_charge_conservation` from
+``max_length=64`` by inspection, and the machine-readable codes the
+scientific checks emit — ``reaction_mass_balance_failed`` and the rest —
+live inside f-string message bodies, discoverable only by reading. The
+earlier hand-written audit at ``docs/reviews/validation_check_audit.md``
+hit exactly this wall: it covers the Pydantic tier only, and every
+conservation law in the database is absent from it.
+
+The inclusion test
+------------------
+**Could this check be wrong in an interesting way?** Elemental balance
+is a position a referee could argue with; ``max_length=64`` is not, and
+``multiplicity >= 1`` is arithmetic rather than chemistry. Membership in
+the register *is* the claim that a check encodes a scientific decision,
+so there is no "paper-worthy" flag — adding an entry that fails the test
+dilutes every other entry.
+
+How to add one
+--------------
+Construct a :class:`ScientificCheck` at module level, immediately below
+the check it describes::
+
+    def validate_reaction_elemental_balance(...) -> None:
+        ...
+
+    CHECK_REACTION_ELEMENTAL_BALANCE = ScientificCheck(
+        code="reaction_mass_balance_failed",
+        asserts="The reactant and product sides of a reaction contain "
+                "the same number of atoms of every element.",
+        tier=CheckTier.block,
+        tier_rationale="...",
+        adr="0008",
+        enforced_by=(PythonCheck(validate_reaction_elemental_balance),),
+        escape_hatch="...",
+    )
+
+then add the module to ``_DECLARING_MODULES`` in :mod:`.declarations`
+(a guard test fails if you forget). Regenerate the register document
+with ``backend/scripts/generate_scientific_check_register.py``.
+
+Why a plain dataclass rather than a decorator
+---------------------------------------------
+A decorator sits in the call path of a check whose behaviour must not
+change. A frozen dataclass constructed beside the function is inert: it
+is data, it wraps nothing, and it cannot alter a signature, a traceback
+or a hot loop. It also works for the two populations a decorator cannot
+reach — a PostgreSQL constraint has no Python object to decorate, and
+``tckdb_schemas`` is forbidden by
+``schemas/python/tckdb-schemas/tests/test_import_boundaries.py`` from
+importing anything under ``app``, so a wire-schema check cannot
+reference a backend decorator. Those two are declared in
+:mod:`.declarations` instead, and say so.
+
+There is deliberately no import-time side effect. Collection walks the
+declaring modules' namespaces (see :func:`collect_registered_checks`),
+so importing a service module registers nothing, mutates no global, and
+cannot fail in a way that takes a check down with it.
+
+What the drift guard enforces
+-----------------------------
+``backend/tests/db/test_scientific_check_register.py``:
+
+* every :class:`PythonCheck` resolves to a real callable (a rename or a
+  deletion breaks the import, so CI goes red before review does);
+* every :class:`DatabaseConstraint` exists in the live PostgreSQL
+  schema, queried from ``pg_constraint`` / ``pg_trigger`` rather than
+  trusted as a string;
+* every code declared as ``emitted=True`` appears verbatim in the
+  source of the function said to emit it;
+* every file in the repository containing ``ScientificCheck(`` is
+  listed in ``_DECLARING_MODULES``;
+* codes are unique across the register.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import ModuleType
+
+
+class CheckTier(str, Enum):
+    """Consequence of a check firing, in ADR 0008's vocabulary.
+
+    ``block`` and ``warn`` carry the same string values as
+    :class:`tckdb_schemas.stationary_point.ValidationTier`, which is the
+    runtime tier type for that module's findings; they are kept as
+    separate enums because this one is documentation and that one is
+    control flow, and the register must be able to name tiers that no
+    ``StationaryPointFinding`` can have.
+    """
+
+    #: Refuse the payload. ADR 0008 reserves this for definitions and
+    #: contracts: a check may block only if no correct calculation could
+    #: produce the record it refuses.
+    block = "block"
+
+    #: Accept the payload and record a machine-readable
+    #: :class:`~tckdb_schemas.upload_warning.UploadWarning`. The tier for
+    #: expectations and for absences.
+    warn = "warn"
+
+    #: Referred to ``machine_review`` under a versioned rubric. ADR 0008
+    #: puts every cross-check against external reference data here.
+    review = "review"
+
+    #: Not an ADR 0008 consequence tier. The position is enforced by the
+    #: *shape* of the schema — a NOT NULL discriminator, a check
+    #: constraint, a trigger — so there is no runtime check to place in a
+    #: tier, and a record violating it cannot be represented at all.
+    structural = "structural"
+
+
+# ---------------------------------------------------------------------------
+# Where a check is enforced
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PythonCheck:
+    """A check enforced by Python code, identified by the function object.
+
+    Holding the callable rather than a dotted string is the whole point:
+    renaming or deleting the function breaks the import of the declaring
+    module, so drift is caught at collection time instead of surviving
+    as a stale string in a document.
+
+    :param func: The function that performs the check.
+    :param note: Optional scope qualifier — which upload paths reach it,
+        what it deliberately does not cover.
+    """
+
+    func: Callable[..., object]
+    note: str | None = None
+
+    @property
+    def location(self) -> str:
+        """``path/to/module.py:LINE``, resolved from the live object."""
+        source_file = inspect.getsourcefile(self.func)
+        if source_file is None:  # pragma: no cover - builtins only
+            return f"{self.func.__module__}.{self.func.__qualname__}"
+        _lines, first = inspect.getsourcelines(self.func)
+        return f"{_repo_relative(source_file)}:{first}"
+
+    @property
+    def label(self) -> str:
+        return f"``{self.func.__qualname__}``"
+
+
+@dataclass(frozen=True)
+class DatabaseConstraint:
+    """A check enforced by PostgreSQL, identified by its schema object name.
+
+    A constraint cannot self-declare in Python, so the register names it
+    and the drift guard verifies the name against live schema metadata.
+    The name must be the **expanded** one that exists in the database
+    (``ck_reaction_atom_map_pair_element_matches``), not the short form
+    written in ``__table_args__`` (``element_matches``) that
+    ``NAMING_CONVENTION`` expands.
+
+    :param table: Table the object is attached to.
+    :param name: Expanded object name as PostgreSQL holds it.
+    :param kind: ``check``, ``unique``, ``foreign_key`` or ``trigger``.
+    :param definition: The SQL predicate, for the register document.
+    """
+
+    table: str
+    name: str
+    kind: str
+    definition: str | None = None
+
+    @property
+    def location(self) -> str:
+        return f"{self.table}.{self.name}"
+
+    @property
+    def label(self) -> str:
+        return f"``{self.name}`` ({self.kind} on ``{self.table}``)"
+
+
+@dataclass(frozen=True)
+class DesignPosition:
+    """A scientific position enforced by schema shape rather than a check.
+
+    Used where the register should record what TCKDB guarantees but
+    there is no single callable or constraint to point at — the
+    reproducibility rubric, for instance, or a discriminator whose
+    meaning is the guarantee.
+
+    :param where: Human-readable description of what carries the
+        position, with paths where they help.
+    """
+
+    where: str
+
+    @property
+    def location(self) -> str:
+        return self.where
+
+    @property
+    def label(self) -> str:
+        return self.where
+
+
+Enforcement = PythonCheck | DatabaseConstraint | DesignPosition
+
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScientificCheck:
+    """One scientific guarantee TCKDB makes about chemistry.
+
+    An entry is a *claim*, not a code location: the same claim may be
+    enforced in more than one place, and ADR 0008 cares which. The atom
+    map's "an element does not change across a reaction" is stated once
+    at the wire boundary and once as a check constraint, and listing
+    both in one entry is what lets a reader see that a second write path
+    cannot get around it.
+
+    :param code: Machine-readable code, or a tuple of them where one
+        claim is reported under more than one code. ``None`` means the
+        check raises with prose only — recorded honestly rather than
+        invented, because a code that appears in no message is a code no
+        client can match on.
+    :param asserts: What the check asserts, in one sentence a chemist
+        would recognise. Not a description of the implementation.
+    :param tier: ADR 0008 consequence tier.
+    :param tier_rationale: Why that tier, in ADR 0008's terms — for
+        ``block``, why no correct calculation could produce the record;
+        for ``warn``, what correct novel result it could otherwise fire
+        on.
+    :param adr: Governing ADR number(s), e.g. ``"0008"`` or
+        ``"0008, 0011"``.
+    :param enforced_by: One or more enforcement sites.
+    :param escape_hatch: How legitimate chemistry that the check would
+        otherwise refuse is deposited instead. ``None`` where none
+        exists. This column is load-bearing: charge conservation is only
+        defensible as a blocking check because an electron can be
+        declared as a participant.
+    :param emitted: Whether the code reaches a producer. The drift guard
+        asserts, for each code, that the literal string appears in the
+        source of the module **defining the enforcing function** — not
+        the module declaring the entry, which would be tautological. So
+        renaming ``reaction_mass_balance_failed`` in
+        ``reaction_resolution.py`` fails the guard even though the
+        declaration sits in the same file, and renaming a
+        ``tckdb_schemas`` code fails it from across the package
+        boundary.
+    :param divergence: A recorded disagreement between the check's
+        documentation and its behaviour. Reported, never silently fixed.
+    """
+
+    code: str | tuple[str, ...] | None
+    asserts: str
+    tier: CheckTier
+    tier_rationale: str
+    adr: str
+    enforced_by: tuple[Enforcement, ...]
+    escape_hatch: str | None = None
+    emitted: bool = True
+    divergence: str | None = None
+    group: str = "Uncategorised"
+    sort_key: int = 0
+
+    @property
+    def codes(self) -> tuple[str, ...]:
+        """Every machine-readable code this entry reports under."""
+        if self.code is None:
+            return ()
+        if isinstance(self.code, str):
+            return (self.code,)
+        return self.code
+
+    def __post_init__(self) -> None:
+        if not self.enforced_by:
+            raise ValueError(
+                f"ScientificCheck({self.code!r}) declares no enforcement site; "
+                "an entry that names no code, constraint or position cannot be "
+                "drift-guarded and is a comment, not a register entry."
+            )
+
+
+def _repo_relative(path: str) -> str:
+    """Render an absolute source path relative to the repository root."""
+    resolved = Path(path).resolve()
+    for parent in resolved.parents:
+        if (parent / ".git").exists():
+            return str(resolved.relative_to(parent))
+    return resolved.name
+
+
+def collect_registered_checks(modules: tuple[ModuleType, ...]) -> list[ScientificCheck]:
+    """Gather every module-level :class:`ScientificCheck` in ``modules``.
+
+    Collection reads namespaces rather than relying on registration side
+    effects, so a declaration is inert until something asks for it and
+    two imports of the same module cannot double-register.
+
+    :param modules: Already-imported modules to scan.
+    :returns: Checks, deduplicated by identity and ordered by group then
+        declared ``sort_key`` then code, so the generated document is
+        stable across runs.
+    """
+
+    seen: dict[int, ScientificCheck] = {}
+    for module in modules:
+        for value in vars(module).values():
+            if isinstance(value, ScientificCheck):
+                seen.setdefault(id(value), value)
+    return sorted(
+        seen.values(),
+        key=lambda check: (check.group, check.sort_key, check.codes),
+    )
+
+
+__all__ = [
+    "CheckTier",
+    "DatabaseConstraint",
+    "DesignPosition",
+    "Enforcement",
+    "PythonCheck",
+    "ScientificCheck",
+    "collect_registered_checks",
+]

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -1,0 +1,708 @@
+"""Collection point for the scientific check register.
+
+Most entries live beside the check they describe, in the service or
+chemistry module that performs it. This module holds the two populations
+that *cannot* declare themselves at the point of definition, plus the
+list of modules the collector walks.
+
+Why these entries are here rather than beside their checks
+----------------------------------------------------------
+**PostgreSQL constraints and triggers have no Python object.** A check
+constraint is a string in ``__table_args__`` that ``NAMING_CONVENTION``
+expands on the way to the database, and a trigger is raw SQL inside an
+Alembic revision. Neither can hold a declaration, so the register names
+the schema object and the drift guard verifies that name against live
+schema metadata — which is a real guard, where a comment would not be.
+
+**The wire-schema package is forbidden from importing the backend.**
+``schemas/python/tckdb-schemas/tests/test_import_boundaries.py`` bans
+every import rooted at ``app`` from ``tckdb_schemas``, by AST scan and by
+a runtime ``sys.modules`` check in a subprocess. A wire-schema check
+therefore cannot reference :class:`~app.scientific_checks.ScientificCheck`
+where it is defined. Declaring it here keeps the boundary intact and
+still holds the real function object, so renaming
+``evaluate_transition_state_frequency`` breaks the import of this module
+rather than leaving a stale string in a document.
+
+Everything else belongs next to its check. Add it there.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from tckdb_schemas.fragments import reaction_atom_map as wire_atom_map
+from tckdb_schemas.stationary_point import (
+    TS_IMAGINARY_FREQUENCY_MIN_CM1,
+    W_N_IMAG_CONTRADICTS_MINIMUM,
+    W_N_IMAG_HIGHER_ORDER_SADDLE,
+    W_N_IMAG_SUGGESTS_TS,
+    W_TS_IMAG_FREQ_TOO_SMALL,
+    W_TS_N_IMAG_NOT_ONE,
+    evaluate_species_entry_frequency,
+    evaluate_transition_state_frequency,
+)
+
+from app.chemistry import species as chemistry_species
+from app.chemistry import units as chemistry_units
+from app.scientific_checks import (
+    CheckTier,
+    DatabaseConstraint,
+    DesignPosition,
+    PythonCheck,
+    ScientificCheck,
+    collect_registered_checks,
+)
+from app.services import (
+    charge_multiplicity_reconciliation,
+    reaction_resolution,
+    species_resolution,
+    transition_state_validation,
+)
+from app.services import geometry_validation as geometry_validation_service
+from app.services import reaction_atom_map as reaction_atom_map_service
+from app.services.provenance_warnings import (
+    W_NETWORK_WIDE_ENERGY_TRANSFER,
+    W_REPORTED_NETWORK_SOLVE,
+)
+
+# ---------------------------------------------------------------------------
+# Stationary points — the imaginary-mode spectrum is the definition
+# ---------------------------------------------------------------------------
+
+CHECK_TRANSITION_STATE_ONE_IMAGINARY_MODE = ScientificCheck(
+    group="Stationary points",
+    sort_key=1,
+    code=W_TS_N_IMAG_NOT_ONE,
+    asserts=(
+        "A transition state has exactly one imaginary vibrational mode."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional — ADR 0008's worked example. The Hessian eigenvalue "
+        "spectrum *is* the definition of a stationary point: zero imaginary "
+        "modes is a minimum and the geometry never reached a barrier top, two "
+        "or more is a higher-order saddle. Either way the record is not the "
+        "first-order saddle point it declares itself to be, and no correct "
+        "calculation produces it as submitted."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            evaluate_transition_state_frequency,
+            note=(
+                "A transition state carries no ``stationary_point_kind`` "
+                "column — the entity *is* the claim — so the rule needs no "
+                "kind argument. Upload schemas call "
+                "``raise_for_blocking_findings`` from a ``model_validator``, "
+                "so the contradiction becomes a 422 before the route body "
+                "opens a submission."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Deposit no frequency evidence: ``n_imag=None`` produces no findings "
+        "at all. Absence is never contradiction."
+    ),
+    divergence=(
+        "The module calls itself 'the single owner' of these findings, and "
+        "ADR 0008 requires that where one fact is checked in more than one "
+        "tier the blocking tier owns it and the others cite it. "
+        "``_check_ts_single_imaginary_frequency_for_ts`` in "
+        "``app/services/trust/rubrics.py`` nevertheless re-derives the same "
+        "physical fact independently at read time, and the trust evaluator "
+        "promotes it to a hard fail. ADR 0008 names this duplication as a "
+        "defect to be collapsed onto one owner; it has not been collapsed."
+    ),
+)
+
+CHECK_MINIMUM_ZERO_IMAGINARY_MODES = ScientificCheck(
+    group="Stationary points",
+    sort_key=2,
+    code=W_N_IMAG_CONTRADICTS_MINIMUM,
+    asserts=(
+        "A species entry declared a minimum has no imaginary vibrational "
+        "modes."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. A covalently bound minimum whose own frequency "
+        "evidence reports an imaginary mode is mislabelled: the correct "
+        "response is to re-optimise on a tighter integration grid or to "
+        "declare it as something else, so refusing the deposit rejects no "
+        "correct calculation."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            evaluate_species_entry_frequency,
+            note=(
+                "One imaginary mode and two-or-more are folded into a single "
+                "blocking message that names "
+                f"``{W_N_IMAG_HIGHER_ORDER_SADDLE}`` for the higher-order "
+                "case. A stationary-point kind the module has not been taught "
+                "about produces no findings — adding an enum member must be a "
+                "deliberate decision, not a default."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare ``species_entry_kind='vdw_complex'``, which records the same "
+        "mode with a warning instead, or deposit the structure through a "
+        "transition-state payload if the single imaginary mode is real."
+    ),
+)
+
+CHECK_VDW_COMPLEX_IMAGINARY_MODE = ScientificCheck(
+    group="Stationary points",
+    sort_key=3,
+    code=(
+        W_N_IMAG_CONTRADICTS_MINIMUM,
+        W_N_IMAG_HIGHER_ORDER_SADDLE,
+        W_N_IMAG_SUGGESTS_TS,
+    ),
+    asserts=(
+        "A van der Waals complex is formally a minimum, so an imaginary mode "
+        "on one is recorded and flagged rather than refused — unless the mode "
+        "is too stiff to be an intermolecular one, which suggests a genuine "
+        "reaction coordinate."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "The carve-out is the scientific content. A van der Waals complex is "
+        "held together by intermolecular forces and its stretch, bends and "
+        "hindered internal rotations sit below roughly 50 cm-1 — the region "
+        "where numerical noise in a finite-difference or quadrature-grid "
+        "Hessian is comparable to the true curvature. A small imaginary mode "
+        "there is usually a grid artifact, so refusing it would force an "
+        "expensive re-run for a physically meaningless mode. This is what "
+        "earns ``vdw_complex`` a separate enum member: it is the only place "
+        "the two minimum kinds behave differently."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            evaluate_species_entry_frequency,
+            note=(
+                "Same entry point as the blocking minimum rule; the declared "
+                "kind decides the tier while the code names the finding. A "
+                f"mode at or above {TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm-1 "
+                f"additionally raises ``{W_N_IMAG_SUGGESTS_TS}``, because that "
+                "is far too stiff to be intermolecular."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "This *is* the escape hatch for the blocking minimum rule. Its own "
+        "cost is that a genuinely mislabelled saddle point deposited as a van "
+        "der Waals complex is accepted with a warning."
+    ),
+)
+
+CHECK_TRANSITION_STATE_IMAGINARY_MODE_MAGNITUDE = ScientificCheck(
+    group="Stationary points",
+    sort_key=4,
+    code=W_TS_IMAG_FREQ_TOO_SMALL,
+    asserts=(
+        "A transition state's single imaginary mode should exceed roughly "
+        f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm-1 in magnitude."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "ADR 0008's worked counter-example, and the sharpest statement of the "
+        "whole rule. A very soft imaginary mode is suspicious — often an "
+        "under-converged geometry or a coarse integration grid — but it can be "
+        "perfectly real, because flat barriers and variational transition "
+        "states genuinely produce them. Magnitude is therefore a quality "
+        "expectation, never a definition, and a check that could fire on a "
+        "correct novel result must not block."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            evaluate_transition_state_frequency,
+            note=(
+                "The threshold is explicitly a starting point rather than a "
+                "physical constant: reaction coordinates for hydrogen "
+                "transfers run to thousands of cm-1, while genuinely flat "
+                "barriers fall well under 100. It is also the scale that "
+                "separates a van der Waals complex's soft intermolecular "
+                "modes from a real reaction coordinate, and is reused for that "
+                "judgement."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "None is needed — the check never refuses. A referee should read the "
+        "threshold as a tunable reporting line, not a claim about physics."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Atom mapping across a reaction (ADR 0011)
+# ---------------------------------------------------------------------------
+
+_ATOM_MAP_DUAL_ENFORCEMENT = (
+    "Stated twice on purpose: once at the wire boundary, where the payload "
+    "already holds every XYZ block the rule needs so the refusal arrives as a "
+    "clean 422 before anything is written, and once as a database constraint, "
+    "where a second write path cannot get around it."
+)
+
+CHECK_ATOM_MAP_ELEMENT_CONSERVED = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=1,
+    code=None,
+    asserts=(
+        "An atom does not change element on the way across a reaction: carbon "
+        "does not map onto nitrogen."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. A map asserting that an element transmutes is a record "
+        "that cannot be what it says it is, not an unusual result."
+    ),
+    adr="0011, 0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(wire_atom_map.validate_reaction_atom_map, note=_ATOM_MAP_DUAL_ENFORCEMENT),
+        DatabaseConstraint(
+            table="reaction_atom_map_pair",
+            name="ck_reaction_atom_map_pair_element_matches",
+            kind="check",
+            definition="upper(element) = upper(ts_element)",
+        ),
+    ),
+    escape_hatch=(
+        "Case is not load-bearing. The comparison is deliberately "
+        "case-insensitive because the two ends quote two different "
+        "geometries, and a geometry stores the symbol its depositor's XYZ "
+        "wrote — carbon becoming nitrogen is a contradiction, while ``Cl`` "
+        "becoming ``CL`` is one program shouting where another did not. "
+        "Isotope mass number is deliberately *not* carried across the same "
+        "way, because a NULL disables a MATCH SIMPLE foreign key; isotope "
+        "consistency is checked in the service layer instead."
+    ),
+)
+
+CHECK_ATOM_MAP_IS_A_BIJECTION = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=2,
+    code=None,
+    asserts=(
+        "One saddle-point atom is claimed by exactly one atom of each leg, and "
+        "one participant atom maps to exactly one saddle-point atom."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. A map is a bijection or it is not a map; an atom "
+        "claimed twice describes no mechanism at all."
+    ),
+    adr="0011, 0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(wire_atom_map.validate_reaction_atom_map, note=_ATOM_MAP_DUAL_ENFORCEMENT),
+        DatabaseConstraint(
+            table="reaction_atom_map_pair",
+            name="uq_reaction_atom_map_pair_ts_atom_index",
+            kind="unique",
+            definition="(atom_map_id, side, ts_atom_index)",
+        ),
+        DatabaseConstraint(
+            table="reaction_atom_map_pair",
+            name="uq_reaction_atom_map_pair_atom_map_id",
+            kind="unique",
+            definition="(atom_map_id, structure_participant_id, atom_index)",
+        ),
+    ),
+    escape_hatch=(
+        "Per leg, not globally: the reactant and product legs each claim the "
+        "whole saddle point, which is the point of storing two maps both "
+        "pointing at it. A ``side`` column exists on the pair row purely so "
+        "this can be a unique constraint, because SQL cannot dereference the "
+        "participant to find its role."
+    ),
+)
+
+CHECK_ATOM_MAP_INDICES_ARE_GEOMETRY_RELATIVE = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=3,
+    code=None,
+    asserts=(
+        "Every atom index in a map is counted against a named geometry that "
+        "the participant actually owns, and names an atom that geometry "
+        "actually has."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional, and it is where ADR 0011's central choice is cashed "
+        "out. Atom indices are not a property of a species — "
+        "``geometry_atom.atom_index`` is a property of a *geometry* — so "
+        "'reactant atom 3' is meaningless until the geometry being counted is "
+        "named. An index counted against the wrong geometry silently means "
+        "the wrong atom, which is the failure mode geometry-relative indexing "
+        "was chosen to make impossible."
+    ),
+    adr="0011, 0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(wire_atom_map.validate_reaction_atom_map, note=_ATOM_MAP_DUAL_ENFORCEMENT),
+        DatabaseConstraint(
+            table="reaction_atom_map_pair",
+            name="fk_reaction_atom_map_pair_geometry_id_geometry_atom",
+            kind="foreign_key",
+            definition=(
+                "(geometry_id, atom_index, element) -> "
+                "geometry_atom(geometry_id, atom_index, element)"
+            ),
+        ),
+        DatabaseConstraint(
+            table="reaction_atom_map_pair",
+            name="fk_reaction_atom_map_pair_ts_geometry_id_geometry_atom",
+            kind="foreign_key",
+            definition=(
+                "(transition_state_geometry_id, ts_atom_index, ts_element) -> "
+                "geometry_atom(geometry_id, atom_index, element)"
+            ),
+        ),
+        DatabaseConstraint(
+            table="reaction_atom_map_pair",
+            name="fk_reaction_atom_map_pair_structure_participant",
+            kind="foreign_key",
+            definition=(
+                "(structure_participant_id, side) -> "
+                "reaction_entry_structure_participant(id, role)"
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "None, and the cost is stated in ADR 0011: the map is welded to the "
+        "geometries it names, so depositing a second conformer or "
+        "re-optimising at another level of theory does not carry it across. "
+        "Canonical-order-relative indexing would be portable, and was "
+        "rejected because its failure mode is a map that looks fine and "
+        "refers to a different atom order than the depositor intended. "
+        "Portability can be added later as a derived view; correctness cannot "
+        "be retrofitted onto records nobody can verify."
+    ),
+)
+
+CHECK_ATOM_MAP_ACCOUNTS_FOR_EVERY_ATOM = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=4,
+    code=None,
+    asserts=(
+        "When a map covers every declared participant of an atom-balanced "
+        "reaction, both legs claim the same saddle-point atoms and no "
+        "saddle-point atom is left unclaimed."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional, but only under a precondition that has to be checked "
+        "first. A reactant atom unaccounted for in the products is a "
+        "contradiction *when no species is missing*. When the declared "
+        "reaction is not atom-balanced a species genuinely is missing, and "
+        "the same discrepancy is incompleteness rather than contradiction — "
+        "so the rule is gated on the map being complete over every "
+        "participant and on the reaction balancing, and warns instead "
+        "otherwise."
+    ),
+    adr="0011, 0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(
+            wire_atom_map.validate_reaction_atom_map,
+            note=(
+                "Wire boundary only. This one has no database counterpart: it "
+                "is a statement about a whole map rather than about one pair "
+                "row, and a per-row constraint cannot see it."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Leave the map incomplete, or deposit an unbalanced reaction — either "
+        "drops the rule to the warning tier by design rather than by "
+        "accident."
+    ),
+)
+
+CHECK_ATOM_MAP_PROVENANCE_IS_DECLARED = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=7,
+    code=None,
+    asserts=(
+        "An atom map records whether a human asserted it or an algorithm "
+        "produced it, an inferred map names the algorithm, and neither "
+        "attribution can be relabelled afterwards."
+    ),
+    tier=CheckTier.structural,
+    tier_rationale=(
+        "Not a runtime check but a shape. ADR 0011 permits inference only as "
+        "a labelled and separable thing, because an atom map is a scientific "
+        "claim about a mechanism and picking one by algorithm and storing it "
+        "unlabelled would manufacture provenance — the same failure ADR 0009 "
+        "identified when a network-wide energy-transfer value was duplicated "
+        "across wells. The immutability trigger closes the laundering path a "
+        "check constraint cannot see: ``UPDATE reaction_atom_map SET "
+        "source='declared', note=NULL`` satisfies both existing constraints, "
+        "and a CHECK cannot read ``OLD``."
+    ),
+    adr="0011",
+    emitted=False,
+    enforced_by=(
+        DatabaseConstraint(
+            table="reaction_atom_map",
+            name="ck_reaction_atom_map_inferred_requires_note",
+            kind="check",
+            definition=(
+                "source <> 'inferred' OR (note IS NOT NULL AND btrim(note) <> '')"
+            ),
+        ),
+        DatabaseConstraint(
+            table="reaction_atom_map",
+            name="trg_reaction_atom_map_source_immutable",
+            kind="trigger",
+            definition=(
+                "BEFORE UPDATE FOR EACH ROW: refuse any change to ``source``"
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "``note`` and ``equivalent_map_count`` stay mutable on purpose, so a "
+        "depositor can correct a description or record newly counted "
+        "symmetry-equivalent maps without touching the attribution. Symmetry "
+        "means a valid map is often not unique; ADR 0011 declines to "
+        "canonicalise among equivalent maps and leaves reaction-path "
+        "degeneracy to a later decision."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Pressure-dependent networks
+# ---------------------------------------------------------------------------
+
+CHECK_NETWORK_SOLVE_KIND_EVIDENCE = ScientificCheck(
+    group="Pressure-dependent networks",
+    sort_key=1,
+    code=W_REPORTED_NETWORK_SOLVE,
+    asserts=(
+        "A set of phenomenological k(T,P) declares whether this database holds "
+        "the master-equation derivation behind it; a ``computed`` solve must "
+        "actually carry master-equation evidence, and a ``reported`` one must "
+        "cite the publication it was transcribed from."
+    ),
+    tier=CheckTier.structural,
+    tier_rationale=(
+        "The blocking half is definitional: a computed solve with *zero* state "
+        "energies contradicts its own kind, and a reported solve with no "
+        "literature would assert rates carrying neither a derivation nor a "
+        "source. The accepting half is why the token exists at all — published "
+        "PLOG and Chebyshev fits are correct, common, citable science, so the "
+        "coverage rules that are right for a solve run here could fire on a "
+        "correct result and must not block. They warn instead, on every read "
+        "path that reaches a rate."
+    ),
+    adr="0010, 0008",
+    enforced_by=(
+        DatabaseConstraint(
+            table="network_solve",
+            name="ck_network_solve_reported_requires_literature",
+            kind="check",
+            definition="kind <> 'reported' OR literature_id IS NOT NULL",
+        ),
+        DatabaseConstraint(
+            table="network_solve",
+            name="ct_network_solve_computed_evidence",
+            kind="trigger",
+            definition=(
+                "Deferred constraint trigger, at COMMIT: a ``computed`` solve "
+                "must hold at least one state energy; at least one "
+                "energy-transfer model if its network declares a well; at "
+                "least one channel barrier if its network declares a "
+                "saddle-point path"
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare ``kind='reported'`` and cite the literature. That relaxes the "
+        "state-energy, channel-barrier and energy-transfer coverage rules a "
+        "computed solve is held to, which is what makes a paper's "
+        "supplementary table depositable at all — before the token existed "
+        "such rates could not be deposited, so they went into somebody's "
+        "private mechanism file, uncited and unversioned."
+    ),
+    divergence=(
+        "Existence, not coverage — and the trigger must not be read as the "
+        "whole contract. The database guarantees a computed solve carries "
+        "nonzero evidence of each applicable class; the three coverage rules "
+        "(one energy per state, one energy-transfer model per (well, collider) "
+        "pair or a network-wide declaration, one barrier per saddle-point "
+        "path) remain properties of the single wired upload path. A computed "
+        "solve with four energies out of five passes the database and fails "
+        "the validator. ADR 0010's amendment states this deliberately: a "
+        "computed solve with *zero* energies is a contradiction and may block, "
+        "while an incomplete one is a true record to be graded by the trust "
+        "and reproducibility layers. Separately, ``kind`` cannot surface in "
+        "CHEMKIN export, which has no provenance field; a tripwire test guards "
+        "the moment network kinetics first reach mechanism output."
+    ),
+)
+
+CHECK_ENERGY_TRANSFER_SCOPE = ScientificCheck(
+    group="Pressure-dependent networks",
+    sort_key=2,
+    code=W_NETWORK_WIDE_ENERGY_TRANSFER,
+    asserts=(
+        "A collisional energy-transfer model records whether its <dE>down was "
+        "determined per (well, collider) pair or declared once for the whole "
+        "network."
+    ),
+    tier=CheckTier.structural,
+    tier_rationale=(
+        "A network-wide <dE>down is correct, common, published science — "
+        "Arkane, RMG and MESS inputs routinely specify a single "
+        "``SingleExponentialDown`` applied network-wide — so a check demanding "
+        "one entry per (well x collider) pair could fire on a correct result "
+        "and must not block. It is an expectation about *resolution*, not a "
+        "definition. What stays definitional still blocks: a ``per_well`` "
+        "entry naming no well contradicts itself, a ``network_wide`` entry "
+        "naming one contradicts itself, and a payload mixing the two is "
+        "genuinely ambiguous."
+    ),
+    adr="0009, 0008",
+    enforced_by=(
+        DatabaseConstraint(
+            table="network_solve_energy_transfer",
+            name="ck_network_solve_energy_transfer_scope_columns_agree",
+            kind="check",
+            definition=(
+                "(scope='per_well' AND state_id IS NOT NULL AND "
+                "collider_species_entry_id IS NOT NULL) OR "
+                "(scope='network_wide' AND state_id IS NULL AND "
+                "collider_species_entry_id IS NULL)"
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare ``scope='network_wide'``. The physics behind the old per-well "
+        "rule was never in dispute — <dE>down depends on the density of states "
+        "of the excited well and on the collider's ability to accept internal "
+        "energy, so argon and helium do not relax the same well identically. "
+        "The rule was wrong in practice because it confused what the quantity "
+        "*is* with what a calculation *determined*: the only way to satisfy it "
+        "was to paste one number once per well, and the repository's own "
+        "Arkane ingester did exactly that. Those rows are indistinguishable "
+        "from independently determined values — a provenance loss manufactured "
+        "by the validation itself, worse than the gap it closed, because an "
+        "absent value is honest while a duplicated one is a false positive "
+        "every consumer will faithfully propagate."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Statistical mechanics
+# ---------------------------------------------------------------------------
+
+CHECK_STATMECH_HAS_EXACTLY_ONE_SUBJECT = ScientificCheck(
+    group="Statistical mechanics",
+    sort_key=1,
+    code=None,
+    asserts=(
+        "A partition function belongs to exactly one subject — a species entry "
+        "or a transition-state entry, never both and never neither."
+    ),
+    tier=CheckTier.structural,
+    tier_rationale=(
+        "A modelling position rather than an arithmetic bound. Canonical "
+        "transition state theory needs the saddle point's own partition "
+        "function, so a transition state has to be a first-class subject of a "
+        "statmech row. The alternative — encoding a transition state as a "
+        "pseudo-species — would make every partition function's subject "
+        "ambiguous and would put saddle points into a kind reserved for lumped "
+        "and phenomenological constructs that the conservation laws "
+        "deliberately exempt."
+    ),
+    adr="0008",
+    emitted=False,
+    enforced_by=(
+        DatabaseConstraint(
+            table="statmech",
+            name="ck_statmech_statmech_exactly_one_subject",
+            kind="check",
+            definition="(species_entry_id IS NULL) <> (transition_state_entry_id IS NULL)",
+        ),
+    ),
+    escape_hatch=None,
+)
+
+# ---------------------------------------------------------------------------
+# Reproducibility
+# ---------------------------------------------------------------------------
+
+CHECK_REPRODUCIBILITY_IS_ITS_OWN_JUDGEMENT = ScientificCheck(
+    group="Reproducibility",
+    sort_key=1,
+    code=None,
+    asserts=(
+        "Whether a record's preserved evidence is sufficient to understand, "
+        "audit or repeat it is assessed separately from how far its evidence "
+        "is trusted and from whether a curator approved it, and the three may "
+        "disagree."
+    ),
+    tier=CheckTier.structural,
+    tier_rationale=(
+        "Not a check that fires but a position about what may never be "
+        "collapsed into a single verdict. Reproducibility is graded under "
+        "append-only, rubric-versioned assessments rather than as a field on a "
+        "scientific row or an alias for review status, so a rubric can be "
+        "revised without rewriting history and an old judgement stays "
+        "interpretable. This is the same reasoning that made ADR 0005 record "
+        "execution environments rather than grade them, and it is what lets "
+        "the warning tiers elsewhere in this register be defensible: an "
+        "incomplete record is accepted precisely because a separate layer "
+        "exists to say how incomplete it is."
+    ),
+    adr="0002, 0005",
+    emitted=False,
+    enforced_by=(
+        DesignPosition(
+            where=(
+                "``reproducibility_assessment`` rows carry ``described`` / "
+                "``auditable`` / ``rerunnable`` under a versioned rubric, "
+                "append-only, independent of ``record_review`` and of the "
+                "trust evaluator (``app/services/trust/``)"
+            )
+        ),
+    ),
+    escape_hatch=None,
+)
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+#: Every module holding :class:`ScientificCheck` declarations. A guard
+#: test fails if a file in the repository constructs one and is not
+#: listed here, so forgetting to register a module is caught rather than
+#: silently omitted from the register.
+DECLARING_MODULES: tuple[ModuleType, ...] = (
+    chemistry_species,
+    chemistry_units,
+    charge_multiplicity_reconciliation,
+    geometry_validation_service,
+    reaction_atom_map_service,
+    reaction_resolution,
+    species_resolution,
+    transition_state_validation,
+    sys.modules[__name__],
+)
+
+
+def register() -> list[ScientificCheck]:
+    """Return the whole scientific check register, deterministically ordered."""
+    return collect_registered_checks(DECLARING_MODULES)
+
+
+__all__ = ["DECLARING_MODULES", "register"]

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -464,7 +464,7 @@ CHECK_ATOM_MAP_PROVENANCE_IS_DECLARED = ScientificCheck(
             name="trg_reaction_atom_map_source_immutable",
             kind="trigger",
             definition=(
-                "BEFORE UPDATE FOR EACH ROW: refuse any change to ``source``"
+                "BEFORE UPDATE FOR EACH ROW: refuse any change to the source column"
             ),
         ),
     ),
@@ -516,7 +516,7 @@ CHECK_NETWORK_SOLVE_KIND_EVIDENCE = ScientificCheck(
             name="ct_network_solve_computed_evidence",
             kind="trigger",
             definition=(
-                "Deferred constraint trigger, at COMMIT: a ``computed`` solve "
+                "deferred constraint trigger, at COMMIT: a computed solve "
                 "must hold at least one state energy; at least one "
                 "energy-transfer model if its network declares a well; at "
                 "least one channel barrier if its network declares a "
@@ -554,13 +554,13 @@ CHECK_ENERGY_TRANSFER_SCOPE = ScientificCheck(
     sort_key=2,
     code=W_NETWORK_WIDE_ENERGY_TRANSFER,
     asserts=(
-        "A collisional energy-transfer model records whether its <dE>down was "
+        "A collisional energy-transfer model records whether its ⟨ΔE⟩down was "
         "determined per (well, collider) pair or declared once for the whole "
         "network."
     ),
     tier=CheckTier.structural,
     tier_rationale=(
-        "A network-wide <dE>down is correct, common, published science — "
+        "A network-wide ⟨ΔE⟩down is correct, common, published science — "
         "Arkane, RMG and MESS inputs routinely specify a single "
         "``SingleExponentialDown`` applied network-wide — so a check demanding "
         "one entry per (well x collider) pair could fire on a correct result "
@@ -586,7 +586,7 @@ CHECK_ENERGY_TRANSFER_SCOPE = ScientificCheck(
     ),
     escape_hatch=(
         "Declare ``scope='network_wide'``. The physics behind the old per-well "
-        "rule was never in dispute — <dE>down depends on the density of states "
+        "rule was never in dispute — ⟨ΔE⟩down depends on the density of states "
         "of the excited well and on the collider's ability to accept internal "
         "energy, so argon and helium do not relax the same well identically. "
         "The rule was wrong in practice because it confused what the quantity "

--- a/backend/app/services/charge_multiplicity_reconciliation.py
+++ b/backend/app/services/charge_multiplicity_reconciliation.py
@@ -46,6 +46,7 @@ from enum import Enum
 
 from tckdb_schemas.upload_warning import UploadWarning
 
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 from app.services.ess_software_detection import SoftwareName, detect_software_from_text
 
 #: Emitted when the declared charge and the log's charge disagree.
@@ -310,3 +311,47 @@ def reconcile_charge_multiplicity(
         software=parsed.software,
         warnings=warnings,
     )
+
+
+CHECK_CHARGE_MULTIPLICITY_VS_LOG = ScientificCheck(
+    group="A structure against its own label",
+    sort_key=4,
+    code=(W_CHARGE_MISMATCH, W_MULTIPLICITY_MISMATCH),
+    asserts=(
+        "The charge and spin multiplicity a depositor declares match the ones "
+        "the electronic-structure log says the calculation was actually run "
+        "at."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "**Placed against the ADR's own reasoning, deliberately.** ADR 0008 "
+        "names both findings as direct contradictions between a declaration "
+        "and the parsed evidence, therefore definitional, therefore belonging "
+        "at the blocking tier — and then defers the promotion, because "
+        "promoting a warning to a blocker rejects payloads that are accepted "
+        "today. These checks have never fired on real data, so their "
+        "false-positive rate is unknown and promoting them first would be "
+        "unsafe. The register records the gap rather than hiding it: this is "
+        "the clearest case in TCKDB of a check sitting one tier below where "
+        "its own governing decision puts it."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            reconcile_charge_multiplicity,
+            note=(
+                "Re-reads charge and multiplicity from the uploaded artifact "
+                "using the wired Gaussian, ORCA, Psi4 and Molpro parsers."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Absence is not contradiction: if the producing program is not one of "
+        "the wired parsers, the artifact is missing, the log is truncated, or "
+        "the declarations inside a single log disagree with each other, the "
+        "value is left unknown and **no** warning is emitted. Only a value "
+        "genuinely read from the log may contradict a declaration — emitting a "
+        "mismatch because parsing failed would fabricate a contradiction out "
+        "of ignorance."
+    ),
+)

--- a/backend/app/services/geometry_validation.py
+++ b/backend/app/services/geometry_validation.py
@@ -94,6 +94,7 @@ from app.db.models.common import (
 )
 from app.db.models.geometry import Geometry
 from app.schemas.fragments.geometry import GeometryPayload
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 logger = logging.getLogger(__name__)
 
@@ -382,3 +383,62 @@ def run_and_persist_geometry_validation(
     )
     session.add(row)
     return row
+
+
+CHECK_OPT_GEOMETRY_MATCHES_DECLARED_SPECIES = ScientificCheck(
+    group="A structure against its own label",
+    sort_key=5,
+    code=None,
+    asserts=(
+        "An optimisation's output geometry still describes the species it was "
+        "declared for — the optimiser handed back the molecule it was given."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "An expectation, and correctly non-blocking. An optimisation that "
+        "rearranged, dissociated or transferred a proton is science to record, "
+        "not a payload to refuse, and connectivity perception from XYZ is "
+        "unreliable for exactly the weak complexes, radicals, ions and "
+        "stretched geometries where a genuine rearrangement would matter. The "
+        "result is written as an evidence row that grades the record at read "
+        "time; it never refuses an upload."
+    ),
+    adr="0008, 0002",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(
+            validate_calculation_geometry,
+            note=(
+                "Species-owned ``opt`` calculations only. Transition states "
+                "are deliberately excluded, having no canonical SMILES to "
+                "compare against. Best-effort by policy: a missing SMILES, a "
+                "missing output geometry, unparseable coordinates or a raising "
+                "chemistry layer all write nothing and let the upload "
+                "continue. A Kabsch RMSD above 1.0 A against the input "
+                "geometry is recorded as a separate suspicion signal."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "The whole check is advisory, so there is nothing to escape. What a "
+        "consumer must not do is read a ``fail`` row as 'this calculation is "
+        "scientifically invalid'; it means only that the automated identity "
+        "validator found a mismatch."
+    ),
+    divergence=(
+        "The stored column is named ``is_isomorphic`` and the surrounding "
+        "policy is worded as graph isomorphism, but the code tests the "
+        "**molecular formula** only. Atom mapping falls back to a "
+        "SMILES-graph matcher whenever bond perception from XYZ fails, which "
+        "is the common case for the radicals, ions and stretched geometries "
+        "this service mostly sees, and that fallback rejects a candidate on "
+        "one condition: the per-element atom counts disagree. Verified by "
+        "direct call in the module docstring — ethanol declared with dimethyl "
+        "ether deposited passes, and methane with one hydrogen pulled to 5 A "
+        "passes. So the rearrangement, bond-breaking, dissociation and "
+        "proton-transfer cases the module was written to catch are not "
+        "caught. Already self-documented in the module docstring rather than "
+        "discovered here; recorded because the field name is what a consumer "
+        "sees and it still overstates the guarantee."
+    ),
+)

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -55,6 +55,7 @@ from app.chemistry.geometry import normalize_element_symbol
 from app.db.models.common import AtomMapSource, ReactionRole
 from app.db.models.geometry import GeometryAtom
 from app.db.models.reaction_atom_map import ReactionAtomMap, ReactionAtomMapPair
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 #: Emitted when a reaction with a transition state is deposited without a map.
 W_MISSING_REACTION_ATOM_MAP = "reaction_atom_map_absent"
@@ -417,6 +418,80 @@ def _warn_incomplete(
                 ),
             )
         )
+
+
+CHECK_ATOM_MAP_ABSENT = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=5,
+    code=W_MISSING_REACTION_ATOM_MAP,
+    asserts=(
+        "A reaction that has a transition state should say which atom of the "
+        "reactants is which atom of the saddle point and of the products."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "Absence, not contradiction. An unmapped reaction is an incomplete "
+        "record rather than a false one — the rate constant is still the rate "
+        "constant and what is missing is the mechanistic detail. Blocking "
+        "would reject correct science over evidence the depositor may not "
+        "have, and would make every reaction already in the database "
+        "undepositable."
+    ),
+    adr="0011, 0008",
+    enforced_by=(
+        PythonCheck(
+            _warn_absent,
+            note=(
+                "A reaction with no transition state is not warned about: both "
+                "legs of a map run toward the saddle point, so a barrierless "
+                "channel has nothing to map onto and a warning it could never "
+                "satisfy would train depositors to ignore the one that "
+                "matters. The PDep bundle has no ``atom_map`` field yet, so on "
+                "that path the warning carries a different remedy sentence "
+                "rather than naming a field that does not exist."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "None is needed — the warning *is* the accommodation. TCKDB "
+        "deliberately will not infer a map: several chemically distinct maps "
+        "are usually consistent with the same reactants and products, so "
+        "choosing one by algorithm would manufacture provenance."
+    ),
+)
+
+CHECK_ATOM_MAP_INCOMPLETE = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=6,
+    code=(W_ATOM_MAP_PARTICIPANTS_INCOMPLETE, W_ATOM_MAP_ATOMS_INCOMPLETE),
+    asserts=(
+        "A supplied atom map should cover every declared participant molecule, "
+        "every atom of each mapped participant, and every atom of the saddle "
+        "point."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "Absence again, at finer grain. A partial map is a true-but-partial "
+        "record; only a map that contradicts *itself* is refused, and that is "
+        "handled at the blocking tier by ``validate_reaction_atom_map`` and by "
+        "the constraints on ``reaction_atom_map_pair``."
+    ),
+    adr="0011, 0008",
+    enforced_by=(
+        PythonCheck(
+            _warn_incomplete,
+            note=(
+                "Two codes from one seam: "
+                "``reaction_atom_map_participants_incomplete`` when a declared "
+                "molecule is missing from the map entirely, "
+                "``reaction_atom_map_atoms_incomplete`` when a mapped "
+                "participant leaves its own atoms unmapped or a leg leaves "
+                "saddle-point atoms claimed by nobody."
+            ),
+        ),
+    ),
+    escape_hatch=None,
+)
 
 
 __all__ = [

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -23,6 +23,7 @@ from app.db.models.reaction import (
 from app.db.models.species import Species, SpeciesEntry
 from app.schemas.reaction_family import find_canonical_reaction_family
 from app.schemas.utils import normalize_optional_text
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 
 def compress_species_stoichiometry(
@@ -181,6 +182,40 @@ def validate_reaction_elemental_balance(
         )
 
 
+CHECK_REACTION_ELEMENTAL_BALANCE = ScientificCheck(
+    group="Conservation across a reaction",
+    sort_key=1,
+    code="reaction_mass_balance_failed",
+    asserts=(
+        "The reactant and product sides of a reaction contain the same number "
+        "of atoms of every element."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. Mass balance is what makes a set of species a reaction "
+        "rather than a list, so no correct calculation can produce an "
+        "unbalanced one; the check cannot fire on a correct novel result."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            validate_reaction_elemental_balance,
+            note=(
+                "Called from ``resolve_chem_reaction``, so it fires on every "
+                "path that resolves a reaction, including the PDep bundle."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare a participant with ``molecule_kind: pseudo``. A lumped or "
+        "phenomenological construct has no atom-resolved composition, so one "
+        "such participant suspends the law for the whole reaction. A declared "
+        "electron does **not** exempt it — an electron contributes zero atoms "
+        "and the reaction still has to balance."
+    ),
+)
+
+
 def validate_reaction_charge_conservation(
     session: Session,
     *,
@@ -279,6 +314,48 @@ def validate_reaction_charge_conservation(
             '"multiplicity": 2}. It balances the charge and still leaves the '
             "elemental balance to be satisfied on its own terms."
         )
+
+
+CHECK_REACTION_CHARGE_CONSERVATION = ScientificCheck(
+    group="Conservation across a reaction",
+    sort_key=2,
+    code="reaction_charge_not_conserved",
+    asserts=(
+        "The summed formal charge of a reaction's reactants equals that of its "
+        "products."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional, and only because the escape hatch exists. Electrons are "
+        "neither created nor destroyed by rearranging bonds. Without a way to "
+        "name a free electron the rule would in fact assert 'every participant "
+        "was declared', which is an expectation about the depositor rather "
+        "than a definition of a reaction, and ADR 0008 disqualifies an "
+        "expectation from blocking."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            validate_reaction_charge_conservation,
+            note=(
+                "Sums ``Species.charge``, which "
+                "``canonical_species_identity`` has already reconciled against "
+                "the formal charge of each species' own SMILES."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare the free electron as a participant — ``{\"molecule_kind\": "
+        "\"electron\", \"smiles\": \"[e-]\", \"charge\": -1, \"multiplicity\": "
+        "2}`` — which is how associative and dissociative attachment, "
+        "photoionization and photodetachment are deposited. It contributes -1 "
+        "to the side it sits on and zero atoms, so elemental balance still has "
+        "to be satisfied separately. A ``pseudo`` participant suspends the law "
+        "entirely, as it does for elemental balance. Conservation is not "
+        "neutrality: any net charge is accepted as long as both sides carry "
+        "the same one, so ion-molecule reactions are unaffected."
+    ),
+)
 
 
 def validate_transition_state_composition(
@@ -381,6 +458,93 @@ def validate_transition_state_composition(
                 "a reaction coordinate, so a saddle point at a different charge "
                 "is on a different potential energy surface."
             )
+
+
+_TS_COMPOSITION_PSEUDO_DIVERGENCE = (
+    "The docstring says pseudo-species exemption 'matches "
+    "``validate_reaction_elemental_balance``'. It does not, quite: this "
+    "function queries only ``ReactionRole.reactant`` and exempts only on a "
+    "*reactant-side* pseudo participant, while "
+    "``_load_participant_species`` exempts the two conservation checks on a "
+    "pseudo participant on **either** side. A reaction whose only pseudo "
+    "species is a product is therefore exempt from elemental balance but "
+    "still held to transition-state composition, and it is compared against "
+    "a reactant side that carries no balance guarantee. Reported, not "
+    "changed — this register alters no check behaviour."
+)
+
+CHECK_TRANSITION_STATE_COMPOSITION = ScientificCheck(
+    group="Conservation across a reaction",
+    sort_key=3,
+    code="transition_state_composition_mismatch",
+    asserts=(
+        "A saddle point is made of exactly the atoms of the reaction it is "
+        "declared to sit in."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. A transition state is a stationary point on the "
+        "potential energy surface *of those atoms*, so a saddle point with a "
+        "different molecular formula cannot be that reaction's saddle point, "
+        "whatever else is true of it."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            validate_transition_state_composition,
+            note=(
+                "Composition is read from the saddle-point geometry when there "
+                "is one and from ``unmapped_smiles`` otherwise. The PDep path "
+                "passes no SMILES, so it compares geometry only."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare the extra species as participants of the reaction. A "
+        "``pseudo`` reactant exempts the reaction. Absence does not block: no "
+        "geometry and no parseable SMILES means nothing is compared, and an "
+        "unparseable transition-state SMILES is treated as silence rather "
+        "than as a contradiction, because a TS SMILES is a lossy label for a "
+        "structure that is by construction not a stable molecule."
+    ),
+    divergence=_TS_COMPOSITION_PSEUDO_DIVERGENCE,
+)
+
+CHECK_TRANSITION_STATE_CHARGE = ScientificCheck(
+    group="Conservation across a reaction",
+    sort_key=4,
+    code="transition_state_charge_mismatch",
+    asserts=(
+        "A saddle point carries the same total charge as the reactants it sits "
+        "between."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. Charge is conserved along a reaction coordinate, so a "
+        "saddle point at a different charge is on a different potential energy "
+        "surface — not a worse calculation of the same one."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            validate_transition_state_composition,
+            note=(
+                "Second, independent leg of the same function. Skipped "
+                "entirely when the caller passes no "
+                "``transition_state_charge``."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Omit the transition state's charge, which skips the comparison. "
+        "Multiplicity is deliberately **not** checked here at all: spin is not "
+        "conserved the way charge and atoms are — two doublets may react over "
+        "a singlet or a triplet surface, and spin-forbidden reactions are real "
+        "chemistry — so a multiplicity rule would fire on correct novel "
+        "results."
+    ),
+    divergence=_TS_COMPOSITION_PSEUDO_DIVERGENCE,
+)
 
 
 def _transition_state_element_counts(

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -26,6 +26,7 @@ from app.db.models.common import MoleculeKind, StereoKind
 from app.db.models.species import Species, SpeciesEntry
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 
 def null_safe_equals(column: ColumnElement, value: str | None) -> ColumnElement[bool]:
@@ -172,6 +173,53 @@ def assert_geometry_isotopes_match_identity(
     )
 
 
+CHECK_GEOMETRY_ISOTOPES_MATCH_IDENTITY = ScientificCheck(
+    group="A structure against its own label",
+    sort_key=2,
+    code=None,
+    asserts=(
+        "The multiset of isotopic substitutions declared in a species entry's "
+        "SMILES equals the multiset carried by the geometry deposited under it."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. The identity's isotope label and the geometry's "
+        "per-atom masses describe the same nuclei; when they disagree one of "
+        "them is wrong and there is no defensible way to pick a winner, so a "
+        "CD3OH identity on an all-protium geometry would yield frequencies for "
+        "a molecule nobody deposited."
+    ),
+    adr="0008",
+    emitted=False,
+    enforced_by=(
+        PythonCheck(
+            assert_geometry_isotopes_match_identity,
+            note=(
+                "Runs from ``resolve_species_entry`` only when a geometry is "
+                "supplied. Raises prose with no machine-readable code, so no "
+                "client can key off it — recorded here as a gap rather than "
+                "papered over."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Deposit no geometry. An explicitly declared *standard* isotope is "
+        "dropped before comparison, so ``{1: 1}`` on a hydrogen cannot fork an "
+        "identity away from an unlabelled deposit of the same molecule."
+    ),
+    divergence=(
+        "Not a divergence but a documented false *acceptance*, restated here "
+        "because a referee will ask: only the multiset is compared, so "
+        "isotopomers are not distinguished. An identity of ``[2H]OC`` (CH3-OD) "
+        "accepts a geometry labelling a methyl hydrogen instead (CH2D-OH) — "
+        "different molecules with different zero-point energies. Closing it "
+        "needs an atom-level SMILES-to-XYZ correspondence the repository does "
+        "not have. Where the two disagree invisibly, the geometry is "
+        "authoritative for masses and the SMILES only for identity."
+    ),
+)
+
+
 def assert_geometry_composition_matches_identity(
     payload: SpeciesEntryIdentityPayload,
     geometry: GeometryPayload,
@@ -307,6 +355,52 @@ def assert_geometry_composition_matches_identity(
         "their element — SMILES [2H] and the XYZ symbols D and T all count as "
         "H — so an isotopologue is not a mismatch."
     )
+
+
+CHECK_GEOMETRY_COMPOSITION_MATCHES_IDENTITY = ScientificCheck(
+    group="A structure against its own label",
+    sort_key=1,
+    code="species_geometry_composition_mismatch",
+    asserts=(
+        "A conformer geometry deposited under a species entry is made of the "
+        "atoms that entry's own SMILES declares."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. No correct calculation produces a geometry that is not "
+        "made of its own molecule's atoms, so a formula disagreement between a "
+        "structure and its own identifier is a contradiction rather than an "
+        "expectation — every energy, frequency and partition function "
+        "downstream would describe a different molecule under the deposited "
+        "label."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            assert_geometry_composition_matches_identity,
+            note=(
+                "Conformer geometries only, via ``resolve_species_entry``: the "
+                "computed-species bundle, ``/uploads/conformers``, the "
+                "computed-reaction bundle and the PDep bundle. **Calculation** "
+                "input and output geometries are reached by no composition "
+                "check on any path — benzene coordinates can still be attached "
+                "as a calculation geometry under a ``smiles: \"C\"`` entry. "
+                "Closing that for *output* geometries would be wrong (an "
+                "optimisation that dissociated is science to record); for "
+                "*input* geometries it is an open gap."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare ``molecule_kind: pseudo``, which has no atom-resolved "
+        "composition to agree with. A free electron is deliberately **not** "
+        "exempt — its composition is not unknown but empty, so any geometry "
+        "deposited under one is refused, which stops ``electron`` becoming a "
+        "quieter way to smuggle a structure past the check. Absence does not "
+        "block: no geometry, or a SMILES RDKit will not parse, is "
+        "incompleteness."
+    ),
+)
 
 
 def resolve_species_entry(

--- a/backend/app/services/transition_state_validation.py
+++ b/backend/app/services/transition_state_validation.py
@@ -24,6 +24,7 @@ from tckdb_schemas.fragments.ts_validation_evidence import (
 from tckdb_schemas.upload_warning import UploadWarning
 
 from app.db.models.transition_state import TransitionStateValidationEvidence
+from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 #: Emitted when a transition state is deposited with no *passing* IRC evidence.
 W_MISSING_TS_IRC_EVIDENCE = "transition_state_missing_irc_evidence"
@@ -95,6 +96,45 @@ def persist_transition_state_validation_evidence(
             )
         )
     return rows
+
+
+CHECK_TS_IRC_EVIDENCE = ScientificCheck(
+    group="Stationary points",
+    sort_key=6,
+    code=W_MISSING_TS_IRC_EVIDENCE,
+    asserts=(
+        "A deposited saddle point should carry passing intrinsic-reaction-"
+        "coordinate evidence that it connects the declared reactants and "
+        "products."
+    ),
+    tier=CheckTier.warn,
+    tier_rationale=(
+        "Absence, not contradiction. Refusing a transition state without an "
+        "IRC would lose the saddle point entirely, and a saddle point with no "
+        "IRC is an incomplete record rather than a false one. The evidence is "
+        "recommended, not required."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            persist_transition_state_validation_evidence,
+            note=(
+                "Every path that can carry a transition state routes through "
+                "this seam — the PDep bundle, the computed-reaction bundle and "
+                "the standalone transition-state upload — so all three write "
+                "identical rows and report an identical gap. Before the seam "
+                "existed only the PDep bundle could deposit the evidence, so a "
+                "TS uploaded any other way always read back as ``irc: "
+                "absent`` even when the depositor had run one."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "None needed — the warning is the accommodation. Note the warning "
+        "fires on absence of a *passing* record, so evidence that was run and "
+        "failed is stored and still warns."
+    ),
+)
 
 
 __all__ = [

--- a/backend/scripts/generate_scientific_check_register.py
+++ b/backend/scripts/generate_scientific_check_register.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+"""Generate ``docs/guides/scientific_check_register.md`` from the declarations.
+
+The register is generated so it cannot drift. Every ``file:line`` below
+is resolved from the live function object at generation time, so the
+document has no pinned commit and no hand-maintained line numbers — the
+failure mode that left ``docs/reviews/validation_check_audit.md`` stale
+by many codes within weeks of being written.
+
+Usage::
+
+    conda run -n tckdb_env python backend/scripts/generate_scientific_check_register.py
+    conda run -n tckdb_env python backend/scripts/generate_scientific_check_register.py --check
+
+``--check`` regenerates in memory and exits non-zero if the committed
+document differs, which is what CI runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+from app.scientific_checks import (  # noqa: E402
+    CheckTier,
+    DatabaseConstraint,
+    DesignPosition,
+    PythonCheck,
+    ScientificCheck,
+)
+from app.scientific_checks.declarations import register  # noqa: E402
+
+OUTPUT = REPO_ROOT / "docs" / "guides" / "scientific_check_register.md"
+
+_TIER_BLURB = {
+    CheckTier.block: (
+        "Refuses the payload. ADR 0008 permits this only for a definition or "
+        "a contract — a record no correct calculation could produce."
+    ),
+    CheckTier.warn: (
+        "Accepts the payload and records a machine-readable warning. The tier "
+        "for expectations (which could fire on a correct novel result) and for "
+        "absences (an incomplete record is still a true one)."
+    ),
+    CheckTier.review: (
+        "Referred to `machine_review` under a versioned rubric. ADR 0008 puts "
+        "every cross-check against external reference data here."
+    ),
+    CheckTier.structural: (
+        "Not an ADR 0008 consequence tier. The position is enforced by the "
+        "shape of the schema, so a record violating it cannot be represented."
+    ),
+}
+
+_PREAMBLE = """# The scientific check register
+
+**Generated. Do not edit by hand.** Regenerate with
+`conda run -n tckdb_env python backend/scripts/generate_scientific_check_register.py`.
+Every `file:line` here is resolved from the live function object at generation
+time, so it cannot go stale the way a hand-written table does.
+
+## What this is
+
+An enumeration of what TCKDB *guarantees about chemistry*, as opposed to what
+it merely stores. TCKDB runs roughly 326 Pydantic validators and 225 database
+check constraints; almost all of them enforce plumbing — string lengths, enum
+membership, foreign-key existence, `multiplicity >= 1`. This register contains
+only the checks that encode a **scientific decision a referee could disagree
+with**.
+
+The inclusion test is *could this check be wrong in an interesting way?*
+Elemental balance is a position. `max_length=64` is not, and `multiplicity >= 1`
+is arithmetic rather than chemistry. There is deliberately no "paper-worthy"
+column: **membership in this register is the claim.** An entry that fails the
+test dilutes every other entry.
+
+## Relationship to `docs/reviews/validation_check_audit.md`
+
+The two sit beside each other and answer different questions. That audit asks
+*is each Pydantic validator in the right ADR 0008 tier* — it is a placement
+review of one tier, pinned to a commit, and it is now stale by several codes.
+This register asks *what does TCKDB guarantee about chemistry* — it spans the
+service layer, the wire schemas and the database, it is generated rather than
+transcribed, and it is guarded in CI. Neither supersedes the other. Where they
+disagree about a line number, this one is right by construction.
+
+## How to read a row
+
+- **Asserts** — what the check claims, in one sentence a chemist would
+  recognise. Not a description of the implementation.
+- **Tier** — the ADR 0008 consequence, with the justification for *that* tier
+  in the ADR's own terms.
+- **Enforced at** — `file:line` for Python, or the constraint/trigger name for
+  PostgreSQL. Database names are verified against live schema metadata by
+  `backend/tests/db/test_scientific_check_register.py`, not trusted as strings.
+- **Escape hatch** — how legitimate chemistry the check would otherwise refuse
+  gets deposited instead. This column carries most of the weight. Charge
+  conservation is only defensible as a blocking check *because* an electron can
+  be declared as a participant; without that door the rule would be asserting
+  "every participant was declared", which is an expectation about the depositor
+  and ADR 0008 disqualifies an expectation from blocking.
+- **Recorded divergence** — where a check's documentation and its behaviour
+  disagree, or where a guarantee is narrower than its name suggests. Reported,
+  never silently fixed.
+
+"""
+
+
+def _md(text: str) -> str:
+    """Render declaration prose as Markdown.
+
+    Declarations are written in the RST flavour the surrounding docstrings
+    use, so ``literal`` becomes `literal` on the way out. Longest marker
+    first, or the double backticks would be eaten one at a time.
+    """
+    return text.replace("``", "`")
+
+
+def _tier_table(checks: list[ScientificCheck]) -> str:
+    counts: dict[CheckTier, int] = {}
+    for check in checks:
+        counts[check.tier] = counts.get(check.tier, 0) + 1
+    lines = [
+        "## Tiers, and how many entries sit in each",
+        "",
+        "| Tier | Entries | Meaning |",
+        "| --- | --- | --- |",
+    ]
+    for tier in CheckTier:
+        lines.append(f"| `{tier.value}` | {counts.get(tier, 0)} | {_TIER_BLURB[tier]} |")
+    lines.append(f"| **total** | **{len(checks)}** | |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_enforcement(check: ScientificCheck) -> str:
+    parts: list[str] = []
+    for site in check.enforced_by:
+        if isinstance(site, PythonCheck):
+            body = f"{site.label} — `{site.location}`"
+        elif isinstance(site, DatabaseConstraint):
+            body = site.label
+            if site.definition:
+                body += f"\n  `{site.definition}`"
+        elif isinstance(site, DesignPosition):
+            body = site.label
+        else:  # pragma: no cover - exhaustive over Enforcement
+            raise TypeError(f"unknown enforcement site: {site!r}")
+        if getattr(site, "note", None):
+            body += f"\n  *{site.note}*"
+        parts.append(_md(f"- {body}"))
+    return "\n".join(parts)
+
+
+def _render_check(check: ScientificCheck, index: int) -> str:
+    codes = ", ".join(f"`{code}`" for code in check.codes) or "*(none — prose only)*"
+    lines = [
+        f"### {index}. {_md(check.asserts)}",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| **Tier** | `{check.tier.value}` |",
+        f"| **Code** | {codes} |",
+        f"| **Governing ADR** | {check.adr} |",
+        "",
+        f"**Why this tier.** {_md(check.tier_rationale)}",
+        "",
+        "**Enforced at.**",
+        "",
+        _render_enforcement(check),
+        "",
+    ]
+    if check.escape_hatch:
+        lines += [f"**Escape hatch.** {_md(check.escape_hatch)}", ""]
+    else:
+        lines += ["**Escape hatch.** None.", ""]
+    if check.divergence:
+        lines += [f"**Recorded divergence.** {_md(check.divergence)}", ""]
+    if check.codes and not check.emitted:
+        lines += [
+            "*(The code above is a register label; this check raises prose "
+            "with no machine-readable code, so no client can match on it.)*",
+            "",
+        ]
+    if not check.codes:
+        lines += [
+            "*(This check raises prose with no machine-readable code. Recorded "
+            "as a gap rather than invented, because a code that appears in no "
+            "message is a code no client can match on.)*",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def _ordered_groups(checks: list[ScientificCheck]) -> list[str]:
+    """Groups in reading order, most fundamental claim first.
+
+    Collection sorts alphabetically for determinism; a reader wants the
+    conservation laws before the atom-map bookkeeping. Any group not
+    listed here still appears, after the ones that are.
+    """
+    preferred = [
+        "Conservation across a reaction",
+        "A structure against its own label",
+        "Stationary points",
+        "Atom mapping across a reaction",
+        "Rate coefficients",
+        "Statistical mechanics",
+        "Pressure-dependent networks",
+        "Reproducibility",
+    ]
+    present = {check.group for check in checks}
+    ordered = [group for group in preferred if group in present]
+    ordered += sorted(present - set(ordered))
+    return ordered
+
+
+def _divergence_index(checks: list[ScientificCheck], numbering: dict[int, int]) -> str:
+    """Short index of every recorded documentation-versus-behaviour gap."""
+    rows = sorted(
+        ((numbering[id(check)], check) for check in checks if check.divergence),
+        key=lambda row: row[0],
+    )
+    if not rows:
+        return ""
+    lines = [
+        "## Recorded divergences",
+        "",
+        "Where a check's documentation and its behaviour disagree, or where a "
+        "guarantee is narrower than its name suggests. Every one of these is "
+        "reported, never silently fixed — the register changes no check "
+        "behaviour.",
+        "",
+    ]
+    for index, check in rows:
+        lines.append(f"- **[{index}]** {_md(check.asserts)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render() -> str:
+    checks = register()
+    out = [_PREAMBLE, _tier_table(checks)]
+
+    groups = _ordered_groups(checks)
+    numbering: dict[int, int] = {}
+    index = 0
+    for group in groups:
+        for check in checks:
+            if check.group == group:
+                index += 1
+                numbering[id(check)] = index
+
+    out.append(_divergence_index(checks, numbering))
+
+    out.append("## Entries\n")
+    for group in groups:
+        out.append(f"## {group}\n")
+        for check in checks:
+            if check.group != group:
+                continue
+            out.append(_render_check(check, numbering[id(check)]))
+
+    out.append(
+        "---\n\n"
+        "Declarations live beside the checks they describe; see "
+        "`backend/app/scientific_checks/__init__.py` for how to add one, and "
+        "`backend/app/scientific_checks/declarations.py` for the two "
+        "populations that cannot self-declare (PostgreSQL objects, and wire "
+        "schemas that are forbidden from importing the backend).\n"
+    )
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if the committed document is out of date",
+    )
+    args = parser.parse_args()
+
+    rendered = render()
+    if args.check:
+        if not OUTPUT.exists():
+            print(f"{OUTPUT} does not exist; run without --check.", file=sys.stderr)
+            return 1
+        if OUTPUT.read_text() != rendered:
+            print(
+                f"{OUTPUT} is out of date with the declarations. "
+                "Regenerate it with "
+                "`python backend/scripts/generate_scientific_check_register.py`.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{OUTPUT} is up to date.")
+        return 0
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(rendered)
+    print(f"Wrote {OUTPUT} ({len(register())} entries).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/db/test_scientific_check_register.py
+++ b/backend/tests/db/test_scientific_check_register.py
@@ -1,0 +1,303 @@
+"""Drift guards for the scientific check register.
+
+The register's whole value is that it cannot quietly stop describing the
+code. These tests are what makes that true:
+
+* a registered Python check must resolve to a real callable;
+* a registered database constraint or trigger must exist in the live
+  PostgreSQL schema, queried from ``pg_constraint`` / ``pg_trigger``
+  rather than trusted as a string;
+* a declared code must appear verbatim in the source of the module
+  defining the enforcing function — so renaming the code string fails
+  here even though the declaration sits next to it;
+* every file constructing a ``ScientificCheck`` must be a declared
+  module, so forgetting to register one is caught rather than silently
+  omitted;
+* the generated document must be in sync with the declarations.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from app.scientific_checks import (
+    CheckTier,
+    DatabaseConstraint,
+    DesignPosition,
+    PythonCheck,
+    ScientificCheck,
+)
+from app.scientific_checks.declarations import DECLARING_MODULES, register
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = REPO_ROOT / "backend"
+GENERATOR = BACKEND_ROOT / "scripts" / "generate_scientific_check_register.py"
+REGISTER_DOC = REPO_ROOT / "docs" / "guides" / "scientific_check_register.md"
+
+REGISTER = register()
+
+
+def test_register_is_non_empty_and_proportionate() -> None:
+    """The register must stay a filter, not a dump of every validator.
+
+    The backend holds roughly 326 Pydantic validators and 225 check
+    constraints. If this count approaches that order the inclusion test
+    has stopped being applied and every entry's claim is diluted.
+    """
+    assert 10 <= len(REGISTER) <= 40, (
+        f"{len(REGISTER)} entries. Below ~10 the register is not describing "
+        "the system; above ~40 the inclusion test ('could this check be wrong "
+        "in an interesting way?') has stopped being applied."
+    )
+
+
+def test_every_python_check_resolves_to_real_code() -> None:
+    """Each ``PythonCheck`` names a live callable with locatable source."""
+    for check in REGISTER:
+        for site in check.enforced_by:
+            if not isinstance(site, PythonCheck):
+                continue
+            assert callable(site.func), f"{check.asserts!r}: {site.func!r} is not callable"
+            source_file = inspect.getsourcefile(site.func)
+            assert source_file is not None, f"{check.asserts!r}: no source file"
+            assert Path(source_file).exists()
+            # Resolving the location is the guard: a renamed or deleted
+            # function cannot be imported by the declaring module at all,
+            # so this test never even runs — which is the point.
+            assert ":" in site.location
+
+
+def _source_without_declarations(module) -> str:
+    """Module source with every ``ScientificCheck(...)`` literal blanked out.
+
+    Without this the code check is tautological: a declaration sitting in
+    the same module as its check would satisfy the assertion by quoting
+    itself, and renaming the real code string would go unnoticed.
+    """
+    source = inspect.getsource(module)
+    lines = source.splitlines()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Call):
+            continue
+        callee = value.func
+        name = callee.id if isinstance(callee, ast.Name) else getattr(callee, "attr", "")
+        if name != "ScientificCheck":
+            continue
+        end = node.end_lineno or node.lineno
+        for index in range(node.lineno - 1, end):
+            lines[index] = ""
+    return "\n".join(lines)
+
+
+def test_every_declared_code_appears_in_the_enforcing_module() -> None:
+    """A declared code must be a string the enforcing module actually holds.
+
+    Checked against the module that defines the *function*, with the
+    register declarations themselves stripped, so the assertion can only
+    be satisfied by the code string the check really uses.
+    """
+    for check in REGISTER:
+        if not check.emitted or not check.codes:
+            continue
+        python_sites = [s for s in check.enforced_by if isinstance(s, PythonCheck)]
+        if not python_sites:
+            continue
+        sources = []
+        for site in python_sites:
+            module = inspect.getmodule(site.func)
+            assert module is not None
+            sources.append(_source_without_declarations(module))
+        for code in check.codes:
+            # Bare substring: codes are routinely embedded mid-message
+            # ("... (species_geometry_composition_mismatch). A deposited
+            # structure must ..."), so a quote-delimited match would miss
+            # them. The tokens are long and distinctive enough that an
+            # accidental match is not a real risk.
+            assert any(code in src for src in sources), (
+                f"Code {code!r} is declared as emitted for {check.asserts!r}, "
+                "but no module defining its enforcing function contains that "
+                "literal string outside the register declaration itself. "
+                "Either the code was renamed and the register not updated, or "
+                "the entry should set emitted=False."
+            )
+
+
+def test_declaring_modules_covers_every_file_that_declares_a_check() -> None:
+    """No file may construct a ``ScientificCheck`` without being collected."""
+    declared_files = {
+        Path(inspect.getsourcefile(module)).resolve()  # type: ignore[arg-type]
+        for module in DECLARING_MODULES
+    }
+    found = subprocess.run(
+        [
+            "git",
+            "grep",
+            "-l",
+            # --untracked matters: a declaration added in a brand-new file
+            # is exactly the case this guard exists for, and plain
+            # ``git grep`` only searches tracked files.
+            "--untracked",
+            "-E",
+            r"^[A-Z_]+ = ScientificCheck\(",
+            "--",
+            "*.py",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    constructing = {
+        (REPO_ROOT / line).resolve()
+        for line in found.stdout.splitlines()
+        if line.strip()
+    }
+    missing = constructing - declared_files
+    assert not missing, (
+        "These files construct a ScientificCheck but are not in "
+        "DECLARING_MODULES, so their entries are silently absent from the "
+        f"register: {sorted(str(p.relative_to(REPO_ROOT)) for p in missing)}"
+    )
+
+
+def test_entries_are_uniquely_addressable() -> None:
+    """No two entries share a (group, sort_key) slot, and codes stay local.
+
+    A code may legitimately appear in more than one entry — ADR 0008 has
+    ``n_imag_contradicts_minimum`` naming the *finding* while the declared
+    stationary-point kind decides the tier — but a code scattered across
+    unrelated groups would mean two different claims share one label.
+    """
+    slots = [(check.group, check.sort_key) for check in REGISTER]
+    assert len(slots) == len(set(slots)), "duplicate (group, sort_key) slot"
+
+    groups_by_code: dict[str, set[str]] = {}
+    for check in REGISTER:
+        for code in check.codes:
+            groups_by_code.setdefault(code, set()).add(check.group)
+    scattered = {code: groups for code, groups in groups_by_code.items() if len(groups) > 1}
+    assert not scattered, f"codes shared across unrelated groups: {scattered}"
+
+
+def test_every_entry_states_its_tier_rationale_and_enforcement() -> None:
+    """Membership is the claim, so no entry may be a stub."""
+    for check in REGISTER:
+        assert check.enforced_by, f"{check.asserts!r} names no enforcement site"
+        assert len(check.asserts) > 30, f"{check.asserts!r} is not a sentence"
+        assert len(check.tier_rationale) > 60, (
+            f"{check.asserts!r} has no real ADR 0008 tier justification"
+        )
+        assert check.adr, f"{check.asserts!r} cites no ADR"
+        if check.tier is CheckTier.block:
+            assert check.escape_hatch is not None, (
+                f"{check.asserts!r} blocks but records no escape hatch. If "
+                "there genuinely is none, say so explicitly — a blocking "
+                "check with no documented door is exactly what a referee will "
+                "probe."
+            )
+
+
+def test_generated_document_is_in_sync() -> None:
+    """The committed register must match what the declarations render."""
+    assert REGISTER_DOC.exists(), f"{REGISTER_DOC} has not been generated"
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR), "--check"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"{REGISTER_DOC} is out of date with the declarations.\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Database-level entries, verified against live schema metadata
+# ---------------------------------------------------------------------------
+
+
+def _database_constraints() -> list[tuple[ScientificCheck, DatabaseConstraint]]:
+    return [
+        (check, site)
+        for check in REGISTER
+        for site in check.enforced_by
+        if isinstance(site, DatabaseConstraint)
+    ]
+
+
+def test_there_are_database_entries_to_verify() -> None:
+    """Guard the guard: an empty list would make the next test vacuous."""
+    assert _database_constraints(), (
+        "No DatabaseConstraint entries. Either the register lost its "
+        "database-level checks or the collection broke; either way the "
+        "existence check below would pass vacuously."
+    )
+
+
+@pytest.mark.parametrize(
+    ("check", "site"),
+    _database_constraints(),
+    ids=lambda value: value.name if isinstance(value, DatabaseConstraint) else "",
+)
+def test_database_object_exists_in_live_schema(
+    check: ScientificCheck, site: DatabaseConstraint, db_session
+) -> None:
+    """A registered constraint or trigger must exist in PostgreSQL.
+
+    Queried from the catalog, not from ``__table_args__``: the ORM holds
+    the short name that ``NAMING_CONVENTION`` expands, so only the
+    database knows what the object is really called.
+    """
+    if site.kind == "trigger":
+        found = db_session.execute(
+            text(
+                "SELECT count(*) FROM pg_trigger t "
+                "JOIN pg_class c ON c.oid = t.tgrelid "
+                "WHERE NOT t.tgisinternal AND t.tgname = :name AND c.relname = :table"
+            ),
+            {"name": site.name, "table": site.table},
+        ).scalar_one()
+        assert found == 1, (
+            f"Trigger {site.name!r} on {site.table!r} is registered as "
+            f"enforcing {check.asserts!r}, but no such trigger exists in the "
+            "live schema."
+        )
+        return
+
+    found = db_session.execute(
+        text(
+            "SELECT count(*) FROM pg_constraint con "
+            "JOIN pg_class c ON c.oid = con.conrelid "
+            "WHERE con.conname = :name AND c.relname = :table"
+        ),
+        {"name": site.name, "table": site.table},
+    ).scalar_one()
+    assert found == 1, (
+        f"Constraint {site.name!r} on {site.table!r} is registered as "
+        f"enforcing {check.asserts!r}, but no such constraint exists in the "
+        "live schema. Note the register must carry the *expanded* name "
+        "PostgreSQL holds, not the short form in __table_args__."
+    )
+
+
+def test_design_positions_are_prose_not_placeholders() -> None:
+    """A ``DesignPosition`` cannot be drift-guarded, so it must be specific."""
+    for check in REGISTER:
+        for site in check.enforced_by:
+            if isinstance(site, DesignPosition):
+                assert len(site.where) > 40, (
+                    f"{check.asserts!r} names a design position too vague to "
+                    "be checkable by a reader: " + site.where
+                )

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -472,7 +472,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - `ck_reaction_atom_map_inferred_requires_note` (check on `reaction_atom_map`)
   `source <> 'inferred' OR (note IS NOT NULL AND btrim(note) <> '')`
 - `trg_reaction_atom_map_source_immutable` (trigger on `reaction_atom_map`)
-  `BEFORE UPDATE FOR EACH ROW: refuse any change to `source``
+  `BEFORE UPDATE FOR EACH ROW: refuse any change to the source column`
 
 **Escape hatch.** `note` and `equivalent_map_count` stay mutable on purpose, so a depositor can correct a description or record newly counted symmetry-equivalent maps without touching the attribution. Symmetry means a valid map is often not unique; ADR 0011 declines to canonicalise among equivalent maps and leaves reaction-path degeneracy to a later decision.
 
@@ -537,13 +537,13 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - `ck_network_solve_reported_requires_literature` (check on `network_solve`)
   `kind <> 'reported' OR literature_id IS NOT NULL`
 - `ct_network_solve_computed_evidence` (trigger on `network_solve`)
-  `Deferred constraint trigger, at COMMIT: a `computed` solve must hold at least one state energy; at least one energy-transfer model if its network declares a well; at least one channel barrier if its network declares a saddle-point path`
+  `deferred constraint trigger, at COMMIT: a computed solve must hold at least one state energy; at least one energy-transfer model if its network declares a well; at least one channel barrier if its network declares a saddle-point path`
 
 **Escape hatch.** Declare `kind='reported'` and cite the literature. That relaxes the state-energy, channel-barrier and energy-transfer coverage rules a computed solve is held to, which is what makes a paper's supplementary table depositable at all — before the token existed such rates could not be deposited, so they went into somebody's private mechanism file, uncited and unversioned.
 
 **Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
 
-### 25. A collisional energy-transfer model records whether its <dE>down was determined per (well, collider) pair or declared once for the whole network.
+### 25. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
 
 | Field | Value |
 | --- | --- |
@@ -551,14 +551,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | **Code** | `network_wide_energy_transfer_scope` |
 | **Governing ADR** | 0009, 0008 |
 
-**Why this tier.** A network-wide <dE>down is correct, common, published science — Arkane, RMG and MESS inputs routinely specify a single `SingleExponentialDown` applied network-wide — so a check demanding one entry per (well x collider) pair could fire on a correct result and must not block. It is an expectation about *resolution*, not a definition. What stays definitional still blocks: a `per_well` entry naming no well contradicts itself, a `network_wide` entry naming one contradicts itself, and a payload mixing the two is genuinely ambiguous.
+**Why this tier.** A network-wide ⟨ΔE⟩down is correct, common, published science — Arkane, RMG and MESS inputs routinely specify a single `SingleExponentialDown` applied network-wide — so a check demanding one entry per (well x collider) pair could fire on a correct result and must not block. It is an expectation about *resolution*, not a definition. What stays definitional still blocks: a `per_well` entry naming no well contradicts itself, a `network_wide` entry naming one contradicts itself, and a payload mixing the two is genuinely ambiguous.
 
 **Enforced at.**
 
 - `ck_network_solve_energy_transfer_scope_columns_agree` (check on `network_solve_energy_transfer`)
   `(scope='per_well' AND state_id IS NOT NULL AND collider_species_entry_id IS NOT NULL) OR (scope='network_wide' AND state_id IS NULL AND collider_species_entry_id IS NULL)`
 
-**Escape hatch.** Declare `scope='network_wide'`. The physics behind the old per-well rule was never in dispute — <dE>down depends on the density of states of the excited well and on the collider's ability to accept internal energy, so argon and helium do not relax the same well identically. The rule was wrong in practice because it confused what the quantity *is* with what a calculation *determined*: the only way to satisfy it was to paste one number once per well, and the repository's own Arkane ingester did exactly that. Those rows are indistinguishable from independently determined values — a provenance loss manufactured by the validation itself, worse than the gap it closed, because an absent value is honest while a duplicated one is a false positive every consumer will faithfully propagate.
+**Escape hatch.** Declare `scope='network_wide'`. The physics behind the old per-well rule was never in dispute — ⟨ΔE⟩down depends on the density of states of the excited well and on the collider's ability to accept internal energy, so argon and helium do not relax the same well identically. The rule was wrong in practice because it confused what the quantity *is* with what a calculation *determined*: the only way to satisfy it was to paste one number once per well, and the repository's own Arkane ingester did exactly that. Those rows are indistinguishable from independently determined values — a provenance loss manufactured by the validation itself, worse than the gap it closed, because an absent value is honest while a duplicated one is a false positive every consumer will faithfully propagate.
 
 ## Reproducibility
 

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -1,0 +1,585 @@
+# The scientific check register
+
+**Generated. Do not edit by hand.** Regenerate with
+`conda run -n tckdb_env python backend/scripts/generate_scientific_check_register.py`.
+Every `file:line` here is resolved from the live function object at generation
+time, so it cannot go stale the way a hand-written table does.
+
+## What this is
+
+An enumeration of what TCKDB *guarantees about chemistry*, as opposed to what
+it merely stores. TCKDB runs roughly 326 Pydantic validators and 225 database
+check constraints; almost all of them enforce plumbing — string lengths, enum
+membership, foreign-key existence, `multiplicity >= 1`. This register contains
+only the checks that encode a **scientific decision a referee could disagree
+with**.
+
+The inclusion test is *could this check be wrong in an interesting way?*
+Elemental balance is a position. `max_length=64` is not, and `multiplicity >= 1`
+is arithmetic rather than chemistry. There is deliberately no "paper-worthy"
+column: **membership in this register is the claim.** An entry that fails the
+test dilutes every other entry.
+
+## Relationship to `docs/reviews/validation_check_audit.md`
+
+The two sit beside each other and answer different questions. That audit asks
+*is each Pydantic validator in the right ADR 0008 tier* — it is a placement
+review of one tier, pinned to a commit, and it is now stale by several codes.
+This register asks *what does TCKDB guarantee about chemistry* — it spans the
+service layer, the wire schemas and the database, it is generated rather than
+transcribed, and it is guarded in CI. Neither supersedes the other. Where they
+disagree about a line number, this one is right by construction.
+
+## How to read a row
+
+- **Asserts** — what the check claims, in one sentence a chemist would
+  recognise. Not a description of the implementation.
+- **Tier** — the ADR 0008 consequence, with the justification for *that* tier
+  in the ADR's own terms.
+- **Enforced at** — `file:line` for Python, or the constraint/trigger name for
+  PostgreSQL. Database names are verified against live schema metadata by
+  `backend/tests/db/test_scientific_check_register.py`, not trusted as strings.
+- **Escape hatch** — how legitimate chemistry the check would otherwise refuse
+  gets deposited instead. This column carries most of the weight. Charge
+  conservation is only defensible as a blocking check *because* an electron can
+  be declared as a participant; without that door the rule would be asserting
+  "every participant was declared", which is an expectation about the depositor
+  and ADR 0008 disqualifies an expectation from blocking.
+- **Recorded divergence** — where a check's documentation and its behaviour
+  disagree, or where a guarantee is narrower than its name suggests. Reported,
+  never silently fixed.
+
+
+## Tiers, and how many entries sit in each
+
+| Tier | Entries | Meaning |
+| --- | --- | --- |
+| `block` | 14 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
+| `warn` | 7 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
+| `review` | 0 | Referred to `machine_review` under a versioned rubric. ADR 0008 puts every cross-check against external reference data here. |
+| `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
+| **total** | **26** | |
+
+## Recorded divergences
+
+Where a check's documentation and its behaviour disagree, or where a guarantee is narrower than its name suggests. Every one of these is reported, never silently fixed — the register changes no check behaviour.
+
+- **[3]** A saddle point is made of exactly the atoms of the reaction it is declared to sit in.
+- **[4]** A saddle point carries the same total charge as the reactants it sits between.
+- **[6]** The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
+- **[9]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
+- **[10]** A transition state has exactly one imaginary vibrational mode.
+- **[24]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+
+## Entries
+
+## Conservation across a reaction
+
+### 1. The reactant and product sides of a reaction contain the same number of atoms of every element.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `reaction_mass_balance_failed` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. Mass balance is what makes a set of species a reaction rather than a list, so no correct calculation can produce an unbalanced one; the check cannot fire on a correct novel result.
+
+**Enforced at.**
+
+- `validate_reaction_elemental_balance` — `backend/app/services/reaction_resolution.py:131`
+  *Called from `resolve_chem_reaction`, so it fires on every path that resolves a reaction, including the PDep bundle.*
+
+**Escape hatch.** Declare a participant with `molecule_kind: pseudo`. A lumped or phenomenological construct has no atom-resolved composition, so one such participant suspends the law for the whole reaction. A declared electron does **not** exempt it — an electron contributes zero atoms and the reaction still has to balance.
+
+### 2. The summed formal charge of a reaction's reactants equals that of its products.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `reaction_charge_not_conserved` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional, and only because the escape hatch exists. Electrons are neither created nor destroyed by rearranging bonds. Without a way to name a free electron the rule would in fact assert 'every participant was declared', which is an expectation about the depositor rather than a definition of a reaction, and ADR 0008 disqualifies an expectation from blocking.
+
+**Enforced at.**
+
+- `validate_reaction_charge_conservation` — `backend/app/services/reaction_resolution.py:219`
+  *Sums `Species.charge`, which `canonical_species_identity` has already reconciled against the formal charge of each species' own SMILES.*
+
+**Escape hatch.** Declare the free electron as a participant — `{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, "multiplicity": 2}` — which is how associative and dissociative attachment, photoionization and photodetachment are deposited. It contributes -1 to the side it sits on and zero atoms, so elemental balance still has to be satisfied separately. A `pseudo` participant suspends the law entirely, as it does for elemental balance. Conservation is not neutrality: any net charge is accepted as long as both sides carry the same one, so ion-molecule reactions are unaffected.
+
+### 3. A saddle point is made of exactly the atoms of the reaction it is declared to sit in.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `transition_state_composition_mismatch` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. A transition state is a stationary point on the potential energy surface *of those atoms*, so a saddle point with a different molecular formula cannot be that reaction's saddle point, whatever else is true of it.
+
+**Enforced at.**
+
+- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:361`
+  *Composition is read from the saddle-point geometry when there is one and from `unmapped_smiles` otherwise. The PDep path passes no SMILES, so it compares geometry only.*
+
+**Escape hatch.** Declare the extra species as participants of the reaction. A `pseudo` reactant exempts the reaction. Absence does not block: no geometry and no parseable SMILES means nothing is compared, and an unparseable transition-state SMILES is treated as silence rather than as a contradiction, because a TS SMILES is a lossy label for a structure that is by construction not a stable molecule.
+
+**Recorded divergence.** The docstring says pseudo-species exemption 'matches `validate_reaction_elemental_balance`'. It does not, quite: this function queries only `ReactionRole.reactant` and exempts only on a *reactant-side* pseudo participant, while `_load_participant_species` exempts the two conservation checks on a pseudo participant on **either** side. A reaction whose only pseudo species is a product is therefore exempt from elemental balance but still held to transition-state composition, and it is compared against a reactant side that carries no balance guarantee. Reported, not changed — this register alters no check behaviour.
+
+### 4. A saddle point carries the same total charge as the reactants it sits between.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `transition_state_charge_mismatch` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. Charge is conserved along a reaction coordinate, so a saddle point at a different charge is on a different potential energy surface — not a worse calculation of the same one.
+
+**Enforced at.**
+
+- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:361`
+  *Second, independent leg of the same function. Skipped entirely when the caller passes no `transition_state_charge`.*
+
+**Escape hatch.** Omit the transition state's charge, which skips the comparison. Multiplicity is deliberately **not** checked here at all: spin is not conserved the way charge and atoms are — two doublets may react over a singlet or a triplet surface, and spin-forbidden reactions are real chemistry — so a multiplicity rule would fire on correct novel results.
+
+**Recorded divergence.** The docstring says pseudo-species exemption 'matches `validate_reaction_elemental_balance`'. It does not, quite: this function queries only `ReactionRole.reactant` and exempts only on a *reactant-side* pseudo participant, while `_load_participant_species` exempts the two conservation checks on a pseudo participant on **either** side. A reaction whose only pseudo species is a product is therefore exempt from elemental balance but still held to transition-state composition, and it is compared against a reactant side that carries no balance guarantee. Reported, not changed — this register alters no check behaviour.
+
+## A structure against its own label
+
+### 5. A conformer geometry deposited under a species entry is made of the atoms that entry's own SMILES declares.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `species_geometry_composition_mismatch` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. No correct calculation produces a geometry that is not made of its own molecule's atoms, so a formula disagreement between a structure and its own identifier is a contradiction rather than an expectation — every energy, frequency and partition function downstream would describe a different molecule under the deposited label.
+
+**Enforced at.**
+
+- `assert_geometry_composition_matches_identity` — `backend/app/services/species_resolution.py:223`
+  *Conformer geometries only, via `resolve_species_entry`: the computed-species bundle, `/uploads/conformers`, the computed-reaction bundle and the PDep bundle. **Calculation** input and output geometries are reached by no composition check on any path — benzene coordinates can still be attached as a calculation geometry under a `smiles: "C"` entry. Closing that for *output* geometries would be wrong (an optimisation that dissociated is science to record); for *input* geometries it is an open gap.*
+
+**Escape hatch.** Declare `molecule_kind: pseudo`, which has no atom-resolved composition to agree with. A free electron is deliberately **not** exempt — its composition is not unknown but empty, so any geometry deposited under one is refused, which stops `electron` becoming a quieter way to smuggle a structure past the check. Absence does not block: no geometry, or a SMILES RDKit will not parse, is incompleteness.
+
+### 6. The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. The identity's isotope label and the geometry's per-atom masses describe the same nuclei; when they disagree one of them is wrong and there is no defensible way to pick a winner, so a CD3OH identity on an all-protium geometry would yield frequencies for a molecule nobody deposited.
+
+**Enforced at.**
+
+- `assert_geometry_isotopes_match_identity` — `backend/app/services/species_resolution.py:103`
+  *Runs from `resolve_species_entry` only when a geometry is supplied. Raises prose with no machine-readable code, so no client can key off it — recorded here as a gap rather than papered over.*
+
+**Escape hatch.** Deposit no geometry. An explicitly declared *standard* isotope is dropped before comparison, so `{1: 1}` on a hydrogen cannot fork an identity away from an unlabelled deposit of the same molecule.
+
+**Recorded divergence.** Not a divergence but a documented false *acceptance*, restated here because a referee will ask: only the multiset is compared, so isotopomers are not distinguished. An identity of `[2H]OC` (CH3-OD) accepts a geometry labelling a methyl hydrogen instead (CH2D-OH) — different molecules with different zero-point energies. Closing it needs an atom-level SMILES-to-XYZ correspondence the repository does not have. Where the two disagree invisibly, the geometry is authoritative for masses and the SMILES only for identity.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+### 7. A species entry's declared charge equals the summed formal charge of its own SMILES.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional, and the anchor the reaction-level charge law stands on: `validate_reaction_charge_conservation` sums `Species.charge` and is only meaningful because each value has already been reconciled with the structure it labels. Per ADR 0008 the blocking tier owns the rule and the others cite it, which is why `assert_geometry_composition_matches_identity` deliberately does not re-check charge.
+
+**Enforced at.**
+
+- `canonical_species_identity` — `backend/app/chemistry/species.py:528`
+  *Charge is compared against `formal_charge` of the sanitized identity molecule — the sum of RDKit per-atom formal charges, which is a notation convention rather than an electron count. A referee may object that formal-charge assignment on hypervalent, zwitterionic or dative-bonded SMILES is notation-dependent.*
+
+**Escape hatch.** A free electron short-circuits before the comparison, returning a pinned identity pair. Multiplicity is deliberately **not** validated against the SMILES at all: standard SMILES does not encode spin state, so RDKit's inferred radical count is only a hint and the uploaded multiplicity is authoritative — which is what lets singlet CH2 (whose SMILES `[CH2]` implies a triplet) and the singlet and triplet states of O2 be represented.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+### 8. The charge and spin multiplicity a depositor declares match the ones the electronic-structure log says the calculation was actually run at.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `charge_mismatch`, `multiplicity_mismatch` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** **Placed against the ADR's own reasoning, deliberately.** ADR 0008 names both findings as direct contradictions between a declaration and the parsed evidence, therefore definitional, therefore belonging at the blocking tier — and then defers the promotion, because promoting a warning to a blocker rejects payloads that are accepted today. These checks have never fired on real data, so their false-positive rate is unknown and promoting them first would be unsafe. The register records the gap rather than hiding it: this is the clearest case in TCKDB of a check sitting one tier below where its own governing decision puts it.
+
+**Enforced at.**
+
+- `reconcile_charge_multiplicity` — `backend/app/services/charge_multiplicity_reconciliation.py:217`
+  *Re-reads charge and multiplicity from the uploaded artifact using the wired Gaussian, ORCA, Psi4 and Molpro parsers.*
+
+**Escape hatch.** Absence is not contradiction: if the producing program is not one of the wired parsers, the artifact is missing, the log is truncated, or the declarations inside a single log disagree with each other, the value is left unknown and **no** warning is emitted. Only a value genuinely read from the log may contradict a declaration — emitting a mismatch because parsing failed would fabricate a contradiction out of ignorance.
+
+### 9. An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0008, 0002 |
+
+**Why this tier.** An expectation, and correctly non-blocking. An optimisation that rearranged, dissociated or transferred a proton is science to record, not a payload to refuse, and connectivity perception from XYZ is unreliable for exactly the weak complexes, radicals, ions and stretched geometries where a genuine rearrangement would matter. The result is written as an evidence row that grades the record at read time; it never refuses an upload.
+
+**Enforced at.**
+
+- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:120`
+  *Species-owned `opt` calculations only. Transition states are deliberately excluded, having no canonical SMILES to compare against. Best-effort by policy: a missing SMILES, a missing output geometry, unparseable coordinates or a raising chemistry layer all write nothing and let the upload continue. A Kabsch RMSD above 1.0 A against the input geometry is recorded as a separate suspicion signal.*
+
+**Escape hatch.** The whole check is advisory, so there is nothing to escape. What a consumer must not do is read a `fail` row as 'this calculation is scientifically invalid'; it means only that the automated identity validator found a mismatch.
+
+**Recorded divergence.** The stored column is named `is_isomorphic` and the surrounding policy is worded as graph isomorphism, but the code tests the **molecular formula** only. Atom mapping falls back to a SMILES-graph matcher whenever bond perception from XYZ fails, which is the common case for the radicals, ions and stretched geometries this service mostly sees, and that fallback rejects a candidate on one condition: the per-element atom counts disagree. Verified by direct call in the module docstring — ethanol declared with dimethyl ether deposited passes, and methane with one hydrogen pulled to 5 A passes. So the rearrangement, bond-breaking, dissociation and proton-transfer cases the module was written to catch are not caught. Already self-documented in the module docstring rather than discovered here; recorded because the field name is what a consumer sees and it still overstates the guarantee.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+## Stationary points
+
+### 10. A transition state has exactly one imaginary vibrational mode.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `transition_state_n_imag_not_one` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional — ADR 0008's worked example. The Hessian eigenvalue spectrum *is* the definition of a stationary point: zero imaginary modes is a minimum and the geometry never reached a barrier top, two or more is a higher-order saddle. Either way the record is not the first-order saddle point it declares itself to be, and no correct calculation produces it as submitted.
+
+**Enforced at.**
+
+- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:298`
+  *A transition state carries no `stationary_point_kind` column — the entity *is* the claim — so the rule needs no kind argument. Upload schemas call `raise_for_blocking_findings` from a `model_validator`, so the contradiction becomes a 422 before the route body opens a submission.*
+
+**Escape hatch.** Deposit no frequency evidence: `n_imag=None` produces no findings at all. Absence is never contradiction.
+
+**Recorded divergence.** The module calls itself 'the single owner' of these findings, and ADR 0008 requires that where one fact is checked in more than one tier the blocking tier owns it and the others cite it. `_check_ts_single_imaginary_frequency_for_ts` in `app/services/trust/rubrics.py` nevertheless re-derives the same physical fact independently at read time, and the trust evaluator promotes it to a hard fail. ADR 0008 names this duplication as a defect to be collapsed onto one owner; it has not been collapsed.
+
+### 11. A species entry declared a minimum has no imaginary vibrational modes.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `n_imag_contradicts_minimum` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. A covalently bound minimum whose own frequency evidence reports an imaginary mode is mislabelled: the correct response is to re-optimise on a tighter integration grid or to declare it as something else, so refusing the deposit rejects no correct calculation.
+
+**Enforced at.**
+
+- `evaluate_species_entry_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:170`
+  *One imaginary mode and two-or-more are folded into a single blocking message that names `n_imag_higher_order_saddle` for the higher-order case. A stationary-point kind the module has not been taught about produces no findings — adding an enum member must be a deliberate decision, not a default.*
+
+**Escape hatch.** Declare `species_entry_kind='vdw_complex'`, which records the same mode with a warning instead, or deposit the structure through a transition-state payload if the single imaginary mode is real.
+
+### 12. A van der Waals complex is formally a minimum, so an imaginary mode on one is recorded and flagged rather than refused — unless the mode is too stiff to be an intermolecular one, which suggests a genuine reaction coordinate.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `n_imag_contradicts_minimum`, `n_imag_higher_order_saddle`, `n_imag_suggests_transition_state` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** The carve-out is the scientific content. A van der Waals complex is held together by intermolecular forces and its stretch, bends and hindered internal rotations sit below roughly 50 cm-1 — the region where numerical noise in a finite-difference or quadrature-grid Hessian is comparable to the true curvature. A small imaginary mode there is usually a grid artifact, so refusing it would force an expensive re-run for a physically meaningless mode. This is what earns `vdw_complex` a separate enum member: it is the only place the two minimum kinds behave differently.
+
+**Enforced at.**
+
+- `evaluate_species_entry_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:170`
+  *Same entry point as the blocking minimum rule; the declared kind decides the tier while the code names the finding. A mode at or above 100 cm-1 additionally raises `n_imag_suggests_transition_state`, because that is far too stiff to be intermolecular.*
+
+**Escape hatch.** This *is* the escape hatch for the blocking minimum rule. Its own cost is that a genuinely mislabelled saddle point deposited as a van der Waals complex is accepted with a warning.
+
+### 13. A transition state's single imaginary mode should exceed roughly 100 cm-1 in magnitude.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `transition_state_imaginary_frequency_too_small` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** ADR 0008's worked counter-example, and the sharpest statement of the whole rule. A very soft imaginary mode is suspicious — often an under-converged geometry or a coarse integration grid — but it can be perfectly real, because flat barriers and variational transition states genuinely produce them. Magnitude is therefore a quality expectation, never a definition, and a check that could fire on a correct novel result must not block.
+
+**Enforced at.**
+
+- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:298`
+  *The threshold is explicitly a starting point rather than a physical constant: reaction coordinates for hydrogen transfers run to thousands of cm-1, while genuinely flat barriers fall well under 100. It is also the scale that separates a van der Waals complex's soft intermolecular modes from a real reaction coordinate, and is reused for that judgement.*
+
+**Escape hatch.** None is needed — the check never refuses. A referee should read the threshold as a tunable reporting line, not a claim about physics.
+
+### 14. A deposited saddle point should carry passing intrinsic-reaction-coordinate evidence that it connects the declared reactants and products.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `transition_state_missing_irc_evidence` |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Absence, not contradiction. Refusing a transition state without an IRC would lose the saddle point entirely, and a saddle point with no IRC is an incomplete record rather than a false one. The evidence is recommended, not required.
+
+**Enforced at.**
+
+- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:33`
+  *Every path that can carry a transition state routes through this seam — the PDep bundle, the computed-reaction bundle and the standalone transition-state upload — so all three write identical rows and report an identical gap. Before the seam existed only the PDep bundle could deposit the evidence, so a TS uploaded any other way always read back as `irc: absent` even when the depositor had run one.*
+
+**Escape hatch.** None needed — the warning is the accommodation. Note the warning fires on absence of a *passing* record, so evidence that was run and failed is stored and still warns.
+
+## Atom mapping across a reaction
+
+### 15. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Definitional. A map asserting that an element transmutes is a record that cannot be what it says it is, not an unusual result.
+
+**Enforced at.**
+
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+  *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
+- `ck_reaction_atom_map_pair_element_matches` (check on `reaction_atom_map_pair`)
+  `upper(element) = upper(ts_element)`
+
+**Escape hatch.** Case is not load-bearing. The comparison is deliberately case-insensitive because the two ends quote two different geometries, and a geometry stores the symbol its depositor's XYZ wrote — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+### 16. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Definitional. A map is a bijection or it is not a map; an atom claimed twice describes no mechanism at all.
+
+**Enforced at.**
+
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+  *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
+- `uq_reaction_atom_map_pair_ts_atom_index` (unique on `reaction_atom_map_pair`)
+  `(atom_map_id, side, ts_atom_index)`
+- `uq_reaction_atom_map_pair_atom_map_id` (unique on `reaction_atom_map_pair`)
+  `(atom_map_id, structure_participant_id, atom_index)`
+
+**Escape hatch.** Per leg, not globally: the reactant and product legs each claim the whole saddle point, which is the point of storing two maps both pointing at it. A `side` column exists on the pair row purely so this can be a unique constraint, because SQL cannot dereference the participant to find its role.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+### 17. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Definitional, and it is where ADR 0011's central choice is cashed out. Atom indices are not a property of a species — `geometry_atom.atom_index` is a property of a *geometry* — so 'reactant atom 3' is meaningless until the geometry being counted is named. An index counted against the wrong geometry silently means the wrong atom, which is the failure mode geometry-relative indexing was chosen to make impossible.
+
+**Enforced at.**
+
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+  *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
+- `fk_reaction_atom_map_pair_geometry_id_geometry_atom` (foreign_key on `reaction_atom_map_pair`)
+  `(geometry_id, atom_index, element) -> geometry_atom(geometry_id, atom_index, element)`
+- `fk_reaction_atom_map_pair_ts_geometry_id_geometry_atom` (foreign_key on `reaction_atom_map_pair`)
+  `(transition_state_geometry_id, ts_atom_index, ts_element) -> geometry_atom(geometry_id, atom_index, element)`
+- `fk_reaction_atom_map_pair_structure_participant` (foreign_key on `reaction_atom_map_pair`)
+  `(structure_participant_id, side) -> reaction_entry_structure_participant(id, role)`
+
+**Escape hatch.** None, and the cost is stated in ADR 0011: the map is welded to the geometries it names, so depositing a second conformer or re-optimising at another level of theory does not carry it across. Canonical-order-relative indexing would be portable, and was rejected because its failure mode is a map that looks fine and refers to a different atom order than the depositor intended. Portability can be added later as a derived view; correctness cannot be retrofitted onto records nobody can verify.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+### 18. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Definitional, but only under a precondition that has to be checked first. A reactant atom unaccounted for in the products is a contradiction *when no species is missing*. When the declared reaction is not atom-balanced a species genuinely is missing, and the same discrepancy is incompleteness rather than contradiction — so the rule is gated on the map being complete over every participant and on the reaction balancing, and warns instead otherwise.
+
+**Enforced at.**
+
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+  *Wire boundary only. This one has no database counterpart: it is a statement about a whole map rather than about one pair row, and a per-row constraint cannot see it.*
+
+**Escape hatch.** Leave the map incomplete, or deposit an unbalanced reaction — either drops the rule to the warning tier by design rather than by accident.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+### 19. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `reaction_atom_map_absent` |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Absence, not contradiction. An unmapped reaction is an incomplete record rather than a false one — the rate constant is still the rate constant and what is missing is the mechanistic detail. Blocking would reject correct science over evidence the depositor may not have, and would make every reaction already in the database undepositable.
+
+**Enforced at.**
+
+- `_warn_absent` — `backend/app/services/reaction_atom_map.py:309`
+  *A reaction with no transition state is not warned about: both legs of a map run toward the saddle point, so a barrierless channel has nothing to map onto and a warning it could never satisfy would train depositors to ignore the one that matters. The PDep bundle has no `atom_map` field yet, so on that path the warning carries a different remedy sentence rather than naming a field that does not exist.*
+
+**Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
+
+### 20. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `reaction_atom_map_participants_incomplete`, `reaction_atom_map_atoms_incomplete` |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Absence again, at finer grain. A partial map is a true-but-partial record; only a map that contradicts *itself* is refused, and that is handled at the blocking tier by `validate_reaction_atom_map` and by the constraints on `reaction_atom_map_pair`.
+
+**Enforced at.**
+
+- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:340`
+  *Two codes from one seam: `reaction_atom_map_participants_incomplete` when a declared molecule is missing from the map entirely, `reaction_atom_map_atoms_incomplete` when a mapped participant leaves its own atoms unmapped or a leg leaves saddle-point atoms claimed by nobody.*
+
+**Escape hatch.** None.
+
+### 21. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `structural` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0011 |
+
+**Why this tier.** Not a runtime check but a shape. ADR 0011 permits inference only as a labelled and separable thing, because an atom map is a scientific claim about a mechanism and picking one by algorithm and storing it unlabelled would manufacture provenance — the same failure ADR 0009 identified when a network-wide energy-transfer value was duplicated across wells. The immutability trigger closes the laundering path a check constraint cannot see: `UPDATE reaction_atom_map SET source='declared', note=NULL` satisfies both existing constraints, and a CHECK cannot read `OLD`.
+
+**Enforced at.**
+
+- `ck_reaction_atom_map_inferred_requires_note` (check on `reaction_atom_map`)
+  `source <> 'inferred' OR (note IS NOT NULL AND btrim(note) <> '')`
+- `trg_reaction_atom_map_source_immutable` (trigger on `reaction_atom_map`)
+  `BEFORE UPDATE FOR EACH ROW: refuse any change to `source``
+
+**Escape hatch.** `note` and `equivalent_map_count` stay mutable on purpose, so a depositor can correct a description or record newly counted symmetry-equivalent maps without touching the attribution. Symmetry means a valid map is often not unique; ADR 0011 declines to canonicalise among equivalent maps and leaves reaction-path degeneracy to a later decision.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+## Rate coefficients
+
+### 22. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. The dimensionality of A follows from the rate law, so an A in cm3/mol/s on a unimolecular reaction is not an unusual result but a number that cannot mean what it says. A mis-declared unit is also silently catastrophic downstream, since nothing later in the stack can recover the intended order from the value alone.
+
+**Enforced at.**
+
+- `validate_a_units_for_molecularity` — `backend/app/chemistry/units.py:49`
+  *Called from the kinetics upload schema, so it refuses at the wire boundary. The order is not simply `len(reactants)`: a simple `+M` third-body reaction carries a `[M]` term on the main line and validates one order higher, while a falloff reaction's main line is the high-pressure limit k-infinity and keeps `len(reactants)`, its low-pressure limit k0 being validated separately one order up.*
+
+**Escape hatch.** None, and the refinements are the reason it can block without firing on correct science: PLOG and Chebyshev are refused the `is_third_body` flag outright, because both already encode the full pressure dependence and the flag would otherwise inflate the expected order by one — rejecting a PLOG entry carrying the *correct* units and accepting one carrying the units of the next order up.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+## Statistical mechanics
+
+### 23. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `structural` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** A modelling position rather than an arithmetic bound. Canonical transition state theory needs the saddle point's own partition function, so a transition state has to be a first-class subject of a statmech row. The alternative — encoding a transition state as a pseudo-species — would make every partition function's subject ambiguous and would put saddle points into a kind reserved for lumped and phenomenological constructs that the conservation laws deliberately exempt.
+
+**Enforced at.**
+
+- `ck_statmech_statmech_exactly_one_subject` (check on `statmech`)
+  `(species_entry_id IS NULL) <> (transition_state_entry_id IS NULL)`
+
+**Escape hatch.** None.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+## Pressure-dependent networks
+
+### 24. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `structural` |
+| **Code** | `reported_network_solve` |
+| **Governing ADR** | 0010, 0008 |
+
+**Why this tier.** The blocking half is definitional: a computed solve with *zero* state energies contradicts its own kind, and a reported solve with no literature would assert rates carrying neither a derivation nor a source. The accepting half is why the token exists at all — published PLOG and Chebyshev fits are correct, common, citable science, so the coverage rules that are right for a solve run here could fire on a correct result and must not block. They warn instead, on every read path that reaches a rate.
+
+**Enforced at.**
+
+- `ck_network_solve_reported_requires_literature` (check on `network_solve`)
+  `kind <> 'reported' OR literature_id IS NOT NULL`
+- `ct_network_solve_computed_evidence` (trigger on `network_solve`)
+  `Deferred constraint trigger, at COMMIT: a `computed` solve must hold at least one state energy; at least one energy-transfer model if its network declares a well; at least one channel barrier if its network declares a saddle-point path`
+
+**Escape hatch.** Declare `kind='reported'` and cite the literature. That relaxes the state-energy, channel-barrier and energy-transfer coverage rules a computed solve is held to, which is what makes a paper's supplementary table depositable at all — before the token existed such rates could not be deposited, so they went into somebody's private mechanism file, uncited and unversioned.
+
+**Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
+
+### 25. A collisional energy-transfer model records whether its <dE>down was determined per (well, collider) pair or declared once for the whole network.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `structural` |
+| **Code** | `network_wide_energy_transfer_scope` |
+| **Governing ADR** | 0009, 0008 |
+
+**Why this tier.** A network-wide <dE>down is correct, common, published science — Arkane, RMG and MESS inputs routinely specify a single `SingleExponentialDown` applied network-wide — so a check demanding one entry per (well x collider) pair could fire on a correct result and must not block. It is an expectation about *resolution*, not a definition. What stays definitional still blocks: a `per_well` entry naming no well contradicts itself, a `network_wide` entry naming one contradicts itself, and a payload mixing the two is genuinely ambiguous.
+
+**Enforced at.**
+
+- `ck_network_solve_energy_transfer_scope_columns_agree` (check on `network_solve_energy_transfer`)
+  `(scope='per_well' AND state_id IS NOT NULL AND collider_species_entry_id IS NOT NULL) OR (scope='network_wide' AND state_id IS NULL AND collider_species_entry_id IS NULL)`
+
+**Escape hatch.** Declare `scope='network_wide'`. The physics behind the old per-well rule was never in dispute — <dE>down depends on the density of states of the excited well and on the collider's ability to accept internal energy, so argon and helium do not relax the same well identically. The rule was wrong in practice because it confused what the quantity *is* with what a calculation *determined*: the only way to satisfy it was to paste one number once per well, and the repository's own Arkane ingester did exactly that. Those rows are indistinguishable from independently determined values — a provenance loss manufactured by the validation itself, worse than the gap it closed, because an absent value is honest while a duplicated one is a false positive every consumer will faithfully propagate.
+
+## Reproducibility
+
+### 26. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `structural` |
+| **Code** | *(none — prose only)* |
+| **Governing ADR** | 0002, 0005 |
+
+**Why this tier.** Not a check that fires but a position about what may never be collapsed into a single verdict. Reproducibility is graded under append-only, rubric-versioned assessments rather than as a field on a scientific row or an alias for review status, so a rubric can be revised without rewriting history and an old judgement stays interpretable. This is the same reasoning that made ADR 0005 record execution environments rather than grade them, and it is what lets the warning tiers elsewhere in this register be defensible: an incomplete record is accepted precisely because a separate layer exists to say how incomplete it is.
+
+**Enforced at.**
+
+- `reproducibility_assessment` rows carry `described` / `auditable` / `rerunnable` under a versioned rubric, append-only, independent of `record_review` and of the trust evaluator (`app/services/trust/`)
+
+**Escape hatch.** None.
+
+*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+
+---
+
+Declarations live beside the checks they describe; see `backend/app/scientific_checks/__init__.py` for how to add one, and `backend/app/scientific_checks/declarations.py` for the two populations that cannot self-declare (PostgreSQL objects, and wire schemas that are forbidden from importing the backend).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Deployment: site/deployment.md
   - Concepts:
       - Core Concepts: guides/core_concepts.md
+      - Scientific Check Register: guides/scientific_check_register.md
       - Public Identifiers: specs/public_identifier_policy.md
       - Internal ID Visibility: specs/internal_ids_visibility_policy.md
   - Guides:


### PR DESCRIPTION
A generated register of the **chemistry** TCKDB guarantees — the checks that encode a scientific position a referee could disagree with, as distinct from the ~600 Pydantic and DB rules that enforce plumbing.

Two consumers: the source for a paper section on what the database guarantees rather than merely stores, and a checklist so work elsewhere can tell whether a scientific check was missed.

**26 entries — 14 block, 7 warn, 5 structural, 0 review.** That zero is informative: [ADR 0008](docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md) reserves the review tier for comparisons against external reference data, and TCKDB performs none.

## Mechanism

A frozen `ScientificCheck` dataclass declared at module level beside the check it describes — deliberately **not** a decorator:

- A decorator sits in the call path of checks whose behaviour must not change. A dataclass is inert: it wraps nothing, alters no signature or traceback, and has no import-time side effect. Diff across the eight modules that gained one is **571 insertions, 0 deletions**.
- It reaches populations a decorator cannot. A PostgreSQL constraint has no Python object to decorate, and `tckdb_schemas` is barred by its own import-boundary test from referencing `app`. Those are declared centrally, with that reason stated.
- It holds the **function object**, not a dotted string — so renaming a registered check breaks the declaring module's import.

An entry is a *claim*, not a code location, so it can name several enforcement sites. That is how "an element does not change across a reaction" appears as enforced both at the wire boundary and as a check constraint.

The document is generated with every `file:line` resolved from the live object, so unlike the existing audit it has no pinned commit to go stale against. That audit is **untouched**; the register's preamble explains they sit beside each other and answer different questions.

## Drift guard — demonstrated, not asserted

All four failure modes were broken deliberately and restored:

| broken | result |
|---|---|
| renamed `validate_reaction_elemental_balance` | `NameError` at import — collection never runs |
| renamed the code `reaction_mass_balance_failed` | source-scan failure naming the code |
| renamed `ck_reaction_atom_map_pair_element_matches` | `pg_constraint` lookup failure **+** doc-sync failure |
| declaration added in an unregistered file | coverage guard names the file |

The code scan strips `ScientificCheck(...)` literals by AST first — otherwise a same-module declaration satisfies the assertion **by quoting itself**, which is what the first implementation did before it was caught.

## Divergences found — reported, not fixed

1. **`validate_transition_state_composition`'s pseudo exemption does not match the balance check's**, though its docstring says it does. The shared loader exempts on `set(reactant) | set(product)`; the TS check queries `role == reactant` only. A reaction whose sole pseudo species is a *product* therefore skips elemental balance and charge conservation but is still held to TS composition — against a reactant side carrying no balance guarantee. Unreachable today, but `electron` has just made that family of kinds live.
2. **`stationary_point.py` calls itself the "single owner"** of imaginary-mode findings, while `trust/rubrics.py` re-derives the same fact at read time and promotes it to a hard fail. ADR 0008 names this duplication as a defect.
3. **`calc_geometry_validation.is_isomorphic` tests molecular formula, not graph isomorphism** — already self-documented, recorded because the field name a consumer reads still overstates it.

**11 of 26 entries emit no machine-readable code at all**, including the isotope check, the SMILES-charge check and all four atom-map wire rules. Recorded as a gap rather than papered over with invented codes.

## Boundary calls

Excluded where someone could argue: `sp_energy_payload_log_mismatch` (transcription integrity, floating-point tolerance); conformer torsional-basin matching (a resolution policy, and its decision record is gitignored); imaginary-mode sign conventions (storage convention); `validate_isotope` (a referee's disagreement would be with RDKit); σ ≥ 1 and rotational constants > 0 (arithmetic).

One is worth its own note: `ck_network_solve_channel_barrier_barriers_finite` rejects only NaN — **negative barriers are deliberately permitted, because submerged saddle points are real**. That is a scientific position enforced by an *absence*, and the register enumerates checks. It is the strongest case for a future "positions deliberately not enforced" section.

## Verification

`test-scientific.sh` **1975 passed**, `test-api.sh` **2424 passed** — both exactly at baseline, as required for a change that alters no behaviour. `ruff check app tests scripts` clean. Register suite 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)