### PR TITLE
Make the test suite order-independent

### DIFF
--- a/backend/app/services/public_refs.py
+++ b/backend/app/services/public_refs.py
@@ -217,6 +217,30 @@ def _canonical_species(obj: Any) -> str:
     ``inchi_key`` instead of the canonical ``smiles`` would collide the
     refs of standard-InChIKey-merged tautomers (2-pyridone vs
     2-hydroxypyridine), which are now distinct species.
+
+    ``kind`` (:class:`~app.db.models.common.MoleculeKind`) is deliberately
+    **not** here, and that is an invariant rather than an oversight: species
+    identity is ``uq_species_identity`` on ``(smiles, charge, multiplicity)``,
+    which does not carry ``kind`` either. Adding ``kind`` to this string alone
+    would mint two distinct refs for a pair of rows the database's own unique
+    constraint cannot hold, which is worse than the omission. The consequence
+    — that a ``pseudo`` species cannot coexist with a ``molecule`` of the same
+    ``(smiles, charge, multiplicity)`` — is a property of the identity key,
+    and changing it is a schema decision (new constraint + migration +
+    backfill), not a ref-generation one.
+
+    Nothing reachable can currently collide across ``kind``:
+    :func:`app.services.species_resolution.resolve_species` is the only
+    writer of a ``species`` row in the application, and
+    :func:`app.chemistry.species.canonical_species_identity` admits only
+    ``molecule`` and ``electron``. ``electron`` is pinned by
+    ``SpeciesIdentityPayload.check_electron_identity`` to
+    ``smiles="[e-]", charge=-1, multiplicity=2`` in *both* directions — a
+    molecule may not carry ``[e-]`` and an electron may not carry anything
+    else — so the one live non-``molecule`` kind occupies an identity tuple
+    no molecule can reach. See
+    ``tests/invariants/test_structure_invariants.py`` for the executable
+    statement of that chain.
     """
     return (
         f"species:smiles={obj.smiles};"

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -338,6 +338,16 @@ that position must confine themselves to a reserved, non-colliding id band
 mistaken for another test's data, and no test may make an *absolute*
 unqualified count over those tables — before/after deltas only.
 
+The other thing that outlives a test is **the schema itself**. The migration
+round-trip tests in `tests/db/` run `alembic downgrade` against the per-run
+database the whole process shares, so they must upgrade back to `head` — not
+to the revision they were written about — in a `finally`. Stopping at a
+historical revision leaves every migration after it un-applied for the rest of
+the session, and the failure surfaces hundreds of tests later as
+`column ... does not exist` in files that have nothing to do with migrations.
+That single omission was what made `make test-full` unusable; see
+`tests/db/test_dataset_release_migration.py::_restore_head`.
+
 ## Test policy
 
 - Full suite is a **gate**, not the edit loop. Don't run Tier 4 on

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -286,6 +286,46 @@ psql -h 127.0.0.1 -U tckdb -d postgres -c "
   reachable — that's expected on a workstation without the dev
   container running.
 
+### Isolation contract: what a test may leave behind
+
+The database is created once per pytest process and shared by every test
+in it. **Nothing a test writes may outlive it**, because the next test
+cannot know what ran before it. Three fixtures deliver that, and a test
+should use one of them rather than opening its own connection:
+
+| Fixture | What you get | Use it when |
+|---|---|---|
+| `db_conn` | A `Connection` inside a transaction rolled back at teardown, with a SAVEPOINT already open so `Session(db_conn)` nests instead of joining | Anything that persists rows — this is the default, and what all of `tests/workflows/` uses |
+| `client` / `db_session` | The same, plus a `TestClient` whose `get_db`/`get_write_db` are bound to it | Anything going through a route |
+| `db_engine` | The raw session-scoped `Engine` | Only when a test genuinely needs **two concurrent transactions** — a race, an advisory lock, a `READ COMMITTED` visibility check |
+
+`Session(db_conn)` keeps working with the ordinary
+`with Session(...) as s, s.begin(): ...` idiom: because `db_conn` is inside a
+SAVEPOINT, SQLAlchemy's default `join_transaction_mode` resolves to
+`create_savepoint`, so the session's commit stays inside the per-test
+transaction and its rollback (including the implicit one when a test asserts
+that an upload raises) undoes only its own work.
+
+A test that takes `db_engine` **commits for real and must clean up after
+itself**, in a fixture `finally` so it also cleans up when the test fails.
+`tests/services/test_concurrent_deposit_isolation.py` and
+`tests/services/test_record_review_write_isolation.py` show the shape.
+
+The one thing a test cannot clean up is an append-only table.
+`record_review_event` and `scientific_record_supersession` carry a
+`BEFORE UPDATE OR DELETE` trigger (`tckdb_reject_mutation`, revision
+`c6f2a9d4e7b1`), and the scientific tables additionally refuse `TRUNCATE`, so
+the rows the record-review race tests commit cannot be removed by any
+test-level code. Deleting them would require the harness to disable a
+production integrity guard — which would leave that guarantee unenforced in
+the very suite meant to enforce it. **The harness answer is the per-run
+disposable database**: `_recreate_test_database` at session start and
+`_drop_test_database` at session end, plus the startup sweep above. Tests in
+that position must confine themselves to a reserved, non-colliding id band
+(as `test_record_review_write_isolation.py` does) so the residue can never be
+mistaken for another test's data, and no test may make an *absolute*
+unqualified count over those tables — before/after deltas only.
+
 ## Test policy
 
 - Full suite is a **gate**, not the edit loop. Don't run Tier 4 on

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -136,10 +136,22 @@ matters when diagnosing cross-file failures (see
 
 - `db_session` / `db_conn` / `client` roll back per test. Rows written
   through these never outlive the test.
-- The session-scoped `db_engine` fixture does **not**. Around 45 test
-  files use it with `with session.begin():`, which commits, so the shared
-  test database genuinely accumulates committed rows for the whole
-  pytest session.
+- The session-scoped `db_engine` fixture does **not**. Test files that
+  use it with `with session.begin():` commit, so the shared test
+  database genuinely accumulates committed rows for the whole pytest
+  session. Those files must delete what they wrote, in a fixture
+  `finally` — see "Isolation contract" below.
+
+All of `tests/workflows/` is now in the first tier and is held there by a
+tripwire in [`tests/workflows/conftest.py`](../tests/workflows/conftest.py)
+that fails any test in that tree which commits. It used to be in the second:
+running `test_network_pdep_upload.py` before `test_computed_reaction_upload.py`
+left fifteen committed `type=irc` calculations behind and five tests that
+locate "the" IRC calculation with an unqualified query then asserted against
+the wrong row — deterministically, under `-p no:randomly`, with no seed
+involved. The same residue accounted for every one of the 75 failures and 47
+errors that `pytest tests/workflows/ tests/services/` produced; that
+combination is green now.
 
 Two consequences worth remembering. Committed rows from tier two are
 visible to every later test file in the same run. And rollback does not

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -348,6 +348,14 @@ the session, and the failure surfaces hundreds of tests later as
 That single omission was what made `make test-full` unusable; see
 `tests/db/test_dataset_release_migration.py::_restore_head`.
 
+Running Alembic in-process also reconfigures **logging**: `alembic/env.py`
+calls `logging.config.fileConfig`, which by default disables existing loggers
+and replaces the root handlers — including the one `caplog` reads. Every
+`caplog` assertion in the process comes back empty afterwards, in trees with
+no connection to migrations. `tests/db/conftest.py` neutralises `fileConfig`
+for that tree; a future in-process Alembic caller anywhere else needs the same
+fixture moved up.
+
 ## Test policy
 
 - Full suite is a **gate**, not the edit loop. Don't run Tier 4 on

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -352,8 +352,35 @@ def db_engine():
 
 @pytest.fixture
 def db_conn(db_engine) -> Iterator[Connection]:
+    """A connection inside a transaction that is always rolled back.
+
+    Two nested scopes are opened deliberately:
+
+    ``begin()``
+        The per-test transaction. Rolling it back at teardown is what makes
+        the shared, session-scoped database safe to reuse — nothing a test
+        writes survives it, whether the test committed or not.
+
+    ``begin_nested()``
+        A SAVEPOINT wrapped around the whole test. This is not about undoing
+        anything; it changes how ``Session(db_conn)`` behaves. SQLAlchemy's
+        default ``join_transaction_mode="conditional_savepoint"`` picks
+        ``"rollback_only"`` for a plain in-transaction Connection, which means
+        one ``session.rollback()`` — including the implicit one when a test
+        asserts that an upload raises — tears down the *outer* transaction and
+        leaves the connection unusable for the rest of the test. With a
+        SAVEPOINT already in progress the same default resolves to
+        ``"create_savepoint"``, so each ``Session`` gets its own nested scope:
+        its commits stay inside the per-test transaction and its rollbacks
+        undo only its own work.
+
+    That second property is what lets test bodies keep writing
+    ``with Session(db_conn) as session, session.begin(): ...`` unchanged while
+    no longer committing anything to the shared database.
+    """
     with db_engine.connect() as connection:
         transaction = connection.begin()
+        connection.begin_nested()
         try:
             yield connection
         finally:

--- a/backend/tests/db/conftest.py
+++ b/backend/tests/db/conftest.py
@@ -1,0 +1,54 @@
+"""Keep in-process Alembic runs from silently disabling log capture.
+
+``tests/db/test_dataset_release_migration.py`` and
+``tests/db/test_upload_job_lease_migration.py`` call ``alembic.command``
+directly, which execs ``alembic/env.py`` in *this* process. That file does::
+
+    if config.config_file_name is not None:
+        fileConfig(config.config_file_name)
+
+and ``logging.config.fileConfig`` defaults to ``disable_existing_loggers=True``
+and replaces the root logger's handlers with the one declared in
+``alembic.ini``. The handler it throws away is the one pytest's ``caplog``
+fixture reads from, and the loggers it disables include every
+``app.*`` logger already created.
+
+Nothing announces this. It reads as five unrelated tests in three other trees
+quietly asserting against an empty ``caplog`` — ``assert 'Refusing to fetch
+unverified' in ''`` — for the rest of the pytest process, hundreds of tests
+after the migration test that caused it. Reproduce it in three seconds with::
+
+    pytest -p no:randomly tests/db/test_upload_job_lease_migration.py \\
+        tests/services/test_best_effort_isolation.py \\
+        tests/importers/cccbdb/test_url_guard.py
+
+Repairing the damage afterwards is the wrong shape — pytest's logging plugin
+adds and removes its own root handlers around each test phase, so restoring a
+snapshot taken at setup would put a stale handler list back at teardown.
+Preventing it is exact: during a test, the harness owns logging configuration,
+so Alembic's copy of it is a no-op. Alembic's own output is unaffected on the
+command line and in deployment, where ``env.py`` is untouched.
+"""
+
+from __future__ import annotations
+
+import logging.config
+from typing import Iterator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _alembic_must_not_reconfigure_logging(monkeypatch) -> Iterator[None]:
+    """Neutralise ``fileConfig`` for the duration of each test in this tree.
+
+    ``env.py`` re-executes ``from logging.config import fileConfig`` every time
+    Alembic runs it, so patching the attribute on the module is enough — there
+    is no early-bound reference to work around.
+
+    Any future test elsewhere that calls ``alembic.command`` in-process needs
+    this too; move the fixture up to ``tests/conftest.py`` rather than
+    rediscovering the symptom.
+    """
+    monkeypatch.setattr(logging.config, "fileConfig", lambda *args, **kwargs: None)
+    yield

--- a/backend/tests/db/test_dataset_release_migration.py
+++ b/backend/tests/db/test_dataset_release_migration.py
@@ -49,6 +49,20 @@ def _configure(db_engine, monkeypatch) -> Config:
     return Config(str(REPO_ROOT / "alembic.ini"))
 
 
+def _restore_head(config: Config) -> None:
+    """Put the shared test database back at ``head``, not at ``CURRENT_HEAD``.
+
+    These tests downgrade the *per-run database every other test in the process
+    is using*, so restoring it is not optional. Restoring to ``CURRENT_HEAD``
+    is not enough either: that is a historical revision, and every migration
+    after it stays un-applied, which is how one file in ``tests/db/`` used to
+    take the rest of the suite down with it — ``species_entry.isotope_key does
+    not exist`` and similar, hundreds of tests later, in files that had nothing
+    to do with releases.
+    """
+    command.upgrade(config, "head")
+
+
 def _table_names(connection) -> set[str]:
     return set(
         connection.scalars(
@@ -87,7 +101,7 @@ def test_downgrade_then_upgrade_round_trips(db_engine, monkeypatch):
             assert set(_OWNED_ENUMS) <= _enum_names(connection)
     finally:
         engine.dispose()
-        command.upgrade(config, CURRENT_HEAD)
+        _restore_head(config)
 
 
 def test_downgrade_refuses_to_orphan_a_published_citation(db_engine, monkeypatch):
@@ -140,7 +154,7 @@ def test_downgrade_refuses_to_orphan_a_published_citation(db_engine, monkeypatch
                 text("DELETE FROM app_user WHERE username = 'release-migration-user'")
             )
         engine.dispose()
-        command.upgrade(config, CURRENT_HEAD)
+        _restore_head(config)
 
 
 def test_downgrade_also_refuses_when_the_release_was_withdrawn(
@@ -202,7 +216,7 @@ def test_downgrade_also_refuses_when_the_release_was_withdrawn(
                 text("DELETE FROM app_user WHERE username = 'release-withdrawn-user'")
             )
         engine.dispose()
-        command.upgrade(config, CURRENT_HEAD)
+        _restore_head(config)
 
 
 def test_append_only_tables_have_both_row_and_truncate_triggers(db_engine):

--- a/backend/tests/db/test_upload_job_lease_migration.py
+++ b/backend/tests/db/test_upload_job_lease_migration.py
@@ -70,3 +70,11 @@ def test_lease_upgrade_recovers_processing_rows_and_creates_index(db_engine, mon
                     {"ids": inserted_ids},
                 )
         engine.dispose()
+        # Put the schema back where this test found it. It downgrades the
+        # *per-run database every other test in the process is using*, and
+        # ``CURRENT_HEAD`` above is a historical revision — stopping there
+        # leaves every later migration un-applied, which is how this one file
+        # used to take the rest of the suite down with it
+        # (``species_entry.isotope_key does not exist``, hundreds of tests
+        # later, in files with nothing to do with upload jobs).
+        command.upgrade(config, "head")

--- a/backend/tests/invariants/test_structure_invariants.py
+++ b/backend/tests/invariants/test_structure_invariants.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
-
 from tckdb_schemas.fragments.identity import (
     ELECTRON_CHARGE,
     ELECTRON_MULTIPLICITY,

--- a/backend/tests/invariants/test_structure_invariants.py
+++ b/backend/tests/invariants/test_structure_invariants.py
@@ -13,8 +13,14 @@ import pytest
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
+from tckdb_schemas.fragments.identity import (
+    ELECTRON_CHARGE,
+    ELECTRON_MULTIPLICITY,
+    ELECTRON_SMILES,
+)
+
 from app.chemistry.geometry import parse_xyz
-from app.db.models.common import ValidationStatus
+from app.db.models.common import MoleculeKind, StereoKind, ValidationStatus
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.workflows.reaction_upload import ReactionUploadRequest
@@ -211,4 +217,104 @@ def test_thermo_upload_schema_rejects_source_calc_key_with_no_declared_calc() ->
             source_calculations=[
                 {"calculation_key": "missing", "role": "sp"},
             ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5: species identity does not carry ``kind``, and nothing reachable
+# needs it to
+# ---------------------------------------------------------------------------
+
+
+def test_species_identity_key_excludes_molecule_kind() -> None:
+    """``uq_species_identity`` and the content-derived public ref agree.
+
+    Species identity is ``(smiles, charge, multiplicity)`` — DR-0031 — and
+    ``Species.kind`` is not part of it. ``_canonical_species`` is keyed on the
+    same tuple (plus ``stereo_kind``, which that constraint makes functionally
+    dependent on it), so the two cannot drift into a state where two rows
+    share a constraint slot but not a ref, or the reverse.
+
+    This test exists so that adding ``kind`` to either side *alone* fails
+    here rather than silently in a hosted database. Making ``kind`` part of
+    species identity is a schema decision — a new unique constraint, a
+    migration, and a story for existing rows — not a ref-generation one.
+    """
+    from app.db.models.species import Species
+    from app.services.public_refs import _canonical_species
+
+    identity = {
+        constraint.name: [column.name for column in constraint.columns]
+        for constraint in Species.__table__.constraints
+        if getattr(constraint, "name", None) == "uq_species_identity"
+    }
+    assert identity["uq_species_identity"] == ["smiles", "charge", "multiplicity"]
+
+    canonical = _canonical_species(
+        Species(
+            kind=MoleculeKind.molecule,
+            smiles="CC",
+            inchi_key="A" * 27,
+            charge=0,
+            multiplicity=1,
+            stereo_kind=StereoKind.achiral,
+        )
+    )
+    assert "kind=" not in canonical.replace("stereo_kind=", "")
+
+
+def test_only_molecule_and_electron_can_reach_a_species_row() -> None:
+    """The write path admits two kinds, and they cannot share one identity.
+
+    ``resolve_species`` is the application's only ``Species`` writer and it
+    canonicalises through ``canonical_species_identity``, which refuses every
+    ``molecule_kind`` but ``molecule`` and ``electron``. The collision the
+    identity key would otherwise permit — a ``pseudo`` row occupying the slot
+    a ``molecule`` needs, silently handing that molecule the pseudo exemption
+    from elemental balance and charge conservation — is therefore unreachable.
+
+    ``electron`` is reachable, and safe for a second, independent reason: its
+    payload validator pins ``electron`` to ``[e-]``/-1/2 in both directions,
+    so it occupies an identity tuple no molecule can express.
+
+    Should ``pseudo`` ever become depositable, this test fails, and the
+    question it fails on is the one worth answering first: ``resolve_species``
+    returns an existing row without comparing its ``kind`` to the payload's,
+    so the first writer's ``kind`` would silently win for every later deposit.
+    """
+    from app.chemistry.species import canonical_species_identity
+
+    electron = SpeciesEntryIdentityPayload(
+        molecule_kind=MoleculeKind.electron,
+        smiles=ELECTRON_SMILES,
+        charge=ELECTRON_CHARGE,
+        multiplicity=ELECTRON_MULTIPLICITY,
+    )
+    assert canonical_species_identity(electron)[0] == ELECTRON_SMILES
+
+    # A molecule may not occupy the electron's identity tuple ...
+    with pytest.raises(ValidationError):
+        SpeciesEntryIdentityPayload(
+            molecule_kind=MoleculeKind.molecule,
+            smiles=ELECTRON_SMILES,
+            charge=ELECTRON_CHARGE,
+            multiplicity=ELECTRON_MULTIPLICITY,
+        )
+    # ... and the electron may not occupy any other.
+    with pytest.raises(ValidationError):
+        SpeciesEntryIdentityPayload(
+            molecule_kind=MoleculeKind.electron,
+            smiles="CC",
+            charge=0,
+            multiplicity=1,
+        )
+
+    with pytest.raises(ValueError, match="only molecule species"):
+        canonical_species_identity(
+            SpeciesEntryIdentityPayload(
+                molecule_kind=MoleculeKind.pseudo,
+                smiles="CC",
+                charge=0,
+                multiplicity=1,
+            )
         )

--- a/backend/tests/services/scientific_read/_factories.py
+++ b/backend/tests/services/scientific_read/_factories.py
@@ -183,7 +183,18 @@ def make_species_entry(
     kind: StationaryPointKind = StationaryPointKind.minimum,
     electronic_state_kind: SpeciesEntryStateKind = SpeciesEntryStateKind.ground,
 ) -> SpeciesEntry:
-    """Create a SpeciesEntry row attached to a Species.
+    """Resolve a SpeciesEntry attached to a Species, creating it if absent.
+
+    Get-or-create, for the same reason :func:`make_species` is: the two are
+    almost always called as a pair, and once ``make_species`` returns a row
+    another suite has already committed, a blind ``INSERT`` here violates
+    ``uq_species_entry_species_id`` — which is unique on
+    ``(species_id, stereo_label, electronic_state_kind, electronic_state_label,
+    term_symbol, isotope_key)`` with ``NULLS NOT DISTINCT``. This factory
+    leaves every discriminator but ``electronic_state_kind`` NULL, so the two
+    parameters below are the whole of the identity it can vary. ``kind`` is
+    deliberately not part of the lookup: it is not part of the constraint, so
+    treating it as identity here would ask for a row the database cannot hold.
 
     Populates the RDKit cartridge ``mol`` column from the parent
     species's SMILES so structure-search tests exercise the same
@@ -196,6 +207,19 @@ def make_species_entry(
     treats NULL ``mol`` rows as un-searchable.
     """
     from rdkit import Chem
+
+    existing = session.scalar(
+        select(SpeciesEntry).where(
+            SpeciesEntry.species_id == species.id,
+            SpeciesEntry.stereo_label.is_(None),
+            SpeciesEntry.electronic_state_kind == electronic_state_kind,
+            SpeciesEntry.electronic_state_label.is_(None),
+            SpeciesEntry.term_symbol.is_(None),
+            SpeciesEntry.isotope_key.is_(None),
+        )
+    )
+    if existing is not None:
+        return existing
 
     mol_value: str | None = None
     if species.smiles is not None:

--- a/backend/tests/services/scientific_read/test_factories.py
+++ b/backend/tests/services/scientific_read/test_factories.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 from sqlalchemy import select
 
+from app.db.models.common import SpeciesEntryStateKind, StationaryPointKind
+from app.db.models.species import SpeciesEntry
 from app.db.models.workflow import WorkflowTool, WorkflowToolRelease
 from tests.services.scientific_read._factories import (
     make_chem_reaction,
     make_literature,
     make_species,
+    make_species_entry,
     make_workflow_tool_release,
     next_inchi_key,
 )
@@ -86,6 +89,50 @@ def test_make_chem_reaction_explicit_hash_override_creates_distinct_row(
     )
     assert forced.id != first.id
     assert forced.public_ref != first.public_ref
+
+
+def test_make_species_entry_is_get_or_create(db_session):
+    """``make_species_entry`` must be get-or-create, like ``make_species``.
+
+    The two are almost always called as a pair. ``make_species`` already
+    returns a pre-existing row for a colliding identity — which is the point,
+    since a shared test database routinely already holds water or argon — so
+    an entry factory that always inserted would violate
+    ``uq_species_entry_species_id`` the moment that happened. That mismatch
+    used to surface as an unexplained ``IntegrityError`` in whichever suite
+    happened to run second.
+    """
+    species = make_species(db_session, smiles="O", inchi_key=next_inchi_key("SEA"))
+    first = make_species_entry(db_session, species)
+    second = make_species_entry(db_session, species)
+    assert first.id == second.id
+
+    entries = db_session.scalars(
+        select(SpeciesEntry).where(SpeciesEntry.species_id == species.id)
+    ).all()
+    assert len(entries) == 1
+
+
+def test_make_species_entry_forks_on_electronic_state(db_session):
+    """Only the discriminators the unique constraint carries fork a row.
+
+    ``electronic_state_kind`` is part of ``uq_species_entry_species_id``, so
+    an excited-state entry is a genuinely different row. ``kind``
+    (``StationaryPointKind``) is *not* part of it — asking for a second entry
+    that differs only in ``kind`` must return the existing row rather than
+    request one the database cannot hold.
+    """
+    species = make_species(db_session, smiles="N", inchi_key=next_inchi_key("SEB"))
+    ground = make_species_entry(db_session, species)
+    excited = make_species_entry(
+        db_session, species, electronic_state_kind=SpeciesEntryStateKind.excited
+    )
+    assert ground.id != excited.id
+
+    same_row = make_species_entry(
+        db_session, species, kind=StationaryPointKind.vdw_complex
+    )
+    assert same_row.id == ground.id
 
 
 def test_make_workflow_tool_release_default_is_duplicate_safe(db_session):

--- a/backend/tests/services/test_calculation_resolution.py
+++ b/backend/tests/services/test_calculation_resolution.py
@@ -80,8 +80,8 @@ def _next_inchi_key(prefix: str) -> str:
     return stem[:27]
 
 
