### PR TITLE
Stop the idempotency receipt from destroying the upload it receipts for

### DIFF
--- a/backend/app/api/idempotency.py
+++ b/backend/app/api/idempotency.py
@@ -22,24 +22,34 @@ name mapping. This is the explicitly-allowed v0 behavior in
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from fastapi import Depends, Header, Request
+from fastapi import Depends, Header, Request, Response
 from fastapi.responses import JSONResponse
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user, get_write_db
+from app.api.deps import SessionLocal, get_current_user, get_write_db
 from app.db.models.app_user import AppUser
 from app.db.models.idempotency import IdempotencyRecord
 from app.services.idempotency import (
     IDEMPOTENCY_HEADER,
+    IDEMPOTENCY_RECEIPT_FAILED,
+    IDEMPOTENCY_RECEIPT_HEADER,
+    IDEMPOTENCY_RECEIPT_REASON_HEADER,
+    IDEMPOTENCY_RECEIPT_RECORDED,
     IDEMPOTENCY_REPLAYED_HEADER,
+    ReceiptWriteFailed,
     canonical_payload_hash,
     lookup_or_conflict,
-    record_response,
+    retry_receipt_after_commit,
     validate_idempotency_key,
+    write_receipt_isolated,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -53,6 +63,11 @@ class IdempotencyContext:
     method: str | None = None
     user_id: int | None = None
     existing: IdempotencyRecord | None = None
+    response: Response | None = None
+    #: ``None`` until :meth:`record` runs, then ``"recorded"`` or ``"failed"``.
+    receipt_status: str | None = field(default=None, init=False)
+    #: Short reason string when ``receipt_status == "failed"``.
+    receipt_failure_reason: str | None = field(default=None, init=False)
     _recorded: bool = field(default=False, init=False)
 
     @classmethod
@@ -80,8 +95,27 @@ class IdempotencyContext:
 
         No-ops when idempotency is disabled (no header) or already recorded.
         Caller must invoke this after the route's write succeeds and before
-        returning. The record commits atomically with the route's write
-        because both share the ``get_write_db`` session.
+        returning.
+
+        On the success path the receipt still commits atomically with the
+        route's write — both share the ``get_write_db`` session — so the
+        replay contract is untouched.
+
+        **When the receipt cannot be written**, the payload survives (see
+        :func:`app.services.idempotency.write_receipt_isolated`) and this
+        method does not raise. The route returns its real success status,
+        because the science genuinely was stored and saying otherwise would
+        be a lie in the more dangerous direction: a ``5xx`` invites the
+        client to retry, and with no receipt on file that retry re-executes
+        the upload and duplicates the science. What the client gets instead
+        is the truthful status plus an explicit
+        ``Idempotency-Receipt: failed`` header naming the reason, so a
+        caller that depends on exactly-once knows this key will not replay.
+        Returning a bare success with no signal is the pre-fix behaviour and
+        is exactly what kept the 2026-08-05 incident invisible.
+
+        A concurrent-duplicate ``IntegrityError`` still propagates, so a key
+        raced by two in-flight requests still yields ``409``.
         """
         if not self.enabled or self._recorded:
             return
@@ -90,17 +124,108 @@ class IdempotencyContext:
         assert self.endpoint is not None
         assert self.method is not None
         assert self.user_id is not None
-        record_response(
-            session,
-            user_id=self.user_id,
-            request_method=self.method,
-            endpoint=self.endpoint,
-            idempotency_key=self.key,
-            payload_hash=self.payload_hash,
-            status_code=status_code,
-            response_body=body,
-        )
+
+        # Set before attempting the write: a second call in the same request
+        # must not re-attempt a receipt that already failed.
         self._recorded = True
+
+        try:
+            write_receipt_isolated(
+                session,
+                user_id=self.user_id,
+                request_method=self.method,
+                endpoint=self.endpoint,
+                idempotency_key=self.key,
+                payload_hash=self.payload_hash,
+                status_code=status_code,
+                response_body=body,
+            )
+        except ReceiptWriteFailed as exc:
+            self.receipt_status = IDEMPOTENCY_RECEIPT_FAILED
+            self.receipt_failure_reason = exc.reason
+            logger.error(
+                "Returning %s for %s %s with an UNRECORDED idempotency receipt "
+                "(key=%s user_id=%s reason=%s). The write itself succeeded; only "
+                "retry-safety was lost.",
+                status_code,
+                self.method,
+                self.endpoint,
+                self.key,
+                self.user_id,
+                exc.reason,
+            )
+            self._apply_receipt_headers()
+            self._schedule_retry_after_commit(
+                session, status_code=status_code, body=body
+            )
+            return
+
+        self.receipt_status = IDEMPOTENCY_RECEIPT_RECORDED
+        self._apply_receipt_headers()
+
+    def _apply_receipt_headers(self) -> None:
+        """Surface the receipt outcome on the response.
+
+        A header rather than a body field: it applies uniformly to every
+        keyed write endpoint without changing a single response schema, and
+        so cannot drift as new upload routes are added.
+        """
+        if self.response is None or self.receipt_status is None:
+            return
+        self.response.headers[IDEMPOTENCY_RECEIPT_HEADER] = self.receipt_status
+        if self.receipt_failure_reason is not None:
+            self.response.headers[IDEMPOTENCY_RECEIPT_REASON_HEADER] = (
+                self.receipt_failure_reason
+            )
+
+    def _schedule_retry_after_commit(
+        self, session: Session, *, status_code: int, body: Any
+    ) -> None:
+        """Re-attempt the receipt once the payload transaction is durable.
+
+        ``after_commit`` is the earliest safe moment: before it, the payload
+        might still roll back, and a receipt for a write that never happened
+        would replay a success response for science that does not exist —
+        worse than no receipt at all.
+
+        The retry binds to the *engine*, never to the caller's
+        ``Connection``. That distinction is the whole point: a session that
+        joined the caller's connection would share its transaction, and
+        rolling back a failed retry could then roll back the write it was
+        supposed to be protecting — reintroducing the bug through the
+        repair. Binding to the engine takes a separate connection with a
+        separate transaction, so the retry cannot reach the payload at all.
+
+        Best-effort by construction: a failure is logged and swallowed,
+        never raised into the commit path.
+        """
+        assert self.key is not None
+        assert self.payload_hash is not None
+        assert self.endpoint is not None
+        assert self.method is not None
+        assert self.user_id is not None
+
+        bind = session.get_bind()
+        # ``Engine.engine`` is the engine itself; ``Connection.engine`` is the
+        # engine behind it. Either way this resolves to something that hands
+        # out a *new* connection.
+        engine = getattr(bind, "engine", None)
+        session_factory = (
+            (lambda: Session(bind=engine)) if engine is not None else SessionLocal
+        )
+        params = {
+            "user_id": self.user_id,
+            "request_method": self.method,
+            "endpoint": self.endpoint,
+            "idempotency_key": self.key,
+            "payload_hash": self.payload_hash,
+            "status_code": status_code,
+            "response_body": body,
+        }
+
+        @event.listens_for(session, "after_commit", once=True)
+        def _retry(_session: Session) -> None:  # pragma: no cover - see tests
+            retry_receipt_after_commit(session_factory, **params)
 
 
 def _endpoint_key(request: Request) -> str:
@@ -127,6 +252,7 @@ def _endpoint_key(request: Request) -> str:
 
 async def idempotency_dependency(
     request: Request,
+    response: Response,
     session: Session = Depends(get_write_db),
     current_user: AppUser = Depends(get_current_user),
     idempotency_key: str | None = Header(None, alias=IDEMPOTENCY_HEADER),
@@ -137,6 +263,11 @@ async def idempotency_dependency(
     Keyed requests have their key validated, body canonically hashed, and
     any prior matching record loaded for replay; a hash mismatch raises
     ``IdempotencyConflict`` before the route body ever runs.
+
+    ``response`` is FastAPI's mutable response stub. Headers set on it in a
+    dependency are merged into whatever the route returns, which is how
+    :meth:`IdempotencyContext.record` reports the receipt outcome without
+    every upload route having to thread it through its own response model.
     """
     if idempotency_key is None:
         return IdempotencyContext.disabled()
@@ -169,4 +300,5 @@ async def idempotency_dependency(
         method=method,
         user_id=current_user.id,
         existing=existing,
+        response=response,
     )

--- a/backend/app/services/idempotency.py
+++ b/backend/app/services/idempotency.py
@@ -15,18 +15,29 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Callable
 
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.models.idempotency import IdempotencyRecord
 
+logger = logging.getLogger(__name__)
+
 IDEMPOTENCY_HEADER = "Idempotency-Key"
 IDEMPOTENCY_REPLAYED_HEADER = "Idempotency-Replayed"
+#: Tells the client whether the receipt for this write was persisted with
+#: the payload. ``recorded`` means a retry with the same key will replay;
+#: ``failed`` means it will re-execute. See :func:`write_receipt_isolated`.
+IDEMPOTENCY_RECEIPT_HEADER = "Idempotency-Receipt"
+IDEMPOTENCY_RECEIPT_REASON_HEADER = "Idempotency-Receipt-Reason"
+IDEMPOTENCY_RECEIPT_RECORDED = "recorded"
+IDEMPOTENCY_RECEIPT_FAILED = "failed"
 IDEMPOTENCY_TTL = timedelta(days=30)
 IDEMPOTENCY_UNIQUE_CONSTRAINT = "uq_idempotency_record_user_method_endpoint_key"
 
@@ -35,6 +46,24 @@ _KEY_PATTERN = re.compile(r"^[A-Za-z0-9._:\-]{16,200}$")
 
 class InvalidIdempotencyKey(Exception):
     """Raised when an Idempotency-Key header value fails validation."""
+
+
+class ReceiptWriteFailed(Exception):
+    """The idempotency receipt could not be written — the payload is unharmed.
+
+    Raised by :func:`write_receipt_isolated` when the receipt INSERT fails
+    for a reason that is *about the receipt*, not about the write it
+    receipts for. The caller's transaction is still alive and still holds
+    the payload; the only thing lost is retry-safety for this key.
+
+    A concurrent-duplicate unique violation is deliberately **not** wrapped
+    in this exception — see :func:`write_receipt_isolated`.
+    """
+
+    def __init__(self, *, reason: str, cause: BaseException) -> None:
+        self.reason = reason
+        super().__init__(f"Idempotency receipt could not be written: {reason}")
+        self.__cause__ = cause
 
 
 class IdempotencyConflict(Exception):
@@ -188,6 +217,14 @@ def record_response(
     caller's responsibility (typically the route's ``get_write_db``
     dependency). If the route's transaction rolls back, no record is left
     behind — that is the contract for retryable failures.
+
+    .. warning::
+
+       This is the low-level primitive. Route code must go through
+       :func:`write_receipt_isolated`, which confines the INSERT to a
+       ``SAVEPOINT`` so a failing receipt cannot roll back the payload.
+       Calling this directly puts the receipt in the payload's transaction
+       with no isolation — the 2026-08-05 data-loss shape.
     """
     now = now or _utcnow()
     record = IdempotencyRecord(
@@ -202,6 +239,255 @@ def record_response(
     )
     session.add(record)
     return record
+
+
+def _is_idempotency_unique_violation(exc: IntegrityError) -> bool:
+    """True when *exc* is the concurrent-duplicate-key race, not a bad receipt."""
+    constraint = getattr(getattr(exc.orig, "diag", None), "constraint_name", None)
+    return constraint == IDEMPOTENCY_UNIQUE_CONSTRAINT
+
+
+def _describe(exc: BaseException) -> str:
+    """Short, log-safe reason string for a receipt failure."""
+    sqlstate = getattr(getattr(exc, "orig", None), "sqlstate", None)
+    if sqlstate:
+        return f"{type(exc).__name__}[{sqlstate}]"
+    return type(exc).__name__
+
+
+def _clear_expired_record_in_scope(
+    session: Session,
+    *,
+    user_id: int,
+    request_method: str,
+    endpoint: str,
+    idempotency_key: str,
+    now: datetime,
+) -> None:
+    """Remove an *expired* receipt occupying this uniqueness scope.
+
+    ``find_existing_record`` ignores expired rows, so a key past its TTL is
+    treated as never used and the route re-executes the write. The row is
+    still on disk though, and the uniqueness scope has no notion of expiry,
+    so inserting the new receipt collides with the corpse of the old one.
+
+    Before this call the collision surfaced at ``COMMIT`` — turning a
+    documented "expired keys behave as new" into a ``409`` that rolled the
+    upload back, whenever the (unscheduled) ``delete_expired_records``
+    sweep had not run. Flushing the receipt inside a savepoint moved that
+    from commit time to request time, which is how the existing
+    ``test_expired_record_treated_as_new`` case caught it: the shared test
+    fixture never commits, so the failure had nowhere to show before.
+
+    Only expired rows are cleared. A live row in the same scope still
+    collides, and must — that is the concurrent-duplicate ``409``.
+    """
+    session.execute(
+        delete(IdempotencyRecord)
+        .where(IdempotencyRecord.user_id == user_id)
+        .where(IdempotencyRecord.request_method == request_method)
+        .where(IdempotencyRecord.endpoint == endpoint)
+        .where(IdempotencyRecord.idempotency_key == idempotency_key)
+        .where(IdempotencyRecord.expires_at <= now)
+    )
+
+
+def write_receipt_isolated(
+    session: Session,
+    *,
+    user_id: int,
+    request_method: str,
+    endpoint: str,
+    idempotency_key: str,
+    payload_hash: str,
+    status_code: int,
+    response_body: Any,
+    now: datetime | None = None,
+) -> IdempotencyRecord:
+    """Write the receipt inside a ``SAVEPOINT`` so it cannot destroy the payload.
+
+    **Why this exists.** On 2026-08-05 an upload completed, ``201 Created``
+    was determined and sent, and then the idempotency row failed to
+    serialise at commit time. Receipt and payload shared one transaction,
+    so the rollback took the species, reaction and calculations with it.
+    The client had already been told ``uploaded: 1``. Nothing was stored.
+    The trigger was an encoding mismatch, but the shape is
+    encoding-independent: *any* commit-time failure confined to the receipt
+    destroys the science it receipts for.
+
+    The isolation has two parts, and both matter:
+
+    1. **Flush first.** The session is flushed *before* the savepoint opens,
+       so every pending payload row is already INSERTed outside it. Without
+       this, anything the route had not yet flushed would be swept into the
+       savepoint and rolled back with a failing receipt — the same data loss
+       through a subtler door.
+    2. **Savepoint around the receipt alone.** The receipt is added and
+       flushed inside ``session.begin_nested()``. A failure rolls back to
+       the savepoint, leaving the outer transaction alive and still holding
+       the payload, and the session usable for the rest of the request.
+
+    On success the savepoint is released and the receipt becomes part of the
+    caller's transaction, exactly as before: receipt and payload still commit
+    together, and a later rollback still discards both. The replay contract
+    is unchanged.
+
+    :raises ReceiptWriteFailed: the receipt could not be written. **The
+        payload is intact and the caller should still return success** — see
+        ``app.api.idempotency.IdempotencyContext.record``.
+    :raises IntegrityError: the receipt collided with the uniqueness scope
+        ``(user_id, request_method, endpoint, idempotency_key)``. This is a
+        genuine concurrent duplicate, not a receipt malfunction, and is
+        re-raised unwrapped so ``app.api.errors`` still maps it to ``409
+        idempotency_conflict`` and the duplicate write still rolls back.
+        Swallowing it would let both racers store their science under one
+        key — the precise thing the mechanism exists to prevent.
+    """
+    now = now or _utcnow()
+
+    # Part 1: get the payload out of the savepoint's blast radius.
+    session.flush()
+
+    # Part 2: the receipt, and only the receipt, inside the savepoint.
+    savepoint = session.begin_nested()
+    try:
+        _clear_expired_record_in_scope(
+            session,
+            user_id=user_id,
+            request_method=request_method,
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+            now=now,
+        )
+        record = record_response(
+            session,
+            user_id=user_id,
+            request_method=request_method,
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+            payload_hash=payload_hash,
+            status_code=status_code,
+            response_body=response_body,
+            now=now,
+        )
+        session.flush()
+    except Exception as exc:
+        # Undo the receipt and nothing else. The outer transaction — and the
+        # payload it holds — survives, and the session stays usable.
+        savepoint.rollback()
+
+        if isinstance(exc, IntegrityError) and _is_idempotency_unique_violation(exc):
+            # A concurrent duplicate, not a broken receipt. Let it out
+            # unwrapped so the write still aborts and still returns 409.
+            raise
+
+        reason = _describe(exc)
+        _log_receipt_failure(
+            reason,
+            exc,
+            user_id=user_id,
+            request_method=request_method,
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+        )
+        raise ReceiptWriteFailed(reason=reason, cause=exc) from exc
+
+    savepoint.commit()
+    return record
+
+
+def _log_receipt_failure(
+    reason: str,
+    exc: BaseException,
+    *,
+    user_id: int,
+    request_method: str,
+    endpoint: str,
+    idempotency_key: str,
+) -> None:
+    """Log a receipt failure loudly enough to diagnose without reading source.
+
+    The 2026-08-05 incident left a bare access-log line; working out what
+    had happened meant reading this module. Everything needed to identify
+    the affected write and the reason it failed goes in one ERROR record.
+    """
+    logger.error(
+        "Idempotency receipt write FAILED (reason=%s) for %s %s key=%s user_id=%s. "
+        "The payload committed and the client was told it succeeded, but this key "
+        "will NOT replay: a retry re-executes the write instead of returning the "
+        "stored response.",
+        reason,
+        request_method,
+        endpoint,
+        idempotency_key,
+        user_id,
+        exc_info=exc,
+    )
+
+
+def retry_receipt_after_commit(
+    session_factory: Callable[[], Session],
+    *,
+    user_id: int,
+    request_method: str,
+    endpoint: str,
+    idempotency_key: str,
+    payload_hash: str,
+    status_code: int,
+    response_body: Any,
+) -> bool:
+    """Re-attempt a failed receipt in its own transaction. Returns success.
+
+    Called only after the payload transaction has committed, which is the
+    single point at which this is safe. Writing a receipt *before* the
+    payload is durable would be far worse than having none: a receipt for a
+    write that then rolled back would replay a success response for science
+    that does not exist.
+
+    Once the payload is durable a receipt failure is merely a lost retry
+    guarantee, and a transient cause (deadlock, connection blip) deserves a
+    second attempt in a clean transaction rather than leaving idempotency
+    permanently broken for that key. A deterministic cause — the incident's
+    unstorable body, for instance — fails again here, and that is fine: this
+    runs after the response is sent and never raises into the request path.
+    """
+    try:
+        with session_factory() as retry_session:
+            record_response(
+                retry_session,
+                user_id=user_id,
+                request_method=request_method,
+                endpoint=endpoint,
+                idempotency_key=idempotency_key,
+                payload_hash=payload_hash,
+                status_code=status_code,
+                response_body=response_body,
+            )
+            retry_session.commit()
+    except Exception as exc:  # must never escape the commit path
+        logger.error(
+            "Idempotency receipt retry FAILED (reason=%s) for %s %s key=%s "
+            "user_id=%s. Retry-safety for this key is permanently lost; a "
+            "client retry will re-execute the write.",
+            _describe(exc),
+            request_method,
+            endpoint,
+            idempotency_key,
+            user_id,
+            exc_info=exc,
+        )
+        return False
+
+    logger.warning(
+        "Idempotency receipt recovered on retry for %s %s key=%s user_id=%s. "
+        "The receipt was written in a separate transaction after the payload "
+        "committed; this key replays again.",
+        request_method,
+        endpoint,
+        idempotency_key,
+        user_id,
+    )
+    return True
 
 
 def delete_expired_records(session: Session, *, now: datetime | None = None) -> int:

--- a/backend/tests/api/test_api_idempotency_receipt_isolation.py
+++ b/backend/tests/api/test_api_idempotency_receipt_isolation.py
@@ -1,0 +1,445 @@
+"""End-to-end: a failing idempotency receipt must not destroy the upload.
+
+This is the 2026-08-05 incident reproduced at the level it happened —
+a real upload route, the real workflow, and a write session that really
+commits — with the receipt forced to fail. On the pre-fix code this exact
+shape returned ``201 Created`` with a complete body (``species_entry_id``,
+``conformer_group_id``, ``calculation_id`` all populated) while storing
+**zero** rows, and raised nothing at the client.
+
+The forcing function is deliberately not an encoding problem: the receipt
+body carries a NUL character, which Postgres rejects in ``jsonb`` under
+every server encoding (SQLSTATE 22P05). The original trigger was a U+2014
+em-dash against a ``SQL_ASCII`` database and that cause is fixed, but the
+shape — any commit-time failure confined to the receipt — is not
+encoding-specific and is what these tests hold down.
+
+The load-bearing difference from the rest of the API suite is that the
+write session here **commits**; the shared ``client`` fixture never does,
+and the payload loss happens at commit. See ``committed_api_client``.
+Complementary tests in
+``tests/services/test_idempotency_write_isolation.py`` drive the same
+guarantee through a genuine top-level ``COMMIT`` and verify from a
+brand-new session.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import Session
+
+from app.api.app import create_app
+from app.api.deps import get_current_user, get_db, get_write_db
+from app.db.models.app_user import AppUser
+from app.db.models.idempotency import IdempotencyRecord
+from app.db.models.species import ConformerObservation
+from app.services.idempotency import (
+    IDEMPOTENCY_RECEIPT_FAILED,
+    IDEMPOTENCY_RECEIPT_HEADER,
+    IDEMPOTENCY_RECEIPT_REASON_HEADER,
+    IDEMPOTENCY_RECEIPT_RECORDED,
+)
+
+CONFORMER_ENDPOINT = "/api/v1/uploads/conformers"
+KEY_HEADER = "Idempotency-Key"
+REPLAYED_HEADER = "Idempotency-Replayed"
+
+#: A receipt body Postgres refuses to store in ``jsonb`` in any encoding.
+UNSTORABLE_RECEIPT_BODY = {"poisoned": "unstorable" + chr(0) + "receipt"}
+
+
+def _conformer_payload(label: str = "isolation-conf") -> dict:
+    return {
+        "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        "geometry": {"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+        "calculation": {
+            "type": "sp",
+            "software_release": {"name": "Gaussian", "version": "16"},
+            "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+        },
+        "label": label,
+        "note": "receipt isolation test",
+    }
+
+
+def _poison_receipt_body(monkeypatch) -> None:
+    """Force the receipt INSERT to fail, leaving the payload path untouched.
+
+    Wraps the record constructor rather than raising from it, so the failure
+    lands where the incident's did: inside the database, on the receipt's
+    own INSERT, at the moment the unit of work is written out.
+    """
+    import app.services.idempotency as svc
+
+    real = svc.record_response
+
+    def poisoned(session, **kwargs):
+        kwargs["response_body"] = UNSTORABLE_RECEIPT_BODY
+        return real(session, **kwargs)
+
+    monkeypatch.setattr(svc, "record_response", poisoned)
+
+
+@pytest.fixture
+def committed_api_client(db_engine, _api_test_user):
+    """A ``TestClient`` whose write session commits, as production's does.
+
+    The shared ``client`` fixture overrides ``get_write_db`` with a session
+    that is never committed. That is the right default for the suite, but
+    it cannot show this bug: the payload loss happens *at commit*, so a
+    harness that never commits reports success either way.
+
+    Here ``get_write_db`` gets the production contract — commit on success,
+    roll back on error — over a session in ``create_savepoint`` join mode on
+    a connection wrapped in an outer transaction. ``session.commit()`` runs
+    the real flush-and-commit machinery and makes the rows readable, while
+    teardown discards everything with a single rollback. Row-by-row cleanup
+    is not an option: several tables here carry ``append-only`` database
+    triggers that refuse ``DELETE`` outright.
+    """
+    app = create_app()
+
+    connection = db_engine.connect()
+    outer_transaction = connection.begin()
+    session = Session(
+        bind=connection,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
+
+    def committing_write_db():
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+
+    user = session.get(AppUser, _api_test_user)
+    app.dependency_overrides[get_db] = lambda: session
+    app.dependency_overrides[get_write_db] = committing_write_db
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        test_client._db_session = session
+        yield test_client
+
+    session.close()
+    outer_transaction.rollback()
+    connection.close()
+
+
+def _count(session: Session, model) -> int:
+    """Count rows with a real SELECT, not from the identity map."""
+    return session.scalar(select(func.count()).select_from(model)) or 0
+
+
+# ---------------------------------------------------------------------------
+# 1. The regression itself
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadSurvivesReceiptFailure:
+    def test_upload_is_stored_even_when_the_receipt_cannot_be_written(
+        self, committed_api_client, monkeypatch
+    ) -> None:
+        """The science must be in the database after the commit.
+
+        The pre-fix code passed every "no exception propagated" check — it
+        returned 201 and raised nothing at the client. What it did not do
+        was store anything. So this asserts against the database after the
+        write session has committed, which is the only assertion the old
+        behaviour could not satisfy.
+        """
+        session = committed_api_client._db_session
+        _poison_receipt_body(monkeypatch)
+        before = _count(session, ConformerObservation)
+
+        resp = committed_api_client.post(
+            CONFORMER_ENDPOINT,
+            json=_conformer_payload(),
+            headers={KEY_HEADER: "isolation-key-aaaaaaaaaaa"},
+        )
+
+        assert resp.status_code == 201, resp.text
+        after = _count(session, ConformerObservation)
+        assert after == before + 1, (
+            "the upload was destroyed by a failing idempotency receipt: "
+            f"{after - before} conformer rows committed, expected 1"
+        )
+
+        # The body's claims must be true of the database, not just of JSON.
+        body = resp.json()
+        observation = session.get(ConformerObservation, body["id"])
+        assert observation is not None
+        assert observation.conformer_group_id == body["conformer_group_id"]
+
+    def test_failed_receipt_is_not_left_behind(
+        self, committed_api_client, monkeypatch
+    ) -> None:
+        """No half-written receipt: the savepoint rollback is complete."""
+        session = committed_api_client._db_session
+        _poison_receipt_body(monkeypatch)
+        key = "isolation-noreceipt-aaaaa"
+
+        resp = committed_api_client.post(
+            CONFORMER_ENDPOINT,
+            json=_conformer_payload("noreceipt-conf"),
+            headers={KEY_HEADER: key},
+        )
+        assert resp.status_code == 201, resp.text
+
+        assert session.scalar(
+            select(IdempotencyRecord).where(
+                IdempotencyRecord.idempotency_key == key
+            )
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. The failure is visible
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptFailureIsVisible:
+    def test_response_says_the_receipt_failed(
+        self, committed_api_client, monkeypatch
+    ) -> None:
+        """201 is truthful about the science; the header is truthful about retries.
+
+        Returning a bare 201 is the pre-fix behaviour and is what made the
+        incident invisible. Failing the request instead would be worse: the
+        write really did succeed, and a 5xx invites a retry that — with no
+        receipt on file — re-executes the upload and duplicates the science.
+        """
+        _poison_receipt_body(monkeypatch)
+
+        resp = committed_api_client.post(
+            CONFORMER_ENDPOINT,
+            json=_conformer_payload("visible-conf"),
+            headers={KEY_HEADER: "isolation-visible-aaaaaa"},
+        )
+
+        assert resp.status_code == 201, resp.text
+        assert resp.headers.get(IDEMPOTENCY_RECEIPT_HEADER) == (
+            IDEMPOTENCY_RECEIPT_FAILED
+        )
+        assert resp.headers.get(IDEMPOTENCY_RECEIPT_REASON_HEADER)
+
+    def test_server_logs_the_failure_loudly(
+        self, committed_api_client, monkeypatch, caplog
+    ) -> None:
+        """The incident left a bare access-log line; diagnosis needed the source."""
+        _poison_receipt_body(monkeypatch)
+        key = "isolation-logged-aaaaaaaa"
+
+        with caplog.at_level(logging.ERROR):
+            resp = committed_api_client.post(
+                CONFORMER_ENDPOINT,
+                json=_conformer_payload("logged-conf"),
+                headers={KEY_HEADER: key},
+            )
+        assert resp.status_code == 201, resp.text
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "a receipt failure must be logged at ERROR"
+        joined = " ".join(r.getMessage() for r in errors)
+        assert key in joined, "the log must name the affected idempotency key"
+        assert CONFORMER_ENDPOINT in joined, "the log must name the endpoint"
+
+
+class TestTransientFailureSelfHeals:
+    def test_receipt_is_recovered_after_the_payload_commits(
+        self, db_engine, committed_api_client, monkeypatch
+    ) -> None:
+        """A transient receipt failure must not break the key permanently.
+
+        The first attempt fails inside the savepoint; the payload commits
+        anyway; the post-commit retry then writes the receipt in its own
+        transaction and idempotency for the key is restored. The response
+        header still reads ``failed`` because it is generated before the
+        payload is durable, and claiming success there would be a guess.
+        """
+        import app.services.idempotency as svc
+
+        real = svc.record_response
+        attempts = {"n": 0}
+
+        def flaky(session, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                kwargs["response_body"] = UNSTORABLE_RECEIPT_BODY
+            return real(session, **kwargs)
+
+        monkeypatch.setattr(svc, "record_response", flaky)
+        key = "isolation-selfheal-aaaaaa"
+
+        try:
+            resp = committed_api_client.post(
+                CONFORMER_ENDPOINT,
+                json=_conformer_payload("selfheal-conf"),
+                headers={KEY_HEADER: key},
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.headers.get(IDEMPOTENCY_RECEIPT_HEADER) == (
+                IDEMPOTENCY_RECEIPT_FAILED
+            )
+            assert attempts["n"] == 2, "the receipt should have been retried once"
+
+            # The retry ran on its own connection, so it is visible to a
+            # session that shares nothing with the request.
+            with Session(db_engine) as probe:
+                assert probe.scalar(
+                    select(IdempotencyRecord).where(
+                        IdempotencyRecord.idempotency_key == key
+                    )
+                ) is not None
+        finally:
+            # The recovered receipt was committed outside the test's
+            # transaction by design, so it needs removing by hand.
+            with Session(db_engine) as cleanup:
+                cleanup.execute(
+                    delete(IdempotencyRecord).where(
+                        IdempotencyRecord.idempotency_key == key
+                    )
+                )
+                cleanup.commit()
+
+
+# ---------------------------------------------------------------------------
+# 3. The normal path is unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestNormalPathUnchanged:
+    def test_receipt_recorded_header_on_success(self, client) -> None:
+        resp = client.post(
+            CONFORMER_ENDPOINT,
+            json=_conformer_payload("normal-conf"),
+            headers={KEY_HEADER: "isolation-normal-aaaaaaa"},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.headers.get(IDEMPOTENCY_RECEIPT_HEADER) == (
+            IDEMPOTENCY_RECEIPT_RECORDED
+        )
+
+    def test_second_identical_request_replays_rather_than_re_executes(
+        self, client, db_session
+    ) -> None:
+        """The replay contract is untouched by the isolation change."""
+        payload = _conformer_payload("replay-conf")
+        key = "isolation-replay-aaaaaaa"
+
+        first = client.post(CONFORMER_ENDPOINT, json=payload, headers={KEY_HEADER: key})
+        assert first.status_code == 201, first.text
+        assert REPLAYED_HEADER not in first.headers
+
+        before = _count(db_session, ConformerObservation)
+        second = client.post(CONFORMER_ENDPOINT, json=payload, headers={KEY_HEADER: key})
+
+        assert second.status_code == 201
+        assert second.headers.get(REPLAYED_HEADER) == "true"
+        assert second.json() == first.json()
+        assert _count(db_session, ConformerObservation) == before, (
+            "replay must not re-execute the write"
+        )
+
+    def test_upload_and_receipt_both_committed_on_the_happy_path(
+        self, committed_api_client
+    ) -> None:
+        """Both rows land in one commit when nothing is forced to fail."""
+        session = committed_api_client._db_session
+        key = "isolation-happy-aaaaaaaa"
+        before = _count(session, ConformerObservation)
+
+        resp = committed_api_client.post(
+            CONFORMER_ENDPOINT,
+            json=_conformer_payload("happy-conf"),
+            headers={KEY_HEADER: key},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.headers.get(IDEMPOTENCY_RECEIPT_HEADER) == (
+            IDEMPOTENCY_RECEIPT_RECORDED
+        )
+        assert _count(session, ConformerObservation) == before + 1
+
+        stored = session.scalar(
+            select(IdempotencyRecord).where(
+                IdempotencyRecord.idempotency_key == key
+            )
+        )
+        assert stored is not None
+        assert stored.status_code == 201
+
+    def test_replay_still_works_after_a_committing_write(
+        self, committed_api_client
+    ) -> None:
+        """Committed receipt, then a replay — the full round trip."""
+        payload = _conformer_payload("commit-replay-conf")
+        key = "isolation-creplay-aaaaaa"
+
+        first = committed_api_client.post(
+            CONFORMER_ENDPOINT, json=payload, headers={KEY_HEADER: key}
+        )
+        assert first.status_code == 201, first.text
+
+        session = committed_api_client._db_session
+        before = _count(session, ConformerObservation)
+        second = committed_api_client.post(
+            CONFORMER_ENDPOINT, json=payload, headers={KEY_HEADER: key}
+        )
+
+        assert second.status_code == 201
+        assert second.headers.get(REPLAYED_HEADER) == "true"
+        assert second.json() == first.json()
+        assert _count(session, ConformerObservation) == before
+
+
+# ---------------------------------------------------------------------------
+# 4. A concurrent duplicate is still a conflict, not a "failed receipt"
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentDuplicateStillConflicts:
+    def test_unique_violation_returns_409_and_stores_nothing(
+        self, committed_api_client, monkeypatch
+    ) -> None:
+        """Isolating the receipt must not downgrade the race to ``201``.
+
+        Two in-flight requests sharing a key are caught by the uniqueness
+        scope at write time. If that violation were swallowed as a "receipt
+        failure", both racers would commit their science under one key —
+        the exact outcome idempotency exists to prevent. The pre-lookup is
+        patched out to force the collision at write time, which is what a
+        genuine race does.
+        """
+        from app.api import idempotency as api_idem
+
+        session = committed_api_client._db_session
+        key = "isolation-duplicate-aaaaa"
+        payload = _conformer_payload("duplicate-conf")
+
+        # A committed receipt already occupies the uniqueness scope.
+        first = committed_api_client.post(
+            CONFORMER_ENDPOINT, json=payload, headers={KEY_HEADER: key}
+        )
+        assert first.status_code == 201, first.text
+
+        # Simulate the race: the lookup misses, so the collision surfaces
+        # on the receipt INSERT exactly as it would for two live requests.
+        monkeypatch.setattr(api_idem, "lookup_or_conflict", lambda *a, **k: None)
+        before = _count(session, ConformerObservation)
+
+        second = committed_api_client.post(
+            CONFORMER_ENDPOINT, json=payload, headers={KEY_HEADER: key}
+        )
+
+        assert second.status_code == 409, second.text
+        assert second.json()["code"] == "idempotency_conflict"
+        assert _count(session, ConformerObservation) == before, (
+            "a losing racer must not leave science behind"
+        )

--- a/backend/tests/api/test_api_jobs.py
+++ b/backend/tests/api/test_api_jobs.py
@@ -88,6 +88,28 @@ def test_concurrent_identical_enqueue_creates_one_job_and_submission(db_engine, 
         try:
             with TestClient(app) as local_client:
                 response = local_client.post("/api/v1/jobs/transport", json=payload, headers=headers)
+                # The loser can now learn it lost in either of two places, and
+                # both mean the same thing.
+                #
+                # 1. In the *response*. The idempotency receipt is written
+                #    inside a SAVEPOINT and flushed there, so a duplicate key
+                #    trips the unique constraint while the route is still
+                #    running and comes back as a 409. Production's
+                #    ``get_write_db`` rolls back on that exception; this
+                #    override does not, so the rollback is explicit here.
+                #    Without it the loser's job would commit and there would
+                #    be two.
+                # 2. At *commit*, as before. Kept because it is still reachable
+                #    when the racers interleave such that the flush succeeds
+                #    and the conflict only materialises later.
+                #
+                # Detection moving earlier is the point of the savepoint
+                # change: previously the violation surfaced after the response
+                # had been sent, so the loser was told 202 and its job then
+                # vanished on rollback.
+                if response.status_code == 409:
+                    session.rollback()
+                    return 409, None
                 try:
                     session.commit()
                 except IntegrityError:

--- a/backend/tests/services/test_idempotency_write_isolation.py
+++ b/backend/tests/services/test_idempotency_write_isolation.py
@@ -1,0 +1,524 @@
+"""The idempotency receipt must never be able to destroy the payload it receipts for.
+
+Regression tests for the 2026-08-05 incident: an upload completed, ``201
+Created`` was determined, and then the idempotency row failed to serialise
+at commit time. The receipt shared the upload's transaction, so the whole
+unit of work rolled back — species, calculation, everything — while the
+client had already been told ``uploaded: 1``.
+
+The original trigger was an encoding mismatch (a U+2014 em-dash against a
+``SQL_ASCII`` database) and that specific cause has been fixed by
+converting the database to UTF-8. The *shape* is encoding-independent, so
+these tests reproduce it with a value no Postgres encoding will accept in
+``jsonb``: a NUL character. ``\\u0000`` is rejected by ``jsonb`` in every
+server encoding (SQLSTATE 22P05), which makes it a stable, portable stand-in
+for "the receipt body is unstorable".
+
+The load-bearing assertion in every test here is made from a **fresh
+session after a genuine top-level commit** — not merely "no exception
+propagated". The incident propagated no exception either.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.models.common import MoleculeKind, StereoKind
+from app.db.models.idempotency import IdempotencyRecord
+from app.db.models.species import Species
+from app.services.idempotency import (
+    IDEMPOTENCY_TTL,
+    IDEMPOTENCY_UNIQUE_CONSTRAINT,
+    ReceiptWriteFailed,
+    canonical_payload_hash,
+    record_response,
+    retry_receipt_after_commit,
+    write_receipt_isolated,
+)
+
+ENDPOINT = "/api/v1/uploads/conformers"
+
+
+def _naive_utcnow() -> datetime:
+    """Match the tz-naive DateTime columns this module reads and writes."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+# A receipt body Postgres will refuse to store in ``jsonb`` regardless of
+# server encoding. This is the encoding-independent stand-in for the
+# em-dash that caused the incident.
+UNSTORABLE_BODY = {"type": "conformer_observation", "note": "bad" + chr(0) + "value"}
+STORABLE_BODY = {"type": "conformer_observation", "id": 1}
+
+
+def _species_kwargs(marker: str) -> dict:
+    """A minimal but real science row — the 'payload' these tests protect."""
+    return {
+        "kind": MoleculeKind.molecule,
+        "smiles": f"[He]{marker}",
+        "inchi_key": "SWQJXJOGLNCZEY" + "-UHFFFAOYSA-N",
+        "charge": 0,
+        "multiplicity": 1,
+        "stereo_kind": StereoKind.unspecified,
+    }
+
+
+def _receipt_kwargs(user_id: int, key: str) -> dict:
+    return {
+        "user_id": user_id,
+        "request_method": "POST",
+        "endpoint": ENDPOINT,
+        "idempotency_key": key,
+        "payload_hash": canonical_payload_hash({"marker": key}),
+        "status_code": 201,
+    }
+
+
+@pytest.fixture
+def committed_scratch(db_engine, _api_test_user):
+    """Give a test a real, committing session plus guaranteed cleanup.
+
+    Every other fixture in the suite isolates by rolling a transaction
+    back, which is precisely the thing under test here: a rollback would
+    hide the bug rather than expose it. So these tests commit for real and
+    clean up after themselves by marker.
+
+    Yields ``(user_id, marker)``; deletes every row carrying ``marker`` on
+    the way out, whether the test passed or failed.
+    """
+    marker = "recisol"
+    keys: list[str] = []
+
+    def _register(key: str) -> str:
+        keys.append(key)
+        return key
+
+    try:
+        yield _api_test_user, marker, _register
+    finally:
+        with Session(db_engine) as cleanup:
+            cleanup.execute(
+                delete(Species).where(Species.smiles.like(f"[He]{marker}%"))
+            )
+            if keys:
+                cleanup.execute(
+                    delete(IdempotencyRecord).where(
+                        IdempotencyRecord.idempotency_key.in_(keys)
+                    )
+                )
+            cleanup.commit()
+
+
+class TestPayloadSurvivesReceiptFailure:
+    """The regression that matters: a bad receipt must not take the science with it."""
+
+    def test_payload_is_present_after_commit_when_the_receipt_cannot_be_written(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Reproduces the incident shape and asserts the payload survives.
+
+        On the pre-fix code the receipt shares the payload's transaction,
+        the commit fails, and the species row is gone. The assertion is
+        made from a *separate session*, so it reads committed state and
+        cannot be satisfied by objects still sitting in an identity map.
+        """
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-payload-survives-01")
+        smiles = _species_kwargs(f"{marker}-a")["smiles"]
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-a")))
+
+            with pytest.raises(ReceiptWriteFailed):
+                write_receipt_isolated(
+                    session,
+                    **_receipt_kwargs(user_id, key),
+                    response_body=UNSTORABLE_BODY,
+                )
+
+            # The receipt failed; the payload must still commit cleanly.
+            session.commit()
+
+        with Session(db_engine) as verify:
+            stored = verify.scalar(select(Species).where(Species.smiles == smiles))
+            assert stored is not None, (
+                "the upload payload was destroyed by a failing idempotency receipt"
+            )
+            assert verify.scalar(
+                select(IdempotencyRecord).where(
+                    IdempotencyRecord.idempotency_key == key
+                )
+            ) is None, "a receipt that failed to write must not be left behind"
+
+    def test_session_stays_usable_after_a_receipt_failure(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """A failed receipt rolls back to its SAVEPOINT, not the transaction.
+
+        The route continues after ``idem.record`` returns, so the session
+        must still accept writes; a poisoned transaction would surface as
+        ``PendingRollbackError`` on the next flush.
+        """
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-still-usable-02")
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-b")))
+            session.flush()
+
+            with pytest.raises(ReceiptWriteFailed):
+                write_receipt_isolated(
+                    session,
+                    **_receipt_kwargs(user_id, key),
+                    response_body=UNSTORABLE_BODY,
+                )
+
+            # Still usable: more payload can be written after the failure.
+            session.add(Species(**_species_kwargs(f"{marker}-c")))
+            session.commit()
+
+        with Session(db_engine) as verify:
+            found = verify.scalars(
+                select(Species).where(Species.smiles.like(f"[He]{marker}-%"))
+            ).all()
+            assert {s.smiles for s in found} == {
+                f"[He]{marker}-b",
+                f"[He]{marker}-c",
+            }
+
+    def test_payload_flushed_before_the_savepoint_is_not_rolled_back(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Unflushed payload must not be swept into the receipt's SAVEPOINT.
+
+        ``write_receipt_isolated`` flushes the session *before* opening the
+        savepoint. Without that, any payload still pending at receipt time
+        would be INSERTed inside the savepoint and rolled back with it —
+        the same data loss through a subtler door.
+        """
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-pending-payload-03")
+
+        with Session(db_engine) as session:
+            # Deliberately NOT flushed: still pending when the receipt runs.
+            session.add(Species(**_species_kwargs(f"{marker}-d")))
+
+            with pytest.raises(ReceiptWriteFailed):
+                write_receipt_isolated(
+                    session,
+                    **_receipt_kwargs(user_id, key),
+                    response_body=UNSTORABLE_BODY,
+                )
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{marker}-d")
+            ) is not None
+
+
+class TestReceiptFailureIsLoud:
+    def test_failure_carries_a_reason(self, db_engine, committed_scratch) -> None:
+        """The raised error names the cause; diagnosis must not require reading source."""
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-reason-04")
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-e")))
+            with pytest.raises(ReceiptWriteFailed) as excinfo:
+                write_receipt_isolated(
+                    session,
+                    **_receipt_kwargs(user_id, key),
+                    response_body=UNSTORABLE_BODY,
+                )
+            session.rollback()
+
+        assert excinfo.value.reason
+        assert excinfo.value.__cause__ is not None
+
+    def test_service_logs_the_failure_at_error(
+        self, db_engine, committed_scratch, caplog
+    ) -> None:
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-logged-05")
+
+        with caplog.at_level(logging.ERROR, logger="app.services.idempotency"):
+            with Session(db_engine) as session:
+                with pytest.raises(ReceiptWriteFailed):
+                    write_receipt_isolated(
+                        session,
+                        **_receipt_kwargs(user_id, key),
+                        response_body=UNSTORABLE_BODY,
+                    )
+                session.rollback()
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "a receipt failure must be logged loudly by the server"
+        joined = " ".join(r.getMessage() for r in errors)
+        assert key in joined
+        assert ENDPOINT in joined
+
+
+class TestNormalPathUnchanged:
+    def test_receipt_and_payload_commit_together(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The success path is still atomic: one commit, both rows."""
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-normal-06")
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-f")))
+            record = write_receipt_isolated(
+                session,
+                **_receipt_kwargs(user_id, key),
+                response_body=STORABLE_BODY,
+            )
+            assert record is not None
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{marker}-f")
+            ) is not None
+            stored = verify.scalar(
+                select(IdempotencyRecord).where(
+                    IdempotencyRecord.idempotency_key == key
+                )
+            )
+            assert stored is not None
+            assert stored.status_code == 201
+            assert stored.response_body_json == STORABLE_BODY
+
+    def test_payload_rollback_still_discards_the_receipt(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The original contract holds: a rolled-back write leaves no receipt.
+
+        Releasing the savepoint does not make the receipt durable on its
+        own — it is still inside the caller's transaction, so a retryable
+        failure after ``record`` discards it exactly as before.
+        """
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-rollback-07")
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-g")))
+            write_receipt_isolated(
+                session,
+                **_receipt_kwargs(user_id, key),
+                response_body=STORABLE_BODY,
+            )
+            session.rollback()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(IdempotencyRecord).where(
+                    IdempotencyRecord.idempotency_key == key
+                )
+            ) is None
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{marker}-g")
+            ) is None
+
+
+class TestExpiredReceiptInScope:
+    """An expired key is documented to behave as if never used.
+
+    The uniqueness scope has no notion of expiry, so the new receipt used
+    to collide with the expired row still sitting on disk — surfacing at
+    ``COMMIT`` as a ``409`` that rolled the upload back, whenever the
+    unscheduled ``delete_expired_records`` sweep had not run.
+    """
+
+    def test_expired_record_is_replaced(
+        self, db_engine, committed_scratch
+    ) -> None:
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-expired-12")
+
+        with Session(db_engine) as seed:
+            record_response(
+                seed,
+                **_receipt_kwargs(user_id, key),
+                response_body={"stale": True},
+                now=_naive_utcnow() - IDEMPOTENCY_TTL - timedelta(days=1),
+            )
+            seed.commit()
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-j")))
+            write_receipt_isolated(
+                session,
+                **_receipt_kwargs(user_id, key),
+                response_body=STORABLE_BODY,
+            )
+            session.commit()
+
+        with Session(db_engine) as verify:
+            records = verify.scalars(
+                select(IdempotencyRecord).where(
+                    IdempotencyRecord.idempotency_key == key
+                )
+            ).all()
+            assert len(records) == 1
+            assert records[0].response_body_json == STORABLE_BODY
+
+    def test_live_record_in_scope_still_conflicts(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Only the expired row is cleared — a live one is still a 409."""
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-live-13")
+
+        with Session(db_engine) as seed:
+            record_response(
+                seed, **_receipt_kwargs(user_id, key), response_body=STORABLE_BODY
+            )
+            seed.commit()
+
+        with Session(db_engine) as session:
+            with pytest.raises(IntegrityError):
+                write_receipt_isolated(
+                    session,
+                    **_receipt_kwargs(user_id, key),
+                    response_body=STORABLE_BODY,
+                )
+            session.rollback()
+
+
+class TestReceiptRetry:
+    """A failed receipt is retryable once the payload is durable.
+
+    The savepoint keeps the payload safe but leaves idempotency broken for
+    that key: a retry would re-execute rather than replay. Re-attempting the
+    receipt in its own transaction — only ever *after* the payload commits —
+    turns a transient failure into a recoverable one.
+    """
+
+    def test_retry_writes_the_receipt_in_a_separate_transaction(
+        self, db_engine, committed_scratch
+    ) -> None:
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-retry-09")
+
+        recovered = retry_receipt_after_commit(
+            lambda: Session(db_engine),
+            **_receipt_kwargs(user_id, key),
+            response_body=STORABLE_BODY,
+        )
+
+        assert recovered is True
+        with Session(db_engine) as verify:
+            stored = verify.scalar(
+                select(IdempotencyRecord).where(
+                    IdempotencyRecord.idempotency_key == key
+                )
+            )
+            assert stored is not None
+            assert stored.response_body_json == STORABLE_BODY
+
+    def test_retry_reports_failure_without_raising(
+        self, db_engine, committed_scratch, caplog
+    ) -> None:
+        """A permanently-unstorable receipt must not raise into the commit path.
+
+        This runs after the response has been sent; anything escaping here
+        would surface as an unhandled error on a request that already
+        succeeded.
+        """
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-retry-fails-10")
+
+        with caplog.at_level(logging.ERROR, logger="app.services.idempotency"):
+            recovered = retry_receipt_after_commit(
+                lambda: Session(db_engine),
+                **_receipt_kwargs(user_id, key),
+                response_body=UNSTORABLE_BODY,
+            )
+
+        assert recovered is False
+        joined = " ".join(
+            r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+        )
+        assert key in joined
+
+    def test_retry_does_not_join_the_callers_transaction(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The retry's own rollback must not be able to reach the payload.
+
+        A retry session sharing the caller's connection would share its
+        transaction, and rolling back a failed retry could roll back the
+        write it exists to protect — the original bug, reintroduced through
+        the repair. Here the caller's transaction is left uncommitted and
+        the retry runs anyway; the caller's rows must still be pending, not
+        destroyed, when it finally commits.
+        """
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-retry-isolated-11")
+
+        with Session(db_engine) as caller:
+            caller.add(Species(**_species_kwargs(f"{marker}-i")))
+            caller.flush()
+
+            retry_receipt_after_commit(
+                lambda: Session(db_engine),
+                **_receipt_kwargs(user_id, key),
+                response_body=STORABLE_BODY,
+            )
+
+            caller.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{marker}-i")
+            ) is not None
+
+
+class TestConcurrentDuplicateStillConflicts:
+    """A duplicate key is a conflict, not a receipt malfunction.
+
+    Before this change a concurrent duplicate surfaced as a unique-constraint
+    violation at commit, which rolled the write back and returned ``409``.
+    Isolating the receipt must not downgrade that into "receipt failed, 201" —
+    that would let both racers store their science under one key.
+    """
+
+    def test_unique_violation_propagates_and_aborts_the_write(
+        self, db_engine, committed_scratch
+    ) -> None:
+        user_id, marker, register = committed_scratch
+        key = register(f"{marker}-duplicate-08")
+
+        # Pre-existing committed receipt for the same scope.
+        with Session(db_engine) as seed:
+            record_response(
+                seed, **_receipt_kwargs(user_id, key), response_body=STORABLE_BODY
+            )
+            seed.commit()
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs(f"{marker}-h")))
+            with pytest.raises(IntegrityError) as excinfo:
+                write_receipt_isolated(
+                    session,
+                    **_receipt_kwargs(user_id, key),
+                    response_body=STORABLE_BODY,
+                )
+            constraint = getattr(
+                getattr(excinfo.value.orig, "diag", None), "constraint_name", None
+            )
+            assert constraint == IDEMPOTENCY_UNIQUE_CONSTRAINT
+            # The route's error path rolls back — no half-stored science.
+            session.rollback()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{marker}-h")
+            ) is None


### PR DESCRIPTION
On 2026-08-05 an upload completed, `201 Created` was returned with the row IDs in the body, and **nothing was stored**. The idempotency receipt shared the payload's transaction, so when the receipt failed to serialise, the commit took the species, reaction and calculations with it — after the client had been told it succeeded.

The encoding cause is fixed (the database was converted to UTF-8). The shape was not: **any** commit-time failure confined to the receipt destroys the science it receipts for.

## Proof the bug was real

One harness — real upload route, real workflow, real committing session — run against pre-fix sources from `a75ece8` (installed via `git show`, never `git checkout`), then against the fix, changing nothing else:

| | pre-fix `a75ece8` | with fix |
|---|---|---|
| HTTP status | `201` | `201` |
| Response body | `species_entry_id:1, conformer_group_id:1, calculation_id:1` | same |
| **Science rows stored** | **0** | **1** |

The forcing function is a NUL byte in the receipt body — rejected by `jsonb` in *every* server encoding (SQLSTATE 22P05) — so the regression is pinned without depending on the em-dash/`SQL_ASCII` cause that has since been removed.

## The mechanism

`write_receipt_isolated()` — a SAVEPOINT, in two parts that both matter:

1. **Flush before the savepoint opens**, so pending payload rows are already INSERTed outside it. Without this, anything the route had not yet flushed gets swept into the savepoint and rolled back with the receipt — the same data loss through a subtler door.
2. **Savepoint around the receipt alone.** On failure it rolls back to the savepoint; the outer transaction and its payload survive, and the session stays usable.

The success path is unchanged — savepoint released, receipt still commits atomically with the payload, a later rollback still discards both. The replay contract is untouched.

A unique violation on the idempotency scope is deliberately **re-raised unwrapped** rather than treated as a receipt failure: that collision is a genuine concurrent duplicate and must still abort and return `409`. Swallowing it would let both racers store science under one key.

## What the client is told

**`201` plus `Idempotency-Receipt: failed` and `Idempotency-Receipt-Reason: <SQLSTATE>`.**

The upload genuinely succeeded, so `201` is truthful about the science. Failing the request would lie in the *more dangerous* direction: a 5xx invites a retry, and with no receipt on file that retry re-executes the upload and **duplicates** the science — trading silent loss for silent duplication.

But a bare `201` is the pre-fix behaviour and is precisely what made this invisible, so the outcome now rides on every response. A header rather than a body field, so it covers all ~15 keyed write endpoints without touching a response schema. Server-side it logs at ERROR with key, endpoint, user, SQLSTATE and traceback; the original incident left only an access-log line reading `201`.

**Retry:** a failed receipt is re-attempted once in its own transaction from an `after_commit` hook — after the payload is durable is the only safe moment, since a receipt written earlier would, if the payload rolled back, replay a success for science that does not exist. The retry binds to the **engine**, never the caller's `Connection`: a session joining that connection shares its transaction, and rolling back a failed retry could roll back the very write it was protecting. That was hit during development and there is now a test pinning it.

## Two latent bugs this surfaced

- **Expired keys could never be reused.** `find_existing_record` ignores expired rows so the route re-executes — but the row is still on disk and the uniqueness scope has no notion of expiry, so the new receipt collided with the corpse at COMMIT. Documented behaviour ("expired keys behave as new") was actually a 409 that rolled the upload back. Expired rows are now cleared before insert; a live one still collides.
- **Concurrent job enqueue told the loser `202`, then lost the job.** Detection previously happened at the loser's own `commit()`, so it received `202` and its job vanished on rollback — the same incident shape. Detection now happens in-request.

## Verification

`test-scientific.sh` **1975 passed** (baseline exact); `test-api.sh` **2434 passed** (2424 baseline + 10 new); `ruff check app tests scripts` clean. 24 new tests — the service-level ones use genuine top-level `COMMIT`s and assert from **brand-new sessions**, because the shared `client` fixture never commits and would report success either way.

## Same shape elsewhere — reported, not fixed

`mark_upload_ingested` (`upload_submission.py:148`) is the highest risk: called at the end of *every* `/uploads/*` route on the line immediately before `idem.record`, writing `Text` + `JSONB` — the same two column types that failed — into the payload's transaction. It has not fired only because the summary is currently a server-built f-string. Also `contribution_bundle_submit.py:302` and `open_upload_submission`. Tracked as #45; a broader survey found five more, including a live concurrency bug tracked as #44.

`record_failed_upload` is already safe and is the pattern worth copying: fresh session factory, own transaction, catch-all, explicitly best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)