### PR TITLE
Stop bookkeeping from destroying the science it describes

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -79,13 +79,29 @@ def get_write_db() -> Iterator[Session]:
     """Yield a database session that commits on success, rolls back on error.
 
     Use this for endpoints that mutate data (uploads, creates).
+
+    The ``commit`` here runs in dependency *teardown* — after the route
+    function has returned and after any decorator wrapping it has finished.
+    That makes this the only place in the request that can observe a
+    commit-time failure, which is the failure class where the response has
+    already been determined and the work is nonetheless gone. So the error
+    path gives ``app.services.upload_submission`` the chance to write the
+    durable failed-upload audit its route decorator structurally cannot
+    reach; the call no-ops for every session that is not a decorated
+    synchronous upload, and never raises.
     """
     session = SessionLocal()
     try:
         yield session
         session.commit()
-    except Exception:
+    except Exception as exc:
         session.rollback()
+        # Imported lazily: ``app.services.upload_submission`` reaches back
+        # into this module for ``SessionLocal``, and a module-level import
+        # would close that loop.
+        from app.services.upload_submission import audit_upload_failure_at_commit
+
+        audit_upload_failure_at_commit(session, exc)
         raise
     finally:
         session.close()

--- a/backend/app/services/best_effort.py
+++ b/backend/app/services/best_effort.py
@@ -1,0 +1,97 @@
+"""Run an opportunistic, write-bearing enrichment without risking the payload.
+
+Several upload hooks are declared best-effort: parameter extraction from an
+input artifact, single-point-energy reconciliation from an output log, Hessian
+extraction. Each *enriches* an artifact that has already been persisted, and
+each route says so — "best-effort (never abort the upload)".
+
+A ``try``/``except`` alone does not deliver that promise once the hook writes
+to the database, and the reason is easy to miss:
+
+* **A swallowed database error leaves the transaction aborted.** PostgreSQL
+  marks the (sub)transaction failed at the point of error. Catching the
+  exception in Python does not undo that; the next statement fails with
+  "current transaction is aborted", and if nothing else touches the session
+  the poison surfaces at ``COMMIT`` — after the response has been determined.
+  A catch-all with no ``ROLLBACK TO SAVEPOINT`` is therefore *worse* than no
+  catch-all: it converts a loud, immediate failure into a silent one that
+  lands where it destroys the payload.
+
+* **An unflushed mutation fails somewhere else entirely.** A hook that only
+  assigns to a mapped attribute has issued no SQL when it returns. Its
+  ``UPDATE`` is emitted by whatever flushes next — in practice the commit —
+  which is outside every guard the hook wrote. This is the exact shape of the
+  2026-08-05 incident.
+
+:func:`isolated_best_effort` addresses both, and mirrors
+:func:`app.services.idempotency.write_receipt_isolated`:
+
+1. **Flush before the savepoint opens**, so rows the caller has pending are
+   INSERTed outside it and cannot be rolled back with the enrichment.
+2. **Savepoint around the enrichment alone**, with a flush *inside* it so a
+   deferred failure surfaces where the savepoint can still absorb it.
+3. **Roll back to the savepoint on any exception**, leaving the outer
+   transaction alive, the payload intact, and the session usable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, TypeVar
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def isolated_best_effort(
+    session: Session,
+    work: Callable[[], T],
+    *,
+    what: str,
+) -> T | None:
+    """Run *work* inside a ``SAVEPOINT``; return its value, or ``None`` on failure.
+
+    :param session: The caller's session. Its transaction and everything
+        already written into it survive any failure of *work*.
+    :param work: The enrichment. May read, write, and flush freely.
+    :param what: Short description used in the log line when *work* fails,
+        e.g. ``"hessian extraction for 'freq.log'"``.
+
+    Never raises. A failure is logged at ``WARNING`` with a traceback and
+    reported as ``None``; the caller continues with its canonical work.
+
+    Note that ``None`` is not by itself a failure signal — several hooks
+    legitimately return ``None`` when there is nothing to do. Callers that
+    must tell the two apart should have *work* return a sentinel.
+    """
+    # Part 1: get the caller's pending rows out of the savepoint's blast radius.
+    session.flush()
+
+    # Part 2: the enrichment, and only the enrichment, inside the savepoint.
+    savepoint = session.begin_nested()
+    try:
+        result = work()
+        # Flush *inside* the savepoint so an unstorable value fails here,
+        # where it can be absorbed, rather than at the caller's COMMIT.
+        session.flush()
+    except Exception as exc:
+        # Undo the enrichment and nothing else. Without this the aborted
+        # (sub)transaction would poison every later statement in the request.
+        savepoint.rollback()
+        logger.warning(
+            "%s skipped after a failure confined to it (%s); the upload is "
+            "unaffected and was not aborted.",
+            what,
+            type(exc).__name__,
+            exc_info=exc,
+        )
+        return None
+
+    savepoint.commit()
+    return result
+
+
+__all__ = ["isolated_best_effort"]

--- a/backend/app/services/calculation_parameter_extraction.py
+++ b/backend/app/services/calculation_parameter_extraction.py
@@ -43,6 +43,7 @@ from app.services import (
     molpro_parameter_parser,
     orca_parameter_parser,
 )
+from app.services.best_effort import isolated_best_effort
 from app.services.artifact_storage import (
     ArtifactStorageUnavailable,
     load_artifact_bytes,
@@ -369,18 +370,41 @@ def _extract_safe(
     *,
     source: str,
 ) -> list[CalculationParameter] | None:
-    """Run extraction and convert any ``ParameterExtractionError`` to a warning.
+    """Run extraction as a genuinely best-effort operation.
 
     ``extract_and_store_calculation_parameters`` is parse-first /
-    write-second, so if this raises ``ParameterExtractionError`` no
-    ``calculation_parameter`` rows have been written and the
-    surrounding artifact transaction is safe.
+    write-second, and ``ParameterExtractionError`` is raised only by the parse
+    half, where no ``calculation_parameter`` rows have been written yet. That
+    is why catching it alone used to look sufficient.
+
+    It was not. The write half does real work — ``persist_calculation_parameters``
+    issues a ``DELETE`` of the previous parser rows and then ``INSERT``s the new
+    batch — and a database error there is not a ``ParameterExtractionError``.
+    It escaped this guard entirely and aborted the artifact upload, despite the
+    calling route declaring the whole step "best-effort (never abort the
+    upload)". The guard existed; it just did not cover the writes.
+
+    :func:`isolated_best_effort` now covers both halves: the artifact rows the
+    route already persisted are flushed outside the savepoint, the extraction
+    runs and flushes inside it, and any failure rolls back to the savepoint
+    with the upload intact and the session still usable for the artifacts that
+    follow in the same request.
     """
 
-    try:
-        return extract_and_store_calculation_parameters(session, calculation, text)
-    except ParameterExtractionError as exc:
-        logger.warning(
-            "calculation_parameter extraction skipped (%s): %s", source, exc
-        )
-        return None
+    def _run() -> list[CalculationParameter] | None:
+        try:
+            return extract_and_store_calculation_parameters(
+                session, calculation, text
+            )
+        except ParameterExtractionError as exc:
+            # A parse-layer refusal is expected and unremarkable — an
+            # unrecognised or malformed input file — so it keeps its quieter,
+            # message-carrying log line rather than a traceback.
+            logger.warning(
+                "calculation_parameter extraction skipped (%s): %s", source, exc
+            )
+            return None
+
+    return isolated_best_effort(
+        session, _run, what=f"calculation_parameter extraction ({source})"
+    )

--- a/backend/app/services/calculation_parameter_extraction.py
+++ b/backend/app/services/calculation_parameter_extraction.py
@@ -43,11 +43,11 @@ from app.services import (
     molpro_parameter_parser,
     orca_parameter_parser,
 )
-from app.services.best_effort import isolated_best_effort
 from app.services.artifact_storage import (
     ArtifactStorageUnavailable,
     load_artifact_bytes,
 )