-def test_resolve_calculation_create_request_creates_and_reuses_refs(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_resolve_calculation_create_request_creates_and_reuses_refs(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(
                 session.connection(), inchi_key=_next_inchi_key("CALCRESOLVE")
@@ -133,8 +133,8 @@ def test_resolve_calculation_create_request_creates_and_reuses_refs(db_engine) -
             )
 
 
-def test_persist_calculation_persists_calculation(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_calculation_persists_calculation(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(
                 session.connection(), inchi_key=_next_inchi_key("CALCCREATE")
@@ -160,9 +160,9 @@ def test_persist_calculation_persists_calculation(db_engine) -> None:
             assert stored.software_release_id == resolved.software_release_id
 
 
-def test_calculation_persistence_keeps_optional_environment_and_deduplicates(db_engine) -> None:
+def test_calculation_persistence_keeps_optional_environment_and_deduplicates(db_conn) -> None:
     """Alias-equivalent release declarations resolve to one shared manifest."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(session.connection(), inchi_key=_next_inchi_key("CALCENV"))
             species_entry_id = _create_species_entry(session.connection(), species_id)
@@ -205,8 +205,8 @@ def test_calculation_persistence_keeps_optional_environment_and_deduplicates(db_
 
 
 @pytest.mark.parametrize("field, value", [("software_release", {"name": "ORCA", "version": "5"}), ("workflow_tool_release", {"name": "ARC", "version": "1"})])
-def test_calculation_resolution_rejects_manifest_release_binding_mismatch(db_engine, field, value) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_calculation_resolution_rejects_manifest_release_binding_mismatch(db_conn, field, value) -> None:
+    with Session(db_conn) as session, session.begin():
         species_id = _create_species(session.connection(), inchi_key=_next_inchi_key("CMM"))
         species_entry_id = _create_species_entry(session.connection(), species_id)
         environment = _execution_environment()
@@ -231,9 +231,9 @@ def _unique_violation(constraint_name: str) -> IntegrityError:
     return IntegrityError("insert", {}, _FakePsycopgUniqueViolation(constraint_name))
 
 
-def test_execution_environment_resolver_recovers_exact_digest_unique_race(db_engine, monkeypatch) -> None:
+def test_execution_environment_resolver_recovers_exact_digest_unique_race(db_conn, monkeypatch) -> None:
     """A unique-race path uses a savepoint and leaves the outer transaction usable."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             payload = ExecutionEnvironmentManifestPayload.model_validate(_execution_environment())
             existing = resolve_execution_environment_manifest(session, payload)
@@ -260,8 +260,8 @@ def test_execution_environment_resolver_recovers_exact_digest_unique_race(db_eng
             assert session.connection().execute(text("SELECT 1")).scalar_one() == 1
 
 
-def test_execution_environment_resolver_reraises_exact_digest_unique_race_without_winner(db_engine, monkeypatch) -> None:
-    with Session(db_engine) as session:
+def test_execution_environment_resolver_reraises_exact_digest_unique_race_without_winner(db_conn, monkeypatch) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             payload = ExecutionEnvironmentManifestPayload.model_validate(_execution_environment())
             original_scalar = session.scalar
@@ -285,9 +285,9 @@ def test_execution_environment_resolver_reraises_exact_digest_unique_race_withou
 
 
 def test_execution_environment_resolver_reraises_unrelated_unique_violation_even_with_winner(
-    db_engine, monkeypatch
+    db_conn, monkeypatch
 ) -> None:
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             payload = ExecutionEnvironmentManifestPayload.model_validate(_execution_environment())
             existing = resolve_execution_environment_manifest(session, payload)
@@ -314,8 +314,8 @@ def test_execution_environment_resolver_reraises_unrelated_unique_violation_even
             assert session.connection().execute(text("SELECT 1")).scalar_one() == 1
 
 
-def test_execution_environment_resolver_rejects_corrupt_digest_match(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_execution_environment_resolver_rejects_corrupt_digest_match(db_conn) -> None:
+    with Session(db_conn) as session:
         try:
             payload = ExecutionEnvironmentManifestPayload.model_validate(_execution_environment())
             manifest = resolve_execution_environment_manifest(session, payload)
@@ -326,9 +326,9 @@ def test_execution_environment_resolver_rejects_corrupt_digest_match(db_engine) 
             session.rollback()
 
 
-def test_execution_environment_manifest_is_database_immutable_without_calculation_reference(db_engine) -> None:
+def test_execution_environment_manifest_is_database_immutable_without_calculation_reference(db_conn) -> None:
     """The registry trigger protects orphan rows as well as shared rows."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             manifest = resolve_execution_environment_manifest(
                 session, ExecutionEnvironmentManifestPayload.model_validate(_execution_environment())
@@ -344,8 +344,8 @@ def test_execution_environment_manifest_is_database_immutable_without_calculatio
             assert stored.runtime_locator == "registry.example/arc@sha256:" + "a" * 64
 
 
-def test_unapproved_calculation_can_attach_and_replace_execution_environment(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_unapproved_calculation_can_attach_and_replace_execution_environment(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(session.connection(), inchi_key=_next_inchi_key("CALCENVRAW"))
             entry_id = _create_species_entry(session.connection(), species_id)
@@ -377,8 +377,8 @@ def test_unapproved_calculation_can_attach_and_replace_execution_environment(db_
             assert calc.execution_environment_manifest_id == second.id
 
 
-def test_database_rejects_manifest_binding_mismatch_on_attach_and_release_update(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_database_rejects_manifest_binding_mismatch_on_attach_and_release_update(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_id = _create_species(session.connection(), inchi_key=_next_inchi_key("CALCENVDB"))
         entry_id = _create_species_entry(session.connection(), species_id)
         calc = persist_calculation(session, resolve_calculation_create_request(session, CalculationCreateRequest(type="sp", species_entry_id=entry_id, software_release={"name": "Gaussian", "version": "16"}, level_of_theory={"method": "wb97xd"})))
@@ -396,8 +396,8 @@ def test_database_rejects_manifest_binding_mismatch_on_attach_and_release_update
             session.flush()
 
 
-def test_approved_calculation_cannot_change_or_remove_execution_environment(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_approved_calculation_cannot_change_or_remove_execution_environment(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(session.connection(), inchi_key=_next_inchi_key("CALCENVAPP"))
             entry_id = _create_species_entry(session.connection(), species_id)
@@ -442,7 +442,7 @@ def test_approved_calculation_cannot_change_or_remove_execution_environment(db_e
                 session.flush()
 
 
-def test_resolve_and_persist_writes_constraints_for_non_scan_calc(db_engine) -> None:
+def test_resolve_and_persist_writes_constraints_for_non_scan_calc(db_conn) -> None:
     """Generic non-scan constraints persist via persist_calculation_result.
 
     Confirms the writer-path generalization: a constrained opt (no
@@ -450,7 +450,7 @@ def test_resolve_and_persist_writes_constraints_for_non_scan_calc(db_engine) -> 
     ``CalculationWithResultsPayload.constraints`` field and lands rows
     in the ``calculation_constraint`` table.
     """
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(
                 session.connection(), inchi_key=_next_inchi_key("CALCCONSTR")
@@ -506,9 +506,9 @@ def test_resolve_and_persist_writes_constraints_for_non_scan_calc(db_engine) -> 
             assert stored_constraints[1].atom4_index == 4
 
 
-def test_resolve_and_persist_no_constraints_writes_no_rows(db_engine) -> None:
+def test_resolve_and_persist_no_constraints_writes_no_rows(db_conn) -> None:
     """A non-scan calc with empty constraints list writes zero rows."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             species_id = _create_species(
                 session.connection(), inchi_key=_next_inchi_key("CALCNOCON")

--- a/backend/tests/services/test_concurrent_deposit_isolation.py
+++ b/backend/tests/services/test_concurrent_deposit_isolation.py
@@ -34,7 +34,16 @@ import pytest
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
-from app.db.models.common import MoleculeKind, StereoKind
+from app.db.models.calculation import (
+    Calculation,
+    CalculationGeometryValidation,
+)
+from app.db.models.common import (
+    CalculationType,
+    MoleculeKind,
+    StereoKind,
+    ValidationStatus,
+)
 from app.db.models.literature import Literature
 from app.db.models.species import Species
 from app.schemas.workflows.literature_upload import LiteratureUploadRequest
@@ -236,12 +245,86 @@ class TestGeometryValidationIsTrulyBestEffort:
             }
             assert found == {f"[He]{MARKER}-geom", f"[He]{MARKER}-geom2"}
 
-    def test_the_function_routes_its_write_through_the_isolation(self) -> None:
-        """Pin the wiring: a future edit must not reintroduce a bare add()."""
-        import inspect
+    def test_the_function_routes_its_write_through_the_isolation(
+        self, db_engine, committed_scratch, monkeypatch
+    ) -> None:
+        """Pin the wiring behaviourally: a bare ``add()`` must not come back.
 
-        source = inspect.getsource(geomval.run_and_persist_geometry_validation)
-        assert "isolated_best_effort(" in source, (
-            "geometry validation persistence must stay inside the best-effort "
-            "isolation; a bare session.add() escapes to the caller's COMMIT"
+        This calls the real ``run_and_persist_geometry_validation`` and makes
+        its verdict row unstorable, by handing it a ``Calculation`` whose id
+        does not exist — so the ``calculation_id`` foreign key fails on the
+        INSERT. The two implementations differ exactly here:
+
+        * inside ``isolated_best_effort`` the INSERT is flushed within a
+          SAVEPOINT, so the failure is absorbed, the function returns ``None``,
+          and the caller's own work still commits;
+        * with a bare ``session.add()`` the row stays pending and its INSERT is
+          emitted by the caller's ``COMMIT`` — which is the shape this test
+          exists to forbid, and which would fail the ``session.commit()`` below
+          and lose the species written before it.
+
+        The predecessor of this test asserted ``"isolated_best_effort("`` was
+        present in ``inspect.getsource(...)``, which passes for a reformat and
+        fails for a rename — it never executed the path it claimed to protect.
+
+        Everything before the persist step is a pure skip-gate on inputs this
+        test does not care about, so the geometry lookups and the chemistry
+        call are stubbed; the write itself is real.
+        """
+        # An id no calculation row will ever have, so the FK cannot resolve.
+        orphan_calculation_id = 2**40
+        calculation = Calculation(
+            id=orphan_calculation_id, type=CalculationType.opt
         )
+
+        class _Link:
+            geometry = object()
+            geometry_id = None
+
+        monkeypatch.setattr(geomval, "_select_output_geometry", lambda s, cid: _Link())
+        monkeypatch.setattr(geomval, "_select_input_geometry", lambda s, cid: None)
+        monkeypatch.setattr(
+            geomval, "_atoms_from_geometry", lambda geometry: (("He", 0.0, 0.0, 0.0),)
+        )
+        monkeypatch.setattr(
+            geomval,
+            "validate_calculation_geometry",
+            lambda **kwargs: geomval.GeometryValidationResult(
+                species_smiles=kwargs["species_smiles"],
+                is_isomorphic=True,
+                rmsd=None,
+                atom_mapping=None,
+                n_mappings=1,
+                validation_status=ValidationStatus.passed,
+                validation_reason=None,
+                rmsd_warning_threshold=None,
+                input_geometry_id=None,
+                output_geometry_id=None,
+            ),
+        )
+
+        with Session(db_engine) as session:
+            session.add(Species(**_species_kwargs("-wiring")))
+
+            assert (
+                geomval.run_and_persist_geometry_validation(
+                    session, calculation, species_smiles=f"[He]{MARKER}"
+                )
+                is None
+            ), "an unstorable verdict must be absorbed, not returned"
+
+            # The caller's commit is where a bare add() would surface.
+            session.commit()
+
+        with Session(db_engine) as verify:
+            assert verify.scalar(
+                select(Species).where(Species.smiles == f"[He]{MARKER}-wiring")
+            ) is not None, (
+                "the upload's own row was lost with the verdict about it"
+            )
+            assert verify.scalar(
+                select(CalculationGeometryValidation).where(
+                    CalculationGeometryValidation.calculation_id
+                    == orphan_calculation_id
+                )
+            ) is None

--- a/backend/tests/workflows/conftest.py
+++ b/backend/tests/workflows/conftest.py
@@ -80,16 +80,17 @@ def _refuse_committed_workflow_rows(_committed_row_probe, request) -> Iterator[N
     """Fail the test that commits, not the test that trips over the residue.
 
     Autouse, so it is set up before the test's own fixtures and therefore torn
-    down after them — the counts below are read once ``db_conn`` has rolled
+    down after them — the second count is read once ``db_conn`` has rolled
     back, so only a genuine commit shows up.
 
-    The baseline is re-synced after a failure so exactly one test is blamed
-    for one leak, instead of every test after it inheriting the accusation.
+    The baseline is taken per test rather than once per session on purpose. A
+    session-wide baseline would be perturbed by any *other* tree committing
+    between two workflow files — which is exactly what happens under
+    ``pytest-randomly``, since it shuffles file order — and the next workflow
+    test would be blamed for a leak it did not cause. A tripwire that reports
+    order-dependent false positives would be a strange thing to install here.
     """
-    before = getattr(request.session, "_tckdb_workflow_row_baseline", None)
-    if before is None:
-        before = _counts(_committed_row_probe)
-        request.session._tckdb_workflow_row_baseline = before
+    before = _counts(_committed_row_probe)
 
     yield
 
@@ -97,7 +98,6 @@ def _refuse_committed_workflow_rows(_committed_row_probe, request) -> Iterator[N
     if after == before:
         return
 
-    request.session._tckdb_workflow_row_baseline = after
     grew = {
         table: (before[table], after[table])
         for table in after

--- a/backend/tests/workflows/conftest.py
+++ b/backend/tests/workflows/conftest.py
@@ -1,0 +1,115 @@
+"""Keep the workflow suite from writing anything the next test can see.
+
+Every test here persists a lot: species, entries, calculations, geometries,
+transition states, and the scientific products hanging off them. They share
+one database for the whole pytest process, and many of them locate "the" row
+they just made with an unqualified query — ``session.scalar(select(Calculation)
+.where(Calculation.type == irc))`` and friends. That only works while the
+database contains nothing but the current test's own writes.
+
+For a long time it did not. The tree used the session-scoped ``db_engine``
+directly with ``with Session(db_engine) as session, session.begin():``, which
+commits on block exit, so each test inherited everything its predecessors had
+written. Running ``test_network_pdep_upload.py`` before
+``test_computed_reaction_upload.py`` left fifteen committed ``irc``
+calculations behind and five computed-reaction tests then asserted against the
+wrong one — deterministically, with no random seed involved.
+
+The tree now takes ``db_conn`` (per-test transaction, rolled back at teardown;
+see ``tests/conftest.py``). The fixture below is the enforcement: it fails the
+individual test that commits, rather than letting the damage surface as an
+inexplicable failure in whatever file happens to run next.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy import text
+
+#: Tables a workflow upload writes to. Not exhaustive by design — it is a
+#: tripwire, not an audit. Any commit big enough to confuse a sibling test
+#: lands in at least one of these.
+_WATCHED_TABLES = (
+    "species",
+    "species_entry",
+    "chem_reaction",
+    "reaction_entry",
+    "transition_state",
+    "transition_state_entry",
+    "calculation",
+    "geometry",
+    "conformer_group",
+    "conformer_observation",
+    "statmech",
+    "thermo",
+    "kinetics",
+    "transport",
+    "network",
+)
+
+_COUNT_SQL = text(
+    " UNION ALL ".join(
+        f"SELECT '{table}' AS t, count(*) AS n FROM public.{table}"
+        for table in _WATCHED_TABLES
+    )
+)
+
+
+@pytest.fixture(scope="session")
+def _committed_row_probe(db_engine) -> Iterator:
+    """A connection that always reads the latest *committed* state.
+
+    ``AUTOCOMMIT`` matters: a pooled connection holding an open transaction
+    would keep returning its first snapshot and the tripwire would never fire.
+    """
+    connection = db_engine.connect().execution_options(isolation_level="AUTOCOMMIT")
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _counts(connection) -> dict[str, int]:
+    return dict(connection.execute(_COUNT_SQL).all())
+
+
+@pytest.fixture(autouse=True)
+def _refuse_committed_workflow_rows(_committed_row_probe, request) -> Iterator[None]:
+    """Fail the test that commits, not the test that trips over the residue.
+
+    Autouse, so it is set up before the test's own fixtures and therefore torn
+    down after them — the counts below are read once ``db_conn`` has rolled
+    back, so only a genuine commit shows up.
+
+    The baseline is re-synced after a failure so exactly one test is blamed
+    for one leak, instead of every test after it inheriting the accusation.
+    """
+    before = getattr(request.session, "_tckdb_workflow_row_baseline", None)
+    if before is None:
+        before = _counts(_committed_row_probe)
+        request.session._tckdb_workflow_row_baseline = before
+
+    yield
+
+    after = _counts(_committed_row_probe)
+    if after == before:
+        return
+
+    request.session._tckdb_workflow_row_baseline = after
+    grew = {
+        table: (before[table], after[table])
+        for table in after
+        if after[table] != before[table]
+    }
+    raise AssertionError(
+        f"{request.node.nodeid} committed rows into the shared test database: "
+        + ", ".join(f"{t} {was}->{now}" for t, (was, now) in sorted(grew.items()))
+        + ". Workflow tests must persist through the `db_conn` fixture, whose "
+        "transaction is rolled back at teardown — committed rows are visible "
+        "to every later test in the process and are what made this suite "
+        "order-dependent. If a test genuinely needs two concurrent "
+        "transactions, take `db_engine` instead and delete its rows in a "
+        "fixture `finally`."
+    )

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -305,13 +305,15 @@ def test_computed_reaction_calculation_environment_persists_dedups_and_is_option
 
 @contextmanager
 def _isolated_session(db_conn) -> Iterator[Session]:
-    """Open a session on a connection-bound transaction that is always rolled back.
+    """A session on the per-test transaction, closed but never committed.
 
-    The workflow tests run against a shared, session-scoped ``db_conn``
-    fixture with no transaction rollback between tests.  The computed reaction
-    workflow persists many rows (species, calcs, TS, thermo, kinetics), and
-    committing them would pollute other workflow tests that make unqualified
-    row counts (e.g. ``len(session.scalars(select(TransitionState)).all())``).
+    ``db_conn`` (``tests/conftest.py``) owns the rollback; this helper only
+    scopes the ORM session's lifetime. It matters because the computed
+    reaction workflow persists a great many rows — species, calcs, TS,
+    thermo, kinetics — and several tests below locate the one they just made
+    with an unqualified query (``session.scalar(select(Calculation).where(
+    Calculation.type == irc))``), which is only correct while the database
+    holds nothing but this test's own writes.
     """
     session = Session(bind=db_conn, expire_on_commit=False)
     try:

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -284,8 +284,8 @@ def _execution_environment() -> dict:
     }
 
 
-def test_computed_reaction_calculation_environment_persists_dedups_and_is_optional(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_computed_reaction_calculation_environment_persists_dedups_and_is_optional(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=50_199, username="computed_rxn_environment"))
         session.flush()
         payload = _minimal_payload()
@@ -304,24 +304,20 @@ def test_computed_reaction_calculation_environment_persists_dedups_and_is_option
 
 
 @contextmanager
-def _isolated_session(db_engine) -> Iterator[Session]:
+def _isolated_session(db_conn) -> Iterator[Session]:
     """Open a session on a connection-bound transaction that is always rolled back.
 
-    The workflow tests run against a shared, session-scoped ``db_engine``
+    The workflow tests run against a shared, session-scoped ``db_conn``
     fixture with no transaction rollback between tests.  The computed reaction
     workflow persists many rows (species, calcs, TS, thermo, kinetics), and
     committing them would pollute other workflow tests that make unqualified
     row counts (e.g. ``len(session.scalars(select(TransitionState)).all())``).
     """
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         yield session
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
 def _patch_artifact_storage(monkeypatch) -> list[str]:
@@ -347,9 +343,9 @@ def _patch_artifact_storage(monkeypatch) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def test_full_round_trip_persistence(db_engine) -> None:
+def test_full_round_trip_persistence(db_conn) -> None:
     """A minimal realistic bundle persists the full graph of related rows."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=501, username="computed_rxn_tester_1"))
         session.flush()
 
@@ -518,11 +514,11 @@ def test_full_round_trip_persistence(db_engine) -> None:
         assert kin.ea_kj_mol == 10.0
 
 
-def test_ts_freq_calc_with_hessian_persists(db_engine) -> None:
+def test_ts_freq_calc_with_hessian_persists(db_conn) -> None:
     """A TS freq calculation carrying a ``hessian`` persists one
     ``calculation_hessian`` row bound to the TS geometry with the correct
     triangle length (5-atom TS → 3N=15 → 15*16/2 = 120 entries)."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=577, username="computed_rxn_ts_hessian"))
         session.flush()
 
@@ -559,7 +555,7 @@ def test_ts_freq_calc_with_hessian_persists(db_engine) -> None:
         assert hess.geometry_id is not None
 
 
-def test_ts_calc_with_spin_diagnostic_persists(db_engine) -> None:
+def test_ts_calc_with_spin_diagnostic_persists(db_conn) -> None:
     """A TS calculation carrying an inline ``spin_diagnostic`` persists one
     ``calc_spin_diagnostic`` (<S^2>) row anchored to the TS calc.
 
@@ -567,7 +563,7 @@ def test_ts_calc_with_spin_diagnostic_persists(db_engine) -> None:
     plus adapter forwarding) reaches ``persist_calculation_result`` through
     the computed_reaction route — the field is no longer dropped by
     ``extra='forbid'`` and is no longer silently ignored by the adapter."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=591, username="computed_rxn_ts_spin"))
         session.flush()
 
@@ -605,7 +601,7 @@ def test_ts_calc_with_spin_diagnostic_persists(db_engine) -> None:
 
 
 def test_canonical_direction_kinetics_reuses_canonical_reaction_entry(
-    db_engine,
+    db_conn,
 ) -> None:
     """A forward-only fit attaches to the bundle's canonical reaction entry.
 
@@ -623,7 +619,7 @@ def test_canonical_direction_kinetics_reuses_canonical_reaction_entry(
     assert payload["kinetics"][0]["reactant_keys"] == payload["reactant_keys"]
     assert payload["kinetics"][0]["product_keys"] == payload["product_keys"]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=540, username="canonical_dir_tester"))
         session.flush()
 
@@ -657,7 +653,7 @@ def test_canonical_direction_kinetics_reuses_canonical_reaction_entry(
 
 
 def test_reverse_direction_kinetics_gets_separate_reaction_entry(
-    db_engine,
+    db_conn,
 ) -> None:
     """A reverse-direction fit gets its own reaction entry with swapped roles.
 
@@ -686,7 +682,7 @@ def test_reverse_direction_kinetics_gets_separate_reaction_entry(
         }
     )
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=541, username="reverse_dir_tester"))
         session.flush()
 
@@ -732,7 +728,7 @@ def test_reverse_direction_kinetics_gets_separate_reaction_entry(
         # Scope SpeciesEntry lookups to entries created by THIS upload —
         # other tests may have committed entries for the same SMILES, so
         # an unqualified ``Species.smiles == 'C'`` query is non-deterministic
-        # under the shared db_engine fixture.
+        # under the shared db_conn fixture.
         upload_se_ids = set(summary["species_entry_ids"])
         ch4_se = session.scalar(
             select(SpeciesEntry)
@@ -762,7 +758,7 @@ def test_reverse_direction_kinetics_gets_separate_reaction_entry(
 # ---------------------------------------------------------------------------
 
 
-def test_species_reuse_across_participants(db_engine) -> None:
+def test_species_reuse_across_participants(db_conn) -> None:
     """Two payload species with the same identity collapse to one species row."""
     payload = {
         "species": [
@@ -782,7 +778,7 @@ def test_species_reuse_across_participants(db_engine) -> None:
         "1\nH\nH 0.0 0.0 0.1"
     )
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -843,7 +839,7 @@ def test_species_reuse_across_participants(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_artifact_persists_and_links_to_calculation(db_engine, monkeypatch) -> None:
+def test_artifact_persists_and_links_to_calculation(db_conn, monkeypatch) -> None:
     """A calculation_artifact row is created and linked to its calculation."""
     _patch_artifact_storage(monkeypatch)
 
@@ -860,7 +856,7 @@ def test_artifact_persists_and_links_to_calculation(db_engine, monkeypatch) -> N
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         _summary = persist_computed_reaction_upload(session, request)
 
@@ -893,9 +889,9 @@ def test_artifact_persists_and_links_to_calculation(db_engine, monkeypatch) -> N
 # ---------------------------------------------------------------------------
 
 
-def test_kinetics_source_calculation_linkage(db_engine) -> None:
+def test_kinetics_source_calculation_linkage(db_conn) -> None:
     """SP calculations on participants are linked to the kinetics row."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**_minimal_payload())
         summary = persist_computed_reaction_upload(session, request)
 
@@ -929,7 +925,7 @@ def test_kinetics_source_calculation_linkage(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_frequency_scale_factor_resolution_on_statmech(db_engine) -> None:
+def test_frequency_scale_factor_resolution_on_statmech(db_conn) -> None:
     """A statmech payload with a freq_scale_factor ref resolves an FSF row."""
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
@@ -946,7 +942,7 @@ def test_frequency_scale_factor_resolution_on_statmech(db_engine) -> None:
         },
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -973,7 +969,7 @@ def test_frequency_scale_factor_resolution_on_statmech(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_statmech_point_group_persists_on_species_block(db_engine) -> None:
+def test_statmech_point_group_persists_on_species_block(db_conn) -> None:
     """Per-species statmech blocks accept and persist ``point_group``."""
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
@@ -984,7 +980,7 @@ def test_statmech_point_group_persists_on_species_block(db_engine) -> None:
         "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -995,7 +991,7 @@ def test_statmech_point_group_persists_on_species_block(db_engine) -> None:
         assert statmech.point_group == "D3h"
 
 
-def test_statmech_optical_isomers_persists_on_species_block(db_engine) -> None:
+def test_statmech_optical_isomers_persists_on_species_block(db_conn) -> None:
     """Per-species statmech blocks accept and persist ``optical_isomers``."""
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
@@ -1006,7 +1002,7 @@ def test_statmech_optical_isomers_persists_on_species_block(db_engine) -> None:
         "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1017,7 +1013,7 @@ def test_statmech_optical_isomers_persists_on_species_block(db_engine) -> None:
         assert statmech.optical_isomers == 2
 
 
-def test_statmech_optical_isomers_defaults_null_when_omitted(db_engine) -> None:
+def test_statmech_optical_isomers_defaults_null_when_omitted(db_conn) -> None:
     """A statmech block without ``optical_isomers`` still validates and
     stores NULL — old bundle payloads remain valid."""
     payload = _minimal_payload()
@@ -1028,7 +1024,7 @@ def test_statmech_optical_isomers_defaults_null_when_omitted(db_engine) -> None:
         "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1039,7 +1035,7 @@ def test_statmech_optical_isomers_defaults_null_when_omitted(db_engine) -> None:
         assert statmech.optical_isomers is None
 
 
-def test_reaction_participant_thermo_links_to_own_statmech(db_engine) -> None:
+def test_reaction_participant_thermo_links_to_own_statmech(db_conn) -> None:
     """Each participant's COMPUTED thermo must link to that same participant's
     statmech (audit finding #3) — never a sibling's. Two participants (ch3,
     ch4) each carry thermo + statmech; the third (h) carries thermo only and
@@ -1056,7 +1052,7 @@ def test_reaction_participant_thermo_links_to_own_statmech(db_engine) -> None:
             "point_group": "C1",
         }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1089,7 +1085,7 @@ def test_reaction_participant_thermo_links_to_own_statmech(db_engine) -> None:
         assert unlinked[0].statmech_id is None
 
 
-def test_reaction_non_computed_thermo_not_linked_to_statmech(db_engine) -> None:
+def test_reaction_non_computed_thermo_not_linked_to_statmech(db_conn) -> None:
     """Origin-guard, reaction side (mirror of the species-path test).
 
     The write path only attaches ``thermo.statmech_id`` when the thermo's
@@ -1122,7 +1118,7 @@ def test_reaction_non_computed_thermo_not_linked_to_statmech(db_engine) -> None:
         "point_group": "Td",
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1151,7 +1147,7 @@ def test_reaction_non_computed_thermo_not_linked_to_statmech(db_engine) -> None:
         assert ch4_thermo.statmech_id == statmech_entry_ids[ch4_entry_id]
 
 
-def test_statmech_optical_isomers_zero_rejected(db_engine) -> None:
+def test_statmech_optical_isomers_zero_rejected(db_conn) -> None:
     """``optical_isomers`` below 1 is rejected at the schema layer (422)."""
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
@@ -1163,7 +1159,7 @@ def test_statmech_optical_isomers_zero_rejected(db_engine) -> None:
         ComputedReactionUploadRequest(**payload)
 
 
-def test_statmech_source_calculations_persist_for_species_owned_calcs(db_engine) -> None:
+def test_statmech_source_calculations_persist_for_species_owned_calcs(db_conn) -> None:
     """Statmech source_calculations links resolve and persist correctly."""
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
@@ -1178,7 +1174,7 @@ def test_statmech_source_calculations_persist_for_species_owned_calcs(db_engine)
         ],
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1211,7 +1207,7 @@ def test_statmech_source_calculations_persist_for_species_owned_calcs(db_engine)
 
 
 def test_statmech_source_calculation_referencing_ts_calc_rejects_with_owned_by_ts_message(
-    db_engine,
+    db_conn,
 ) -> None:
     """A species statmech referencing a TS-owned calc rejects 422."""
     payload = _minimal_payload()
@@ -1224,7 +1220,7 @@ def test_statmech_source_calculation_referencing_ts_calc_rejects_with_owned_by_t
     }
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(
             ValueError, match=r"refers to a calculation owned by a transition state"
@@ -1233,7 +1229,7 @@ def test_statmech_source_calculation_referencing_ts_calc_rejects_with_owned_by_t
 
 
 def test_statmech_source_calculation_referencing_sibling_species_rejects_with_other_species_message(
-    db_engine,
+    db_conn,
 ) -> None:
     """A species statmech referencing a sibling-species-owned calc rejects 422."""
     payload = _minimal_payload()
@@ -1248,7 +1244,7 @@ def test_statmech_source_calculation_referencing_sibling_species_rejects_with_ot
     }
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(
             ValueError,
@@ -1274,7 +1270,7 @@ def test_statmech_source_calculation_undefined_key_rejects_at_schema_layer() -> 
         ComputedReactionUploadRequest(**payload)
 
 
-def test_statmech_without_new_fields_remains_valid(db_engine) -> None:
+def test_statmech_without_new_fields_remains_valid(db_conn) -> None:
     """Pre-expansion payloads without point_group / source_calculations still persist."""
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
@@ -1284,7 +1280,7 @@ def test_statmech_without_new_fields_remains_valid(db_engine) -> None:
         "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1324,7 +1320,7 @@ def _payload_with_ch4_scan() -> dict:
     return payload
 
 
-def test_reaction_statmech_torsion_with_one_coordinate_persists(db_engine) -> None:
+def test_reaction_statmech_torsion_with_one_coordinate_persists(db_conn) -> None:
     """1D rotor: one statmech_torsion_definition row, atom quartet 1-based."""
     payload = _payload_with_ch4_scan()
     payload["species"][2]["statmech"] = {
@@ -1351,7 +1347,7 @@ def test_reaction_statmech_torsion_with_one_coordinate_persists(db_engine) -> No
             }
         ],
     }
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1386,7 +1382,7 @@ def test_reaction_statmech_torsion_with_one_coordinate_persists(db_engine) -> No
 
 
 def test_reaction_statmech_torsion_without_coordinates_writes_no_definitions(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _minimal_payload()
     payload["species"][2]["statmech"] = {
@@ -1395,7 +1391,7 @@ def test_reaction_statmech_torsion_without_coordinates_writes_no_definitions(
         "source_calculations": [{"calculation_key": "ch4-freq", "role": "freq"}],
         "torsions": [{"torsion_index": 1, "symmetry_number": 3}],
     }
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1555,7 +1551,7 @@ def _ch4_scan_result_payload(*, points: int = 3) -> dict:
 
 
 def test_reaction_bundle_scan_calculation_persists_scan_result_rows(
-    db_engine,
+    db_conn,
 ) -> None:
     """A computed-reaction bundle with a type=scan species calc carrying
     scan_result persists rows in calc_scan_result, calc_scan_coordinate,
@@ -1569,7 +1565,7 @@ def test_reaction_bundle_scan_calculation_persists_scan_result_rows(
         "scan_result": _ch4_scan_result_payload(points=3),
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1645,7 +1641,7 @@ def test_reaction_bundle_scan_calc_rejects_non_scan_inline_results() -> None:
 
 
 def test_reaction_torsion_resolves_to_scan_calc_with_scan_result(
-    db_engine,
+    db_conn,
 ) -> None:
     """A statmech torsion's ``source_scan_calculation_key`` resolves to a
     bundle-local type=scan calc that carries a ``scan_result``; the
@@ -1673,7 +1669,7 @@ def test_reaction_torsion_resolves_to_scan_calc_with_scan_result(
         ],
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -1698,7 +1694,7 @@ def test_reaction_torsion_resolves_to_scan_calc_with_scan_result(
 
 
 def test_same_basin_conformer_payloads_create_distinct_observations_and_anchor_calcs(
-    db_engine,
+    db_conn,
 ) -> None:
     """Two conformer payloads may share a group but still own separate observations."""
     payload = _minimal_payload()
@@ -1747,7 +1743,7 @@ def test_same_basin_conformer_payloads_create_distinct_observations_and_anchor_c
         },
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=502, username="computed_rxn_tester_2"))
         session.flush()
 
@@ -1809,7 +1805,7 @@ def test_same_basin_conformer_payloads_create_distinct_observations_and_anchor_c
 # ---------------------------------------------------------------------------
 
 
-def test_bundle_calculation_parameters_persist_via_shared_seam(db_engine) -> None:
+def test_bundle_calculation_parameters_persist_via_shared_seam(db_conn) -> None:
     """Parsed parameters on a bundle ``CalculationIn`` land as relational rows
     and snapshot metadata when routed through the shared calculation seam."""
     from datetime import datetime, timezone
@@ -1847,7 +1843,7 @@ def test_bundle_calculation_parameters_persist_via_shared_seam(db_engine) -> Non
         }
     )
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         existing = session.scalar(
             select(CalculationParameterVocab).where(
                 CalculationParameterVocab.canonical_key == canonical_key
@@ -1884,7 +1880,7 @@ def test_bundle_calculation_parameters_persist_via_shared_seam(db_engine) -> Non
         assert second.canonical_key is None
 
 
-def test_bundle_inline_results_and_artifacts_preserved(db_engine, monkeypatch) -> None:
+def test_bundle_inline_results_and_artifacts_preserved(db_conn, monkeypatch) -> None:
     """Inline results (opt/freq/sp) and artifact persistence still work after
     convergence onto the shared seam. Artifact persistence is intentionally
     still bundle-owned — it is orchestration, not calculation creation."""
@@ -1903,7 +1899,7 @@ def test_bundle_inline_results_and_artifacts_preserved(db_engine, monkeypatch) -
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         baseline_calc_id = session.scalar(select(func.max(Calculation.id))) or 0
         baseline_artifact_id = (
             session.scalar(select(func.max(CalculationArtifact.id))) or 0
@@ -1942,10 +1938,10 @@ def test_bundle_inline_results_and_artifacts_preserved(db_engine, monkeypatch) -
         assert artifacts[0].bytes == len(content)
 
 
-def test_bundle_owner_semantics_preserved_after_convergence(db_engine) -> None:
+def test_bundle_owner_semantics_preserved_after_convergence(db_conn) -> None:
     """Calculations produced via the bundle path keep their exclusive-owner FKs
     (species XOR TS), and TS-owned calculations never leak a species-entry id."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         baseline_calc_id = session.scalar(select(func.max(Calculation.id))) or 0
 
         request = ComputedReactionUploadRequest(**_minimal_payload())
@@ -2009,7 +2005,7 @@ def _payload_with_ts_irc() -> dict:
     return payload
 
 
-def test_kinetics_source_calculations_explicit_local_keys(db_engine) -> None:
+def test_kinetics_source_calculations_explicit_local_keys(db_conn) -> None:
     """source_calculations declarations resolve to KineticsSourceCalculation
     rows with the exact (calc_id, role) pairs the producer asked for."""
     payload = _payload_with_ts_irc()
@@ -2024,7 +2020,7 @@ def test_kinetics_source_calculations_explicit_local_keys(db_engine) -> None:
         {"calculation_key": "ch3-opt", "role": "fit_source"},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -2057,7 +2053,7 @@ def test_kinetics_source_calculations_explicit_local_keys(db_engine) -> None:
         assert (KineticsCalculationRole.fit_source, CalculationType.opt) in role_owner_pairs
 
 
-def test_declared_source_calculations_override_legacy_fallback(db_engine) -> None:
+def test_declared_source_calculations_override_legacy_fallback(db_conn) -> None:
     """Even when species SPs exist (which the legacy fallback would auto-link),
     a non-empty source_calculations writes only the declared rows."""
     payload = _payload_with_ts_irc()
@@ -2065,7 +2061,7 @@ def test_declared_source_calculations_override_legacy_fallback(db_engine) -> Non
         {"calculation_key": "ts-sp", "role": "ts_energy"},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         kin_id = summary["kinetics_ids"][0]
@@ -2087,11 +2083,11 @@ def test_declared_source_calculations_override_legacy_fallback(db_engine) -> Non
         )
 
 
-def test_empty_source_calculations_preserves_legacy_fallback(db_engine) -> None:
+def test_empty_source_calculations_preserves_legacy_fallback(db_conn) -> None:
     """When source_calculations is empty, the legacy auto-link still
     produces species-owned SP reactant_energy/product_energy rows."""
     # _minimal_payload() leaves source_calculations empty by default.
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**_minimal_payload())
         summary = persist_computed_reaction_upload(session, request)
         kin_id = summary["kinetics_ids"][0]
@@ -2110,7 +2106,7 @@ def test_empty_source_calculations_preserves_legacy_fallback(db_engine) -> None:
         }
 
 
-def test_unknown_source_calculation_key_raises(db_engine) -> None:
+def test_unknown_source_calculation_key_raises(db_conn) -> None:
     """A calculation_key not present in the bundle is rejected at validation."""
     payload = _minimal_payload()
     payload["kinetics"][0]["source_calculations"] = [
@@ -2135,7 +2131,7 @@ def test_duplicate_source_calculation_pair_raises() -> None:
         ComputedReactionUploadRequest(**payload)
 
 
-def test_role_owner_mismatch_rejects_species_sp_for_ts_energy(db_engine) -> None:
+def test_role_owner_mismatch_rejects_species_sp_for_ts_energy(db_conn) -> None:
     """ts_energy must point to a TS-owned sp, not species-owned."""
     payload = _payload_with_ts_irc()
     payload["kinetics"][0]["source_calculations"] = [
@@ -2143,13 +2139,13 @@ def test_role_owner_mismatch_rejects_species_sp_for_ts_energy(db_engine) -> None
     ]
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError, match="ts_energy"):
             persist_computed_reaction_upload(session, request)
 
 
-def test_role_owner_mismatch_rejects_ts_sp_for_reactant_energy(db_engine) -> None:
+def test_role_owner_mismatch_rejects_ts_sp_for_reactant_energy(db_conn) -> None:
     """reactant_energy must point to a species-owned sp, not TS-owned."""
     payload = _payload_with_ts_irc()
     payload["kinetics"][0]["source_calculations"] = [
@@ -2157,13 +2153,13 @@ def test_role_owner_mismatch_rejects_ts_sp_for_reactant_energy(db_engine) -> Non
     ]
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError, match="reactant_energy"):
             persist_computed_reaction_upload(session, request)
 
 
-def test_role_type_mismatch_rejects_sp_for_freq_role(db_engine) -> None:
+def test_role_type_mismatch_rejects_sp_for_freq_role(db_conn) -> None:
     """role=freq requires a TS-owned freq, not a TS-owned sp."""
     payload = _payload_with_ts_irc()
     payload["kinetics"][0]["source_calculations"] = [
@@ -2171,13 +2167,13 @@ def test_role_type_mismatch_rejects_sp_for_freq_role(db_engine) -> None:
     ]
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError, match="freq"):
             persist_computed_reaction_upload(session, request)
 
 
-def test_role_type_mismatch_rejects_freq_for_irc_role(db_engine) -> None:
+def test_role_type_mismatch_rejects_freq_for_irc_role(db_conn) -> None:
     """role=irc requires a TS-owned irc, not a TS-owned freq."""
     payload = _payload_with_ts_irc()
     payload["kinetics"][0]["source_calculations"] = [
@@ -2185,13 +2181,13 @@ def test_role_type_mismatch_rejects_freq_for_irc_role(db_engine) -> None:
     ]
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError, match="irc"):
             persist_computed_reaction_upload(session, request)
 
 
-def test_freq_role_rejects_species_owned_freq(db_engine) -> None:
+def test_freq_role_rejects_species_owned_freq(db_conn) -> None:
     """v0 contract: role=freq is TS frequency only, never species frequency.
 
     Reactant/product frequency provenance belongs in
@@ -2214,13 +2210,13 @@ def test_freq_role_rejects_species_owned_freq(db_engine) -> None:
     ]
     import pytest
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError, match="freq"):
             persist_computed_reaction_upload(session, request)
 
 
-def test_input_geometries_persist(db_engine) -> None:
+def test_input_geometries_persist(db_conn) -> None:
     """A producer-declared input_geometries list creates input geometry rows."""
     payload = _minimal_payload()
     # Attach an explicit input_geometries entry to the CH3 SP calc using
@@ -2230,7 +2226,7 @@ def test_input_geometries_persist(db_engine) -> None:
         {"xyz_text": _XYZ_CH3},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         persist_computed_reaction_upload(session, request)
 
@@ -2258,7 +2254,7 @@ def test_input_geometries_persist(db_engine) -> None:
         assert rows[0].input_order == 1
 
 
-def test_output_geometries_persist_with_declared_role_and_order(db_engine) -> None:
+def test_output_geometries_persist_with_declared_role_and_order(db_conn) -> None:
     """A producer-declared output_geometries list creates rows with role/order."""
     payload = _payload_with_ts_irc()
     # Attach an explicit output_geometries to the TS-IRC calc with two
@@ -2272,7 +2268,7 @@ def test_output_geometries_persist_with_declared_role_and_order(db_engine) -> No
     # index 2 is "ts-sp" since _payload_with_ts_irc appends them in that order).
     # We re-look up by key below.
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         persist_computed_reaction_upload(session, request)
 
@@ -2295,7 +2291,7 @@ def test_output_geometries_persist_with_declared_role_and_order(db_engine) -> No
         assert rows[1].role == CalculationGeometryRole.irc_reverse
 
 
-def test_depends_on_persists_with_role(db_engine) -> None:
+def test_depends_on_persists_with_role(db_conn) -> None:
     """A computed-reaction calc may declare depends_on edges by local key."""
     payload = _payload_with_ts_irc()
     # Make the TS SP depend on the TS opt, role=single_point_on (compatible:
@@ -2305,7 +2301,7 @@ def test_depends_on_persists_with_role(db_engine) -> None:
         {"parent_calculation_key": "ts-opt", "role": "single_point_on"},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         persist_computed_reaction_upload(session, request)
 
@@ -2333,7 +2329,7 @@ def test_depends_on_persists_with_role(db_engine) -> None:
         assert edges[0].dependency_role == CalculationDependencyRole.single_point_on
 
 
-def test_depends_on_optimized_from_with_freq_parent_raises(db_engine) -> None:
+def test_depends_on_optimized_from_with_freq_parent_raises(db_conn) -> None:
     """``optimized_from`` parent must be opt or path_search.
 
     Regression: the bundle path delivers ``role`` as a wire-mirror enum
@@ -2353,14 +2349,14 @@ def test_depends_on_optimized_from_with_freq_parent_raises(db_engine) -> None:
         {"parent_calculation_key": "ts-freq", "role": "optimized_from"},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError) as exc:
             persist_computed_reaction_upload(session, request)
         assert "optimized_from" in str(exc.value)
 
 
-def test_loose_roles_accept_any_calc_type_and_owner(db_engine) -> None:
+def test_loose_roles_accept_any_calc_type_and_owner(db_conn) -> None:
     """master_equation and fit_source are intentionally unrestricted in v0.
 
     Linking a species-owned opt under fit_source must succeed; linking
@@ -2383,7 +2379,7 @@ def test_loose_roles_accept_any_calc_type_and_owner(db_engine) -> None:
             {"calculation_key": "ch3-master-freq", "role": "master_equation"},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         kin_id = summary["kinetics_ids"][0]
@@ -2476,7 +2472,7 @@ def _find_ts_irc_calc(session: Session) -> Calculation:
     return calc
 
 
-def test_computed_reaction_accepts_structured_irc_result(db_engine) -> None:
+def test_computed_reaction_accepts_structured_irc_result(db_conn) -> None:
     """A structured ``irc_result`` on the TS-IRC calc creates one
     ``calc_irc_result`` row through the existing persistence seam."""
     payload = _payload_with_ts_irc()
@@ -2486,7 +2482,7 @@ def test_computed_reaction_accepts_structured_irc_result(db_engine) -> None:
     )
     ts_irc_in["irc_result"] = _irc_result_block(with_points=False)
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         persist_computed_reaction_upload(session, request)
 
@@ -2499,7 +2495,7 @@ def test_computed_reaction_accepts_structured_irc_result(db_engine) -> None:
 
 
 def test_computed_reaction_irc_points_persist_with_directions_and_geometries(
-    db_engine,
+    db_conn,
 ) -> None:
     """Forward/reverse IRC points persist with directions preserved and
     inline geometries resolved through the shared geometry resolver."""
@@ -2509,7 +2505,7 @@ def test_computed_reaction_irc_points_persist_with_directions_and_geometries(
     )
     ts_irc_in["irc_result"] = _irc_result_block(with_points=True)
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         persist_computed_reaction_upload(session, request)
 
@@ -2539,7 +2535,7 @@ def test_computed_reaction_irc_points_persist_with_directions_and_geometries(
 
 
 def test_computed_reaction_irc_dependency_and_kinetics_source_coexist(
-    db_engine,
+    db_conn,
 ) -> None:
     """A bundle may simultaneously declare an ``irc_start`` dependency
     edge from TS-opt to TS-IRC, a ``role=irc`` kinetics source link
@@ -2556,7 +2552,7 @@ def test_computed_reaction_irc_dependency_and_kinetics_source_coexist(
         {"calculation_key": "ts-irc", "role": "irc"},
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -2688,7 +2684,7 @@ def _payload_with_aec_carriers() -> dict:
 # --- Species-side: 1-12 ----------------------------------------------------
 
 
-def test_species_aec_total_no_components_persists(db_engine) -> None:
+def test_species_aec_total_no_components_persists(db_conn) -> None:
     """Spec test 1: species-side AEC persists targeting species_entry."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2701,7 +2697,7 @@ def test_species_aec_total_no_components_persists(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -2726,7 +2722,7 @@ def test_species_aec_total_no_components_persists(db_engine) -> None:
         assert source_calc.species_entry_id == ac.target_species_entry_id
 
 
-def test_species_bac_total_persists(db_engine) -> None:
+def test_species_bac_total_persists(db_conn) -> None:
     """Spec test 2: species-side BAC persists targeting species_entry."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2739,7 +2735,7 @@ def test_species_bac_total_persists(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
 
@@ -2755,7 +2751,7 @@ def test_species_bac_total_persists(db_engine) -> None:
         assert scheme.kind.value == "bac_petersson"
 
 
-def test_species_correction_components_optional(db_engine) -> None:
+def test_species_correction_components_optional(db_conn) -> None:
     """Spec test 3: components are optional (no rows when omitted)."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2768,7 +2764,7 @@ def test_species_correction_components_optional(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -2786,7 +2782,7 @@ def test_species_correction_components_optional(db_engine) -> None:
         assert comps == []
 
 
-def test_species_correction_components_persist_when_supplied(db_engine) -> None:
+def test_species_correction_components_persist_when_supplied(db_conn) -> None:
     """Spec test 4: components persist when supplied."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2810,7 +2806,7 @@ def test_species_correction_components_persist_when_supplied(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -2832,7 +2828,7 @@ def test_species_correction_components_persist_when_supplied(db_engine) -> None:
 
 
 def test_species_source_calculation_key_resolves_to_species_owned_calc(
-    db_engine,
+    db_conn,
 ) -> None:
     """Spec test 5: source_calculation_key resolves into the bundle namespace."""
     payload = _payload_with_aec_carriers()
@@ -2846,7 +2842,7 @@ def test_species_source_calculation_key_resolves_to_species_owned_calc(
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -2899,7 +2895,7 @@ def test_species_role_scheme_kind_mismatch_returns_422() -> None:
         ComputedReactionUploadRequest(**payload)
 
 
-def test_species_repeated_scheme_identity_reuses_scheme_row(db_engine) -> None:
+def test_species_repeated_scheme_identity_reuses_scheme_row(db_conn) -> None:
     """Spec test 8: duplicate scheme refs across two species reuse one row."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2921,7 +2917,7 @@ def test_species_repeated_scheme_identity_reuses_scheme_row(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         applied = session.scalars(
@@ -2936,7 +2932,7 @@ def test_species_repeated_scheme_identity_reuses_scheme_row(db_engine) -> None:
         assert len(scheme_ids) == 1
 
 
-def test_species_note_does_not_affect_scheme_identity(db_engine) -> None:
+def test_species_note_does_not_affect_scheme_identity(db_conn) -> None:
     """Spec test 9: scheme ``note`` differs but identity tuple matches → same row."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2958,7 +2954,7 @@ def test_species_note_does_not_affect_scheme_identity(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         applied = session.scalars(
@@ -2971,7 +2967,7 @@ def test_species_note_does_not_affect_scheme_identity(db_engine) -> None:
         assert {ac.scheme_id for ac in applied} == {applied[0].scheme_id}
 
 
-def test_species_aec_does_not_create_freq_scale_factor_row(db_engine) -> None:
+def test_species_aec_does_not_create_freq_scale_factor_row(db_conn) -> None:
     """Spec test 10: AEC/BAC corrections do not create a frequency_scale_factor row."""
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
@@ -2984,7 +2980,7 @@ def test_species_aec_does_not_create_freq_scale_factor_row(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         before = session.scalar(
             select(func.count()).select_from(FrequencyScaleFactor)
         )
@@ -2996,9 +2992,9 @@ def test_species_aec_does_not_create_freq_scale_factor_row(db_engine) -> None:
         assert after == before
 
 
-def test_existing_payload_without_corrections_remains_valid(db_engine) -> None:
+def test_existing_payload_without_corrections_remains_valid(db_conn) -> None:
     """Spec test 11: bundles without applied_energy_corrections still work."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**_minimal_payload())
         summary = persist_computed_reaction_upload(session, request)
         assert summary["species_count"] == 3
@@ -3013,7 +3009,7 @@ def test_existing_payload_without_corrections_remains_valid(db_engine) -> None:
         assert applied == []
 
 
-def test_computed_species_applied_correction_behavior_unchanged(db_engine) -> None:
+def test_computed_species_applied_correction_behavior_unchanged(db_conn) -> None:
     """Spec test 12: computed-species AEC behavior remains unchanged.
 
     Smoke-test the species-side primitive payload by re-running one
@@ -3077,7 +3073,7 @@ def test_computed_species_applied_correction_behavior_unchanged(db_engine) -> No
         }
     )
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -3092,7 +3088,7 @@ def test_computed_species_applied_correction_behavior_unchanged(db_engine) -> No
 # --- TS-side: 13-17 --------------------------------------------------------
 
 
-def test_ts_aec_total_persists_targeting_transition_state_entry(db_engine) -> None:
+def test_ts_aec_total_persists_targeting_transition_state_entry(db_conn) -> None:
     """Spec test 13: TS-side AEC targets transition_state_entry_id."""
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
@@ -3105,7 +3101,7 @@ def test_ts_aec_total_persists_targeting_transition_state_entry(db_engine) -> No
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         applied = session.scalars(
@@ -3121,7 +3117,7 @@ def test_ts_aec_total_persists_targeting_transition_state_entry(db_engine) -> No
         assert ac.application_role.value == "aec_total"
 
 
-def test_ts_bac_total_persists_targeting_transition_state_entry(db_engine) -> None:
+def test_ts_bac_total_persists_targeting_transition_state_entry(db_conn) -> None:
     """Spec test 14: TS-side BAC targets transition_state_entry_id."""
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
@@ -3134,7 +3130,7 @@ def test_ts_bac_total_persists_targeting_transition_state_entry(db_engine) -> No
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -3147,7 +3143,7 @@ def test_ts_bac_total_persists_targeting_transition_state_entry(db_engine) -> No
         assert scheme.kind.value == "bac_petersson"
 
 
-def test_ts_source_calculation_key_resolves_to_ts_sp(db_engine) -> None:
+def test_ts_source_calculation_key_resolves_to_ts_sp(db_conn) -> None:
     """Spec test 15: TS-side ``source_calculation_key="ts-sp"`` resolves correctly."""
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
@@ -3160,7 +3156,7 @@ def test_ts_source_calculation_key_resolves_to_ts_sp(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -3177,7 +3173,7 @@ def test_ts_source_calculation_key_resolves_to_ts_sp(db_engine) -> None:
         )
 
 
-def test_ts_correction_never_uses_target_reaction_entry_id(db_engine) -> None:
+def test_ts_correction_never_uses_target_reaction_entry_id(db_conn) -> None:
     """Spec test 16: TS corrections are never stored as reaction-entry corrections."""
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
@@ -3190,7 +3186,7 @@ def test_ts_correction_never_uses_target_reaction_entry_id(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         # The reaction entry must have ZERO applied corrections attached.
@@ -3206,7 +3202,7 @@ def test_ts_correction_never_uses_target_reaction_entry_id(db_engine) -> None:
 @pytest.mark.filterwarnings(
     "ignore:transaction already deassociated from connection"
 )
-def test_target_exclusivity_enforced_by_check_constraint(db_engine) -> None:
+def test_target_exclusivity_enforced_by_check_constraint(db_conn) -> None:
     """Spec test 17: exactly one of species/reaction/TS target may be set.
 
     The check constraint ``num_nonnulls(target_species_entry_id,
@@ -3222,7 +3218,7 @@ def test_target_exclusivity_enforced_by_check_constraint(db_engine) -> None:
 
     # First isolated session: persist a real bundle so we have valid
     # FK targets for the probe row.
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**_payload_with_aec_carriers())
         summary = persist_computed_reaction_upload(session, request)
         # Capture the ids while the row visibility is still in scope.
@@ -3265,7 +3261,7 @@ def test_target_exclusivity_enforced_by_check_constraint(db_engine) -> None:
 # --- Cross-owner negatives -------------------------------------------------
 
 
-def test_species_correction_referencing_ts_calc_returns_422(db_engine) -> None:
+def test_species_correction_referencing_ts_calc_returns_422(db_conn) -> None:
     """Species-side correction whose ``source_calculation_key`` names a
     TS-owned calc rejects with 422."""
     import pytest
@@ -3281,13 +3277,13 @@ def test_species_correction_referencing_ts_calc_returns_422(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(ValueError, match="not owned by this species entry"):
             persist_computed_reaction_upload(session, request)
 
 
-def test_ts_correction_referencing_species_calc_returns_422(db_engine) -> None:
+def test_ts_correction_referencing_species_calc_returns_422(db_conn) -> None:
     """TS-side correction whose ``source_calculation_key`` names a
     species-owned calc rejects with 422."""
     import pytest
@@ -3303,7 +3299,7 @@ def test_ts_correction_referencing_species_calc_returns_422(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         with pytest.raises(
             ValueError, match="not owned by this transition state entry"
@@ -3311,7 +3307,7 @@ def test_ts_correction_referencing_species_calc_returns_422(db_engine) -> None:
             persist_computed_reaction_upload(session, request)
 
 
-def test_ts_side_scheme_atom_params_persist(db_engine) -> None:
+def test_ts_side_scheme_atom_params_persist(db_conn) -> None:
     """TS-side AEC scheme params populate the atom_param table."""
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
@@ -3330,7 +3326,7 @@ def test_ts_side_scheme_atom_params_persist(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -3350,7 +3346,7 @@ def test_ts_side_scheme_atom_params_persist(db_engine) -> None:
         }
 
 
-def test_ts_side_scheme_bond_params_persist(db_engine) -> None:
+def test_ts_side_scheme_bond_params_persist(db_conn) -> None:
     """TS-side BAC scheme params populate the bond_param table."""
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
@@ -3369,7 +3365,7 @@ def test_ts_side_scheme_bond_params_persist(db_engine) -> None:
         }
     ]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
         summary = persist_computed_reaction_upload(session, request)
         ac = session.scalars(
@@ -3469,12 +3465,12 @@ def test_computed_reaction_payload_accepts_degeneracy_regression() -> None:
     assert request.kinetics[0].degeneracy == 2.0
 
 
-def test_computed_reaction_persists_degeneracy(db_engine) -> None:
+def test_computed_reaction_persists_degeneracy(db_conn) -> None:
     """``kinetics[].degeneracy`` is written to the kinetics row."""
     payload = _minimal_payload()
     payload["kinetics"][0]["degeneracy"] = 3.0
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=601, username="degeneracy_persist_tester"))
         session.flush()
 
@@ -3489,12 +3485,12 @@ def test_computed_reaction_persists_degeneracy(db_engine) -> None:
         assert kin.degeneracy == 3.0
 
 
-def test_computed_reaction_persists_null_degeneracy_when_omitted(db_engine) -> None:
+def test_computed_reaction_persists_null_degeneracy_when_omitted(db_conn) -> None:
     """Omitting ``degeneracy`` persists a NULL — never silently defaulted to 1.0."""
     payload = _minimal_payload()
     assert "degeneracy" not in payload["kinetics"][0]
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=602, username="degeneracy_null_tester"))
         session.flush()
 
@@ -3509,12 +3505,12 @@ def test_computed_reaction_persists_null_degeneracy_when_omitted(db_engine) -> N
         assert kin.degeneracy is None
 
 
-def test_computed_reaction_persists_explicit_degeneracy_convention(db_engine) -> None:
+def test_computed_reaction_persists_explicit_degeneracy_convention(db_conn) -> None:
     payload = _minimal_payload()
     payload["kinetics"][0]["degeneracy"] = 3.0
     payload["kinetics"][0]["degeneracy_convention"] = "not_applied"
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         session.add(AppUser(id=603, username="degeneracy_convention_tester"))
         session.flush()
         summary = persist_computed_reaction_upload(
@@ -3564,7 +3560,7 @@ def _payload_with_ts_evidence(**evidence_overrides) -> dict:
     return payload
 
 
-def test_bundle_transition_state_persists_irc_evidence(db_engine) -> None:
+def test_bundle_transition_state_persists_irc_evidence(db_conn) -> None:
     from app.db.models.transition_state import TransitionStateValidationEvidence
     from app.services.scientific_read.transition_states import (
         _build_validation_descriptor,
@@ -3572,7 +3568,7 @@ def test_bundle_transition_state_persists_irc_evidence(db_engine) -> None:
 
     # Rolled back: this bundle persists species/conformers that other workflow
     # tests count without qualification.
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = persist_computed_reaction_upload(
             session,
             ComputedReactionUploadRequest(**_payload_with_ts_evidence()),

--- a/backend/tests/workflows/test_computed_species_upload.py
+++ b/backend/tests/workflows/test_computed_species_upload.py
@@ -151,10 +151,8 @@ def _execution_environment() -> dict:
     }
 
 
-def test_computed_species_calculation_environment_persists_dedups_and_is_optional(db_engine) -> None:
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+def test_computed_species_calculation_environment_persists_dedups_and_is_optional(db_conn) -> None:
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         user_id = _ensure_user(session, username="bundle_environment")
         with_env = _hydrogen_bundle()
@@ -169,8 +167,6 @@ def test_computed_species_calculation_environment_persists_dedups_and_is_optiona
         assert legacy.conformers[0].primary_calculation.execution_environment_manifest_id is None
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
 # ---------------------------------------------------------------------------
@@ -178,8 +174,8 @@ def test_computed_species_calculation_environment_persists_dedups_and_is_optiona
 # ---------------------------------------------------------------------------
 
 
-def test_minimal_bundle_persists(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_minimal_bundle_persists(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_min")
         outcome = persist_computed_species_upload(
             session, _hydrogen_bundle(), created_by=user_id
@@ -191,12 +187,12 @@ def test_minimal_bundle_persists(db_engine) -> None:
 
 
 def test_bundle_sp_calc_with_wavefunction_diagnostic_persists(
-    db_engine,
+    db_conn,
 ) -> None:
     """A bundle SP additional calc carrying ``wavefunction_diagnostic``
     persists one ``calc_wavefunction_diagnostic`` row anchored to the SP
     calculation row."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_wfn_diag")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
@@ -229,13 +225,13 @@ def test_bundle_sp_calc_with_wavefunction_diagnostic_persists(
 
 
 def test_bundle_sp_calc_with_spin_diagnostic_persists(
-    db_engine,
+    db_conn,
 ) -> None:
     """A bundle SP additional calc carrying ``spin_diagnostic`` persists one
     ``calc_spin_diagnostic`` (<S^2>) row anchored to the SP calculation row.
     Guards ``computed_species._to_payload`` forwarding of
     ``spin_diagnostic``."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_spin_diag")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
@@ -269,11 +265,11 @@ def test_bundle_sp_calc_with_spin_diagnostic_persists(
         assert rows[0].note == "UHF doublet"
 
 
-def test_bundle_freq_calc_with_hessian_persists(db_engine) -> None:
+def test_bundle_freq_calc_with_hessian_persists(db_conn) -> None:
     """A bundle freq additional calc carrying a ``hessian`` persists one
     ``calculation_hessian`` row bound to the geometry the Hessian was
     computed at, with the correct triangle length (3N(3N+1)/2)."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_hessian")
         bundle = _hydrogen_bundle()
         # 1-atom geometry → 3N = 3 → lower triangle length = 3*4/2 = 6.
@@ -317,10 +313,10 @@ def test_bundle_freq_calc_with_hessian_persists(db_engine) -> None:
         assert hess.geometry_id == input_geom.geometry_id
 
 
-def test_bundle_with_freq_and_sp_creates_auto_dependencies(db_engine) -> None:
+def test_bundle_with_freq_and_sp_creates_auto_dependencies(db_conn) -> None:
     """Additional freq + sp calcs auto-link freq_on / single_point_on
     edges to the primary opt — same semantics as /uploads/conformers."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_auto_deps")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
@@ -356,14 +352,14 @@ def test_bundle_with_freq_and_sp_creates_auto_dependencies(db_engine) -> None:
         )
 
 
-def test_bundle_freq_and_sp_get_input_geometry_rows(db_engine) -> None:
+def test_bundle_freq_and_sp_get_input_geometry_rows(db_conn) -> None:
     """Bundle additionals of type freq/sp must produce one
     calculation_input_geometry row each, pointing at the conformer
     geometry. The primary opt has one output_geometry row (role=final);
     freq/sp produce zero output_geometry rows under the narrowed
     fallback (only opt qualifies for the auto-create).
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_input_geom")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
@@ -434,7 +430,7 @@ def test_bundle_freq_and_sp_get_input_geometry_rows(db_engine) -> None:
         # Bundle scope: exactly the freq + sp calcs get input rows;
         # the primary opt does not. Scope to the three calcs in this
         # bundle to avoid coupling to rows persisted by prior tests
-        # (db_engine is session-scoped; see conftest).
+        # (db_conn is session-scoped; see conftest).
         bundle_calc_ids = [primary_id, freq_id, sp_id]
         bundle_input_rows = session.scalars(
             select(CalculationInputGeometry).where(
@@ -445,13 +441,13 @@ def test_bundle_freq_and_sp_get_input_geometry_rows(db_engine) -> None:
         assert {r.calculation_id for r in bundle_input_rows} == {freq_id, sp_id}
 
 
-def test_bundle_explicit_input_geometries_for_opt(db_engine) -> None:
+def test_bundle_explicit_input_geometries_for_opt(db_conn) -> None:
     """A producer that knows opt's pre-opt input xyz can declare it via
     ``input_geometries``; the workflow lands one
     ``calculation_input_geometry`` row pointing at the resolved geometry,
     which is distinct from opt's output (the conformer geometry)."""
     pre_opt_xyz = "1\npre-opt H\nH 0.0 0.0 0.123"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_explicit_opt")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].primary_calculation.input_geometries = [
@@ -482,13 +478,13 @@ def test_bundle_explicit_input_geometries_for_opt(db_engine) -> None:
 
 
 def test_bundle_explicit_input_geometries_overrides_freq_sp_fallback(
-    db_engine,
+    db_conn,
 ) -> None:
     """When ``input_geometries`` is set on a freq calc, the workflow must
     use the producer-declared geometry, not the conformer geometry that
     the fallback would otherwise pick."""
     declared_xyz = "1\ndeclared\nH 0.0 0.0 0.999"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_explicit_freq")
         bundle = _hydrogen_bundle()
         freq_in = type(bundle.conformers[0].primary_calculation)(
@@ -522,11 +518,11 @@ def test_bundle_explicit_input_geometries_overrides_freq_sp_fallback(
         assert freq_inputs[0].geometry_id != conformer_geom_id
 
 
-def test_bundle_empty_input_geometries_uses_fallback(db_engine) -> None:
+def test_bundle_empty_input_geometries_uses_fallback(db_conn) -> None:
     """When every calc has an empty ``input_geometries``, the workflow
     preserves the prior PR's behavior: freq+sp link to the conformer
     geometry, opt skips."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_fallback")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
@@ -554,12 +550,12 @@ def test_bundle_empty_input_geometries_uses_fallback(db_engine) -> None:
         assert {r.calculation_id for r in rows} == {freq_id, sp_id}
 
 
-def test_bundle_multi_input_geometries_for_one_calc(db_engine) -> None:
+def test_bundle_multi_input_geometries_for_one_calc(db_conn) -> None:
     """A producer can declare multiple input geometries for one calc;
     each lands at ``input_order = 1, 2, ...`` in declaration order."""
     xyz_a = "1\ngeom-a\nH 0.0 0.0 0.111"
     xyz_b = "1\ngeom-b\nH 0.0 0.0 0.222"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_multi_input")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].primary_calculation.input_geometries = [
@@ -580,12 +576,12 @@ def test_bundle_multi_input_geometries_for_one_calc(db_engine) -> None:
         assert rows[0].geometry_id != rows[1].geometry_id
 
 
-def test_bundle_duplicate_input_geometries_rejected(db_engine) -> None:
+def test_bundle_duplicate_input_geometries_rejected(db_conn) -> None:
     """Declaring the same geometry twice in a single calc's
     ``input_geometries`` list is rejected as a 422 (``ValueError`` from
     a workflow-level pre-check, not a bare ``IntegrityError``)."""
     same_xyz = "1\nsame\nH 0.0 0.0 0.314"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         _ensure_user(session, username="bundle_dup_input")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].primary_calculation.input_geometries = [
@@ -596,12 +592,12 @@ def test_bundle_duplicate_input_geometries_rejected(db_engine) -> None:
             persist_computed_species_upload(session, bundle)
 
 
-def test_bundle_explicit_output_geometries_for_opt(db_engine) -> None:
+def test_bundle_explicit_output_geometries_for_opt(db_conn) -> None:
     """A producer can declare opt's converged output explicitly via
     ``output_geometries``; the producer-explicit path runs and the
     fallback does NOT also fire."""
     declared_xyz = "1\ndeclared-final\nH 0.0 0.0 0.987"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         from app.db.models.common import CalculationGeometryRole
 
         _ensure_user(session, username="bundle_explicit_output_opt")
@@ -627,13 +623,13 @@ def test_bundle_explicit_output_geometries_for_opt(db_engine) -> None:
         assert rows[0].role == CalculationGeometryRole.final
 
 
-def test_bundle_explicit_output_geometries_for_scan(db_engine) -> None:
+def test_bundle_explicit_output_geometries_for_scan(db_conn) -> None:
     """A scan calc that declares three output geometries with role=scan_point
     produces three rows at output_order=1, 2, 3 with the matching role."""
     xyz_a = "1\nscan-1\nH 0.0 0.0 0.10"
     xyz_b = "1\nscan-2\nH 0.0 0.0 0.20"
     xyz_c = "1\nscan-3\nH 0.0 0.0 0.30"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         from app.db.models.common import CalculationGeometryRole
 
         _ensure_user(session, username="bundle_scan_outputs")
@@ -672,12 +668,12 @@ def test_bundle_explicit_output_geometries_for_scan(db_engine) -> None:
         assert len({r.geometry_id for r in rows}) == 3
 
 
-def test_bundle_explicit_output_geometries_with_irc_roles(db_engine) -> None:
+def test_bundle_explicit_output_geometries_with_irc_roles(db_conn) -> None:
     """An IRC calc that declares one ``irc_forward`` and one ``irc_reverse``
     output geometry produces two rows with the producer-declared roles."""
     xyz_fwd = "1\nirc-fwd\nH 0.0 0.0 0.40"
     xyz_rev = "1\nirc-rev\nH 0.0 0.0 0.50"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         from app.db.models.common import CalculationGeometryRole
 
         _ensure_user(session, username="bundle_irc_outputs")
@@ -714,11 +710,11 @@ def test_bundle_explicit_output_geometries_with_irc_roles(db_engine) -> None:
         assert [r.output_order for r in rows] == [1, 2]
 
 
-def test_bundle_empty_output_geometries_opt_uses_fallback(db_engine) -> None:
+def test_bundle_empty_output_geometries_opt_uses_fallback(db_conn) -> None:
     """When opt has empty ``output_geometries``, the narrowed fallback
     fires: one row at (role=final, output_order=1) pointing at the
     conformer geometry."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         _ensure_user(session, username="bundle_opt_fallback")
         bundle = _hydrogen_bundle()
         outcome = persist_computed_species_upload(session, bundle)
@@ -736,12 +732,12 @@ def test_bundle_empty_output_geometries_opt_uses_fallback(db_engine) -> None:
         assert rows[0].output_order == 1
 
 
-def test_bundle_empty_output_geometries_freq_sp_get_zero_rows(db_engine) -> None:
+def test_bundle_empty_output_geometries_freq_sp_get_zero_rows(db_conn) -> None:
     """Freq and sp with empty ``output_geometries`` produce ZERO
     calculation_output_geometry rows. THIS IS THE BEHAVIOR CHANGE: the
     pre-PR fallback would have written one row each; the narrowed
     fallback only fires for opt."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         _ensure_user(session, username="bundle_freq_sp_zero_outputs")
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
@@ -797,10 +793,10 @@ def test_bundle_output_geometries_with_role_required_at_schema_layer() -> None:
     assert "role" in str(excinfo.value).lower()
 
 
-def test_multiple_conformers_create_distinct_groups(db_engine) -> None:
+def test_multiple_conformers_create_distinct_groups(db_conn) -> None:
     """3 distinct geometries → 3 conformer_observation rows (groups may
     share for trivial single-atom species without a torsion fingerprint)."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         _ensure_user(session, username="bundle_multi")
         bundle_data = {
             "species_entry": {
@@ -843,8 +839,8 @@ def test_multiple_conformers_create_distinct_groups(db_engine) -> None:
         )
 
 
-def test_chemistry_only_bundle_omits_thermo(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_chemistry_only_bundle_omits_thermo(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _hydrogen_bundle()
         )
@@ -895,8 +891,8 @@ def _bundle_with_thermo() -> ComputedSpeciesUploadRequest:
     )
 
 
-def test_thermo_block_persists_with_source_links(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_thermo_block_persists_with_source_links(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _bundle_with_thermo()
         )
@@ -982,12 +978,12 @@ def _bundle_multi_conformer_thermo_statmech() -> ComputedSpeciesUploadRequest:
     )
 
 
-def test_bundle_species_calcs_carry_conformer_observation_id(db_engine) -> None:
+def test_bundle_species_calcs_carry_conformer_observation_id(db_conn) -> None:
     """Every species-side calculation a computed-species bundle persists must
     carry ``conformer_observation_id`` (the audit invariant). Mirrors the SQL
     audit predicate: zero species-side calcs with a NULL conformer link.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _bundle_multi_conformer_thermo_statmech()
         )
@@ -1030,13 +1026,13 @@ def test_bundle_species_calcs_carry_conformer_observation_id(db_engine) -> None:
 
 
 def test_bundle_thermo_statmech_sources_trace_to_conformer_observations(
-    db_engine,
+    db_conn,
 ) -> None:
     """Computed thermo and statmech source calculations must trace back to a
     conformer observation — i.e. each source calc carries a non-null
     ``conformer_observation_id``.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _bundle_multi_conformer_thermo_statmech()
         )
@@ -1077,13 +1073,13 @@ def test_bundle_thermo_statmech_sources_trace_to_conformer_observations(
 # ---------------------------------------------------------------------------
 
 
-def test_bundle_computed_thermo_links_to_statmech(db_engine) -> None:
+def test_bundle_computed_thermo_links_to_statmech(db_conn) -> None:
     """A bundle carrying a COMPUTED thermo alongside a statmech must set
     ``thermo.statmech_id`` to the statmech it was derived from — so the read
     layer never has to fall back to ``min(statmech_id)`` when a species entry
     accumulates multiple statmech rows.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _bundle_multi_conformer_thermo_statmech()
         )
@@ -1093,10 +1089,10 @@ def test_bundle_computed_thermo_links_to_statmech(db_engine) -> None:
         assert outcome.thermo.statmech_id == outcome.statmech.id
 
 
-def test_bundle_thermo_without_statmech_leaves_statmech_id_null(db_engine) -> None:
+def test_bundle_thermo_without_statmech_leaves_statmech_id_null(db_conn) -> None:
     """A computed thermo with no statmech in the bundle has nothing to link to;
     ``statmech_id`` must remain NULL."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _bundle_with_thermo()
         )
@@ -1105,7 +1101,7 @@ def test_bundle_thermo_without_statmech_leaves_statmech_id_null(db_engine) -> No
         assert outcome.thermo.statmech_id is None
 
 
-def test_bundle_experimental_thermo_not_linked_to_statmech(db_engine) -> None:
+def test_bundle_experimental_thermo_not_linked_to_statmech(db_conn) -> None:
     """An experimental (non-computed) thermo that happens to coexist with a
     statmech must NOT be linked — only computed thermo is derived from a
     statmech basis."""
@@ -1113,7 +1109,7 @@ def test_bundle_experimental_thermo_not_linked_to_statmech(db_engine) -> None:
     bundle.thermo.scientific_origin = ScientificOriginKind.experimental
     # Experimental thermo is not derived from bundle calcs; drop source links.
     bundle.thermo.source_calculations = []
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         assert outcome.thermo is not None
         assert outcome.statmech is not None
@@ -1123,8 +1119,8 @@ def test_bundle_experimental_thermo_not_linked_to_statmech(db_engine) -> None:
         assert outcome.thermo.statmech_id is None
 
 
-def test_thermo_role_type_mismatch_raises(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_thermo_role_type_mismatch_raises(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         # source role=opt but pointing at a freq calc → 422 in route, ValueError here.
         bundle = _bundle_with_thermo()
         bundle.thermo.source_calculations[0].calculation_key = "freq0"
@@ -1133,10 +1129,10 @@ def test_thermo_role_type_mismatch_raises(db_engine) -> None:
         assert "incompatible" in str(exc.value)
 
 
-def test_dependency_role_type_mismatch_raises(db_engine) -> None:
+def test_dependency_role_type_mismatch_raises(db_conn) -> None:
     """freq_on must point at an opt parent. Pointing it at the same
     calc as another freq calc (which is type=freq) raises ValueError."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle = _hydrogen_bundle()
         bundle.conformers[0].additional_calculations = [
             type(bundle.conformers[0].primary_calculation)(
@@ -1160,7 +1156,7 @@ def test_dependency_role_type_mismatch_raises(db_engine) -> None:
         assert "incompatible" in str(exc.value)
 
 
-def test_optimized_from_with_freq_parent_raises(db_engine) -> None:
+def test_optimized_from_with_freq_parent_raises(db_conn) -> None:
     """``optimized_from`` parent must be opt or path_search.
 
     Regression: the bundle path delivers ``role`` as a wire-mirror enum
@@ -1169,7 +1165,7 @@ def test_optimized_from_with_freq_parent_raises(db_engine) -> None:
     enum and silently skipped this validation. Pointing ``optimized_from``
     at a freq parent must now raise 422-style ValueError.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle = _hydrogen_bundle()
         klass = type(bundle.conformers[0].primary_calculation)
         bundle.conformers[0].additional_calculations = [
@@ -1221,12 +1217,12 @@ def _hydrogen_bundle_with_freq_dep() -> ComputedSpeciesUploadRequest:
 
 
 def test_redundant_explicit_dep_matching_auto_edge_is_idempotent(
-    db_engine,
+    db_conn,
 ) -> None:
     """Bundle declares an explicit ``depends_on`` that matches the
     auto-edge created from primary→freq. Insertion must be idempotent:
     one edge persisted, no duplicate-key error."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _hydrogen_bundle_with_freq_dep()
         )
@@ -1243,14 +1239,14 @@ def test_redundant_explicit_dep_matching_auto_edge_is_idempotent(
 
 
 def test_explicit_dep_with_conflicting_role_to_auto_edge_raises(
-    db_engine,
+    db_conn,
 ) -> None:
     """Auto-edge fires with role=freq_on for a primary→freq pair. An
     explicit depends_on for the same pair but with a different role
     (``optimized_from`` — type-compatible since parent is opt) must
     surface as a clear ValueError, not a silent overwrite or pk
     violation."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle = _hydrogen_bundle()
         klass = type(bundle.conformers[0].primary_calculation)
         bundle.conformers[0].additional_calculations = [
@@ -1276,12 +1272,12 @@ def test_explicit_dep_with_conflicting_role_to_auto_edge_raises(
 
 
 def test_duplicate_explicit_deps_in_same_bundle_is_idempotent(
-    db_engine,
+    db_conn,
 ) -> None:
     """Same ``depends_on`` triple declared twice within a single bundle
     must not double-insert. Exercises the in-session ``session.new``
     branch of the helper directly."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle = _hydrogen_bundle()
         klass = type(bundle.conformers[0].primary_calculation)
         bundle.conformers[0].additional_calculations = [
@@ -1309,7 +1305,7 @@ def test_duplicate_explicit_deps_in_same_bundle_is_idempotent(
 
 
 def test_dependency_edge_idempotent_across_committed_transactions(
-    db_engine,
+    db_conn,
 ) -> None:
     """Faithful reproduction of the original migration bug: edge persisted
     in transaction A, fresh session in transaction B re-inserts the same
@@ -1319,7 +1315,7 @@ def test_dependency_edge_idempotent_across_committed_transactions(
         add_dependency_edge_idempotent as _add_dependency_edge_idempotent,
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _hydrogen_bundle_with_freq_dep()
         )
@@ -1327,7 +1323,7 @@ def test_dependency_edge_idempotent_across_committed_transactions(
         freq_id = outcome.conformers[0].additional_calculations[0].id
 
     # Fresh session — identity map is empty, helper must round-trip.
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         before = session.scalar(
             select(func.count()).select_from(CalculationDependency)
         )
@@ -1357,7 +1353,7 @@ def test_dependency_edge_idempotent_across_committed_transactions(
         assert "different role" in str(exc.value)
 
 
-def test_per_role_child_uniqueness_rejected_in_session(db_engine) -> None:
+def test_per_role_child_uniqueness_rejected_in_session(db_conn) -> None:
     """In-session: a ``freq_on`` edge is pending for child=C from parent=A.
     A second pending ``freq_on`` for the same child from a different
     parent must be rejected by the helper before flush — never reach
@@ -1366,7 +1362,7 @@ def test_per_role_child_uniqueness_rejected_in_session(db_engine) -> None:
         add_dependency_edge_idempotent as _add_dependency_edge_idempotent,
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _hydrogen_bundle_with_freq_dep()
         )
@@ -1414,7 +1410,7 @@ def test_per_role_child_uniqueness_rejected_in_session(db_engine) -> None:
 
 
 def test_per_role_child_uniqueness_rejected_across_transactions(
-    db_engine,
+    db_conn,
 ) -> None:
     """Persisted: a committed ``freq_on`` edge already exists for child=C
     from parent=A. A fresh transaction trying to add a second
@@ -1424,7 +1420,7 @@ def test_per_role_child_uniqueness_rejected_across_transactions(
         add_dependency_edge_idempotent as _add_dependency_edge_idempotent,
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome_a = persist_computed_species_upload(
             session, _hydrogen_bundle_with_freq_dep()
         )
@@ -1451,7 +1447,7 @@ def test_per_role_child_uniqueness_rejected_across_transactions(
         primary_b_id = outcome_b.conformers[0].primary_calculation.id
 
     # Fresh transaction — identity map empty, helper must round-trip.
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         before = session.scalar(
             select(func.count()).select_from(CalculationDependency)
         )
@@ -1491,7 +1487,7 @@ def _opt_only_bundle(geom_xyz: str) -> ComputedSpeciesUploadRequest:
 
 
 def test_per_role_child_uniqueness_does_not_block_unrestricted_role(
-    db_engine,
+    db_conn,
 ) -> None:
     """``arkane_source`` is not in the per-role-child uniqueness set.
     Two parents pointing to the same child with role=arkane_source must
@@ -1512,7 +1508,7 @@ def test_per_role_child_uniqueness_does_not_block_unrestricted_role(
         not in _ONE_PARENT_PER_CHILD_ROLES
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         a = persist_computed_species_upload(
             session, _opt_only_bundle("1\nH\nH 0.0 0.0 0.0")
         )
@@ -1556,7 +1552,7 @@ def test_per_role_child_uniqueness_does_not_block_unrestricted_role(
 
 
 def test_dependency_edge_helper_idempotent_against_persisted_row(
-    db_engine,
+    db_conn,
 ) -> None:
     """Direct exercise of the helper: a persisted DB row plus a re-insert
     attempt with the same role no-ops; with a different role raises."""
@@ -1564,7 +1560,7 @@ def test_dependency_edge_helper_idempotent_against_persisted_row(
         add_dependency_edge_idempotent as _add_dependency_edge_idempotent,
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _hydrogen_bundle_with_freq_dep()
         )
@@ -1606,10 +1602,10 @@ def test_dependency_edge_helper_idempotent_against_persisted_row(
 # ---------------------------------------------------------------------------
 
 
-def test_two_bundles_same_basin_reuse_conformer_group(db_engine) -> None:
+def test_two_bundles_same_basin_reuse_conformer_group(db_conn) -> None:
     """Bundle A creates a group; bundle B with the same molecule and
     geometry reuses A's group but creates a fresh conformer_observation."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome_a = persist_computed_species_upload(session, _hydrogen_bundle())
         outcome_b = persist_computed_species_upload(session, _hydrogen_bundle())
 
@@ -1628,7 +1624,7 @@ def test_two_bundles_same_basin_reuse_conformer_group(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_computed_species_statmech_block_persists_with_fsf(db_engine) -> None:
+def test_computed_species_statmech_block_persists_with_fsf(db_conn) -> None:
     """The computed-species bundle accepts an inline statmech block,
     resolves the unified ``FreqScaleFactorRef`` through the shared
     resolver, and links the resulting FSF row through
@@ -1667,7 +1663,7 @@ def test_computed_species_statmech_block_persists_with_fsf(db_engine) -> None:
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_statmech")
         aec_before = session.scalar(
             select(func.count()).select_from(AppliedEnergyCorrection)
@@ -1712,7 +1708,7 @@ def test_computed_species_statmech_block_persists_with_fsf(db_engine) -> None:
         assert aec_after == aec_before
 
 
-def test_computed_species_statmech_optical_isomers_persists(db_engine) -> None:
+def test_computed_species_statmech_optical_isomers_persists(db_conn) -> None:
     """The computed-species bundle accepts ``optical_isomers`` on the
     inline statmech block and persists it (reads back as given). This
     reaches the DB column through the bundle path, closing the gap where
@@ -1727,7 +1723,7 @@ def test_computed_species_statmech_optical_isomers_persists(db_engine) -> None:
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_optical")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -1739,7 +1735,7 @@ def test_computed_species_statmech_optical_isomers_persists(db_engine) -> None:
         assert statmech.optical_isomers == 2
 
 
-def test_computed_species_statmech_optical_isomers_defaults_null(db_engine) -> None:
+def test_computed_species_statmech_optical_isomers_defaults_null(db_conn) -> None:
     """A statmech block without ``optical_isomers`` still validates and
     stores NULL — old bundle payloads remain valid."""
     bundle = _hydrogen_bundle(
@@ -1751,7 +1747,7 @@ def test_computed_species_statmech_optical_isomers_defaults_null(db_engine) -> N
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_optical_null")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -1763,7 +1759,7 @@ def test_computed_species_statmech_optical_isomers_defaults_null(db_engine) -> N
         assert statmech.optical_isomers is None
 
 
-def test_computed_species_statmech_optical_isomers_zero_rejected(db_engine) -> None:
+def test_computed_species_statmech_optical_isomers_zero_rejected(db_conn) -> None:
     """``optical_isomers`` below 1 is rejected at the schema layer (422)."""
     from pydantic import ValidationError
 
@@ -1777,7 +1773,7 @@ def test_computed_species_statmech_optical_isomers_zero_rejected(db_engine) -> N
         )
 
 
-def test_computed_species_statmech_source_key_must_resolve(db_engine) -> None:
+def test_computed_species_statmech_source_key_must_resolve(db_conn) -> None:
     """Statmech ``source_calculations`` keys are validated against the
     bundle's global calc namespace at the schema layer; ghost keys are
     rejected before the workflow runs."""
@@ -1838,7 +1834,7 @@ def _ethane_bundle_with_scan(**overrides) -> dict:
     return payload
 
 
-def test_species_statmech_torsion_with_one_coordinate_persists(db_engine) -> None:
+def test_species_statmech_torsion_with_one_coordinate_persists(db_conn) -> None:
     """1D rotor with a single coordinate writes one
     ``statmech_torsion_definition`` row, atom quartet preserved 1-based."""
     bundle = ComputedSpeciesUploadRequest(
@@ -1869,7 +1865,7 @@ def test_species_statmech_torsion_with_one_coordinate_persists(db_engine) -> Non
         )
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_torsion_1d")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -1905,7 +1901,7 @@ def test_species_statmech_torsion_with_one_coordinate_persists(db_engine) -> Non
 
 
 def test_species_statmech_torsion_without_coordinates_writes_no_definitions(
-    db_engine,
+    db_conn,
 ) -> None:
     """Producers may omit ``coordinates``: the torsion row is created
     but no ``statmech_torsion_definition`` rows are written. This
@@ -1921,7 +1917,7 @@ def test_species_statmech_torsion_without_coordinates_writes_no_definitions(
         )
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_torsion_nocoords")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -1943,7 +1939,7 @@ def test_species_statmech_torsion_without_coordinates_writes_no_definitions(
 
 
 def test_species_statmech_torsion_dimension_two_persists_two_definitions(
-    db_engine,
+    db_conn,
 ) -> None:
     """A 2D coupled rotor with two coordinates writes two definition rows."""
     bundle = ComputedSpeciesUploadRequest(
@@ -1975,7 +1971,7 @@ def test_species_statmech_torsion_dimension_two_persists_two_definitions(
             }
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_torsion_2d")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -2142,7 +2138,7 @@ def _ethane_scan_result_payload(
     }
 
 
-def test_bundle_scan_calculation_persists_scan_result_rows(db_engine) -> None:
+def test_bundle_scan_calculation_persists_scan_result_rows(db_conn) -> None:
     """A bundle with a type=scan additional calc carrying scan_result
     persists rows in calc_scan_result, calc_scan_coordinate,
     calc_scan_point, and calc_scan_point_coordinate_value."""
@@ -2156,7 +2152,7 @@ def test_bundle_scan_calculation_persists_scan_result_rows(db_engine) -> None:
     }
     bundle = ComputedSpeciesUploadRequest(**payload)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_scan_result")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -2207,7 +2203,7 @@ def test_bundle_scan_calculation_persists_scan_result_rows(db_engine) -> None:
         assert [v.coordinate_value for v in values] == [0.0, 30.0, 60.0]
 
 
-def test_bundle_scan_inline_point_geometry_populates_geometry_id(db_engine) -> None:
+def test_bundle_scan_inline_point_geometry_populates_geometry_id(db_conn) -> None:
     """A scan_result whose points carry inline ``geometry`` payloads is
     resolved through ``resolve_geometry_payload`` and the resolved IDs land
     on ``calc_scan_point.geometry_id``."""
@@ -2222,7 +2218,7 @@ def test_bundle_scan_inline_point_geometry_populates_geometry_id(db_engine) -> N
     additional[scan_idx] = {**additional[scan_idx], "scan_result": scan_result}
     bundle = ComputedSpeciesUploadRequest(**payload)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user_id = _ensure_user(session, username="bundle_scan_inline_geom")
         outcome = persist_computed_species_upload(
             session, bundle, created_by=user_id
@@ -2270,7 +2266,7 @@ def test_bundle_scan_calc_rejects_non_scan_result_blocks() -> None:
         ComputedSpeciesUploadRequest(**payload)
 
 
-def test_bundle_torsion_resolves_to_scan_calc_with_scan_result(db_engine) -> None:
+def test_bundle_torsion_resolves_to_scan_calc_with_scan_result(db_conn) -> None:
     """A statmech torsion's ``source_scan_calculation_key`` resolves to a
     bundle-local type=scan calc that itself carries a ``scan_result`` —
     the torsion's ``source_scan_calculation_id`` points at that calc."""
@@ -2297,7 +2293,7 @@ def test_bundle_torsion_resolves_to_scan_calc_with_scan_result(db_engine) -> Non
     }
     bundle = ComputedSpeciesUploadRequest(**payload)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         _ensure_user(session, username="bundle_torsion_scan_result")
         outcome = persist_computed_species_upload(session, bundle)
 
@@ -2419,7 +2415,7 @@ def _geom_for_smiles(smiles: str) -> str:
 def _bundle_with_sp_calc(*, smiles: str, **overrides) -> dict:
     """Bundle template that exposes a 'sp0' calc key for source linking.
 
-    A distinct ``smiles`` per test is required because ``db_engine`` is
+    A distinct ``smiles`` per test is required because ``db_conn`` is
     session-scoped and writes commit between tests; reusing the same
     species across tests would accumulate ``applied_energy_correction``
     rows that target the same species entry.
@@ -2440,7 +2436,7 @@ def _bundle_with_sp_calc(*, smiles: str, **overrides) -> dict:
     }
 
 
-def test_aec_total_no_components_persists(db_engine) -> None:
+def test_aec_total_no_components_persists(db_conn) -> None:
     """Spec test 1: AEC applied correction persists with scheme and no components."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -2456,7 +2452,7 @@ def test_aec_total_no_components_persists(db_engine) -> None:
             ]
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         applied = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -2480,7 +2476,7 @@ def test_aec_total_no_components_persists(db_engine) -> None:
         assert comps == []
 
 
-def test_aec_total_with_atom_components_persists(db_engine) -> None:
+def test_aec_total_with_atom_components_persists(db_conn) -> None:
     """Spec test 2: AEC applied correction persists with atom components."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -2510,7 +2506,7 @@ def test_aec_total_with_atom_components_persists(db_engine) -> None:
             ]
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -2536,7 +2532,7 @@ def test_aec_total_with_atom_components_persists(db_engine) -> None:
         assert {p.element for p in atom_params} == {"H"}
 
 
-def test_bac_petersson_with_bond_components_persists(db_engine) -> None:
+def test_bac_petersson_with_bond_components_persists(db_conn) -> None:
     """Spec test 3: Petersson BAC persists with bond components."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -2566,7 +2562,7 @@ def test_bac_petersson_with_bond_components_persists(db_engine) -> None:
             ]
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -2594,7 +2590,7 @@ def test_bac_petersson_with_bond_components_persists(db_engine) -> None:
         assert {p.bond_key for p in bond_params} == {"C-H"}
 
 
-def test_bac_melius_no_components_persists(db_engine) -> None:
+def test_bac_melius_no_components_persists(db_conn) -> None:
     """Spec test 4: Melius BAC persists with no components.
 
     Melius BAC totals are scientifically meaningful but lack a stable
@@ -2614,7 +2610,7 @@ def test_bac_melius_no_components_persists(db_engine) -> None:
             ]
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -2632,7 +2628,7 @@ def test_bac_melius_no_components_persists(db_engine) -> None:
         assert comps == []
 
 
-def test_source_calculation_key_resolves_by_local_key(db_engine) -> None:
+def test_source_calculation_key_resolves_by_local_key(db_conn) -> None:
     """Spec test 5: source_calculation_key resolves by local key.
 
     The applied correction row's ``source_calculation_id`` must match
@@ -2652,7 +2648,7 @@ def test_source_calculation_key_resolves_by_local_key(db_engine) -> None:
             ]
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         sp_calc = next(
             c
@@ -2731,7 +2727,7 @@ def test_bac_total_with_non_bac_scheme_returns_422() -> None:
         )
 
 
-def test_repeated_upload_reuses_scheme_row(db_engine) -> None:
+def test_repeated_upload_reuses_scheme_row(db_conn) -> None:
     """Spec test 9: repeated upload with same scheme identity reuses the row."""
     payload = {
         "applied_energy_corrections": [
@@ -2744,7 +2740,7 @@ def test_repeated_upload_reuses_scheme_row(db_engine) -> None:
             }
         ]
     }
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(smiles="CCCCCCCCCC", **payload)
         )
@@ -2793,7 +2789,7 @@ def test_repeated_upload_reuses_scheme_row(db_engine) -> None:
         )
 
 
-def test_note_does_not_affect_scheme_identity(db_engine) -> None:
+def test_note_does_not_affect_scheme_identity(db_conn) -> None:
     """Spec test 10: note does not affect scheme identity.
 
     Two uploads with the same identity tuple but different ``note`` text
@@ -2801,7 +2797,7 @@ def test_note_does_not_affect_scheme_identity(db_engine) -> None:
     ignored, mirroring FrequencyScaleFactor's note semantics.
     """
     scheme_name = "AEC note-identity test"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="CCCCCCCCCCCC",
@@ -2856,9 +2852,9 @@ def test_note_does_not_affect_scheme_identity(db_engine) -> None:
         assert scheme.note == "first run"
 
 
-def test_aec_bac_does_not_create_frequency_scale_factor_row(db_engine) -> None:
+def test_aec_bac_does_not_create_frequency_scale_factor_row(db_conn) -> None:
     """Spec test 11: no frequency_scale_factor row is created for AEC/BAC."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         before = session.scalar(
             select(func.count()).select_from(FrequencyScaleFactor)
         )
@@ -2956,7 +2952,7 @@ def _ac_with_scheme(scheme: dict, *, application_role: str, value: float) -> dic
     }
 
 
-def test_aec_scheme_atom_params_persist(db_engine) -> None:
+def test_aec_scheme_atom_params_persist(db_conn) -> None:
     """Spec 1: AEC scheme atom_params populate the atom_param table."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -2977,7 +2973,7 @@ def test_aec_scheme_atom_params_persist(db_engine) -> None:
             ],
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -2997,7 +2993,7 @@ def test_aec_scheme_atom_params_persist(db_engine) -> None:
         }
 
 
-def test_pbac_scheme_bond_params_persist(db_engine) -> None:
+def test_pbac_scheme_bond_params_persist(db_conn) -> None:
     """Spec 2: Petersson BAC scheme bond_params populate the bond_param table."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -3018,7 +3014,7 @@ def test_pbac_scheme_bond_params_persist(db_engine) -> None:
             ],
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -3038,7 +3034,7 @@ def test_pbac_scheme_bond_params_persist(db_engine) -> None:
         }
 
 
-def test_melius_scheme_component_params_persist(db_engine) -> None:
+def test_melius_scheme_component_params_persist(db_conn) -> None:
     """Spec 3: Melius BAC scheme component_params populate the table."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -3059,7 +3055,7 @@ def test_melius_scheme_component_params_persist(db_engine) -> None:
             ],
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -3079,11 +3075,11 @@ def test_melius_scheme_component_params_persist(db_engine) -> None:
         }
 
 
-def test_repeated_scheme_param_upload_is_idempotent(db_engine) -> None:
+def test_repeated_scheme_param_upload_is_idempotent(db_conn) -> None:
     """Spec 4: re-uploading the same scheme + params is a no-op."""
     name = "AEC idempotency"
     atom_params = [{"element": "H", "value": -0.5}, {"element": "C", "value": -37.7}]
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCN",
@@ -3127,10 +3123,10 @@ def test_repeated_scheme_param_upload_is_idempotent(db_engine) -> None:
         assert {(r.element, r.value) for r in rows} == {("H", -0.5), ("C", -37.7)}
 
 
-def test_conflicting_atom_param_value_raises(db_engine) -> None:
+def test_conflicting_atom_param_value_raises(db_conn) -> None:
     """Spec 5: same atom key with a different value raises ValueError (→ 422)."""
     name = "AEC atom conflict"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCN",
@@ -3148,7 +3144,7 @@ def test_conflicting_atom_param_value_raises(db_engine) -> None:
         )
         persist_computed_species_upload(session, bundle_a)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_b = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCCN",
@@ -3171,10 +3167,10 @@ def test_conflicting_atom_param_value_raises(db_engine) -> None:
             persist_computed_species_upload(session, bundle_b)
 
 
-def test_conflicting_bond_param_value_raises(db_engine) -> None:
+def test_conflicting_bond_param_value_raises(db_conn) -> None:
     """Spec 6: same bond key with a different value raises ValueError (→ 422)."""
     name = "PBAC bond conflict"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrC=CC",
@@ -3192,7 +3188,7 @@ def test_conflicting_bond_param_value_raises(db_engine) -> None:
         )
         persist_computed_species_upload(session, bundle_a)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_b = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrC=CCC",
@@ -3215,10 +3211,10 @@ def test_conflicting_bond_param_value_raises(db_engine) -> None:
             persist_computed_species_upload(session, bundle_b)
 
 
-def test_conflicting_component_param_value_raises(db_engine) -> None:
+def test_conflicting_component_param_value_raises(db_conn) -> None:
     """Bonus: same component (kind, key) with different value raises (→ 422)."""
     name = "Melius component conflict"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrC=CCCO",
@@ -3238,7 +3234,7 @@ def test_conflicting_component_param_value_raises(db_engine) -> None:
         )
         persist_computed_species_upload(session, bundle_a)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_b = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrC=CCCCO",
@@ -3263,7 +3259,7 @@ def test_conflicting_component_param_value_raises(db_engine) -> None:
             persist_computed_species_upload(session, bundle_b)
 
 
-def test_scheme_without_params_remains_valid(db_engine) -> None:
+def test_scheme_without_params_remains_valid(db_conn) -> None:
     """Spec 8: schemes without params still work (no params persisted, no error)."""
     bundle = ComputedSpeciesUploadRequest(
         **_bundle_with_sp_calc(
@@ -3277,7 +3273,7 @@ def test_scheme_without_params_remains_valid(db_engine) -> None:
             ],
         )
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(session, bundle)
         ac = session.scalars(
             select(AppliedEnergyCorrection).where(
@@ -3293,10 +3289,10 @@ def test_scheme_without_params_remains_valid(db_engine) -> None:
         assert rows == []
 
 
-def test_existing_paramless_scheme_can_be_extended_with_params(db_engine) -> None:
+def test_existing_paramless_scheme_can_be_extended_with_params(db_conn) -> None:
     """A scheme created without params can have params added by a later upload."""
     name = "Extend-with-params"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCCO",
@@ -3342,10 +3338,10 @@ def test_existing_paramless_scheme_can_be_extended_with_params(db_engine) -> Non
         assert {(r.element, r.value) for r in rows} == {("H", -0.5)}
 
 
-def test_existing_paramless_scheme_can_be_backfilled_with_bond_params(db_engine) -> None:
+def test_existing_paramless_scheme_can_be_backfilled_with_bond_params(db_conn) -> None:
     """A paramless PBAC scheme can have bond_params added by a later upload."""
     name = "Backfill bond params"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCCCCO",
@@ -3398,11 +3394,11 @@ def test_existing_paramless_scheme_can_be_backfilled_with_bond_params(db_engine)
 
 
 def test_existing_paramless_scheme_can_be_backfilled_with_component_params(
-    db_engine,
+    db_conn,
 ) -> None:
     """A paramless Melius scheme can have component_params added by a later upload."""
     name = "Backfill component params"
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCCCCCCO",
@@ -3462,11 +3458,11 @@ def test_existing_paramless_scheme_can_be_backfilled_with_component_params(
         }
 
 
-def test_repeated_bond_param_upload_is_idempotent(db_engine) -> None:
+def test_repeated_bond_param_upload_is_idempotent(db_conn) -> None:
     """Re-uploading the same scheme + same bond params keeps a single row set."""
     name = "PBAC idempotency"
     bond_params = [{"bond_key": "C-H", "value": -0.11}, {"bond_key": "C-C", "value": -0.13}]
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCCCCCCCCO",
@@ -3512,14 +3508,14 @@ def test_repeated_bond_param_upload_is_idempotent(db_engine) -> None:
         }
 
 
-def test_repeated_component_param_upload_is_idempotent(db_engine) -> None:
+def test_repeated_component_param_upload_is_idempotent(db_conn) -> None:
     """Re-uploading the same scheme + same component params keeps a single row set."""
     name = "Melius idempotency"
     component_params = [
         {"component_kind": "atom_corr", "key": "C", "value": -0.001},
         {"component_kind": "bond_corr_length", "key": "C-H", "value": 0.04},
     ]
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         bundle_a = ComputedSpeciesUploadRequest(
             **_bundle_with_sp_calc(
                 smiles="BrCCCCCCCCCCCCCCO",
@@ -3604,7 +3600,7 @@ def _deuterated_methyl_request(second_conformer_isotopes: dict[int, int] | None)
     )
 
 
-def test_every_conformer_geometry_is_isotope_checked(db_engine) -> None:
+def test_every_conformer_geometry_is_isotope_checked(db_conn) -> None:
     """A later conformer cannot smuggle in an all-protium geometry.
 
     Only ``conformers[0]`` used to be cross-checked, so a deuterated entry
@@ -3612,16 +3608,16 @@ def test_every_conformer_geometry_is_isotope_checked(db_engine) -> None:
     analysis reading those geometries would compute a different molecule
     from the one the identity names.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         with pytest.raises(ValueError, match="does not match"):
             persist_computed_species_upload(
                 session, _deuterated_methyl_request(second_conformer_isotopes=None)
             )
 
 
-def test_consistently_labelled_conformers_still_upload(db_engine) -> None:
+def test_consistently_labelled_conformers_still_upload(db_conn) -> None:
     """Regression guard: matching labels on every conformer still succeed."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_computed_species_upload(
             session, _deuterated_methyl_request(second_conformer_isotopes={2: 2})
         )

--- a/backend/tests/workflows/test_computed_species_upload.py
+++ b/backend/tests/workflows/test_computed_species_upload.py
@@ -429,8 +429,8 @@ def test_bundle_freq_and_sp_get_input_geometry_rows(db_conn) -> None:
 
         # Bundle scope: exactly the freq + sp calcs get input rows;
         # the primary opt does not. Scope to the three calcs in this
-        # bundle to avoid coupling to rows persisted by prior tests
-        # (db_conn is session-scoped; see conftest).
+        # bundle so the assertion cannot pick up rows another tree committed
+        # into the shared database.
         bundle_calc_ids = [primary_id, freq_id, sp_id]
         bundle_input_rows = session.scalars(
             select(CalculationInputGeometry).where(
@@ -2415,10 +2415,9 @@ def _geom_for_smiles(smiles: str) -> str:
 def _bundle_with_sp_calc(*, smiles: str, **overrides) -> dict:
     """Bundle template that exposes a 'sp0' calc key for source linking.
 
-    A distinct ``smiles`` per test is required because ``db_conn`` is
-    session-scoped and writes commit between tests; reusing the same
-    species across tests would accumulate ``applied_energy_correction``
-    rows that target the same species entry.
+    A distinct ``smiles`` per test keeps each test's
+    ``applied_energy_correction`` rows on their own species entry, so the
+    unqualified assertions below cannot pick up a sibling test's.
     """
     return {
         "species_entry": {"smiles": smiles, "charge": 0, "multiplicity": 1},

--- a/backend/tests/workflows/test_conformer_upload.py
+++ b/backend/tests/workflows/test_conformer_upload.py
@@ -50,8 +50,8 @@ def _hydrogen_request(*, label: str | None = None) -> ConformerUploadRequest:
     )
 
 
-def test_persist_conformer_upload_creates_expected_rows(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_conformer_upload_creates_expected_rows(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             outcome = persist_conformer_upload(
                 session, _hydrogen_request(label="conf-a")
@@ -111,9 +111,9 @@ def test_persist_conformer_upload_creates_expected_rows(db_engine) -> None:
 
 
 def test_persist_conformer_upload_reuses_species_entry_and_labeled_group(
-    db_engine,
+    db_conn,
 ) -> None:
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             first_outcome = persist_conformer_upload(
                 session, _hydrogen_request(label="conf-a")
@@ -156,7 +156,7 @@ def test_persist_conformer_upload_reuses_species_entry_and_labeled_group(
             assert {first.id, second.id}.issubset(grouped_ids)
 
 
-def test_persist_conformer_upload_creates_linked_statmech_record(db_engine) -> None:
+def test_persist_conformer_upload_creates_linked_statmech_record(db_conn) -> None:
     request = ConformerUploadRequest(
         species_entry={
             "smiles": "[H]",
@@ -195,7 +195,7 @@ def test_persist_conformer_upload_creates_linked_statmech_record(db_engine) -> N
         },
     )
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             observation = persist_conformer_upload(session, request).observation
 
@@ -218,7 +218,7 @@ def test_persist_conformer_upload_creates_linked_statmech_record(db_engine) -> N
             assert len(statmech.torsions[0].coordinates) == 1
 
 
-def test_conformer_upload_with_additional_calculations(db_engine) -> None:
+def test_conformer_upload_with_additional_calculations(db_conn) -> None:
     """Upload with primary opt + freq and sp additional calculations."""
     request = ConformerUploadRequest(
         species_entry={
@@ -260,7 +260,7 @@ def test_conformer_upload_with_additional_calculations(db_engine) -> None:
         label="h2-full",
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         observation = persist_conformer_upload(session, request).observation
 
         primary_calc = observation.calculations[0]
@@ -351,7 +351,7 @@ def test_conformer_upload_with_additional_calculations(db_engine) -> None:
         assert sp_inputs[0].geometry_id == shared_geo_id
 
 
-def test_conformer_upload_opt_primary_has_no_input_geometry(db_engine) -> None:
+def test_conformer_upload_opt_primary_has_no_input_geometry(db_conn) -> None:
     """An opt-primary upload yields one output_geometry row (final) and
     zero input_geometry rows — opt's true input is the pre-opt xyz, which
     the producer doesn't surface."""
@@ -370,7 +370,7 @@ def test_conformer_upload_opt_primary_has_no_input_geometry(db_engine) -> None:
         },
         label="opt-only",
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_conformer_upload(session, request)
         opt_id = outcome.primary_calculation.calculation_id
 
@@ -390,7 +390,7 @@ def test_conformer_upload_opt_primary_has_no_input_geometry(db_engine) -> None:
 
 
 def test_conformer_upload_statmech_resolves_literature_from_payload(
-    db_engine, monkeypatch,
+    db_conn, monkeypatch,
 ) -> None:
     """Nested literature payload on statmech must resolve into a Literature row,
     without the upload ever exposing a raw ``literature_id`` FK.
@@ -429,7 +429,7 @@ def test_conformer_upload_statmech_resolves_literature_from_payload(
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         observation = persist_conformer_upload(session, request).observation
         calculation = observation.calculations[0]
 
@@ -449,7 +449,7 @@ def test_conformer_upload_statmech_resolves_literature_from_payload(
 
 
 def test_primitive_conformer_explicit_input_geometries_for_opt(
-    db_engine,
+    db_conn,
 ) -> None:
     """Primitive ``/uploads/conformers``: a primary opt that declares
     ``input_geometries`` lands a row, distinct from opt's converged
@@ -471,7 +471,7 @@ def test_primitive_conformer_explicit_input_geometries_for_opt(
         },
         label="opt-explicit-input",
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_conformer_upload(session, request)
         opt_id = outcome.primary_calculation.calculation_id
 
@@ -493,7 +493,7 @@ def test_primitive_conformer_explicit_input_geometries_for_opt(
 
 
 def test_primitive_conformer_empty_input_geometries_uses_fallback(
-    db_engine,
+    db_conn,
 ) -> None:
     """With no ``input_geometries`` declared, the prior PR's freq fallback
     still fires for an additional freq calc and skips the primary opt."""
@@ -520,7 +520,7 @@ def test_primitive_conformer_empty_input_geometries_uses_fallback(
         ],
         label="primitive-fallback",
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_conformer_upload(session, request)
         opt_id = outcome.primary_calculation.calculation_id
         freq_id = outcome.additional_calculations[0].calculation_id
@@ -541,7 +541,7 @@ def test_primitive_conformer_empty_input_geometries_uses_fallback(
 
 
 def test_primitive_conformer_explicit_output_geometries_for_opt(
-    db_engine,
+    db_conn,
 ) -> None:
     """Primitive ``/uploads/conformers``: a primary opt that declares
     ``output_geometries`` lands a row with the producer-declared role,
@@ -568,7 +568,7 @@ def test_primitive_conformer_explicit_output_geometries_for_opt(
         },
         label="opt-explicit-output",
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_conformer_upload(session, request)
         opt_id = outcome.primary_calculation.calculation_id
 
@@ -582,7 +582,7 @@ def test_primitive_conformer_explicit_output_geometries_for_opt(
         assert rows[0].output_order == 1
 
 
-def test_primitive_conformer_empty_output_geometries_freq_sp(db_engine) -> None:
+def test_primitive_conformer_empty_output_geometries_freq_sp(db_conn) -> None:
     """Primitive ``/uploads/conformers``: with no ``output_geometries``
     declared on the additional freq calc, the narrowed fallback skips
     freq (not in the {opt} set), so freq gets ZERO rows."""
@@ -615,7 +615,7 @@ def test_primitive_conformer_empty_output_geometries_freq_sp(db_engine) -> None:
         ],
         label="primitive-output-fallback",
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         outcome = persist_conformer_upload(session, request)
         opt_id = outcome.primary_calculation.calculation_id
         freq_id = outcome.additional_calculations[0].calculation_id

--- a/backend/tests/workflows/test_geometry_validation_wiring.py
+++ b/backend/tests/workflows/test_geometry_validation_wiring.py
@@ -97,21 +97,17 @@ _LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
 
 
 @contextmanager
-def _isolated_session(db_engine) -> Iterator[Session]:
+def _isolated_session(db_conn) -> Iterator[Session]:
     """Open a session on a connection-bound transaction that is always
     rolled back. Mirrors the helper used in
     ``test_computed_reaction_upload.py``: keeps each wiring test
     hermetic against species/InChI conflicts when reusing common
     SMILES like water."""
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         yield session
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
 # ---------------------------------------------------------------------------
@@ -233,8 +229,8 @@ def _make_minimal_species_calc(
 # ---------------------------------------------------------------------------
 
 
-def test_computed_species_opt_persists_passed_row(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_computed_species_opt_persists_passed_row(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         outcome = persist_computed_species_upload(
             session, _species_bundle(smiles="O", xyz=_XYZ_WATER)
         )
@@ -257,7 +253,7 @@ def test_computed_species_opt_persists_passed_row(db_engine) -> None:
 
 
 def test_computed_species_opt_records_fail_when_identity_mismatch(
-    db_engine,
+    db_conn,
 ) -> None:
     """The declared species is ethanol and the opt calculation reports a
     methane output geometry — the chemistry layer must reject isomorphism, and
@@ -279,7 +275,7 @@ def test_computed_species_opt_records_fail_when_identity_mismatch(
     differ, which is what ``resolve_atom_mapping`` actually detects — see the
     note in this module's docstring about how narrow ``is_isomorphic=False``
     has become."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         bundle = _species_bundle(
             smiles="CCO", xyz=_XYZ_ETHANOL, output_xyz=_XYZ_METHANE
         )
@@ -301,12 +297,12 @@ def test_computed_species_opt_records_fail_when_identity_mismatch(
 # ---------------------------------------------------------------------------
 
 
-def test_helper_skips_when_output_geometry_missing(db_engine) -> None:
+def test_helper_skips_when_output_geometry_missing(db_conn) -> None:
     """If a calculation has no attached output geometry, the helper is a
     no-op and writes nothing. Constructed by adding a bare
     Calculation row directly so we can assert the skip semantics
     without fighting the workflow's fallback geometry attachment."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         calc = _make_minimal_species_calc(
             session, inchi_key="GVSKIP000000000000000000001"
         )
@@ -322,8 +318,8 @@ def test_helper_skips_when_output_geometry_missing(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_freq_calc_does_not_get_geometry_validation(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_freq_calc_does_not_get_geometry_validation(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         outcome = persist_computed_species_upload(
             session, _species_bundle_with_freq()
         )
@@ -458,8 +454,8 @@ def _reaction_payload_h2o_self() -> dict:
     }
 
 
-def test_computed_reaction_species_opt_writes_validation_rows(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_computed_reaction_species_opt_writes_validation_rows(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         # Snapshot the max calc id BEFORE running the workflow so we
         # can filter strictly to calcs created in THIS transaction.
         # Prior committed tests in the same session may have left
@@ -495,7 +491,7 @@ def test_computed_reaction_species_opt_writes_validation_rows(db_engine) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_ts_opt_does_not_get_geometry_validation(db_engine) -> None:
+def test_ts_opt_does_not_get_geometry_validation(db_conn) -> None:
     """End-to-end TS deferral: a computed-reaction bundle with a TS
     must persist validation rows for the species-side opt calcs but
     NOT for the TS opt calc. The species-graph isomorphism check
@@ -615,7 +611,7 @@ def test_ts_opt_does_not_get_geometry_validation(db_engine) -> None:
         },
     }
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         baseline = session.scalar(
             select(func.coalesce(func.max(Calculation.id), 0))
         )
@@ -672,7 +668,7 @@ def test_ts_opt_does_not_get_geometry_validation(db_engine) -> None:
         )
 
 
-def test_helper_skips_when_species_smiles_is_none(db_engine) -> None:
+def test_helper_skips_when_species_smiles_is_none(db_conn) -> None:
     """TS opt geometry validation is intentionally NOT wired in phase 1.
 
     The current ``validate_calculation_geometry`` service takes a
@@ -691,7 +687,7 @@ def test_helper_skips_when_species_smiles_is_none(db_engine) -> None:
 
     This test asserts the second half of that contract directly.
     """
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         calc = _make_minimal_species_calc(
             session, inchi_key="GVTSDEFER000000000000000001"
         )

--- a/backend/tests/workflows/test_kinetics_upload.py
+++ b/backend/tests/workflows/test_kinetics_upload.py
@@ -174,7 +174,7 @@ def test_tunneling_label_must_match_its_evidence() -> None:
 
 
 def test_computed_kinetics_round_trips_explicit_subject_assignments_and_wigner(
-    db_engine,
+    db_conn,
 ) -> None:
     """A deposited computed rate retains every statmech subject and Wigner input."""
     from tests.workflows.test_network_pdep_upload import _parallel_path_payload
@@ -204,7 +204,7 @@ def test_computed_kinetics_round_trips_explicit_subject_assignments_and_wigner(
         "degeneracy_interpretation": "reaction_path_degeneracy",
     }
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=77, username="computed_kinetics_roundtrip"))
         session.flush()
         persist_network_pdep_upload(session, NetworkPDepUploadRequest(**payload), created_by=77)
@@ -298,7 +298,7 @@ def test_computed_kinetics_round_trips_explicit_subject_assignments_and_wigner(
 
 
 def test_persist_kinetics_upload_resolves_reaction_and_provenance(
-    db_engine,
+    db_conn,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
@@ -315,7 +315,7 @@ def test_persist_kinetics_upload_resolves_reaction_and_provenance(
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user = AppUser(username="kinetics_tester")
         session.add(user)
         session.flush()
@@ -343,7 +343,7 @@ def test_persist_kinetics_upload_resolves_reaction_and_provenance(
 
 
 def test_persist_kinetics_upload_reuses_existing_literature_by_doi(
-    db_engine,
+    db_conn,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
@@ -353,7 +353,7 @@ def test_persist_kinetics_upload_reuses_existing_literature_by_doi(
 
     request = _kinetics_request()
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         before_kinetics = len(session.scalars(select(Kinetics)).all())
         first = persist_kinetics_upload(session, request)
         after_first_literature = len(session.scalars(select(Literature)).all())
@@ -403,7 +403,7 @@ def test_additive_a_uncertainty_accepts_small_values() -> None:
     ["already_applied", "not_applied", "unknown"],
 )
 def test_persist_kinetics_upload_preserves_degeneracy_convention(
-    db_engine, convention
+    db_conn, convention
 ) -> None:
     request = _kinetics_request(
         degeneracy_convention=convention,
@@ -411,7 +411,7 @@ def test_persist_kinetics_upload_preserves_degeneracy_convention(
         software_release=None,
         workflow_tool_release=None,
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, request)
         assert kinetics.degeneracy_convention.value == convention
 
@@ -452,7 +452,7 @@ def test_kinetics_upload_rejects_non_positive_or_nonfinite_degeneracy(
 
 
 def test_persist_kinetics_upload_carries_multiplicative_uncertainty(
-    db_engine,
+    db_conn,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
@@ -465,7 +465,7 @@ def test_persist_kinetics_upload_carries_multiplicative_uncertainty(
     payload["a_uncertainty_kind"] = "multiplicative"
     request = KineticsUploadRequest.model_validate(payload)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, request)
         assert kinetics.a_uncertainty == 2.0
         assert kinetics.a_uncertainty_kind == KineticsUncertaintyKind.multiplicative
@@ -483,18 +483,18 @@ def _patch_doi(monkeypatch) -> None:
     )
 
 
-def test_tunneling_model_defaults_to_null_without_application(db_engine, monkeypatch) -> None:
+def test_tunneling_model_defaults_to_null_without_application(db_conn, monkeypatch) -> None:
     _patch_doi(monkeypatch)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, _kinetics_request())
         assert kinetics.tunneling_model is None
 
 
-def test_pressure_context_high_p_limit_persists(db_engine, monkeypatch) -> None:
+def test_pressure_context_high_p_limit_persists(db_conn, monkeypatch) -> None:
     from app.db.models.common import PressureContext
 
     _patch_doi(monkeypatch)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(
             session, _kinetics_request(pressure_context="high_p_limit")
         )
@@ -502,11 +502,11 @@ def test_pressure_context_high_p_limit_persists(db_engine, monkeypatch) -> None:
         assert kinetics.pressure_bar is None
 
 
-def test_apparent_at_pressure_persists_with_pressure(db_engine, monkeypatch) -> None:
+def test_apparent_at_pressure_persists_with_pressure(db_conn, monkeypatch) -> None:
     from app.db.models.common import PressureContext
 
     _patch_doi(monkeypatch)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(
             session,
             _kinetics_request(
@@ -527,7 +527,7 @@ def test_apparent_at_pressure_without_pressure_bar_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_troe_falloff_and_third_body_persist(db_engine, monkeypatch) -> None:
+def test_troe_falloff_and_third_body_persist(db_conn, monkeypatch) -> None:
     from app.db.models.kinetics import (
         KineticsFalloff,
         KineticsThirdBodyEfficiency,
@@ -553,7 +553,7 @@ def test_troe_falloff_and_third_body_persist(db_engine, monkeypatch) -> None:
              "efficiency": 0.7},
         ],
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, request)
         session.flush()
 
@@ -586,7 +586,7 @@ def test_negative_third_body_efficiency_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_standalone_plog_persists(db_engine, monkeypatch) -> None:
+def test_standalone_plog_persists(db_conn, monkeypatch) -> None:
     from app.db.models.kinetics import KineticsPlog
 
     _patch_doi(monkeypatch)
@@ -599,7 +599,7 @@ def test_standalone_plog_persists(db_engine, monkeypatch) -> None:
              "ea_kj_mol": 52.0, "a_units": "cm3_mol_s"},
         ],
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, request)
         session.flush()
         entries = session.scalars(
@@ -610,7 +610,7 @@ def test_standalone_plog_persists(db_engine, monkeypatch) -> None:
         assert [e.pressure_bar for e in entries] == [0.1, 1.0]
 
 
-def test_standalone_chebyshev_persists(db_engine, monkeypatch) -> None:
+def test_standalone_chebyshev_persists(db_conn, monkeypatch) -> None:
     from app.db.models.kinetics import KineticsChebyshev
 
     _patch_doi(monkeypatch)
@@ -626,7 +626,7 @@ def test_standalone_chebyshev_persists(db_engine, monkeypatch) -> None:
             "coefficients": [[1.0, 0.1], [0.2, 0.02]],
         },
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, request)
         session.flush()
         cheb = session.get(KineticsChebyshev, kinetics.id)
@@ -693,13 +693,13 @@ def test_falloff_main_line_uses_k_inf_order() -> None:
     assert request.a_units == ArrheniusAUnits.cm3_mol_s
 
 
-def test_persist_simple_third_body_flag(db_engine, monkeypatch) -> None:
+def test_persist_simple_third_body_flag(db_conn, monkeypatch) -> None:
     _patch_doi(monkeypatch)
     payload = _kinetics_request().model_dump()
     payload["is_third_body"] = True
     payload["a_units"] = "cm6_mol2_s"
     request = KineticsUploadRequest.model_validate(payload)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         kinetics = persist_kinetics_upload(session, request)
         session.flush()
         assert kinetics.is_third_body is True
@@ -711,14 +711,14 @@ def test_persist_simple_third_body_flag(db_engine, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_forward_and_reverse_kinetics_persist_distinctly(db_engine, monkeypatch):
+def test_forward_and_reverse_kinetics_persist_distinctly(db_conn, monkeypatch):
     """Forward and reverse fits persist with distinct direction (previously
     indistinguishable). The single-reaction_entry coexistence case is covered
     at the read layer in test_get_reaction_kinetics."""
     from app.db.models.common import KineticsDirection
 
     _patch_doi(monkeypatch)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         fwd = persist_kinetics_upload(
             session, _kinetics_request(direction="forward")
         )
@@ -730,14 +730,14 @@ def test_forward_and_reverse_kinetics_persist_distinctly(db_engine, monkeypatch)
         assert rev.direction == KineticsDirection.reverse
 
 
-def test_direction_defaults_to_null(db_engine, monkeypatch):
+def test_direction_defaults_to_null(db_conn, monkeypatch):
     _patch_doi(monkeypatch)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         k = persist_kinetics_upload(session, _kinetics_request())
         assert k.direction is None
 
 
-def test_multi_arrhenius_persists_summed_terms(db_engine, monkeypatch):
+def test_multi_arrhenius_persists_summed_terms(db_conn, monkeypatch):
     from app.db.models.kinetics import KineticsArrheniusEntry
 
     _patch_doi(monkeypatch)
@@ -752,7 +752,7 @@ def test_multi_arrhenius_persists_summed_terms(db_engine, monkeypatch):
     ]
     request = KineticsUploadRequest.model_validate(payload)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         k = persist_kinetics_upload(session, request)
         session.flush()
         assert k.a is None
@@ -842,12 +842,12 @@ def _make_network_kinetics(session):
     return nk
 
 
-def test_network_bridge_resolves(db_engine, monkeypatch):
+def test_network_bridge_resolves(db_conn, monkeypatch):
     _patch_doi(monkeypatch)
     # Roll back rather than commit: the shared session-scoped test DB is
     # global, and other tests select NetworkKinetics without a network
     # filter, so a committed bridge row here would pollute them.
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         nk = _make_network_kinetics(session)
         k = persist_kinetics_upload(
             session,
@@ -859,9 +859,9 @@ def test_network_bridge_resolves(db_engine, monkeypatch):
         session.rollback()
 
 
-def test_network_bridge_unknown_id_rejected(db_engine, monkeypatch):
+def test_network_bridge_unknown_id_rejected(db_conn, monkeypatch):
     _patch_doi(monkeypatch)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         with pytest.raises(ValueError, match="does not reference an existing"):
             persist_kinetics_upload(
                 session,
@@ -1252,7 +1252,7 @@ def test_model_identifier_is_a_machine_token_and_only_for_other() -> None:
 
 
 def test_computed_statmech_without_source_calculations_cannot_back_a_rate(
-    db_engine,
+    db_conn,
 ) -> None:
     """Deposit-time statmech only warns; a rate that DEPENDS on it must not.
 
@@ -1272,17 +1272,13 @@ def test_computed_statmech_without_source_calculations_cannot_back_a_rate(
 
     @contextmanager
     def _rolled_back_session(engine):
-        connection = engine.connect()
-        transaction = connection.begin()
-        opened = Session(bind=connection, expire_on_commit=False)
+        opened = Session(bind=engine, expire_on_commit=False)
         try:
             yield opened
         finally:
             opened.close()
-            transaction.rollback()
-            connection.close()
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         # One species entry: the H atom is both sides of this trivial rate, so
         # the workflow resolves both participants onto the entry that owns the
         # statmech under test.

--- a/backend/tests/workflows/test_kinetics_upload.py
+++ b/backend/tests/workflows/test_kinetics_upload.py
@@ -844,9 +844,9 @@ def _make_network_kinetics(session):
 
 def test_network_bridge_resolves(db_conn, monkeypatch):
     _patch_doi(monkeypatch)
-    # Roll back rather than commit: the shared session-scoped test DB is
-    # global, and other tests select NetworkKinetics without a network
-    # filter, so a committed bridge row here would pollute them.
+    # Other tests select NetworkKinetics without a network filter, so a
+    # committed bridge row here would pollute them; ``db_conn`` is what
+    # keeps this one out of their way.
     with Session(db_conn) as session:
         nk = _make_network_kinetics(session)
         k = persist_kinetics_upload(

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -487,7 +487,7 @@ def _parallel_path_payload() -> dict:
     return payload
 
 
-def test_parallel_path_upload_persists_ts_subject_and_distinct_barriers(db_engine) -> None:
+def test_parallel_path_upload_persists_ts_subject_and_distinct_barriers(db_conn) -> None:
     """One elementary step retains two distinct saddle-point pathways.
 
     Regression guard for the schema rule that used to forbid a second TS per
@@ -496,7 +496,7 @@ def test_parallel_path_upload_persists_ts_subject_and_distinct_barriers(db_engin
     a duplicate row into an identity table. Here the two paths share ONE
     reaction entry and differ only by transition state.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         # Let the sequence assign the id: hard-coded ids do not advance the
         # app_user sequence and collide with other files that insert without one.
         actor = AppUser(username="parallel_path_tester")
@@ -589,9 +589,9 @@ def test_parallel_path_upload_persists_ts_subject_and_distinct_barriers(db_engin
         )
 
 
-def test_full_end_to_end_upload(db_engine) -> None:
+def test_full_end_to_end_upload(db_conn) -> None:
     """Full PDep upload creates all entities end-to-end."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         actor = AppUser(username="e2e_tester")
         session.add(actor)
         session.flush()
@@ -756,9 +756,9 @@ def test_full_end_to_end_upload(db_engine) -> None:
         assert len(energy_transfers) == 1
 
 
-def test_upload_without_solve(db_engine) -> None:
+def test_upload_without_solve(db_conn) -> None:
     """Upload without solve creates species, calcs, TS, but no solve."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**_full_payload(include_solve=False))
         network = persist_network_pdep_upload(session, request)
 
@@ -784,9 +784,9 @@ def test_composition_hash_order_independent() -> None:
     assert len(hash_a) == 64
 
 
-def test_geometry_reuse_via_key(db_engine) -> None:
+def test_geometry_reuse_via_key(db_conn) -> None:
     """A species freq calculation using geometry_key should share the geometry."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**_full_payload(include_solve=False))
         network = persist_network_pdep_upload(session, request)
 
@@ -831,7 +831,7 @@ def test_geometry_reuse_via_key(db_engine) -> None:
 
 
 def test_same_basin_species_conformers_keep_distinct_observations_and_calc_anchors(
-    db_engine,
+    db_conn,
 ) -> None:
     """Species-side calculations should anchor to the observation for their geometry key."""
     payload = _full_payload(include_solve=False)
@@ -881,7 +881,7 @@ def test_same_basin_species_conformers_keep_distinct_observations_and_calc_ancho
         },
     ]
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         actor = AppUser(username="anchor_tester")
         session.add(actor)
         session.flush()
@@ -937,21 +937,17 @@ from typing import Iterator as _Iterator
 
 
 @contextmanager
-def _rolled_back_session(db_engine) -> _Iterator[Session]:
+def _rolled_back_session(db_conn) -> _Iterator[Session]:
     """Connection-bound session that always rolls back, to isolate tests
     that exercise the bundle workflow without committing to the shared DB."""
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         yield session
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
-def test_bundle_calculation_parameters_persist_via_shared_seam(db_engine) -> None:
+def test_bundle_calculation_parameters_persist_via_shared_seam(db_conn) -> None:
     """Parsed parameters on a bundle CalculationIn now flow through the shared
     seam and land as ``calculation_parameter`` rows plus snapshot metadata."""
     from datetime import datetime, timezone
@@ -991,7 +987,7 @@ def test_bundle_calculation_parameters_persist_via_shared_seam(db_engine) -> Non
         }
     )
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         session.add(CalculationParameterVocab(canonical_key=canonical_key))
         session.flush()
 
@@ -1029,7 +1025,7 @@ def test_bundle_calculation_parameters_persist_via_shared_seam(db_engine) -> Non
         assert second.unit == "GB"
 
 
-def test_bundle_unknown_canonical_key_demoted_through_shared_seam(db_engine) -> None:
+def test_bundle_unknown_canonical_key_demoted_through_shared_seam(db_conn) -> None:
     """Unknown canonical_key observations still persist (with canonical_key=NULL)
     — shared-seam vocab demotion applies through the bundle path."""
     from app.db.models.calculation import CalculationParameter
@@ -1044,7 +1040,7 @@ def test_bundle_unknown_canonical_key_demoted_through_shared_seam(db_engine) -> 
         }
     ]
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**payload)
         persist_network_pdep_upload(session, request, created_by=None)
 
@@ -1058,10 +1054,10 @@ def test_bundle_unknown_canonical_key_demoted_through_shared_seam(db_engine) -> 
         assert rows[0].canonical_value is None
 
 
-def test_bundle_owner_semantics_preserved_after_convergence(db_engine) -> None:
+def test_bundle_owner_semantics_preserved_after_convergence(db_conn) -> None:
     """Species-owned and TS-owned calculations keep their exclusive-owner FKs
     after routing through the shared seam."""
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         baseline_calc_id = session.scalar(select(func.max(Calculation.id))) or 0
 
         request = NetworkPDepUploadRequest(**_full_payload(include_solve=False))
@@ -1088,10 +1084,10 @@ def test_bundle_owner_semantics_preserved_after_convergence(db_engine) -> None:
         assert all(c.species_entry_id is None for c in ts_calcs)
 
 
-def test_bundle_inline_results_and_geometry_links_preserved(db_engine) -> None:
+def test_bundle_inline_results_and_geometry_links_preserved(db_conn) -> None:
     """Inline opt/freq/sp results and the CalculationOutputGeometry link still
     persist correctly after routing through the shared seam."""
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         # Record the highest calculation.id before the upload so we can scope
         # subsequent queries to just-created rows and ignore any state that
         # prior committed tests may have left behind.
@@ -1150,7 +1146,7 @@ def test_bundle_inline_results_and_geometry_links_preserved(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_pdep_workflow_rejects_imbalanced_micro_reaction(db_engine) -> None:
+def test_pdep_workflow_rejects_imbalanced_micro_reaction(db_conn) -> None:
     """PDep uploads reuse the shared reaction seam and must enforce
     strict elemental balance on their micro reactions.
 
@@ -1162,24 +1158,24 @@ def test_pdep_workflow_rejects_imbalanced_micro_reaction(db_engine) -> None:
     payload = _full_payload(include_solve=False)
     payload["micro_reactions"][0]["reactants"] = [{"species_key": "ethyl"}]
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**payload)
         with pytest.raises(ValueError, match="not element-balanced"):
             persist_network_pdep_upload(session, request)
 
 
-def test_pdep_workflow_allows_balanced_micro_reaction(db_engine) -> None:
+def test_pdep_workflow_allows_balanced_micro_reaction(db_conn) -> None:
     """Regression guard: the canonical balanced PDep payload
     (``ethyl + O2 -> ethylperoxy``) must still succeed under the strict
     elemental-balance rule."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**_full_payload(include_solve=False))
         network = persist_network_pdep_upload(session, request)
         assert network.id is not None
 
 
 def test_pdep_workflow_persists_calculation_artifacts(
-    db_engine, monkeypatch,
+    db_conn, monkeypatch,
 ) -> None:
     """Inline ``calc_in.artifacts`` on a PDep calculation must produce
     a real ``CalculationArtifact`` row.
@@ -1211,30 +1207,22 @@ def test_pdep_workflow_persists_calculation_artifacts(
         }
     ]
 
-    # Use a connection-bound rollback so this artifact row does not leak
-    # into other workflow tests sharing the session-scoped ``db_engine``.
-    connection = db_engine.connect()
-    transaction = connection.begin()
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
-        session = Session(bind=connection, expire_on_commit=False)
-        try:
-            request = NetworkPDepUploadRequest(**payload)
-            persist_network_pdep_upload(session, request)
-            session.flush()
-            rows = session.scalars(
-                select(CalculationArtifact).where(
-                    CalculationArtifact.uri.like("s3://test-bucket/%")
-                )
-            ).all()
-            assert len(rows) == 1
-        finally:
-            session.close()
+        request = NetworkPDepUploadRequest(**payload)
+        persist_network_pdep_upload(session, request)
+        session.flush()
+        rows = session.scalars(
+            select(CalculationArtifact).where(
+                CalculationArtifact.uri.like("s3://test-bucket/%")
+            )
+        ).all()
+        assert len(rows) == 1
     finally:
-        transaction.rollback()
-        connection.close()
+        session.close()
 
 
-def test_pdep_workflow_persists_and_reads_back_channel_kinetics(db_engine) -> None:
+def test_pdep_workflow_persists_and_reads_back_channel_kinetics(db_conn) -> None:
     """A Chebyshev ``channel_kinetics`` entry on the solve produces a
     ``NetworkKinetics`` + ``NetworkKineticsChebyshev`` row for the referenced
     channel, and round-trips through the existing network-kinetics read path.
@@ -1275,7 +1263,7 @@ def test_pdep_workflow_persists_and_reads_back_channel_kinetics(db_engine) -> No
         }
     ]
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**payload)
         network = persist_network_pdep_upload(session, request)
         session.flush()
@@ -1655,7 +1643,7 @@ def test_pdep_channel_kinetics_rejects_duplicate_plog_pressure_index() -> None:
 
 
 def test_pdep_workflow_persists_and_reads_back_plog_channel_kinetics(
-    db_engine,
+    db_conn,
 ) -> None:
     """A ``model_kind=plog`` ``channel_kinetics`` entry produces a
     ``NetworkKinetics`` (model_kind=plog) + one ``NetworkKineticsPlog`` row per
@@ -1701,7 +1689,7 @@ def test_pdep_workflow_persists_and_reads_back_plog_channel_kinetics(
         }
     ]
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**payload)
         network = persist_network_pdep_upload(session, request)
         session.flush()
@@ -1767,7 +1755,7 @@ def test_pdep_workflow_persists_and_reads_back_plog_channel_kinetics(
 
 
 def test_pdep_workflow_persists_mixed_chebyshev_and_plog_channel_kinetics(
-    db_engine,
+    db_conn,
 ) -> None:
     """One payload may carry a Chebyshev fit on one channel and a PLOG fit on
     another; both persist to their respective child tables."""
@@ -1824,7 +1812,7 @@ def test_pdep_workflow_persists_mixed_chebyshev_and_plog_channel_kinetics(
         },
     ]
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**payload)
         network = persist_network_pdep_upload(session, request)
         session.flush()
@@ -1864,7 +1852,7 @@ def test_pdep_workflow_persists_mixed_chebyshev_and_plog_channel_kinetics(
         assert cheb_plog == []
 
 
-def test_pdep_species_statmech_persists_via_shared_seam(db_engine) -> None:
+def test_pdep_species_statmech_persists_via_shared_seam(db_conn) -> None:
     """A network species carrying a statmech block persists a Statmech row
     (external_symmetry / optical_isomers) with a resolved source-calc link,
     reusing the computed-species bundle's shared statmech seam."""
@@ -1883,7 +1871,7 @@ def test_pdep_species_statmech_persists_via_shared_seam(db_engine) -> None:
         ],
     }
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         baseline_statmech_id = session.scalar(select(func.max(Statmech.id))) or 0
         request = NetworkPDepUploadRequest(**payload)
         persist_network_pdep_upload(session, request, created_by=None)
@@ -1953,7 +1941,7 @@ def _payload_with_ethyl_scan() -> dict:
     return payload
 
 
-def test_pdep_species_statmech_torsion_scan_persists(db_engine) -> None:
+def test_pdep_species_statmech_torsion_scan_persists(db_conn) -> None:
     """A per-species torsion with a scan-type source persists and links the
     scan calculation owned by the same species entry."""
     from app.db.models.statmech import Statmech, StatmechTorsion
@@ -1977,7 +1965,7 @@ def test_pdep_species_statmech_torsion_scan_persists(db_engine) -> None:
         ],
     }
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         baseline_statmech_id = session.scalar(select(func.max(Statmech.id))) or 0
         request = NetworkPDepUploadRequest(**payload)
         persist_network_pdep_upload(session, request, created_by=None)
@@ -2066,7 +2054,7 @@ def test_pdep_species_statmech_torsion_rejects_cross_species_scan_key() -> None:
         NetworkPDepUploadRequest(**payload)
 
 
-def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_engine) -> None:
+def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_conn) -> None:
     """Direct unit test of the shared seam's torsion ownership guard.
 
     Bypasses the network request validator to prove the seam itself rejects a
@@ -2095,7 +2083,7 @@ def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_engine) -> N
         }
     )
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         baseline_calc_id = session.scalar(select(func.max(Calculation.id))) or 0
         baseline_torsion_id = (
             session.scalar(select(func.max(StatmechTorsion.id))) or 0
@@ -2242,12 +2230,12 @@ def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_engine) -> N
     ids=lambda case: case if isinstance(case, str) else None,
 )
 def test_pdep_strict_v2_schema_rejects_incomplete_path_and_evidence_matrix(
-    db_engine, mutate, label
+    db_conn, mutate, label
 ) -> None:
     """Strict v2 rejects malformed path, solve-scope, and TS evidence input before writes."""
     payload = _full_payload()
     mutate(payload)
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         before = session.scalar(select(func.count()).select_from(Network))
         with pytest.raises(ValueError):
             NetworkPDepUploadRequest(**payload)
@@ -2259,14 +2247,14 @@ def test_pdep_strict_v2_schema_rejects_incomplete_path_and_evidence_matrix(
 # ---------------------------------------------------------------------------
 
 
-def test_barrierless_channel_round_trips_without_a_transition_state(db_engine) -> None:
+def test_barrierless_channel_round_trips_without_a_transition_state(db_conn) -> None:
     """A barrierless association persists with a NULL TS and no barrier row.
 
     Radical-radical association has no saddle point. Before this, the only
     way to deposit such a channel was to invent a transition state and a
     barrier height for it.
     """
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**_full_payload())
         network = persist_network_pdep_upload(session, request)
         session.flush()
@@ -2309,11 +2297,11 @@ def test_barrierless_channel_round_trips_without_a_transition_state(db_engine) -
         assert association_read.microreactions[0].transition_state_entry_ref is None
 
 
-def test_submerged_barrier_is_accepted(db_engine) -> None:
+def test_submerged_barrier_is_accepted(db_conn) -> None:
     """A barrier below the declared zero is legitimate, not a validation error."""
     payload = _full_payload()
     payload["solve"]["channel_barriers"][0]["forward_barrier_kj_mol"] = -8.0
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**payload)
         network = persist_network_pdep_upload(session, request)
         session.flush()
@@ -2336,13 +2324,13 @@ def test_non_finite_barrier_is_rejected() -> None:
 
 
 def test_transition_state_without_irc_evidence_succeeds_with_a_warning(
-    db_engine,
+    db_conn,
 ) -> None:
     """IRC evidence is recommended, not required — but its absence is stated."""
     payload = _full_payload()
     payload["transition_states"][0]["validation_evidence"] = []
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         warnings: list[UploadWarning] = []
         request = NetworkPDepUploadRequest(**payload)
         network = persist_network_pdep_upload(session, request, warnings=warnings)
@@ -2359,7 +2347,7 @@ def test_transition_state_without_irc_evidence_succeeds_with_a_warning(
 
 
 def test_every_pdep_saddle_point_reports_its_missing_atom_map(
-    db_engine,
+    db_conn,
 ) -> None:
     """A network's micro reactions are reactions, and their gaps are visible.
 
@@ -2372,7 +2360,7 @@ def test_every_pdep_saddle_point_reports_its_missing_atom_map(
     """
     payload = _full_payload()
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         warnings: list[UploadWarning] = []
         request = NetworkPDepUploadRequest(**payload)
         persist_network_pdep_upload(session, request, warnings=warnings)
@@ -2619,7 +2607,7 @@ def test_two_network_wide_energy_transfer_entries_are_refused() -> None:
         NetworkPDepUploadRequest(**payload)
 
 
-def test_network_wide_energy_transfer_round_trips_and_warns(db_engine) -> None:
+def test_network_wide_energy_transfer_round_trips_and_warns(db_conn) -> None:
     """Accepted, annotated, and readable back as network-wide.
 
     The three things a reader needs: the row survives with its scope intact,
@@ -2637,7 +2625,7 @@ def test_network_wide_energy_transfer_round_trips_and_warns(db_engine) -> None:
             "note": "one energyTransferModel declared for the whole network",
         }
     ]
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**payload)
         warnings: list[UploadWarning] = []
         network = persist_network_pdep_upload(session, request, warnings=warnings)
@@ -2671,14 +2659,14 @@ def test_network_wide_energy_transfer_round_trips_and_warns(db_engine) -> None:
         assert read_rows[0].collider_species_entry_ref is None
 
 
-def test_per_well_energy_transfer_round_trips_and_does_not_warn(db_engine) -> None:
+def test_per_well_energy_transfer_round_trips_and_does_not_warn(db_conn) -> None:
     """The preferred form keeps working and stays unannotated.
 
     Lowering the barrier for the network-wide case must not blur the two: a
     per-well deposit still resolves both axes on the read surface and carries
     no completeness warning.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         request = NetworkPDepUploadRequest(**_parallel_path_payload())
         warnings: list[UploadWarning] = []
         network = persist_network_pdep_upload(session, request, warnings=warnings)
@@ -2866,7 +2854,7 @@ def test_well_skipping_rejected_without_a_well_intermediate() -> None:
         NetworkPDepUploadRequest(**payload)
 
 
-def test_well_skipping_channel_round_trips(db_engine) -> None:
+def test_well_skipping_channel_round_trips(db_conn) -> None:
     """A declared chemically-activated channel uploads, persists, and reads back.
 
     It stores zero ``network_channel_microreaction`` rows and zero barriers —
@@ -2877,7 +2865,7 @@ def test_well_skipping_channel_round_trips(db_engine) -> None:
     from app.db.models.common import NetworkChannelMechanism
     from app.db.models.network_pdep import NetworkKinetics
 
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**_well_skipping_payload())
         network = persist_network_pdep_upload(session, request)
         session.flush()
@@ -3161,7 +3149,7 @@ def test_reported_solve_still_validates_what_it_does_supply() -> None:
     assert len(request.solve.state_energies) == 1
 
 
-def test_reported_solve_round_trips_and_warns(db_engine) -> None:
+def test_reported_solve_round_trips_and_warns(db_conn) -> None:
     """The kind survives persistence and the read path, and is annotated.
 
     Both halves are load-bearing. A reported record that could not be told
@@ -3171,11 +3159,11 @@ def test_reported_solve_round_trips_and_warns(db_engine) -> None:
     """
     from app.db.models.network_pdep import NetworkKinetics
 
-    # Rolled back rather than committed: ``db_engine`` is session-scoped, and
+    # Rolled back rather than committed: ``db_conn`` is session-scoped, and
     # a leaked NetworkKinetics row breaks
     # ``test_pdep_workflow_persists_and_reads_back_channel_kinetics``, which
     # counts them across the whole table.
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**_reported_payload())
         warnings: list[UploadWarning] = []
         network = persist_network_pdep_upload(session, request, warnings=warnings)
@@ -3222,14 +3210,14 @@ def test_reported_solve_round_trips_and_warns(db_engine) -> None:
         assert solve_read.record.network_solve.kind is NetworkSolveKind.reported
 
 
-def test_computed_solve_carries_no_reported_warning(db_engine) -> None:
+def test_computed_solve_carries_no_reported_warning(db_conn) -> None:
     """The preferred form stays unannotated.
 
     Admitting the weaker record must not blur the two: a computed deposit
     reads back as computed and carries no completeness warning about its
     origin.
     """
-    with _rolled_back_session(db_engine) as session:
+    with _rolled_back_session(db_conn) as session:
         request = NetworkPDepUploadRequest(**_full_payload())
         warnings: list[UploadWarning] = []
         network = persist_network_pdep_upload(session, request, warnings=warnings)

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -938,8 +938,11 @@ from typing import Iterator as _Iterator
 
 @contextmanager
 def _rolled_back_session(db_conn) -> _Iterator[Session]:
-    """Connection-bound session that always rolls back, to isolate tests
-    that exercise the bundle workflow without committing to the shared DB."""
+    """A session on the per-test transaction ``db_conn`` owns and rolls back.
+
+    Kept as a named helper because the bundle tests below read it as an
+    explicit statement of intent: nothing this file persists reaches the
+    shared database."""
     session = Session(bind=db_conn, expire_on_commit=False)
     try:
         yield session
@@ -3159,8 +3162,7 @@ def test_reported_solve_round_trips_and_warns(db_conn) -> None:
     """
     from app.db.models.network_pdep import NetworkKinetics
 
-    # Rolled back rather than committed: ``db_conn`` is session-scoped, and
-    # a leaked NetworkKinetics row breaks
+    # Named rather than implicit: a leaked NetworkKinetics row would break
     # ``test_pdep_workflow_persists_and_reads_back_channel_kinetics``, which
     # counts them across the whole table.
     with _rolled_back_session(db_conn) as session:

--- a/backend/tests/workflows/test_network_upload.py
+++ b/backend/tests/workflows/test_network_upload.py
@@ -74,7 +74,7 @@ def _network_request() -> NetworkUploadRequest:
 
 
 def test_persist_network_upload_resolves_links_and_provenance(
-    db_engine,
+    db_conn,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
@@ -88,7 +88,7 @@ def test_persist_network_upload_resolves_links_and_provenance(
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         user = AppUser(username="network_tester")
         session.add(user)
         session.flush()
@@ -121,9 +121,9 @@ def test_persist_network_upload_resolves_links_and_provenance(
 
 
 def test_persist_network_upload_creates_species_and_reaction_entries_without_user_ids(
-    db_engine,
+    db_conn,
 ) -> None:
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         reactions_before = len(session.scalars(select(ReactionEntry)).all())
 
         network = persist_network_upload(session, _network_request())

--- a/backend/tests/workflows/test_reaction_atom_map.py
+++ b/backend/tests/workflows/test_reaction_atom_map.py
@@ -81,19 +81,15 @@ _USER_ID = 50_411
 
 
 @contextmanager
-def _isolated_session(db_engine) -> Iterator[Session]:
+def _isolated_session(db_conn) -> Iterator[Session]:
     """Roll back everything: the workflow writes a large graph per call."""
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         session.add(AppUser(id=_USER_ID, username="reaction_atom_map_tests"))
         session.flush()
         yield session
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
 def _species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
@@ -225,12 +221,12 @@ def _codes(result: dict) -> set[str]:
 
 
 def test_declared_map_persists_both_legs_toward_the_transition_state(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _payload()
     payload["atom_map"] = _complete_map(equivalent_map_count=3)
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
 
         atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
@@ -286,22 +282,22 @@ def test_declared_map_persists_both_legs_toward_the_transition_state(
 
 
 def test_declared_map_emits_no_absence_or_incompleteness_warning(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _payload()
     payload["atom_map"] = _complete_map()
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
     assert W_MISSING_REACTION_ATOM_MAP not in _codes(result)
     assert W_ATOM_MAP_PARTICIPANTS_INCOMPLETE not in _codes(result)
     assert W_ATOM_MAP_ATOMS_INCOMPLETE not in _codes(result)
 
 
-def test_equivalent_map_count_absent_is_no_claim_not_one(db_engine) -> None:
+def test_equivalent_map_count_absent_is_no_claim_not_one(db_conn) -> None:
     """Symmetry makes a valid map non-unique; silence is not a count of 1."""
     payload = _payload()
     payload["atom_map"] = _complete_map()
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
         assert atom_map.equivalent_map_count is None
@@ -312,12 +308,12 @@ def test_equivalent_map_count_absent_is_no_claim_not_one(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_inferred_map_is_stored_and_read_back_as_inferred(db_engine) -> None:
+def test_inferred_map_is_stored_and_read_back_as_inferred(db_conn) -> None:
     payload = _payload()
     payload["atom_map"] = _complete_map(
         source="inferred", note="mapped by a maximum-common-substructure search"
     )
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
         assert atom_map.source is AtomMapSource.inferred
@@ -325,7 +321,7 @@ def test_inferred_map_is_stored_and_read_back_as_inferred(db_engine) -> None:
         assert "maximum-common-substructure" in atom_map.note
 
 
-def test_inferred_map_without_a_note_is_refused(db_engine) -> None:
+def test_inferred_map_without_a_note_is_refused(db_conn) -> None:
     """An inferred map whose origin is anonymous is one step from a lie."""
     payload = _payload()
     payload["atom_map"] = _complete_map(source="inferred")
@@ -333,7 +329,7 @@ def test_inferred_map_without_a_note_is_refused(db_engine) -> None:
         ComputedReactionUploadRequest(**payload)
 
 
-def test_a_blank_note_does_not_name_an_algorithm(db_engine) -> None:
+def test_a_blank_note_does_not_name_an_algorithm(db_conn) -> None:
     """Whitespace is not the name of an inference engine.
 
     Without normalisation ``note='   '`` satisfies "an inferred map says what
@@ -346,26 +342,26 @@ def test_a_blank_note_does_not_name_an_algorithm(db_engine) -> None:
         ComputedReactionUploadRequest(**payload)
 
 
-def test_a_declared_map_note_is_trimmed(db_engine) -> None:
+def test_a_declared_map_note_is_trimmed(db_conn) -> None:
     payload = _payload()
     payload["atom_map"] = _complete_map(note="  followed the IRC by hand  ")
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
         assert atom_map.note == "followed the IRC by hand"
 
 
-def test_a_blank_declared_note_becomes_no_note(db_engine) -> None:
+def test_a_blank_declared_note_becomes_no_note(db_conn) -> None:
     payload = _payload()
     payload["atom_map"] = _complete_map(note="  ")
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
         assert atom_map.note is None
 
 
 def test_database_refuses_relabelling_an_inferred_map_as_declared(
-    db_engine,
+    db_conn,
 ) -> None:
     """The laundering path, closed where a second write path cannot reopen it.
 
@@ -385,7 +381,7 @@ def test_database_refuses_relabelling_an_inferred_map_as_declared(
         source="inferred", note="mapped by RXNMapper"
     )
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         atom_map_id = result["atom_map_id"]
 
@@ -402,7 +398,7 @@ def test_database_refuses_relabelling_an_inferred_map_as_declared(
 
 @pytest.mark.parametrize("blanked", ["'   '", "''", "NULL"])
 def test_database_refuses_blanking_an_inferred_maps_note(
-    db_engine, blanked: str
+    db_conn, blanked: str
 ) -> None:
     """Freezing ``source`` is only half of "an inferred map names its origin".
 
@@ -425,7 +421,7 @@ def test_database_refuses_blanking_an_inferred_maps_note(
         source="inferred", note="mapped by RXNMapper"
     )
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
 
         with pytest.raises(DBAPIError) as excinfo:
@@ -439,7 +435,7 @@ def test_database_refuses_blanking_an_inferred_maps_note(
         assert "inferred_requires_note" in str(excinfo.value)
 
 
-def test_an_inferred_map_may_still_have_its_note_corrected(db_engine) -> None:
+def test_an_inferred_map_may_still_have_its_note_corrected(db_conn) -> None:
     """Freezing the token must not freeze the record it labels.
 
     A depositor correcting the name of the algorithm is completing the record,
@@ -453,7 +449,7 @@ def test_an_inferred_map_may_still_have_its_note_corrected(db_engine) -> None:
     payload = _payload()
     payload["atom_map"] = _complete_map(source="inferred", note="RXNMapper")
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         atom_map_id = result["atom_map_id"]
 
@@ -478,8 +474,8 @@ def test_an_inferred_map_may_still_have_its_note_corrected(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_reaction_without_a_map_is_accepted_and_warned(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_reaction_without_a_map_is_accepted_and_warned(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, _payload())
 
     assert result["reaction_entry_id"] is not None
@@ -494,14 +490,14 @@ def test_reaction_without_a_map_is_accepted_and_warned(db_engine) -> None:
     assert "intrinsic reaction coordinate" in warning.message
 
 
-def test_reaction_without_a_transition_state_is_not_warned(db_engine) -> None:
+def test_reaction_without_a_transition_state_is_not_warned(db_conn) -> None:
     """A barrierless channel has nothing for the two legs to point at."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, _payload(with_ts=False))
     assert W_MISSING_REACTION_ATOM_MAP not in _codes(result)
 
 
-def test_map_without_a_transition_state_is_refused(db_engine) -> None:
+def test_map_without_a_transition_state_is_refused(db_conn) -> None:
     payload = _payload(with_ts=False)
     payload["atom_map"] = _complete_map()
     with pytest.raises(ValidationError, match="no transition state"):
@@ -513,7 +509,7 @@ def test_map_without_a_transition_state_is_refused(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_map_omitting_a_participant_is_accepted_and_warned(db_engine) -> None:
+def test_map_omitting_a_participant_is_accepted_and_warned(db_conn) -> None:
     payload = _payload()
     atom_map = _complete_map()
     atom_map["participants"] = [
@@ -521,7 +517,7 @@ def test_map_omitting_a_participant_is_accepted_and_warned(db_engine) -> None:
     ]
     payload["atom_map"] = atom_map
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         assert result["atom_map_id"] is not None
 
@@ -534,7 +530,7 @@ def test_map_omitting_a_participant_is_accepted_and_warned(db_engine) -> None:
 
 
 def test_map_omitting_atoms_of_a_mapped_participant_is_accepted_and_warned(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _payload()
     atom_map = _complete_map()
@@ -549,7 +545,7 @@ def test_map_omitting_atoms_of_a_mapped_participant_is_accepted_and_warned(
             break
     payload["atom_map"] = atom_map
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         assert result["atom_map_id"] is not None
 
@@ -564,7 +560,7 @@ def test_map_omitting_atoms_of_a_mapped_participant_is_accepted_and_warned(
 # ---------------------------------------------------------------------------
 
 
-def test_element_changing_across_the_map_is_refused(db_engine) -> None:
+def test_element_changing_across_the_map_is_refused(db_conn) -> None:
     """Carbon does not become nitrogen."""
     payload = _payload()
     payload["species"][0] = _species("ch3", "[NH3]", 1, _XYZ_NH3)
@@ -580,7 +576,7 @@ def test_element_changing_across_the_map_is_refused(db_engine) -> None:
     assert "An element does not change across a reaction" in message
 
 
-def test_transition_state_atom_claimed_twice_is_refused(db_engine) -> None:
+def test_transition_state_atom_claimed_twice_is_refused(db_conn) -> None:
     """One saddle-point atom is one atom."""
     payload = _payload()
     atom_map = _complete_map()
@@ -597,7 +593,7 @@ def test_transition_state_atom_claimed_twice_is_refused(db_engine) -> None:
     assert "reactant leg" in message
 
 
-def test_saddle_point_atom_claimed_by_neither_leg_is_refused(db_engine) -> None:
+def test_saddle_point_atom_claimed_by_neither_leg_is_refused(db_conn) -> None:
     """A balanced, fully mapped reaction cannot leave a saddle-point atom over.
 
     Both legs are complete over every declared participant and the reaction
@@ -661,7 +657,7 @@ def test_unbalanced_reaction_is_not_refused_for_an_unaccounted_atom() -> None:
 
 
 def test_legs_covering_different_atoms_of_a_balanced_reaction_is_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     """The named case from ADR 0011, with nothing missing to explain it.
 
@@ -695,7 +691,7 @@ def test_legs_covering_different_atoms_of_a_balanced_reaction_is_refused(
     assert "No species is missing" in message
 
 
-def test_index_outside_the_named_geometry_is_refused(db_engine) -> None:
+def test_index_outside_the_named_geometry_is_refused(db_conn) -> None:
     payload = _payload()
     atom_map = _complete_map()
     for participant in atom_map["participants"]:
@@ -710,7 +706,7 @@ def test_index_outside_the_named_geometry_is_refused(db_engine) -> None:
 
 
 def test_transition_state_index_outside_the_saddle_point_geometry_is_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _payload()
     atom_map = _complete_map()
@@ -725,7 +721,7 @@ def test_transition_state_index_outside_the_saddle_point_geometry_is_refused(
 
 
 def test_map_written_against_a_geometry_that_is_not_the_saddle_point_is_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     """Atom indices are geometry-relative; the wrong geometry is wrong atoms."""
     payload = _payload()
@@ -736,7 +732,7 @@ def test_map_written_against_a_geometry_that_is_not_the_saddle_point_is_refused(
 
 
 def test_participant_mapped_against_another_species_geometry_is_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _payload()
     atom_map = _complete_map()
@@ -751,7 +747,7 @@ def test_participant_mapped_against_another_species_geometry_is_refused(
 
 
 def test_map_naming_a_participant_the_reaction_does_not_declare_is_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     payload = _payload()
     atom_map = _complete_map()
@@ -771,7 +767,7 @@ def test_map_naming_a_participant_the_reaction_does_not_declare_is_refused(
     assert "which this reaction does not declare" in str(excinfo.value)
 
 
-def test_same_participant_mapped_twice_is_refused(db_engine) -> None:
+def test_same_participant_mapped_twice_is_refused(db_conn) -> None:
     payload = _payload()
     atom_map = _complete_map()
     atom_map["participants"].append(
@@ -804,7 +800,7 @@ _XYZ_CH3_LOWER = (
 
 
 def test_map_across_geometries_that_disagree_only_about_case_persists(
-    db_engine,
+    db_conn,
 ) -> None:
     """``c`` and ``C`` are one element, and a map across them is one map.
 
@@ -822,7 +818,7 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
     payload["species"][0] = _species("ch3", "[CH3]", 2, _XYZ_CH3_LOWER)
     payload["atom_map"] = _complete_map()
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
 
         atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
@@ -850,7 +846,7 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
 
 
 def test_an_element_really_changing_across_the_map_is_still_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     """Normalising case must not cost the rule it is normalising for.
 
@@ -879,7 +875,7 @@ def test_an_element_really_changing_across_the_map_is_still_refused(
 
 
 def test_database_refuses_a_pair_whose_two_ends_are_really_different_elements(
-    db_engine,
+    db_conn,
 ) -> None:
     """The check constraint owns the element rule; prove it is not dead.
 
@@ -895,7 +891,7 @@ def test_database_refuses_a_pair_whose_two_ends_are_really_different_elements(
     payload = _payload()
     payload["atom_map"] = _complete_map()
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         pair = session.scalars(
             select(ReactionAtomMapPair)
@@ -911,7 +907,7 @@ def test_database_refuses_a_pair_whose_two_ends_are_really_different_elements(
 
 
 def test_database_refuses_a_pair_whose_two_ends_are_different_elements(
-    db_engine,
+    db_conn,
 ) -> None:
     """The element rule is a constraint, not just a validator on one path.
 
@@ -923,7 +919,7 @@ def test_database_refuses_a_pair_whose_two_ends_are_different_elements(
     payload = _payload()
     payload["atom_map"] = _complete_map()
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         pair = session.scalars(
             select(ReactionAtomMapPair)
@@ -939,14 +935,14 @@ def test_database_refuses_a_pair_whose_two_ends_are_different_elements(
 
 
 def test_database_refuses_two_reactant_atoms_claiming_one_saddle_point_atom(
-    db_engine,
+    db_conn,
 ) -> None:
     from sqlalchemy.exc import IntegrityError
 
     payload = _payload()
     payload["atom_map"] = _complete_map()
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
         session.add(
             ReactionAtomMapPair(

--- a/backend/tests/workflows/test_reaction_charge_conservation.py
+++ b/backend/tests/workflows/test_reaction_charge_conservation.py
@@ -61,13 +61,13 @@ def _request(*, reactants: list[dict], products: list[dict]) -> ReactionUploadRe
 # ---------------------------------------------------------------------------
 
 
-def test_a_reaction_that_loses_an_electron_is_refused(db_engine) -> None:
+def test_a_reaction_that_loses_an_electron_is_refused(db_conn) -> None:
     """``[OH-] + [H] -> H2O``: element-balanced (OH2 both sides), charge -1 -> 0.
 
     The exact deposit that used to succeed silently.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             before = session.scalar(select(func.count()).select_from(ChemReaction))
             with pytest.raises(ValueError) as excinfo:
@@ -83,7 +83,7 @@ def test_a_reaction_that_loses_an_electron_is_refused(db_engine) -> None:
             assert after == before
 
 
-def test_stoichiometric_coefficients_are_multiplied_in(db_engine) -> None:
+def test_stoichiometric_coefficients_are_multiplied_in(db_conn) -> None:
     """``2 [OH-] -> H2O + O``: two hydroxides carry -2, not -1.
 
     A per-participant comparison that ignored the coefficient would read this
@@ -93,7 +93,7 @@ def test_stoichiometric_coefficients_are_multiplied_in(db_engine) -> None:
     sees it, exactly as elemental balance receives it.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             with pytest.raises(ValueError) as excinfo:
                 persist_reaction_upload(
@@ -111,10 +111,10 @@ def test_stoichiometric_coefficients_are_multiplied_in(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_a_neutral_reaction_is_accepted(db_engine) -> None:
+def test_a_neutral_reaction_is_accepted(db_conn) -> None:
     """The overwhelming majority of the database: 0 on both sides."""
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -125,10 +125,10 @@ def test_a_neutral_reaction_is_accepted(db_engine) -> None:
             assert entry.id is not None
 
 
-def test_ion_recombination_to_a_neutral_product_is_accepted(db_engine) -> None:
+def test_ion_recombination_to_a_neutral_product_is_accepted(db_conn) -> None:
     """``[OH-] + [H+] -> H2O``. Charge -1 and +1 sum to the product's 0."""
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -137,7 +137,7 @@ def test_ion_recombination_to_a_neutral_product_is_accepted(db_engine) -> None:
             assert entry.id is not None
 
 
-def test_a_reaction_with_a_conserved_nonzero_charge_is_accepted(db_engine) -> None:
+def test_a_reaction_with_a_conserved_nonzero_charge_is_accepted(db_conn) -> None:
     """``[OH-] + CH4 -> [CH3-] + H2O``, a proton transfer that stays at -1.
 
     Conservation, not neutrality, is the rule. Requiring both sides to be
@@ -145,7 +145,7 @@ def test_a_reaction_with_a_conserved_nonzero_charge_is_accepted(db_engine) -> No
     is the false-positive ADR 0008 disqualifies a blocking check for.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -157,10 +157,10 @@ def test_a_reaction_with_a_conserved_nonzero_charge_is_accepted(db_engine) -> No
             assert entry.id is not None
 
 
-def test_a_reaction_conserving_a_charge_of_minus_two_is_accepted(db_engine) -> None:
+def test_a_reaction_conserving_a_charge_of_minus_two_is_accepted(db_conn) -> None:
     """``2 [OH-] -> H2O + [O-2]``. -2 on both sides, with a coefficient of 2."""
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -172,14 +172,14 @@ def test_a_reaction_conserving_a_charge_of_minus_two_is_accepted(db_engine) -> N
             assert entry.id is not None
 
 
-def test_a_pseudo_species_participant_is_exempt(db_engine) -> None:
+def test_a_pseudo_species_participant_is_exempt(db_conn) -> None:
     """Mirrors the elemental-balance exemption, and shares its implementation.
 
     A lumped or phenomenological construct is not atom-resolved, so neither its
     elements nor its charge is a quantity a conservation law applies to.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             # An anion on one side and a neutral pseudo-species on the other:
             # -1 against 0, which would be refused were the reaction judged.

--- a/backend/tests/workflows/test_reaction_electron_participant.py
+++ b/backend/tests/workflows/test_reaction_electron_participant.py
@@ -80,7 +80,7 @@ def _request(*, reactants: list[dict], products: list[dict]) -> ReactionUploadRe
 # ---------------------------------------------------------------------------
 
 
-def test_associative_detachment_deposits(db_engine) -> None:
+def test_associative_detachment_deposits(db_conn) -> None:
     """``OH- + H -> H2O + e-``. The reaction the refusal was really about.
 
     Atoms: OH2 on both sides, the electron contributing none. Charge: -1 on
@@ -89,7 +89,7 @@ def test_associative_detachment_deposits(db_engine) -> None:
     the second one true.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -98,7 +98,7 @@ def test_associative_detachment_deposits(db_engine) -> None:
             assert entry.id is not None
 
 
-def test_the_same_reaction_without_its_electron_is_still_refused(db_engine) -> None:
+def test_the_same_reaction_without_its_electron_is_still_refused(db_conn) -> None:
     """The check did not go soft. Omit the electron and the deposit still fails.
 
     This is the pairing that makes the tier claim honest: the rule now refuses
@@ -107,7 +107,7 @@ def test_the_same_reaction_without_its_electron_is_still_refused(db_engine) -> N
     participant list happened to be inexpressible.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             with pytest.raises(ValueError) as excinfo:
                 persist_reaction_upload(
@@ -121,14 +121,14 @@ def test_the_same_reaction_without_its_electron_is_still_refused(db_engine) -> N
     assert "pseudo" not in message
 
 
-def test_an_electron_may_be_a_reactant(db_engine) -> None:
+def test_an_electron_may_be_a_reactant(db_conn) -> None:
     """Dissociative attachment: ``e- + H2 -> H- + H``.
 
     Charge -1 both sides; atoms H2 both sides. Nothing about the electron's
     handling depends on which side of the arrow it sits on.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -137,7 +137,7 @@ def test_an_electron_may_be_a_reactant(db_engine) -> None:
             assert entry.id is not None
 
 
-def test_two_electrons_carry_a_stoichiometric_coefficient(db_engine) -> None:
+def test_two_electrons_carry_a_stoichiometric_coefficient(db_conn) -> None:
     """``[O-2] -> O + 2 e-``. A two-electron process needs two electrons.
 
     Both electrons resolve to the same species row and are compressed into a
@@ -147,7 +147,7 @@ def test_two_electrons_carry_a_stoichiometric_coefficient(db_engine) -> None:
     correct chemistry.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             entry = persist_reaction_upload(
                 session,
@@ -164,7 +164,7 @@ def test_two_electrons_carry_a_stoichiometric_coefficient(db_engine) -> None:
             assert electron_rows[0].stoichiometry == 2
 
 
-def test_the_electron_is_part_of_the_reaction_identity(db_engine) -> None:
+def test_the_electron_is_part_of_the_reaction_identity(db_conn) -> None:
     """It is a participant row, so it is inside the stoichiometry hash.
 
     ``A -> B`` and ``A -> B + e-`` are different reactions and must not dedupe
@@ -173,7 +173,7 @@ def test_the_electron_is_part_of_the_reaction_identity(db_engine) -> None:
     makes that automatic.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             with_electron = persist_reaction_upload(
                 session,
@@ -193,7 +193,7 @@ def test_the_electron_is_part_of_the_reaction_identity(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_an_electron_does_not_switch_off_elemental_balance(db_engine) -> None:
+def test_an_electron_does_not_switch_off_elemental_balance(db_conn) -> None:
     """The whole risk of this feature, pinned.
 
     ``OH- + H + CH4 -> H2O + e-`` has a carbon and four hydrogens that simply
@@ -204,7 +204,7 @@ def test_an_electron_does_not_switch_off_elemental_balance(db_engine) -> None:
     adding an electron to it.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             before = session.scalar(select(func.count()).select_from(ChemReaction))
             with pytest.raises(ValueError) as excinfo:
@@ -220,7 +220,7 @@ def test_an_electron_does_not_switch_off_elemental_balance(db_engine) -> None:
             assert after == before
 
 
-def test_an_electron_does_not_switch_off_charge_conservation(db_engine) -> None:
+def test_an_electron_does_not_switch_off_charge_conservation(db_conn) -> None:
     """``OH- + H -> H2O + 2 e-`` releases one electron too many.
 
     Atoms balance, so only the charge rule can catch it: -1 on the left
@@ -228,7 +228,7 @@ def test_an_electron_does_not_switch_off_charge_conservation(db_engine) -> None:
     expressible, never optional.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             with pytest.raises(ValueError) as excinfo:
                 persist_reaction_upload(
@@ -245,7 +245,7 @@ def test_an_electron_does_not_switch_off_charge_conservation(db_engine) -> None:
 
 
 def test_a_pseudo_participant_still_exempts_and_an_electron_still_does_not(
-    db_engine,
+    db_conn,
 ) -> None:
     """The contrast, in one place, on the same unbalanced reaction.
 
@@ -259,12 +259,12 @@ def test_a_pseudo_participant_still_exempts_and_an_electron_still_does_not(
         "products": [_WATER, _ELECTRON],
     }
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             with pytest.raises(ValueError):
                 persist_reaction_upload(session, _request(**unbalanced))
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             # Same reaction, with a lumped construct standing in for the
             # electron. The composition is now declared unknowable, so nothing
@@ -355,7 +355,7 @@ def test_an_electron_payload_may_not_contradict_itself(payload, reason) -> None:
         SpeciesEntryIdentityPayload(**payload)
 
 
-def test_every_electron_deposit_resolves_to_the_one_electron(db_engine) -> None:
+def test_every_electron_deposit_resolves_to_the_one_electron(db_conn) -> None:
     """There is one electron, so there is one row, with no molecular graph.
 
     ``smiles`` holds the reserved token and ``inchi_key`` a sentinel that
@@ -363,7 +363,7 @@ def test_every_electron_deposit_resolves_to_the_one_electron(db_engine) -> None:
     graph-derived column of the entry is NULL, because there is no graph.
     """
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             detachment = persist_reaction_upload(
                 session,
@@ -400,7 +400,7 @@ def test_every_electron_deposit_resolves_to_the_one_electron(db_engine) -> None:
             assert entries[0].isotope_key is None
 
             # It is a participant of both reactions, not a decoration on one.
-            # Asserted per reaction rather than as a total: ``db_engine`` is
+            # Asserted per reaction rather than as a total: ``db_conn`` is
             # session-scoped and these tests commit, so other reactions in
             # this file share the one electron row.
             participating = set(

--- a/backend/tests/workflows/test_reaction_electron_participant.py
+++ b/backend/tests/workflows/test_reaction_electron_participant.py
@@ -400,9 +400,9 @@ def test_every_electron_deposit_resolves_to_the_one_electron(db_conn) -> None:
             assert entries[0].isotope_key is None
 
             # It is a participant of both reactions, not a decoration on one.
-            # Asserted per reaction rather than as a total: ``db_conn`` is
-            # session-scoped and these tests commit, so other reactions in
-            # this file share the one electron row.
+            # Asserted per reaction rather than as a total: both reactions in
+            # this test share the one electron row, so a total would be a
+            # statement about this test's own arithmetic, not about linkage.
             participating = set(
                 session.scalars(
                     select(ReactionParticipant.reaction_id).where(

--- a/backend/tests/workflows/test_reaction_upload.py
+++ b/backend/tests/workflows/test_reaction_upload.py
@@ -101,7 +101,7 @@ def _conformer_request(
     )
 
 
-def test_persist_reaction_upload_creates_graph_and_entry_layers(db_engine) -> None:
+def test_persist_reaction_upload_creates_graph_and_entry_layers(db_conn) -> None:
     request = ReactionUploadRequest(
         reversible=False,
         reactants=[
@@ -134,7 +134,7 @@ def test_persist_reaction_upload_creates_graph_and_entry_layers(db_engine) -> No
         ],
     )
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             reaction_entry = persist_reaction_upload(session, request)
 
@@ -184,9 +184,9 @@ def test_persist_reaction_upload_creates_graph_and_entry_layers(db_engine) -> No
 
 
 def test_persist_reaction_upload_reuses_graph_layer_for_matching_submission(
-    db_engine,
+    db_conn,
 ) -> None:
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             # Distinct species that still balance (isomers, both C2H6O):
             # under DR-0031 two "[He]" resolve to one species, which would
@@ -228,9 +228,9 @@ def test_persist_reaction_upload_reuses_graph_layer_for_matching_submission(
 
 
 def test_persist_reaction_upload_reuses_species_entries_from_conformer_upload(
-    db_engine,
+    db_conn,
 ) -> None:
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             species_entry_count_before = session.scalar(
                 select(func.count()).select_from(SpeciesEntry)
@@ -311,7 +311,7 @@ def test_persist_reaction_upload_reuses_species_entries_from_conformer_upload(
 # exception. See ``docs/strict-reaction-balance-policy-spec.md``.
 
 
-def test_balanced_ordinary_reaction_persists(db_engine) -> None:
+def test_balanced_ordinary_reaction_persists(db_conn) -> None:
     """Balanced ordinary reactions must continue to upload successfully."""
     request = ReactionUploadRequest(
         reversible=False,
@@ -324,14 +324,14 @@ def test_balanced_ordinary_reaction_persists(db_engine) -> None:
         ],
     )
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             reaction_entry = persist_reaction_upload(session, request)
             assert reaction_entry.id is not None
             assert session.get(ChemReaction, reaction_entry.reaction_id) is not None
 
 
-def test_imbalanced_ordinary_reaction_is_rejected(db_engine) -> None:
+def test_imbalanced_ordinary_reaction_is_rejected(db_conn) -> None:
     """Imbalanced ordinary reactions must fail with a stable error and
     leave no reaction rows persisted."""
     request = ReactionUploadRequest(
@@ -340,7 +340,7 @@ def test_imbalanced_ordinary_reaction_is_rejected(db_engine) -> None:
         products=[{"species_entry": {"smiles": "[He]", "charge": 0, "multiplicity": 1}}],
     )
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             chem_reaction_count_before = session.scalar(
                 select(func.count()).select_from(ChemReaction)
@@ -354,10 +354,10 @@ def test_imbalanced_ordinary_reaction_is_rejected(db_engine) -> None:
             assert chem_reaction_count_after == chem_reaction_count_before
 
 
-def test_pseudo_species_participant_skips_elemental_balance(db_engine) -> None:
+def test_pseudo_species_participant_skips_elemental_balance(db_conn) -> None:
     """A reaction participant with ``species.kind == pseudo`` exempts the
     reaction from strict elemental-balance rejection in this first pass."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             # Unique smiles (identity is smiles+charge+multiplicity, DR-0031);
             # balance is skipped for pseudo reactions so it is never parsed.

--- a/backend/tests/workflows/test_species_geometry_composition.py
+++ b/backend/tests/workflows/test_species_geometry_composition.py
@@ -127,18 +127,14 @@ _XYZ_NH4 = (
 
 
 @contextmanager
-def _isolated_session(db_engine) -> Iterator[Session]:
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+def _isolated_session(db_conn) -> Iterator[Session]:
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         session.add(AppUser(id=_USER_ID, username="species_composition_tests"))
         session.flush()
         yield session
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
 def _bundle(
@@ -187,10 +183,10 @@ def _upload(session: Session, payload: dict):
 # ---------------------------------------------------------------------------
 
 
-def test_methane_declared_with_a_methyl_geometry_is_refused(db_engine) -> None:
+def test_methane_declared_with_a_methyl_geometry_is_refused(db_conn) -> None:
     """The exact deposit that used to succeed: CH4's entry given CH3's XYZ."""
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(session, _bundle(smiles="C", xyz=_XYZ_CH3))
     message = str(excinfo.value)
@@ -199,14 +195,14 @@ def test_methane_declared_with_a_methyl_geometry_is_refused(db_engine) -> None:
     assert "is CH4" in message
 
 
-def test_a_geometry_that_omits_hydrogen_entirely_is_refused(db_engine) -> None:
+def test_a_geometry_that_omits_hydrogen_entirely_is_refused(db_conn) -> None:
     """The fixture-rot shape: heavy atoms listed, hydrogens simply absent.
 
     Ethyl deposited as ``C C H``. Three atoms where C2H5 has seven, which is
     what went unnoticed for as long as those fixtures existed.
     """
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(
                 session,
@@ -227,7 +223,7 @@ def test_a_geometry_that_omits_hydrogen_entirely_is_refused(db_engine) -> None:
     assert "is C2H5" in message
 
 
-def test_a_later_conformer_with_the_wrong_atoms_is_refused(db_engine) -> None:
+def test_a_later_conformer_with_the_wrong_atoms_is_refused(db_conn) -> None:
     """Every conformer is checked, not only the first.
 
     The first conformer is the one that drives stereo perception, and checking
@@ -248,7 +244,7 @@ def test_a_later_conformer_with_the_wrong_atoms_is_refused(db_engine) -> None:
         },
     }
     payload["conformers"].append(second)
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(session, payload)
     assert "species_geometry_composition_mismatch" in str(excinfo.value)
@@ -259,13 +255,13 @@ def test_a_later_conformer_with_the_wrong_atoms_is_refused(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_a_geometry_that_matches_its_smiles_is_accepted(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_a_geometry_that_matches_its_smiles_is_accepted(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(session, _bundle(smiles="C", xyz=_XYZ_CH4))
     assert outcome.species_entry_id is not None
 
 
-def test_a_deuterated_isotopologue_is_accepted(db_engine) -> None:
+def test_a_deuterated_isotopologue_is_accepted(db_conn) -> None:
     """CD4 declares four ``[2H]``; its geometry declares four H at mass 2.
 
     The canonical form stores element ``H`` for ``[2H]``, and the XYZ writes
@@ -276,7 +272,7 @@ def test_a_deuterated_isotopologue_is_accepted(db_engine) -> None:
     deposit as well.
     """
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(
             session,
             _bundle(
@@ -288,10 +284,10 @@ def test_a_deuterated_isotopologue_is_accepted(db_engine) -> None:
     assert outcome.species_entry_id is not None
 
 
-def test_a_partially_deuterated_isotopologue_is_accepted(db_engine) -> None:
+def test_a_partially_deuterated_isotopologue_is_accepted(db_conn) -> None:
     """CH3D: one deuterium, three protium, still C1H4 by element."""
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(
             session,
             _bundle(smiles="[2H]C", xyz=_XYZ_CH4, isotopes={2: 2}),
@@ -299,39 +295,39 @@ def test_a_partially_deuterated_isotopologue_is_accepted(db_engine) -> None:
     assert outcome.species_entry_id is not None
 
 
-def test_an_anion_is_accepted(db_engine) -> None:
+def test_an_anion_is_accepted(db_conn) -> None:
     """Hydroxide. RDKit's implicit-H handling on a charged heteroatom is the
     thing most likely to be got wrong here: ``[OH-]`` carries one hydrogen,
     not zero and not two."""
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(
             session, _bundle(smiles="[OH-]", xyz=_XYZ_OH, charge=-1)
         )
     assert outcome.species_entry_id is not None
 
 
-def test_a_cation_is_accepted(db_engine) -> None:
+def test_a_cation_is_accepted(db_conn) -> None:
     """Ammonium. Four hydrogens on a positively charged nitrogen."""
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(
             session, _bundle(smiles="[NH4+]", xyz=_XYZ_NH4, charge=1)
         )
     assert outcome.species_entry_id is not None
 
 
-def test_a_radical_is_accepted(db_engine) -> None:
+def test_a_radical_is_accepted(db_conn) -> None:
     """Methyl, where the implicit-H count depends on reading the radical."""
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(
             session, _bundle(smiles="[CH3]", xyz=_XYZ_CH3, multiplicity=2)
         )
     assert outcome.species_entry_id is not None
 
 
-def test_deuterium_written_as_the_element_D_is_accepted(db_engine) -> None:
+def test_deuterium_written_as_the_element_D_is_accepted(db_conn) -> None:
     """``D`` is hydrogen, and this check must know it.
 
     ``D`` is a legal, common XYZ token — Gaussian, ORCA, Molpro and CFOUR all
@@ -350,21 +346,21 @@ def test_deuterium_written_as_the_element_D_is_accepted(db_engine) -> None:
     here.
     """
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(session, _bundle(smiles="O", xyz=_XYZ_D2O))
     assert outcome.species_entry_id is not None
 
 
-def test_tritium_written_as_the_element_T_is_accepted(db_engine) -> None:
+def test_tritium_written_as_the_element_T_is_accepted(db_conn) -> None:
     """``T`` is hydrogen too, and for exactly the same reason."""
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(session, _bundle(smiles="C", xyz=_XYZ_CH3T))
     assert outcome.species_entry_id is not None
 
 
 def test_a_D_geometry_with_the_wrong_atom_count_is_still_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     """Resolving ``D`` to ``H`` must not blunt the check.
 
@@ -372,7 +368,7 @@ def test_a_D_geometry_with_the_wrong_atom_count_is_still_refused(
     acceptance by making the rule stop counting hydrogens at all.
     """
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(
                 session,
@@ -387,7 +383,7 @@ def test_a_D_geometry_with_the_wrong_atom_count_is_still_refused(
     assert "is H2O" in message
 
 
-def test_element_symbols_in_any_case_are_accepted(db_engine) -> None:
+def test_element_symbols_in_any_case_are_accepted(db_conn) -> None:
     """``CL`` is chlorine and ``c`` is carbon.
 
     ``geometry_atom.element`` holds whatever the depositor's XYZ said, and
@@ -406,14 +402,14 @@ def test_element_symbols_in_any_case_are_accepted(db_engine) -> None:
     one.
     """
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         outcome = _upload(
             session, _bundle(smiles="CCl", xyz=_XYZ_CH3CL_MIXED_CASE)
         )
         assert outcome.species_entry_id is not None
 
         session.flush()
-        # Scoped to this deposit's own calculation: ``db_engine`` is
+        # Scoped to this deposit's own calculation: ``db_conn`` is
         # session-scoped and other test modules commit, so an unfiltered
         # count would depend on what else ran first.
         validation = session.scalar(
@@ -430,7 +426,7 @@ def test_element_symbols_in_any_case_are_accepted(db_engine) -> None:
         assert validation.validation_status == ValidationStatus.passed
 
 
-def test_a_deposit_with_no_geometry_is_accepted(db_engine) -> None:
+def test_a_deposit_with_no_geometry_is_accepted(db_conn) -> None:
     """Absence is incompleteness, not contradiction.
 
     A thermo or transport record uploaded from a paper has an identity and no
@@ -438,7 +434,7 @@ def test_a_deposit_with_no_geometry_is_accepted(db_engine) -> None:
     at all. There is nothing to disagree with, so there is nothing to refuse.
     """
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         entry = resolve_species_entry(
             session, _identity("C"), created_by=_USER_ID
         )

--- a/backend/tests/workflows/test_species_geometry_composition.py
+++ b/backend/tests/workflows/test_species_geometry_composition.py
@@ -409,9 +409,9 @@ def test_element_symbols_in_any_case_are_accepted(db_conn) -> None:
         assert outcome.species_entry_id is not None
 
         session.flush()
-        # Scoped to this deposit's own calculation: ``db_conn`` is
-        # session-scoped and other test modules commit, so an unfiltered
-        # count would depend on what else ran first.
+        # Scoped to this deposit's own calculation: the database is shared
+        # for the whole pytest process and other trees commit into it, so an
+        # unfiltered count would depend on what else ran first.
         validation = session.scalar(
             select(CalculationGeometryValidation).where(
                 CalculationGeometryValidation.calculation_id.in_(

--- a/backend/tests/workflows/test_statmech_upload.py
+++ b/backend/tests/workflows/test_statmech_upload.py
@@ -100,10 +100,10 @@ def _basic_request(**overrides) -> StatmechUploadRequest:
 # ---------------------------------------------------------------------------
 
 
-def test_persist_statmech_upload_creates_row_linked_to_species_entry(db_engine) -> None:
+def test_persist_statmech_upload_creates_row_linked_to_species_entry(db_conn) -> None:
     """A minimal standalone upload creates one ``Statmech`` row correctly
     linked to the resolved ``species_entry``."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=2201, username="statmech_tester_basic"))
         session.flush()
 
@@ -127,10 +127,10 @@ def test_persist_statmech_upload_creates_row_linked_to_species_entry(db_engine) 
         assert statmech.torsions == []
 
 
-def test_persist_statmech_upload_persists_rotational_constants(db_engine) -> None:
+def test_persist_statmech_upload_persists_rotational_constants(db_conn) -> None:
     """First-class rotational constants (cm⁻¹) on the request are applied
     to the created ``Statmech`` row."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=2209, username="statmech_tester_rot"))
         session.flush()
 
@@ -152,7 +152,7 @@ def test_persist_statmech_upload_persists_rotational_constants(db_engine) -> Non
 
 
 def test_persist_statmech_upload_resolves_all_provenance_refs(
-    db_engine, monkeypatch,
+    db_conn, monkeypatch,
 ) -> None:
     """Literature, software release, and workflow tool release all resolve
     via the canonical resolvers used by the nested path."""
@@ -176,7 +176,7 @@ def test_persist_statmech_upload_resolves_all_provenance_refs(
         workflow_tool_release={"name": "ARC", "version": "1.1.0"},
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         statmech = persist_statmech_upload(session, request)
 
         assert statmech.literature_id is not None
@@ -202,7 +202,7 @@ def test_persist_statmech_upload_resolves_all_provenance_refs(
 # ---------------------------------------------------------------------------
 
 
-def test_persist_statmech_upload_persists_source_calculations(db_engine) -> None:
+def test_persist_statmech_upload_persists_source_calculations(db_conn) -> None:
     """Inline calcs + source_calculations persist (statmech, calc, role) links
     and preserve the declared roles."""
     request = _basic_request(
@@ -217,7 +217,7 @@ def test_persist_statmech_upload_persists_source_calculations(db_engine) -> None
         ],
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         statmech = persist_statmech_upload(session, request)
 
         links = session.scalars(
@@ -250,7 +250,7 @@ def test_persist_statmech_upload_persists_source_calculations(db_engine) -> None
 
 
 def test_persist_statmech_upload_persists_torsions_and_definitions(
-    db_engine,
+    db_conn,
 ) -> None:
     """Torsion rows, coordinate definitions, ordering, and the local-key
     resolution of ``source_scan_calculation_key`` all persist correctly."""
@@ -300,7 +300,7 @@ def test_persist_statmech_upload_persists_torsions_and_definitions(
         ],
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         statmech = persist_statmech_upload(session, request)
 
         torsions = session.scalars(
@@ -343,12 +343,12 @@ def test_persist_statmech_upload_persists_torsions_and_definitions(
 # ---------------------------------------------------------------------------
 
 
-def test_repeated_statmech_uploads_are_append_only(db_engine) -> None:
+def test_repeated_statmech_uploads_are_append_only(db_conn) -> None:
     """Two uploads against the same species entry yield two distinct
     statmech rows; statmech is a provenance-bearing result table and must
     never silently dedupe."""
     species = {"smiles": "N", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         first = persist_statmech_upload(
             session,
             _basic_request(species_entry=dict(species), note="first"),
@@ -583,7 +583,7 @@ def _statmech_request_with_fsf(
     )
 
 
-def test_unified_fsf_ref_supports_full_identity(db_engine, monkeypatch) -> None:
+def test_unified_fsf_ref_supports_full_identity(db_conn, monkeypatch) -> None:
     """A FreqScaleFactorRef carrying every identity field — LoT, software,
     scale_kind, value, source_literature, workflow_tool_release — and a
     descriptive note round-trips into a single FrequencyScaleFactor row,
@@ -610,7 +610,7 @@ def test_unified_fsf_ref_supports_full_identity(db_engine, monkeypatch) -> None:
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         statmech = persist_statmech_upload(session, request)
 
         assert statmech.frequency_scale_factor_id is not None
@@ -629,7 +629,7 @@ def test_unified_fsf_ref_supports_full_identity(db_engine, monkeypatch) -> None:
         assert fsf.note == "wB97X-D/def2-TZVP fundamental factor"
 
 
-def test_bare_citation_string_lives_in_note_no_fake_literature(db_engine) -> None:
+def test_bare_citation_string_lives_in_note_no_fake_literature(db_conn) -> None:
     """When a producer has only a citation string, it goes into the FSF
     note. No Literature row is synthesized from raw prose, and the
     ``source_literature_id`` stays NULL."""
@@ -639,7 +639,7 @@ def test_bare_citation_string_lives_in_note_no_fake_literature(db_engine) -> Non
         fsf_overrides={"note": citation},
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         lit_count_before = session.scalar(select(func.count()).select_from(Literature))
         statmech = persist_statmech_upload(session, request)
         lit_count_after = session.scalar(select(func.count()).select_from(Literature))
@@ -652,7 +652,7 @@ def test_bare_citation_string_lives_in_note_no_fake_literature(db_engine) -> Non
         assert fsf.note == citation
 
 
-def test_note_does_not_affect_identity_first_writer_wins(db_engine) -> None:
+def test_note_does_not_affect_identity_first_writer_wins(db_conn) -> None:
     """Two refs that share every identity field but differ only in
     ``note`` resolve to the SAME FrequencyScaleFactor row. The note from
     the first writer is preserved; subsequent notes are silently
@@ -673,7 +673,7 @@ def test_note_does_not_affect_identity_first_writer_wins(db_engine) -> None:
         },
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         sm_a = persist_statmech_upload(session, request_a)
         sm_b = persist_statmech_upload(session, request_b)
 
@@ -702,7 +702,7 @@ def test_note_does_not_affect_identity_first_writer_wins(db_engine) -> None:
         assert len(matching) == 1
 
 
-def test_fsf_in_statmech_does_not_create_applied_energy_correction(db_engine) -> None:
+def test_fsf_in_statmech_does_not_create_applied_energy_correction(db_conn) -> None:
     """Linking a frequency scale factor through ``statmech.frequency_scale_factor_id``
     is statmech provenance, not an applied correction. No
     ``applied_energy_correction`` row should be produced for this path."""
@@ -711,7 +711,7 @@ def test_fsf_in_statmech_does_not_create_applied_energy_correction(db_engine) ->
         fsf_overrides={"software": {"name": "Gaussian"}},
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         aec_before = session.scalar(
             select(func.count()).select_from(AppliedEnergyCorrection)
         )
@@ -729,7 +729,7 @@ def test_fsf_in_statmech_does_not_create_applied_energy_correction(db_engine) ->
 # ---------------------------------------------------------------------------
 
 
-def test_optical_isomers_and_electronic_levels_persist(db_engine) -> None:
+def test_optical_isomers_and_electronic_levels_persist(db_conn) -> None:
     from app.db.models.statmech import Statmech, StatmechElectronicLevel
 
     # OH-like: doublet ground state split by spin-orbit coupling (~139 cm-1),
@@ -743,7 +743,7 @@ def test_optical_isomers_and_electronic_levels_persist(db_engine) -> None:
             {"level_index": 2, "energy_cm1": 139.7, "degeneracy": 2},
         ],
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         statmech = persist_statmech_upload(session, request)
         session.flush()
 
@@ -788,13 +788,11 @@ def _water_identity_payload():
     )
 
 
-def test_bundle_statmech_persists_rotational_constants(db_engine) -> None:
+def test_bundle_statmech_persists_rotational_constants(db_conn) -> None:
     """Strict standalone statmech persistence writes A/B/C (cm^-1)."""
     from app.db.models.statmech import Statmech
 
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         stm = persist_statmech_upload(session, _basic_request(
             rotational_constant_a_cm1=27.88,
@@ -809,11 +807,9 @@ def test_bundle_statmech_persists_rotational_constants(db_engine) -> None:
         assert row.rotational_constant_c_cm1 == pytest.approx(9.28)
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
-def test_rotational_constant_positive_check(db_engine) -> None:
+def test_rotational_constant_positive_check(db_conn) -> None:
     """The columns exist and the per-column ``> 0`` CHECK rejects
     zero/negative values while accepting positive ones."""
     from sqlalchemy.exc import IntegrityError
@@ -821,9 +817,7 @@ def test_rotational_constant_positive_check(db_engine) -> None:
     from app.db.models.statmech import Statmech
     from app.services.species_resolution import resolve_species_entry
 
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         se = resolve_species_entry(session, _water_identity_payload())
         session.flush()
@@ -852,5 +846,3 @@ def test_rotational_constant_positive_check(db_engine) -> None:
             savepoint.rollback()
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()

--- a/backend/tests/workflows/test_thermo_nasa9_wilhoit.py
+++ b/backend/tests/workflows/test_thermo_nasa9_wilhoit.py
@@ -28,11 +28,11 @@ def rb_session(db_conn):
     """A Session whose work is fully rolled back at teardown.
 
     These tests both persist and immediately read back, so they must not
-    commit into the session-scoped test DB — a committed species with a
-    common SMILES would collide (on the content-derived ``public_ref``)
-    with species other tests create via ``unique_smiles()``. Binding the
-    Session to a connection-level transaction that is rolled back keeps the
-    flushed rows visible for the read-back yet leaves the DB untouched.
+    commit into the shared test DB — a committed species with a common
+    SMILES would collide (on the content-derived ``public_ref``) with
+    species other tests create via ``unique_smiles()``. Binding to
+    ``db_conn`` keeps the flushed rows visible for the read-back while the
+    per-test transaction it owns leaves the database untouched.
     """
     session = Session(bind=db_conn)
     try:

--- a/backend/tests/workflows/test_thermo_nasa9_wilhoit.py
+++ b/backend/tests/workflows/test_thermo_nasa9_wilhoit.py
@@ -24,7 +24,7 @@ from app.workflows.thermo import persist_thermo_upload
 
 
 @pytest.fixture
-def rb_session(db_engine):
+def rb_session(db_conn):
     """A Session whose work is fully rolled back at teardown.
 
     These tests both persist and immediately read back, so they must not
@@ -34,15 +34,11 @@ def rb_session(db_engine):
     Session to a connection-level transaction that is rolled back keeps the
     flushed rows visible for the read-back yet leaves the DB untouched.
     """
-    conn = db_engine.connect()
-    txn = conn.begin()
-    session = Session(bind=conn)
+    session = Session(bind=db_conn)
     try:
         yield session
     finally:
         session.close()
-        txn.rollback()
-        conn.close()
 
 
 def _nasa9_intervals() -> list[dict]:

--- a/backend/tests/workflows/test_thermo_upload.py
+++ b/backend/tests/workflows/test_thermo_upload.py
@@ -145,9 +145,9 @@ def _make_calculation(
 # ---------------------------------------------------------------------------
 
 
-def test_persist_thermo_upload_creates_row_with_scalar_fields(db_engine) -> None:
+def test_persist_thermo_upload_creates_row_with_scalar_fields(db_conn) -> None:
     """A1: scalar thermo fields persist and link to the resolved species entry."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         # Let Postgres assign the id rather than pinning a specific value:
         # other tests in the session-scoped DB create app_user rows via API
         # endpoints (auto-increment) that can advance the sequence past any
@@ -178,9 +178,9 @@ def test_persist_thermo_upload_creates_row_with_scalar_fields(db_engine) -> None
         assert thermo.source_calculations == []
 
 
-def test_persist_thermo_upload_creates_and_links_nasa_row(db_engine) -> None:
+def test_persist_thermo_upload_creates_and_links_nasa_row(db_conn) -> None:
     """A2: a NASA block creates one child row attached to the parent thermo."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session,
             _thermo_request(nasa=_nasa_block()),
@@ -200,10 +200,10 @@ def test_persist_thermo_upload_creates_and_links_nasa_row(db_engine) -> None:
         assert nasa.b6 == pytest.approx(-3.00042971e4)
 
 
-def test_persist_thermo_upload_persists_tabulated_points(db_engine) -> None:
+def test_persist_thermo_upload_persists_tabulated_points(db_conn) -> None:
     """A3: each ThermoPoint is persisted keyed by (thermo_id, temperature_k)."""
     points = _thermo_points()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session, _thermo_request(points=points)
         )
@@ -225,7 +225,7 @@ def test_persist_thermo_upload_persists_tabulated_points(db_engine) -> None:
             assert by_temp[t].g_kj_mol == pytest.approx(expected["g_kj_mol"])
 
 
-def test_persist_thermo_source_calculations_link_by_role(db_engine) -> None:
+def test_persist_thermo_source_calculations_link_by_role(db_conn) -> None:
     """A4: ``thermo_source_calculation`` rows persist the correct (calc, role).
 
     NOTE: ``ThermoUploadRequest`` has no ``source_calculations`` field, so
@@ -233,7 +233,7 @@ def test_persist_thermo_source_calculations_link_by_role(db_engine) -> None:
     exercises the internal ``persist_thermo`` path directly, which is the
     surface that will be wired up once the upload schema is extended.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session,
             SpeciesEntryIdentityPayload(**_SPECIES_ENTRY),
@@ -279,7 +279,7 @@ def test_persist_thermo_source_calculations_link_by_role(db_engine) -> None:
 
 
 def test_persist_thermo_upload_resolves_all_provenance_refs(
-    db_engine, monkeypatch,
+    db_conn, monkeypatch,
 ) -> None:
     """A5: literature, software release, and workflow tool release all resolve."""
     monkeypatch.setattr(
@@ -301,7 +301,7 @@ def test_persist_thermo_upload_resolves_all_provenance_refs(
         workflow_tool_release={"name": "ARC", "version": "1.1.0"},
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
 
         assert thermo.literature_id is not None
@@ -322,7 +322,7 @@ def test_persist_thermo_upload_resolves_all_provenance_refs(
         assert wtr.workflow_tool.name == "ARC"
 
 
-def test_repeated_thermo_uploads_are_append_only(db_engine) -> None:
+def test_repeated_thermo_uploads_are_append_only(db_conn) -> None:
     """A6: two uploads for the same species entry create two distinct thermo rows.
 
     Thermo is an append-only result table — deduplication lives at the species
@@ -332,7 +332,7 @@ def test_repeated_thermo_uploads_are_append_only(db_engine) -> None:
     # Use a distinct species so this test is independent of any other test
     # that writes thermo for water or similar common species.
     distinct_species = {"smiles": "CCO", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         first = persist_thermo_upload(
             session,
             _thermo_request(species_entry=dict(distinct_species), note="first"),
@@ -457,14 +457,14 @@ def test_schema_rejects_duplicate_thermo_point_temperatures() -> None:
 # --- B6: source-calculation reference errors -------------------------------
 
 
-def test_persist_thermo_raises_on_unknown_source_calculation(db_engine) -> None:
+def test_persist_thermo_raises_on_unknown_source_calculation(db_conn) -> None:
     """B6: an unknown calculation_id fails cleanly at DB commit time.
 
     The workflow route cannot reach this today (no source_calculations in
     the upload schema) but the internal persistence path must still raise
     rather than silently accept a dangling FK.
     """
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         try:
             with session.begin():
                 species_entry = resolve_species_entry(
@@ -490,13 +490,13 @@ def test_persist_thermo_raises_on_unknown_source_calculation(db_engine) -> None:
             pass
 
 
-def test_schema_rejects_duplicate_source_calculation_role_pairs(db_engine) -> None:
+def test_schema_rejects_duplicate_source_calculation_role_pairs(db_conn) -> None:
     """B6: two source-calc rows with the same (calculation_id, role) are rejected.
 
     Pydantic catches the duplicate before the DB sees the row, protecting
     the ``(thermo_id, calculation_id, role)`` primary key.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session, _thermo_request().species_entry,
         )
@@ -529,7 +529,7 @@ def test_schema_rejects_duplicate_source_calculation_role_pairs(db_engine) -> No
 # and ``docs/thermo_tests.md §B8``.
 
 
-def test_schema_rejects_empty_scientific_thermo_payload(db_engine) -> None:
+def test_schema_rejects_empty_scientific_thermo_payload(db_conn) -> None:
     """B8: an upload with no scalars, no NASA, and no points is rejected.
 
     Verifies the schema-level validator fires and that the database sees
@@ -539,7 +539,7 @@ def test_schema_rejects_empty_scientific_thermo_payload(db_engine) -> None:
     empty_species = {"smiles": "N#N", "charge": 0, "multiplicity": 1}
 
     # Baseline: any rows for this species that may exist from other tests.
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         before_entry_ids = {
             row.species_entry_id
             for row in session.scalars(
@@ -557,7 +557,7 @@ def test_schema_rejects_empty_scientific_thermo_payload(db_engine) -> None:
     # DB-clean check: no new thermo / nasa / point rows resulted from the
     # rejected request (schema validation runs before any session work, so
     # this is a belt-and-suspenders assertion).
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         after_entries = {
             row.species_entry_id
             for row in session.scalars(
@@ -576,10 +576,10 @@ def test_schema_rejects_empty_scientific_thermo_payload(db_engine) -> None:
         assert hollow_rows == []
 
 
-def test_scalar_only_thermo_upload_is_valid(db_engine) -> None:
+def test_scalar_only_thermo_upload_is_valid(db_conn) -> None:
     """Scalar-only payloads (no NASA, no points) remain valid."""
     distinct = {"smiles": "CO", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session,
             ThermoUploadRequest(
@@ -597,14 +597,14 @@ def test_scalar_only_thermo_upload_is_valid(db_engine) -> None:
         ).all() == []
 
 
-def test_nasa_only_thermo_upload_is_valid(db_engine) -> None:
+def test_nasa_only_thermo_upload_is_valid(db_conn) -> None:
     """NASA-only payloads (no scalars, no points) remain valid.
 
     The schema has no rule tying NASA presence to scalar or point presence,
     and NASA carries its own full thermodynamic model, so this is accepted.
     """
     distinct = {"smiles": "C#N", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session,
             ThermoUploadRequest(
@@ -623,14 +623,14 @@ def test_nasa_only_thermo_upload_is_valid(db_engine) -> None:
         assert len(nasa_rows) == 1
 
 
-def test_points_only_thermo_upload_is_valid(db_engine) -> None:
+def test_points_only_thermo_upload_is_valid(db_conn) -> None:
     """Points-only payloads (no scalars, no NASA) remain valid.
 
     Tabulated points are a standalone thermodynamic representation and the
     schema does not require NASA coefficients alongside them.
     """
     distinct = {"smiles": "[C-]#[O+]", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session,
             ThermoUploadRequest(
@@ -677,7 +677,7 @@ def _freq_calc_payload() -> dict:
     }
 
 
-def test_thermo_upload_persists_source_calculations_via_upload(db_engine) -> None:
+def test_thermo_upload_persists_source_calculations_via_upload(db_conn) -> None:
     """Uploading thermo with declared calcs + source_calculations populates
     ``thermo_source_calculation`` with the right (calculation_id, role)."""
     distinct = {"smiles": "CCCC", "charge": 0, "multiplicity": 1}
@@ -693,7 +693,7 @@ def test_thermo_upload_persists_source_calculations_via_upload(db_engine) -> Non
         ],
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
 
         links = session.scalars(
@@ -711,7 +711,7 @@ def test_thermo_upload_persists_source_calculations_via_upload(db_engine) -> Non
         assert calc.type == CalculationType.sp
 
 
-def test_thermo_upload_with_multiple_source_calculations_and_roles(db_engine) -> None:
+def test_thermo_upload_with_multiple_source_calculations_and_roles(db_conn) -> None:
     """Multiple inline calcs with distinct roles persist as distinct rows."""
     distinct = {"smiles": "c1ccccc1", "charge": 0, "multiplicity": 1}
     request = ThermoUploadRequest(
@@ -728,7 +728,7 @@ def test_thermo_upload_with_multiple_source_calculations_and_roles(db_engine) ->
         ],
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
 
         links = session.scalars(
@@ -749,7 +749,7 @@ def test_thermo_upload_with_multiple_source_calculations_and_roles(db_engine) ->
         assert freq_calc.species_entry_id == thermo.species_entry_id
 
 
-def test_applied_correction_source_calculation_key_resolves_to_id(db_engine) -> None:
+def test_applied_correction_source_calculation_key_resolves_to_id(db_conn) -> None:
     """Applied corrections attached to a thermo upload no longer drop their
     source-calculation provenance.
 
@@ -780,7 +780,7 @@ def test_applied_correction_source_calculation_key_resolves_to_id(db_engine) -> 
         ],
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
 
         applied = session.scalars(
@@ -874,7 +874,7 @@ def test_schema_rejects_applied_correction_with_undefined_source_calc_key() -> N
         )
 
 
-def test_wrong_owner_source_calc_rejected_by_workflow_check(db_engine) -> None:
+def test_wrong_owner_source_calc_rejected_by_workflow_check(db_conn) -> None:
     """Owner-consistency check fires when a resolved calculation's
     ``species_entry_id`` does not match the thermo target.
 
@@ -883,7 +883,7 @@ def test_wrong_owner_source_calc_rejected_by_workflow_check(db_engine) -> None:
     entry. This test exercises the defensive check directly so regressions
     in that guard are caught.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_a = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**_SPECIES_ENTRY),
         )
@@ -898,7 +898,7 @@ def test_wrong_owner_source_calc_rejected_by_workflow_check(db_engine) -> None:
 
 
 def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
-    db_engine,
+    db_conn,
 ) -> None:
     """If owner-consistency fails for an applied correction's source calc,
     the whole thermo transaction rolls back — no partial thermo row, no
@@ -952,7 +952,7 @@ def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
         )
 
     with pytest.raises(ValueError, match="simulated cross-owner"):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             original = thermo_module._assert_calculation_owned_by
             thermo_module._assert_calculation_owned_by = _fail_on_second_call
             try:
@@ -961,7 +961,7 @@ def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
                 thermo_module._assert_calculation_owned_by = original
 
     # Verify no partial persistence.
-    with Session(db_engine) as verify:
+    with Session(db_conn) as verify:
         leaked_thermo = session_scalar_count(
             verify, Thermo, note="wrong-owner-sentinel",
         )
@@ -979,7 +979,7 @@ def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
 # ---------------------------------------------------------------------------
 
 
-def test_child_nasa_failure_rolls_back_parent_thermo(db_engine) -> None:
+def test_child_nasa_failure_rolls_back_parent_thermo(db_conn) -> None:
     """D1: if NASA insertion fails after the parent is flushed, the whole
     transaction rolls back and no partial thermo row remains.
 
@@ -990,13 +990,13 @@ def test_child_nasa_failure_rolls_back_parent_thermo(db_engine) -> None:
     """
     unique_note = "rollback-sentinel-D1"
 
-    with Session(db_engine) as outer_session, outer_session.begin():
+    with Session(db_conn) as outer_session, outer_session.begin():
         # Any pre-existing data is already committed from other tests.
         baseline = session_scalar_count(outer_session, Thermo, note=unique_note)
         assert baseline == 0
 
     with pytest.raises(IntegrityError):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             species_entry = resolve_species_entry(
                 session, _thermo_request().species_entry,
             )
@@ -1019,7 +1019,7 @@ def test_child_nasa_failure_rolls_back_parent_thermo(db_engine) -> None:
             # session.begin() context will call commit on exit; the FK
             # violation surfaces there, triggering rollback.
 
-    with Session(db_engine) as verify_session:
+    with Session(db_conn) as verify_session:
         leaked = session_scalar_count(verify_session, Thermo, note=unique_note)
         assert leaked == 0, "rollback should have removed the parent thermo row"
 
@@ -1056,12 +1056,12 @@ def _make_persisted_calc(
 
 
 def test_thermo_upload_links_existing_calculation_ids_for_opt_freq_sp(
-    db_engine,
+    db_conn,
 ) -> None:
     """DR-0028: existing_calculation_id references for opt/freq/sp produce
     thermo_source_calculation rows that point at those exact calc ids."""
     distinct = {"smiles": "CC", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**distinct),
         )
@@ -1106,12 +1106,12 @@ def test_thermo_upload_links_existing_calculation_ids_for_opt_freq_sp(
 
 
 def test_thermo_upload_with_existing_calc_id_creates_no_duplicate_calc(
-    db_engine,
+    db_conn,
 ) -> None:
     """DR-0028: linking an existing calc must NOT insert a new calculation
     row — the whole point is to avoid row explosion."""
     distinct = {"smiles": "CCN", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**distinct),
         )
@@ -1146,12 +1146,12 @@ def test_thermo_upload_with_existing_calc_id_creates_no_duplicate_calc(
         assert {row.id for row in after} == {calc.id}
 
 
-def test_thermo_upload_mixed_inline_and_existing_calc_references(db_engine) -> None:
+def test_thermo_upload_mixed_inline_and_existing_calc_references(db_conn) -> None:
     """DR-0028: a single source_calculations list may mix inline keys with
     existing-id references. Both produce link rows; inline calcs are
     inserted as new calc rows, existing references reuse prior rows."""
     distinct = {"smiles": "CCO", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**distinct),
         )
@@ -1205,7 +1205,7 @@ def test_thermo_upload_mixed_inline_and_existing_calc_references(db_engine) -> N
 
 
 def test_thermo_upload_existing_calc_id_not_found_raises_not_found(
-    db_engine,
+    db_conn,
 ) -> None:
     """DR-0028 Req 2: a missing existing_calculation_id must surface as 404
     via NotFoundError (mapped to HTTP 404 by the API exception handler)."""
@@ -1222,12 +1222,12 @@ def test_thermo_upload_existing_calc_id_not_found_raises_not_found(
     )
 
     with pytest.raises(NotFoundError, match="does not exist"):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             persist_thermo_upload(session, request)
 
 
 def test_thermo_upload_existing_calc_id_wrong_species_entry_raises_422(
-    db_engine,
+    db_conn,
 ) -> None:
     """DR-0028 Req 2: an existing_calculation_id whose species_entry_id
     differs from the thermo target's must surface as 422 (ValueError) and
@@ -1236,7 +1236,7 @@ def test_thermo_upload_existing_calc_id_wrong_species_entry_raises_422(
     species_b = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
 
     with pytest.raises(ValueError, match="different species entry") as exc_info:
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             entry_a = resolve_species_entry(
                 session, SpeciesEntryIdentityPayload(**species_a),
             )
@@ -1261,11 +1261,11 @@ def test_thermo_upload_existing_calc_id_wrong_species_entry_raises_422(
     assert "id=" not in detail
 
 
-def test_thermo_upload_role_freq_with_opt_calc_raises_422(db_engine) -> None:
+def test_thermo_upload_role_freq_with_opt_calc_raises_422(db_conn) -> None:
     """DR-0028 Req 1: role=freq pointing at a calc whose type=opt is rejected."""
     distinct = {"smiles": "CCC", "charge": 0, "multiplicity": 1}
     with pytest.raises(ValueError, match="incompatible"):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             species_entry = resolve_species_entry(
                 session, SpeciesEntryIdentityPayload(**distinct),
             )
@@ -1286,11 +1286,11 @@ def test_thermo_upload_role_freq_with_opt_calc_raises_422(db_engine) -> None:
             )
 
 
-def test_thermo_upload_role_sp_with_freq_calc_raises_422(db_engine) -> None:
+def test_thermo_upload_role_sp_with_freq_calc_raises_422(db_conn) -> None:
     """DR-0028 Req 1: role=sp pointing at a calc whose type=freq is rejected."""
     distinct = {"smiles": "CCCO", "charge": 0, "multiplicity": 1}
     with pytest.raises(ValueError, match="incompatible"):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             species_entry = resolve_species_entry(
                 session, SpeciesEntryIdentityPayload(**distinct),
             )
@@ -1311,13 +1311,13 @@ def test_thermo_upload_role_sp_with_freq_calc_raises_422(db_engine) -> None:
             )
 
 
-def test_thermo_upload_inline_calc_role_type_mismatch_raises_422(db_engine) -> None:
+def test_thermo_upload_inline_calc_role_type_mismatch_raises_422(db_conn) -> None:
     """DR-0028 Req 1: the role/type compatibility check applies to inline
     calcs too. Declaring a freq inline and tagging it role=opt is the same
     error class as a typo'd existing_calculation_id."""
     distinct = {"smiles": "CCCN", "charge": 0, "multiplicity": 1}
     with pytest.raises(ValueError, match="incompatible"):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             persist_thermo_upload(
                 session,
                 ThermoUploadRequest(
@@ -1385,11 +1385,11 @@ def test_schema_rejects_existing_calculation_id_zero_or_negative() -> None:
         )
 
 
-def test_schema_allows_role_composite_with_any_calc_type(db_engine) -> None:
+def test_schema_allows_role_composite_with_any_calc_type(db_conn) -> None:
     """DR-0028 Req 1: role=composite has no strict type check at v0 — it
     describes a scientific origin rather than a specific job type."""
     distinct = {"smiles": "CCCC=O", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**distinct),
         )
@@ -1441,10 +1441,10 @@ def _make_statmech(
     return statmech
 
 
-def test_thermo_upload_persists_reference_state_fields(db_engine) -> None:
+def test_thermo_upload_persists_reference_state_fields(db_conn) -> None:
     """Reference pressure, phase, and ΔfH°(0 K) persist and read back."""
     distinct = {"smiles": "CCCCCC", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session,
             _thermo_request(
@@ -1469,7 +1469,7 @@ def test_thermo_upload_persists_reference_state_fields(db_engine) -> None:
         assert read.enthalpy_formation_0k_uncertainty_kj_mol == pytest.approx(0.4)
 
 
-def test_thermo_upload_defaults_reference_pressure_and_phase(db_engine) -> None:
+def test_thermo_upload_defaults_reference_pressure_and_phase(db_conn) -> None:
     """Omitting reference pressure / phase applies the IUPAC 1 bar, gas defaults."""
     distinct = {"smiles": "CCCCCCC", "charge": 0, "multiplicity": 1}
     request = ThermoUploadRequest(
@@ -1480,7 +1480,7 @@ def test_thermo_upload_defaults_reference_pressure_and_phase(db_engine) -> None:
     assert request.reference_pressure_bar == pytest.approx(1.0)
     assert request.phase == PhaseKind.gas
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
         assert thermo.reference_pressure_bar == pytest.approx(1.0)
         assert thermo.phase == PhaseKind.gas
@@ -1488,10 +1488,10 @@ def test_thermo_upload_defaults_reference_pressure_and_phase(db_engine) -> None:
         assert thermo.enthalpy_formation_0k_kj_mol is None
 
 
-def test_thermo_upload_allows_condensed_phase_override(db_engine) -> None:
+def test_thermo_upload_allows_condensed_phase_override(db_conn) -> None:
     """A liquid-phase record overrides the gas default."""
     distinct = {"smiles": "CCCCCCCC", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(
             session,
             _thermo_request(
@@ -1504,7 +1504,7 @@ def test_thermo_upload_allows_condensed_phase_override(db_engine) -> None:
 
 @pytest.mark.parametrize("origin", ["experimental", "estimated"])
 def test_non_computed_origin_does_not_default_phase_or_pressure(
-    db_engine, origin: str,
+    db_conn, origin: str,
 ) -> None:
     """Experimental/literature/estimated uploads must NOT be silently
     stamped gas @ 1 bar. Only computed uploads get the QC defaults; other
@@ -1519,13 +1519,13 @@ def test_non_computed_origin_does_not_default_phase_or_pressure(
     assert request.reference_pressure_bar is None
     assert request.phase is None
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
         assert thermo.reference_pressure_bar is None
         assert thermo.phase is None
 
 
-def test_computed_origin_defaults_phase_and_pressure(db_engine) -> None:
+def test_computed_origin_defaults_phase_and_pressure(db_conn) -> None:
     """A computed upload without phase/pressure defaults to gas @ 1 bar."""
     request = ThermoUploadRequest(
         species_entry={"smiles": "CCCCCCCCCCC", "charge": 0, "multiplicity": 1},
@@ -1535,14 +1535,14 @@ def test_computed_origin_defaults_phase_and_pressure(db_engine) -> None:
     assert request.reference_pressure_bar == pytest.approx(1.0)
     assert request.phase == PhaseKind.gas
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
         assert thermo.reference_pressure_bar == pytest.approx(1.0)
         assert thermo.phase == PhaseKind.gas
 
 
 def test_explicit_reference_state_honored_for_experimental_origin(
-    db_engine,
+    db_conn,
 ) -> None:
     """Explicit phase/pressure are honored regardless of origin: an
     experimental liquid record keeps its own values, not the QC defaults."""
@@ -1556,7 +1556,7 @@ def test_explicit_reference_state_honored_for_experimental_origin(
     assert request.phase == PhaseKind.liquid
     assert request.reference_pressure_bar == pytest.approx(1.01325)
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
         assert thermo.phase == PhaseKind.liquid
         assert thermo.reference_pressure_bar == pytest.approx(1.01325)
@@ -1577,10 +1577,10 @@ def test_explicit_none_phase_honored_for_computed_origin() -> None:
     assert request.reference_pressure_bar is None
 
 
-def test_thermo_upload_links_existing_statmech(db_engine) -> None:
+def test_thermo_upload_links_existing_statmech(db_conn) -> None:
     """A computed thermo cites its statmech basis via existing_statmech_id."""
     distinct = {"smiles": "CCCCCCCCC", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**distinct),
         )
@@ -1604,13 +1604,13 @@ def test_thermo_upload_links_existing_statmech(db_engine) -> None:
         assert thermo.id in {t.id for t in statmech.thermo_records}
 
 
-def test_thermo_upload_statmech_not_found_raises_not_found(db_engine) -> None:
+def test_thermo_upload_statmech_not_found_raises_not_found(db_conn) -> None:
     """A missing existing_statmech_id surfaces as 404 (NotFoundError)."""
     from app.api.errors import NotFoundError
 
     distinct = {"smiles": "CCCCCCCCCC", "charge": 0, "multiplicity": 1}
     with pytest.raises(NotFoundError, match="does not exist"):
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             persist_thermo_upload(
                 session,
                 ThermoUploadRequest(
@@ -1622,14 +1622,14 @@ def test_thermo_upload_statmech_not_found_raises_not_found(db_engine) -> None:
             )
 
 
-def test_thermo_upload_statmech_wrong_species_entry_raises_422(db_engine) -> None:
+def test_thermo_upload_statmech_wrong_species_entry_raises_422(db_conn) -> None:
     """A statmech owned by a different species entry is rejected (422) and
     the message must not leak internal ids."""
     species_a = {"smiles": "[NH2]", "charge": 0, "multiplicity": 2}
     species_b = {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}
 
     with pytest.raises(ValueError, match="different species entry") as exc_info:
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             entry_a = resolve_species_entry(
                 session, SpeciesEntryIdentityPayload(**species_a),
             )

--- a/backend/tests/workflows/test_transition_state_composition.py
+++ b/backend/tests/workflows/test_transition_state_composition.py
@@ -115,18 +115,14 @@ _USER_ID = 50_612
 
 
 @contextmanager
-def _isolated_session(db_engine) -> Iterator[Session]:
-    connection = db_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, expire_on_commit=False)
+def _isolated_session(db_conn) -> Iterator[Session]:
+    session = Session(bind=db_conn, expire_on_commit=False)
     try:
         session.add(AppUser(id=_USER_ID, username="ts_composition_tests"))
         session.flush()
         yield session
     finally:
         session.close()
-        transaction.rollback()
-        connection.close()
 
 
 def _species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
@@ -202,14 +198,14 @@ def _upload(session: Session, payload: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_a_saddle_point_with_its_reaction_atoms_is_accepted(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_a_saddle_point_with_its_reaction_atoms_is_accepted(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, _bundle())
     assert result["transition_state_entry_id"] is not None
 
 
-def test_a_saddle_point_missing_an_atom_is_refused(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_a_saddle_point_missing_an_atom_is_refused(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(session, _bundle(ts_xyz=_XYZ_TS_MISSING_AN_ATOM))
     message = str(excinfo.value)
@@ -218,14 +214,14 @@ def test_a_saddle_point_missing_an_atom_is_refused(db_engine) -> None:
 
 
 def test_a_saddle_point_carrying_an_undeclared_spectator_is_refused(
-    db_engine,
+    db_conn,
 ) -> None:
     """Extra atoms are a *different* reaction, not a richer description of this one.
 
     The message points at the fix that keeps the science: declare the spectator
     as a participant, so the record says what was actually computed.
     """
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(
                 session, _bundle(ts_xyz=_XYZ_TS_WITH_AN_UNDECLARED_SPECTATOR)
@@ -235,9 +231,9 @@ def test_a_saddle_point_carrying_an_undeclared_spectator_is_refused(
     assert "declare them as participants" in message
 
 
-def test_a_saddle_point_at_the_wrong_charge_is_refused(db_engine) -> None:
+def test_a_saddle_point_at_the_wrong_charge_is_refused(db_conn) -> None:
     """Charge is conserved along a reaction coordinate."""
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(session, _bundle(ts_charge=1))
     message = str(excinfo.value)
@@ -290,7 +286,7 @@ def _chlorine_bundle(*, ts_xyz: str) -> dict:
 
 
 def test_a_saddle_point_whose_xyz_shouts_its_elements_is_accepted(
-    db_engine,
+    db_conn,
 ) -> None:
     """``CL`` and ``c`` are ``Cl`` and ``C``, and this check must know it.
 
@@ -301,18 +297,18 @@ def test_a_saddle_point_whose_xyz_shouts_its_elements_is_accepted(
     correct chemistry over capitalisation, which ADR 0008 disqualifies a
     blocking check from doing.
     """
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, _chlorine_bundle(ts_xyz=_XYZ_TS_MIXED_CASE))
     assert result["transition_state_entry_id"] is not None
 
 
-def test_normalising_case_does_not_blunt_the_check(db_engine) -> None:
+def test_normalising_case_does_not_blunt_the_check(db_conn) -> None:
     """A mixed-case saddle point with the wrong *atoms* is still refused.
 
     Otherwise the fix for the capitalisation regression would have bought
     acceptance by making the rule stop firing.
     """
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             _upload(
                 session,
@@ -325,7 +321,7 @@ def test_normalising_case_does_not_blunt_the_check(db_engine) -> None:
     assert "is CH3, but the reaction it sits in is CH3Cl" in message
 
 
-def test_multiplicity_is_deliberately_not_checked(db_engine) -> None:
+def test_multiplicity_is_deliberately_not_checked(db_conn) -> None:
     """Spin is not conserved the way charge and atoms are.
 
     Two doublets may react over a singlet or a triplet surface, and
@@ -334,7 +330,7 @@ def test_multiplicity_is_deliberately_not_checked(db_engine) -> None:
     """
     payload = _bundle()
     payload["transition_state"]["multiplicity"] = 4
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         result = _upload(session, payload)
     assert result["transition_state_entry_id"] is not None
 
@@ -369,8 +365,8 @@ def _standalone_ts_payload(xyz: str, *, charge: int = 0) -> dict:
     }
 
 
-def test_standalone_transition_state_upload_is_checked_too(db_engine) -> None:
-    with _isolated_session(db_engine) as session:
+def test_standalone_transition_state_upload_is_checked_too(db_conn) -> None:
+    with _isolated_session(db_conn) as session:
         entry = persist_transition_state_upload(
             session,
             TransitionStateUploadRequest(**_standalone_ts_payload(_XYZ_TS)),
@@ -378,7 +374,7 @@ def test_standalone_transition_state_upload_is_checked_too(db_engine) -> None:
         )
         assert entry.id is not None
 
-    with _isolated_session(db_engine) as session:
+    with _isolated_session(db_conn) as session:
         with pytest.raises(ValueError) as excinfo:
             persist_transition_state_upload(
                 session,

--- a/backend/tests/workflows/test_transition_state_upload.py
+++ b/backend/tests/workflows/test_transition_state_upload.py
@@ -98,9 +98,9 @@ def _basic_ts_request() -> TransitionStateUploadRequest:
 # ---------------------------------------------------------------------------
 
 
-def test_basic_ts_upload_creates_concept_and_entry(db_engine) -> None:
+def test_basic_ts_upload_creates_concept_and_entry(db_conn) -> None:
     """Primary opt only — verifies TS concept, entry, geometry, and calc."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=50, username="ts_tester"))
         session.flush()
 
@@ -140,9 +140,9 @@ def test_basic_ts_upload_creates_concept_and_entry(db_engine) -> None:
         assert len(geo_links) == 1
 
 
-def test_ts_upload_with_additional_calcs_and_results(db_engine) -> None:
+def test_ts_upload_with_additional_calcs_and_results(db_conn) -> None:
     """Upload with freq (+ result) and sp (+ result) additional calcs."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=51, username="ts_tester_full"))
         session.flush()
 
@@ -238,9 +238,9 @@ def test_ts_upload_with_additional_calcs_and_results(db_engine) -> None:
         assert geo_links[0].calculation_id == opt_calc.id
 
 
-def test_ts_upload_without_results_succeeds(db_engine) -> None:
+def test_ts_upload_without_results_succeeds(db_conn) -> None:
     """Additional calcs without result blocks are fine."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=52, username="ts_no_results"))
         session.flush()
 
@@ -365,10 +365,10 @@ _XYZ_PS_0 = "1\nI0\nH  0.0  0.0  0.0\n"
 _XYZ_PS_2 = "1\nI2\nH  0.0  0.0  1.5\n"
 
 
-def test_ts_upload_with_irc_additional_persists_irc_result(db_engine) -> None:
+def test_ts_upload_with_irc_additional_persists_irc_result(db_conn) -> None:
     """TS upload carrying an IRC additional calc persists IRC structured rows."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         # Let the DB assign the user id rather than hardcoding 60 — other
         # committed tests in the suite may consume IDs in that range and
         # trigger a unique-constraint violation under certain orderings.
@@ -469,14 +469,14 @@ def test_ts_upload_with_irc_additional_persists_irc_result(db_engine) -> None:
 
 
 def test_ts_upload_with_path_search_neb_additional_persists_points(
-    db_engine,
+    db_conn,
 ) -> None:
     """TS upload carrying a path_search (NEB) additional calc persists
     path-search points and wires the inverted ``optimized_from`` edge:
     the path-search calc is the *parent* of the primary TS opt.
     """
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=61, username="ts_path_search_writer"))
         session.flush()
 
@@ -625,7 +625,7 @@ def _ts_request_with_evidence(**evidence_overrides) -> TransitionStateUploadRequ
     )
 
 
-def test_standalone_ts_upload_persists_irc_evidence(db_engine) -> None:
+def test_standalone_ts_upload_persists_irc_evidence(db_conn) -> None:
     """The owner's "optional but visible on read" decision is reachable here.
 
     Before this, structured evidence was depositable only through the PDep
@@ -637,7 +637,7 @@ def test_standalone_ts_upload_persists_irc_evidence(db_engine) -> None:
         _build_validation_descriptor,
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         warnings: list = []
         ts_entry = persist_transition_state_upload(
             session, _ts_request_with_evidence(), warnings=warnings
@@ -662,8 +662,8 @@ def test_standalone_ts_upload_persists_irc_evidence(db_engine) -> None:
         assert _build_validation_descriptor(session, ts_entry.id).irc == "present"
 
 
-def test_standalone_ts_upload_without_evidence_warns(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_standalone_ts_upload_without_evidence_warns(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         warnings: list = []
         ts_entry = persist_transition_state_upload(
             session, _basic_ts_request(), warnings=warnings

--- a/backend/tests/workflows/test_transport_upload.py
+++ b/backend/tests/workflows/test_transport_upload.py
@@ -86,9 +86,9 @@ def _transport_request(**overrides) -> TransportUploadRequest:
 # ---------------------------------------------------------------------------
 
 
-def test_persist_transport_upload_creates_row_with_scalar_fields(db_engine) -> None:
+def test_persist_transport_upload_creates_row_with_scalar_fields(db_conn) -> None:
     """Transport scalar fields persist and link to the resolved species entry."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         session.add(AppUser(id=1201, username="transport_tester_basic"))
         session.flush()
 
@@ -110,7 +110,7 @@ def test_persist_transport_upload_creates_row_with_scalar_fields(db_engine) -> N
 
 
 def test_persist_transport_upload_resolves_all_provenance_refs(
-    db_engine, monkeypatch,
+    db_conn, monkeypatch,
 ) -> None:
     """Literature, software release, and workflow tool release all resolve."""
     monkeypatch.setattr(
@@ -133,7 +133,7 @@ def test_persist_transport_upload_resolves_all_provenance_refs(
         workflow_tool_release={"name": "ARC", "version": "1.1.0"},
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         transport = persist_transport_upload(session, request)
 
         assert transport.literature_id is not None
@@ -154,7 +154,7 @@ def test_persist_transport_upload_resolves_all_provenance_refs(
         assert wtr.workflow_tool.name == "ARC"
 
 
-def test_persist_transport_upload_persists_source_calculations(db_engine) -> None:
+def test_persist_transport_upload_persists_source_calculations(db_conn) -> None:
     """Inline calcs + source_calculations persist the correct (calc, role) links."""
     distinct = {"smiles": "CCO", "charge": 0, "multiplicity": 1}
     request = TransportUploadRequest(
@@ -172,7 +172,7 @@ def test_persist_transport_upload_persists_source_calculations(db_engine) -> Non
         ],
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         transport = persist_transport_upload(session, request)
 
         links = session.scalars(
@@ -201,14 +201,14 @@ def test_persist_transport_upload_persists_source_calculations(db_engine) -> Non
         assert freq_calc.species_entry_id == transport.species_entry_id
 
 
-def test_repeated_transport_uploads_are_append_only(db_engine) -> None:
+def test_repeated_transport_uploads_are_append_only(db_conn) -> None:
     """Two uploads for the same species entry create two distinct transport rows.
 
     Transport is append-only — repeated uploads for the same species
     entry are valid and must not dedupe.
     """
     distinct = {"smiles": "CCCC", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         first = persist_transport_upload(
             session,
             _transport_request(species_entry=dict(distinct), note="first"),
@@ -230,7 +230,7 @@ def test_repeated_transport_uploads_are_append_only(db_engine) -> None:
         assert [r.note for r in rows] == ["first", "second"]
 
 
-def test_transport_without_lj_pair_is_valid(db_engine) -> None:
+def test_transport_without_lj_pair_is_valid(db_conn) -> None:
     """A transport upload with neither sigma nor epsilon is accepted.
 
     Only the paired presence/absence of the LJ parameters is enforced;
@@ -244,7 +244,7 @@ def test_transport_without_lj_pair_is_valid(db_engine) -> None:
         epsilon_over_k_k=None,
         note="dipole-only",
     )
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         transport = persist_transport_upload(session, request)
         assert transport.sigma_angstrom is None
         assert transport.epsilon_over_k_k is None
@@ -348,7 +348,7 @@ def test_schema_rejects_duplicate_source_calculation_pairs() -> None:
         )
 
 
-def test_wrong_owner_source_calc_rejected_by_workflow_check(db_engine) -> None:
+def test_wrong_owner_source_calc_rejected_by_workflow_check(db_conn) -> None:
     """The defensive owner-consistency guard fires when a calculation's
     species_entry_id does not match the transport target.
 
@@ -357,7 +357,7 @@ def test_wrong_owner_source_calc_rejected_by_workflow_check(db_engine) -> None:
     species entry. This test exercises the defensive check directly so
     regressions in that guard are caught.
     """
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_a = resolve_species_entry(
             session, SpeciesEntryIdentityPayload(**_SPECIES_ENTRY),
         )

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -245,7 +245,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:120`
+- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:121`
   *Species-owned `opt` calculations only. Transition states are deliberately excluded, having no canonical SMILES to compare against. Best-effort by policy: a missing SMILES, a missing output geometry, unparseable coordinates or a raising chemistry layer all write nothing and let the upload continue. A Kabsch RMSD above 1.0 A against the input geometry is recorded as a separate suspicion signal.*
 
 **Escape hatch.** The whole check is advisory, so there is nothing to escape. What a consumer must not do is read a `fail` row as 'this calculation is scientifically invalid'; it means only that the automated identity validator found a mismatch.


### PR DESCRIPTION
The suite was unreliable enough that "did I break this?" was **unfalsifiable** in `tests/workflows/`. Every agent this week burned time deciding whether a failure was theirs, and several reports were hedged on it. An unreliable suite raises the noise floor above the signal.

**Tier 4 (`test-full.sh`, the whole tree, documented as required before merging): 876 failed / 85 errors → 3 failed.**

## The mechanism — evidence, not inference

`tests/workflows/` was the only tree that wrote to the session-scoped database and never took it back: ~200 sites used `with Session(db_engine) as session, session.begin():`, which **commits** on block exit.

Running `test_network_pdep_upload.py` alone with a probe test appended that dumped committed state left **183 calculations, 15 of them `type=irc` with a non-null `transition_state_entry_id`, each with exactly 1 output geometry**. The five failing computed-reaction tests locate "the" IRC calculation with an unqualified `select(...)`, get the lowest-id *leaked* row, and assert it has 2 output geometries. Deterministic and seed-independent.

`tests/workflows/` now uses the existing per-test rollback fixture. One harness change made that possible without touching test bodies: `db_conn` opens a **SAVEPOINT** around the test. Verified with a standalone SQLAlchemy 2.0.46 probe that the default `join_transaction_mode="conditional_savepoint"` resolves to `rollback_only` for a plain in-transaction Connection — so a single `session.rollback()` (every `pytest.raises` upload test) tears down the outer transaction and leaves the connection unusable. Inside a SAVEPOINT the same default resolves to `create_savepoint`, and the existing `session.begin()` idiom keeps working untouched.

**A tripwire holds it there.** `tests/workflows/conftest.py` counts rows in the tables a workflow upload writes, at setup and teardown of each test, on an AUTOCOMMIT connection. A committing test gets a teardown error naming itself and the tables it grew. Verified both directions — a deliberately committing test is blamed and its neighbour stays green; a committing services file interleaved between two workflow files accuses no one. The baseline is per-test precisely because a session-wide one would have been order-dependent itself.

## Two more leaks the first was hiding

1. **`tests/db/` downgraded the shared database and left it there.** Both migration round-trip tests run `alembic downgrade` against the per-run database *the whole process shares*, then upgrade only to their own historical `CURRENT_HEAD`. Every later migration stayed unapplied for the rest of the session — `species_entry.isotope_key does not exist`, `calc_freq_result.reaction_coordinate_mode_index does not exist`, hundreds of tests later. `pytest tests/db/ tests/workflows/test_transport_upload.py` reproduced it at 21 failed; restoring to `head` in the existing `finally` brings that pair to 2. Round-trip assertions untouched.

2. **In-process Alembic silently disabled `caplog` for the session.** `alembic/env.py` calls `logging.config.fileConfig`, which defaults to `disable_existing_loggers=True` and replaces the root handlers — including the one `caplog` reads. Five tests in three unrelated trees then asserted against an empty log. Reproduces in 3 seconds across `tests/db/`, `tests/services/` and `tests/importers/`. **Prevented** (a fixture neutralises `fileConfig` for that tree) rather than repaired, because pytest adds and removes its own root handlers per phase and restoring a setup-time snapshot would hand back a stale list. `env.py` untouched; Alembic's CLI and deployment behaviour unchanged.

## Order-independence proof

| order | base `6b8a8bd` | branch |
|---|---|---|
| alphabetical, `-p no:randomly` | 580 passed | **580 passed** |
| the failing pair, `-p no:randomly` | **5 failed** | **178 passed** |
| reverse file order | **14 failed** (5/5 runs) | **580 passed** |
| `--randomly-seed=12345` | **13 failed** | **580 passed** |
| `--randomly-seed=999` | **17 failed** | **580 passed** |
| seeds 1, 20260809, 424242 | — | **580 passed** |

`test-scientific.sh` 1979, `test-api.sh` 2464, `ruff` clean.

## Two decisions, both against my framing

**`tests/workflows/ tests/services/` is not an unsupported combination.** I suggested it might be incompatible fixture assumptions and that the fix could be a guard. Wrong: `test-full.sh` runs `pytest tests/` and `docs/testing.md` calls Tier 4 required before merging — it *is* the documented gate, and all 75 failures were the same leak. That pair is now green.

**`public_ref` ignoring `kind` is an invariant to state, not a bug to fix.** `_canonical_species` omits `kind` because `uq_species_identity` omits it too (DR-0031). Adding it to the ref alone would mint two refs for a row pair the database cannot hold; making it part of identity is a schema decision, not a ref-generation one. Nothing reachable can collide: `canonical_species_identity` admits only `molecule` and `electron`, and `check_electron_identity` binds `electron ↔ [e-] ↔ (-1, 2)` in both directions, so the electron occupies a tuple no molecule can express. Stated in the code and pinned by two executable tests.

## Product bugs found — tracked, not fixed here

- **Unstable `ORDER BY` in a public read** (`scientific_read/kinetics.py:656`) — orders by `role` alone, and the model's own comment says a role is not unique for bimolecular reactions. Two `product` rows tie, so the same GET can return `interpretation_assignments` in different orders. The sibling `_third_body_blocks` already documents the requirement it violates. **#55.**
- **`resolve_species` returns an existing row without comparing `kind`** — latent while `pseudo` is undepositable, but the first writer's kind would silently win, and `pseudo` disables elemental-balance and charge-conservation checking. **#56.**
- **The register's `file:line` anchors make the generated doc a build artifact of every file containing a check** — this PR includes the one-line regeneration that unbreaks main, but any future edit above a declaration does it again. **#57.**

## The 3 remaining Tier 4 failures

`test_identifier_lengths` (pre-existing, known); the register sync (fixed in this PR); and the `ORDER BY` flake above — intermittent at ~20% in some orders, and previously *masked* because the leak made that test fail earlier for a different reason. Not weakened to hide it.

## Also

The geometry-validation `inspect.getsource` guard is replaced with a behavioural test that calls the real function with an unstorable verdict row — verified by reverting the production wiring, where the new test fails and the old one passed.

The `record_review` isolation tests still leave rows behind, **by design**: `tckdb_reject_mutation` blocks `DELETE` and the scientific tables block `TRUNCATE`, so cleanup would require the harness to disable a production integrity guard inside the suite meant to enforce it. The per-run disposable database is the answer, and the contract is now written into `backend/docs/testing.md` — reserved id band, deltas only, never absolute counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)