### PR TITLE
Give the kinetics interpretation blocks a total order

### DIFF
--- a/backend/app/services/scientific_read/kinetics.py
+++ b/backend/app/services/scientific_read/kinetics.py
@@ -653,7 +653,16 @@ def _interpretation_blocks(session: Session, kinetics_id: int) -> list[KineticsI
         .outerjoin(ConformerGroup, ConformerGroup.id == ConformerSelection.conformer_group_id)
         .outerjoin(ConformerAssignmentScheme, ConformerAssignmentScheme.id == ConformerSelection.assignment_scheme_id)
         .where(KineticsInterpretationAssignment.kinetics_id == kinetics_id)
-        .order_by(KineticsInterpretationAssignment.role)
+        # ``subject_key`` is the tiebreaker, not decoration. The model states
+        # that "a role alone is not unique for bimolecular or higher-molecularity
+        # reactions", so ordering by role alone leaves two ``product`` rows tied
+        # and lets the same GET return these blocks in different orders between
+        # requests. Together the two columns are the primary key, so this is
+        # total. ``_third_body_blocks`` documents the same requirement.
+        .order_by(
+            KineticsInterpretationAssignment.role,
+            KineticsInterpretationAssignment.subject_key,
+        )
     ).all()
     return [
         KineticsInterpretationAssignmentBlock(


### PR DESCRIPTION
`_interpretation_blocks` (`app/services/scientific_read/kinetics.py`) ordered by `role` alone. The model says, in its own comment on the column two lines below:

> `subject_key` is `reactant:<1-based slot>`, `product:<slot>`, or `transition_state`. **A role alone is not unique for bimolecular or higher-molecularity reactions.**

So two `product` rows tie, and **the same GET can return `interpretation_assignments` in a different order between requests.**

A non-deterministic public read breaks response caching, makes diffing two fetches meaningless, and silently corrupts any client that indexes the list positionally — the failure mode that looks like a data bug and isn't.

`subject_key` completes the primary key, so ordering by both is total. `_third_body_blocks` in the same module already documents this exact requirement — *"sorted … for a deterministic read order across requests"* — so the convention existed and this was the exception.

## How it was found

While fixing the test suite's order dependence (#50). This is the cause of the one remaining intermittent Tier 4 failure — and it had been failing **all along**, but earlier and for a different reason, because the fixture leak tripped the same test first. Cleaning the noise did not create this bug; it revealed one that was indistinguishable from the churn.

## Swept the rest of the read layer

Every other single-column `order_by` in `scientific_read/` orders on a column that is unique within its filtered scope — `atom_index` per geometry, `mode_index` per freq result, `input_order`/`output_order` per calculation, and several on `id`. This was the only one ordering by a column its own model documents as non-unique.

## Verification

`pytest tests/ -k "interpretation or kinetics"` → **419 passed, 2 skipped**. No behaviour changes beyond ordering; no schema, no migration.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)