### PR TITLE
Make an atom map and its IRC mapping agree about the same saddle point

### DIFF
--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -624,7 +624,7 @@ CHECK_ATOM_MAP_ACCOUNTS_FOR_EVERY_ATOM = ScientificCheck(
 
 CHECK_ATOM_MAP_PROVENANCE_IS_DECLARED = ScientificCheck(
     group="Atom mapping across a reaction",
-    sort_key=7,
+    sort_key=8,
     code=None,
     asserts=(
         "An atom map records whether a human asserted it or an algorithm "

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -463,8 +463,11 @@ def _raise_on_partition_disagreement(
     """Compare the two partitions one side at a time, tolerating relabelling."""
 
     for role in (ReactionRole.reactant, ReactionRole.product):
+        # ``==`` rather than ``is``: ``ReactionRole`` is a ``str`` enum, so a
+        # driver handing back a bare ``'reactant'`` would compare equal and fail
+        # an identity test, silently dropping a whole leg from the comparison.
         side_claims = {
-            slot: atoms for slot, atoms in irc_claims.items() if slot[0] is role
+            slot: atoms for slot, atoms in irc_claims.items() if slot[0] == role
         }
         if not side_claims:
             continue

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -14,13 +14,24 @@ the warning is all that path can honestly offer, so it says so rather than
 telling a depositor to fill in a field that does not exist: see
 ``_PDEP_ABSENCE_REMEDY`` in :mod:`app.workflows.network_pdep`.
 
-Blocking validation is *not* here. A self-contradictory map is refused by
+Validation a map can fail *on its own* is not here. A self-contradictory map is
+refused by
 :func:`tckdb_schemas.fragments.reaction_atom_map.validate_reaction_atom_map`
 at the schema boundary — the payload already holds every XYZ block the checks
 need, so the refusal arrives as a clean 422 before anything is written — and by
 the constraints on ``reaction_atom_map_pair``, which are the same rules stated
 where a second write path cannot get around them. This module resolves keys to
 rows, writes the map, and turns what is *missing* into warnings.
+
+One blocking rule does live here, because it is the only one that cannot be
+seen from the ``atom_map`` fragment alone.
+:func:`validate_atom_map_agrees_with_irc_evidence` compares the map against the
+IRC participant mappings on ``transition_state_validation_evidence``, which the
+same deposit writes through a different surface. Those mappings partition the
+saddle-point atoms among the declared participants and the map refines that
+partition into a bijection, so the two are one claim at two resolutions and may
+not disagree. Both surfaces passed independently until this existed, and
+nothing compared them.
 
 Absence warns
 -------------
@@ -44,6 +55,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from itertools import permutations
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -54,7 +66,9 @@ from tckdb_schemas.upload_warning import UploadWarning
 from app.chemistry.geometry import normalize_element_symbol
 from app.db.models.common import AtomMapSource, ReactionRole
 from app.db.models.geometry import GeometryAtom
+from app.db.models.reaction import ReactionEntryStructureParticipant
 from app.db.models.reaction_atom_map import ReactionAtomMap, ReactionAtomMapPair
+from app.db.models.transition_state import TransitionStateValidationEvidence
 from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
 
 #: Emitted when a reaction with a transition state is deposited without a map.
@@ -66,6 +80,10 @@ SUPPLY_THE_MAP_REMEDY = (
     "If you followed the intrinsic reaction coordinate, you already have "
     "this — supply it as 'atom_map' (ADR 0011)."
 )
+
+#: Raised when a deposit's atom map and its IRC participant mapping give two
+#: different answers about which saddle-point atoms a participant is made of.
+W_ATOM_MAP_CONTRADICTS_IRC_MAPPING = "atom_map_contradicts_irc_mapping"
 
 #: Emitted when a map omits a declared participant molecule entirely.
 W_ATOM_MAP_PARTICIPANTS_INCOMPLETE = "reaction_atom_map_participants_incomplete"
@@ -106,6 +124,7 @@ def persist_reaction_atom_map(
     geometry_id_by_key: Mapping[str, int],
     field_path: str = "atom_map",
     absence_remedy: str = SUPPLY_THE_MAP_REMEDY,
+    subject_label: str = "transition state",
     created_by: int | None = None,
     warnings: list[UploadWarning] | None = None,
 ) -> ReactionAtomMap | None:
@@ -125,6 +144,8 @@ def persist_reaction_atom_map(
         this deposit path's user what to actually do. Overridden by a path
         whose payload schema has nowhere to put a map, so the warning does not
         name a field that does not exist.
+    :param subject_label: Producer-facing name of the saddle point, used by the
+        agreement check below when it has to name what it refused.
     :param warnings: Optional sink for the absence and incompleteness warnings.
     :returns: The persisted map, or ``None`` when none was supplied.
     """
@@ -250,6 +271,18 @@ def persist_reaction_atom_map(
 
     session.flush()
 
+    # Blocking, and it has to run here rather than at the wire boundary: the
+    # IRC partition lives in rows this payload's *other* surface wrote, not in
+    # the atom_map fragment. Called from both seams so the deposit order does
+    # not decide whether the contradiction is seen.
+    validate_atom_map_agrees_with_irc_evidence(
+        session,
+        reaction_entry_id=reaction_entry_id,
+        transition_state_entry_id=transition_state_entry_id,
+        subject_label=subject_label,
+        field_path=field_path,
+    )
+
     _warn_incomplete(
         warnings,
         field_path=field_path,
@@ -266,6 +299,221 @@ def persist_reaction_atom_map(
         transition_state_geometry_id=transition_state_geometry_id,
     )
     return row
+
+
+def validate_atom_map_agrees_with_irc_evidence(
+    session: Session,
+    *,
+    reaction_entry_id: int,
+    transition_state_entry_id: int | None,
+    subject_label: str = "transition state",
+    field_path: str = "atom_map",
+) -> None:
+    """Refuse two contradictory partitions of one saddle point.
+
+    ``transition_state_validation_evidence``'s participant mappings *partition*
+    the saddle-point atoms among the declared participants — "TS atoms 1,2,3
+    belong to reactant 1". An atom map says which reactant atom each of those
+    saddle-point atoms **is**. As
+    :mod:`app.db.models.reaction_atom_map` puts it, the atom map is "the
+    refinement of that partition into a bijection": they are one claim at two
+    resolutions, so a refinement that contradicts what it refines is a
+    contradiction rather than a difference of detail. Until this existed both
+    could be deposited on the same saddle point, stating incompatible
+    partitions, and each passed on its own because nothing compared them.
+
+    Reads both surfaces from the database rather than from either caller's
+    payload, so it gives the same verdict from whichever seam runs second — see
+    the ordering note on the call sites.
+
+    What is compared, and what deliberately is not
+    ----------------------------------------------
+    Only saddle-point atoms *both* surfaces speak about. The rule is a subset
+    containment per participant, not an equality, and that is what makes
+    partiality safe:
+
+    * **A partial atom map is not a contradiction.** A map covering three of a
+      molecule's five atoms, or omitting a participant altogether, simply says
+      nothing about the rest; the coverage guard next door already reports that
+      as ``reaction_atom_map_participants_incomplete`` /
+      ``reaction_atom_map_atoms_incomplete``. Absence is not disagreement.
+    * **An absent IRC mapping is not a contradiction.** The mappings are
+      optional on every path. A reaction releasing a free electron *must* omit
+      them — ``TransitionStateValidationEvidenceIn`` refuses an empty atom list
+      and ``validate_ts_evidence_set`` requires every declared participant to be
+      named, so a zero-atom participant cannot be expressed at all (recorded as
+      the divergence on ``CHECK_TS_IRC_MAPPING_ELEMENTS``). Such a deposit
+      carries a map and no partition, and must still be accepted.
+    * **A barrierless channel has neither.** Both legs of a map run toward the
+      saddle point, so a reaction with no transition state has no map to compare
+      and no evidence to compare it with.
+    * **Failed evidence is not compared.** ``passed=False`` records are skipped,
+      matching ``validate_ts_evidence_participant_composition``: a mapping that
+      does not claim to be evidence is not contradicted by anything, and
+      ``validate_ts_evidence_set`` only holds *passing* mappings to covering
+      every atom, so a failed one may be partial or exploratory by design.
+
+    Indistinguishable participants
+    ------------------------------
+    Two participants on the same side that are the same species entry are
+    interchangeable, and which one a depositor called "reactant 1" is arbitrary
+    in each surface independently. A disagreement that a permutation *within
+    such a group* would resolve is a labelling difference, not a contradiction,
+    so it is not refused. The partition itself is still checked: swapping one
+    atom between two identical methyls changes which atoms form a molecule and
+    no permutation repairs that. Symmetry *inside* one molecule never reaches
+    this check at all, because the comparison is between sets of saddle-point
+    atoms rather than between per-atom bijections.
+
+    :param reaction_entry_id: The micro reaction both surfaces describe.
+    :param transition_state_entry_id: The saddle point both surfaces describe.
+        ``None`` compares nothing.
+    :raises ValueError: If the two surfaces assign a saddle-point atom to
+        different participants.
+    """
+
+    if transition_state_entry_id is None:
+        return
+
+    atom_map_id = session.execute(
+        select(ReactionAtomMap.id).where(
+            ReactionAtomMap.reaction_entry_id == reaction_entry_id,
+            ReactionAtomMap.transition_state_entry_id == transition_state_entry_id,
+        )
+    ).scalar_one_or_none()
+    if atom_map_id is None:
+        return
+
+    evidence_rows = session.execute(
+        select(
+            TransitionStateValidationEvidence.reactant_participant_mapping,
+            TransitionStateValidationEvidence.product_participant_mapping,
+        ).where(
+            TransitionStateValidationEvidence.transition_state_entry_id
+            == transition_state_entry_id,
+            TransitionStateValidationEvidence.passed.is_(True),
+        )
+    ).all()
+    if not evidence_rows:
+        return
+
+    slot_by_participant_id: dict[int, tuple[ReactionRole, int]] = {}
+    species_by_slot: dict[tuple[ReactionRole, int], int | None] = {}
+    for participant_id, role, participant_index, species_entry_id in session.execute(
+        select(
+            ReactionEntryStructureParticipant.id,
+            ReactionEntryStructureParticipant.role,
+            ReactionEntryStructureParticipant.participant_index,
+            ReactionEntryStructureParticipant.species_entry_id,
+        ).where(
+            ReactionEntryStructureParticipant.reaction_entry_id == reaction_entry_id
+        )
+    ).all():
+        slot = (role, participant_index)
+        slot_by_participant_id[participant_id] = slot
+        species_by_slot[slot] = species_entry_id
+
+    map_claims: dict[tuple[ReactionRole, int], set[int]] = {}
+    for structure_participant_id, ts_atom_index in session.execute(
+        select(
+            ReactionAtomMapPair.structure_participant_id,
+            ReactionAtomMapPair.ts_atom_index,
+        ).where(ReactionAtomMapPair.atom_map_id == atom_map_id)
+    ).all():
+        slot = slot_by_participant_id.get(structure_participant_id)
+        if slot is None:  # pragma: no cover - composite FK already guarantees it
+            continue
+        map_claims.setdefault(slot, set()).add(ts_atom_index)
+
+    if not map_claims:  # pragma: no cover - a map with no pairs cannot be written
+        return
+
+    for reactant_mapping, product_mapping in evidence_rows:
+        if reactant_mapping is None or product_mapping is None:
+            continue
+        irc_claims: dict[tuple[ReactionRole, int], set[int]] = {}
+        for role, mapping in (
+            (ReactionRole.reactant, reactant_mapping),
+            (ReactionRole.product, product_mapping),
+        ):
+            for participant_key, atom_indices in mapping.items():
+                _, _, index_text = participant_key.partition(":")
+                try:
+                    participant_index = int(index_text)
+                except ValueError:  # pragma: no cover - shape already validated
+                    continue
+                irc_claims[(role, participant_index)] = set(atom_indices)
+        _raise_on_partition_disagreement(
+            map_claims=map_claims,
+            irc_claims=irc_claims,
+            species_by_slot=species_by_slot,
+            subject_label=subject_label,
+            field_path=field_path,
+        )
+
+
+def _raise_on_partition_disagreement(
+    *,
+    map_claims: Mapping[tuple[ReactionRole, int], set[int]],
+    irc_claims: Mapping[tuple[ReactionRole, int], set[int]],
+    species_by_slot: Mapping[tuple[ReactionRole, int], int | None],
+    subject_label: str,
+    field_path: str,
+) -> None:
+    """Compare the two partitions one side at a time, tolerating relabelling."""
+
+    for role in (ReactionRole.reactant, ReactionRole.product):
+        side_claims = {
+            slot: atoms for slot, atoms in irc_claims.items() if slot[0] is role
+        }
+        if not side_claims:
+            continue
+
+        groups: dict[int | None, list[tuple[ReactionRole, int]]] = {}
+        for slot in side_claims:
+            groups.setdefault(species_by_slot.get(slot), []).append(slot)
+
+        for slots in groups.values():
+            slots.sort()
+            mapped = [slot for slot in slots if map_claims.get(slot)]
+            if not mapped:
+                continue
+            # ``tuple(mapped)`` is itself one of these candidates, so reaching
+            # the raise below guarantees the identity assignment failed too.
+            if any(
+                all(
+                    map_claims[claimed] <= side_claims[against]
+                    for claimed, against in zip(mapped, candidate, strict=True)
+                )
+                for candidate in permutations(slots, len(mapped))
+            ):
+                continue
+
+            offender = next(
+                slot
+                for slot in mapped
+                if not map_claims[slot] <= side_claims[slot]
+            )
+            disputed = sorted(map_claims[offender] - side_claims[offender])
+            elsewhere = sorted(
+                {
+                    f"{other[0].value} {other[1]}"
+                    for other in side_claims
+                    if side_claims[other] & set(disputed)
+                }
+            )
+            raise ValueError(
+                f"Transition state '{subject_label}' {field_path} contradicts "
+                "its own IRC participant mapping: the atom map assigns "
+                f"saddle-point atom(s) {disputed} to {offender[0].value} "
+                f"{offender[1]}, which the IRC mapping assigns to "
+                f"{', '.join(elsewhere) or 'no participant'} "
+                f"({W_ATOM_MAP_CONTRADICTS_IRC_MAPPING}). An atom map is the "
+                "refinement of that partition into a bijection, so the two are "
+                "one claim about one saddle point at two resolutions and a "
+                "record cannot assert both. Correct whichever surface is wrong, "
+                "or omit one of them."
+            )
 
 
 def _element_index(
@@ -420,9 +668,80 @@ def _warn_incomplete(
         )
 
 
-CHECK_ATOM_MAP_ABSENT = ScientificCheck(
+CHECK_ATOM_MAP_AGREES_WITH_IRC_MAPPING = ScientificCheck(
     group="Atom mapping across a reaction",
     sort_key=5,
+    code=W_ATOM_MAP_CONTRADICTS_IRC_MAPPING,
+    asserts=(
+        "Where a deposit carries both an atom map and an IRC participant "
+        "mapping for the same saddle point, they agree about which "
+        "saddle-point atoms each participant is made of."
+    ),
+    tier=CheckTier.block,
+    tier_rationale=(
+        "Definitional, because the two surfaces are one claim at two "
+        "resolutions rather than two claims. An IRC participant mapping "
+        "partitions the saddle-point atoms among the declared participants; an "
+        "atom map is, in this schema's own words, 'the refinement of that "
+        "partition into a bijection'. A refinement that contradicts what it "
+        "refines is not extra detail, it is a record asserting that one saddle "
+        "point is two incompatible things at once, and no correct calculation "
+        "produces both halves of it — the depositor followed one intrinsic "
+        "reaction coordinate, not two. This is the same class of claim as "
+        "``CHECK_TS_IRC_MAPPING_ELEMENTS`` and "
+        "``CHECK_ATOM_MAP_ELEMENT_CONSERVED``, which already block, and leaving "
+        "it advisory would let the pair assert together what neither is allowed "
+        "to assert alone."
+    ),
+    adr="0011, 0008",
+    enforced_by=(
+        PythonCheck(
+            validate_atom_map_agrees_with_irc_evidence,
+            note=(
+                "Called from *both* seams — ``persist_reaction_atom_map`` and "
+                "``persist_transition_state_validation_evidence`` — and reads "
+                "both surfaces from the database rather than from either "
+                "caller's payload, so whichever a deposit writes second "
+                "delivers the same verdict. Today the second is always the "
+                "atom map: the computed-reaction bundle is the only payload "
+                "with an ``atom_map`` field and writes it after the evidence, "
+                "and no path can attach a map to a saddle point deposited "
+                "earlier because every transition-state entry is created fresh "
+                "by the deposit that writes it. Both are incidental orderings, "
+                "so neither is relied on."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Omit one surface, or correct whichever is wrong — the mappings are "
+        "optional on every path and a partial atom map is always accepted. "
+        "Three absences are deliberately *not* disagreements: an atom map that "
+        "omits a participant or leaves atoms unmapped is compared only over "
+        "what it does claim, a transition state with no passing IRC mapping is "
+        "not compared at all, and a barrierless channel has neither surface. "
+        "Two participants on one side that are the same species entry are "
+        "interchangeable, so a disagreement a permutation within that group "
+        "would resolve is treated as arbitrary labelling rather than "
+        "contradiction."
+    ),
+    divergence=(
+        "A reaction releasing a free electron is compared over its atom map "
+        "alone, and silently. ``MoleculeKind.electron`` gives a participant "
+        "with no atoms, which neither surface can express — "
+        "``TransitionStateValidationEvidenceIn`` refuses an empty atom list "
+        "and ``atom_to_ts`` carries ``min_length=1`` — so the IRC mappings must "
+        "be omitted entirely and the atom map must skip that participant. "
+        "There is therefore nothing to compare and nothing said about it, "
+        "which is correct but weaker than for every other reaction. Widening "
+        "both wire schemas to accept a zero-atom participant is the fix and is "
+        "a wire-package change with its own version bump, tracked alongside "
+        "the identical gap recorded on ``CHECK_TS_IRC_MAPPING_ELEMENTS``."
+    ),
+)
+
+CHECK_ATOM_MAP_ABSENT = ScientificCheck(
+    group="Atom mapping across a reaction",
+    sort_key=6,
     code=W_MISSING_REACTION_ATOM_MAP,
     asserts=(
         "A reaction that has a transition state should say which atom of the "
@@ -462,7 +781,7 @@ CHECK_ATOM_MAP_ABSENT = ScientificCheck(
 
 CHECK_ATOM_MAP_INCOMPLETE = ScientificCheck(
     group="Atom mapping across a reaction",
-    sort_key=6,
+    sort_key=7,
     code=(W_ATOM_MAP_PARTICIPANTS_INCOMPLETE, W_ATOM_MAP_ATOMS_INCOMPLETE),
     asserts=(
         "A supplied atom map should cover every declared participant molecule, "
@@ -497,8 +816,10 @@ CHECK_ATOM_MAP_INCOMPLETE = ScientificCheck(
 __all__ = [
     "SUPPLY_THE_MAP_REMEDY",
     "W_ATOM_MAP_ATOMS_INCOMPLETE",
+    "W_ATOM_MAP_CONTRADICTS_IRC_MAPPING",
     "W_ATOM_MAP_PARTICIPANTS_INCOMPLETE",
     "W_MISSING_REACTION_ATOM_MAP",
     "ResolvedAtomMapParticipant",
     "persist_reaction_atom_map",
+    "validate_atom_map_agrees_with_irc_evidence",
 ]

--- a/backend/app/services/transition_state_validation.py
+++ b/backend/app/services/transition_state_validation.py
@@ -25,6 +25,9 @@ from tckdb_schemas.upload_warning import UploadWarning
 
 from app.db.models.transition_state import TransitionStateValidationEvidence
 from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.services.reaction_atom_map import (
+    validate_atom_map_agrees_with_irc_evidence,
+)
 from app.services.reaction_resolution import (
     validate_ts_evidence_participant_composition,
 )
@@ -109,6 +112,24 @@ def persist_transition_state_validation_evidence(
         )
         session.add(row)
         rows.append(row)
+
+    # The same comparison the atom-map seam runs, from the other side. Whichever
+    # of the two surfaces a deposit writes second is the one that can see both,
+    # and today that is always the atom map — ``persist_computed_reaction_upload``
+    # is the only path with an ``atom_map`` field and writes it after this call,
+    # while every transition-state entry is created fresh by the deposit that
+    # writes it, so a map can never arrive for a saddle point deposited earlier.
+    # Both of those are incidental orderings a later edit could reverse, and the
+    # check reads both surfaces from the database precisely so it does not
+    # depend on either. Calling it here costs one indexed lookup that finds
+    # nothing on today's paths and removes the ordering from the contract.
+    validate_atom_map_agrees_with_irc_evidence(
+        session,
+        reaction_entry_id=reaction_entry_id,
+        transition_state_entry_id=transition_state_entry_id,
+        subject_label=subject_label,
+        field_path=field_path,
+    )
 
     if warnings is not None and not any(record.passed for record in evidence):
         warnings.append(

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -614,6 +614,11 @@ def persist_computed_reaction_upload(
             for species_key, row in structure_participants
         ],
         geometry_id_by_key=geometry_key_to_id,
+        subject_label=(
+            (request.transition_state.label or "transition state")
+            if request.transition_state is not None
+            else "transition state"
+        ),
         created_by=created_by,
         warnings=sp_energy_warnings,
     )

--- a/backend/tests/workflows/test_atom_map_irc_agreement.py
+++ b/backend/tests/workflows/test_atom_map_irc_agreement.py
@@ -1,0 +1,863 @@
+"""Two surfaces, one saddle point: the atom map and the IRC partition must agree.
+
+``transition_state_validation_evidence``'s participant mappings *partition* the
+saddle-point atoms among the declared participants — "TS atoms 1,2,3 belong to
+reactant 1". A ``reaction_atom_map`` says which reactant atom each of those
+saddle-point atoms **is**. The schema's own words are that the map is "the
+refinement of that partition into a bijection", so the two are one claim at two
+resolutions and cannot disagree about which atoms a participant is made of.
+
+They could, though. A deposit was able to carry both, stating two incompatible
+partitions of the same saddle point, and each passed on its own because nothing
+compared them. The reaction here is ``CH3 + H -> CH4``, the same bundle the rest
+of the computed-reaction workflow tests use, and the contradiction it is built
+around is deliberately invisible to every check that came before: the atom map
+says the methyl is saddle-point atoms 1-4 and the incoming hydrogen is atom 5,
+while the IRC mapping says the methyl is 1,2,3,5 and the incoming hydrogen is
+atom 4. Both are well-formed. Both partition the five atoms exactly once. Both
+give the methyl one carbon and three hydrogens, so the element check added for
+the IRC side sees nothing wrong. They still cannot both be true, and which
+hydrogen is the transferring one is the entire content of the reaction.
+
+The false-positive tests are as load-bearing as the refusal ones. ADR 0008 lets
+a check block only where no correct calculation could produce the record it
+refuses, and this is the rule most likely to get that wrong: a partial atom map,
+an absent IRC mapping, failed evidence, a barrierless channel and a reaction
+releasing a free electron are all *absences*, and absence is not disagreement.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.app_user import AppUser
+from app.db.models.reaction_atom_map import ReactionAtomMap
+from app.schemas.workflows.computed_reaction_upload import (
+    ComputedReactionUploadRequest,
+)
+from app.services.reaction_atom_map import (
+    W_ATOM_MAP_CONTRADICTS_IRC_MAPPING,
+    W_ATOM_MAP_PARTICIPANTS_INCOMPLETE,
+)
+from app.workflows.computed_reaction import persist_computed_reaction_upload
+
+_XYZ_H = "1\nH\nH 0.0 0.0 0.0"
+_XYZ_CH3 = (
+    "4\nmethyl\n"
+    "C  0.000  0.000  0.000\n"
+    "H  1.080  0.000  0.000\n"
+    "H -0.540  0.935  0.000\n"
+    "H -0.540 -0.935  0.000"
+)
+_XYZ_CH4 = (
+    "5\nmethane\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
+)
+#: Saddle point for ``CH3 + H -> CH4``: carbon, three methyl hydrogens, then
+#: the incoming hydrogen as atom 5. Every atom after the carbon is a hydrogen,
+#: which is exactly why a partition can be wrong without being wrong about
+#: elements.
+_XYZ_TS = (
+    "5\nTS for CH3 + H -> CH4\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.000  0.000  1.400"
+)
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+_USER_ID = 50_711
+
+
+@contextmanager
+def _isolated_session(db_engine) -> Iterator[Session]:
+    """Roll back everything: the workflow writes a large graph per call."""
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection, expire_on_commit=False)
+    try:
+        session.add(AppUser(id=_USER_ID, username="atom_map_irc_agreement_tests"))
+        session.flush()
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+def _species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [
+            {
+                "key": f"{key}-freq",
+                "type": "freq",
+                "geometry_key": f"{key}-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 0,
+            }
+        ],
+    }
+
+
+def _payload() -> dict:
+    """``CH3 + H -> CH4`` with its saddle point and an IRC calculation."""
+    return {
+        "species": [
+            _species("ch3", "[CH3]", 2, _XYZ_CH3),
+            _species("h", "[H]", 2, _XYZ_H),
+            _species("ch4", "C", 1, _XYZ_CH4),
+        ],
+        "reversible": True,
+        "reactant_keys": ["ch3", "h"],
+        "product_keys": ["ch4"],
+        "transition_state": {
+            "charge": 0,
+            "multiplicity": 2,
+            "geometry": {"key": "ts-geom", "xyz_text": _XYZ_TS},
+            "calculation": {
+                "key": "ts-opt",
+                "type": "opt",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "opt_converged": True,
+            },
+            "calculations": [
+                {
+                    "key": "ts-freq",
+                    "type": "freq",
+                    "geometry_key": "ts-geom",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "freq_n_imag": 1,
+                    "freq_imag_freq_cm1": -1500.0,
+                },
+                {
+                    "key": "ts-irc",
+                    "type": "irc",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                },
+            ],
+            "label": "ch3+h->ch4 TS",
+        },
+    }
+
+
+#: The map and the partition that agree: methyl is saddle-point atoms 1-4, the
+#: incoming hydrogen is atom 5, methane is all five.
+_MAP_METHYL_IS_1234 = [
+    {
+        "side": "reactant",
+        "species_key": "ch3",
+        "participant_index": 1,
+        "geometry_key": "ch3-geom",
+        "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4},
+    },
+    {
+        "side": "reactant",
+        "species_key": "h",
+        "participant_index": 2,
+        "geometry_key": "h-geom",
+        "atom_to_ts": {1: 5},
+    },
+    {
+        "side": "product",
+        "species_key": "ch4",
+        "participant_index": 1,
+        "geometry_key": "ch4-geom",
+        "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
+    },
+]
+
+_IRC_METHYL_IS_1234 = {
+    "reactant:1": [1, 2, 3, 4],
+    "reactant:2": [5],
+}
+#: The same reaction, described so that saddle-point atoms 4 and 5 swap
+#: molecules. Still a partition, still C+3H for the methyl, still passes the
+#: element check — and it says the other hydrogen is the one being transferred.
+_IRC_METHYL_IS_1235 = {
+    "reactant:1": [1, 2, 3, 5],
+    "reactant:2": [4],
+}
+_IRC_PRODUCTS = {"product:1": [1, 2, 3, 4, 5]}
+
+
+def _with_map(payload: dict, participants: list[dict]) -> dict:
+    payload["atom_map"] = {
+        "source": "declared",
+        "ts_geometry_key": "ts-geom",
+        "participants": participants,
+    }
+    return payload
+
+
+def _with_evidence(
+    payload: dict,
+    *,
+    reactants: dict | None,
+    products: dict | None,
+    passed: bool = True,
+) -> dict:
+    payload["transition_state"]["validation_evidence"] = [
+        {
+            "kind": "irc",
+            "passed": passed,
+            "rationale": "IRC descends to CH3 + H one way and CH4 the other.",
+            "source_calculation_key": "ts-irc",
+            "reactant_participant_mapping": reactants,
+            "product_participant_mapping": products,
+        }
+    ]
+    return payload
+
+
+def _upload(session: Session, payload: dict) -> dict:
+    return persist_computed_reaction_upload(
+        session,
+        ComputedReactionUploadRequest(**payload),
+        created_by=_USER_ID,
+    )
+
+
+def _codes(result: dict) -> set[str]:
+    return {warning.code for warning in result["warnings"]}
+
+
+# ---------------------------------------------------------------------------
+# The proof that matters: contradiction is refused, agreement is not
+# ---------------------------------------------------------------------------
+
+
+def test_two_contradictory_partitions_of_one_saddle_point_are_refused(
+    db_engine,
+) -> None:
+    """The gap, closed. Neither surface is wrong on its own; together they are."""
+
+    payload = _with_evidence(
+        _with_map(_payload(), _MAP_METHYL_IS_1234),
+        reactants=_IRC_METHYL_IS_1235,
+        products=_IRC_PRODUCTS,
+    )
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(session, payload)
+
+    message = str(excinfo.value)
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING in message
+    # The message has to name the atom the two surfaces fight over and both
+    # participants that claim it, or a depositor cannot act on it.
+    assert "[4]" in message
+    assert "reactant 1" in message
+    assert "reactant 2" in message
+
+
+def test_two_agreeing_partitions_of_one_saddle_point_still_deposit(
+    db_engine,
+) -> None:
+    """The other half of the proof: the check refuses only the contradiction."""
+
+    payload = _with_evidence(
+        _with_map(_payload(), _MAP_METHYL_IS_1234),
+        reactants=_IRC_METHYL_IS_1234,
+        products=_IRC_PRODUCTS,
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+
+        assert result["atom_map_id"] is not None
+        atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
+        assert atom_map is not None
+        assert (
+            atom_map.transition_state_entry_id
+            == result["transition_state_entry_id"]
+        )
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+def test_the_product_leg_is_compared_too(db_engine) -> None:
+    """Both legs run toward the saddle point, so both are checked.
+
+    Written as the dissociation ``CH4 -> CH3 + H`` rather than the recombination
+    above, because a side carrying one participant has only one possible
+    partition and cannot disagree with anything. Here the *products* are the two
+    molecules, and the same swap of saddle-point atoms 4 and 5 is a
+    contradiction on the leg the previous tests exercised from the other end.
+    """
+
+    payload = _payload()
+    payload["reactant_keys"] = ["ch4"]
+    payload["product_keys"] = ["ch3", "h"]
+    _with_map(
+        payload,
+        [
+            {
+                "side": "product",
+                "species_key": "ch3",
+                "participant_index": 1,
+                "geometry_key": "ch3-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4},
+            },
+            {
+                "side": "product",
+                "species_key": "h",
+                "participant_index": 2,
+                "geometry_key": "h-geom",
+                "atom_to_ts": {1: 5},
+            },
+            {
+                "side": "reactant",
+                "species_key": "ch4",
+                "participant_index": 1,
+                "geometry_key": "ch4-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
+            },
+        ],
+    )
+    _with_evidence(
+        payload,
+        reactants={"reactant:1": [1, 2, 3, 4, 5]},
+        products={"product:1": [1, 2, 3, 5], "product:2": [4]},
+    )
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(session, payload)
+
+    message = str(excinfo.value)
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING in message
+    assert "product 1" in message
+    assert "product 2" in message
+
+
+# ---------------------------------------------------------------------------
+# Absence is not disagreement
+# ---------------------------------------------------------------------------
+
+
+def test_a_map_with_no_irc_mapping_at_all_is_not_compared(db_engine) -> None:
+    """Evidence without participant mappings says nothing to contradict.
+
+    The mappings are optional on every path, and this is the shape a reaction
+    releasing a free electron is *forced* into — see the electron test below.
+    """
+
+    payload = _with_evidence(
+        _with_map(_payload(), _MAP_METHYL_IS_1234),
+        reactants=None,
+        products=None,
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+def test_an_irc_mapping_with_no_map_is_not_compared(db_engine) -> None:
+    """The reverse absence. Most deposits with IRC evidence carry no map."""
+
+    payload = _with_evidence(
+        _payload(),
+        reactants=_IRC_METHYL_IS_1235,
+        products=_IRC_PRODUCTS,
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+def test_failed_irc_evidence_is_not_compared(db_engine) -> None:
+    """``passed=False`` is not a claim, so nothing contradicts it.
+
+    Matching ``validate_ts_evidence_participant_composition``: a failed record
+    is stored as the negative result it is, and ``validate_ts_evidence_set``
+    never held it to covering every atom, so comparing it would refuse deposits
+    whose mappings were never asserted as evidence in the first place.
+    """
+
+    payload = _with_evidence(
+        _with_map(_payload(), _MAP_METHYL_IS_1234),
+        reactants=_IRC_METHYL_IS_1235,
+        products=_IRC_PRODUCTS,
+        passed=False,
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+def test_a_barrierless_channel_has_neither_surface(db_engine) -> None:
+    """No saddle point, so no map to compare and no partition to compare it to."""
+
+    payload = _payload()
+    payload.pop("transition_state")
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+# ---------------------------------------------------------------------------
+# A partial map is compared only over what it claims
+# ---------------------------------------------------------------------------
+
+
+def test_a_map_omitting_a_participant_is_not_a_contradiction(db_engine) -> None:
+    """The coverage guard's ``participants_incomplete`` case, under this rule.
+
+    The map covers the methyl and methane and says nothing about the incoming
+    hydrogen. A complete IRC partition names all three. Absence is not
+    disagreement, so this deposits — with the incompleteness warning it already
+    earned.
+    """
+
+    payload = _with_evidence(
+        _with_map(
+            _payload(),
+            [p for p in _MAP_METHYL_IS_1234 if p["species_key"] != "h"],
+        ),
+        reactants=_IRC_METHYL_IS_1234,
+        products=_IRC_PRODUCTS,
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+    assert W_ATOM_MAP_PARTICIPANTS_INCOMPLETE in _codes(result)
+
+
+def test_a_participant_mapping_only_some_of_its_atoms_is_not_a_contradiction(
+    db_engine,
+) -> None:
+    """The ``atoms_incomplete`` case. Three of the methyl's four atoms, agreeing."""
+
+    partial = [dict(p) for p in _MAP_METHYL_IS_1234]
+    partial[0]["atom_to_ts"] = {1: 1, 2: 2, 3: 3}
+
+    payload = _with_evidence(
+        _with_map(_payload(), partial),
+        reactants=_IRC_METHYL_IS_1234,
+        products=_IRC_PRODUCTS,
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+def test_a_partial_map_that_contradicts_what_it_does_claim_still_blocks(
+    db_engine,
+) -> None:
+    """Partiality is not immunity.
+
+    The map says nothing about three of the methyl's atoms, but it does say
+    that methyl atom 4 is saddle-point atom 5 — and the partition says
+    saddle-point atom 5 is the *other* reactant. Comparing only what is claimed
+    is what makes the earlier tests pass; it is not a way to smuggle a
+    contradiction through.
+    """
+
+    partial = [dict(p) for p in _MAP_METHYL_IS_1234]
+    partial[0]["atom_to_ts"] = {4: 5}
+    partial[1]["atom_to_ts"] = {1: 4}
+
+    payload = _with_evidence(
+        _with_map(_payload(), partial),
+        reactants=_IRC_METHYL_IS_1234,
+        products=_IRC_PRODUCTS,
+    )
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(session, payload)
+
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Order independence
+# ---------------------------------------------------------------------------
+
+
+def test_the_verdict_does_not_depend_on_which_surface_is_written_first(
+    db_engine,
+) -> None:
+    """The check reads both surfaces from the database, so either order works.
+
+    ``persist_computed_reaction_upload`` writes the evidence first and the map
+    second, so today only the atom-map seam can see both. That is an incidental
+    ordering — nothing in the schema requires it — and the check is called from
+    both seams so that reversing it cannot silently switch the rule off. Here
+    the seams run in the reverse order against the same rows, and the
+    contradiction is still refused.
+    """
+
+    from app.services.reaction_atom_map import (
+        validate_atom_map_agrees_with_irc_evidence,
+    )
+
+    payload = _with_map(_payload(), _MAP_METHYL_IS_1234)
+
+    with _isolated_session(db_engine) as session:
+        # Deposit the map with no evidence at all, which cannot block.
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+
+        # Now write the contradicting evidence against the saddle point that
+        # already carries the map — the order the workflow never produces.
+        from app.db.models.transition_state import TransitionStateValidationEvidence
+
+        session.add(
+            TransitionStateValidationEvidence(
+                transition_state_entry_id=result["transition_state_entry_id"],
+                kind="irc",
+                passed=True,
+                rationale="IRC, deposited after the map.",
+                reconstruction_calculation_id=_irc_calculation_id(session, result),
+                reactant_participant_mapping=_IRC_METHYL_IS_1235,
+                product_participant_mapping=_IRC_PRODUCTS,
+            )
+        )
+        session.flush()
+
+        with pytest.raises(ValueError) as excinfo:
+            validate_atom_map_agrees_with_irc_evidence(
+                session,
+                reaction_entry_id=result["reaction_entry_id"],
+                transition_state_entry_id=result["transition_state_entry_id"],
+            )
+
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Interchangeable participants: which identical molecule is "reactant 1"
+# ---------------------------------------------------------------------------
+
+_XYZ_C2H6 = (
+    "8\nethane\n"
+    "C  0.000  0.000  0.765\n"
+    "H  1.019  0.000  1.163\n"
+    "H -0.510  0.883  1.163\n"
+    "H -0.510 -0.883  1.163\n"
+    "C  0.000  0.000 -0.765\n"
+    "H  1.019  0.000 -1.163\n"
+    "H -0.510  0.883 -1.163\n"
+    "H -0.510 -0.883 -1.163"
+)
+_XYZ_TS_C2H6 = (
+    "8\nTS for CH3 + CH3 -> C2H6\n"
+    "C  0.000  0.000  1.100\n"
+    "H  1.030  0.000  1.450\n"
+    "H -0.515  0.892  1.450\n"
+    "H -0.515 -0.892  1.450\n"
+    "C  0.000  0.000 -1.100\n"
+    "H  1.030  0.000 -1.450\n"
+    "H -0.515  0.892 -1.450\n"
+    "H -0.515 -0.892 -1.450"
+)
+
+
+def _recombination_payload() -> dict:
+    """``CH3 + CH3 -> C2H6``: the same species twice on one side.
+
+    The shape ``reaction_atom_map_pair`` exists to keep straight — "the same
+    species may appear twice on one side and the two copies map to different
+    transition-state atoms".
+    """
+    payload = {
+        "species": [
+            _species("ch3", "[CH3]", 2, _XYZ_CH3),
+            _species("c2h6", "CC", 1, _XYZ_C2H6),
+        ],
+        "reversible": True,
+        "reactant_keys": ["ch3", "ch3"],
+        "product_keys": ["c2h6"],
+        "transition_state": {
+            "charge": 0,
+            "multiplicity": 1,
+            "geometry": {"key": "ts-geom", "xyz_text": _XYZ_TS_C2H6},
+            "calculation": {
+                "key": "ts-opt",
+                "type": "opt",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "opt_converged": True,
+            },
+            "calculations": [
+                {
+                    "key": "ts-freq",
+                    "type": "freq",
+                    "geometry_key": "ts-geom",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "freq_n_imag": 1,
+                    "freq_imag_freq_cm1": -420.0,
+                },
+                {
+                    "key": "ts-irc",
+                    "type": "irc",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                },
+            ],
+            "label": "ch3+ch3->c2h6 TS",
+        },
+    }
+    _with_map(
+        payload,
+        [
+            {
+                "side": "reactant",
+                "species_key": "ch3",
+                "participant_index": 1,
+                "geometry_key": "ch3-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4},
+            },
+            {
+                "side": "reactant",
+                "species_key": "ch3",
+                "participant_index": 2,
+                "geometry_key": "ch3-geom",
+                "atom_to_ts": {1: 5, 2: 6, 3: 7, 4: 8},
+            },
+            {
+                "side": "product",
+                "species_key": "c2h6",
+                "participant_index": 1,
+                "geometry_key": "c2h6-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8},
+            },
+        ],
+    )
+    return payload
+
+
+def test_relabelling_two_identical_participants_is_not_a_contradiction(
+    db_engine,
+) -> None:
+    """Which methyl a depositor called "reactant 1" is arbitrary in each surface.
+
+    The atom map says the first methyl is saddle-point atoms 1-4; the IRC
+    partition says it is 5-8, and the second methyl the other four. The two
+    molecules are the same species entry, so the surfaces describe the identical
+    physical partition under a different arbitrary labelling. Refusing that
+    would refuse correct science over bookkeeping, which is what ADR 0008 puts
+    out of bounds for a blocking check.
+    """
+
+    payload = _with_evidence(
+        _recombination_payload(),
+        reactants={"reactant:1": [5, 6, 7, 8], "reactant:2": [1, 2, 3, 4]},
+        products={"product:1": [1, 2, 3, 4, 5, 6, 7, 8]},
+    )
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+
+
+def test_identical_participants_do_not_buy_a_blanket_exemption(db_engine) -> None:
+    """The partition is still physical even when the labelling is not.
+
+    Here one hydrogen is swapped between the two methyls, so the IRC says atoms
+    1,2,3,6 form one molecule while the map says 1,2,3,4 do. Both surfaces still
+    give each methyl a carbon and three hydrogens, so the element check sees
+    nothing; and no relabelling of the two participants repairs it, because the
+    two descriptions genuinely disagree about which atoms are bonded together.
+    """
+
+    payload = _with_evidence(
+        _recombination_payload(),
+        reactants={"reactant:1": [1, 2, 3, 6], "reactant:2": [4, 5, 7, 8]},
+        products={"product:1": [1, 2, 3, 4, 5, 6, 7, 8]},
+    )
+
+    with _isolated_session(db_engine) as session:
+        with pytest.raises(ValueError) as excinfo:
+            _upload(session, payload)
+
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# A reaction releasing a free electron
+# ---------------------------------------------------------------------------
+
+_XYZ_OH = "2\nhydroxide\nO  0.000  0.000  0.000\nH  0.964  0.000  0.000"
+_XYZ_H2O = (
+    "3\nwater\n"
+    "O  0.000  0.000  0.000\n"
+    "H  0.958  0.000  0.000\n"
+    "H -0.240  0.927  0.000"
+)
+_XYZ_TS_AD = (
+    "3\nTS for OH- + H -> H2O + e-\n"
+    "O  0.000  0.000  0.000\n"
+    "H  0.960  0.000  0.000\n"
+    "H -0.400  1.400  0.000"
+)
+
+
+def _charged_species(
+    key: str, smiles: str, charge: int, multiplicity: int, xyz: str
+) -> dict:
+    species = _species(key, smiles, multiplicity, xyz)
+    species["species_entry"]["charge"] = charge
+    return species
+
+
+def test_a_reaction_releasing_an_electron_deposits_its_map_unopposed(
+    db_engine,
+) -> None:
+    """``OH- + H -> H2O + e-``. An absence that must not read as disagreement.
+
+    A free electron is a participant with no atoms, and *neither* surface can
+    express one: ``TransitionStateValidationEvidenceIn`` refuses an empty atom
+    list and ``validate_ts_evidence_set`` requires a passing mapping to name
+    every declared participant, so the IRC mappings have to be omitted
+    altogether; ``atom_to_ts`` carries ``min_length=1``, so the atom map has to
+    skip that participant. The deposit therefore carries a map and no partition,
+    and must still be accepted — with the incompleteness warning the electron
+    already earns it, and nothing from this rule.
+    """
+
+    payload = {
+        "species": [
+            _charged_species("oh", "[OH-]", -1, 1, _XYZ_OH),
+            _species("h", "[H]", 2, _XYZ_H),
+            _species("h2o", "O", 1, _XYZ_H2O),
+            {
+                "key": "electron",
+                "species_entry": {
+                    "molecule_kind": "electron",
+                    "smiles": "[e-]",
+                    "charge": -1,
+                    "multiplicity": 2,
+                },
+            },
+        ],
+        "reversible": False,
+        "reactant_keys": ["oh", "h"],
+        "product_keys": ["h2o", "electron"],
+        "transition_state": {
+            "charge": -1,
+            "multiplicity": 2,
+            "geometry": {"key": "ts-geom", "xyz_text": _XYZ_TS_AD},
+            "calculation": {
+                "key": "ts-opt",
+                "type": "opt",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "opt_converged": True,
+            },
+            "calculations": [
+                {
+                    "key": "ts-freq",
+                    "type": "freq",
+                    "geometry_key": "ts-geom",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "freq_n_imag": 1,
+                    "freq_imag_freq_cm1": -900.0,
+                },
+                {
+                    "key": "ts-irc",
+                    "type": "irc",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                },
+            ],
+            "label": "associative detachment TS",
+        },
+    }
+    _with_map(
+        payload,
+        [
+            {
+                "side": "reactant",
+                "species_key": "oh",
+                "participant_index": 1,
+                "geometry_key": "oh-geom",
+                "atom_to_ts": {1: 1, 2: 2},
+            },
+            {
+                "side": "reactant",
+                "species_key": "h",
+                "participant_index": 2,
+                "geometry_key": "h-geom",
+                "atom_to_ts": {1: 3},
+            },
+            {
+                "side": "product",
+                "species_key": "h2o",
+                "participant_index": 1,
+                "geometry_key": "h2o-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3},
+            },
+        ],
+    )
+    _with_evidence(payload, reactants=None, products=None)
+
+    with _isolated_session(db_engine) as session:
+        result = _upload(session, payload)
+        assert result["atom_map_id"] is not None
+    assert W_ATOM_MAP_CONTRADICTS_IRC_MAPPING not in _codes(result)
+    # The electron is the participant the map could not cover.
+    assert W_ATOM_MAP_PARTICIPANTS_INCOMPLETE in _codes(result)
+
+
+def _irc_calculation_id(session: Session, result: dict) -> int:
+    from app.db.models.calculation import Calculation
+    from app.db.models.common import CalculationType
+
+    return session.scalar(
+        select(Calculation.id).where(
+            Calculation.transition_state_entry_id
+            == result["transition_state_entry_id"],
+            Calculation.type == CalculationType.irc,
+        )
+    )

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -64,11 +64,11 @@ disagree about a line number, this one is right by construction.
 
 | Tier | Entries | Meaning |
 | --- | --- | --- |
-| `block` | 15 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
+| `block` | 16 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
 | `warn` | 8 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
 | `review` | 0 | Referred to `machine_review` under a versioned rubric. ADR 0008 puts every cross-check against external reference data here. |
 | `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
-| **total** | **28** | |
+| **total** | **29** | |
 
 ## Recorded divergences
 
@@ -78,7 +78,8 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - **[7]** The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
 - **[10]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
 - **[14]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
-- **[26]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+- **[21]** Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
+- **[27]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 ## Entries
 
@@ -259,7 +260,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:120`
+- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:121`
   *Species-owned `opt` calculations only. Transition states are deliberately excluded, having no canonical SMILES to compare against. Best-effort by policy: a missing SMILES, a missing output geometry, unparseable coordinates or a raising chemistry layer all write nothing and let the upload continue. A Kabsch RMSD above 1.0 A against the input geometry is recorded as a separate suspicion signal.*
 
 **Escape hatch.** The whole check is advisory, so there is nothing to escape. What a consumer must not do is read a `fail` row as 'this calculation is scientifically invalid'; it means only that the automated identity validator found a mismatch.
@@ -402,7 +403,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:36`
+- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:39`
   *Every path that can carry a transition state routes through this seam — the PDep bundle, the computed-reaction bundle and the standalone transition-state upload — so all three write identical rows and report an identical gap. Before the seam existed only the PDep bundle could deposit the evidence, so a TS uploaded any other way always read back as `irc: absent` even when the depositor had run one.*
 
 **Escape hatch.** None needed — the warning is the accommodation. Note the warning fires on absence of a *passing* record, so evidence that was run and failed is stored and still warns.
@@ -497,7 +498,26 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 *(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
-### 21. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
+### 21. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `atom_map_contradicts_irc_mapping` |
+| **Governing ADR** | 0011, 0008 |
+
+**Why this tier.** Definitional, because the two surfaces are one claim at two resolutions rather than two claims. An IRC participant mapping partitions the saddle-point atoms among the declared participants; an atom map is, in this schema's own words, 'the refinement of that partition into a bijection'. A refinement that contradicts what it refines is not extra detail, it is a record asserting that one saddle point is two incompatible things at once, and no correct calculation produces both halves of it — the depositor followed one intrinsic reaction coordinate, not two. This is the same class of claim as `CHECK_TS_IRC_MAPPING_ELEMENTS` and `CHECK_ATOM_MAP_ELEMENT_CONSERVED`, which already block, and leaving it advisory would let the pair assert together what neither is allowed to assert alone.
+
+**Enforced at.**
+
+- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:304`
+  *Called from *both* seams — `persist_reaction_atom_map` and `persist_transition_state_validation_evidence` — and reads both surfaces from the database rather than from either caller's payload, so whichever a deposit writes second delivers the same verdict. Today the second is always the atom map: the computed-reaction bundle is the only payload with an `atom_map` field and writes it after the evidence, and no path can attach a map to a saddle point deposited earlier because every transition-state entry is created fresh by the deposit that writes it. Both are incidental orderings, so neither is relied on.*
+
+**Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction.
+
+**Recorded divergence.** A reaction releasing a free electron is compared over its atom map alone, and silently. `MoleculeKind.electron` gives a participant with no atoms, which neither surface can express — `TransitionStateValidationEvidenceIn` refuses an empty atom list and `atom_to_ts` carries `min_length=1` — so the IRC mappings must be omitted entirely and the atom map must skip that participant. There is therefore nothing to compare and nothing said about it, which is correct but weaker than for every other reaction. Widening both wire schemas to accept a zero-atom participant is the fix and is a wire-package change with its own version bump, tracked alongside the identical gap recorded on `CHECK_TS_IRC_MAPPING_ELEMENTS`.
+
+### 22. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
 
 | Field | Value |
 | --- | --- |
@@ -509,12 +529,12 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_absent` — `backend/app/services/reaction_atom_map.py:309`
+- `_warn_absent` — `backend/app/services/reaction_atom_map.py:557`
   *A reaction with no transition state is not warned about: both legs of a map run toward the saddle point, so a barrierless channel has nothing to map onto and a warning it could never satisfy would train depositors to ignore the one that matters. The PDep bundle has no `atom_map` field yet, so on that path the warning carries a different remedy sentence rather than naming a field that does not exist.*
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
 
-### 22. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
+### 23. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
 
 | Field | Value |
 | --- | --- |
@@ -526,12 +546,12 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:340`
+- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:588`
   *Two codes from one seam: `reaction_atom_map_participants_incomplete` when a declared molecule is missing from the map entirely, `reaction_atom_map_atoms_incomplete` when a mapped participant leaves its own atoms unmapped or a leg leaves saddle-point atoms claimed by nobody.*
 
 **Escape hatch.** None.
 
-### 23. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
+### 24. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
 
 | Field | Value |
 | --- | --- |
@@ -554,7 +574,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Rate coefficients
 
-### 24. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
+### 25. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
 
 | Field | Value |
 | --- | --- |
@@ -575,7 +595,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Statistical mechanics
 
-### 25. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
+### 26. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
 
 | Field | Value |
 | --- | --- |
@@ -596,7 +616,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Pressure-dependent networks
 
-### 26. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+### 27. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 | Field | Value |
 | --- | --- |
@@ -617,7 +637,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
 
-### 27. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
+### 28. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
 
 | Field | Value |
 | --- | --- |
@@ -636,7 +656,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Reproducibility
 
-### 28. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
+### 29. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
 
 | Field | Value |
 | --- | --- |


### PR DESCRIPTION
A deposit could carry **both** a `reaction_atom_map` and `transition_state_validation_evidence` participant mappings, stating two incompatible partitions of the same saddle point, and both passed — because nothing compared them.

`app/services/reaction_atom_map.py` calls the atom map *"the refinement of that partition into a bijection"*. By its own account they are one claim at two resolutions, so a refinement contradicting what it refines is a record asserting that one saddle point is two incompatible things. The depositor followed one IRC, not two.

This is the third instance of one pattern: **two places assert the same fact and nothing reconciles them.** The first was `n_imag`, derived at upload and again at read (#107). The second was IRC mappings never element-checked against the chemistry (#110).

## Why it survived undetected

**No fixture anywhere held two partitions at all.** `test_reaction_atom_map.py` deposits maps without evidence; `test_computed_reaction_upload.py` deposits evidence without maps; the PDep path cannot carry a map. The two surfaces had **never been deposited together in the repo**. The contradiction wasn't missed by a weak test — it was unreachable by every existing test.

## Where the check runs, and why that point sees both

Called from **both** seams — `persist_reaction_atom_map` and `persist_transition_state_validation_evidence` — and it reads both surfaces **from the database**, not from either caller's payload, so whichever runs second gives the same verdict.

The current ordering is proved rather than assumed: `persist_computed_reaction_upload` is the only path with an `atom_map` field (evidence at `computed_reaction.py:525`, map at `:597`), and a map can never arrive for a saddle point deposited earlier because all three write paths construct a fresh `TransitionStateEntry` and no `existing_transition_state_entry_id` chaining field exists. Both are incidental orderings a later edit could reverse, so neither is relied on.

**Tier: block.** Definitional under ADR 0008 — same class as `CHECK_TS_IRC_MAPPING_ELEMENTS` and `CHECK_ATOM_MAP_ELEMENT_CONSERVED`, which already block.

**The rule is per-participant subset containment, not equality** — which is what makes absence safe by construction rather than by special-casing.

## The test that matters

`CH3 + H → CH4`. The map says the methyl is TS atoms 1-4 and the incoming H is atom 5. The IRC says 1,2,3,5 and atom 4. **Both are well-formed, both partition all five atoms, and both give the methyl one C and three H** — so #110's element check sees nothing wrong. The only difference is *which hydrogen transfers*, which is the entire content of the reaction.

Agreement deposits. 14 tests total, covering product-leg contradiction, absent mapping, absent map, `passed=False`, barrierless, omitted participant, partially-mapped participant, a *partial* map that contradicts what it does claim (partiality is not immunity), an electron-bearing reaction, and order-independence with the seams run in reverse.

## False positives

**Interchangeable participants** was the one real risk. Two participants on a side that are the same species entry are permutable, and which is "reactant 1" is arbitrary *in each surface independently*. A disagreement that a permutation within that group resolves is not refused. Two tests on `CH3 + CH3 → C2H6` pin both directions: a clean swap passes; a single hydrogen exchanged between the two methyls still blocks, because the partition is physical even when the numbering is not.

**Within-molecule symmetry** is immune by construction — the comparison is between *sets* of TS atoms, so permuting a methyl's three hydrogens is invisible to it.

**Electron reactions** compare nothing: a zero-atom participant is inexpressible in both surfaces. Recorded as the entry's divergence.

## Verification

Baselines on `2eb3e76`: scientific **1977**, API **2464** — both unchanged. `ruff` clean; register regenerated (29 entries, blocking 15 → 16). No model touched, so no migration.

The regeneration also corrected a pre-existing stale anchor (`geometry_validation.py:120` → `:121`) — the #57 scenario, unrelated to this change.

## Reported, now tracked

- **#58** — `transition_state_validation_evidence` never names the geometry its atom indices count into. ADR 0011 made this explicit for atom maps precisely because implicit indexing silently means the wrong atom; the evidence table never got that treatment, and both this check and #110's inherit the assumption.
- **#59** — the standalone TS upload never reports a missing atom map, contradicting both the module docstring and ADR 0011. Of three deposit paths, one can carry a map, one warns without being able to, and one does neither.
- **#50** — `test_computed_reaction_upload.py` order-dependence, confirmed pre-existing by A/B: the sibling set fails at seeds 2, 4, 6 *without* this branch's file, and all of `tests/workflows/` passes deterministically with and without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)