### PR TITLE
Element-check IRC participant mappings, and settle the pseudo-exemption disagreement

### DIFF
--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -9,6 +9,9 @@ from rdkit import Chem
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from tckdb_schemas.fragments.ts_validation_evidence import (
+    TransitionStateValidationEvidenceIn,
+)
 
 from app.chemistry.geometry import resolve_element_symbol
 from app.chemistry.species import element_counts_from_smiles, format_element_counts
@@ -397,9 +400,21 @@ def validate_transition_state_composition(
     surface, and spin-forbidden reactions are real chemistry. A multiplicity
     rule would fire on correct novel results, which ADR 0008 disqualifies.
 
-    Reactions carrying a pseudo-species participant are exempt, matching
-    ``validate_reaction_elemental_balance``: a lumped or phenomenological
-    construct has no atom-resolved composition to compare against.
+    The pseudo exemption is narrower here than in the balance checks, on purpose
+    ----------------------------------------------------------------------------
+    ``_load_participant_species`` exempts elemental balance and charge
+    conservation when a pseudo-species appears on **either** side, because those
+    two checks compare one side against the other and a lumped or
+    phenomenological construct makes the side it sits on unknowable. This check
+    compares the saddle point against the **reactant side only**, so only a
+    *reactant* being pseudo can make its comparison meaningless. A pseudo
+    *product* is therefore not exempted here, and that asymmetry is the correct
+    behaviour rather than a drift: a lumped product says nothing about whether
+    the reactant side is atom-resolved, so exempting on one would discard a
+    guarantee that is still perfectly well-defined. It also matters most exactly
+    there — a reaction with a pseudo product has already lost elemental balance
+    and charge conservation, and this check is then the only atom-level
+    statement left about the saddle point.
 
     :raises ValueError: If the saddle point's elements or charge contradict
         the reactants it is declared to sit between.
@@ -460,17 +475,22 @@ def validate_transition_state_composition(
             )
 
 
-_TS_COMPOSITION_PSEUDO_DIVERGENCE = (
-    "The docstring says pseudo-species exemption 'matches "
-    "``validate_reaction_elemental_balance``'. It does not, quite: this "
-    "function queries only ``ReactionRole.reactant`` and exempts only on a "
-    "*reactant-side* pseudo participant, while "
-    "``_load_participant_species`` exempts the two conservation checks on a "
-    "pseudo participant on **either** side. A reaction whose only pseudo "
-    "species is a product is therefore exempt from elemental balance but "
-    "still held to transition-state composition, and it is compared against "
-    "a reactant side that carries no balance guarantee. Reported, not "
-    "changed — this register alters no check behaviour."
+#: Why this check's pseudo exemption is deliberately narrower than the balance
+#: checks', rather than drifted from them. Recorded on both legs of the
+#: function, because both are scoped to the reactant side.
+_TS_COMPOSITION_PSEUDO_SCOPE = (
+    "The pseudo-species exemption here is narrower than "
+    "``_load_participant_species``'s, and deliberately so. That helper exempts "
+    "elemental balance and charge conservation on a pseudo participant on "
+    "**either** side, because both compare one side against the other and a "
+    "lumped construct makes the side it sits on unknowable. This check compares "
+    "the saddle point against the **reactant side only**, so only a *reactant* "
+    "being pseudo can make it meaningless; a pseudo *product* leaves the "
+    "reactant side fully atom-resolved and is not exempted. Aligning the two "
+    "would discard a guarantee that is still well-defined, and would discard it "
+    "exactly where it is worth most: a reaction with a pseudo product has "
+    "already lost elemental balance and charge conservation, so this is the "
+    "only atom-level statement left about its saddle point."
 )
 
 CHECK_TRANSITION_STATE_COMPOSITION = ScientificCheck(
@@ -501,13 +521,14 @@ CHECK_TRANSITION_STATE_COMPOSITION = ScientificCheck(
     ),
     escape_hatch=(
         "Declare the extra species as participants of the reaction. A "
-        "``pseudo`` reactant exempts the reaction. Absence does not block: no "
+        "``pseudo`` *reactant* exempts the reaction; a pseudo product does not, "
+        "and that is not an oversight — see below. Absence does not block: no "
         "geometry and no parseable SMILES means nothing is compared, and an "
         "unparseable transition-state SMILES is treated as silence rather "
         "than as a contradiction, because a TS SMILES is a lossy label for a "
-        "structure that is by construction not a stable molecule."
+        "structure that is by construction not a stable molecule. "
+        + _TS_COMPOSITION_PSEUDO_SCOPE
     ),
-    divergence=_TS_COMPOSITION_PSEUDO_DIVERGENCE,
 )
 
 CHECK_TRANSITION_STATE_CHARGE = ScientificCheck(
@@ -541,9 +562,255 @@ CHECK_TRANSITION_STATE_CHARGE = ScientificCheck(
         "conserved the way charge and atoms are — two doublets may react over "
         "a singlet or a triplet surface, and spin-forbidden reactions are real "
         "chemistry — so a multiplicity rule would fire on correct novel "
-        "results."
+        "results. " + _TS_COMPOSITION_PSEUDO_SCOPE
     ),
-    divergence=_TS_COMPOSITION_PSEUDO_DIVERGENCE,
+)
+
+
+#: Emitted when an IRC mapping hands a declared participant saddle-point atoms
+#: whose elements are not that participant's own.
+W_IRC_MAPPING_ELEMENT_MISMATCH = "transition_state_irc_mapping_element_mismatch"
+
+
+def _resolved_participant_element_counts(species: Species) -> Counter[str] | None:
+    """Element counts for one declared participant, or ``None`` where exempt.
+
+    ``None`` means "this participant has no atom-resolved composition to compare
+    against" and is returned only for a pseudo-species, matching the exemption
+    :func:`validate_transition_state_composition` applies to the reactant side.
+    A free electron is *not* exempt: it returns an empty count, because its
+    composition is not unknown but known to be nothing.
+
+    Counts come back resolved through
+    :func:`~app.chemistry.geometry.resolve_element_symbol` so they can be
+    compared against ``geometry_atom.element``, which stores whatever the
+    depositor's XYZ wrote.
+    """
+
+    if species.kind == MoleculeKind.pseudo:
+        return None
+
+    resolved: Counter[str] = Counter()
+    for element, count in _element_counts_for_species(species).items():
+        resolved[resolve_element_symbol(element)] += count
+    return resolved
+
+
+def validate_ts_evidence_participant_composition(
+    session: Session,
+    evidence: Sequence[TransitionStateValidationEvidenceIn],
+    *,
+    reaction_entry_id: int,
+    transition_state_geometry_id: int | None,
+    subject_label: str = "transition state",
+    field_path: str = "validation_evidence",
+) -> None:
+    """Refuse an IRC mapping that makes a participant out of the wrong atoms.
+
+    ``transition_state_validation_evidence.reactant_participant_mapping`` and
+    ``product_participant_mapping`` say which saddle-point atom indices become
+    which declared participant. Until this check existed those mappings were
+    only ever *bounds*-checked — ``validate_ts_evidence_set`` verifies that the
+    keys name every declared participant and that the indices partition the TS
+    atoms exactly once — and nothing looked at what the atoms actually **are**.
+
+    A well-formed partition of the wrong atoms therefore passed. The failure is
+    not hypothetical: a nine-atom ``C C O O H H H H H`` saddle point for
+    ``ethylperoxy -> ethene + HO2`` was deposited with ``product:1 = [1..6]``,
+    handing ethene two oxygens and HO2 three hydrogens, under a comment that
+    correctly read "C2H4 (six atoms)". The partition was valid; the chemistry
+    was not.
+
+    Why this blocks
+    ---------------
+    Definitional under ADR 0008, and the register's own consistency demands it.
+    "These saddle-point atoms become C2H4" while those atoms are C2O2H2 is a
+    contradiction no correct calculation can produce — the same class of claim
+    as :func:`validate_transition_state_composition`, one level finer. Crucially,
+    the *identical assertion expressed as a* ``reaction_atom_map`` **is already
+    refused**, by ``CHECK_ATOM_MAP_ELEMENT_CONSERVED``'s composite foreign key
+    into ``geometry_atom`` and by
+    :func:`~app.services.reaction_atom_map.persist_reaction_atom_map`. Two
+    surfaces enforcing different standards on the same claim is not a defensible
+    position for either, so this closes the gap on the IRC side.
+
+    This is a *composition* check, not a bijection: an atom map names which
+    participant atom becomes which saddle-point atom, while an IRC mapping only
+    names the set. So the comparison is between multisets of elements, which is
+    the strongest statement the mapping's own shape supports.
+
+    Only what is present is checked
+    ------------------------------
+    Records that are not ``passed``, and records carrying no mappings, are
+    skipped: a mapping that does not claim to be evidence is not contradicted by
+    anything, and evidence is optional on every path. A pseudo-species
+    participant is skipped individually rather than exempting the whole record,
+    because the other participants' compositions are still perfectly
+    well-defined. Absent geometry means nothing is compared.
+
+    :param evidence: Producer-declared evidence records, already shape-validated
+        by ``validate_ts_evidence_set``.
+    :param reaction_entry_id: The reaction whose participants the mapping names.
+    :param transition_state_geometry_id: Saddle-point geometry the mapping's
+        atom indices count into. ``None`` skips the check.
+    :raises ValueError: If a participant is assigned saddle-point atoms whose
+        elements are not that participant's own.
+    """
+
+    if transition_state_geometry_id is None:
+        return
+    if not any(
+        record.passed and record.reactant_participant_mapping is not None
+        for record in evidence
+    ):
+        return
+
+    ts_element_by_index = {
+        atom_index: resolve_element_symbol(element)
+        for atom_index, element in session.execute(
+            select(GeometryAtom.atom_index, GeometryAtom.element).where(
+                GeometryAtom.geometry_id == transition_state_geometry_id
+            )
+        ).all()
+    }
+    if not ts_element_by_index:
+        return
+
+    participants = session.execute(
+        select(
+            ReactionEntryStructureParticipant.role,
+            ReactionEntryStructureParticipant.participant_index,
+            Species,
+        )
+        .select_from(ReactionEntryStructureParticipant)
+        .join(
+            SpeciesEntry,
+            SpeciesEntry.id == ReactionEntryStructureParticipant.species_entry_id,
+        )
+        .join(Species, Species.id == SpeciesEntry.species_id)
+        .where(
+            ReactionEntryStructureParticipant.reaction_entry_id == reaction_entry_id
+        )
+    ).all()
+    species_by_slot = {
+        (role, participant_index): species
+        for role, participant_index, species in participants
+    }
+
+    for record in evidence:
+        if not record.passed or record.reactant_participant_mapping is None:
+            continue
+        assert record.product_participant_mapping is not None
+        for role, mapping in (
+            (ReactionRole.reactant, record.reactant_participant_mapping),
+            (ReactionRole.product, record.product_participant_mapping),
+        ):
+            for participant_key, atom_indices in sorted(mapping.items()):
+                _, _, index_text = participant_key.partition(":")
+                try:
+                    participant_index = int(index_text)
+                except ValueError:  # pragma: no cover - shape already validated
+                    continue
+                species = species_by_slot.get((role, participant_index))
+                if species is None:  # pragma: no cover - shape already validated
+                    continue
+
+                declared = _resolved_participant_element_counts(species)
+                if declared is None:
+                    continue
+
+                assigned: Counter[str] = Counter()
+                for atom_index in atom_indices:
+                    element = ts_element_by_index.get(atom_index)
+                    if element is None:  # pragma: no cover - bounds already checked
+                        return
+                    assigned[element] += 1
+
+                if assigned != declared:
+                    raise ValueError(
+                        f"Transition state '{subject_label}' {field_path} assigns "
+                        f"saddle-point atoms "
+                        f"{sorted(atom_indices)} to {participant_key}, which is "
+                        f"{format_element_counts(assigned)}, but {role.value} "
+                        f"{participant_index} is declared as '{species.smiles}', "
+                        f"which is {format_element_counts(declared)} "
+                        f"({W_IRC_MAPPING_ELEMENT_MISMATCH}). An IRC mapping says "
+                        "which saddle-point atoms become which declared "
+                        "participant, so a participant cannot be made of atoms it "
+                        "does not contain. The identical claim written as an "
+                        "atom_map is already refused; correct the mapping per "
+                        "atom, not per count."
+                    )
+
+
+CHECK_TS_IRC_MAPPING_ELEMENTS = ScientificCheck(
+    group="Conservation across a reaction",
+    sort_key=5,
+    code=W_IRC_MAPPING_ELEMENT_MISMATCH,
+    asserts=(
+        "The saddle-point atoms an IRC mapping assigns to a declared "
+        "participant are that participant's own atoms, element for element."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional. 'These saddle-point atoms become C2H4' while those atoms "
+        "are C2O2H2 is a contradiction no correct calculation can produce — the "
+        "same class of claim ``CHECK_TRANSITION_STATE_COMPOSITION`` already "
+        "blocks, one level finer, per participant rather than per side. It is "
+        "also what the register's own consistency requires: the identical "
+        "assertion expressed as a ``reaction_atom_map`` is refused by "
+        "``CHECK_ATOM_MAP_ELEMENT_CONSERVED``, at the wire boundary and again "
+        "by a composite foreign key into ``geometry_atom``. Two surfaces "
+        "enforcing different standards on the same claim is not a defensible "
+        "position for either — and the divergence was not theoretical: a "
+        "well-formed partition handing ethene two oxygens and HO2 three "
+        "hydrogens was accepted, under a fixture comment that correctly said "
+        "'C2H4 (six atoms)'."
+    ),
+    adr="0008, 0011",
+    enforced_by=(
+        PythonCheck(
+            validate_ts_evidence_participant_composition,
+            note=(
+                "Called from "
+                "``persist_transition_state_validation_evidence``, the single "
+                "seam every deposit path that can carry a transition state "
+                "already routes through, so the PDep bundle, the "
+                "computed-reaction bundle and the standalone transition-state "
+                "upload cannot enforce different standards. It is a service-"
+                "layer check rather than a wire-boundary one because a "
+                "participant's composition comes from its SMILES, and "
+                "``tckdb_schemas`` is chemistry-free — RDKit is not available "
+                "where ``validate_ts_evidence_set`` runs. That function keeps "
+                "the *shape* half of the rule: keys name every declared "
+                "participant, indices partition the TS atoms exactly once."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Omit the participant mappings. They are optional on every path — "
+        "evidence without them still deposits and still reads back as "
+        "``irc: present`` — so a depositor who cannot resolve the partition per "
+        "atom is never forced to guess at one. Declaring a participant "
+        "``molecule_kind: pseudo`` skips that participant alone rather than the "
+        "whole record, because the others' compositions are still well-defined. "
+        "Isotopologues are safe by construction: both sides are compared "
+        "through ``resolve_element_symbol``, so a geometry written ``D`` counts "
+        "as the hydrogen its SMILES spells ``[2H]``."
+    ),
+    divergence=(
+        "A zero-atom participant cannot be expressed. "
+        "``TransitionStateValidationEvidenceIn`` refuses an empty atom list, "
+        "and ``validate_ts_evidence_set`` requires every declared participant "
+        "to be named, so a reaction releasing a free electron — "
+        "``MoleculeKind.electron``, newly reachable — has no way to write "
+        "``product:2: []``. Before this check such a reaction could deposit a "
+        "*wrong* mapping that stole a real atom for the electron; it now "
+        "correctly cannot, but it also cannot deposit a right one, and must "
+        "omit the mappings instead. Widening the wire schema to accept an empty "
+        "list for a participant with no atoms is the fix, and is a wire-package "
+        "change with its own version bump."
+    ),
 )
 
 

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -581,19 +581,19 @@ def _resolved_participant_element_counts(species: Species) -> Counter[str] | Non
     A free electron is *not* exempt: it returns an empty count, because its
     composition is not unknown but known to be nothing.
 
-    Counts come back resolved through
-    :func:`~app.chemistry.geometry.resolve_element_symbol` so they can be
-    compared against ``geometry_atom.element``, which stores whatever the
-    depositor's XYZ wrote.
+    Counts arrive already resolved through
+    :func:`~app.chemistry.geometry.resolve_element_symbol`, because
+    :func:`~app.chemistry.species.element_counts_from_smiles` applies it on the
+    SMILES side for exactly this reason — so that both sides of a comparison are
+    counted by one rule rather than two that have to be remembered to agree. The
+    caller resolves the geometry side with the same function, which is what
+    keeps a deuterated saddle point written ``D`` from contradicting the
+    ``[2H]`` its own SMILES spells.
     """
 
     if species.kind == MoleculeKind.pseudo:
         return None
-
-    resolved: Counter[str] = Counter()
-    for element, count in _element_counts_for_species(species).items():
-        resolved[resolve_element_symbol(element)] += count
-    return resolved
+    return _element_counts_for_species(species)
 
 
 def validate_ts_evidence_participant_composition(

--- a/backend/app/services/transition_state_validation.py
+++ b/backend/app/services/transition_state_validation.py
@@ -25,6 +25,9 @@ from tckdb_schemas.upload_warning import UploadWarning
 
 from app.db.models.transition_state import TransitionStateValidationEvidence
 from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.services.reaction_resolution import (
+    validate_ts_evidence_participant_composition,
+)
 
 #: Emitted when a transition state is deposited with no *passing* IRC evidence.
 W_MISSING_TS_IRC_EVIDENCE = "transition_state_missing_irc_evidence"
@@ -38,6 +41,8 @@ def persist_transition_state_validation_evidence(
     reconstruction_calculation_ids: Sequence[int | None],
     subject_label: str,
     field_path: str,
+    reaction_entry_id: int,
+    transition_state_geometry_id: int | None,
     created_by: int | None = None,
     warnings: list[UploadWarning] | None = None,
 ) -> list[TransitionStateValidationEvidence]:
@@ -51,6 +56,13 @@ def persist_transition_state_validation_evidence(
         calculation) before calling in.
     :param subject_label: Producer-facing name of the TS, for the warning text.
     :param field_path: Dot-path of the evidence field, for the warning.
+    :param reaction_entry_id: The reaction whose declared participants the
+        evidence's ``reactant:N`` / ``product:N`` mappings name. Required rather
+        than optional: it is what lets the element check below run on *every*
+        path, and a default would let a new path silently opt out of it.
+    :param transition_state_geometry_id: Saddle-point geometry the mappings'
+        atom indices count into. ``None`` where the path has no geometry, which
+        skips the element check as an absence.
     :param warnings: Optional sink for the absent-evidence warning.
     :returns: The persisted rows.
     """
@@ -59,6 +71,22 @@ def persist_transition_state_validation_evidence(
         raise ValueError(
             "reconstruction_calculation_ids must align with the evidence records."
         )
+
+    # Definitional, therefore blocking (ADR 0008). The mappings' *shape* was
+    # already settled at the wire boundary by ``validate_ts_evidence_set``;
+    # what the mapped atoms actually **are** needs a species SMILES and so
+    # needs RDKit, which the chemistry-free wire package does not have. Doing
+    # it here rather than in the three workflows is deliberate: this seam is
+    # the one place all three deposit paths already meet, and three call sites
+    # is exactly how the pseudo-exemption divergence next door happened.
+    validate_ts_evidence_participant_composition(
+        session,
+        evidence,
+        reaction_entry_id=reaction_entry_id,
+        transition_state_geometry_id=transition_state_geometry_id,
+        subject_label=subject_label,
+        field_path=field_path,
+    )
 
     rows: list[TransitionStateValidationEvidence] = []
     for record, calculation_id in zip(

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -532,6 +532,8 @@ def persist_computed_reaction_upload(
             ],
             subject_label=ts_in.label or "transition state",
             field_path="transition_state.validation_evidence",
+            reaction_entry_id=canonical_reaction_entry.id,
+            transition_state_geometry_id=ts_geom.id,
             created_by=created_by,
             warnings=sp_energy_warnings,
         )

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -513,6 +513,8 @@ def persist_network_pdep_upload(
             ],
             subject_label=ts_in.key,
             field_path=f"transition_states[{ts_in.key}].validation_evidence",
+            reaction_entry_id=reaction_entry.id,
+            transition_state_geometry_id=ts_geometry.id,
             created_by=created_by,
             warnings=warning_sink,
         )

--- a/backend/app/workflows/transition_state.py
+++ b/backend/app/workflows/transition_state.py
@@ -144,6 +144,8 @@ def persist_transition_state_upload(
         ],
         subject_label=request.label or "transition state",
         field_path="validation_evidence",
+        reaction_entry_id=reaction_entry.id,
+        transition_state_geometry_id=geometry.id,
         created_by=created_by,
         warnings=warnings,
     )

--- a/backend/tests/services/test_ts_irc_mapping_elements.py
+++ b/backend/tests/services/test_ts_irc_mapping_elements.py
@@ -1,0 +1,352 @@
+"""Element checks on IRC participant mappings.
+
+``transition_state_validation_evidence.reactant_participant_mapping`` and
+``product_participant_mapping`` say which saddle-point atom indices become which
+declared participant. ``validate_ts_evidence_set`` checks the *shape* of that
+claim — the keys name every declared participant, the indices partition the TS
+atoms exactly once — and for a long time nothing checked what the atoms **are**.
+
+A well-formed partition of the wrong atoms therefore passed. The case these
+tests are built around is real: a nine-atom ``C C O O H H H H H`` saddle point
+for ``ethylperoxy -> ethene + HO2`` was written with ``product:1 = [1..6]``,
+handing ethene two oxygens and HO2 three hydrogens, under a comment that
+correctly read "C2H4 (six atoms)". The partition was valid; the chemistry was
+not. The identical claim written as a ``reaction_atom_map`` was refused the
+whole time, by the composite foreign key into ``geometry_atom``.
+
+The false-positive tests are as load-bearing as the refusal ones: ADR 0008 lets
+a check block only when no correct calculation could produce the record it
+refuses, so a blocking rule that fires on a pseudo participant, an isotopologue
+or a deposit that simply declined to map its atoms would be the wrong rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.models.common import MoleculeKind
+from app.schemas.fragments.geometry import GeometryPayload
+from app.services.geometry_resolution import resolve_geometry_payload
+from app.services.reaction_resolution import (
+    validate_ts_evidence_participant_composition,
+)
+from tckdb_schemas.fragments.ts_validation_evidence import (
+    TransitionStateValidationEvidenceIn,
+)
+
+from tests.services.scientific_read._factories import (
+    make_chem_reaction,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    next_inchi_key,
+)
+
+# The saddle point at the centre of this file: C2H5O2, listed 1 C, 2 C, 3 O,
+# 4 O, 5-9 H. It is the ethylperoxy -> ethene + HO2 concerted elimination TS.
+_XYZ_ELIM_TS = (
+    "9\nTS for C2H5OO -> C2H4 + HO2\n"
+    "C  0.00  0.00  0.00\n"
+    "C  1.42  0.00  0.00\n"
+    "O  2.14  1.24  0.00\n"
+    "O  3.42  1.06  0.00\n"
+    "H -0.32  1.03  0.00\n"
+    "H -0.42 -0.55  0.86\n"
+    "H -0.42 -0.55 -0.86\n"
+    "H  1.92 -0.61  0.78\n"
+    "H  2.71 -0.74 -0.42"
+)
+
+#: The correct partition. C2H4 takes both carbons and four hydrogens; HO2 takes
+#: both oxygens and the fifth hydrogen.
+_CORRECT_PRODUCTS = {
+    "product:1": [1, 2, 5, 6, 7, 8],  # C2H4: C, C, H, H, H, H
+    "product:2": [3, 4, 9],  # HO2: O, O, H
+}
+
+#: The partition that used to pass. Nine atoms, each claimed exactly once, and
+#: ethene is made of two carbons, two oxygens and two hydrogens.
+_ETHENE_MADE_OF_OXYGENS = {
+    "product:1": [1, 2, 3, 4, 5, 6],  # "C2H4" -- actually C2O2H2
+    "product:2": [7, 8, 9],  # "HO2"   -- actually H3
+}
+
+_WHOLE_SKELETON = {"reactant:1": list(range(1, 10))}
+
+
+def _evidence(reactants: dict | None, products: dict | None, *, passed: bool = True):
+    return [
+        TransitionStateValidationEvidenceIn(
+            kind="irc",
+            passed=passed,
+            rationale="IRC descends to C2H5OO one way and C2H4 + HO2 the other.",
+            reactant_participant_mapping=reactants,
+            product_participant_mapping=products,
+        )
+    ]
+
+
+def _elimination_reaction(
+    session,
+    *,
+    reactant_smiles: str = "CCO[O]",
+    product_smiles: tuple[str, ...] = ("C=C", "O[O]"),
+    product_kinds: tuple[MoleculeKind, ...] | None = None,
+):
+    """Build ``ethylperoxy -> ethene + HO2`` and return its reaction entry."""
+    kinds = product_kinds or tuple(MoleculeKind.molecule for _ in product_smiles)
+    reactant = make_species(
+        session,
+        smiles=reactant_smiles,
+        inchi_key=next_inchi_key("IRCR"),
+        multiplicity=2,
+    )
+    products = [
+        make_species(
+            session,
+            smiles=smiles,
+            inchi_key=next_inchi_key("IRCP"),
+            kind=kind,
+        )
+        for smiles, kind in zip(product_smiles, kinds, strict=True)
+    ]
+    chem = make_chem_reaction(session, reactants=[reactant], products=products)
+    return make_reaction_entry(
+        session,
+        reaction=chem,
+        reactant_entries=[make_species_entry(session, reactant)],
+        product_entries=[make_species_entry(session, species) for species in products],
+    )
+
+
+def _geometry_id(session, xyz_text: str) -> int:
+    return resolve_geometry_payload(session, GeometryPayload(xyz_text=xyz_text)).id
+
+
+def _check(session, reaction_entry, geometry_id, evidence) -> None:
+    validate_ts_evidence_participant_composition(
+        session,
+        evidence,
+        reaction_entry_id=reaction_entry.id,
+        transition_state_geometry_id=geometry_id,
+        subject_label="ts_elim",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The rule fires
+# ---------------------------------------------------------------------------
+
+
+def test_ethene_made_of_two_oxygens_is_refused(db_session) -> None:
+    """The headline case: a valid partition of the wrong atoms.
+
+    Every one of the nine atoms is claimed exactly once, so the shape rule in
+    ``validate_ts_evidence_set`` has nothing to say. What is wrong is that
+    ``product:1`` is declared as ``C=C`` and made of C2O2H2.
+    """
+    reaction_entry = _elimination_reaction(db_session)
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    with pytest.raises(ValueError) as excinfo:
+        _check(
+            db_session,
+            reaction_entry,
+            geometry_id,
+            _evidence(_WHOLE_SKELETON, _ETHENE_MADE_OF_OXYGENS),
+        )
+
+    message = str(excinfo.value)
+    assert "transition_state_irc_mapping_element_mismatch" in message
+    # The error has to name the formula it was handed and the formula it
+    # expected, or a depositor cannot correct the mapping per atom -- which is
+    # the mistake that created this gap in the first place.
+    assert "C2H2O2" in message
+    assert "C2H4" in message
+    assert "product:1" in message
+
+
+def test_the_reactant_leg_is_checked_too(db_session) -> None:
+    """Both legs, not just the products."""
+    reaction_entry = _elimination_reaction(db_session)
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    with pytest.raises(ValueError, match="reactant:1"):
+        _check(
+            db_session,
+            reaction_entry,
+            geometry_id,
+            # The lone reactant is C2H5O2 and must take the whole skeleton;
+            # eight atoms is a formula it does not have.
+            _evidence({"reactant:1": list(range(1, 9))}, _CORRECT_PRODUCTS),
+        )
+
+
+def test_a_swap_between_two_participants_is_refused(db_session) -> None:
+    """Right formulas on the side as a whole, wrong ones per participant.
+
+    This is the case an aggregate composition check cannot reach:
+    ``validate_transition_state_composition`` compares the saddle point against
+    the reactant side in total, and the total is correct here. Only the
+    per-participant rule sees that ethene has been handed HO2's atoms.
+    """
+    reaction_entry = _elimination_reaction(db_session)
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    with pytest.raises(ValueError, match="transition_state_irc_mapping_element_mismatch"):
+        _check(
+            db_session,
+            reaction_entry,
+            geometry_id,
+            _evidence(
+                _WHOLE_SKELETON,
+                {
+                    "product:1": [3, 4, 9, 5, 6, 7],  # O, O, H, H, H, H
+                    "product:2": [1, 2, 8],  # C, C, H
+                },
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The rule does not fire on correct chemistry
+# ---------------------------------------------------------------------------
+
+
+def test_the_correct_partition_of_the_same_saddle_point_passes(db_session) -> None:
+    """The other half of the headline case, and the one that matters most."""
+    reaction_entry = _elimination_reaction(db_session)
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    _check(
+        db_session,
+        reaction_entry,
+        geometry_id,
+        _evidence(_WHOLE_SKELETON, _CORRECT_PRODUCTS),
+    )
+
+
+def test_evidence_that_did_not_pass_is_not_contradicted(db_session) -> None:
+    """A record that does not claim to be passing evidence claims nothing.
+
+    An IRC that ran and *failed* is worth storing — it is the record of a
+    saddle point that does not connect what its depositor hoped — and its
+    mapping is a description of what was found, not an assertion about it.
+    """
+    reaction_entry = _elimination_reaction(db_session)
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    _check(
+        db_session,
+        reaction_entry,
+        geometry_id,
+        _evidence(_WHOLE_SKELETON, _ETHENE_MADE_OF_OXYGENS, passed=False),
+    )
+
+
+def test_evidence_without_mappings_is_not_checked(db_session) -> None:
+    """Mappings are optional on every path; absence is never contradiction.
+
+    This is also what a barrierless association deposits when it has run an
+    IRC-like scan but has no atom partition to declare, and it is the escape
+    hatch the blocking tier depends on.
+    """
+    reaction_entry = _elimination_reaction(db_session)
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    _check(db_session, reaction_entry, geometry_id, _evidence(None, None))
+
+
+def test_absent_geometry_is_not_a_contradiction(db_session) -> None:
+    """A barrierless path has no saddle point, so there is nothing to compare.
+
+    Nothing about the mapping can be judged without the geometry its indices
+    count into, and refusing on that basis would refuse a deposit for what it
+    does not contain rather than for what it says.
+    """
+    reaction_entry = _elimination_reaction(db_session)
+
+    validate_ts_evidence_participant_composition(
+        db_session,
+        _evidence(_WHOLE_SKELETON, _ETHENE_MADE_OF_OXYGENS),
+        reaction_entry_id=reaction_entry.id,
+        transition_state_geometry_id=None,
+        subject_label="barrierless",
+    )
+
+
+def test_a_pseudo_participant_is_skipped_without_exempting_its_siblings(
+    db_session,
+) -> None:
+    """A lumped construct has no atom-resolved composition to compare against.
+
+    It is skipped *individually* rather than exempting the whole record: the
+    other participants' formulas are still perfectly well-defined, and dropping
+    them would discard a guarantee for no reason -- the same reasoning that
+    keeps ``validate_transition_state_composition``'s exemption scoped to the
+    reactant side.
+    """
+    reaction_entry = _elimination_reaction(
+        db_session,
+        product_smiles=("C=C", "O[O]"),
+        product_kinds=(MoleculeKind.pseudo, MoleculeKind.molecule),
+    )
+    geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
+
+    # ``product:1`` is pseudo and declared ``C=C``, and is handed two oxygens.
+    # A lumped construct has no atom-resolved composition to contradict, so
+    # this is accepted -- while ``product:2`` beside it is given its own
+    # correct O, O, H.
+    _check(
+        db_session,
+        reaction_entry,
+        geometry_id,
+        _evidence(_WHOLE_SKELETON, {"product:1": [3, 4], "product:2": [3, 4, 9]}),
+    )
+
+    # The exemption stops at the pseudo participant. ``product:2`` is an
+    # ordinary molecule, is declared ``O[O]``, and has just been handed O, H, H.
+    with pytest.raises(ValueError, match="product:2"):
+        _check(
+            db_session,
+            reaction_entry,
+            geometry_id,
+            _evidence(_WHOLE_SKELETON, {"product:1": [3, 4], "product:2": [4, 8, 9]}),
+        )
+
+
+def test_an_isotopologue_written_with_D_is_not_a_mismatch(db_session) -> None:
+    """``D`` in an XYZ is hydrogen, and a blocking check may not say otherwise.
+
+    Gaussian, ORCA, Molpro and CFOUR all emit or accept ``D``/``T`` for
+    hydrogen's isotopes, and ``geometry_atom.element`` stores them verbatim by
+    design. The SMILES side spells the same nucleus ``[2H]``. Both sides are
+    counted through ``resolve_element_symbol``, so the two agree; comparing raw
+    symbols would read a perfectly ordinary deuterated saddle point as
+    containing an element its participants never mention.
+    """
+    deuterated_ts = (
+        "9\nd5-TS for C2D5OO -> C2D4 + DO2\n"
+        "C  0.00  0.00  0.00\n"
+        "C  1.42  0.00  0.00\n"
+        "O  2.14  1.24  0.00\n"
+        "O  3.42  1.06  0.00\n"
+        "D -0.32  1.03  0.00\n"
+        "D -0.42 -0.55  0.86\n"
+        "D -0.42 -0.55 -0.86\n"
+        "D  1.92 -0.61  0.78\n"
+        "D  2.71 -0.74 -0.42"
+    )
+    reaction_entry = _elimination_reaction(
+        db_session,
+        reactant_smiles="[2H]C([2H])([2H])C([2H])([2H])O[O]",
+        product_smiles=("[2H]C([2H])=C([2H])[2H]", "[2H]O[O]"),
+    )
+    geometry_id = _geometry_id(db_session, deuterated_ts)
+
+    _check(
+        db_session,
+        reaction_entry,
+        geometry_id,
+        _evidence(_WHOLE_SKELETON, _CORRECT_PRODUCTS),
+    )

--- a/backend/tests/services/test_ts_irc_mapping_elements.py
+++ b/backend/tests/services/test_ts_irc_mapping_elements.py
@@ -23,6 +23,9 @@ or a deposit that simply declined to map its atoms would be the wrong rule.
 from __future__ import annotations
 
 import pytest
+from tckdb_schemas.fragments.ts_validation_evidence import (
+    TransitionStateValidationEvidenceIn,
+)
 
 from app.db.models.common import MoleculeKind
 from app.schemas.fragments.geometry import GeometryPayload
@@ -30,10 +33,6 @@ from app.services.geometry_resolution import resolve_geometry_payload
 from app.services.reaction_resolution import (
     validate_ts_evidence_participant_composition,
 )
-from tckdb_schemas.fragments.ts_validation_evidence import (
-    TransitionStateValidationEvidenceIn,
-)
-
 from tests.services.scientific_read._factories import (
     make_chem_reaction,
     make_reaction_entry,

--- a/backend/tests/services/test_ts_irc_mapping_elements.py
+++ b/backend/tests/services/test_ts_irc_mapping_elements.py
@@ -23,11 +23,13 @@ or a deposit that simply declined to map its atoms would be the wrong rule.
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 from tckdb_schemas.fragments.ts_validation_evidence import (
     TransitionStateValidationEvidenceIn,
 )
 
 from app.db.models.common import MoleculeKind
+from app.db.models.species import SpeciesEntry
 from app.schemas.fragments.geometry import GeometryPayload
 from app.services.geometry_resolution import resolve_geometry_payload
 from app.services.reaction_resolution import (
@@ -39,6 +41,7 @@ from tests.services.scientific_read._factories import (
     make_species,
     make_species_entry,
     next_inchi_key,
+    unique_smiles,
 )
 
 # The saddle point at the centre of this file: C2H5O2, listed 1 C, 2 C, 3 O,
@@ -85,14 +88,37 @@ def _evidence(reactants: dict | None, products: dict | None, *, passed: bool = T
     ]
 
 
+def _species_entry(session, species):
+    """Get-or-create the default species entry for *species*.
+
+    ``make_species`` deliberately returns a pre-existing row for an ordinary
+    collider — the test database is session-scoped and other suites commit
+    ethene and HO2 — but ``make_species_entry`` always inserts, so pairing the
+    two directly trips ``uq_species_entry_species_id`` as soon as anything else
+    in the run has committed the same species. This file only reads
+    ``Species.smiles`` and ``Species.kind`` through the entry, so reusing an
+    existing one is equivalent and order-independent.
+    """
+    existing = session.scalar(
+        select(SpeciesEntry).where(SpeciesEntry.species_id == species.id).limit(1)
+    )
+    return existing if existing is not None else make_species_entry(session, species)
+
+
 def _elimination_reaction(
     session,
     *,
     reactant_smiles: str = "CCO[O]",
     product_smiles: tuple[str, ...] = ("C=C", "O[O]"),
     product_kinds: tuple[MoleculeKind, ...] | None = None,
+    product_multiplicities: tuple[int, ...] = (1, 2),
 ):
-    """Build ``ethylperoxy -> ethene + HO2`` and return its reaction entry."""
+    """Build ``ethylperoxy -> ethene + HO2`` and return its reaction entry.
+
+    Multiplicities are the real ones — ethylperoxy and HO2 are radicals — so
+    ``make_species`` resolves onto the same identity another suite would have
+    committed rather than manufacturing a near-duplicate.
+    """
     kinds = product_kinds or tuple(MoleculeKind.molecule for _ in product_smiles)
     reactant = make_species(
         session,
@@ -106,15 +132,18 @@ def _elimination_reaction(
             smiles=smiles,
             inchi_key=next_inchi_key("IRCP"),
             kind=kind,
+            multiplicity=multiplicity,
         )
-        for smiles, kind in zip(product_smiles, kinds, strict=True)
+        for smiles, kind, multiplicity in zip(
+            product_smiles, kinds, product_multiplicities, strict=True
+        )
     ]
     chem = make_chem_reaction(session, reactants=[reactant], products=products)
     return make_reaction_entry(
         session,
         reaction=chem,
-        reactant_entries=[make_species_entry(session, reactant)],
-        product_entries=[make_species_entry(session, species) for species in products],
+        reactant_entries=[_species_entry(session, reactant)],
+        product_entries=[_species_entry(session, species) for species in products],
     )
 
 
@@ -285,17 +314,21 @@ def test_a_pseudo_participant_is_skipped_without_exempting_its_siblings(
     keeps ``validate_transition_state_composition``'s exemption scoped to the
     reactant side.
     """
+    # The lumped participant gets a SMILES no other suite commits. ``kind`` is
+    # not part of ``Species.public_ref``, which is content-addressed on
+    # (smiles, charge, multiplicity), so a *pseudo* row reusing an ordinary
+    # molecule's SMILES cannot be inserted alongside it at all.
     reaction_entry = _elimination_reaction(
         db_session,
-        product_smiles=("C=C", "O[O]"),
+        product_smiles=(unique_smiles(), "O[O]"),
         product_kinds=(MoleculeKind.pseudo, MoleculeKind.molecule),
     )
     geometry_id = _geometry_id(db_session, _XYZ_ELIM_TS)
 
-    # ``product:1`` is pseudo and declared ``C=C``, and is handed two oxygens.
-    # A lumped construct has no atom-resolved composition to contradict, so
-    # this is accepted -- while ``product:2`` beside it is given its own
-    # correct O, O, H.
+    # ``product:1`` is the lumped construct, and is handed two oxygens that are
+    # nothing like the alkane its SMILES names. A pseudo species has no
+    # atom-resolved composition to contradict, so this is accepted -- while
+    # ``product:2`` beside it is given its own correct O, O, H.
     _check(
         db_session,
         reaction_entry,

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -3601,6 +3601,32 @@ def test_bundle_ts_evidence_must_name_an_irc_calculation() -> None:
         )
 
 
+def test_bundle_ts_evidence_element_checks_its_participant_mapping(
+    db_engine,
+) -> None:
+    """The element rule reaches the bundle path too, through the shared seam.
+
+    The CH3 + H saddle point is listed ``1 C, 2-5 H``. This mapping hands the
+    carbon to ``reactant:2``, which is declared ``[H]``, and the four hydrogens
+    to ``reactant:1``, which is declared ``[CH3]``. The partition is still
+    perfectly well-formed — five atoms, each claimed once — and the *side* still
+    totals CH4, so ``validate_transition_state_composition``'s aggregate
+    comparison sees nothing wrong either. Only the per-participant rule does.
+    """
+    payload = _payload_with_ts_evidence(
+        reactant_participant_mapping={"reactant:1": [2, 3, 4, 5], "reactant:2": [1]},
+    )
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            persist_computed_reaction_upload(
+                session, ComputedReactionUploadRequest(**payload)
+            )
+
+    message = str(excinfo.value)
+    assert "transition_state_irc_mapping_element_mismatch" in message
+    assert "reactant:2" in message or "reactant:1" in message
+
+
 def test_bundle_ts_evidence_enforces_full_atom_coverage() -> None:
     with pytest.raises(ValueError, match="cover every one of the 5 TS atoms"):
         ComputedReactionUploadRequest(

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -123,11 +123,14 @@ _CONVENTIONS = {
 # partition has to follow the *atoms*, not just their count. The micro
 # reaction is ethylperoxy -> ethene + HO2, so ``product:1`` (C2H4) takes both
 # carbons and four hydrogens, and ``product:2`` (HO2) takes both oxygens and
-# the fifth hydrogen. Handing ethene the oxygens would still cover nine atoms
-# exactly once and still pass, because
-# ``transition_state_validation_evidence`` bounds-checks the partition and
-# never element-checks it — so the indices below are only as trustworthy as
-# this comment, and both are stated against the geometry above.
+# the fifth hydrogen.
+#
+# Handing ethene the oxygens instead would still cover nine atoms exactly once,
+# and for a while that was enough to pass: the partition was bounds-checked and
+# never element-checked, so the indices below were only as trustworthy as this
+# comment. ``validate_ts_evidence_participant_composition`` now checks them
+# against the geometry, and
+# ``test_pdep_ts_evidence_refuses_ethene_made_of_oxygens`` holds that door shut.
 _ELIM_TS_ATOMS = list(range(1, 10))
 _ELIM_REACTANT_MAP = {"reactant:1": _ELIM_TS_ATOMS}
 _ELIM_PRODUCT_MAP = {
@@ -2333,6 +2336,60 @@ def test_non_finite_barrier_is_rejected() -> None:
     payload["solve"]["channel_barriers"][0]["forward_barrier_kj_mol"] = float("nan")
     with pytest.raises(ValueError, match="finite"):
         NetworkPDepUploadRequest(**payload)
+
+
+def test_pdep_ts_evidence_refuses_ethene_made_of_oxygens(db_engine) -> None:
+    """The partition that used to pass, refused end to end on this path.
+
+    ``product:1`` is declared ``C=C`` and handed atoms 1-6 of a saddle point
+    listed ``1 C, 2 C, 3 O, 4 O, 5-9 H`` — two carbons, two oxygens and two
+    hydrogens. Every one of the nine atoms is still claimed exactly once, so the
+    shape rule has nothing to object to; only the element rule sees it. This is
+    the exact mapping a fixture "correction" once wrote here, under a comment
+    that correctly said "C2H4 (six atoms)".
+    """
+    payload = _full_payload()
+    payload["transition_states"][0]["validation_evidence"][0].update(
+        {
+            "product_participant_mapping": {
+                "product:1": [1, 2, 3, 4, 5, 6],
+                "product:2": [7, 8, 9],
+            }
+        }
+    )
+
+    with _rolled_back_session(db_engine) as session:
+        request = NetworkPDepUploadRequest(**payload)
+        with pytest.raises(ValueError) as excinfo:
+            persist_network_pdep_upload(session, request, warnings=[])
+
+    message = str(excinfo.value)
+    assert "transition_state_irc_mapping_element_mismatch" in message
+    # Named per formula, so the depositor can correct it per atom.
+    assert "C2H2O2" in message and "C2H4" in message
+
+
+def test_pdep_ts_evidence_accepts_the_correct_partition(db_engine) -> None:
+    """The other half: the same saddle point, partitioned per atom, deposits.
+
+    Guards against closing the gap by refusing the whole family — the check has
+    to distinguish ethene from C2O2H2, not merely notice that a mapping exists.
+    """
+    payload = _full_payload()
+    assert payload["transition_states"][0]["validation_evidence"][0][
+        "product_participant_mapping"
+    ] == _ELIM_PRODUCT_MAP
+
+    with _rolled_back_session(db_engine) as session:
+        warnings: list[UploadWarning] = []
+        network = persist_network_pdep_upload(
+            session, NetworkPDepUploadRequest(**payload), warnings=warnings
+        )
+        session.flush()
+        assert network.id is not None
+        assert "transition_state_missing_irc_evidence" not in [
+            w.code for w in warnings
+        ]
 
 
 def test_transition_state_without_irc_evidence_succeeds_with_a_warning(

--- a/backend/tests/workflows/test_transition_state_upload.py
+++ b/backend/tests/workflows/test_transition_state_upload.py
@@ -662,6 +662,33 @@ def test_standalone_ts_upload_persists_irc_evidence(db_engine) -> None:
         assert _build_validation_descriptor(session, ts_entry.id).irc == "present"
 
 
+def test_standalone_ts_evidence_element_checks_its_participant_mapping(
+    db_engine,
+) -> None:
+    """The element rule reaches this path too, through the shared persist seam.
+
+    The saddle point is H + H2, so no participant can be handed the *wrong
+    element* — but ``reactant:1`` is a single H atom and this mapping hands it
+    two, which is the same contradiction in the only form this reaction can
+    express it. What matters is that the rule is enforced here at all: it lives
+    on ``persist_transition_state_validation_evidence``, the one seam all three
+    deposit paths meet at, so the standalone upload, the computed-reaction
+    bundle and the PDep bundle cannot hold the same claim to different
+    standards.
+    """
+    request = _ts_request_with_evidence(
+        reactant_participant_mapping={"reactant:1": [1, 2], "reactant:2": [3]},
+    )
+    with Session(db_engine) as session, session.begin():
+        with pytest.raises(ValueError) as excinfo:
+            persist_transition_state_upload(session, request, warnings=[])
+        session.rollback()
+
+    message = str(excinfo.value)
+    assert "transition_state_irc_mapping_element_mismatch" in message
+    assert "reactant:1" in message
+
+
 def test_standalone_ts_upload_without_evidence_warns(db_engine) -> None:
     with Session(db_engine) as session, session.begin():
         warnings: list = []

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -64,22 +64,21 @@ disagree about a line number, this one is right by construction.
 
 | Tier | Entries | Meaning |
 | --- | --- | --- |
-| `block` | 14 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
+| `block` | 15 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
 | `warn` | 8 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
 | `review` | 0 | Referred to `machine_review` under a versioned rubric. ADR 0008 puts every cross-check against external reference data here. |
 | `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
-| **total** | **27** | |
+| **total** | **28** | |
 
 ## Recorded divergences
 
 Where a check's documentation and its behaviour disagree, or where a guarantee is narrower than its name suggests. Every one of these is reported, never silently fixed — the register changes no check behaviour.
 
-- **[3]** A saddle point is made of exactly the atoms of the reaction it is declared to sit in.
-- **[4]** A saddle point carries the same total charge as the reactants it sits between.
-- **[6]** The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
-- **[9]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
-- **[13]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
-- **[25]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+- **[5]** The saddle-point atoms an IRC mapping assigns to a declared participant are that participant's own atoms, element for element.
+- **[7]** The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
+- **[10]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
+- **[14]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
+- **[26]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 ## Entries
 
@@ -97,7 +96,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_reaction_elemental_balance` — `backend/app/services/reaction_resolution.py:131`
+- `validate_reaction_elemental_balance` — `backend/app/services/reaction_resolution.py:134`
   *Called from `resolve_chem_reaction`, so it fires on every path that resolves a reaction, including the PDep bundle.*
 
 **Escape hatch.** Declare a participant with `molecule_kind: pseudo`. A lumped or phenomenological construct has no atom-resolved composition, so one such participant suspends the law for the whole reaction. A declared electron does **not** exempt it — an electron contributes zero atoms and the reaction still has to balance.
@@ -114,7 +113,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_reaction_charge_conservation` — `backend/app/services/reaction_resolution.py:219`
+- `validate_reaction_charge_conservation` — `backend/app/services/reaction_resolution.py:222`
   *Sums `Species.charge`, which `canonical_species_identity` has already reconciled against the formal charge of each species' own SMILES.*
 
 **Escape hatch.** Declare the free electron as a participant — `{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, "multiplicity": 2}` — which is how associative and dissociative attachment, photoionization and photodetachment are deposited. It contributes -1 to the side it sits on and zero atoms, so elemental balance still has to be satisfied separately. A `pseudo` participant suspends the law entirely, as it does for elemental balance. Conservation is not neutrality: any net charge is accepted as long as both sides carry the same one, so ion-molecule reactions are unaffected.
@@ -131,12 +130,10 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:361`
+- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:364`
   *Composition is read from the saddle-point geometry when there is one and from `unmapped_smiles` otherwise. The PDep path passes no SMILES, so it compares geometry only.*
 
-**Escape hatch.** Declare the extra species as participants of the reaction. A `pseudo` reactant exempts the reaction. Absence does not block: no geometry and no parseable SMILES means nothing is compared, and an unparseable transition-state SMILES is treated as silence rather than as a contradiction, because a TS SMILES is a lossy label for a structure that is by construction not a stable molecule.
-
-**Recorded divergence.** The docstring says pseudo-species exemption 'matches `validate_reaction_elemental_balance`'. It does not, quite: this function queries only `ReactionRole.reactant` and exempts only on a *reactant-side* pseudo participant, while `_load_participant_species` exempts the two conservation checks on a pseudo participant on **either** side. A reaction whose only pseudo species is a product is therefore exempt from elemental balance but still held to transition-state composition, and it is compared against a reactant side that carries no balance guarantee. Reported, not changed — this register alters no check behaviour.
+**Escape hatch.** Declare the extra species as participants of the reaction. A `pseudo` *reactant* exempts the reaction; a pseudo product does not, and that is not an oversight — see below. Absence does not block: no geometry and no parseable SMILES means nothing is compared, and an unparseable transition-state SMILES is treated as silence rather than as a contradiction, because a TS SMILES is a lossy label for a structure that is by construction not a stable molecule. The pseudo-species exemption here is narrower than `_load_participant_species`'s, and deliberately so. That helper exempts elemental balance and charge conservation on a pseudo participant on **either** side, because both compare one side against the other and a lumped construct makes the side it sits on unknowable. This check compares the saddle point against the **reactant side only**, so only a *reactant* being pseudo can make it meaningless; a pseudo *product* leaves the reactant side fully atom-resolved and is not exempted. Aligning the two would discard a guarantee that is still well-defined, and would discard it exactly where it is worth most: a reaction with a pseudo product has already lost elemental balance and charge conservation, so this is the only atom-level statement left about its saddle point.
 
 ### 4. A saddle point carries the same total charge as the reactants it sits between.
 
@@ -150,16 +147,33 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:361`
+- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:364`
   *Second, independent leg of the same function. Skipped entirely when the caller passes no `transition_state_charge`.*
 
-**Escape hatch.** Omit the transition state's charge, which skips the comparison. Multiplicity is deliberately **not** checked here at all: spin is not conserved the way charge and atoms are — two doublets may react over a singlet or a triplet surface, and spin-forbidden reactions are real chemistry — so a multiplicity rule would fire on correct novel results.
+**Escape hatch.** Omit the transition state's charge, which skips the comparison. Multiplicity is deliberately **not** checked here at all: spin is not conserved the way charge and atoms are — two doublets may react over a singlet or a triplet surface, and spin-forbidden reactions are real chemistry — so a multiplicity rule would fire on correct novel results. The pseudo-species exemption here is narrower than `_load_participant_species`'s, and deliberately so. That helper exempts elemental balance and charge conservation on a pseudo participant on **either** side, because both compare one side against the other and a lumped construct makes the side it sits on unknowable. This check compares the saddle point against the **reactant side only**, so only a *reactant* being pseudo can make it meaningless; a pseudo *product* leaves the reactant side fully atom-resolved and is not exempted. Aligning the two would discard a guarantee that is still well-defined, and would discard it exactly where it is worth most: a reaction with a pseudo product has already lost elemental balance and charge conservation, so this is the only atom-level statement left about its saddle point.
 
-**Recorded divergence.** The docstring says pseudo-species exemption 'matches `validate_reaction_elemental_balance`'. It does not, quite: this function queries only `ReactionRole.reactant` and exempts only on a *reactant-side* pseudo participant, while `_load_participant_species` exempts the two conservation checks on a pseudo participant on **either** side. A reaction whose only pseudo species is a product is therefore exempt from elemental balance but still held to transition-state composition, and it is compared against a reactant side that carries no balance guarantee. Reported, not changed — this register alters no check behaviour.
+### 5. The saddle-point atoms an IRC mapping assigns to a declared participant are that participant's own atoms, element for element.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `transition_state_irc_mapping_element_mismatch` |
+| **Governing ADR** | 0008, 0011 |
+
+**Why this tier.** Definitional. 'These saddle-point atoms become C2H4' while those atoms are C2O2H2 is a contradiction no correct calculation can produce — the same class of claim `CHECK_TRANSITION_STATE_COMPOSITION` already blocks, one level finer, per participant rather than per side. It is also what the register's own consistency requires: the identical assertion expressed as a `reaction_atom_map` is refused by `CHECK_ATOM_MAP_ELEMENT_CONSERVED`, at the wire boundary and again by a composite foreign key into `geometry_atom`. Two surfaces enforcing different standards on the same claim is not a defensible position for either — and the divergence was not theoretical: a well-formed partition handing ethene two oxygens and HO2 three hydrogens was accepted, under a fixture comment that correctly said 'C2H4 (six atoms)'.
+
+**Enforced at.**
+
+- `validate_ts_evidence_participant_composition` — `backend/app/services/reaction_resolution.py:599`
+  *Called from `persist_transition_state_validation_evidence`, the single seam every deposit path that can carry a transition state already routes through, so the PDep bundle, the computed-reaction bundle and the standalone transition-state upload cannot enforce different standards. It is a service-layer check rather than a wire-boundary one because a participant's composition comes from its SMILES, and `tckdb_schemas` is chemistry-free — RDKit is not available where `validate_ts_evidence_set` runs. That function keeps the *shape* half of the rule: keys name every declared participant, indices partition the TS atoms exactly once.*
+
+**Escape hatch.** Omit the participant mappings. They are optional on every path — evidence without them still deposits and still reads back as `irc: present` — so a depositor who cannot resolve the partition per atom is never forced to guess at one. Declaring a participant `molecule_kind: pseudo` skips that participant alone rather than the whole record, because the others' compositions are still well-defined. Isotopologues are safe by construction: both sides are compared through `resolve_element_symbol`, so a geometry written `D` counts as the hydrogen its SMILES spells `[2H]`.
+
+**Recorded divergence.** A zero-atom participant cannot be expressed. `TransitionStateValidationEvidenceIn` refuses an empty atom list, and `validate_ts_evidence_set` requires every declared participant to be named, so a reaction releasing a free electron — `MoleculeKind.electron`, newly reachable — has no way to write `product:2: []`. Before this check such a reaction could deposit a *wrong* mapping that stole a real atom for the electron; it now correctly cannot, but it also cannot deposit a right one, and must omit the mappings instead. Widening the wire schema to accept an empty list for a participant with no atoms is the fix, and is a wire-package change with its own version bump.
 
 ## A structure against its own label
 
-### 5. A conformer geometry deposited under a species entry is made of the atoms that entry's own SMILES declares.
+### 6. A conformer geometry deposited under a species entry is made of the atoms that entry's own SMILES declares.
 
 | Field | Value |
 | --- | --- |
@@ -176,7 +190,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Declare `molecule_kind: pseudo`, which has no atom-resolved composition to agree with. A free electron is deliberately **not** exempt — its composition is not unknown but empty, so any geometry deposited under one is refused, which stops `electron` becoming a quieter way to smuggle a structure past the check. Absence does not block: no geometry, or a SMILES RDKit will not parse, is incompleteness.
 
-### 6. The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
+### 7. The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
 
 | Field | Value |
 | --- | --- |
@@ -197,7 +211,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 7. A species entry's declared charge equals the summed formal charge of its own SMILES.
+### 8. A species entry's declared charge equals the summed formal charge of its own SMILES.
 
 | Field | Value |
 | --- | --- |
@@ -216,7 +230,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 8. The charge and spin multiplicity a depositor declares match the ones the electronic-structure log says the calculation was actually run at.
+### 9. The charge and spin multiplicity a depositor declares match the ones the electronic-structure log says the calculation was actually run at.
 
 | Field | Value |
 | --- | --- |
@@ -233,7 +247,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Absence is not contradiction: if the producing program is not one of the wired parsers, the artifact is missing, the log is truncated, or the declarations inside a single log disagree with each other, the value is left unknown and **no** warning is emitted. Only a value genuinely read from the log may contradict a declaration — emitting a mismatch because parsing failed would fabricate a contradiction out of ignorance.
 
-### 9. An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
+### 10. An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
 
 | Field | Value |
 | --- | --- |
@@ -256,7 +270,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Stationary points
 
-### 10. A transition state has at least one imaginary vibrational mode, exactly one of them is designated the reaction coordinate, and no undeclared mode is stiff enough to make that designation meaningless.
+### 11. A transition state has at least one imaginary vibrational mode, exactly one of them is designated the reaction coordinate, and no undeclared mode is stiff enough to make that designation meaningless.
 
 | Field | Value |
 | --- | --- |
@@ -274,7 +288,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Three, and they are the point of the rule. Deposit no frequency evidence: `n_imag=None` produces no findings at all, because absence is never contradiction. Or deposit the extra imaginary modes honestly — designate the reaction coordinate and give each other mode a disposition (`torsion`, `rigid_body_residue`, `intermolecular`, `ring_pucker`, `symmetry_breaking`, or an explicit `unassigned`) — and a genuine higher-order saddle is accepted with a warning and a structural flag. Or, if the extra mode really is the barrier, designate *it*. What has no door is refusing to say which mode is the reaction coordinate.
 
-### 11. A species entry declared a minimum has no imaginary vibrational modes.
+### 12. A species entry declared a minimum has no imaginary vibrational modes.
 
 | Field | Value |
 | --- | --- |
@@ -291,7 +305,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Declare `species_entry_kind='vdw_complex'`, which records the same mode with a warning instead, or deposit the structure through a transition-state payload if the single imaginary mode is real.
 
-### 12. A van der Waals complex is formally a minimum, so an imaginary mode on one is recorded and flagged rather than refused — unless the mode is too stiff to be an intermolecular one, which suggests a genuine reaction coordinate.
+### 13. A van der Waals complex is formally a minimum, so an imaginary mode on one is recorded and flagged rather than refused — unless the mode is too stiff to be an intermolecular one, which suggests a genuine reaction coordinate.
 
 | Field | Value |
 | --- | --- |
@@ -308,7 +322,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** This *is* the escape hatch for the blocking minimum rule. Its own cost is that a genuinely mislabelled saddle point deposited as a van der Waals complex is accepted with a warning.
 
-### 13. A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
+### 14. A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
 
 | Field | Value |
 | --- | --- |
@@ -342,7 +356,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** ADR 0012 recommends replacing the threshold with a determination — projecting each imaginary eigenvector onto the six rigid-body vectors (more than about 90 percent overlap means projection residue) and onto dihedral-rotation vectors (more than about 70 percent means a torsion) — and says those should be implemented *before* tau is tuned, because a determination beats a threshold wherever one is available. They are not implemented, and cannot be: `backend/app/db/models/transition_state.py` records that normal-mode displacement evidence is deliberately absent from TCKDB, 'a producer-side heuristic, not a database record'. So the disposition on each extra mode is *declared by the depositor* and TCKDB cannot check it. Recorded, not resolved: reversing that decision is a schema change and its own ADR.
 
-### 14. A transition state's reaction coordinate should exceed roughly 100 cm-1 in magnitude.
+### 15. A transition state's reaction coordinate should exceed roughly 100 cm-1 in magnitude.
 
 | Field | Value |
 | --- | --- |
@@ -376,7 +390,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None is needed — the check never refuses. A referee should read the threshold as a tunable reporting line, not a claim about physics.
 
-### 15. A deposited saddle point should carry passing intrinsic-reaction-coordinate evidence that it connects the declared reactants and products.
+### 16. A deposited saddle point should carry passing intrinsic-reaction-coordinate evidence that it connects the declared reactants and products.
 
 | Field | Value |
 | --- | --- |
@@ -388,14 +402,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:33`
+- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:36`
   *Every path that can carry a transition state routes through this seam — the PDep bundle, the computed-reaction bundle and the standalone transition-state upload — so all three write identical rows and report an identical gap. Before the seam existed only the PDep bundle could deposit the evidence, so a TS uploaded any other way always read back as `irc: absent` even when the depositor had run one.*
 
 **Escape hatch.** None needed — the warning is the accommodation. Note the warning fires on absence of a *passing* record, so evidence that was run and failed is stored and still warns.
 
 ## Atom mapping across a reaction
 
-### 16. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
+### 17. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
 
 | Field | Value |
 | --- | --- |
@@ -416,7 +430,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 17. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
+### 18. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 
 | Field | Value |
 | --- | --- |
@@ -439,7 +453,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 18. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
+### 19. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
 
 | Field | Value |
 | --- | --- |
@@ -464,7 +478,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 19. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
+### 20. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
 
 | Field | Value |
 | --- | --- |
@@ -483,7 +497,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 20. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
+### 21. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
 
 | Field | Value |
 | --- | --- |
@@ -500,7 +514,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
 
-### 21. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
+### 22. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
 
 | Field | Value |
 | --- | --- |
@@ -517,7 +531,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-### 22. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
+### 23. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
 
 | Field | Value |
 | --- | --- |
@@ -540,7 +554,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Rate coefficients
 
-### 23. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
+### 24. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
 
 | Field | Value |
 | --- | --- |
@@ -561,7 +575,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Statistical mechanics
 
-### 24. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
+### 25. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
 
 | Field | Value |
 | --- | --- |
@@ -582,7 +596,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Pressure-dependent networks
 
-### 25. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+### 26. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 | Field | Value |
 | --- | --- |
@@ -603,7 +617,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
 
-### 26. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
+### 27. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
 
 | Field | Value |
 | --- | --- |
@@ -622,7 +636,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Reproducibility
 
-### 27. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
+### 28. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
 
 | Field | Value |
 | --- | --- |


### PR DESCRIPTION
Two related gaps: a transition state validated against a reference that may itself be unverified.

## Gap 1 — IRC participant mappings were bounds-checked but never element-checked

`transition_state_validation_evidence` records which saddle-point atom indices become which declared participant. Nothing verified the *elements* agreed — which is how a 9-atom `C C O O H H H H H` partition for `ethylperoxy → ethene + HO2` could hand ethene two oxygens and HO₂ three hydrogens under a comment that correctly said "C2H4 (six atoms)".

The identical claim written as a `reaction_atom_map` **was** already refused, by the `element` composite-FK design. Two surfaces, one assertion, different standards.

`validate_ts_evidence_participant_composition` now runs at `persist_transition_state_validation_evidence` — the single seam all three deposit paths already route through, so PDep, the computed-reaction bundle and the standalone TS upload cannot diverge.

**Tier: block.** "These saddle-point atoms become C₂H₄" while those atoms are C₂O₂H₂ is a contradiction no correct calculation can produce. Registered as `CHECK_TS_IRC_MAPPING_ELEMENTS`; register regenerated 27 → 28 entries, blocking 14 → 15, drift guard green.

**Why the service layer rather than the wire boundary:** participant composition comes from SMILES, and `tckdb_schemas` is chemistry-free by an enforced import boundary — RDKit is not available where `validate_ts_evidence_set` runs. That function keeps the shape half of the rule.

**Fires:** the exact bad partition, refused end-to-end on all three paths, paired with proof the *same* saddle point still deposits under a correct partition.
**Does not fire:** barrierless paths, absent geometry, evidence without mappings, pseudo participants (skipped individually, siblings still checked), and isotopologues — a `D` geometry against a `[2H]` SMILES, both sides counted through `resolve_element_symbol`.

## Gap 2 — the asymmetry is correct; the docstring was wrong

`validate_transition_state_composition` exempts only when a **reactant** is pseudo, while the balance checks exempt on either side. Its docstring claimed they matched.

**Decision: keep the behaviour, fix the claim.** The two answer different questions. Elemental balance and charge conservation compare *one side against the other*, so a pseudo participant anywhere makes the comparison meaningless. TS composition compares the saddle point against the **reactant side only** — a pseudo *product* leaves the reactant side fully atom-resolved, so exempting on it would discard a guarantee that is still well-defined, and discard it **precisely where it is worth most**: that reaction has already lost both conservation laws, so this is the only atom-level statement left about its saddle point.

`_TS_COMPOSITION_PSEUDO_DIVERGENCE` becomes `_TS_COMPOSITION_PSEUDO_SCOPE`; the two register `divergence=` entries are now resolved rather than reported.

## Fixtures

**None needed correcting.** Every mapping fixture was verified per atom index and all four were already right — the bad partition had been fixed earlier in the week. What was stale was the *comment* asserting no element check exists.

## Verification

Baselines established independently on `fe2a3ac`: scientific **1977**, API **2464** — both unchanged on the branch. (These differ from the 1975/2434 measured on `0c6a623`, which predates #105/#106/#107; each branch's baseline is correct for its own base.)

`ruff` clean; drift guard 26 passed; register regenerates byte-identically. No models, migrations or wire-package files touched.

## Reported, not fixed

- **An atom map and an IRC mapping are never checked against each other.** `reaction_atom_map.py` calls the atom map "the refinement of that partition into a bijection", yet a deposit carrying both can state two contradictory partitions and both pass independently. Same shape as Gap 1, one level up.
- **A zero-atom participant cannot be mapped.** `MoleculeKind.electron` is newly live, but the schema refuses an empty atom list while every participant must be named — so `product:2: []` is unwritable. Such a reaction previously could deposit a *wrong* mapping stealing a real atom for the electron; it now correctly cannot, but must omit mappings entirely. Widening the wire schema is a `tckdb_schemas` change with its own version bump.
- **`tests/workflows/` cross-file order dependence is real and not seed-related** — running `test_network_pdep_upload.py` before `test_computed_reaction_upload.py` fails 5 tests even under `-p no:randomly`, identically at `fe2a3ac` with none of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)