+from app.services.best_effort import isolated_best_effort
 from app.services.calculation_resolution import (
     persist_calculation_parameters,
     record_software_reconciliation,

--- a/backend/app/services/geometry_validation.py
+++ b/backend/app/services/geometry_validation.py
@@ -95,6 +95,7 @@ from app.db.models.common import (
 from app.db.models.geometry import Geometry
 from app.schemas.fragments.geometry import GeometryPayload
 from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.services.best_effort import isolated_best_effort
 
 logger = logging.getLogger(__name__)
 
@@ -368,21 +369,37 @@ def run_and_persist_geometry_validation(
         )
         return None
 
-    row = CalculationGeometryValidation(
-        calculation_id=calculation.id,
-        input_geometry_id=result.input_geometry_id,
-        output_geometry_id=result.output_geometry_id,
-        species_smiles=result.species_smiles,
-        is_isomorphic=result.is_isomorphic,
-        rmsd=result.rmsd,
-        atom_mapping=result.atom_mapping,
-        n_mappings=result.n_mappings,
-        validation_status=result.validation_status,
-        validation_reason=result.validation_reason,
-        rmsd_warning_threshold=result.rmsd_warning_threshold,
+    def _persist() -> CalculationGeometryValidation:
+        row = CalculationGeometryValidation(
+            calculation_id=calculation.id,
+            input_geometry_id=result.input_geometry_id,
+            output_geometry_id=result.output_geometry_id,
+            species_smiles=result.species_smiles,
+            is_isomorphic=result.is_isomorphic,
+            rmsd=result.rmsd,
+            atom_mapping=result.atom_mapping,
+            n_mappings=result.n_mappings,
+            validation_status=result.validation_status,
+            validation_reason=result.validation_reason,
+            rmsd_warning_threshold=result.rmsd_warning_threshold,
+        )
+        session.add(row)
+        return row
+
+    # The write is isolated for the same reason the ``except`` above exists:
+    # this is best-effort by policy and must never abort the upload. Catching
+    # the chemistry call alone did not deliver that, because the row was added
+    # without a flush — so its INSERT was emitted by whatever flushed next, in
+    # practice the route's COMMIT, outside every guard here. That is the
+    # 2026-08-05 shape: a verdict *about* a calculation taking the calculation
+    # with it. ``isolated_best_effort`` flushes inside a savepoint so an
+    # unstorable ``atom_mapping``/``validation_reason`` fails where it can be
+    # absorbed.
+    return isolated_best_effort(
+        session,
+        _persist,
+        what=f"geometry validation for calculation id={calculation.id}",
     )
-    session.add(row)
-    return row
 
 
 CHECK_OPT_GEOMETRY_MATCHES_DECLARED_SPECIES = ScientificCheck(

--- a/backend/app/services/hessian_extraction.py
+++ b/backend/app/services/hessian_extraction.py
@@ -52,6 +52,7 @@ from app.db.models.calculation import (
 from app.db.models.common import ArtifactKind, CalculationType
 from app.db.models.geometry import Geometry, GeometryAtom
 from app.schemas.fragments.artifact import ArtifactIn
+from app.services.best_effort import isolated_best_effort
 from app.services.hessian_parsing import (
     HESSIAN_PARSER_VERSION,
     ParsedHessian,
@@ -97,23 +98,23 @@ def try_extract_hessian_from_artifact_upload(
     ``kind`` is compared by value across the ``tckdb_schemas`` / ORM enum
     boundary (both are ``(str, Enum)`` with identical members), matching the
     sibling energy hook.
+
+    Isolation is via :func:`isolated_best_effort`, not a bare catch-all. A
+    database error swallowed without a ``ROLLBACK TO SAVEPOINT`` leaves the
+    transaction aborted, so the previous ``except Exception`` converted a
+    loud, immediate failure into a silent one that resurfaced at the caller's
+    ``COMMIT`` — where it takes the artifact upload with it.
     """
     if artifact_in.kind not in _HESSIAN_ARTIFACT_KINDS:
         return
     if calculation.type not in _HESSIAN_CALC_TYPES:
         return
 
-    try:
-        _extract_and_store(session, calculation, artifact_in)
-    except Exception:
-        # Artifact upload is canonical and must never be aborted by an
-        # extraction failure — swallow anything and log it.
-        logger.warning(
-            "hessian extraction failed for artifact '%s'",
-            artifact_in.filename,
-            exc_info=True,
-        )
-        return
+    isolated_best_effort(
+        session,
+        lambda: _extract_and_store(session, calculation, artifact_in),
+        what=f"hessian extraction for artifact '{artifact_in.filename}'",
+    )
 
 
 def _extract_and_store(
@@ -265,7 +266,18 @@ def _insert(
             )
         )
         session.flush()
-    except IntegrityError:
+    except Exception as exc:
+        # Wider than the concurrent-duplicate ``IntegrityError`` this was
+        # written for: a savepoint whose failure is not rolled back leaves the
+        # transaction aborted, and the caller's safety net would then hide
+        # that until COMMIT. Undoing the insert is right regardless of cause.
         savepoint.rollback()
         session.expire(calculation, ["hessian"])
+        if not isinstance(exc, IntegrityError):
+            logger.warning(
+                "hessian insert skipped for calculation id=%s (%s)",
+                calculation.id,
+                type(exc).__name__,
+                exc_info=exc,
+            )
         return

--- a/backend/app/services/literature_resolution.py
+++ b/backend/app/services/literature_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.models.common import LiteratureKind
@@ -113,21 +114,19 @@ def resolve_literature_submission(
     )
 
 
-def resolve_or_create_literature(
+def _select_existing_literature(
     session: Session,
-    request: LiteratureUploadRequest,
-) -> Literature:
-    """Resolve or create a literature row from workflow submission data.
+    *,
+    normalized_doi: str | None,
+    normalized_isbn: str | None,
+) -> Literature | None:
+    """Look up an existing citation by normalized DOI, then normalized ISBN.
 
-    :param session: Active SQLAlchemy session.
-    :param request: Workflow-facing literature submission payload.
-    :returns: Existing or newly created ``Literature`` row.
-    :raises ValueError: If identifier normalization or literature resolution fails.
+    Shared by the pre-insert check and the concurrent-insert recovery so both
+    answer "is this citation already here?" the same way.
+
+    :raises ValueError: If the DOI and ISBN resolve to two different rows.
     """
-
-    normalized_doi = normalize_doi(request.doi)
-    normalized_isbn = normalize_isbn(request.isbn) if request.isbn is not None else None
-
     existing_by_doi = None
     if normalized_doi is not None:
         existing_by_doi = session.scalar(
@@ -147,25 +146,83 @@ def resolve_or_create_literature(
     ):
         raise ValueError("DOI and ISBN resolve to different existing literature rows")
 
-    existing = existing_by_doi or existing_by_isbn
+    return existing_by_doi or existing_by_isbn
+
+
+def resolve_or_create_literature(
+    session: Session,
+    request: LiteratureUploadRequest,
+) -> Literature:
+    """Resolve or create a literature row from workflow submission data.
+
+    Idempotent across transactions as well as within one: a concurrent upload
+    that creates the same citation first is adopted rather than collided with.
+
+    :param session: Active SQLAlchemy session.
+    :param request: Workflow-facing literature submission payload.
+    :returns: Existing or newly created ``Literature`` row.
+    :raises ValueError: If identifier normalization or literature resolution fails.
+    """
+
+    normalized_doi = normalize_doi(request.doi)
+    normalized_isbn = normalize_isbn(request.isbn) if request.isbn is not None else None
+
+    existing = _select_existing_literature(
+        session,
+        normalized_doi=normalized_doi,
+        normalized_isbn=normalized_isbn,
+    )
     if existing is not None:
         return existing
 
     literature_create = resolve_literature_submission(session, request)
-    literature = Literature(
-        kind=literature_create.kind,
-        title=literature_create.title,
-        journal=literature_create.journal,
-        year=literature_create.year,
-        volume=literature_create.volume,
-        issue=literature_create.issue,
-        pages=literature_create.pages,
-        doi=literature_create.doi,
-        isbn=literature_create.isbn,
-        url=str(literature_create.url) if literature_create.url is not None else None,
-        publisher=literature_create.publisher,
-        institution=literature_create.institution,
-    )
-    session.add(literature)
-    session.flush()
+
+    def _build() -> Literature:
+        return Literature(
+            kind=literature_create.kind,
+            title=literature_create.title,
+            journal=literature_create.journal,
+            year=literature_create.year,
+            volume=literature_create.volume,
+            issue=literature_create.issue,
+            pages=literature_create.pages,
+            doi=literature_create.doi,
+            isbn=literature_create.isbn,
+            url=(
+                str(literature_create.url)
+                if literature_create.url is not None
+                else None
+            ),
+            publisher=literature_create.publisher,
+            institution=literature_create.institution,
+        )
+
+    # Check-then-insert against the normalized DOI/ISBN uniqueness indexes
+    # (``ix_literature_doi_normalized`` / ``ix_literature_isbn_normalized``).
+    # Two contributors citing the same paper at the same time both read
+    # ``None`` above, and the loser's violation would abort a transaction that
+    # already holds its entire upload — literature is resolved *during*
+    # deposit, so the collateral is scientific records, not a citation.
+    #
+    # Every sibling resolver (species, reaction, geometry, software,
+    # calculation, energy-correction) already wraps its identity insert this
+    # way; this one was the exception. Losing the race is not a conflict: the
+    # winner's row is the same citation this call was about to create, so the
+    # loser adopts it, exactly as it would have done had it arrived a moment
+    # later.
+    try:
+        with session.begin_nested():
+            literature = _build()
+            session.add(literature)
+            session.flush()
+    except IntegrityError:
+        existing = _select_existing_literature(
+            session,
+            normalized_doi=normalized_doi,
+            normalized_isbn=normalized_isbn,
+        )
+        if existing is None:
+            # Not the identity race — a genuinely broken row. Let it out.
+            raise
+        return existing
     return literature

--- a/backend/app/services/record_review.py
+++ b/backend/app/services/record_review.py
@@ -37,6 +37,7 @@ from datetime import datetime, timezone
 from typing import Iterable, Optional
 
 from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from app.api.errors import DomainError
@@ -56,6 +57,12 @@ _CURATION_ROLES = frozenset({AppUserRole.curator, AppUserRole.admin})
 
 #: Role recorded on ``submission_record_link`` rows for artifact evidence.
 _ARTIFACT_LINK_ROLE = "artifact"
+
+#: Uniqueness scope that makes "one review row per record" true.
+_RECORD_REVIEW_UNIQUE_CONSTRAINT = "uq_record_review_record"
+
+#: Uniqueness scope for ``(submission, record, role)`` attachment.
+_RECORD_LINK_UNIQUE_CONSTRAINT = "uq_submission_record_link_identity"
 
 _TERMINAL_STATUSES = frozenset(
     {
@@ -247,6 +254,97 @@ def list_record_review_events(
 # ---------------------------------------------------------------------------
 
 
+def _insert_or_adopt_review(
+    session: Session,
+    *,
+    record_type: SubmissionRecordType,
+    record_id: int,
+    status: RecordReviewStatus,
+    submission_id: Optional[int],
+    created_by: Optional[int],
+    note: Optional[str],
+) -> tuple[RecordReview, bool]:
+    """Create the review row for one record, or adopt a concurrent one.
+
+    Returns ``(review, created)``. ``created`` is ``False`` when another
+    transaction got there first — the caller must then *not* append a
+    ``created`` event, because the row was only ever created once.
+
+    **Why this is not a plain check-then-insert.** The review row's targets
+    include reused identity rows — ``species_entry``, ``reaction_entry``,
+    ``conformer_group`` — that resolution deliberately dedupes *across*
+    uploads. Two contributors depositing against the same molecule at the
+    same time therefore aim at the same ``(record_type, record_id)``. Before
+    this, both read ``None``, both INSERTed, and the loser took a
+    ``uq_record_review_record`` violation as the **last statement of its
+    upload workflow** — poisoning a transaction that already held every
+    scientific row it had just persisted, so ``get_write_db`` rolled the
+    whole upload back. No exotic content was required: two people working on
+    one shared species is the normal case for a shared database, and the
+    window is not the instant between the SELECT and the INSERT but the
+    *entire duration* of the winner's transaction, during which it holds the
+    uncommitted unique-index entry.
+
+    **Adopt rather than fail.** Losing the race is not a conflict; it is the
+    documented outcome arriving by a different route. This helper already
+    returns the existing row unchanged when it finds one, and the review row
+    describes the *identity*, which both uploads legitimately share. Adopting
+    therefore reaches exactly the state a sequential pair of uploads reaches,
+    and nothing is lost: per-submission traceability lives in
+    ``submission_record_link``, which is written per submission, so the
+    loser's contribution is still fully attributed even though it did not
+    author the review row. Failing instead would destroy a correct upload to
+    protect a row that already says what the loser wanted it to say.
+
+    **Why ``ON CONFLICT`` rather than a ``SAVEPOINT``.** The neighbouring
+    identity resolvers (``resolve_species``, ``resolve_reaction``) use
+    ``begin_nested()`` + ``IntegrityError``, but they insert *one* row per
+    upload while this runs once per target — tens to hundreds of times for a
+    single network upload. That many subtransactions push a transaction past
+    PostgreSQL's 64-entry ``pg_subtrans`` cache and degrade concurrent
+    readers. ``ON CONFLICT DO NOTHING`` needs no subtransaction, blocks on a
+    concurrent uncommitted insert and then resolves cleanly rather than by
+    raising, and — the part that matters most — leaves the database to
+    discriminate the expected collision from a genuine integrity failure. An
+    FK violation on ``submission_id`` still raises normally instead of being
+    swallowed by a blanket ``except IntegrityError``.
+    """
+    values = {
+        "record_type": record_type,
+        "record_id": record_id,
+        "status": status,
+        "submission_id": submission_id,
+        "created_by": created_by,
+        "note": note,
+    }
+    # ``session.execute`` autoflushes, so anything the caller has pending —
+    # the upload's scientific rows — is INSERTed before this statement and is
+    # never entangled with it.
+    inserted_id = session.execute(
+        pg_insert(RecordReview)
+        .values(**values)
+        .on_conflict_do_nothing(constraint=_RECORD_REVIEW_UNIQUE_CONSTRAINT)
+        .returning(RecordReview.id)
+    ).scalar_one_or_none()
+
+    if inserted_id is not None:
+        review = session.get(RecordReview, inserted_id)
+        assert review is not None  # just inserted in this transaction
+        return review, True
+
+    # Lost the race. Under READ COMMITTED the winner's row is visible now:
+    # ``ON CONFLICT`` blocked until that transaction resolved.
+    adopted = get_record_review(
+        session, record_type=record_type, record_id=record_id
+    )
+    if adopted is None:  # pragma: no cover - would mean the conflict vanished
+        raise DomainError(
+            "Review row for this record conflicted on insert but could not be "
+            "read back; the record's review state is indeterminate."
+        )
+    return adopted, False
+
+
 def ensure_record_review(
     session: Session,
     *,
@@ -262,6 +360,10 @@ def ensure_record_review(
     First call inserts. Subsequent calls return the existing row unchanged
     — this helper does not mutate ``status`` once written. Use
     :func:`set_record_review_status` (or ``bulk_*``) for status changes.
+
+    Idempotent across transactions as well as within one: a concurrent
+    upload that creates the row first is adopted rather than collided with.
+    See :func:`_insert_or_adopt_review` for why that is the correct outcome.
 
     The default ``status=not_reviewed`` is for internal/nested callers that
     create records outside a contribution event. Both ingestion pathways —
@@ -284,7 +386,8 @@ def ensure_record_review(
     if existing is not None:
         return existing
 
-    review = RecordReview(
+    review, created = _insert_or_adopt_review(
+        session,
         record_type=record_type,
         record_id=record_id,
         status=status,
@@ -292,8 +395,11 @@ def ensure_record_review(
         created_by=created_by,
         note=note,
     )
-    session.add(review)
-    session.flush()
+    if not created:
+        # Someone else created it; ``record_review_event`` is append-only
+        # history and must not claim this identity entered review twice.
+        return review
+
     _emit_review_event(
         session,
         review=review,
@@ -337,7 +443,11 @@ def set_record_review_status(
     if existing is None:
         # Bootstrap row at not_reviewed and then transition, so the
         # transition policy and reviewer-stamp logic below run uniformly.
-        existing = RecordReview(
+        # Same check-then-insert race as ``ensure_record_review`` — two
+        # curators acting on one record at once — and the same resolution:
+        # adopt the row the other transaction created and transition that.
+        existing, created = _insert_or_adopt_review(
+            session,
             record_type=record_type,
             record_id=record_id,
             status=RecordReviewStatus.not_reviewed,
@@ -345,16 +455,15 @@ def set_record_review_status(
             created_by=None,
             note=None,
         )
-        session.add(existing)
-        session.flush()
-        _emit_review_event(
-            session,
-            review=existing,
-            event_kind=RecordReviewEventKind.created,
-            from_status=None,
-            to_status=RecordReviewStatus.not_reviewed,
-            actor_user_id=None,
-        )
+        if created:
+            _emit_review_event(
+                session,
+                review=existing,
+                event_kind=RecordReviewEventKind.created,
+                from_status=None,
+                to_status=RecordReviewStatus.not_reviewed,
+                actor_user_id=None,
+            )
 
     previous_status = existing.status
     previous_reviewed_by = existing.reviewed_by
@@ -549,31 +658,29 @@ def _ensure_record_link(
     (``app.services.submission`` imports from here). Review-target links use
     ``role=None``; artifact evidence links use ``role="artifact"``. The
     curated links the bundle workflow makes remain its own responsibility.
+
+    ``ON CONFLICT DO NOTHING`` for the same reasons as
+    :func:`_insert_or_adopt_review`, with which this shares a loop: it makes
+    the idempotency one atomic statement instead of a check-then-insert, and
+    costs no subtransaction per target. ``uq_submission_record_link_identity``
+    is declared ``NULLS NOT DISTINCT``, so a ``role=None`` link collides with
+    an existing ``role=None`` link exactly as intended.
+
+    A collision here is currently only reachable within one transaction (a
+    submission id is not visible to another session until its creating
+    upload commits), so this is hardening rather than a live-race fix — but
+    it also removes a per-target ``SELECT``.
     """
-    role_predicate = (
-        SubmissionRecordLink.role.is_(None)
-        if role is None
-        else SubmissionRecordLink.role == role
-    )
-    existing = session.scalar(
-        select(SubmissionRecordLink).where(
-            SubmissionRecordLink.submission_id == submission_id,
-            SubmissionRecordLink.record_type == record_type,
-            SubmissionRecordLink.record_id == record_id,
-            role_predicate,
-        )
-    )
-    if existing is not None:
-        return
-    session.add(
-        SubmissionRecordLink(
+    session.execute(
+        pg_insert(SubmissionRecordLink)
+        .values(
             submission_id=submission_id,
             record_type=record_type,
             record_id=record_id,
             role=role,
         )
+        .on_conflict_do_nothing(constraint=_RECORD_LINK_UNIQUE_CONSTRAINT)
     )
-    session.flush()
 
 
 def _artifact_ids_for_calculations(

--- a/backend/app/services/record_review.py
+++ b/backend/app/services/record_review.py
@@ -708,8 +708,26 @@ def apply_review_policy(
 ) -> list[RecordReview]:
     """Workflow-side entry point for ensuring review rows post-persist.
 
-    Idempotent — existing review rows are returned unchanged. Pass
-    ``policy=None`` to opt out (used by callers that only want to recurse
+    Idempotent — existing review rows are returned unchanged, including one
+    created by a *concurrent* upload against the same deduped identity (see
+    :func:`_insert_or_adopt_review`). This is the last statement of every
+    upload workflow, so it runs holding a transaction that already contains
+    the whole payload; it must not be able to collide with a row that says
+    what it was about to say.
+
+    It is deliberately not otherwise isolated from that payload. Unlike the
+    idempotency receipt or the ``ingestion_succeeded`` audit event, a
+    ``record_review`` row is not a description of the science — it is the
+    record's admission ticket into the review pipeline. A record deposited
+    without one reads as ``not_reviewed`` (``_NO_REVIEW_ROW_RANK`` in
+    ``app.services.scientific_read.sql_review``), indistinguishable from a
+    legacy internal record, and without its ``submission_record_link`` no
+    curator can ever approve it. Swallowing a failure here would store
+    stranded science and return ``201``. And because this runs before the
+    response is determined, failing yields an honest ``5xx`` to a client that
+    can retry the same payload — a recoverable outcome, unlike the incident's.
+
+    Pass ``policy=None`` to opt out (used by callers that only want to recurse
     into nested workflows without double-writing).
 
     When the policy carries a ``submission_id`` and ``link_records`` is set,

--- a/backend/app/services/sp_energy_extraction.py
+++ b/backend/app/services/sp_energy_extraction.py
@@ -36,6 +36,7 @@ from tckdb_schemas.upload_warning import UploadWarning
 from app.db.models.calculation import Calculation, CalculationSPResult
 from app.db.models.common import ArtifactKind, CalculationType
 from app.schemas.fragments.artifact import ArtifactIn
+from app.services.best_effort import isolated_best_effort
 from app.services.sp_energy_reconciliation import (
     SpEnergyAction,
     SpEnergyReconciliation,
@@ -63,6 +64,18 @@ def try_reconcile_sp_energy_from_output_upload(
     failure — a broad safety net guarantees the canonical artifact upload
     is never aborted by a reconciliation error, matching the sibling
     parameter-extraction hook.
+
+    The safety net is :func:`isolated_best_effort` rather than a bare
+    ``try``/``except``. Catching the exception was never enough on its own:
+
+    * The fill path's in-place ``existing.electronic_energy_hartree = energy``
+      issues no SQL, so an unstorable value used to fail at the caller's
+      ``COMMIT`` — outside this guard, after the response was determined.
+      The savepoint's flush now surfaces it here instead.
+    * A database error that reached the old ``except Exception`` left the
+      transaction aborted, because nothing rolled back to a savepoint. The
+      catch-all then *hid* that until commit. Swallowing without rolling back
+      is worse than not swallowing at all.
     """
     # ``artifact_in.kind`` is typed against ``tckdb_schemas.enums.ArtifactKind``
     # while ``ArtifactKind`` here is the parallel ORM enum; both are
@@ -73,17 +86,11 @@ def try_reconcile_sp_energy_from_output_upload(
     if calculation.type != CalculationType.sp:
         return None
 
-    try:
-        return _reconcile_and_fill(session, calculation, artifact_in)
-    except Exception:
-        # Artifact upload is canonical and must never be aborted by a
-        # reconciliation failure — swallow anything and log it.
-        logger.warning(
-            "sp_energy reconciliation failed for artifact '%s'",
-            artifact_in.filename,
-            exc_info=True,
-        )
-        return None
+    return isolated_best_effort(
+        session,
+        lambda: _reconcile_and_fill(session, calculation, artifact_in),
+        what=f"sp_energy reconciliation for artifact '{artifact_in.filename}'",
+    )
 
 
 def _reconcile_and_fill(
@@ -151,8 +158,20 @@ def _fill(
             )
         )
         session.flush()
-    except IntegrityError:
+    except Exception as exc:
+        # The concurrent-duplicate ``IntegrityError`` is the expected case,
+        # but the ``except`` is deliberately wider. A savepoint whose failure
+        # is not rolled back leaves the transaction aborted, and the hook's
+        # outer safety net would then hide that until the caller's COMMIT.
+        # Whatever went wrong, undoing the fill is the correct response.
         savepoint.rollback()
         session.expire(calculation, ["sp_result"])
+        if not isinstance(exc, IntegrityError):
+            logger.warning(
+                "sp_energy fill skipped for calculation id=%s (%s)",
+                calculation.id,
+                type(exc).__name__,
+                exc_info=exc,
+            )
         return None
     return outcome.warning

--- a/backend/app/services/upload_submission.py
+++ b/backend/app/services/upload_submission.py
@@ -20,11 +20,29 @@ Usage in a route (flat, exception-safe by ordering)::
 
 Transaction management stays with the route's ``get_write_db`` dependency. If
 the wrapped workflow raises, control never reaches
-:func:`mark_upload_ingested`, and the whole transaction — submission, audit,
-record links, review rows, and scientific records — rolls back together. There
-is therefore no orphan-submission state to clean up on the synchronous path,
-and ``ingestion_failed`` is reserved for a future async/two-phase path that can
-commit a failure record independently.
+:func:`mark_upload_ingested`, the whole transaction rolls back, and
+:func:`record_failed_upload` writes the durable failure audit in a session of
+its own. There is therefore no orphan-submission state to clean up on the
+synchronous path.
+
+**The audit event does not get a vote on the science.** An earlier version of
+this note argued the coupling was a feature — "the whole transaction rolls
+back together" — and that reasoning is what produced the 2026-08-05 incident
+one line further down, where a failing idempotency receipt destroyed the
+upload it receipted for. The two directions are not symmetric:
+
+* Workflow fails → the audit event is meaningless and must roll back. Kept.
+* Audit event fails → the science is already correct, already persisted, and
+  irreproducible in the sense that nothing else in the system can regenerate
+  it. Letting a row that merely *describes* the upload veto it inverts what
+  the database is for.
+
+So :func:`mark_upload_ingested` confines its write to a ``SAVEPOINT`` and
+degrades to a loud log rather than taking the upload down with it. The
+remaining audit trail — the ``submission`` row, its ``submission_created``
+event, the record links and the review rows — is untouched by that
+degradation, so a lost ``ingestion_succeeded`` event costs one line of history
+and never a scientific record.
 
 A submission is the audit wrapper for an upload event; it is *not* a claim of
 scientific approval. ``submission.status`` stays ``pending`` (awaiting curator
@@ -150,17 +168,68 @@ def mark_upload_ingested(
     sub: UploadSubmissionContext,
     *,
     summary: Optional[str] = None,
-) -> None:
+) -> bool:
     """Append the ``ingestion_succeeded`` audit event for a finished upload.
 
     Status is unchanged (``pending``): successful ingestion is not scientific
     approval.
+
+    Returns ``True`` when the event was appended, ``False`` when it could not
+    be and was skipped. **Never raises** for a reason confined to the event
+    itself — see the module docstring for why a description must not be able
+    to veto the thing it describes.
+
+    The isolation has the same two parts as
+    :func:`app.services.idempotency.write_receipt_isolated`, which sits one
+    line below this in all eleven synchronous upload routes:
+
+    1. **Flush first**, so every pending scientific row is INSERTed *outside*
+       the savepoint. Without this, anything the workflow had not yet flushed
+       would be swept into the savepoint and rolled back alongside a failing
+       audit event — the same data loss through a subtler door.
+    2. **Savepoint around the event alone.** On failure the savepoint rolls
+       back, the outer transaction and its payload survive, and the session
+       stays usable for the rest of the request (``idem.record`` still runs).
+
+    On success the savepoint is released and the event commits with the
+    payload exactly as before.
+
+    This has not yet fired in production only because ``summary`` is currently
+    a server-built f-string. It is not a server-only field: the signature
+    accepts arbitrary ``summary`` text, and
+    :func:`app.services.submission.mark_ingestion_succeeded` accepts arbitrary
+    ``details_json`` — ``Text`` and ``JSONB``, the same two column types that
+    failed in the incident.
     """
-    mark_ingestion_succeeded(
-        session,
-        submission=sub.submission,
-        summary=summary or f"Ingested {sub.kind.value} upload via direct API.",
-    )
+    text = summary or f"Ingested {sub.kind.value} upload via direct API."
+
+    # Part 1: get the payload out of the savepoint's blast radius.
+    session.flush()
+
+    # Part 2: the audit event, and only the audit event, inside the savepoint.
+    savepoint = session.begin_nested()
+    try:
+        mark_ingestion_succeeded(
+            session,
+            submission=sub.submission,
+            summary=text,
+        )
+    except Exception as exc:
+        savepoint.rollback()
+        logger.error(
+            "ingestion_succeeded audit event could not be written for "
+            "submission_id=%s (kind=%s): %s. The upload itself succeeded and "
+            "its scientific records, review rows and record links are intact; "
+            "only this line of the submission's audit history is missing.",
+            sub.submission_id,
+            sub.kind.value,
+            type(exc).__name__,
+            exc_info=exc,
+        )
+        return False
+
+    savepoint.commit()
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +292,12 @@ def record_failed_upload(
         return None
 
 
+#: Key under which a sync upload route parks its failure-audit intent on the
+#: write session, so ``get_write_db`` can finish the job the decorator cannot
+#: reach. See :func:`audit_sync_upload_failure`.
+SYNC_UPLOAD_AUDIT_KEY = "sync_upload_failure_audit"
+
+
 def audit_sync_upload_failure(kind: SubmissionKind) -> Callable:
     """Decorator: durably audit a synchronous upload route's failures.
 
@@ -231,16 +306,43 @@ def audit_sync_upload_failure(kind: SubmissionKind) -> Callable:
     (see :func:`record_failed_upload`) before propagating — the scientific
     transaction still rolls back atomically. The handler must take a
     ``current_user`` keyword (every upload route does).
+
+    **The blind spot this closes.** A decorator can only observe what happens
+    inside the function it wraps, and the route function is not where an
+    upload finishes. ``get_write_db`` commits in dependency *teardown*, after
+    the route has returned — so a commit-time failure raises outside this
+    ``try`` entirely and used to leave **no failed-upload audit row for
+    precisely the failure class that matters most**: the one where the
+    response was already determined and the work is already gone. The
+    2026-08-05 incident was exactly such a failure, and it is invisible in the
+    audit tables for exactly this reason.
+
+    The intent (who, what kind) is therefore parked on the write session under
+    :data:`SYNC_UPLOAD_AUDIT_KEY` *before* the handler runs, so
+    :func:`app.api.deps.get_write_db` can record the audit for a failure this
+    wrapper never sees. ``audited`` guards against both paths recording the
+    same failure twice.
     """
 
     def decorator(fn: Callable) -> Callable:
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
+            user = kwargs.get("current_user")
+            session = kwargs.get("session")
+            state: Optional[dict] = None
+            if user is not None and isinstance(session, Session):
+                state = {
+                    "created_by": user.id,
+                    "kind": kind,
+                    "audited": False,
+                }
+                session.info[SYNC_UPLOAD_AUDIT_KEY] = state
             try:
                 return fn(*args, **kwargs)
             except Exception as exc:
-                user = kwargs.get("current_user")
                 if user is not None:
+                    if state is not None:
+                        state["audited"] = True
                     record_failed_upload(
                         created_by=user.id,
                         kind=kind,
@@ -253,9 +355,41 @@ def audit_sync_upload_failure(kind: SubmissionKind) -> Callable:
     return decorator
 
 
+def audit_upload_failure_at_commit(session: Session, exc: BaseException) -> None:
+    """Record the failure audit for an upload that died after the route returned.
+
+    Called from :func:`app.api.deps.get_write_db`'s error path, which is the
+    only place that can see a commit-time failure. No-ops for every session
+    that is not a decorated synchronous upload, and for one whose failure the
+    decorator already audited.
+
+    Best-effort by construction — :func:`record_failed_upload` swallows its
+    own errors — so this can never mask the exception on its way out.
+    """
+    state = session.info.get(SYNC_UPLOAD_AUDIT_KEY)
+    if not isinstance(state, dict) or state.get("audited"):
+        return
+    state["audited"] = True
+    logger.error(
+        "Synchronous %s upload failed at commit, after the route returned "
+        "(%s). Nothing was stored; recording the failed-upload audit that the "
+        "route decorator could not reach.",
+        state["kind"].value,
+        type(exc).__name__,
+        exc_info=exc,
+    )
+    record_failed_upload(
+        created_by=state["created_by"],
+        kind=state["kind"],
+        error_summary=f"{type(exc).__name__}: {exc}",
+    )
+
+
 __all__ = [
+    "SYNC_UPLOAD_AUDIT_KEY",
     "UploadSubmissionContext",
     "audit_sync_upload_failure",
+    "audit_upload_failure_at_commit",
     "mark_upload_ingested",
     "open_job_submission",
     "open_upload_submission",

--- a/backend/app/workers/upload_worker.py
+++ b/backend/app/workers/upload_worker.py
@@ -376,6 +376,96 @@ def _fail_expired_exhausted_jobs(session: Session) -> int:
     return reaped
 
 
+def _append_ingestion_audit(
+    session: Session, job: UploadJob, submission: Submission
+) -> bool:
+    """Append ``ingestion_succeeded`` for a finished job, isolated from the science.
+
+    The event is a description of the ingestion; the ingestion is the fact.
+    Confined to a ``SAVEPOINT`` after an explicit flush so a ``Text``/``JSONB``
+    failure here costs one line of audit history rather than the scientific
+    records the job just persisted. Returns whether the event was written.
+    """
+    session.flush()
+    savepoint = session.begin_nested()
+    try:
+        mark_ingestion_succeeded(
+            session,
+            submission=submission,
+            summary=f"Ingested async {job.kind.value} job.",
+        )
+    except Exception as exc:
+        savepoint.rollback()
+        logger.error(
+            "ingestion_succeeded audit event could not be written for job %s "
+            "(submission_id=%s): %s. The job's scientific records are intact; "
+            "only this line of the submission's audit history is missing.",
+            job.id,
+            submission.id,
+            type(exc).__name__,
+            exc_info=exc,
+        )
+        return False
+    savepoint.commit()
+    return True
+
+
+def _store_job_result(session: Session, job: UploadJob, result) -> None:
+    """Write ``job.result``, isolated so it cannot cost the job its science.
+
+    ``result`` is presentational: it is what the polling client renders. It is
+    also arbitrary handler output going into a ``JSONB`` column, so a value
+    PostgreSQL will not store — a NUL character, an unserialisable object —
+    fails **deterministically**. Sharing the persistence transaction, that
+    meant every retry failed identically on the same value until
+    ``max_attempts`` was exhausted, and a presentational field permanently
+    prevented the science from ever being stored.
+
+    So the terminal job state — ``status``, ``completed_at``, the cleared
+    lease — is flushed *before* the savepoint opens, and only the ``result``
+    assignment goes inside it. That ordering is deliberate and is the reason
+    this is not simply wrapped wholesale: the terminal state is **not**
+    bookkeeping. It is the exactly-once fence. If the science committed while
+    the job stayed claimable, the reaper would re-lease it and a second run
+    would duplicate the records. The fence belongs in the primary unit; only
+    the rendering of the outcome does not.
+
+    On failure the job still completes, carrying a stand-in that says what
+    happened instead of the value that could not be stored.
+    """
+    savepoint = session.begin_nested()
+    try:
+        job.result = result
+        session.flush()
+    except Exception as exc:
+        savepoint.rollback()
+        logger.error(
+            "job %s finished successfully but its result could not be stored "
+            "(%s). The scientific records are committed and the job is marked "
+            "complete; the polling client sees a placeholder instead of the "
+            "result body.",
+            job.id,
+            type(exc).__name__,
+            exc_info=exc,
+        )
+        fallback = session.begin_nested()
+        try:
+            job.result = {
+                "result_unavailable": True,
+                "reason": type(exc).__name__,
+            }
+            session.flush()
+        except Exception:  # pragma: no cover - the stand-in is trivially storable
+            fallback.rollback()
+            logger.exception(
+                "job %s could not store even the placeholder result", job.id
+            )
+            return
+        fallback.commit()
+        return
+    savepoint.commit()
+
+
 def run_one_job(session: Session, job: UploadJob) -> None:
     """Execute a claimed job and write the result/error back to the row.
 
@@ -383,6 +473,10 @@ def run_one_job(session: Session, job: UploadJob) -> None:
     under review and linked to the submission, and an ``ingestion_succeeded``
     audit event is appended. The submission status stays ``pending`` —
     successful ingestion is not scientific approval.
+
+    Everything after the handler returns is about *describing* what the
+    handler did, with one exception: the terminal job state is the fence that
+    makes processing exactly-once. See :func:`_store_job_result`.
     """
     handler = _DISPATCH.get(job.kind)
     if handler is None:
@@ -398,20 +492,19 @@ def run_one_job(session: Session, job: UploadJob) -> None:
     result = handler(session, job, policy)
 
     if submission is not None:
-        mark_ingestion_succeeded(
-            session,
-            submission=submission,
-            summary=f"Ingested async {job.kind.value} job.",
-        )
+        _append_ingestion_audit(session, job, submission)
         if isinstance(result, dict):
             result = {**result, "submission_id": submission.id}
 
+    # The exactly-once fence, flushed outside any savepoint.
     job.status = UploadJobStatus.complete
     job.completed_at = _utcnow()
     job.lease_expires_at = None
     job.heartbeat_at = _utcnow()
-    job.result = result
     job.error = None
+    session.flush()
+
+    _store_job_result(session, job, result)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/workflows/contribution_bundle_submit.py
+++ b/backend/app/workflows/contribution_bundle_submit.py
@@ -14,9 +14,19 @@ Transaction management lives in the route's ``get_write_db`` dependency:
 this function only needs to *raise* on failure for everything (including
 the submission, audit, and link rows it created moments earlier) to roll
 back atomically.
+
+That atomicity is right for the import and its record links, and wrong for
+the audit event, and the difference is what a row *is* rather than when it is
+written. A ``submission_record_link`` is load-bearing — approval flips exactly
+the linked records, so a bundle imported without its links is permanently
+unapprovable. The ``ingestion_succeeded`` event describes an import that has
+already happened. Only the latter is confined to a ``SAVEPOINT``; see
+:func:`_append_import_audit` and the comments at each site.
 """
 
 from __future__ import annotations
+
+import logging
 
 from sqlalchemy.orm import Session
 
@@ -56,6 +66,62 @@ from app.services.submission import (
 )
 from app.workflows.kinetics import persist_kinetics_upload
 from app.workflows.thermo import persist_thermo_upload
+
+logger = logging.getLogger(__name__)
+
+
+def _append_import_audit(
+    session: Session,
+    *,
+    submission,
+    bundle_kind: BundleKind,
+    imported_count: int,
+    linked_count: int,
+) -> bool:
+    """Append ``ingestion_succeeded`` without risking the imported bundle.
+
+    Lowest failure probability in this workflow, largest blast radius: it runs
+    after the biggest payload the API accepts has been fully imported. The
+    event's ``summary`` is ``Text`` and its ``details_json`` is ``JSONB`` — the
+    two column types that failed in the 2026-08-05 incident — so it is flushed
+    inside a ``SAVEPOINT``, after an explicit flush that puts the whole import
+    outside the savepoint's reach.
+
+    Returns whether the event was written. Never raises for a reason confined
+    to the event.
+    """
+    session.flush()
+    savepoint = session.begin_nested()
+    try:
+        mark_ingestion_succeeded(
+            session,
+            submission=submission,
+            summary=(
+                f"Imported {imported_count} {bundle_kind.value} "
+                f"record(s) from contribution bundle."
+            ),
+            details_json={
+                "bundle_kind": bundle_kind.value,
+                "records_imported": imported_count,
+                "records_linked": linked_count,
+            },
+        )
+    except Exception as exc:
+        savepoint.rollback()
+        logger.error(
+            "ingestion_succeeded audit event could not be written for bundle "
+            "submission_id=%s (kind=%s): %s. The bundle imported successfully "
+            "and its records, links and review rows are intact; only this line "
+            "of the submission's audit history is missing.",
+            submission.id,
+            bundle_kind.value,
+            type(exc).__name__,
+            exc_info=exc,
+        )
+        return False
+    savepoint.commit()
+    return True
+
 
 # ---------------------------------------------------------------------------
 # Dry-run gate
@@ -281,6 +347,16 @@ def submit_contribution_bundle(
     # 4. Create record links — products and immediate identity parents,
     #    deduped per (record_type, record_id) since a bundle may touch the
     #    same species_entry from multiple uploads.
+    #
+    #    These are deliberately NOT isolated from the import, unlike the audit
+    #    event below. A ``submission_record_link`` is not a description of the
+    #    bundle; it is the index a curator approves *through*
+    #    (``approve_submission`` flips exactly the linked records). A bundle
+    #    imported with missing links would be permanently unapprovable —
+    #    stranded science that reads as ``not_reviewed`` forever. And because
+    #    this runs before the response is determined, failing here yields an
+    #    honest error to a client that can simply resubmit the same bundle.
+    #    Isolation would trade a recoverable failure for an unrecoverable one.
     seen: set[tuple[SubmittedRecordType, int]] = set()
     for rec in records:
         key = (rec.record_type, rec.record_id)
@@ -296,21 +372,22 @@ def submit_contribution_bundle(
 
     # 5. Audit-log the successful import. Status stays at ``pending`` —
     #    ingestion success is not curator approval.
+    #
+    #    This one *is* isolated. It is purely a description of an import that
+    #    has already happened, and it lands after the largest payload the API
+    #    accepts: the lowest probability of failure in the flow, attached to
+    #    the largest blast radius. Losing it costs one line of a submission's
+    #    audit history, which the submission row, its ``submission_created``
+    #    event, the record links and the review rows all survive.
     imported_count = sum(
         1 for r in records if r.action is SubmittedRecordAction.imported
     )
-    mark_ingestion_succeeded(
+    _append_import_audit(
         session,
         submission=submission,
-        summary=(
-            f"Imported {imported_count} {bundle.bundle_kind.value} "
-            f"record(s) from contribution bundle."
-        ),
-        details_json={
-            "bundle_kind": bundle.bundle_kind.value,
-            "records_imported": imported_count,
-            "records_linked": len(records) - imported_count,
-        },
+        bundle_kind=bundle.bundle_kind,
+        imported_count=imported_count,
+        linked_count=len(records) - imported_count,
     )
 
     # 6. Carry warnings forward; add an ingestion_succeeded info note so

--- a/backend/tests/services/test_best_effort_isolation.py
+++ b/backend/tests/services/test_best_effort_isolation.py
@@ -1,0 +1,299 @@
+"""Opportunistic enrichment hooks must not be able to abort the upload.
+
+``POST /calculations/{id}/artifacts`` persists the artifact rows and then runs
+three enrichment hooks over each artifact, described in the route as
+"best-effort (never abort the upload)": parameter extraction from input files,
+single-point-energy reconciliation from output logs, and Hessian extraction.
+
+Each hook had a guard, and none of the guards covered its writes:
+
+* ``_extract_safe`` caught ``ParameterExtractionError`` — a *parse*-layer
+  exception. ``persist_calculation_parameters`` then issues a ``DELETE`` and a
+  batch of ``INSERT``s, and a database error there is not a
+  ``ParameterExtractionError``. It escaped uncaught.
+
+* The SP-energy and Hessian hooks had ``except Exception`` catch-alls, which
+  is worse rather than better. PostgreSQL marks a transaction aborted at the
+  point of error; catching the exception in Python does not undo that. With no
+  ``ROLLBACK TO SAVEPOINT``, the swallowed error left the session poisoned and
+  the failure resurfaced at ``COMMIT`` — after the response was determined,
+  where it destroys the artifact upload rather than merely the enrichment.
+
+Every assertion is made from a **fresh session after a genuine top-level
+commit**. A NUL character is the encoding-independent stand-in for a value
+PostgreSQL will not store.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.orm import Session
+
+from app.db.models.common import (
+    ArtifactKind,
+    CalculationType,
+    MoleculeKind,
+    StereoKind,
+)
+from app.db.models.species import Species
+from app.schemas.fragments.artifact import ArtifactIn
+from app.services import calculation_parameter_extraction as cpe
+from app.services import hessian_extraction as hess
+from app.services import sp_energy_extraction as spx
+from app.services.best_effort import isolated_best_effort
+
+MARKER = "besteffort"
+
+GAUSSIAN_LOG = (
+    Path(__file__).parent.parent / "fixtures" / "gaussian" / "opt_g09.log"
+)
+
+
+def _species_kwargs(suffix: str) -> dict:
+    return {
+        "kind": MoleculeKind.molecule,
+        "smiles": f"[He]{MARKER}{suffix}",
+        "inchi_key": "SWQJXJOGLNCZEY-UHFFFAOYSA-N",
+        "charge": 0,
+        "multiplicity": 1,
+        "stereo_kind": StereoKind.unspecified,
+    }
+
+
+@pytest.fixture
+def committed_scratch(db_engine):
+    """Commits for real; a rollback would hide the very failure under test."""
+    try:
+        yield
+    finally:
+        with Session(db_engine) as cleanup:
+            cleanup.execute(
+                delete(Species).where(Species.smiles.like(f"[He]{MARKER}%"))
+            )
+            cleanup.commit()
+
+
+def _explode(session: Session) -> None:
+    """Provoke a real, transaction-aborting database error."""
+    session.execute(text("SELECT 1 FROM table_that_does_not_exist"))
+
+
+class TestIsolatedBestEffort:
+    def test_payload_survives_a_failing_enrichment(
+        self, db_engine, committed_scratch
+    ) -> None:
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-a")))
+
+            assert isolated_best_effort(
+                session, lambda: _explode(session), what="test enrichment"
+            ) is None
+
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-a")
+            ) is not None
+
+    def test_session_stays_usable_for_the_rest_of_the_request(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The route loops over every artifact; one bad file must not end it."""
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-b")))
+            isolated_best_effort(
+                session, lambda: _explode(session), what="test enrichment"
+            )
+
+            # A poisoned transaction would fail here, not above.
+            session.add(Species(**_species_kwargs("-c")))
+            session.commit()
+
+        with Session(db_engine) as verify:
+            found = {
+                s.smiles
+                for s in verify.scalars(
+                    select(Species).where(Species.smiles.like(f"[He]{MARKER}-%"))
+                ).all()
+            }
+            assert {f"[He]{MARKER}-b", f"[He]{MARKER}-c"} <= found
+
+    def test_an_unflushed_mutation_fails_inside_the_savepoint(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """A hook that only assigns must not defer its failure to COMMIT.
+
+        This is the 2026-08-05 shape: no SQL is issued by the hook itself, so
+        without a flush inside the savepoint the ``UPDATE``/``INSERT`` is
+        emitted by the commit — outside every guard the hook wrote.
+        """
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-d")))
+
+            def _assign_only() -> None:
+                # Never flushed by the hook; storable only at flush time.
+                session.add(
+                    Species(
+                        **{
+                            **_species_kwargs("-unstorable"),
+                            "smiles": f"[He]{MARKER}" + chr(0) + "x",
+                        }
+                    )
+                )
+
+            assert isolated_best_effort(
+                session, _assign_only, what="test enrichment"
+            ) is None
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-d")
+            ) is not None
+
+    def test_success_returns_the_value_and_keeps_the_write(
+        self, db_engine, committed_scratch
+    ) -> None:
+        with Session(db_engine) as session:
+            def _work() -> str:
+                session.add(Species(**_species_kwargs("-e")))
+                return "done"
+
+            assert isolated_best_effort(session, _work, what="test") == "done"
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-e")
+            ) is not None
+
+    def test_failure_is_logged(self, db_engine, committed_scratch, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="app.services.best_effort"):
+            with Session(db_engine) as session:
+                isolated_best_effort(
+                    session, lambda: _explode(session), what="widget extraction"
+                )
+                session.rollback()
+
+        assert "widget extraction" in " ".join(
+            r.getMessage() for r in caplog.records
+        )
+
+
+class TestParameterExtractionWriteHalf:
+    """Site 5 proper: the guard existed, it just did not cover the writes."""
+
+    def test_a_database_error_in_the_write_half_no_longer_escapes(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        """``_extract_safe`` must survive a failure past the parse layer.
+
+        A real Gaussian log is parsed all the way through — so the parse half
+        genuinely succeeds and control genuinely reaches the writes — and the
+        write is then made to fail the way a database failure does.
+        """
+        calls: list[str] = []
+
+        def _failing_persist(session_, calculation, observations, **kwargs):
+            calls.append("write half reached")
+            _explode(session_)
+
+        monkeypatch.setattr(cpe, "persist_calculation_parameters", _failing_persist)
+
+        class _Calc:
+            """Minimal stand-in: text-sniff dispatch, no software_release."""
+
+            id = 1
+            software_release = None
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-params")))
+
+            assert cpe._extract_safe(
+                session, _Calc(), GAUSSIAN_LOG.read_text(), source="job.inp"
+            ) is None
+            assert calls, "the parse half short-circuited; the writes were never run"
+
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-params")
+            ) is not None
+
+
+class TestCatchAllsThatLeftTheTransactionAborted:
+    """A swallowed DB error without a savepoint rollback is a delayed bomb."""
+
+    def _artifact(self, kind: ArtifactKind) -> ArtifactIn:
+        return ArtifactIn(
+            kind=kind.value, filename="run.log", content_base64="aGVsbG8="
+        )
+
+    def test_hessian_hook_leaves_the_session_usable(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        class _Calc:
+            type = CalculationType.freq
+            id = 1
+
+        with Session(db_engine) as session:
+            monkeypatch.setattr(
+                hess,
+                "_extract_and_store",
+                lambda s, c, a: _explode(session),
+            )
+            session.add(Species(**_species_kwargs("-hess")))
+
+            hess.try_extract_hessian_from_artifact_upload(
+                session, _Calc(), self._artifact(ArtifactKind.output_log)
+            )
+
+            # Pre-fix this raised: the transaction was already aborted.
+            session.add(Species(**_species_kwargs("-hess2")))
+            session.commit()
+
+        with Session(db_engine) as verify:
+            found = {
+                s.smiles
+                for s in verify.scalars(
+                    select(Species).where(Species.smiles.like(f"[He]{MARKER}-hess%"))
+                ).all()
+            }
+            assert found == {f"[He]{MARKER}-hess", f"[He]{MARKER}-hess2"}
+
+    def test_sp_energy_hook_leaves_the_session_usable(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        class _Calc:
+            type = CalculationType.sp
+            id = 1
+
+        with Session(db_engine) as session:
+            monkeypatch.setattr(
+                spx,
+                "_reconcile_and_fill",
+                lambda s, c, a: _explode(session),
+            )
+            session.add(Species(**_species_kwargs("-sp")))
+
+            assert spx.try_reconcile_sp_energy_from_output_upload(
+                session, _Calc(), self._artifact(ArtifactKind.output_log)
+            ) is None
+
+            session.add(Species(**_species_kwargs("-sp2")))
+            session.commit()
+
+        with Session(db_engine) as verify:
+            found = {
+                s.smiles
+                for s in verify.scalars(
+                    select(Species).where(Species.smiles.like(f"[He]{MARKER}-sp%"))
+                ).all()
+            }
+            assert found == {f"[He]{MARKER}-sp", f"[He]{MARKER}-sp2"}

--- a/backend/tests/services/test_concurrent_deposit_isolation.py
+++ b/backend/tests/services/test_concurrent_deposit_isolation.py
@@ -1,0 +1,247 @@
+"""Two more instances of the bug class, found by sweeping for its shape.
+
+Both were located by looking for what the five named sites had in common
+rather than for the sites themselves, and both destroy an upload for a reason
+that is not about the upload.
+
+**Literature.** ``resolve_or_create_literature`` is check-then-insert against
+the normalized DOI/ISBN uniqueness indexes, and it runs *during* deposit — so
+the collateral of losing that race is scientific records, not a citation. Two
+contributors citing the same paper at the same time is at least as ordinary as
+two contributors depositing against the same molecule. Every sibling identity
+resolver (species, reaction, geometry, software, calculation,
+energy-correction) already wraps its insert in ``begin_nested()``; this one
+was the exception.
+
+**Geometry validation.** ``run_and_persist_geometry_validation`` is
+best-effort by policy — its own docstring says "never aborts the upload" and
+"recorded as evidence, never used as a hard upload gate", and its call sites
+in ``computed_species`` / ``computed_reaction`` repeat the promise. But its
+``except Exception`` covered only the chemistry call, and the row was added
+with no flush, so the INSERT was emitted by whatever flushed next — the
+route's COMMIT, outside every guard. A verdict *about* a calculation could
+take the calculation with it.
+
+Assertions are made from a fresh session after a genuine top-level commit.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.db.models.common import MoleculeKind, StereoKind
+from app.db.models.literature import Literature
+from app.db.models.species import Species
+from app.schemas.workflows.literature_upload import LiteratureUploadRequest
+from app.services import geometry_validation as geomval
+from app.services.literature_resolution import resolve_or_create_literature
+
+MARKER = "concurdep"
+DOI = "10.1000/concurdep-shared-paper"
+
+
+def _species_kwargs(suffix: str) -> dict:
+    return {
+        "kind": MoleculeKind.molecule,
+        "smiles": f"[He]{MARKER}{suffix}",
+        "inchi_key": "SWQJXJOGLNCZEY-UHFFFAOYSA-N",
+        "charge": 0,
+        "multiplicity": 1,
+        "stereo_kind": StereoKind.unspecified,
+    }
+
+
+@pytest.fixture
+def committed_scratch(db_engine):
+    """Commits for real; a rollback would hide the failure under test."""
+    try:
+        yield
+    finally:
+        with Session(db_engine) as cleanup:
+            cleanup.execute(delete(Literature).where(Literature.doi == DOI))
+            cleanup.execute(
+                delete(Species).where(Species.smiles.like(f"[He]{MARKER}%"))
+            )
+            cleanup.commit()
+
+
+def _request() -> LiteratureUploadRequest:
+    return LiteratureUploadRequest(
+        doi=DOI,
+        title="A paper two contributors both cite",
+        journal="Journal of Simultaneous Deposits",
+        year=2026,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_doi_lookup(monkeypatch):
+    """Keep the resolver offline; metadata enrichment is not under test."""
+    monkeypatch.setattr(
+        "app.services.literature_resolution.fetch_doi_metadata",
+        lambda doi: {},
+    )
+
+
+class TestConcurrentCitationOfOnePaper:
+    def test_the_loser_adopts_the_citation_and_keeps_its_upload(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The winner holds the uncommitted index entry; the loser must survive.
+
+        Fully ordered so it reproduces every run: the loser reads (nothing),
+        the winner inserts and holds, the loser's INSERT blocks on the unique
+        index, the winner commits, and the loser's INSERT violates.
+        """
+        loser_selected = threading.Event()
+        winner_inserted = threading.Event()
+        outcome: dict[str, object] = {}
+
+        def _loser() -> None:
+            with Session(db_engine) as session:
+                try:
+                    assert session.scalar(
+                        select(Literature).where(Literature.doi == DOI)
+                    ) is None
+                    # The upload's science is already written by the time
+                    # literature is resolved.
+                    session.add(Species(**_species_kwargs("-loser")))
+                    session.flush()
+                    loser_selected.set()
+                    assert winner_inserted.wait(timeout=30)
+
+                    lit = resolve_or_create_literature(session, _request())
+                    outcome["literature_id"] = lit.id
+                    session.commit()
+                except BaseException as exc:
+                    outcome["error"] = exc
+                    session.rollback()
+
+        with Session(db_engine) as winner:
+            assert winner.scalar(
+                select(Literature).where(Literature.doi == DOI)
+            ) is None
+
+            thread = threading.Thread(target=_loser, daemon=True)
+            thread.start()
+            assert loser_selected.wait(timeout=30)
+
+            winner_lit = resolve_or_create_literature(winner, _request())
+            winner_literature_id = winner_lit.id
+            winner_inserted.set()
+            time.sleep(1.5)  # let the loser reach and block on its INSERT
+            winner.commit()
+
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+        assert "error" not in outcome, (
+            f"the second contributor's upload was destroyed: {outcome.get('error')!r}"
+        )
+        assert outcome["literature_id"] == winner_literature_id
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-loser")
+            ) is not None
+            rows = verify.scalars(
+                select(Literature).where(Literature.doi == DOI)
+            ).all()
+            assert len(rows) == 1, "one paper must yield one citation row"
+
+    def test_the_sequential_path_is_unchanged(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Resolving the same DOI twice in one transaction still dedupes."""
+        with Session(db_engine) as session:
+            first = resolve_or_create_literature(session, _request())
+            second = resolve_or_create_literature(session, _request())
+            assert first.id == second.id
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert len(
+                verify.scalars(
+                    select(Literature).where(Literature.doi == DOI)
+                ).all()
+            ) == 1
+
+
+class TestGeometryValidationIsTrulyBestEffort:
+    """Its docstring and both call sites promise it never aborts the upload.
+
+    The behaviour of the isolation itself is pinned by
+    ``tests/services/test_best_effort_isolation.py``; what matters here is
+    that this function's write actually goes through it, because previously
+    the row was added with no flush and its INSERT escaped to the caller's
+    ``COMMIT`` where no guard could reach it.
+    """
+
+    def test_the_persist_step_runs_inside_the_isolation(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        """A failing persist must be absorbed, not raised at the caller."""
+        calls: list[str] = []
+        real_isolate = geomval.isolated_best_effort
+
+        def _tracking_isolate(session, work, *, what):
+            calls.append(what)
+            return real_isolate(session, work, what=what)
+
+        monkeypatch.setattr(geomval, "isolated_best_effort", _tracking_isolate)
+        # Reach the persist step without building a full opt calculation:
+        # everything before it is a pure skip-gate.
+        monkeypatch.setattr(
+            geomval,
+            "validate_calculation_geometry",
+            lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("unreachable in this test")
+            ),
+        )
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-geom")))
+
+            # The persist closure, exercised through the same helper the
+            # function now routes it through, with an unstorable verdict.
+            result = geomval.isolated_best_effort(
+                session,
+                lambda: session.add(
+                    Species(
+                        **{
+                            **_species_kwargs("-unstorable"),
+                            "smiles": f"[He]{MARKER}" + chr(0) + "z",
+                        }
+                    )
+                ),
+                what="geometry validation for calculation id=1",
+            )
+            assert result is None
+            assert calls == ["geometry validation for calculation id=1"]
+
+            # Still usable: the workflow validates every additional calc next.
+            session.add(Species(**_species_kwargs("-geom2")))
+            session.commit()
+
+        with Session(db_engine) as verify:
+            found = {
+                s.smiles
+                for s in verify.scalars(
+                    select(Species).where(Species.smiles.like(f"[He]{MARKER}-geom%"))
+                ).all()
+            }
+            assert found == {f"[He]{MARKER}-geom", f"[He]{MARKER}-geom2"}
+
+    def test_the_function_routes_its_write_through_the_isolation(self) -> None:
+        """Pin the wiring: a future edit must not reintroduce a bare add()."""
+        import inspect
+
+        source = inspect.getsource(geomval.run_and_persist_geometry_validation)
+        assert "isolated_best_effort(" in source, (
+            "geometry validation persistence must stay inside the best-effort "
+            "isolation; a bare session.add() escapes to the caller's COMMIT"
+        )

--- a/backend/tests/services/test_record_review_write_isolation.py
+++ b/backend/tests/services/test_record_review_write_isolation.py
@@ -1,0 +1,427 @@
+"""Two contributors depositing against one shared identity must both survive.
+
+``ensure_record_review`` is check-then-insert against
+``uq_record_review_record``. Its targets include *reused identity rows* —
+``species_entry``, ``reaction_entry``, ``conformer_group`` — that resolution
+deliberately dedupes across uploads. So two contributors depositing against
+the same molecule concurrently both read ``None`` inside
+``ensure_record_review``, both INSERT, and on the pre-fix code the loser takes
+an ``IntegrityError`` that rolls back its entire upload: hundreds of science
+rows destroyed by a bookkeeping row describing something the winner had
+already recorded.
+
+No exotic content is required to trigger this — just two people working at
+once on a shared species, which is the normal case for a shared database.
+
+The window is *inside* ``ensure_record_review``, between its own ``SELECT``
+and its ``INSERT``; a caller that looks first does not widen it, because the
+helper looks again under ``READ COMMITTED`` and sees the winner's committed
+row. Two tests below enter that window from both directions: one
+deterministically (the winner commits between the loser's SELECT and its
+INSERT) and one for real (the loser's INSERT blocks on the winner's
+uncommitted index entry, which is the path two simultaneous uploads actually
+take).
+
+The load-bearing assertion in every test is made from a **fresh session after
+a genuine top-level commit**, never merely "no exception propagated".
+
+``ensure_record_review`` is documented as idempotent ("First call inserts.
+Subsequent calls return the existing row unchanged."). These tests pin that
+the promise now holds across transactions as well as within one.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+import time
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.models.common import (
+    MoleculeKind,
+    RecordReviewStatus,
+    StereoKind,
+    SubmissionRecordType,
+)
+from app.db.models.record_review import RecordReview, RecordReviewEvent
+from app.db.models.species import Species
+from app.services import record_review as record_review_service
+from app.services.record_review import (
+    RecordRef,
+    ReviewPolicy,
+    apply_review_policy,
+    ensure_record_review,
+    get_record_review,
+)
+
+MARKER = "revrace"
+
+#: Synthetic ids, allocated once per module so committed rows from one test
+#: can never be mistaken for a fresh identity by the next. ``record_review``
+#: is polymorphic over ``record_type`` and carries no FK on ``record_id``, so
+#: these need not resolve to live rows for the uniqueness race to be exactly
+#: the real one. ``record_review_event`` is append-only at the database level
+#: (``tckdb_reject_mutation``), so these rows are deliberately never deleted —
+#: the per-run test database is dropped wholesale instead.
+_record_ids = itertools.count(900_100)
+
+
+def _species_kwargs(suffix: str) -> dict:
+    """A minimal but real science row — the 'payload' these tests protect."""
+    return {
+        "kind": MoleculeKind.molecule,
+        "smiles": f"[He]{MARKER}{suffix}",
+        "inchi_key": "SWQJXJOGLNCZEY-UHFFFAOYSA-N",
+        "charge": 0,
+        "multiplicity": 1,
+        "stereo_kind": StereoKind.unspecified,
+    }
+
+
+@pytest.fixture
+def committed_scratch(db_engine):
+    """A committing scratch space with guaranteed payload cleanup.
+
+    Every other fixture in the suite isolates by rolling a transaction back,
+    which is precisely the thing under test here: the loser's rollback is the
+    bug. So these tests commit for real.
+
+    Yields a fresh ``record_id`` allocator. Payload species rows are deleted
+    on the way out, whether the test passed or failed.
+    """
+    try:
+        yield lambda: next(_record_ids)
+    finally:
+        with Session(db_engine) as cleanup:
+            cleanup.execute(
+                delete(Species).where(Species.smiles.like(f"[He]{MARKER}%"))
+            )
+            cleanup.commit()
+
+
+def _commit_winner_during(monkeypatch, *, winner: Session, ref: RecordRef):
+    """Make the winner commit inside the loser's check-then-insert window.
+
+    ``ensure_record_review`` reads, finds nothing, and inserts. This patches
+    the read so that the *first* time it returns ``None``, the competing
+    transaction commits its own row for the same identity before the caller
+    proceeds to INSERT — the exact interleaving of two uploads resolving to
+    one deduped ``species_entry``, made deterministic.
+    """
+    real_get = record_review_service.get_record_review
+    fired = {"done": False}
+
+    def _racing_get(session, *, record_type, record_id):
+        found = real_get(session, record_type=record_type, record_id=record_id)
+        if (
+            found is None
+            and not fired["done"]
+            and record_type is ref.record_type
+            and record_id == ref.record_id
+        ):
+            fired["done"] = True
+            real_ensure = record_review_service.ensure_record_review
+            monkeypatch.setattr(
+                record_review_service, "get_record_review", real_get
+            )
+            try:
+                real_ensure(
+                    winner,
+                    record_type=ref.record_type,
+                    record_id=ref.record_id,
+                    status=RecordReviewStatus.under_review,
+                )
+                winner.commit()
+            finally:
+                monkeypatch.setattr(
+                    record_review_service, "get_record_review", _racing_get
+                )
+        return found
+
+    monkeypatch.setattr(record_review_service, "get_record_review", _racing_get)
+    return fired
+
+
+class TestConcurrentDepositAgainstOneIdentity:
+    """The live race: two uploads, one shared species_entry, no exotic content."""
+
+    def test_loser_adopts_the_existing_review_row_and_keeps_its_payload(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        """The winner commits inside the loser's check-then-insert window.
+
+        On the pre-fix code the loser's INSERT violates
+        ``uq_record_review_record``, the ``IntegrityError`` poisons its
+        transaction, ``get_write_db`` rolls it back, and every scientific row
+        the loser had written goes with it — while nothing was wrong with the
+        loser's science and nothing was wrong with the review row either.
+        """
+        record_id = committed_scratch()
+        ref = RecordRef(SubmissionRecordType.species_entry, record_id)
+
+        winner = Session(db_engine)
+        loser = Session(db_engine)
+        try:
+            winner.add(Species(**_species_kwargs("-winner")))
+            # The loser has already written its science by the time it gets
+            # here — the review row is the *last* statement of every upload
+            # workflow.
+            loser.add(Species(**_species_kwargs("-loser")))
+
+            fired = _commit_winner_during(monkeypatch, winner=winner, ref=ref)
+
+            review = ensure_record_review(
+                loser,
+                record_type=ref.record_type,
+                record_id=ref.record_id,
+                status=RecordReviewStatus.under_review,
+            )
+            assert fired["done"], "the race window was never entered"
+
+            loser.commit()
+        finally:
+            winner.close()
+            loser.close()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-loser")
+            ) is not None, (
+                "the losing contributor's upload was destroyed by a review row "
+                "describing an identity the winner had already recorded"
+            )
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-winner")
+            ) is not None
+            rows = verify.scalars(
+                select(RecordReview).where(RecordReview.record_id == record_id)
+            ).all()
+            assert len(rows) == 1, (
+                "the shared identity must carry exactly one review row"
+            )
+            assert review.id == rows[0].id, (
+                "the loser must adopt the row the winner created for this "
+                "shared identity, not invent a second one"
+            )
+
+    def test_loser_blocked_on_the_index_also_adopts(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The genuinely-concurrent path: the loser's INSERT waits on the index.
+
+        This is the wide window, and the one two simultaneous uploads actually
+        take. The winner INSERTs its review row and then holds the uncommitted
+        unique-index entry for the remainder of its transaction — the rest of
+        an upload, potentially seconds. Any contributor whose ``SELECT`` lands
+        anywhere in that period sees ``None``, blocks on the index at INSERT,
+        and takes the violation the moment the winner commits.
+
+        The handoff below is fully ordered, so this reproduces every run
+        rather than depending on thread scheduling.
+        """
+        record_id = committed_scratch()
+        ref = RecordRef(SubmissionRecordType.species_entry, record_id)
+
+        loser_selected = threading.Event()
+        winner_inserted = threading.Event()
+        outcome: dict[str, object] = {}
+
+        def _loser() -> None:
+            with Session(db_engine) as session:
+                try:
+                    assert get_record_review(
+                        session,
+                        record_type=ref.record_type,
+                        record_id=ref.record_id,
+                    ) is None
+                    session.add(Species(**_species_kwargs("-blocked")))
+                    session.flush()
+                    loser_selected.set()
+                    assert winner_inserted.wait(timeout=30)
+                    # The winner now holds the uncommitted index entry; this
+                    # INSERT blocks until the winner commits, then violates.
+                    review = ensure_record_review(
+                        session,
+                        record_type=ref.record_type,
+                        record_id=ref.record_id,
+                        status=RecordReviewStatus.under_review,
+                    )
+                    outcome["review_id"] = review.id
+                    session.commit()
+                except BaseException as exc:  # surfaced in the main thread
+                    outcome["error"] = exc
+                    session.rollback()
+
+        with Session(db_engine) as winner:
+            assert get_record_review(
+                winner, record_type=ref.record_type, record_id=ref.record_id
+            ) is None
+
+            thread = threading.Thread(target=_loser, daemon=True)
+            thread.start()
+            assert loser_selected.wait(timeout=30)
+
+            review_winner = ensure_record_review(
+                winner,
+                record_type=ref.record_type,
+                record_id=ref.record_id,
+                status=RecordReviewStatus.under_review,
+            )
+            winner_review_id = review_winner.id
+            winner_inserted.set()
+            # Let the loser actually reach (and block on) its INSERT, so the
+            # lock-wait path is the one exercised rather than a plain re-read.
+            time.sleep(1.5)
+            winner.commit()
+
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+        assert "error" not in outcome, (
+            f"the blocked contributor's upload failed: {outcome.get('error')!r}"
+        )
+        assert outcome["review_id"] == winner_review_id
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-blocked")
+            ) is not None
+            rows = verify.scalars(
+                select(RecordReview).where(RecordReview.record_id == record_id)
+            ).all()
+            assert len(rows) == 1
+
+    def test_adopted_row_emits_no_duplicate_created_event(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        """Adoption must not append a second ``created`` event.
+
+        ``record_review_event`` is append-only history, enforced by a database
+        trigger. The row was created once; a loser that re-stamps ``created``
+        would make the history claim the identity entered review twice.
+        """
+        record_id = committed_scratch()
+        ref = RecordRef(SubmissionRecordType.species_entry, record_id)
+
+        winner = Session(db_engine)
+        loser = Session(db_engine)
+        try:
+            _commit_winner_during(monkeypatch, winner=winner, ref=ref)
+            ensure_record_review(
+                loser,
+                record_type=ref.record_type,
+                record_id=ref.record_id,
+                status=RecordReviewStatus.under_review,
+            )
+            loser.commit()
+        finally:
+            winner.close()
+            loser.close()
+
+        with Session(db_engine) as verify:
+            review = verify.scalar(
+                select(RecordReview).where(RecordReview.record_id == record_id)
+            )
+            events = verify.scalars(
+                select(RecordReviewEvent).where(
+                    RecordReviewEvent.record_review_id == review.id
+                )
+            ).all()
+            assert len(events) == 1
+
+    def test_apply_review_policy_survives_the_race_end_to_end(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        """The workflow-level entry point, which is what all 11 uploads call."""
+        record_id = committed_scratch()
+        ref = RecordRef(SubmissionRecordType.species_entry, record_id)
+        policy = ReviewPolicy(status=RecordReviewStatus.under_review)
+
+        winner = Session(db_engine)
+        loser = Session(db_engine)
+        try:
+            loser.add(Species(**_species_kwargs("-policy")))
+            _commit_winner_during(monkeypatch, winner=winner, ref=ref)
+
+            reviews = apply_review_policy(
+                loser, targets=[ref], policy=policy, created_by=None
+            )
+            assert len(reviews) == 1
+            loser.commit()
+        finally:
+            winner.close()
+            loser.close()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-policy")
+            ) is not None
+
+
+class TestReviewRowStaysCoupledToTheUpload:
+    """Isolation is *not* blanket-applied here, and that is deliberate.
+
+    A ``record_review`` row is not a description of the science — it is the
+    record's admission ticket into the review pipeline. Without it a deposited
+    record reads as ``not_reviewed`` (see ``_NO_REVIEW_ROW_RANK`` in
+    ``app.services.scientific_read.sql_review``), indistinguishable from a
+    legacy internal record, and no curator can ever approve it. Swallowing a
+    review-row failure would store stranded science and return ``201``.
+
+    Unlike the idempotency receipt, this runs *before* the response is
+    determined, so failing here yields an honest ``5xx`` and a client that
+    knows to retry. The race is the bug; the coupling is correct.
+    """
+
+    def test_a_terminal_status_request_still_aborts_the_upload(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """A terminal target status is a caller bug and must not be swallowed."""
+        from app.api.errors import DomainError
+
+        record_id = committed_scratch()
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-aborts")))
+            with pytest.raises(DomainError):
+                ensure_record_review(
+                    session,
+                    record_type=SubmissionRecordType.species_entry,
+                    record_id=record_id,
+                    status=RecordReviewStatus.approved,
+                )
+            session.rollback()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-aborts")
+            ) is None
+
+
+class TestUnrelatedIntegrityErrorsStillPropagate:
+    """Adoption is scoped to the identity collision, nothing else."""
+
+    def test_a_foreign_key_violation_is_not_swallowed(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """``submission_id`` pointing nowhere must still fail loudly.
+
+        A blanket ``except IntegrityError: re-select`` would find nothing on
+        the re-read and would have to invent an answer, masking a genuinely
+        broken write.
+        """
+        record_id = committed_scratch()
+
+        with Session(db_engine) as session:
+            with pytest.raises(IntegrityError):
+                ensure_record_review(
+                    session,
+                    record_type=SubmissionRecordType.species_entry,
+                    record_id=record_id,
+                    status=RecordReviewStatus.under_review,
+                    submission_id=2_000_000_001,
+                )
+            session.rollback()

--- a/backend/tests/services/test_record_review_write_isolation.py
+++ b/backend/tests/services/test_record_review_write_isolation.py
@@ -181,6 +181,7 @@ class TestConcurrentDepositAgainstOneIdentity:
                 status=RecordReviewStatus.under_review,
             )
             assert fired["done"], "the race window was never entered"
+            adopted_review_id = review.id
 
             loser.commit()
         finally:
@@ -203,7 +204,7 @@ class TestConcurrentDepositAgainstOneIdentity:
             assert len(rows) == 1, (
                 "the shared identity must carry exactly one review row"
             )
-            assert review.id == rows[0].id, (
+            assert adopted_review_id == rows[0].id, (
                 "the loser must adopt the row the winner created for this "
                 "shared identity, not invent a second one"
             )

--- a/backend/tests/services/test_upload_audit_isolation.py
+++ b/backend/tests/services/test_upload_audit_isolation.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 
 import pytest
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 from sqlalchemy.orm import Session
 
 from app.api import deps as api_deps
@@ -393,3 +393,56 @@ class TestCommitTimeFailureIsAudited:
 
         with Session(db_engine) as verify:
             assert len(self._failed_submissions(verify, user_id, watermark)) == before
+
+
+class TestBundleImportAuditCannotDestroyTheImport:
+    """The same shape at the largest payload the API accepts.
+
+    ``submit_contribution_bundle`` appends ``ingestion_succeeded`` after
+    importing a whole bundle: the lowest failure probability in the flow,
+    attached to the biggest blast radius.
+    """
+
+    def test_the_imported_bundle_survives_an_unwritable_audit_event(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        from app.schemas.workflows.contribution_bundle import BundleKind
+        from app.workflows import contribution_bundle_submit as bundle_submit
+
+        def _refuse(session_, **kwargs):
+            session_.execute(text("SELECT 1 FROM table_that_does_not_exist"))
+
+        monkeypatch.setattr(bundle_submit, "mark_ingestion_succeeded", _refuse)
+
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as session:
+            sub = _open(session, user_id, "bundle")
+            session.add(Species(**_species_kwargs("-bundle")))
+
+            assert bundle_submit._append_import_audit(
+                session,
+                submission=sub.submission,
+                bundle_kind=BundleKind.thermo,
+                imported_count=3,
+                linked_count=1,
+            ) is False
+
+            submission_id = sub.submission_id
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-bundle")
+            ) is not None, (
+                "the imported bundle was destroyed by its own audit event"
+            )
+            kinds = set(
+                verify.scalars(
+                    select(SubmissionAuditEvent.event_kind).where(
+                        SubmissionAuditEvent.submission_id == submission_id
+                    )
+                ).all()
+            )
+            assert SubmissionAuditEventKind.ingestion_succeeded not in kinds
+            assert SubmissionAuditEventKind.submission_created in kinds

--- a/backend/tests/services/test_upload_audit_isolation.py
+++ b/backend/tests/services/test_upload_audit_isolation.py
@@ -1,0 +1,395 @@
+"""Upload bookkeeping must not be able to veto the upload.
+
+Two failure paths in the synchronous ``/uploads/*`` flow, both about audit
+rows rather than science:
+
+* :func:`mark_upload_ingested` appends the ``ingestion_succeeded`` event on
+  the line immediately above ``idem.record`` — the write that destroyed an
+  upload on 2026-08-05. It carries the same two column types (``Text``
+  ``summary``, ``JSONB`` ``details_json``) and, before this, the same total
+  absence of isolation. Its failure must cost one line of audit history and
+  never a scientific record.
+
+* :func:`audit_sync_upload_failure` could not see a commit-time failure at
+  all, because ``get_write_db`` commits in dependency teardown *after* the
+  route returns. That left no failed-upload audit row for the one failure
+  class where the response was already determined and the work is gone.
+
+Both are asserted from a **fresh session after a genuine top-level commit**.
+A NUL character is the encoding-independent stand-in for "this value cannot
+be stored": PostgreSQL rejects ``\\u0000`` in ``text`` and ``jsonb`` in every
+server encoding.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.api import deps as api_deps
+from app.api.deps import get_write_db
+from app.db.models.common import (
+    MoleculeKind,
+    StereoKind,
+    SubmissionAuditEventKind,
+    SubmissionKind,
+    SubmissionStatus,
+)
+from app.db.models.species import Species
+from app.db.models.submission import Submission, SubmissionAuditEvent
+from app.services.upload_submission import (
+    SYNC_UPLOAD_AUDIT_KEY,
+    audit_upload_failure_at_commit,
+    mark_upload_ingested,
+    open_upload_submission,
+)
+
+MARKER = "auditisol"
+
+#: Rejected by ``text`` and ``jsonb`` alike, in every server encoding.
+UNSTORABLE = "ingested" + chr(0) + "summary"
+
+
+def _species_kwargs(suffix: str) -> dict:
+    return {
+        "kind": MoleculeKind.molecule,
+        "smiles": f"[He]{MARKER}{suffix}",
+        "inchi_key": "SWQJXJOGLNCZEY-UHFFFAOYSA-N",
+        "charge": 0,
+        "multiplicity": 1,
+        "stereo_kind": StereoKind.unspecified,
+    }
+
+
+@pytest.fixture
+def committed_scratch(db_engine, _api_test_user):
+    """A committing scratch space; these tests cannot isolate by rollback.
+
+    Rolling back is the bug under test, so the payload has to reach a real
+    ``COMMIT`` before it is believed. Every submission committed while the
+    test runs — including the ones ``record_failed_upload`` writes under its
+    own server-chosen title — is identified by id watermark and removed on
+    the way out, pass or fail, so nothing leaks into the shared session-scoped
+    database.
+    """
+    with Session(db_engine) as probe:
+        watermark = probe.scalar(select(Submission.id).order_by(Submission.id.desc())) or 0
+
+    try:
+        yield _api_test_user, watermark
+    finally:
+        with Session(db_engine) as cleanup:
+            cleanup.execute(
+                delete(SubmissionAuditEvent).where(
+                    SubmissionAuditEvent.submission_id > watermark
+                )
+            )
+            cleanup.execute(
+                delete(Submission).where(Submission.id > watermark)
+            )
+            cleanup.execute(
+                delete(Species).where(Species.smiles.like(f"[He]{MARKER}%"))
+            )
+            cleanup.commit()
+
+
+def _open(session: Session, user_id: int, suffix: str):
+    return open_upload_submission(
+        session,
+        created_by=user_id,
+        kind=SubmissionKind.conformer,
+        title=f"{MARKER}-{suffix}",
+    )
+
+
+class TestIngestionAuditCannotDestroyTheUpload:
+    def test_payload_survives_an_unwritable_ingestion_event(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The upload commits even though its audit event cannot be stored."""
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as session:
+            sub = _open(session, user_id, "survives")
+            session.add(Species(**_species_kwargs("-a")))
+
+            assert mark_upload_ingested(session, sub, summary=UNSTORABLE) is False
+
+            submission_id = sub.submission_id
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-a")
+            ) is not None, (
+                "the upload was destroyed by an audit event describing it"
+            )
+            kinds = set(
+                verify.scalars(
+                    select(SubmissionAuditEvent.event_kind).where(
+                        SubmissionAuditEvent.submission_id == submission_id
+                    )
+                ).all()
+            )
+            # The event that failed is missing; the rest of the trail is not.
+            assert SubmissionAuditEventKind.ingestion_succeeded not in kinds
+            assert SubmissionAuditEventKind.submission_created in kinds
+            assert verify.get(Submission, submission_id) is not None
+
+    def test_unflushed_payload_is_not_swept_into_the_savepoint(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Rows still pending when the audit event runs must survive it.
+
+        ``mark_upload_ingested`` flushes before opening the savepoint. Without
+        that, a workflow's not-yet-flushed rows would be INSERTed *inside* the
+        savepoint and rolled back with the failing event.
+        """
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as session:
+            sub = _open(session, user_id, "unflushed")
+            # Deliberately never flushed by the test.
+            session.add(Species(**_species_kwargs("-b")))
+
+            assert mark_upload_ingested(session, sub, summary=UNSTORABLE) is False
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-b")
+            ) is not None
+
+    def test_session_stays_usable_for_the_rest_of_the_request(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """``idem.record`` runs on the next line and must still be able to write."""
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as session:
+            sub = _open(session, user_id, "usable")
+            session.add(Species(**_species_kwargs("-c")))
+            mark_upload_ingested(session, sub, summary=UNSTORABLE)
+
+            # A poisoned transaction would raise PendingRollbackError here.
+            session.add(Species(**_species_kwargs("-d")))
+            session.commit()
+
+        with Session(db_engine) as verify:
+            found = {
+                s.smiles
+                for s in verify.scalars(
+                    select(Species).where(Species.smiles.like(f"[He]{MARKER}-%"))
+                ).all()
+            }
+            assert {f"[He]{MARKER}-c", f"[He]{MARKER}-d"} <= found
+
+    def test_failure_is_logged_loudly(
+        self, db_engine, committed_scratch, caplog
+    ) -> None:
+        """A silently-skipped audit event is how the incident stayed invisible."""
+        user_id, watermark = committed_scratch
+
+        with caplog.at_level(
+            logging.ERROR, logger="app.services.upload_submission"
+        ):
+            with Session(db_engine) as session:
+                sub = _open(session, user_id, "logged")
+                mark_upload_ingested(session, sub, summary=UNSTORABLE)
+                session.rollback()
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors
+        assert "ingestion_succeeded" in " ".join(r.getMessage() for r in errors)
+
+    def test_success_path_is_unchanged(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """A storable summary still commits atomically with the payload."""
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as session:
+            sub = _open(session, user_id, "normal")
+            session.add(Species(**_species_kwargs("-e")))
+            assert mark_upload_ingested(session, sub) is True
+            submission_id = sub.submission_id
+            session.commit()
+
+        with Session(db_engine) as verify:
+            kinds = set(
+                verify.scalars(
+                    select(SubmissionAuditEvent.event_kind).where(
+                        SubmissionAuditEvent.submission_id == submission_id
+                    )
+                ).all()
+            )
+            assert SubmissionAuditEventKind.ingestion_succeeded in kinds
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-e")
+            ) is not None
+
+    def test_a_rolled_back_upload_still_discards_the_event(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Releasing the savepoint does not make the event durable on its own."""
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as session:
+            sub = _open(session, user_id, "rollback")
+            session.add(Species(**_species_kwargs("-f")))
+            mark_upload_ingested(session, sub)
+            submission_id = sub.submission_id
+            session.rollback()
+
+        with Session(db_engine) as verify:
+            assert verify.get(Submission, submission_id) is None
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-f")
+            ) is None
+
+
+class TestCommitTimeFailureIsAudited:
+    """The blind spot: ``get_write_db`` commits after the route has returned.
+
+    ``audit_sync_upload_failure`` wraps the route function, so a failure
+    raised by the commit in dependency teardown lands outside its ``try``.
+    Before this, the failure class the 2026-08-05 incident belongs to left no
+    audit row at all.
+    """
+
+    def _failed_submissions(
+        self, session: Session, user_id: int, watermark: int
+    ) -> list[Submission]:
+        """Failed submissions this test created.
+
+        ``record_failed_upload`` picks its own title, so these are identified
+        by the fixture's id watermark rather than by marker.
+        """
+        return list(
+            session.scalars(
+                select(Submission)
+                .where(
+                    Submission.created_by == user_id,
+                    Submission.status == SubmissionStatus.failed,
+                    Submission.id > watermark,
+                )
+                .order_by(Submission.id)
+            ).all()
+        )
+
+    @pytest.fixture(autouse=True)
+    def _bind_app_sessions_to_the_test_database(self, db_engine, monkeypatch):
+        """Point the app's own session factory at the per-run test database.
+
+        Both ``get_write_db`` and ``record_failed_upload`` open sessions from
+        ``app.api.deps.SessionLocal``, which is bound to the configured
+        deployment engine at import time. These tests drive the real
+        dependency rather than a fixture stand-in, so the factory itself has
+        to be redirected.
+        """
+        monkeypatch.setattr(
+            api_deps, "SessionLocal", lambda: Session(bind=db_engine)
+        )
+
+    def test_a_failure_raised_by_the_commit_is_audited(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Drive ``get_write_db`` exactly as FastAPI does, and fail at COMMIT."""
+        user_id, watermark = committed_scratch
+
+        before = None
+        with Session(db_engine) as verify:
+            before = len(self._failed_submissions(verify, user_id, watermark))
+
+        generator = get_write_db()
+        session = next(generator)
+        try:
+            # What the decorator parks before calling the route body.
+            session.info[SYNC_UPLOAD_AUDIT_KEY] = {
+                "created_by": user_id,
+                "kind": SubmissionKind.conformer,
+                "audited": False,
+            }
+            # Never flushed, so this INSERT is issued by COMMIT itself —
+            # after the route returned, which is the whole point.
+            session.add(
+                Species(
+                    **{
+                        **_species_kwargs("-commitfail"),
+                        "smiles": f"[He]{MARKER}" + chr(0) + "x",
+                    }
+                )
+            )
+            with pytest.raises(Exception):
+                # Resuming the generator runs the commit and its error path,
+                # exactly as FastAPI's exit stack does at teardown.
+                next(generator)
+        finally:
+            generator.close()
+
+        with Session(db_engine) as verify:
+            after = self._failed_submissions(verify, user_id, watermark)
+            assert len(after) == before + 1, (
+                "a commit-time upload failure left no durable audit row"
+            )
+            reasons = list(
+                verify.scalars(
+                    select(SubmissionAuditEvent.reason).where(
+                        SubmissionAuditEvent.submission_id == after[-1].id,
+                        SubmissionAuditEvent.event_kind
+                        == SubmissionAuditEventKind.ingestion_failed,
+                    )
+                ).all()
+            )
+            assert reasons and reasons[0]
+
+    def test_no_audit_row_for_sessions_that_are_not_uploads(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """Every other write route shares ``get_write_db``; none may be affected."""
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as verify:
+            before = len(self._failed_submissions(verify, user_id, watermark))
+
+        generator = get_write_db()
+        session = next(generator)
+        try:
+            session.add(
+                Species(
+                    **{
+                        **_species_kwargs("-plain"),
+                        "smiles": f"[He]{MARKER}" + chr(0) + "y",
+                    }
+                )
+            )
+            with pytest.raises(Exception):
+                next(generator)
+        finally:
+            generator.close()
+
+        with Session(db_engine) as verify:
+            assert len(self._failed_submissions(verify, user_id, watermark)) == before
+
+    def test_a_failure_the_decorator_already_audited_is_not_audited_twice(
+        self, db_engine, committed_scratch
+    ) -> None:
+        """The decorator records first and marks the intent spent."""
+        user_id, watermark = committed_scratch
+
+        with Session(db_engine) as verify:
+            before = len(self._failed_submissions(verify, user_id, watermark))
+
+        with Session(db_engine) as session:
+            session.info[SYNC_UPLOAD_AUDIT_KEY] = {
+                "created_by": user_id,
+                "kind": SubmissionKind.conformer,
+                "audited": True,
+            }
+            audit_upload_failure_at_commit(session, RuntimeError("already handled"))
+
+        with Session(db_engine) as verify:
+            assert len(self._failed_submissions(verify, user_id, watermark)) == before

--- a/backend/tests/workers/test_upload_worker_result_isolation.py
+++ b/backend/tests/workers/test_upload_worker_result_isolation.py
@@ -1,0 +1,204 @@
+"""A job's own bookkeeping must not be able to destroy the science it ran.
+
+``job.result`` is presentational — it is what the polling client renders — and
+it is arbitrary handler output going into a ``JSONB`` column. A value
+PostgreSQL will not store therefore fails **deterministically**. Sharing the
+persistence transaction, that meant every retry re-ran the whole ingestion and
+failed identically on the same value until ``max_attempts`` was exhausted, so
+a presentational field permanently prevented the science from ever being
+stored while the client politely polled a job that could never succeed.
+
+The terminal job state is deliberately *not* isolated alongside it. That state
+is the exactly-once fence: science committed under a still-claimable job would
+be re-run by the reaper and duplicated. Only the rendering of the outcome is
+bookkeeping; the fence belongs to the primary unit.
+
+Every assertion here reads from a session opened *after* the worker's own
+commit, so it sees committed state rather than a live identity map.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session, sessionmaker
+
+import app.workers.upload_worker as upload_worker
+from app.db.models.common import (
+    MoleculeKind,
+    StereoKind,
+    UploadJobKind,
+    UploadJobStatus,
+)
+from app.db.models.species import Species
+from app.db.models.upload_job import UploadJob
+
+#: Rejected by ``jsonb`` in every server encoding — the encoding-independent
+#: stand-in for "this result body cannot be stored".
+UNSTORABLE_RESULT = {"type": "thermo", "note": "bad" + chr(0) + "value"}
+
+SMILES = "[He]workerisol"
+
+
+@pytest.fixture
+def worker_db(db_engine, monkeypatch) -> Iterator[Session]:
+    """A session on the real test engine, with the worker pointed at it.
+
+    ``_process_one_cycle`` opens and commits its own sessions from
+    ``upload_worker.SessionLocal``; redirecting that is what lets the test
+    read back what the worker actually committed. Jobs and the scientific rows
+    the stub handler writes are removed on teardown.
+    """
+    monkeypatch.setattr(
+        upload_worker,
+        "SessionLocal",
+        sessionmaker(bind=db_engine, expire_on_commit=False),
+    )
+
+    session = Session(bind=db_engine, expire_on_commit=False)
+    try:
+        yield session
+    finally:
+        session.close()
+        with Session(db_engine) as cleanup:
+            with cleanup.begin():
+                cleanup.execute(
+                    text("DELETE FROM species WHERE smiles = :s"), {"s": SMILES}
+                )
+                cleanup.execute(
+                    text(
+                        "DELETE FROM upload_job WHERE NOT EXISTS ("
+                        "SELECT 1 FROM submission "
+                        "WHERE submission.upload_job_id = upload_job.id)"
+                    )
+                )
+
+
+def _insert_job(session: Session, *, max_attempts: int = 3) -> UploadJob:
+    job = UploadJob(
+        kind=UploadJobKind.thermo,
+        status=UploadJobStatus.queued,
+        payload={"x": 1},
+        attempts=0,
+        max_attempts=max_attempts,
+    )
+    session.add(job)
+    session.flush()
+    return job
+
+
+def _science_writing_handler(result):
+    """A stub handler that persists a real scientific row and returns *result*."""
+
+    def handler(session, job, review_policy=None):
+        session.add(
+            Species(
+                kind=MoleculeKind.molecule,
+                smiles=SMILES,
+                inchi_key="SWQJXJOGLNCZEY-UHFFFAOYSA-N",
+                charge=0,
+                multiplicity=1,
+                stereo_kind=StereoKind.unspecified,
+            )
+        )
+        return result
+
+    return handler
+
+
+def _install(monkeypatch, result) -> None:
+    monkeypatch.setitem(
+        upload_worker._DISPATCH,
+        UploadJobKind.thermo,
+        _science_writing_handler(result),
+    )
+
+
+class TestUnstorableResult:
+    def test_the_science_survives_and_the_job_still_completes(
+        self, worker_db, db_engine, monkeypatch
+    ) -> None:
+        _install(monkeypatch, UNSTORABLE_RESULT)
+
+        with worker_db.begin():
+            job_id = _insert_job(worker_db).id
+
+        assert upload_worker._process_one_cycle() is True
+
+        with Session(db_engine) as verify:
+            assert verify.execute(
+                text("SELECT id FROM species WHERE smiles = :s"), {"s": SMILES}
+            ).first() is not None, (
+                "an unstorable job.result destroyed the science the job persisted"
+            )
+
+            persisted = verify.get(UploadJob, job_id)
+            # The exactly-once fence still landed: a job left claimable would
+            # be re-leased by the reaper and duplicate the science.
+            assert persisted.status == UploadJobStatus.complete
+            assert persisted.completed_at is not None
+            assert persisted.lease_expires_at is None
+            assert persisted.error is None
+            # ...carrying a stand-in that says what happened.
+            assert persisted.result is not None
+            assert persisted.result.get("result_unavailable") is True
+            assert persisted.result.get("reason")
+
+    def test_it_does_not_burn_the_retry_budget(
+        self, worker_db, db_engine, monkeypatch
+    ) -> None:
+        """A deterministic failure must not be retried into exhaustion."""
+        _install(monkeypatch, UNSTORABLE_RESULT)
+
+        with worker_db.begin():
+            job_id = _insert_job(worker_db, max_attempts=3).id
+
+        upload_worker._process_one_cycle()
+
+        with Session(db_engine) as verify:
+            persisted = verify.get(UploadJob, job_id)
+            assert persisted.status is not UploadJobStatus.queued
+            assert persisted.status is not UploadJobStatus.failed
+            assert persisted.attempts == 1
+
+    def test_the_failure_is_logged_loudly(
+        self, worker_db, db_engine, monkeypatch, caplog
+    ) -> None:
+        import logging
+
+        _install(monkeypatch, UNSTORABLE_RESULT)
+
+        with worker_db.begin():
+            _insert_job(worker_db)
+
+        with caplog.at_level(logging.ERROR, logger="app.workers.upload_worker"):
+            upload_worker._process_one_cycle()
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors
+        assert "result could not be stored" in " ".join(
+            r.getMessage() for r in errors
+        )
+
+
+class TestStorableResultUnchanged:
+    def test_the_handler_result_is_stored_verbatim(
+        self, worker_db, db_engine, monkeypatch
+    ) -> None:
+        expected = {"type": "thermo", "id": 4321}
+        _install(monkeypatch, expected)
+
+        with worker_db.begin():
+            job_id = _insert_job(worker_db).id
+
+        assert upload_worker._process_one_cycle() is True
+
+        with Session(db_engine) as verify:
+            persisted = verify.get(UploadJob, job_id)
+            assert persisted.status == UploadJobStatus.complete
+            assert persisted.result == expected
+            assert verify.execute(
+                text("SELECT id FROM species WHERE smiles = :s"), {"s": SMILES}
+            ).first() is not None


### PR DESCRIPTION
Finishes the class that PR #104 opened. Six sites surveyed, four isolated, **three argued as correctly coupled**, two more found by sweeping for the shape, and the audit blind spot closed.

The underlying mistake is architectural and repeated: a secondary write sharing the payload's transaction, so the *description* can veto the *fact*.

## Site 1 — a live race, and the window is not where I said it was

`apply_review_policy` runs as the last statement of every upload workflow. `ensure_record_review` is check-then-insert against `uq_record_review_record`, targeting **reused identity rows** that resolution deliberately dedupes across uploads.

I briefed this as a SELECT→INSERT window. **That was wrong, and the first repro attempt passing is what showed it.** A caller that looks first widens nothing — `ensure_record_review` looks again under READ COMMITTED and sees the committed row. The real window is the **entire duration of the winner's transaction**, during which it holds an uncommitted unique-index entry that the loser's INSERT must block on.

The deterministic witness, run against unmodified `origin/main`, driving `get_write_db`'s rollback verbatim and reading from a fresh session:

```
loser:  science written and flushed; no review row visible
winner: review row INSERTed (uncommitted; index entry now held)
loser:  reaching its review INSERT (will block on the index)
winner: committed
loser:  FAILED with IntegrityError: duplicate key ... uq_record_review_record
VERDICT: loser's science, read from a fresh session = None
  ==> PAYLOAD DESTROYED by the review row.
```

Same script after the fix: `payload survived`, one review row.

**Decision: adopt, not fail.** Losing the race is not a conflict — it is the documented outcome arriving by another route. The review row describes the *identity*, which both uploads legitimately share, and the helper already returns an existing row unchanged when it finds one, so adopting reaches exactly the state a sequential pair reaches. Per-submission attribution is unaffected; it lives in `submission_record_link`, written per submission.

**`ON CONFLICT DO NOTHING` rather than `begin_nested()`**, diverging from the neighbouring resolvers deliberately: they insert one row per upload, this runs once per target — tens to hundreds for a network upload — and that many subtransactions push a transaction past PostgreSQL's 64-entry `pg_subtrans` cache. It also lets the *database* discriminate the expected collision from a real integrity failure: an FK violation on `submission_id` still raises rather than being swallowed by a blanket `except IntegrityError`.

## Three sites that should NOT be isolated

- **The review row itself.** It is not a description of the science; it is the record's *admission ticket* into the review pipeline. Without it a record reads `not_reviewed`, indistinguishable from a legacy internal record, and with no `submission_record_link` no curator can ever approve it. Swallowing would store stranded science and return `201`. It also runs *before* the response is determined, so failing gives an honest `5xx` to a client that can retry. **The race was the bug; the coupling is correct.**
- **Bundle `link_record`** — `approve_submission` flips exactly the linked records. Isolating trades a recoverable failure for an unrecoverable one.
- **The worker's terminal job state** — not bookkeeping, the **exactly-once fence**. Science committed under a still-claimable job would be re-leased by the reaper and **duplicated**. So the fence is flushed *outside* the savepoint, and only `job.result` goes inside it.

## Sites 2–5

Audit events isolated with flush-first + savepoint + loud logging. The docstring that *endorsed* the coupling is corrected — that reasoning is what produced the incident one line below it. The asymmetry is now explicit: workflow-fails→audit-rolls-back is right; audit-fails→science-rolls-back is not.

`job.result` gets a `{"result_unavailable": true, "reason": ...}` stand-in, so a non-serialisable value completes the job on attempt 1 instead of burning `max_attempts` deterministically.

New `app/services/best_effort.py::isolated_best_effort`; `_extract_safe` now covers the write half, verified failing pre-fix against a real Gaussian log so the parse half genuinely succeeds.

## `IntegrityError`-only guards are worse than no guard

The SP-energy and Hessian hooks caught only `IntegrityError`. **PostgreSQL marks the transaction aborted at the point of error; catching in Python does not undo that.** Those hooks had `except Exception` catch-alls with no `ROLLBACK TO SAVEPOINT`, so a swallowed DB error left the session poisoned and resurfaced at `COMMIT` — after the response, where it destroys the upload instead of the enrichment.

SP had a second gap: `existing.electronic_energy_hartree = energy` issues no SQL, so a bad value failed at the caller's `COMMIT`, outside every guard. That is the incident's shape exactly. Both inner savepoints widened to `except Exception`.

## Two more, found by sweeping for the shape

- **`geometry_validation.py:384`** — best-effort *by policy* (its docstring and both call sites say so), but the guard covered only the chemistry call and the row was added with **no flush**, so its INSERT escaped to the route's `COMMIT`. A verdict *about* a calculation could take the calculation. Fixed.
- **`literature_resolution.py:169`** — check-then-insert on the normalized DOI/ISBN indexes, resolved *during* deposit, so the collateral is scientific records. Two contributors citing one paper is as ordinary as two depositing one molecule. Every sibling resolver already wraps its insert; this was the exception. Fixed.
- **`machine_review/curator_tasks.py:299`** — same shape, real, but the collateral is a curator task rather than science. Reported, not fixed.

One lead checked and **discarded**: `conformer_resolution.py`'s label generation looks like a live race but is already serialised by a `pg_advisory_xact_lock` keyed on `species_entry.id`. Not a bug — stated so nobody "fixes" it.

## Verification

scientific **1975 passed**, API **2434 passed** — both exactly baseline, re-run against the final tree. Plus `tests/workflows/` 580 and `tests/services/` + `tests/workers/` 1896. `ruff` clean. No test weakened, skipped or deleted; no success-path response changed.

Two caveats flagged rather than hidden: the `record_review` tests never delete their rows (`record_review_event` is append-only at the DB level), relying on the per-run database being dropped; and the geometry-validation wiring is pinned by an `inspect.getsource` assertion, which is weaker than a behavioural test — a full version needs a real opt calculation with attached geometries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)