### PR TITLE
Stop the smoke test demanding a dependency it does not supply

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -157,14 +157,28 @@ jobs:
             docker logs smoke-api 2>&1 | tail -50
             exit 1
           }
-          # Having migrated above, the deployment must now report itself fully
-          # healthy. Asserting only on the worker would let a broken database
-          # component pass unnoticed.
-          echo "$status" | grep -q '"status":"ok"' || {
-            echo "::error::image did not report status=ok after migrating"
+          # Every component this environment actually provides must be healthy.
+          #
+          # Deliberately NOT `status == ok`. This harness starts a database and
+          # nothing else, so `/status` correctly reports `artifact_storage` as
+          # degraded -- there is no object store to reach. Asserting overall ok
+          # would make the smoke test demand a dependency it never supplies,
+          # which is how it broke when artifact storage was added as a
+          # component. Asserting only on the worker would let a broken database
+          # pass unnoticed, so both are checked directly, and `degraded` is
+          # pinned to exactly the one component this harness omits -- anything
+          # else appearing there is a real regression.
+          echo "$status" | grep -q '"database":{"healthy":true' || {
+            echo "::error::image reported an unhealthy database after migrating"
             docker logs smoke-api 2>&1 | tail -50
             exit 1
           }
+          degraded="$(echo "$status" | sed -n 's/.*"degraded":\[\([^]]*\)\].*/\1/p')"
+          if [ "$degraded" != '"artifact_storage"' ] && [ -n "$degraded" ]; then
+            echo "::error::unexpected degraded components: ${degraded}"
+            docker logs smoke-api 2>&1 | tail -50
+            exit 1
+          fi
 
           docker rm -f smoke-api smoke-db >/dev/null
           docker network rm smoke-net >/dev/null


### PR DESCRIPTION
The image build for `fe2a3ac` failed, so `main` is currently **not deployable**.

Adding artifact storage to `/status` (#105) is the cause, and the endpoint is behaving correctly. The smoke harness starts a database and nothing else, so `/status` now honestly reports:

```json
{"status":"degraded","degraded":["artifact_storage"],
 "components":{"database":{"healthy":true,...},
               "worker":{"thread_alive":true,...},
               "artifact_storage":{"healthy":false,"reachable":false,
                 "reason":"cannot reach object store (EndpointConnectionError)"}}}
```

and the harness asserted `status == ok`.

**The assertion was wrong, not the endpoint** — it demanded a component the environment never supplied. That is the failure mode a health check acquires the moment it becomes honest about its dependencies, and it will recur for every component added later.

## What it asserts now

Asserting only on the worker would let a broken database pass unnoticed, so both are checked directly, and `degraded` is pinned to **exactly** the one component this harness omits. Anything else appearing there is a real regression and still fails the build.

Verified in both directions before pushing — against the body that actually failed the build:

```
db assertion: PASS      parsed degraded: ["artifact_storage"]      => would PASS
```

and against a synthetic body with the database degraded as well:

```
=> correctly FAILS ("database","artifact_storage")
```

## The alternative I did not take

Giving the smoke test its own MinIO would exercise more of the real path, but the harness exists to prove *the image imports, migrates and serves* — not to stand up the full dependency stack. Requiring every dependency would make it slower and more brittle for no additional signal about the image itself. If artifact storage ever needs end-to-end coverage in CI, that belongs in the API gate, which already has fixtures for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)