### PR TITLE
Let a client tell one scientific refusal from another

### DIFF
--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -5,6 +5,25 @@ The public interface is deliberately small: domain code may raise
 use :func:`error_envelope` for both new and legacy errors.  Legacy
 ``"code: message"`` details remain valid and are promoted into the additive
 top-level ``code`` field.
+
+Three ways a ``code`` can be found, in descending order of trust
+---------------------------------------------------------------
+1. **The exception says so.** A :class:`CodedValidationError` — raised
+   directly by service code, or raised inside a Pydantic validator and
+   preserved by Pydantic in ``errors()[i]["ctx"]["error"]`` — carries
+   ``.code`` as an attribute. Nothing is parsed. This is the mechanism
+   every scientific refusal uses, and the only one a new one should.
+2. **A legacy ``"code: message"`` detail**, promoted by :func:`detail_code`.
+3. **A nested ``code:`` inside a framework-generated validation message**,
+   promoted by :func:`validation_detail_code`.
+
+(2) and (3) read English, and reading English is how a code silently stops
+being reported when somebody rewords a sentence — which is exactly what had
+happened to the parenthesised convention the scientific checks used to use
+(``"... (reaction_mass_balance_failed)."``): the pattern below requires a
+colon, so those codes matched nothing and every chemistry refusal reached
+its client as the generic ``validation_error``. They are kept because
+existing details are a published surface, not because they are a good idea.
 """
 
 from __future__ import annotations
@@ -12,6 +31,8 @@ from __future__ import annotations
 import math
 import re
 from typing import Any
+
+from tckdb_schemas.coded_error import CodedValidationError
 
 _NESTED_CODE_PATTERN = re.compile(r"(?<![a-z0-9_])([a-z][a-z0-9_]*_[a-z0-9_]+): ")
 
@@ -36,20 +57,15 @@ def _json_safe(obj: Any) -> Any:
     return obj
 
 
-class CodedValueError(ValueError):
-    """A 422 domain error with a stable code and machine-readable context."""
+class CodedValueError(CodedValidationError):
+    """A 422 domain error with a stable code and machine-readable context.
 
-    def __init__(
-        self,
-        code: str,
-        detail: str,
-        *,
-        context: dict[str, Any] | None = None,
-    ) -> None:
-        self.code = code
-        self.detail = detail
-        self.context = dict(context or {})
-        super().__init__(f"{code}: {detail}")
+    The backend-side name for :class:`~tckdb_schemas.coded_error.CodedValidationError`,
+    which lives in the wire package so that a schema-level check — forbidden
+    from importing anything under ``app`` — can raise the same thing. Both
+    are caught by the same handler and reported the same way; use whichever
+    one the module you are in can import.
+    """
 
 
 def detail_code(detail: object, *, fallback: str) -> str:
@@ -66,14 +82,56 @@ def detail_code(detail: object, *, fallback: str) -> str:
     return fallback
 
 
+def _declared_codes(detail: object) -> set[str]:
+    """Codes taken from the exception object Pydantic preserved, not from prose.
+
+    A ``ValueError`` raised inside a validator reaches ``errors()`` as
+    ``{"type": "value_error", "msg": "Value error, <prose>", "ctx":
+    {"error": <the exception>}}``. When that exception is a
+    :class:`CodedValidationError` the code is an attribute of it, so the
+    code a client receives is the code the check declared — not whatever
+    survives in the sentence. This is what lets a refusal gain a code
+    without its ``detail`` moving by a single byte.
+    """
+
+    codes: set[str] = set()
+
+    def visit(value: object) -> None:
+        if isinstance(value, dict):
+            context = value.get("ctx")
+            if isinstance(context, dict):
+                error = context.get("error")
+                if isinstance(error, CodedValidationError) and error.code:
+                    codes.add(error.code)
+        elif isinstance(value, (list, tuple)):
+            for nested in value:
+                visit(nested)
+
+    visit(detail)
+    return codes
+
+
 def validation_detail_code(detail: object, *, fallback: str) -> str:
-    """Promote one unambiguous nested ``snake_case:`` validation code."""
+    """Promote one unambiguous validation code.
+
+    Prefers a code the raising exception *declared* (see
+    :func:`_declared_codes`) over one spelled inside a message.
+    """
 
     # Pydantic/FastAPI expose the independent validation failures as the
     # outer list. Even if two failures happen to carry the same embedded
     # code, promoting that code would hide the fact that the request failed
     # in more than one place.
     if isinstance(detail, (list, tuple)) and len(detail) != 1:
+        return fallback
+
+    declared = _declared_codes(detail)
+    if len(declared) == 1:
+        return declared.pop()
+    if declared:
+        # More than one distinct declared code in a single failure means the
+        # refusal is genuinely about more than one thing; naming one of them
+        # would be a lie about which.
         return fallback
 
     candidates: set[str] = set()
@@ -146,6 +204,7 @@ def reject_unsupported_filters(
 
 
 __all__ = [
+    "CodedValidationError",
     "CodedValueError",
     "detail_code",
     "error_envelope",

--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -82,19 +82,19 @@ def detail_code(detail: object, *, fallback: str) -> str:
     return fallback
 
 
-def _declared_codes(detail: object) -> set[str]:
-    """Codes taken from the exception object Pydantic preserved, not from prose.
+def _declared_errors(detail: object) -> list[CodedValidationError]:
+    """The coded exceptions Pydantic preserved inside a validation detail.
 
     A ``ValueError`` raised inside a validator reaches ``errors()`` as
     ``{"type": "value_error", "msg": "Value error, <prose>", "ctx":
     {"error": <the exception>}}``. When that exception is a
-    :class:`CodedValidationError` the code is an attribute of it, so the
-    code a client receives is the code the check declared — not whatever
-    survives in the sentence. This is what lets a refusal gain a code
-    without its ``detail`` moving by a single byte.
+    :class:`CodedValidationError` its code and context are attributes of
+    it, so what a client receives is what the check declared — not
+    whatever survives in the sentence. This is what lets a refusal gain a
+    code without its message moving by a single byte.
     """
 
-    codes: set[str] = set()
+    found: list[CodedValidationError] = []
 
     def visit(value: object) -> None:
         if isinstance(value, dict):
@@ -102,13 +102,38 @@ def _declared_codes(detail: object) -> set[str]:
             if isinstance(context, dict):
                 error = context.get("error")
                 if isinstance(error, CodedValidationError) and error.code:
-                    codes.add(error.code)
+                    found.append(error)
         elif isinstance(value, (list, tuple)):
             for nested in value:
                 visit(nested)
 
     visit(detail)
-    return codes
+    return found
+
+
+def validation_detail_context(detail: object) -> dict[str, Any]:
+    """Structured facts from the coded error behind a validation failure.
+
+    A check raised from service code hands its ``context`` straight to the
+    handler; one raised inside a Pydantic validator has it buried in the
+    error list, where the only way to find the two element counts that
+    disagreed is to parse the sentence that named them. Lifting it to the
+    envelope's own ``context`` puts both kinds of refusal in the same
+    place, which is what makes "read ``context``, never ``detail``"
+    advice a client can actually follow.
+
+    Empty unless exactly one code was promoted, for the same reason
+    :func:`validation_detail_code` falls back there: facts attached to a
+    code the envelope is not reporting would be facts about nothing.
+    """
+
+    errors = _declared_errors(detail)
+    if len({error.code for error in errors}) != 1:
+        return {}
+    merged: dict[str, Any] = {}
+    for error in errors:
+        merged.update(error.context)
+    return merged
 
 
 def validation_detail_code(detail: object, *, fallback: str) -> str:
@@ -125,7 +150,7 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
     if isinstance(detail, (list, tuple)) and len(detail) != 1:
         return fallback
 
-    declared = _declared_codes(detail)
+    declared = {error.code for error in _declared_errors(detail)}
     if len(declared) == 1:
         return declared.pop()
     if declared:
@@ -210,4 +235,5 @@ __all__ = [
     "error_envelope",
     "reject_unsupported_filters",
     "validation_detail_code",
+    "validation_detail_context",
 ]

--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -140,7 +140,7 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
     """Promote one unambiguous validation code.
 
     Prefers a code the raising exception *declared* (see
-    :func:`_declared_codes`) over one spelled inside a message.
+    :func:`_declared_errors`) over one spelled inside a message.
     """
 
     # Pydantic/FastAPI expose the independent validation failures as the

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -16,6 +16,7 @@ from app.api.error_contract import (
     CodedValidationError,
     error_envelope,
     validation_detail_code,
+    validation_detail_context,
 )
 from app.services.artifact_storage import (
     ArtifactIntegrityError,
@@ -76,6 +77,7 @@ def _value_error_handler(_request: Request, exc: ValueError) -> JSONResponse:
             code=validation_detail_code(
                 validation_detail, fallback="validation_error"
             ),
+            context=validation_detail_context(validation_detail),
             fallback_code="validation_error",
         )
     return JSONResponse(status_code=422, content=content)
@@ -93,6 +95,7 @@ def _request_validation_error_handler(
                 code=validation_detail_code(
                     details, fallback="request_validation_error"
                 ),
+                context=validation_detail_context(details),
                 fallback_code="request_validation_error",
             )
         ),

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound, OperationalError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.api.error_contract import (
-    CodedValueError,
+    CodedValidationError,
     error_envelope,
     validation_detail_code,
 )
@@ -58,7 +58,9 @@ class DataIntegrityError(Exception):
 
 
 def _value_error_handler(_request: Request, exc: ValueError) -> JSONResponse:
-    if isinstance(exc, CodedValueError):
+    # ``CodedValueError`` is the backend subclass; a wire-schema check raises
+    # the base directly, because ``tckdb_schemas`` may not import ``app``.
+    if isinstance(exc, CodedValidationError):
         content = error_envelope(
             str(exc),
             code=exc.code,

--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -8,13 +8,23 @@ from rdkit import Chem
 from rdkit.Chem import AllChem, inchi, rdDetermineBonds
 from tckdb_schemas.fragments.identity import ELECTRON_SMILES
 
+from app.api.error_contract import CodedValueError
 from app.chemistry.geometry import resolve_element_symbol
 from app.chemistry.isotopes import normalize_isotope, validate_isotope
 from app.db.models.common import MoleculeKind, StereoKind
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
 
 logger = logging.getLogger(__name__)
+
+#: Raised when a species entry's declared charge is not the formal charge of
+#: its own SMILES.
+W_SPECIES_SMILES_CHARGE_MISMATCH = "species_smiles_charge_mismatch"
 
 #: The value stored in ``species.inchi_key`` for the free electron.
 #:
@@ -567,8 +577,14 @@ def canonical_species_identity(
     charge = formal_charge(ident)
 
     if charge != payload.charge:
-        raise ValueError(
-            f"species_entry.charge={payload.charge} does not match SMILES charge {charge}"
+        raise CodedValueError(
+            W_SPECIES_SMILES_CHARGE_MISMATCH,
+            f"species_entry.charge={payload.charge} does not match SMILES charge {charge}",
+            context={
+                "declared_charge": payload.charge,
+                "smiles_charge": charge,
+            },
+            message_prefix=False,
         )
 
     bare = strip_isotopes(ident)
@@ -580,12 +596,13 @@ def canonical_species_identity(
 CHECK_SMILES_CHARGE_MATCHES_DECLARED = ScientificCheck(
     group="A structure against its own label",
     sort_key=3,
-    code=None,
+    code=W_SPECIES_SMILES_CHARGE_MISMATCH,
     asserts=(
         "A species entry's declared charge equals the summed formal charge of "
         "its own SMILES."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional, and the anchor the reaction-level charge law stands on: "
         "``validate_reaction_charge_conservation`` sums ``Species.charge`` and "
@@ -596,7 +613,6 @@ CHECK_SMILES_CHARGE_MATCHES_DECLARED = ScientificCheck(
         "not re-check charge."
     ),
     adr="0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(
             canonical_species_identity,

--- a/backend/app/chemistry/units.py
+++ b/backend/app/chemistry/units.py
@@ -1,7 +1,20 @@
 """Unit conversion utilities for scientific quantities."""
 
+from app.api.error_contract import CodedValueError
 from app.db.models.common import ActivationEnergyUnits, ArrheniusAUnits
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
+
+#: Raised when an Arrhenius A carries units of the wrong dimensionality for
+#: the reaction order it is declared at.
+W_ARRHENIUS_A_UNITS_MISMATCH = "arrhenius_a_units_molecularity_mismatch"
+
+#: Raised when a molecularity outside 1..3 is asked for.
+W_UNSUPPORTED_MOLECULARITY = "unsupported_reaction_molecularity"
 
 # 1 cal = 4.184 J (thermochemical calorie)
 _CAL_TO_J = 4.184
@@ -58,24 +71,34 @@ def validate_a_units_for_molecularity(
     """
     allowed = _A_UNITS_BY_ORDER.get(molecularity)
     if allowed is None:
-        raise ValueError(
+        raise CodedValueError(
+            W_UNSUPPORTED_MOLECULARITY,
             f"Unsupported reaction molecularity: {molecularity}. "
-            "Expected 1 (unimolecular), 2 (bimolecular), or 3 (termolecular)."
+            "Expected 1 (unimolecular), 2 (bimolecular), or 3 (termolecular).",
+            context={"molecularity": molecularity},
+            message_prefix=False,
         )
     if a_units not in allowed:
         order_label = {1: "unimolecular", 2: "bimolecular", 3: "termolecular"}
         allowed_names = sorted(u.value for u in allowed)
-        raise ValueError(
+        raise CodedValueError(
+            W_ARRHENIUS_A_UNITS_MISMATCH,
             f"a_units '{a_units.value}' is incompatible with "
             f"{order_label[molecularity]} reaction (molecularity={molecularity}). "
-            f"Expected one of: {allowed_names}."
+            f"Expected one of: {allowed_names}.",
+            context={
+                "a_units": a_units.value,
+                "molecularity": molecularity,
+                "expected": allowed_names,
+            },
+            message_prefix=False,
         )
 
 
 CHECK_ARRHENIUS_A_UNITS_MATCH_MOLECULARITY = ScientificCheck(
     group="Rate coefficients",
     sort_key=1,
-    code=None,
+    code=W_ARRHENIUS_A_UNITS_MISMATCH,
     asserts=(
         "An Arrhenius pre-exponential factor carries units of the "
         "dimensionality its reaction order requires — per-second for "
@@ -83,6 +106,7 @@ CHECK_ARRHENIUS_A_UNITS_MATCH_MOLECULARITY = ScientificCheck(
         "concentration^-2 time^-1 for termolecular."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. The dimensionality of A follows from the rate law, so "
         "an A in cm3/mol/s on a unimolecular reaction is not an unusual result "
@@ -91,7 +115,6 @@ CHECK_ARRHENIUS_A_UNITS_MATCH_MOLECULARITY = ScientificCheck(
         "stack can recover the intended order from the value alone."
     ),
     adr="0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(
             validate_a_units_for_molecularity,

--- a/backend/app/scientific_checks/__init__.py
+++ b/backend/app/scientific_checks/__init__.py
@@ -144,6 +144,55 @@ class CheckTier(str, Enum):
     structural = "structural"
 
 
+class CodeChannel(str, Enum):
+    """Where a check's code actually surfaces to a client.
+
+    ``code`` alone was never enough. An entry could name a code that
+    nothing carried anywhere a consumer could read it, and for eleven of
+    the register's entries — and, more quietly, for *every* blocking
+    chemistry check — that is exactly what had happened: the code was
+    spelled inside an English sentence, ``"Reaction is not
+    element-balanced (reaction_mass_balance_failed)."``, and the response
+    body's own ``code`` field said ``validation_error``. Reading the
+    register you would have concluded a client could branch on mass
+    balance. It could not.
+
+    Naming the channel is what makes that checkable. The guards in
+    ``backend/tests/db/test_scientific_check_register.py`` hold each
+    channel to its own obligation, so "declared but unreachable" fails CI
+    instead of being found by reading.
+    """
+
+    #: The ``code`` field of the 422 error envelope, carried there by a
+    #: :class:`~tckdb_schemas.coded_error.CodedValidationError`. Guarded
+    #: twice: the enforcing module must construct the coded error with
+    #: this code, and an end-to-end test must assert the code arrives in
+    #: an HTTP response body.
+    error_envelope = "error_envelope"
+
+    #: The ``code`` field of an
+    #: :class:`~tckdb_schemas.upload_warning.UploadWarning` returned
+    #: alongside a *successful* upload. The warn tier's surface; it has
+    #: been machine-readable since the class was written.
+    upload_warning = "upload_warning"
+
+    #: A read-time label — a ``HardFailReason`` from the trust evaluator.
+    #: Reaches a consumer through the trust payload of a record, not
+    #: through any request that could have been refused.
+    trust_label = "trust_label"
+
+    #: Enforced only by PostgreSQL, so the refusal arrives through the
+    #: integrity handler as a 409 whose code names the SQLSTATE class
+    #: (``state_conflict`` and friends) rather than the scientific claim.
+    #: An honest "the client is told *something*, but not which check".
+    database_constraint = "database_constraint"
+
+    #: No machine-readable code reaches anybody. Recorded rather than
+    #: papered over: an entry declaring no code must also declare that
+    #: nothing carries one.
+    none = "none"
+
+
 # ---------------------------------------------------------------------------
 # Where a check is enforced
 # ---------------------------------------------------------------------------
@@ -372,6 +421,10 @@ class ScientificCheck:
         declaration sits in the same file, and renaming a
         ``tckdb_schemas`` code fails it from across the package
         boundary.
+    :param channel: Where the code surfaces to a client — see
+        :class:`CodeChannel`. Must be :attr:`CodeChannel.none` exactly
+        when the entry declares no code, so "this check has a code" and
+        "a client can act on it" can never drift apart again.
     :param divergence: A recorded disagreement between the check's
         documentation and its behaviour. Reported, never silently fixed.
     :param thresholds: The numeric lines the check fires on, each
@@ -391,6 +444,7 @@ class ScientificCheck:
     enforced_by: tuple[Enforcement, ...]
     escape_hatch: str | None = None
     emitted: bool = True
+    channel: CodeChannel = CodeChannel.none
     divergence: str | None = None
     thresholds: tuple[Threshold, ...] = ()
     group: str = "Uncategorised"
@@ -411,6 +465,14 @@ class ScientificCheck:
                 f"ScientificCheck({self.code!r}) declares no enforcement site; "
                 "an entry that names no code, constraint or position cannot be "
                 "drift-guarded and is a comment, not a register entry."
+            )
+        if bool(self.codes) != (self.channel is not CodeChannel.none):
+            raise ValueError(
+                f"ScientificCheck({self.code!r}) declares "
+                f"{len(self.codes)} code(s) and channel={self.channel.value}. "
+                "A code with no channel is a code nothing carries, and a "
+                "channel with no code is a channel carrying nothing; the "
+                "register must not be able to say either."
             )
 
 
@@ -449,6 +511,7 @@ def collect_registered_checks(modules: tuple[ModuleType, ...]) -> list[Scientifi
 
 __all__ = [
     "CheckTier",
+    "CodeChannel",
     "ConstantThreshold",
     "DatabaseConstraint",
     "DesignPosition",

--- a/backend/app/scientific_checks/__init__.py
+++ b/backend/app/scientific_checks/__init__.py
@@ -14,7 +14,11 @@ Nothing in the code distinguishes the two populations. A generator
 cannot tell :func:`validate_reaction_charge_conservation` from
 ``max_length=64`` by inspection, and the machine-readable codes the
 scientific checks emit — ``reaction_mass_balance_failed`` and the rest —
-live inside f-string message bodies, discoverable only by reading. The
+used to live inside f-string message bodies, discoverable only by reading
+and reportable to nobody. They now travel as attributes of the exception
+that carries the refusal, which is a change this package forced: the
+register asked "which checks emit a code?" and the honest answer, once
+somebody looked, was "none of them, to any consumer". The
 earlier hand-written audit at ``docs/reviews/validation_check_audit.md``
 hit exactly this wall: it covers the Pydantic tier only, and every
 conservation law in the database is absent from it.
@@ -41,11 +45,17 @@ the check it describes::
         asserts="The reactant and product sides of a reaction contain "
                 "the same number of atoms of every element.",
         tier=CheckTier.block,
+        channel=CodeChannel.error_envelope,
         tier_rationale="...",
         adr="0008",
         enforced_by=(PythonCheck(validate_reaction_elemental_balance),),
         escape_hatch="...",
     )
+
+A check that declares a code must raise it, not spell it — the code goes
+to :class:`~tckdb_schemas.coded_error.CodedValidationError` as its first
+argument, and ``message_prefix=False`` where an existing message must not
+move. A code written only into the sentence reaches no client.
 
 then add the module to ``_DECLARING_MODULES`` in :mod:`.declarations`
 (a guard test fails if you forget). Regenerate the register document
@@ -80,6 +90,18 @@ What the drift guard enforces
   trusted as a string;
 * every code declared as ``emitted=True`` appears verbatim in the
   source of the function said to emit it;
+* every entry declares a :class:`CodeChannel`, and a code and a channel
+  imply each other — a blocking check enforced from Python must reach
+  the error envelope, because a refusal a client cannot identify is a
+  refusal it has to string-match English to understand;
+* every ``error_envelope`` code is passed as the *first argument* of a
+  ``CodedValidationError`` in a module that defines an enforcing
+  function, which is what separates a code the module reports from a
+  code it merely mentions inside a sentence;
+* every ``error_envelope`` code is named by an end-to-end test that
+  asserts it against a real HTTP response body, because none of the
+  above proves it survives Pydantic, the exception handler and the JSON
+  encoder — and that path is exactly where the codes were being lost;
 * every file in the repository containing ``ScientificCheck(`` is
   listed in ``_DECLARING_MODULES``;
 * every :class:`ProvenanceThreshold` resolves to a real callable, and

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -60,6 +60,7 @@ from app.chemistry import species as chemistry_species
 from app.chemistry import units as chemistry_units
 from app.scientific_checks import (
     CheckTier,
+    CodeChannel,
     ConstantThreshold,
     DatabaseConstraint,
     DesignPosition,
@@ -162,6 +163,7 @@ CHECK_TRANSITION_STATE_REACTION_COORDINATE = ScientificCheck(
         "undeclared mode is stiff enough to make that designation meaningless."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional, and narrower than what it replaced. ADR 0008's worked "
         "example was ``n_imag == 1``; ADR 0012 retired that, because "
@@ -235,6 +237,7 @@ CHECK_MINIMUM_ZERO_IMAGINARY_MODES = ScientificCheck(
         "modes."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. A covalently bound minimum whose own frequency "
         "evidence reports an imaginary mode is mislabelled: the correct "
@@ -278,6 +281,7 @@ CHECK_VDW_COMPLEX_IMAGINARY_MODE = ScientificCheck(
         "reaction coordinate."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "The carve-out is the scientific content. A van der Waals complex is "
         "held together by intermolecular forces and its stretch, bends and "
@@ -323,6 +327,7 @@ CHECK_TRANSITION_STATE_EXTRA_IMAGINARY_MODES = ScientificCheck(
         "protocol that produced them, not by counting them."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "The extra modes cannot be classified from the frequency list, so "
         "refusing the deposit would assert a determination the deposit does "
@@ -388,6 +393,7 @@ CHECK_TRANSITION_STATE_SOFT_REACTION_COORDINATE = ScientificCheck(
         f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm-1 in magnitude."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "ADR 0008's worked counter-example, and the sharpest statement of the "
         "whole rule. A very soft imaginary mode is suspicious — often an "
@@ -453,18 +459,18 @@ _ATOM_MAP_DUAL_ENFORCEMENT = (
 CHECK_ATOM_MAP_ELEMENT_CONSERVED = ScientificCheck(
     group="Atom mapping across a reaction",
     sort_key=1,
-    code=None,
+    code=wire_atom_map.W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
     asserts=(
         "An atom does not change element on the way across a reaction: carbon "
         "does not map onto nitrogen."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. A map asserting that an element transmutes is a record "
         "that cannot be what it says it is, not an unusual result."
     ),
     adr="0011, 0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(wire_atom_map.validate_reaction_atom_map, note=_ATOM_MAP_DUAL_ENFORCEMENT),
         DatabaseConstraint(
@@ -489,18 +495,18 @@ CHECK_ATOM_MAP_ELEMENT_CONSERVED = ScientificCheck(
 CHECK_ATOM_MAP_IS_A_BIJECTION = ScientificCheck(
     group="Atom mapping across a reaction",
     sort_key=2,
-    code=None,
+    code=wire_atom_map.W_ATOM_MAP_NOT_A_BIJECTION,
     asserts=(
         "One saddle-point atom is claimed by exactly one atom of each leg, and "
         "one participant atom maps to exactly one saddle-point atom."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. A map is a bijection or it is not a map; an atom "
         "claimed twice describes no mechanism at all."
     ),
     adr="0011, 0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(wire_atom_map.validate_reaction_atom_map, note=_ATOM_MAP_DUAL_ENFORCEMENT),
         DatabaseConstraint(
@@ -528,13 +534,14 @@ CHECK_ATOM_MAP_IS_A_BIJECTION = ScientificCheck(
 CHECK_ATOM_MAP_INDICES_ARE_GEOMETRY_RELATIVE = ScientificCheck(
     group="Atom mapping across a reaction",
     sort_key=3,
-    code=None,
+    code=wire_atom_map.W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
     asserts=(
         "Every atom index in a map is counted against a named geometry that "
         "the participant actually owns, and names an atom that geometry "
         "actually has."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional, and it is where ADR 0011's central choice is cashed "
         "out. Atom indices are not a property of a species — "
@@ -545,7 +552,6 @@ CHECK_ATOM_MAP_INDICES_ARE_GEOMETRY_RELATIVE = ScientificCheck(
         "was chosen to make impossible."
     ),
     adr="0011, 0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(wire_atom_map.validate_reaction_atom_map, note=_ATOM_MAP_DUAL_ENFORCEMENT),
         DatabaseConstraint(
@@ -591,13 +597,14 @@ CHECK_ATOM_MAP_INDICES_ARE_GEOMETRY_RELATIVE = ScientificCheck(
 CHECK_ATOM_MAP_ACCOUNTS_FOR_EVERY_ATOM = ScientificCheck(
     group="Atom mapping across a reaction",
     sort_key=4,
-    code=None,
+    code=wire_atom_map.W_ATOM_MAP_ATOMS_UNACCOUNTED_FOR,
     asserts=(
         "When a map covers every declared participant of an atom-balanced "
         "reaction, both legs claim the same saddle-point atoms and no "
         "saddle-point atom is left unclaimed."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional, but only under a precondition that has to be checked "
         "first. A reactant atom unaccounted for in the products is a "
@@ -609,7 +616,6 @@ CHECK_ATOM_MAP_ACCOUNTS_FOR_EVERY_ATOM = ScientificCheck(
         "otherwise."
     ),
     adr="0011, 0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(
             wire_atom_map.validate_reaction_atom_map,
@@ -630,13 +636,14 @@ CHECK_ATOM_MAP_ACCOUNTS_FOR_EVERY_ATOM = ScientificCheck(
 CHECK_ATOM_MAP_PROVENANCE_IS_DECLARED = ScientificCheck(
     group="Atom mapping across a reaction",
     sort_key=8,
-    code=None,
+    code=wire_atom_map.W_ATOM_MAP_INFERRED_REQUIRES_NOTE,
     asserts=(
         "An atom map records whether a human asserted it or an algorithm "
         "produced it, an inferred map names the algorithm, and neither "
         "attribution can be relabelled afterwards."
     ),
     tier=CheckTier.structural,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Not a runtime check but a shape. ADR 0011 permits inference only as "
         "a labelled and separable thing, because an atom map is a scientific "
@@ -649,8 +656,19 @@ CHECK_ATOM_MAP_PROVENANCE_IS_DECLARED = ScientificCheck(
         "and a CHECK cannot read ``OLD``."
     ),
     adr="0011",
-    emitted=False,
     enforced_by=(
+        PythonCheck(
+            wire_atom_map.ReactionAtomMapIn.validate_inferred_names_its_algorithm,
+            note=(
+                "The wire half of the rule, and it was missing from this entry "
+                "until the codes were audited: the register listed only the two "
+                "schema objects, so it read as enforced by the database alone "
+                "when in fact an inferred map with no note is refused at the "
+                "payload boundary first. Only the note half is stated here — "
+                "the immutability of ``source`` is a statement about an UPDATE, "
+                "which no payload validator can see."
+            ),
+        ),
         DatabaseConstraint(
             table="reaction_atom_map",
             name="ck_reaction_atom_map_inferred_requires_note",
@@ -693,6 +711,7 @@ CHECK_NETWORK_SOLVE_KIND_EVIDENCE = ScientificCheck(
         "cite the publication it was transcribed from."
     ),
     tier=CheckTier.structural,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "The blocking half is definitional: a computed solve with *zero* state "
         "energies contradicts its own kind, and a reported solve with no "
@@ -759,6 +778,7 @@ CHECK_ENERGY_TRANSFER_SCOPE = ScientificCheck(
         "network."
     ),
     tier=CheckTier.structural,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "A network-wide ⟨ΔE⟩down is correct, common, published science — "
         "Arkane, RMG and MESS inputs routinely specify a single "
@@ -813,6 +833,7 @@ CHECK_STATMECH_HAS_EXACTLY_ONE_SUBJECT = ScientificCheck(
         "or a transition-state entry, never both and never neither."
     ),
     tier=CheckTier.structural,
+    channel=CodeChannel.none,
     tier_rationale=(
         "A modelling position rather than an arithmetic bound. Canonical "
         "transition state theory needs the saddle point's own partition "
@@ -850,6 +871,7 @@ CHECK_STORED_ARTIFACT_BYTES_MATCH_THEIR_DIGEST = ScientificCheck(
         "as such at read time rather than graded as if it were intact."
     ),
     tier=CheckTier.label,
+    channel=CodeChannel.trust_label,
     tier_rationale=(
         "It cannot block, because the fact does not exist at upload: the "
         "artifact hashed correctly when it was accepted, and the break "
@@ -954,6 +976,7 @@ CHECK_REPRODUCIBILITY_IS_ITS_OWN_JUDGEMENT = ScientificCheck(
         "disagree."
     ),
     tier=CheckTier.structural,
+    channel=CodeChannel.none,
     tier_rationale=(
         "Not a check that fires but a position about what may never be "
         "collapsed into a single verdict. Reproducibility is graded under "

--- a/backend/app/services/calculation_resolution.py
+++ b/backend/app/services/calculation_resolution.py
@@ -1439,7 +1439,15 @@ def persist_additional_calculations(
     """
 
     results: list[Calculation] = []
-    for calc_upload in additional_uploads:
+    for position, calc_upload in enumerate(additional_uploads):
+        # The label names the calculation's position in the payload the
+        # caller sent, not its row id. A primary key is an internal handle
+        # the caller cannot use, cannot verify, and did not ask for; the
+        # index is the only identifier that means anything on their side of
+        # the request.
+        upload_label = (
+            f"additional_calculations[{position}] (type='{calc_upload.type.value}')"
+        )
         child_calc = resolve_and_persist_calculation_with_results(
             session,
             calc_upload,
@@ -1458,10 +1466,7 @@ def persist_additional_calculations(
             calc=child_calc,
             explicit_output_geometries=calc_upload.output_geometries,
             fallback_geometry_id=geometry_id,
-            context=(
-                f"additional calculation (type='{calc_upload.type.value}', "
-                f"id={child_calc.id})"
-            ),
+            context=upload_label,
         )
 
         attach_calculation_input_geometries(
@@ -1469,10 +1474,7 @@ def persist_additional_calculations(
             calc=child_calc,
             explicit_input_geometries=calc_upload.input_geometries,
             fallback_geometry_id=geometry_id,
-            context=(
-                f"additional calculation (type='{calc_upload.type.value}', "
-                f"id={child_calc.id})"
-            ),
+            context=upload_label,
         )
 
         dep_role = _DEPENDENCY_ROLE_FOR_TYPE.get(calc_upload.type)

--- a/backend/app/services/charge_multiplicity_reconciliation.py
+++ b/backend/app/services/charge_multiplicity_reconciliation.py
@@ -46,7 +46,12 @@ from enum import Enum
 
 from tckdb_schemas.upload_warning import UploadWarning
 
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
 from app.services.ess_software_detection import SoftwareName, detect_software_from_text
 
 #: Emitted when the declared charge and the log's charge disagree.
@@ -323,6 +328,7 @@ CHECK_CHARGE_MULTIPLICITY_VS_LOG = ScientificCheck(
         "at."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "**Placed against the ADR's own reasoning, deliberately.** ADR 0008 "
         "names both findings as direct contradictions between a declaration "

--- a/backend/app/services/geometry_validation.py
+++ b/backend/app/services/geometry_validation.py
@@ -94,7 +94,12 @@ from app.db.models.common import (
 )
 from app.db.models.geometry import Geometry
 from app.schemas.fragments.geometry import GeometryPayload
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
 from app.services.best_effort import isolated_best_effort
 
 logger = logging.getLogger(__name__)
@@ -411,6 +416,7 @@ CHECK_OPT_GEOMETRY_MATCHES_DECLARED_SPECIES = ScientificCheck(
         "declared for — the optimiser handed back the molecule it was given."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.none,
     tier_rationale=(
         "An expectation, and correctly non-blocking. An optimisation that "
         "rearranged, dissociated or transferred a proton is science to record, "

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -60,7 +60,13 @@ from itertools import permutations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from tckdb_schemas.enums import ReactionRole as WireReactionRole
-from tckdb_schemas.fragments.reaction_atom_map import ReactionAtomMapIn
+from tckdb_schemas.fragments.reaction_atom_map import (
+    W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
+    W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
+    W_ATOM_MAP_PARTICIPANT_NOT_DECLARED,
+    W_ATOM_MAP_WITHOUT_TRANSITION_STATE,
+    ReactionAtomMapIn,
+)
 from tckdb_schemas.upload_warning import UploadWarning
 
 from app.api.error_contract import CodedValueError
@@ -169,10 +175,13 @@ def persist_reaction_atom_map(
         # The schema layer refuses this; repeated here because this seam is
         # callable from any path and a map with no saddle point to run toward
         # is not a map.
-        raise ValueError(
+        raise CodedValueError(
+            W_ATOM_MAP_WITHOUT_TRANSITION_STATE,
             f"{field_path} was supplied for a reaction with no transition "
             "state. Both legs of an atom map run toward the saddle point "
-            "(ADR 0011)."
+            "(ADR 0011).",
+            context={"field_path": field_path},
+            message_prefix=False,
         )
 
     row = ReactionAtomMap(
@@ -196,9 +205,12 @@ def persist_reaction_atom_map(
     for mapping in atom_map.participants:
         geometry_id = geometry_id_by_key.get(mapping.geometry_key)
         if geometry_id is None:
-            raise ValueError(
+            raise CodedValueError(
+                W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                 f"{field_path} names geometry '{mapping.geometry_key}', which "
-                "this deposit does not define."
+                "this deposit does not define.",
+                context={"geometry_key": mapping.geometry_key},
+                message_prefix=False,
             )
         geometry_ids.add(geometry_id)
 
@@ -215,28 +227,43 @@ def persist_reaction_atom_map(
         slot = (side, mapping.participant_index)
         participant = participant_by_slot.get(slot)
         if participant is None:
-            raise ValueError(
+            raise CodedValueError(
+                W_ATOM_MAP_PARTICIPANT_NOT_DECLARED,
                 f"{field_path} names {side.value} {mapping.participant_index}, "
-                "which this reaction does not declare."
+                "which this reaction does not declare.",
+                context={
+                    "side": side.value,
+                    "participant_index": mapping.participant_index,
+                },
+                message_prefix=False,
             )
         geometry_id = geometry_id_by_key[mapping.geometry_key]
 
         for atom_index, ts_atom_index in sorted(mapping.atom_to_ts.items()):
             element = element_by_atom.get((geometry_id, atom_index))
             if element is None:
-                raise ValueError(
+                raise CodedValueError(
+                    W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                     f"{field_path} maps atom {atom_index} of {side.value} "
                     f"{mapping.participant_index}, which geometry "
-                    f"'{mapping.geometry_key}' does not have."
+                    f"'{mapping.geometry_key}' does not have.",
+                    context={
+                        "atom_index": atom_index,
+                        "geometry_key": mapping.geometry_key,
+                    },
+                    message_prefix=False,
                 )
             ts_element = element_by_atom.get(
                 (transition_state_geometry_id, ts_atom_index)
             )
             if ts_element is None:
-                raise ValueError(
+                raise CodedValueError(
+                    W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                     f"{field_path} maps onto transition-state atom "
                     f"{ts_atom_index}, which the saddle-point geometry does "
-                    "not have."
+                    "not have.",
+                    context={"ts_atom_index": ts_atom_index},
+                    message_prefix=False,
                 )
             # Compared normalised, stored raw. The two ends quote two
             # geometries, each of which stores the element symbol its own XYZ
@@ -248,12 +275,20 @@ def persist_reaction_atom_map(
             if normalize_element_symbol(element) != normalize_element_symbol(
                 ts_element
             ):
-                raise ValueError(
+                raise CodedValueError(
+                    W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
                     f"{field_path} maps atom {atom_index} of {side.value} "
                     f"{mapping.participant_index}, which is {element}, onto "
                     f"transition-state atom {ts_atom_index}, which is "
                     f"{ts_element}. An element does not change across a "
-                    "reaction."
+                    "reaction.",
+                    context={
+                        "atom_index": atom_index,
+                        "element": element,
+                        "ts_atom_index": ts_atom_index,
+                        "ts_element": ts_element,
+                    },
+                    message_prefix=False,
                 )
             session.add(
                 ReactionAtomMapPair(

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -63,13 +63,19 @@ from tckdb_schemas.enums import ReactionRole as WireReactionRole
 from tckdb_schemas.fragments.reaction_atom_map import ReactionAtomMapIn
 from tckdb_schemas.upload_warning import UploadWarning
 
+from app.api.error_contract import CodedValueError
 from app.chemistry.geometry import normalize_element_symbol
 from app.db.models.common import AtomMapSource, ReactionRole
 from app.db.models.geometry import GeometryAtom
 from app.db.models.reaction import ReactionEntryStructureParticipant
 from app.db.models.reaction_atom_map import ReactionAtomMap, ReactionAtomMapPair
 from app.db.models.transition_state import TransitionStateValidationEvidence
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
 
 #: Emitted when a reaction with a transition state is deposited without a map.
 W_MISSING_REACTION_ATOM_MAP = "reaction_atom_map_absent"
@@ -505,7 +511,8 @@ def _raise_on_partition_disagreement(
                     if side_claims[other] & set(disputed)
                 }
             )
-            raise ValueError(
+            raise CodedValueError(
+                W_ATOM_MAP_CONTRADICTS_IRC_MAPPING,
                 f"Transition state '{subject_label}' {field_path} contradicts "
                 "its own IRC participant mapping: the atom map assigns "
                 f"saddle-point atom(s) {disputed} to {offender[0].value} "
@@ -515,7 +522,13 @@ def _raise_on_partition_disagreement(
                 "refinement of that partition into a bijection, so the two are "
                 "one claim about one saddle point at two resolutions and a "
                 "record cannot assert both. Correct whichever surface is wrong, "
-                "or omit one of them."
+                "or omit one of them.",
+                context={
+                    "disputed_ts_atoms": disputed,
+                    "atom_map_assigns_to": f"{offender[0].value} {offender[1]}",
+                    "irc_mapping_assigns_to": elsewhere,
+                },
+                message_prefix=False,
             )
 
 
@@ -681,6 +694,7 @@ CHECK_ATOM_MAP_AGREES_WITH_IRC_MAPPING = ScientificCheck(
         "saddle-point atoms each participant is made of."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional, because the two surfaces are one claim at two "
         "resolutions rather than two claims. An IRC participant mapping "
@@ -751,6 +765,7 @@ CHECK_ATOM_MAP_ABSENT = ScientificCheck(
         "reactants is which atom of the saddle point and of the products."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "Absence, not contradiction. An unmapped reaction is an incomplete "
         "record rather than a false one — the rate constant is still the rate "
@@ -792,6 +807,7 @@ CHECK_ATOM_MAP_INCOMPLETE = ScientificCheck(
         "point."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "Absence again, at finer grain. A partial map is a true-but-partial "
         "record; only a map that contradicts *itself* is refused, and that is "

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections import Counter
 from typing import Mapping, Sequence
 
@@ -13,6 +14,7 @@ from tckdb_schemas.fragments.ts_validation_evidence import (
     TransitionStateValidationEvidenceIn,
 )
 
+from app.api.error_contract import CodedValueError
 from app.chemistry.geometry import resolve_element_symbol
 from app.chemistry.species import element_counts_from_smiles, format_element_counts
 from app.db.models.common import MoleculeKind, ReactionRole
@@ -26,7 +28,29 @@ from app.db.models.reaction import (
 from app.db.models.species import Species, SpeciesEntry
 from app.schemas.reaction_family import find_canonical_reaction_family
 from app.schemas.utils import normalize_optional_text
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Raised when a reaction's two sides do not hold the same atoms.
+W_REACTION_MASS_BALANCE_FAILED = "reaction_mass_balance_failed"
+
+#: Raised when a reaction's two sides do not hold the same total charge.
+W_REACTION_CHARGE_NOT_CONSERVED = "reaction_charge_not_conserved"
+
+#: Raised when a saddle point is not made of its own reaction's atoms.
+W_TRANSITION_STATE_COMPOSITION_MISMATCH = "transition_state_composition_mismatch"
+
+#: Raised when a saddle point does not carry its reactants' total charge.
+W_TRANSITION_STATE_CHARGE_MISMATCH = "transition_state_charge_mismatch"
+
+#: Raised when a stored SMILES cannot be parsed while balancing a reaction.
+W_STORED_SMILES_UNPARSEABLE = "stored_species_smiles_unparseable"
 
 
 def compress_species_stoichiometry(
@@ -73,7 +97,7 @@ def _element_counts_for_species(species: Species) -> Counter[str]:
     :func:`_load_participant_species` before it ever gets here: an electron
     still has to balance, it simply has no atoms to bring to the balance.
 
-    :raises ValueError: If the stored SMILES cannot be parsed by RDKit.
+    :raises CodedValueError: If the stored SMILES cannot be parsed by RDKit.
     """
 
     if species.kind == MoleculeKind.electron:
@@ -82,9 +106,26 @@ def _element_counts_for_species(species: Species) -> Counter[str]:
     try:
         return element_counts_from_smiles(species.smiles)
     except ValueError as exc:
-        raise ValueError(
-            f"Cannot parse stored SMILES for species_id={species.id} "
-            "while validating reaction elemental balance."
+        # The species is named by its public ref, never by ``species.id``.
+        # A primary key is an internal identifier a caller can neither use
+        # nor verify, and handing one out in an error body is the leak the
+        # project rule forbids; the row id goes to the log, where whoever
+        # has to fix the stored row can act on it.
+        logger.warning(
+            "Unparseable stored SMILES on species id=%s public_ref=%s: %r",
+            species.id,
+            species.public_ref,
+            species.smiles,
+        )
+        raise CodedValueError(
+            W_STORED_SMILES_UNPARSEABLE,
+            f"Cannot parse the stored SMILES {species.smiles!r} of participant "
+            f"{species.public_ref} while validating reaction elemental balance.",
+            context={
+                "species_ref": species.public_ref,
+                "smiles": species.smiles,
+            },
+            message_prefix=False,
         ) from exc
 
 
@@ -180,8 +221,14 @@ def validate_reaction_elemental_balance(
             product_totals[element] += coefficient * count
 
     if reactant_totals != product_totals:
-        raise ValueError(
-            "Reaction is not element-balanced (reaction_mass_balance_failed)."
+        raise CodedValueError(
+            W_REACTION_MASS_BALANCE_FAILED,
+            "Reaction is not element-balanced (reaction_mass_balance_failed).",
+            context={
+                "reactants": dict(sorted(reactant_totals.items())),
+                "products": dict(sorted(product_totals.items())),
+            },
+            message_prefix=False,
         )
 
 
@@ -194,6 +241,7 @@ CHECK_REACTION_ELEMENTAL_BALANCE = ScientificCheck(
         "of atoms of every element."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. Mass balance is what makes a set of species a reaction "
         "rather than a list, so no correct calculation can produce an "
@@ -304,7 +352,8 @@ def validate_reaction_charge_conservation(
     )
 
     if reactant_charge != product_charge:
-        raise ValueError(
+        raise CodedValueError(
+            W_REACTION_CHARGE_NOT_CONSERVED,
             f"Reaction reactants total charge {reactant_charge:+d} but products "
             f"total {product_charge:+d} (reaction_charge_not_conserved). Charge "
             "is conserved across a reaction, so the two sides describe "
@@ -315,7 +364,12 @@ def validate_reaction_charge_conservation(
             "photodetachment — declare the electron as a participant: "
             '{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, '
             '"multiplicity": 2}. It balances the charge and still leaves the '
-            "elemental balance to be satisfied on its own terms."
+            "elemental balance to be satisfied on its own terms.",
+            context={
+                "reactant_charge": reactant_charge,
+                "product_charge": product_charge,
+            },
+            message_prefix=False,
         )
 
 
@@ -328,6 +382,7 @@ CHECK_REACTION_CHARGE_CONSERVATION = ScientificCheck(
         "products."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional, and only because the escape hatch exists. Electrons are "
         "neither created nor destroyed by rearranging bonds. Without a way to "
@@ -450,7 +505,8 @@ def validate_transition_state_composition(
             reactant_totals += _element_counts_for_species(species)
 
         if ts_counts != reactant_totals:
-            raise ValueError(
+            raise CodedValueError(
+                W_TRANSITION_STATE_COMPOSITION_MISMATCH,
                 f"Transition state '{subject_label}' is "
                 f"{format_element_counts(ts_counts)}, but the reaction it sits "
                 f"in is {format_element_counts(reactant_totals)} "
@@ -459,19 +515,30 @@ def validate_transition_state_composition(
                 "reaction's atoms, so a saddle point made of different atoms "
                 "cannot be that reaction's saddle point. If the saddle-point "
                 "structure genuinely contains additional species, declare them "
-                "as participants of the reaction."
+                "as participants of the reaction.",
+                context={
+                    "transition_state": dict(sorted(ts_counts.items())),
+                    "reaction": dict(sorted(reactant_totals.items())),
+                },
+                message_prefix=False,
             )
 
     if transition_state_charge is not None:
         reactant_charge = sum(species.charge for species in reactants)
         if transition_state_charge != reactant_charge:
-            raise ValueError(
+            raise CodedValueError(
+                W_TRANSITION_STATE_CHARGE_MISMATCH,
                 f"Transition state '{subject_label}' carries charge "
                 f"{transition_state_charge:+d}, but its reactants total "
                 f"{reactant_charge:+d} "
                 "(transition_state_charge_mismatch). Charge is conserved along "
                 "a reaction coordinate, so a saddle point at a different charge "
-                "is on a different potential energy surface."
+                "is on a different potential energy surface.",
+                context={
+                    "transition_state_charge": transition_state_charge,
+                    "reactant_charge": reactant_charge,
+                },
+                message_prefix=False,
             )
 
 
@@ -502,6 +569,7 @@ CHECK_TRANSITION_STATE_COMPOSITION = ScientificCheck(
         "declared to sit in."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. A transition state is a stationary point on the "
         "potential energy surface *of those atoms*, so a saddle point with a "
@@ -540,6 +608,7 @@ CHECK_TRANSITION_STATE_CHARGE = ScientificCheck(
         "between."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. Charge is conserved along a reaction coordinate, so a "
         "saddle point at a different charge is on a different potential energy "
@@ -727,7 +796,8 @@ def validate_ts_evidence_participant_composition(
                     assigned[element] += 1
 
                 if assigned != declared:
-                    raise ValueError(
+                    raise CodedValueError(
+                        W_IRC_MAPPING_ELEMENT_MISMATCH,
                         f"Transition state '{subject_label}' {field_path} assigns "
                         f"saddle-point atoms "
                         f"{sorted(atom_indices)} to {participant_key}, which is "
@@ -752,6 +822,7 @@ CHECK_TS_IRC_MAPPING_ELEMENTS = ScientificCheck(
         "participant are that participant's own atoms, element for element."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. 'These saddle-point atoms become C2H4' while those atoms "
         "are C2O2H2 is a contradiction no correct calculation can produce — the "

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import ColumnElement
 
+from app.api.error_contract import CodedValueError
 from app.chemistry.geometry import parse_xyz, resolve_element_symbol
 from app.chemistry.species import (
     canonical_isotope_key,
@@ -26,7 +27,19 @@ from app.db.models.common import MoleculeKind, StereoKind
 from app.db.models.species import Species, SpeciesEntry
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
+
+#: Raised when a geometry is not made of the atoms its own SMILES declares.
+W_SPECIES_GEOMETRY_COMPOSITION_MISMATCH = "species_geometry_composition_mismatch"
+
+#: Raised when the isotope substitutions in a SMILES and in the geometry
+#: deposited under it are different multisets.
+W_SPECIES_GEOMETRY_ISOTOPE_MISMATCH = "species_geometry_isotope_mismatch"
 
 
 def null_safe_equals(column: ColumnElement, value: str | None) -> ColumnElement[bool]:
@@ -164,24 +177,31 @@ def assert_geometry_isotopes_match_identity(
             for (element, mass_number), count in sorted(counts.items())
         )
 
-    raise ValueError(
+    raise CodedValueError(
+        W_SPECIES_GEOMETRY_ISOTOPE_MISMATCH,
         "Isotope substitution declared in species_entry.smiles does not match "
         "the uploaded geometry. "
         f"smiles={_render(from_smiles)}; geometry.isotopes={_render(from_geometry)}. "
         "Declare the same substitution on both: use SMILES isotope notation "
-        "(e.g. [2H]) for identity and geometry.isotopes for the per-atom masses."
+        "(e.g. [2H]) for identity and geometry.isotopes for the per-atom masses.",
+        context={
+            "smiles_substitutions": _render(from_smiles),
+            "geometry_substitutions": _render(from_geometry),
+        },
+        message_prefix=False,
     )
 
 
 CHECK_GEOMETRY_ISOTOPES_MATCH_IDENTITY = ScientificCheck(
     group="A structure against its own label",
     sort_key=2,
-    code=None,
+    code=W_SPECIES_GEOMETRY_ISOTOPE_MISMATCH,
     asserts=(
         "The multiset of isotopic substitutions declared in a species entry's "
         "SMILES equals the multiset carried by the geometry deposited under it."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. The identity's isotope label and the geometry's "
         "per-atom masses describe the same nuclei; when they disagree one of "
@@ -190,15 +210,14 @@ CHECK_GEOMETRY_ISOTOPES_MATCH_IDENTITY = ScientificCheck(
         "a molecule nobody deposited."
     ),
     adr="0008",
-    emitted=False,
     enforced_by=(
         PythonCheck(
             assert_geometry_isotopes_match_identity,
             note=(
                 "Runs from ``resolve_species_entry`` only when a geometry is "
-                "supplied. Raises prose with no machine-readable code, so no "
-                "client can key off it — recorded here as a gap rather than "
-                "papered over."
+                "supplied. The refusal was prose-only until the code above was "
+                "attached; a client could not tell it from any other 422, "
+                "which is why the entry used to record the gap here."
             ),
         ),
     ),
@@ -344,7 +363,8 @@ def assert_geometry_composition_matches_identity(
         format_element_counts(from_smiles)
         or "nothing at all — a free electron has no atoms"
     )
-    raise ValueError(
+    raise CodedValueError(
+        W_SPECIES_GEOMETRY_COMPOSITION_MISMATCH,
         f"Species geometry is {geometry_formula}, but "
         f"species_entry.smiles={payload.smiles!r} is "
         f"{identity_formula} "
@@ -353,7 +373,12 @@ def assert_geometry_composition_matches_identity(
         "computed from it describes a different molecule. Hydrogens are "
         "counted explicitly on both sides, and isotope labels are counted as "
         "their element — SMILES [2H] and the XYZ symbols D and T all count as "
-        "H — so an isotopologue is not a mismatch."
+        "H — so an isotopologue is not a mismatch.",
+        context={
+            "geometry_formula": geometry_formula,
+            "identity_formula": identity_formula,
+        },
+        message_prefix=False,
     )
 
 
@@ -366,6 +391,7 @@ CHECK_GEOMETRY_COMPOSITION_MATCHES_IDENTITY = ScientificCheck(
         "atoms that entry's own SMILES declares."
     ),
     tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
     tier_rationale=(
         "Definitional. No correct calculation produces a geometry that is not "
         "made of its own molecule's atoms, so a formula disagreement between a "

--- a/backend/app/services/transition_state_validation.py
+++ b/backend/app/services/transition_state_validation.py
@@ -24,7 +24,12 @@ from tckdb_schemas.fragments.ts_validation_evidence import (
 from tckdb_schemas.upload_warning import UploadWarning
 
 from app.db.models.transition_state import TransitionStateValidationEvidence
-from app.scientific_checks import CheckTier, PythonCheck, ScientificCheck
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
 from app.services.reaction_atom_map import (
     validate_atom_map_agrees_with_irc_evidence,
 )
@@ -157,6 +162,7 @@ CHECK_TS_IRC_EVIDENCE = ScientificCheck(
         "products."
     ),
     tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
     tier_rationale=(
         "Absence, not contradiction. Refusing a transition state without an "
         "IRC would lose the saddle point entirely, and a saddle point with no "

--- a/backend/app/workflows/conformer.py
+++ b/backend/app/workflows/conformer.py
@@ -105,10 +105,11 @@ def persist_conformer_upload(
         calc=calculation,
         explicit_output_geometries=request.calculation.output_geometries,
         fallback_geometry_id=geometry.id,
-        context=(
-            f"primary calculation (type='{calculation.type.value}', "
-            f"id={calculation.id})"
-        ),
+        # No row id: the caller sent one primary calculation and the type
+        # is enough to name it. Its ``calculation.id`` is an internal
+        # handle they cannot act on, and this label is copied verbatim
+        # into a 422 body.
+        context=f"primary calculation (type='{calculation.type.value}')",
     )
     # Producer-explicit input_geometries take precedence; otherwise the
     # freq/sp fallback links the conformer geometry. opt skips the
@@ -119,10 +120,11 @@ def persist_conformer_upload(
         calc=calculation,
         explicit_input_geometries=request.calculation.input_geometries,
         fallback_geometry_id=geometry.id,
-        context=(
-            f"primary calculation (type='{calculation.type.value}', "
-            f"id={calculation.id})"
-        ),
+        # No row id: the caller sent one primary calculation and the type
+        # is enough to name it. Its ``calculation.id`` is an internal
+        # handle they cannot act on, and this label is copied verbatim
+        # into a 422 body.
+        context=f"primary calculation (type='{calculation.type.value}')",
     )
 
     additional_calcs = []

--- a/backend/app/workflows/statmech.py
+++ b/backend/app/workflows/statmech.py
@@ -9,6 +9,8 @@ payload is routed through the canonical
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy.orm import Session
 
 from app.db.models.calculation import Calculation
@@ -32,6 +34,8 @@ from app.services.record_review import (
 from app.services.species_resolution import resolve_species_entry
 from app.services.statmech_resolution import resolve_or_create_statmech
 
+logger = logging.getLogger(__name__)
+
 
 def _assert_calculation_owned_by(
     calculation: Calculation,
@@ -49,10 +53,21 @@ def _assert_calculation_owned_by(
         ``species_entry_id``.
     """
     if calculation.species_entry_id != species_entry_id:
+        # ``context`` already names the calculation by the caller's own key,
+        # which is the identifier they can act on. The three row ids this
+        # message used to interpolate are internal handles that go to the
+        # log instead — a 422 body must not hand out primary keys.
+        logger.warning(
+            "%s: calculation id=%s owned by species_entry_id=%s, not %s",
+            context,
+            calculation.id,
+            calculation.species_entry_id,
+            species_entry_id,
+        )
         raise ValueError(
-            f"{context}: calculation id={calculation.id} belongs to "
-            f"species_entry_id={calculation.species_entry_id}, not to the "
-            f"statmech target species_entry_id={species_entry_id}."
+            f"{context}: this calculation belongs to another species entry, "
+            "not to the statmech target. A supporting calculation must be one "
+            "of the target species entry's own."
         )
 
 

--- a/backend/app/workflows/transport.py
+++ b/backend/app/workflows/transport.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy.orm import Session
 
 from app.db.models.calculation import Calculation
@@ -20,6 +22,8 @@ from app.services.record_review import (
 from app.services.species_resolution import resolve_species_entry
 from app.services.transport_resolution import resolve_and_create_transport
 
+logger = logging.getLogger(__name__)
+
 
 def _assert_calculation_owned_by(
     calculation: Calculation,
@@ -37,10 +41,21 @@ def _assert_calculation_owned_by(
         ``species_entry_id``.
     """
     if calculation.species_entry_id != species_entry_id:
+        # ``context`` already names the calculation by the caller's own key,
+        # which is the identifier they can act on. The three row ids this
+        # message used to interpolate are internal handles that go to the
+        # log instead — a 422 body must not hand out primary keys.
+        logger.warning(
+            "%s: calculation id=%s owned by species_entry_id=%s, not %s",
+            context,
+            calculation.id,
+            calculation.species_entry_id,
+            species_entry_id,
+        )
         raise ValueError(
-            f"{context}: calculation id={calculation.id} belongs to "
-            f"species_entry_id={calculation.species_entry_id}, not to the "
-            f"transport target species_entry_id={species_entry_id}."
+            f"{context}: this calculation belongs to another species entry, "
+            "not to the transport target. A supporting calculation must be one "
+            "of the target species entry's own."
         )
 
 

--- a/backend/scripts/generate_scientific_check_register.py
+++ b/backend/scripts/generate_scientific_check_register.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(REPO_ROOT / "backend"))
 
 from app.scientific_checks import (  # noqa: E402
     CheckTier,
+    CodeChannel,
     ConstantThreshold,
     DatabaseConstraint,
     DesignPosition,
@@ -62,6 +63,24 @@ _TIER_BLURB = {
         "Not an ADR 0008 consequence tier. The position is enforced by the "
         "shape of the schema, so a record violating it cannot be represented."
     ),
+}
+
+_CHANNEL_BLURB = {
+    CodeChannel.error_envelope: (
+        "the `code` field of the 422 error body — a client can branch on it"
+    ),
+    CodeChannel.upload_warning: (
+        "the `code` field of an `UploadWarning` returned alongside the "
+        "accepted upload"
+    ),
+    CodeChannel.trust_label: (
+        "a read-time trust label (`HardFailReason`), not any refusal"
+    ),
+    CodeChannel.database_constraint: (
+        "PostgreSQL only, so the client sees a generic 409 integrity code "
+        "rather than this check's name"
+    ),
+    CodeChannel.none: "*nothing carries a code*",
 }
 
 _PREAMBLE = """# The scientific check register
@@ -102,6 +121,16 @@ disagree about a line number, this one is right by construction.
   recognise. Not a description of the implementation.
 - **Tier** — the ADR 0008 consequence, with the justification for *that* tier
   in the ADR's own terms.
+- **Code**, and **where it reaches a client** — these are two different facts
+  and the register used to state only the first. A code is not a contract until
+  something carries it somewhere a consumer can read it, and for a long time
+  nothing did: six checks spelled their code inside an English sentence
+  (`"... (reaction_mass_balance_failed)."`) that no parser matched, and the 422
+  body's own `code` field said `validation_error` for every chemistry refusal
+  in the system. Naming the channel is what makes the claim checkable —
+  `backend/tests/db/test_scientific_check_register.py` holds each channel to
+  its obligation, and an `error_envelope` code must both be raised through the
+  typed path and be proved to arrive by an end-to-end HTTP test.
 - **Enforced at** — `file:line` for Python, or the constraint/trigger name for
   PostgreSQL. Database names are verified against live schema metadata by
   `backend/tests/db/test_scientific_check_register.py`, not trusted as strings.
@@ -150,6 +179,35 @@ def _tier_table(checks: list[ScientificCheck]) -> str:
     ]
     for tier in CheckTier:
         lines.append(f"| `{tier.value}` | {counts.get(tier, 0)} | {_TIER_BLURB[tier]} |")
+    lines.append(f"| **total** | **{len(checks)}** | |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _channel_table(checks: list[ScientificCheck]) -> str:
+    """How many entries carry a code a client can actually act on.
+
+    This table is the answer to a question the register could not answer
+    before: "how much of what TCKDB refuses can a program understand?" It
+    is printed rather than left to be counted, because the last time
+    somebody counted — eleven entries with no code, and every blocking
+    chemistry check reporting ``validation_error`` — it took reading the
+    whole document to find out.
+    """
+    counts: dict[CodeChannel, int] = {}
+    for check in checks:
+        counts[check.channel] = counts.get(check.channel, 0) + 1
+    lines = [
+        "## Where a check's code reaches a client",
+        "",
+        "| Channel | Entries | What a consumer can do with it |",
+        "| --- | --- | --- |",
+    ]
+    for channel in CodeChannel:
+        lines.append(
+            f"| `{channel.value}` | {counts.get(channel, 0)} | "
+            f"{_CHANNEL_BLURB[channel]} |"
+        )
     lines.append(f"| **total** | **{len(checks)}** | |")
     lines.append("")
     return "\n".join(lines)
@@ -228,6 +286,7 @@ def _render_check(check: ScientificCheck, index: int) -> str:
         "| --- | --- |",
         f"| **Tier** | `{check.tier.value}` |",
         f"| **Code** | {codes} |",
+        f"| **Code reaches a client via** | {_CHANNEL_BLURB[check.channel]} |",
         f"| **Governing ADR** | {check.adr} |",
         "",
         f"**Why this tier.** {_md(check.tier_rationale)}",
@@ -252,9 +311,12 @@ def _render_check(check: ScientificCheck, index: int) -> str:
         ]
     if not check.codes:
         lines += [
-            "*(This check raises prose with no machine-readable code. Recorded "
-            "as a gap rather than invented, because a code that appears in no "
-            "message is a code no client can match on.)*",
+            "*(No machine-readable code reaches anybody for this one. Recorded "
+            "as a gap rather than invented, because a code nothing carries is a "
+            "code no client can match on. See the enforcement sites above for "
+            "why: a position held by a database constraint alone surfaces as a "
+            "generic integrity conflict, and one held by schema shape or by a "
+            "stored evidence row never surfaces as a refusal at all.)*",
             "",
         ]
     return "\n".join(lines)
@@ -309,7 +371,7 @@ def _divergence_index(checks: list[ScientificCheck], numbering: dict[int, int]) 
 
 def render() -> str:
     checks = register()
-    out = [_PREAMBLE, _tier_table(checks)]
+    out = [_PREAMBLE, _tier_table(checks), _channel_table(checks)]
 
     groups = _ordered_groups(checks)
     numbering: dict[int, int] = {}

--- a/backend/tests/api/test_api_scientific_rejection_codes.py
+++ b/backend/tests/api/test_api_scientific_rejection_codes.py
@@ -1,0 +1,672 @@
+"""The proof that a scientific refusal names itself in the response body.
+
+Every other guard in this repository stops one step short of the thing a
+client actually reads. ``test_scientific_check_register`` proves a code is
+declared and passed to a coded error; the workflow tests prove the right
+deposits are refused. Neither noticed that the ``code`` field of the 422
+body said ``validation_error`` for every chemistry refusal TCKDB makes —
+because the codes the checks carried were spelled inside their English
+sentences (``"... (reaction_mass_balance_failed)."``) where the envelope's
+promoter, which requires a ``code: `` prefix, never looked.
+
+So the assertion here is deliberately narrow and deliberately awkward:
+
+    assert response.json()["code"] == "reaction_mass_balance_failed"
+
+**not** ``assert code in response.json()["detail"]``. The second passes on
+the broken system. That distinction is the whole point of the file, and it
+is why a new ``error_envelope`` code in the register is not accepted until
+it is named here — see
+``test_every_error_envelope_code_is_proved_end_to_end``.
+
+Each test also asserts the status is 422 and, where the message is a
+published one, that ``detail`` still carries the sentence it always did.
+Attaching a code was meant to be purely additive: a client matching prose
+keeps working, and a client matching ``code`` gets something useful for
+the first time.
+"""
+
+from __future__ import annotations
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+
+def _envelope(response) -> dict:
+    """The parsed body, asserted to be a 422 with the standard envelope."""
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert set(body) >= {"code", "detail"}, body
+    return body
+
+
+def _assert_code(response, expected: str) -> dict:
+    """The response names *expected* in its ``code`` field, not in its prose.
+
+    A helper rather than a bare assert so the failure message can say what
+    was actually reported — which, before this branch, was
+    ``validation_error`` for every single one of these.
+    """
+    body = _envelope(response)
+    assert body["code"] == expected, (
+        f"expected code={expected!r}, got {body['code']!r}. "
+        f"detail={body['detail']!r}"
+    )
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Conservation across a reaction
+# ---------------------------------------------------------------------------
+
+
+def _reaction_payload(reactants: list[dict], products: list[dict]) -> dict:
+    return {
+        "reversible": True,
+        "reactants": [{"species_entry": entry} for entry in reactants],
+        "products": [{"species_entry": entry} for entry in products],
+    }
+
+
+_H_ATOM = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+_METHANE = {"smiles": "C", "charge": 0, "multiplicity": 1}
+_H2 = {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}
+_METHYL = {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}
+_HYDROXIDE = {"smiles": "[OH-]", "charge": -1, "multiplicity": 1}
+_WATER = {"smiles": "O", "charge": 0, "multiplicity": 1}
+
+
+class TestConservationAcrossAReaction:
+    def test_unbalanced_reaction_names_mass_balance(self, client):
+        response = client.post(
+            "/api/v1/uploads/reactions",
+            json=_reaction_payload([_H_ATOM, _METHANE], [_METHYL]),
+        )
+        body = _assert_code(response, "reaction_mass_balance_failed")
+        # Additive, not a rewrite: the sentence a prose-matching client has
+        # always seen is byte-for-byte the one it still sees.
+        assert "not element-balanced" in str(body["detail"])
+
+    def test_charge_losing_reaction_names_charge_conservation(self, client):
+        # [OH-] + [H] -> H2O drops an electron on the way across. The
+        # elemental balance is satisfied, so only the charge law can fire.
+        response = client.post(
+            "/api/v1/uploads/reactions",
+            json=_reaction_payload([_HYDROXIDE, _H_ATOM], [_WATER]),
+        )
+        body = _assert_code(response, "reaction_charge_not_conserved")
+        assert "conserved across a reaction" in str(body["detail"])
+
+
+# ---------------------------------------------------------------------------
+# A structure against its own label
+# ---------------------------------------------------------------------------
+
+
+def _conformer_payload(
+    *,
+    species_entry: dict,
+    xyz_text: str,
+    label: str = "conf-a",
+) -> dict:
+    return {
+        "species_entry": species_entry,
+        "geometry": {"xyz_text": xyz_text},
+        "calculation": {
+            "type": "sp",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "label": label,
+    }
+
+
+_METHANE_XYZ = (
+    "5\nmethane\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
+)
+_METHYL_XYZ = (
+    "4\nmethyl\n"
+    "C  0.000  0.000  0.000\n"
+    "H  1.079  0.000  0.000\n"
+    "H -0.539  0.934  0.000\n"
+    "H -0.539 -0.934  0.000"
+)
+
+
+class TestAStructureAgainstItsOwnLabel:
+    def test_geometry_of_a_different_molecule_names_composition(self, client):
+        response = client.post(
+            "/api/v1/uploads/conformers",
+            json=_conformer_payload(
+                species_entry=_METHANE, xyz_text=_METHYL_XYZ
+            ),
+        )
+        body = _assert_code(response, "species_geometry_composition_mismatch")
+        assert "species_geometry_composition_mismatch" in str(body["detail"])
+
+    def test_isotope_labels_that_disagree_name_the_isotope_check(self, client):
+        # CH3D by SMILES, all-protium by geometry. Same formula, so the
+        # composition check above passes and only the isotope one can fire.
+        response = client.post(
+            "/api/v1/uploads/conformers",
+            json=_conformer_payload(
+                species_entry={
+                    "smiles": "[2H]C",
+                    "charge": 0,
+                    "multiplicity": 1,
+                },
+                xyz_text=_METHANE_XYZ,
+            ),
+        )
+        body = _assert_code(response, "species_geometry_isotope_mismatch")
+        assert "Isotope substitution" in str(body["detail"])
+
+    def test_declared_charge_that_the_smiles_denies_names_the_charge_check(
+        self, client
+    ):
+        response = client.post(
+            "/api/v1/uploads/conformers",
+            json=_conformer_payload(
+                species_entry={"smiles": "C", "charge": -1, "multiplicity": 1},
+                xyz_text=_METHANE_XYZ,
+            ),
+        )
+        body = _assert_code(response, "species_smiles_charge_mismatch")
+        assert "does not match SMILES charge" in str(body["detail"])
+
+
+# ---------------------------------------------------------------------------
+# Stationary points
+# ---------------------------------------------------------------------------
+#
+# These reach the envelope through ``raise_for_blocking_findings``, which
+# reports the code the blocking findings agreed on. They are the reason the
+# promotion had to be typed rather than textual: the finding's own ``code``
+# is the contract, while its ``message`` is a paragraph of advice that will
+# be reworded.
+
+
+def _freq_calc(
+    *,
+    n_imag: int,
+    imag_freq_cm1: float | None = None,
+    frequencies: list[float] | None = None,
+    reaction_coordinate_mode_index: int | None = None,
+    dispositions: dict[int, str] | None = None,
+) -> dict:
+    result: dict = {"n_imag": n_imag, "imag_freq_cm1": imag_freq_cm1}
+    if frequencies is not None:
+        dispositions = dispositions or {}
+        result["modes"] = [
+            {
+                "mode_index": index + 1,
+                "frequency_cm1": value,
+                "is_imaginary": value < 0,
+                "imaginary_disposition": dispositions.get(index + 1),
+            }
+            for index, value in enumerate(frequencies)
+        ]
+    if reaction_coordinate_mode_index is not None:
+        result["reaction_coordinate_mode_index"] = reaction_coordinate_mode_index
+    return {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "freq_result": result,
+    }
+
+
+#: H + CH4 -> H2 + CH3, so the saddle point is CH5.
+_TS_XYZ = (
+    "6\nH...H-CH3 abstraction TS\n"
+    "C  0.000  0.000  0.000\n"
+    "H -0.510  0.883  0.000\n"
+    "H -0.510 -0.883  0.000\n"
+    "H  0.000  0.000 -1.090\n"
+    "H  0.000  0.000  1.350\n"
+    "H  0.000  0.000  2.250"
+)
+
+
+def _transition_state_payload(
+    *,
+    label: str,
+    charge: int = 0,
+    xyz_text: str = _TS_XYZ,
+    freq: dict | None = None,
+) -> dict:
+    payload: dict = {
+        "reaction": _reaction_payload([_H_ATOM, _METHANE], [_H2, _METHYL]),
+        "charge": charge,
+        "multiplicity": 2,
+        "geometry": {"xyz_text": xyz_text},
+        "primary_opt": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [freq] if freq is not None else [],
+        "label": label,
+    }
+    return payload
+
+
+class TestStationaryPoints:
+    def test_a_transition_state_with_no_imaginary_mode(self, client):
+        response = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                label="ts-none", freq=_freq_calc(n_imag=0)
+            ),
+        )
+        _assert_code(response, "transition_state_no_imaginary_mode")
+
+    def test_extra_imaginary_modes_with_no_designation(self, client):
+        response = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                label="ts-ambiguous",
+                freq=_freq_calc(n_imag=3, imag_freq_cm1=-1300.0),
+            ),
+        )
+        _assert_code(
+            response, "transition_state_reaction_coordinate_not_designated"
+        )
+
+    def test_an_undeclared_mode_stiffer_than_the_designated_one(self, client):
+        response = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                label="ts-stiff",
+                freq=_freq_calc(
+                    n_imag=2,
+                    imag_freq_cm1=-100.0,
+                    frequencies=[-100.0, -1300.0, 800.0],
+                    reaction_coordinate_mode_index=1,
+                ),
+            ),
+        )
+        _assert_code(
+            response, "transition_state_reaction_coordinate_ambiguous"
+        )
+
+    def test_a_minimum_with_an_imaginary_mode(self, client):
+        payload = _conformer_payload(
+            species_entry=_METHANE, xyz_text=_METHANE_XYZ
+        )
+        payload["calculation"] = _freq_calc(n_imag=1, imag_freq_cm1=-250.0)
+        response = client.post("/api/v1/uploads/conformers", json=payload)
+        _assert_code(response, "n_imag_contradicts_minimum")
+
+
+# ---------------------------------------------------------------------------
+# Conservation, against the saddle point
+# ---------------------------------------------------------------------------
+
+
+class TestTheSaddlePointAgainstItsReaction:
+    def test_a_saddle_point_made_of_other_atoms(self, client):
+        # The reaction is CH5; the geometry deposited is CH3.
+        response = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                label="ts-wrong-atoms",
+                xyz_text=_METHYL_XYZ,
+                freq=_freq_calc(n_imag=1, imag_freq_cm1=-1500.0),
+            ),
+        )
+        body = _assert_code(response, "transition_state_composition_mismatch")
+        assert "transition_state_composition_mismatch" in str(body["detail"])
+
+    def test_a_saddle_point_at_another_charge(self, client):
+        response = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                label="ts-wrong-charge",
+                charge=-1,
+                freq=_freq_calc(n_imag=1, imag_freq_cm1=-1500.0),
+            ),
+        )
+        body = _assert_code(response, "transition_state_charge_mismatch")
+        assert "transition_state_charge_mismatch" in str(body["detail"])
+
+
+# ---------------------------------------------------------------------------
+# Rate coefficients
+# ---------------------------------------------------------------------------
+
+
+class TestRateCoefficients:
+    def test_a_units_of_the_wrong_dimensionality(self, client):
+        # One reactant, so the rate law is first order and A must be per
+        # second. Bimolecular units on it are not an unusual result but a
+        # number that cannot mean what it says.
+        response = client.post(
+            "/api/v1/uploads/kinetics",
+            json={
+                "reaction": _reaction_payload([_METHANE], [_METHANE]),
+                "scientific_origin": "experimental",
+                "a": 2.16e8,
+                "a_units": "cm3_mol_s",
+                "n": 0.0,
+                "reported_ea": 14.35,
+                "reported_ea_units": "kj_mol",
+            },
+        )
+        body = _assert_code(response, "arrhenius_a_units_molecularity_mismatch")
+        assert "is incompatible with" in str(body["detail"])
+
+
+# ---------------------------------------------------------------------------
+# Atom mapping across a reaction
+# ---------------------------------------------------------------------------
+#
+# ``CH3 + H -> CH4`` and its saddle point: small enough to state a whole map
+# inline, asymmetric enough that a wrong one is visibly wrong. The bundle
+# below is the same shape as
+# ``tests/api/scientific/test_api_reaction_atom_map.py``'s, which is the
+# only endpoint carrying an ``atom_map`` at all.
+#
+# These refuse inside a Pydantic model validator rather than in service
+# code, so they exercise the other half of the promotion: the exception
+# object survives into ``errors()[i]["ctx"]["error"]`` and its ``.code`` is
+# read from there. Nothing about the message is parsed, which is what lets
+# these sentences stay exactly as they were written.
+
+_XYZ_H = "1\nH\nH 0.0 0.0 0.0"
+_XYZ_CH3 = (
+    "4\nmethyl\n"
+    "C  0.000  0.000  0.000\n"
+    "H  1.080  0.000  0.000\n"
+    "H -0.540  0.935  0.000\n"
+    "H -0.540 -0.935  0.000"
+)
+_XYZ_NH3 = (
+    "4\nammonia\n"
+    "N  0.000  0.000  0.000\n"
+    "H  1.010  0.000  0.000\n"
+    "H -0.505  0.875  0.000\n"
+    "H -0.505 -0.875  0.000"
+)
+_XYZ_CH4 = _METHANE_XYZ
+_XYZ_TS = (
+    "5\nTS for CH3 + H -> CH4\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.000  0.000  1.400"
+)
+#: The reaction's five atoms plus a spare hydrogen, so a complete map of a
+#: balanced reaction can still leave a saddle-point atom over.
+_XYZ_TS_SPARE_ATOM = (
+    "6\nTS with a spare atom\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.000  0.000  1.400\n"
+    "H  0.000  0.000  3.000"
+)
+_BUNDLE_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+
+def _bundle_species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _BUNDLE_LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [],
+    }
+
+
+def _bundle(
+    atom_map: dict | None = None,
+    *,
+    species: list[dict] | None = None,
+    validation_evidence: list[dict] | None = None,
+) -> dict:
+    transition_state: dict = {
+        "charge": 0,
+        "multiplicity": 2,
+        "geometry": {"key": "ts-geom", "xyz_text": _XYZ_TS},
+        "calculation": {
+            "key": "ts-opt",
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _BUNDLE_LOT,
+            "opt_converged": True,
+        },
+        "calculations": [
+            {
+                "key": "ts-freq",
+                "type": "freq",
+                "geometry_key": "ts-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _BUNDLE_LOT,
+                "freq_n_imag": 1,
+                "freq_imag_freq_cm1": -1500.0,
+            }
+        ],
+    }
+    if validation_evidence is not None:
+        transition_state["calculations"].append(
+            {
+                "key": "ts-irc",
+                "type": "irc",
+                "geometry_key": "ts-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _BUNDLE_LOT,
+            }
+        )
+        transition_state["validation_evidence"] = validation_evidence
+    bundle: dict = {
+        "species": species
+        or [
+            _bundle_species("ch3", "[CH3]", 2, _XYZ_CH3),
+            _bundle_species("h", "[H]", 2, _XYZ_H),
+            _bundle_species("ch4", "C", 1, _XYZ_CH4),
+        ],
+        "reversible": True,
+        "reactant_keys": ["ch3", "h"],
+        "product_keys": ["ch4"],
+        "transition_state": transition_state,
+    }
+    if atom_map is not None:
+        bundle["atom_map"] = atom_map
+    return bundle
+
+
+def _map(source: str = "declared", **overrides) -> dict:
+    atom_map: dict = {
+        "source": source,
+        "ts_geometry_key": "ts-geom",
+        "participants": [
+            {
+                "side": "reactant",
+                "species_key": "ch3",
+                "participant_index": 1,
+                "geometry_key": "ch3-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4},
+            },
+            {
+                "side": "reactant",
+                "species_key": "h",
+                "participant_index": 2,
+                "geometry_key": "h-geom",
+                "atom_to_ts": {1: 5},
+            },
+            {
+                "side": "product",
+                "species_key": "ch4",
+                "participant_index": 1,
+                "geometry_key": "ch4-geom",
+                "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
+            },
+        ],
+    }
+    atom_map.update(overrides)
+    return atom_map
+
+
+class TestAtomMapping:
+    def test_an_element_that_changes_across_the_map(self, client):
+        # Ammonia in the methyl's slot: the map's reactant end is now N
+        # where its saddle-point end is C.
+        species = [
+            _bundle_species("ch3", "[NH3]", 2, _XYZ_NH3),
+            _bundle_species("h", "[H]", 2, _XYZ_H),
+            _bundle_species("ch4", "C", 1, _XYZ_CH4),
+        ]
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(_map(), species=species),
+        )
+        _assert_code(response, "atom_map_element_not_conserved")
+
+    def test_one_saddle_point_atom_claimed_twice(self, client):
+        participants = _map()["participants"]
+        participants[1]["atom_to_ts"] = {1: 2}
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(_map(participants=participants)),
+        )
+        _assert_code(response, "atom_map_not_a_bijection")
+
+    def test_an_index_the_named_geometry_does_not_have(self, client):
+        participants = _map()["participants"]
+        participants[0]["atom_to_ts"] = {1: 1, 2: 2, 3: 3, 9: 4}
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(_map(participants=participants)),
+        )
+        _assert_code(response, "atom_map_indices_not_geometry_relative")
+
+    def test_a_geometry_the_participant_does_not_own(self, client):
+        participants = _map()["participants"]
+        participants[0]["geometry_key"] = "ch4-geom"
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(_map(participants=participants)),
+        )
+        _assert_code(response, "atom_map_indices_not_geometry_relative")
+
+    def test_a_saddle_point_atom_claimed_by_neither_leg(self, client):
+        # A six-atom saddle point on a five-atom reaction. Both legs are
+        # complete over every declared participant and the reaction
+        # balances, so nothing is missing to explain an atom that comes
+        # from nothing and becomes nothing — which is the precondition the
+        # rule is gated on.
+        bundle = _bundle(_map())
+        bundle["transition_state"]["geometry"]["xyz_text"] = _XYZ_TS_SPARE_ATOM
+        response = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        _assert_code(response, "atom_map_atoms_unaccounted_for")
+
+    def test_two_legs_that_do_not_cover_the_same_atoms(self, client):
+        # Same six-atom saddle point, but now methane's fifth hydrogen
+        # lands on the spare atom: each leg is a bijection and the two
+        # disagree about which saddle-point atoms the reaction is made of.
+        participants = _map()["participants"]
+        participants[2]["atom_to_ts"] = {1: 1, 2: 2, 3: 3, 4: 4, 5: 6}
+        bundle = _bundle(_map(participants=participants))
+        bundle["transition_state"]["geometry"]["xyz_text"] = _XYZ_TS_SPARE_ATOM
+        response = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        body = _assert_code(response, "atom_map_atoms_unaccounted_for")
+        assert "No species is missing" in str(body["detail"])
+
+    def test_an_inferred_map_that_names_no_algorithm(self, client):
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(_map(source="inferred")),
+        )
+        body = _assert_code(response, "atom_map_inferred_requires_note")
+        assert "ADR 0011" in str(body["detail"])
+
+
+# ---------------------------------------------------------------------------
+# The atom map against the IRC partition
+# ---------------------------------------------------------------------------
+
+
+_IRC_EVIDENCE_CONTRADICTING_THE_MAP = [
+    {
+        "kind": "irc",
+        "passed": True,
+        "rationale": "IRC descends to CH3 + H on the reactant side.",
+        "source_calculation_key": "ts-irc",
+        # The map says methyl is saddle-point atoms 1-4 and the lone
+        # hydrogen is 5. This partition swaps 4 and 5, so both surfaces
+        # describe the same saddle point and disagree about one atom.
+        "reactant_participant_mapping": {
+            "reactant:1": [1, 2, 3, 5],
+            "reactant:2": [4],
+        },
+        "product_participant_mapping": {"product:1": [1, 2, 3, 4, 5]},
+    }
+]
+
+
+class TestTheAtomMapAgainstTheIrcPartition:
+    def test_a_map_that_contradicts_its_own_irc_partition(self, client):
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(
+                _map(),
+                validation_evidence=_IRC_EVIDENCE_CONTRADICTING_THE_MAP,
+            ),
+        )
+        body = _assert_code(response, "atom_map_contradicts_irc_mapping")
+        assert "atom_map_contradicts_irc_mapping" in str(body["detail"])
+
+    def test_an_irc_partition_that_hands_a_participant_other_elements(
+        self, client
+    ):
+        # No atom map at all, so the agreement check above cannot fire and
+        # only the element check can: the lone hydrogen is handed the
+        # saddle point's carbon.
+        evidence = [
+            {
+                "kind": "irc",
+                "passed": True,
+                "rationale": "IRC descends to CH3 + H on the reactant side.",
+                "source_calculation_key": "ts-irc",
+                "reactant_participant_mapping": {
+                    "reactant:1": [2, 3, 4, 5],
+                    "reactant:2": [1],
+                },
+                "product_participant_mapping": {
+                    "product:1": [1, 2, 3, 4, 5]
+                },
+            }
+        ]
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(validation_evidence=evidence),
+        )
+        body = _assert_code(
+            response, "transition_state_irc_mapping_element_mismatch"
+        )
+        assert "transition_state_irc_mapping_element_mismatch" in str(
+            body["detail"]
+        )

--- a/backend/tests/api/test_api_scientific_rejection_codes.py
+++ b/backend/tests/api/test_api_scientific_rejection_codes.py
@@ -85,7 +85,15 @@ class TestConservationAcrossAReaction:
         body = _assert_code(response, "reaction_mass_balance_failed")
         # Additive, not a rewrite: the sentence a prose-matching client has
         # always seen is byte-for-byte the one it still sees.
-        assert "not element-balanced" in str(body["detail"])
+        assert body["detail"] == (
+            "Reaction is not element-balanced (reaction_mass_balance_failed)."
+        )
+        # The message says the reaction does not balance; the context says
+        # what it is short of, without anyone parsing a sentence for it.
+        assert body["context"] == {
+            "reactants": {"C": 1, "H": 5},
+            "products": {"C": 1, "H": 3},
+        }
 
     def test_charge_losing_reaction_names_charge_conservation(self, client):
         # [OH-] + [H] -> H2O drops an electron on the way across. The
@@ -602,6 +610,29 @@ class TestAtomMapping:
         )
         body = _assert_code(response, "atom_map_inferred_requires_note")
         assert "ADR 0011" in str(body["detail"])
+
+    def test_the_structured_facts_reach_the_envelope_context(self, client):
+        """``context`` is the half of the contract that is not prose.
+
+        A wire-schema refusal is reported as a Pydantic error list, so its
+        structured facts used to be reachable only by parsing the sentence
+        that named them. They are lifted to the envelope's own ``context``,
+        which is where a service-raised refusal has always put them — so a
+        client reads one place regardless of which side of the boundary
+        refused it.
+        """
+        participants = _map()["participants"]
+        participants[0]["atom_to_ts"] = {1: 1, 2: 2, 3: 3, 9: 4}
+        response = client.post(
+            "/api/v1/uploads/computed-reaction",
+            json=_bundle(_map(participants=participants)),
+        )
+        body = _assert_code(response, "atom_map_indices_not_geometry_relative")
+        assert body["context"] == {
+            "atom_index": 9,
+            "geometry_key": "ch3-geom",
+            "geometry_atom_count": 4,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_error_contract_coded_promotion.py
+++ b/backend/tests/api/test_error_contract_coded_promotion.py
@@ -1,0 +1,148 @@
+"""The seam that turns a raised code into the envelope's ``code`` field.
+
+The end-to-end proofs in ``test_api_scientific_rejection_codes.py`` show
+that twenty specific codes arrive. These pin the *rules* they arrive by,
+including the two that are decisions rather than plumbing: a refusal may
+attach a code without moving its message, and a failure carrying two
+different codes reports neither.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ValidationError, model_validator
+from tckdb_schemas.coded_error import CodedValidationError
+
+from app.api.error_contract import (
+    CodedValueError,
+    error_envelope,
+    validation_detail_code,
+    validation_detail_context,
+)
+
+
+class TestTheMessageDoesNotMove:
+    def test_message_prefix_false_leaves_the_prose_exactly_as_written(self):
+        """The additive guarantee, stated once where it is implemented.
+
+        Attaching a code to an existing refusal must not change a byte of
+        what a client already receives — that is what lets ``code`` be
+        introduced without a deprecation for anyone matching prose.
+        """
+        prose = "Reaction is not element-balanced (reaction_mass_balance_failed)."
+        exc = CodedValueError(
+            "reaction_mass_balance_failed", prose, message_prefix=False
+        )
+        assert str(exc) == prose
+        assert error_envelope(str(exc), code=exc.code, fallback_code="x") == {
+            "code": "reaction_mass_balance_failed",
+            "detail": prose,
+            "context": {},
+        }
+
+    def test_the_default_still_prefixes(self):
+        """The read API's published details carry ``"code: message"``.
+
+        ``unsupported_filter: filter(s) ['inchi'] are not supported by ...``
+        is a shape client tests already pin, so the default must not move
+        either.
+        """
+        exc = CodedValueError("unsupported_filter", "filter is unavailable")
+        assert str(exc) == "unsupported_filter: filter is unavailable"
+
+
+class _Coded(BaseModel):
+    value: int
+
+    @model_validator(mode="after")
+    def check(self):
+        if self.value < 0:
+            raise CodedValidationError(
+                "negative_value",
+                "value must not be negative.",
+                context={"value": self.value},
+                message_prefix=False,
+            )
+        return self
+
+
+def _errors(value: int) -> list[dict]:
+    try:
+        _Coded(value=value)
+    except ValidationError as exc:
+        return exc.errors()
+    raise AssertionError("expected a ValidationError")
+
+
+class TestPromotionIsTypedNotTextual:
+    def test_a_code_is_read_from_the_exception_not_the_message(self):
+        """Nothing about the sentence is parsed.
+
+        The message here contains no code at all, in any spelling. If the
+        promotion were textual this would fall back to the generic code,
+        which is exactly what every chemistry refusal used to do.
+        """
+        details = _errors(-1)
+        assert "negative_value" not in str(details[0]["msg"])
+        assert validation_detail_code(details, fallback="validation_error") == (
+            "negative_value"
+        )
+
+    def test_the_structured_context_comes_with_it(self):
+        assert validation_detail_context(_errors(-3)) == {"value": -3}
+
+    def test_a_plain_value_error_still_falls_back(self):
+        class _Plain(BaseModel):
+            value: int
+
+            @model_validator(mode="after")
+            def check(self):
+                raise ValueError("something went wrong.")
+
+        try:
+            _Plain(value=1)
+        except ValidationError as exc:
+            details = exc.errors()
+        assert validation_detail_code(details, fallback="validation_error") == (
+            "validation_error"
+        )
+        assert validation_detail_context(details) == {}
+
+
+def _failure(code: str, field: str) -> dict:
+    """One entry of a Pydantic ``errors()`` list, carrying a coded cause."""
+    return {
+        "type": "value_error",
+        "loc": ["body", field],
+        "msg": f"Value error, {field} is wrong.",
+        "ctx": {
+            "error": CodedValidationError(
+                code, f"{field} is wrong.", context={"field": field}
+            )
+        },
+    }
+
+
+class TestTwoCodesReportNeither:
+    def test_two_failures_fall_back_rather_than_pick_one(self):
+        """Naming one of two contradictions would deny the other.
+
+        A payload that is wrong in two ways is two things to fix. The
+        envelope says so by declining to name either; the ``detail`` list
+        still carries both, so nothing is hidden — only the single-code
+        summary is withheld, because there is no single code.
+        """
+        failures = [_failure("a_code", "alpha"), _failure("b_code", "beta")]
+        assert (
+            validation_detail_code(failures, fallback="request_validation_error")
+            == "request_validation_error"
+        )
+        assert validation_detail_context(failures) == {}
+
+    def test_one_failure_is_promoted(self):
+        """Guard the guard: the case above must fail for the right reason."""
+        failures = [_failure("a_code", "alpha")]
+        assert (
+            validation_detail_code(failures, fallback="request_validation_error")
+            == "a_code"
+        )
+        assert validation_detail_context(failures) == {"field": "alpha"}

--- a/backend/tests/db/test_scientific_check_register.py
+++ b/backend/tests/db/test_scientific_check_register.py
@@ -29,6 +29,7 @@ from sqlalchemy import text
 
 from app.scientific_checks import (
     CheckTier,
+    CodeChannel,
     ConstantThreshold,
     DatabaseConstraint,
     DesignPosition,
@@ -42,6 +43,16 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 BACKEND_ROOT = REPO_ROOT / "backend"
 GENERATOR = BACKEND_ROOT / "scripts" / "generate_scientific_check_register.py"
 REGISTER_DOC = REPO_ROOT / "docs" / "guides" / "scientific_check_register.md"
+
+#: The end-to-end proof that an ``error_envelope`` code actually arrives in
+#: an HTTP response body. Named here so the guard below can require every
+#: such code to appear in it.
+ENVELOPE_PROOF = (
+    BACKEND_ROOT / "tests" / "api" / "test_api_scientific_rejection_codes.py"
+)
+
+#: The exception types that carry a code out of a check as an attribute.
+CODED_ERROR_TYPES = frozenset({"CodedValueError", "CodedValidationError"})
 
 REGISTER = register()
 
@@ -133,6 +144,161 @@ def test_every_declared_code_appears_in_the_enforcing_module() -> None:
                 "Either the code was renamed and the register not updated, or "
                 "the entry should set emitted=False."
             )
+
+
+def _coded_error_codes(module) -> tuple[set[str], bool]:
+    """Codes this module raises through the typed path, and whether any is dynamic.
+
+    Reads the first positional argument of every ``CodedValueError`` /
+    ``CodedValidationError`` construction, resolving a bare name against
+    the module's own top-level string constants. A first argument that is
+    neither a literal nor a resolvable constant — ``codes.pop()`` in
+    ``raise_for_blocking_findings``, which reports whichever code the
+    findings agreed on — is reported as *dynamic* rather than guessed at.
+
+    Register declarations are blanked out first, for the same reason the
+    code-literal guard blanks them: a declaration must not be able to
+    satisfy an assertion about the check.
+    """
+    source = _source_without_declarations(module)
+    tree = ast.parse(source)
+
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Constant):
+            continue
+        if not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = node.value.value
+
+    resolved: set[str] = set()
+    dynamic = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        name = callee.id if isinstance(callee, ast.Name) else getattr(callee, "attr", "")
+        if name not in CODED_ERROR_TYPES:
+            continue
+        if not node.args:
+            dynamic = True
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            resolved.add(first.value)
+        elif isinstance(first, ast.Name) and first.id in constants:
+            resolved.add(constants[first.id])
+        elif isinstance(first, ast.Attribute) and first.attr in constants:
+            resolved.add(constants[first.attr])
+        else:
+            dynamic = True
+    return resolved, dynamic
+
+
+def test_every_entry_declares_where_its_code_reaches_a_client() -> None:
+    """A code and a channel imply each other, and blocking checks name one.
+
+    The gap this exists to catch was found by reading, not by CI: eleven
+    entries declared no code at all, and every entry that *did* declare
+    one spelled it inside an English sentence that the response envelope
+    never promoted — so the register read as though a client could branch
+    on elemental balance when it could only branch on
+    ``validation_error``. The construction-time invariant in
+    :class:`ScientificCheck` covers the first half; this covers the half
+    that matters for a refusal, which is that a check able to refuse an
+    upload must say something a program can act on.
+    """
+    for check in REGISTER:
+        assert bool(check.codes) == (check.channel is not CodeChannel.none), (
+            f"{check.asserts!r} declares {len(check.codes)} code(s) with "
+            f"channel={check.channel.value}"
+        )
+        if check.tier is not CheckTier.block:
+            continue
+        if not any(isinstance(s, PythonCheck) for s in check.enforced_by):
+            continue
+        assert check.channel is CodeChannel.error_envelope, (
+            f"{check.asserts!r} refuses payloads from Python and would reach a "
+            f"client as channel={check.channel.value}. A blocking check whose "
+            "refusal carries no code in the error envelope leaves a client "
+            "string-matching English to find out what it did wrong — which is "
+            "the exact condition this field was added to make impossible."
+        )
+
+
+def test_error_envelope_codes_are_raised_through_the_typed_path() -> None:
+    """An ``error_envelope`` code must be an argument, never only a substring.
+
+    The parenthesised convention — ``"... (reaction_mass_balance_failed)."``
+    — satisfied the older "the literal appears in the module" guard while
+    reaching no client at all, because the envelope promoter's pattern
+    requires a colon. Requiring the code to be the *first argument* of a
+    coded-error construction is the difference between a code the module
+    mentions and a code the module reports.
+    """
+    for check in REGISTER:
+        if check.channel is not CodeChannel.error_envelope:
+            continue
+        python_sites = [s for s in check.enforced_by if isinstance(s, PythonCheck)]
+        assert python_sites, (
+            f"{check.asserts!r} claims to reach the error envelope but names no "
+            "Python enforcement site, so nothing can raise it."
+        )
+        resolved: set[str] = set()
+        dynamic = False
+        for site in python_sites:
+            module = inspect.getmodule(site.func)
+            assert module is not None
+            site_resolved, site_dynamic = _coded_error_codes(module)
+            resolved |= site_resolved
+            dynamic |= site_dynamic
+        assert resolved or dynamic, (
+            f"{check.asserts!r} is declared to reach the error envelope, but no "
+            "module defining its enforcing function constructs a "
+            f"{' or '.join(sorted(CODED_ERROR_TYPES))} at all — so it raises a "
+            "bare ValueError and the response body will say validation_error."
+        )
+        for code in check.codes:
+            assert code in resolved or dynamic, (
+                f"Code {code!r} is declared to reach the error envelope, but no "
+                "enforcing module passes it to a coded error. Embedding a code "
+                "in a message is not reporting it: only the exception's own "
+                "attribute survives into the response body's code field."
+            )
+
+
+def test_every_error_envelope_code_is_proved_end_to_end() -> None:
+    """Each envelope code must be asserted against a real HTTP response body.
+
+    The two guards above are about the raise site. Neither can tell you
+    whether the code survives Pydantic wrapping, the exception handler and
+    the JSON encoder — and that whole path is where the codes were being
+    lost. So the register's claim is anchored to a test that reads
+    ``response.json()["code"]``, and a new envelope code cannot be
+    declared without one.
+    """
+    assert ENVELOPE_PROOF.exists(), f"{ENVELOPE_PROOF} is missing"
+    proof = ENVELOPE_PROOF.read_text()
+    declared = sorted(
+        {
+            code
+            for check in REGISTER
+            if check.channel is CodeChannel.error_envelope
+            for code in check.codes
+        }
+    )
+    assert declared, "no error_envelope codes — this guard would pass vacuously"
+    missing = [code for code in declared if code not in proof]
+    assert not missing, (
+        f"These codes are declared to reach the 422 body but no end-to-end test "
+        f"in {ENVELOPE_PROOF.name} names them: {missing}. Add one that asserts "
+        "response.json()['code'] == the code — not that the message contains "
+        "it, which is the assertion that let the gap survive."
+    )
 
 
 def test_declaring_modules_covers_every_file_that_declares_a_check() -> None:

--- a/docs/clients/generic-client-targeting.md
+++ b/docs/clients/generic-client-targeting.md
@@ -425,8 +425,44 @@ instance is to upload it to that instance directly via its API.
 
 - **422 on upload even though authentication works.** The request reached
   TCKDB, but the payload failed schema/scientific validation. Check
-  `Content-Type: application/json`, inspect the response `detail`, and
-  verify you are using the upload schema for the target endpoint.
+  `Content-Type: application/json`, read the response `code` (see below),
+  and verify you are using the upload schema for the target endpoint.
+
+---
+
+## Telling one 422 from another
+
+A refusal body is `{"code": ..., "detail": ..., "context": {...}}`. **Branch
+on `code`, never on `detail`.** `detail` is a paragraph of advice written for
+a human, and it will be reworded; `code` is the contract.
+
+`request_validation_error` means the payload did not match the schema — a
+missing field, a wrong type — and the `detail` list names the offending
+path. Anything else is a *scientific* refusal: the payload was well-formed
+and the chemistry in it contradicted itself. Those codes are enumerated,
+one per claim, in
+[the scientific check register](../guides/scientific_check_register.md);
+every entry whose "code reaches a client via" row says `error_envelope`
+appears in a 422 body exactly as written there.
+
+The distinction worth building on is what a client should *do*:
+
+| Code | What it means | What to do |
+| --- | --- | --- |
+| `species_geometry_composition_mismatch`, `species_geometry_isotope_mismatch`, `species_smiles_charge_mismatch` | the structure you deposited and the label you gave it describe different molecules | fix the payload and retry — one of the two is a typo |
+| `reaction_mass_balance_failed`, `reaction_charge_not_conserved`, `transition_state_composition_mismatch`, `transition_state_charge_mismatch` | the reaction as written is not a reaction | stop and investigate; retrying the same thing cannot help |
+| `atom_map_*`, `transition_state_irc_mapping_element_mismatch` | the mechanism you described contradicts itself, or an index counts against the wrong geometry | correct the mapping; note that indices are geometry-relative (ADR 0011) |
+| `transition_state_no_imaginary_mode`, `transition_state_reaction_coordinate_*`, `n_imag_contradicts_minimum` | the frequency evidence contradicts the kind of stationary point declared | re-declare the entry as what it is, or deposit no frequency evidence |
+| `arrhenius_a_units_molecularity_mismatch` | `a_units` do not have the dimensionality the reaction order requires | fix the unit token |
+| `validation_error` | a refusal that carries no more specific code | read `detail`; and please report it, because a scientific refusal reaching you as this is a gap |
+
+`context` carries the same facts in structured form — the two element
+counts that disagreed, the two charges, the disputed atom indices — so a
+client can render a useful message without parsing the sentence.
+
+A warning is not a refusal: an accepted upload returns `201` with a
+`warnings` list whose entries carry their own `code`. The register's
+`upload_warning` rows are those.
 
 ---
 

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -36,6 +36,16 @@ disagree about a line number, this one is right by construction.
   recognise. Not a description of the implementation.
 - **Tier** — the ADR 0008 consequence, with the justification for *that* tier
   in the ADR's own terms.
+- **Code**, and **where it reaches a client** — these are two different facts
+  and the register used to state only the first. A code is not a contract until
+  something carries it somewhere a consumer can read it, and for a long time
+  nothing did: six checks spelled their code inside an English sentence
+  (`"... (reaction_mass_balance_failed)."`) that no parser matched, and the 422
+  body's own `code` field said `validation_error` for every chemistry refusal
+  in the system. Naming the channel is what makes the claim checkable —
+  `backend/tests/db/test_scientific_check_register.py` holds each channel to
+  its obligation, and an `error_envelope` code must both be raised through the
+  typed path and be proved to arrive by an end-to-end HTTP test.
 - **Enforced at** — `file:line` for Python, or the constraint/trigger name for
   PostgreSQL. Database names are verified against live schema metadata by
   `backend/tests/db/test_scientific_check_register.py`, not trusted as strings.
@@ -71,6 +81,17 @@ disagree about a line number, this one is right by construction.
 | `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
 | **total** | **30** | |
 
+## Where a check's code reaches a client
+
+| Channel | Entries | What a consumer can do with it |
+| --- | --- | --- |
+| `error_envelope` | 17 | the `code` field of the 422 error body — a client can branch on it |
+| `upload_warning` | 9 | the `code` field of an `UploadWarning` returned alongside the accepted upload |
+| `trust_label` | 1 | a read-time trust label (`HardFailReason`), not any refusal |
+| `database_constraint` | 0 | PostgreSQL only, so the client sees a generic 409 integrity code rather than this check's name |
+| `none` | 3 | *nothing carries a code* |
+| **total** | **30** | |
+
 ## Recorded divergences
 
 Where a check's documentation and its behaviour disagree, or where a guarantee is narrower than its name suggests. Every one of these is reported, never silently fixed — the register changes no check behaviour.
@@ -92,13 +113,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `reaction_mass_balance_failed` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. Mass balance is what makes a set of species a reaction rather than a list, so no correct calculation can produce an unbalanced one; the check cannot fire on a correct novel result.
 
 **Enforced at.**
 
-- `validate_reaction_elemental_balance` — `backend/app/services/reaction_resolution.py:134`
+- `validate_reaction_elemental_balance` — `backend/app/services/reaction_resolution.py:175`
   *Called from `resolve_chem_reaction`, so it fires on every path that resolves a reaction, including the PDep bundle.*
 
 **Escape hatch.** Declare a participant with `molecule_kind: pseudo`. A lumped or phenomenological construct has no atom-resolved composition, so one such participant suspends the law for the whole reaction. A declared electron does **not** exempt it — an electron contributes zero atoms and the reaction still has to balance.
@@ -109,13 +131,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `reaction_charge_not_conserved` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional, and only because the escape hatch exists. Electrons are neither created nor destroyed by rearranging bonds. Without a way to name a free electron the rule would in fact assert 'every participant was declared', which is an expectation about the depositor rather than a definition of a reaction, and ADR 0008 disqualifies an expectation from blocking.
 
 **Enforced at.**
 
-- `validate_reaction_charge_conservation` — `backend/app/services/reaction_resolution.py:222`
+- `validate_reaction_charge_conservation` — `backend/app/services/reaction_resolution.py:270`
   *Sums `Species.charge`, which `canonical_species_identity` has already reconciled against the formal charge of each species' own SMILES.*
 
 **Escape hatch.** Declare the free electron as a participant — `{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, "multiplicity": 2}` — which is how associative and dissociative attachment, photoionization and photodetachment are deposited. It contributes -1 to the side it sits on and zero atoms, so elemental balance still has to be satisfied separately. A `pseudo` participant suspends the law entirely, as it does for elemental balance. Conservation is not neutrality: any net charge is accepted as long as both sides carry the same one, so ion-molecule reactions are unaffected.
@@ -126,13 +149,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `transition_state_composition_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. A transition state is a stationary point on the potential energy surface *of those atoms*, so a saddle point with a different molecular formula cannot be that reaction's saddle point, whatever else is true of it.
 
 **Enforced at.**
 
-- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:364`
+- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:419`
   *Composition is read from the saddle-point geometry when there is one and from `unmapped_smiles` otherwise. The PDep path passes no SMILES, so it compares geometry only.*
 
 **Escape hatch.** Declare the extra species as participants of the reaction. A `pseudo` *reactant* exempts the reaction; a pseudo product does not, and that is not an oversight — see below. Absence does not block: no geometry and no parseable SMILES means nothing is compared, and an unparseable transition-state SMILES is treated as silence rather than as a contradiction, because a TS SMILES is a lossy label for a structure that is by construction not a stable molecule. The pseudo-species exemption here is narrower than `_load_participant_species`'s, and deliberately so. That helper exempts elemental balance and charge conservation on a pseudo participant on **either** side, because both compare one side against the other and a lumped construct makes the side it sits on unknowable. This check compares the saddle point against the **reactant side only**, so only a *reactant* being pseudo can make it meaningless; a pseudo *product* leaves the reactant side fully atom-resolved and is not exempted. Aligning the two would discard a guarantee that is still well-defined, and would discard it exactly where it is worth most: a reaction with a pseudo product has already lost elemental balance and charge conservation, so this is the only atom-level statement left about its saddle point.
@@ -143,13 +167,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `transition_state_charge_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. Charge is conserved along a reaction coordinate, so a saddle point at a different charge is on a different potential energy surface — not a worse calculation of the same one.
 
 **Enforced at.**
 
-- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:364`
+- `validate_transition_state_composition` — `backend/app/services/reaction_resolution.py:419`
   *Second, independent leg of the same function. Skipped entirely when the caller passes no `transition_state_charge`.*
 
 **Escape hatch.** Omit the transition state's charge, which skips the comparison. Multiplicity is deliberately **not** checked here at all: spin is not conserved the way charge and atoms are — two doublets may react over a singlet or a triplet surface, and spin-forbidden reactions are real chemistry — so a multiplicity rule would fire on correct novel results. The pseudo-species exemption here is narrower than `_load_participant_species`'s, and deliberately so. That helper exempts elemental balance and charge conservation on a pseudo participant on **either** side, because both compare one side against the other and a lumped construct makes the side it sits on unknowable. This check compares the saddle point against the **reactant side only**, so only a *reactant* being pseudo can make it meaningless; a pseudo *product* leaves the reactant side fully atom-resolved and is not exempted. Aligning the two would discard a guarantee that is still well-defined, and would discard it exactly where it is worth most: a reaction with a pseudo product has already lost elemental balance and charge conservation, so this is the only atom-level statement left about its saddle point.
@@ -160,13 +185,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `transition_state_irc_mapping_element_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008, 0011 |
 
 **Why this tier.** Definitional. 'These saddle-point atoms become C2H4' while those atoms are C2O2H2 is a contradiction no correct calculation can produce — the same class of claim `CHECK_TRANSITION_STATE_COMPOSITION` already blocks, one level finer, per participant rather than per side. It is also what the register's own consistency requires: the identical assertion expressed as a `reaction_atom_map` is refused by `CHECK_ATOM_MAP_ELEMENT_CONSERVED`, at the wire boundary and again by a composite foreign key into `geometry_atom`. Two surfaces enforcing different standards on the same claim is not a defensible position for either — and the divergence was not theoretical: a well-formed partition handing ethene two oxygens and HO2 three hydrogens was accepted, under a fixture comment that correctly said 'C2H4 (six atoms)'.
 
 **Enforced at.**
 
-- `validate_ts_evidence_participant_composition` — `backend/app/services/reaction_resolution.py:599`
+- `validate_ts_evidence_participant_composition` — `backend/app/services/reaction_resolution.py:668`
   *Called from `persist_transition_state_validation_evidence`, the single seam every deposit path that can carry a transition state already routes through, so the PDep bundle, the computed-reaction bundle and the standalone transition-state upload cannot enforce different standards. It is a service-layer check rather than a wire-boundary one because a participant's composition comes from its SMILES, and `tckdb_schemas` is chemistry-free — RDKit is not available where `validate_ts_evidence_set` runs. That function keeps the *shape* half of the rule: keys name every declared participant, indices partition the TS atoms exactly once.*
 
 **Escape hatch.** Omit the participant mappings. They are optional on every path — evidence without them still deposits and still reads back as `irc: present` — so a depositor who cannot resolve the partition per atom is never forced to guess at one. Declaring a participant `molecule_kind: pseudo` skips that participant alone rather than the whole record, because the others' compositions are still well-defined. Isotopologues are safe by construction: both sides are compared through `resolve_element_symbol`, so a geometry written `D` counts as the hydrogen its SMILES spells `[2H]`.
@@ -181,13 +207,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `species_geometry_composition_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. No correct calculation produces a geometry that is not made of its own molecule's atoms, so a formula disagreement between a structure and its own identifier is a contradiction rather than an expectation — every energy, frequency and partition function downstream would describe a different molecule under the deposited label.
 
 **Enforced at.**
 
-- `assert_geometry_composition_matches_identity` — `backend/app/services/species_resolution.py:223`
+- `assert_geometry_composition_matches_identity` — `backend/app/services/species_resolution.py:242`
   *Conformer geometries only, via `resolve_species_entry`: the computed-species bundle, `/uploads/conformers`, the computed-reaction bundle and the PDep bundle. **Calculation** input and output geometries are reached by no composition check on any path — benzene coordinates can still be attached as a calculation geometry under a `smiles: "C"` entry. Closing that for *output* geometries would be wrong (an optimisation that dissociated is science to record); for *input* geometries it is an open gap.*
 
 **Escape hatch.** Declare `molecule_kind: pseudo`, which has no atom-resolved composition to agree with. A free electron is deliberately **not** exempt — its composition is not unknown but empty, so any geometry deposited under one is refused, which stops `electron` becoming a quieter way to smuggle a structure past the check. Absence does not block: no geometry, or a SMILES RDKit will not parse, is incompleteness.
@@ -197,40 +224,38 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `species_geometry_isotope_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. The identity's isotope label and the geometry's per-atom masses describe the same nuclei; when they disagree one of them is wrong and there is no defensible way to pick a winner, so a CD3OH identity on an all-protium geometry would yield frequencies for a molecule nobody deposited.
 
 **Enforced at.**
 
-- `assert_geometry_isotopes_match_identity` — `backend/app/services/species_resolution.py:103`
-  *Runs from `resolve_species_entry` only when a geometry is supplied. Raises prose with no machine-readable code, so no client can key off it — recorded here as a gap rather than papered over.*
+- `assert_geometry_isotopes_match_identity` — `backend/app/services/species_resolution.py:116`
+  *Runs from `resolve_species_entry` only when a geometry is supplied. The refusal was prose-only until the code above was attached; a client could not tell it from any other 422, which is why the entry used to record the gap here.*
 
 **Escape hatch.** Deposit no geometry. An explicitly declared *standard* isotope is dropped before comparison, so `{1: 1}` on a hydrogen cannot fork an identity away from an unlabelled deposit of the same molecule.
 
 **Recorded divergence.** Not a divergence but a documented false *acceptance*, restated here because a referee will ask: only the multiset is compared, so isotopomers are not distinguished. An identity of `[2H]OC` (CH3-OD) accepts a geometry labelling a methyl hydrogen instead (CH2D-OH) — different molecules with different zero-point energies. Closing it needs an atom-level SMILES-to-XYZ correspondence the repository does not have. Where the two disagree invisibly, the geometry is authoritative for masses and the SMILES only for identity.
-
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
 ### 8. A species entry's declared charge equals the summed formal charge of its own SMILES.
 
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `species_smiles_charge_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional, and the anchor the reaction-level charge law stands on: `validate_reaction_charge_conservation` sums `Species.charge` and is only meaningful because each value has already been reconciled with the structure it labels. Per ADR 0008 the blocking tier owns the rule and the others cite it, which is why `assert_geometry_composition_matches_identity` deliberately does not re-check charge.
 
 **Enforced at.**
 
-- `canonical_species_identity` — `backend/app/chemistry/species.py:528`
+- `canonical_species_identity` — `backend/app/chemistry/species.py:538`
   *Charge is compared against `formal_charge` of the sanitized identity molecule — the sum of RDKit per-atom formal charges, which is a notation convention rather than an electron count. A referee may object that formal-charge assignment on hypervalent, zwitterionic or dative-bonded SMILES is notation-dependent.*
 
 **Escape hatch.** A free electron short-circuits before the comparison, returning a pinned identity pair. Multiplicity is deliberately **not** validated against the SMILES at all: standard SMILES does not encode spin state, so RDKit's inferred radical count is only a hint and the uploaded multiplicity is authoritative — which is what lets singlet CH2 (whose SMILES `[CH2]` implies a triplet) and the singlet and triplet states of O2 be represented.
-
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
 ### 9. The charge and spin multiplicity a depositor declares match the ones the electronic-structure log says the calculation was actually run at.
 
@@ -238,13 +263,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `charge_mismatch`, `multiplicity_mismatch` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** **Placed against the ADR's own reasoning, deliberately.** ADR 0008 names both findings as direct contradictions between a declaration and the parsed evidence, therefore definitional, therefore belonging at the blocking tier — and then defers the promotion, because promoting a warning to a blocker rejects payloads that are accepted today. These checks have never fired on real data, so their false-positive rate is unknown and promoting them first would be unsafe. The register records the gap rather than hiding it: this is the clearest case in TCKDB of a check sitting one tier below where its own governing decision puts it.
 
 **Enforced at.**
 
-- `reconcile_charge_multiplicity` — `backend/app/services/charge_multiplicity_reconciliation.py:217`
+- `reconcile_charge_multiplicity` — `backend/app/services/charge_multiplicity_reconciliation.py:222`
   *Re-reads charge and multiplicity from the uploaded artifact using the wired Gaussian, ORCA, Psi4 and Molpro parsers.*
 
 **Escape hatch.** Absence is not contradiction: if the producing program is not one of the wired parsers, the artifact is missing, the log is truncated, or the declarations inside a single log disagree with each other, the value is left unknown and **no** warning is emitted. Only a value genuinely read from the log may contradict a declaration — emitting a mismatch because parsing failed would fabricate a contradiction out of ignorance.
@@ -255,20 +281,21 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | *(none — prose only)* |
+| **Code reaches a client via** | *nothing carries a code* |
 | **Governing ADR** | 0008, 0002 |
 
 **Why this tier.** An expectation, and correctly non-blocking. An optimisation that rearranged, dissociated or transferred a proton is science to record, not a payload to refuse, and connectivity perception from XYZ is unreliable for exactly the weak complexes, radicals, ions and stretched geometries where a genuine rearrangement would matter. The result is written as an evidence row that grades the record at read time; it never refuses an upload.
 
 **Enforced at.**
 
-- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:121`
+- `validate_calculation_geometry` — `backend/app/services/geometry_validation.py:126`
   *Species-owned `opt` calculations only. Transition states are deliberately excluded, having no canonical SMILES to compare against. Best-effort by policy: a missing SMILES, a missing output geometry, unparseable coordinates or a raising chemistry layer all write nothing and let the upload continue. A Kabsch RMSD above 1.0 A against the input geometry is recorded as a separate suspicion signal.*
 
 **Escape hatch.** The whole check is advisory, so there is nothing to escape. What a consumer must not do is read a `fail` row as 'this calculation is scientifically invalid'; it means only that the automated identity validator found a mismatch.
 
 **Recorded divergence.** The stored column is named `is_isomorphic` and the surrounding policy is worded as graph isomorphism, but the code tests the **molecular formula** only. Atom mapping falls back to a SMILES-graph matcher whenever bond perception from XYZ fails, which is the common case for the radicals, ions and stretched geometries this service mostly sees, and that fallback rejects a candidate on one condition: the per-element atom counts disagree. Verified by direct call in the module docstring — ethanol declared with dimethyl ether deposited passes, and methane with one hydrogen pulled to 5 A passes. So the rearrangement, bond-breaking, dissociation and proton-transfer cases the module was written to catch are not caught. Already self-documented in the module docstring rather than discovered here; recorded because the field name is what a consumer sees and it still overstates the guarantee.
 
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by a database constraint alone surfaces as a generic integrity conflict, and one held by schema shape or by a stored evidence row never surfaces as a refusal at all.)*
 
 ## Stationary points
 
@@ -278,13 +305,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `transition_state_no_imaginary_mode`, `transition_state_reaction_coordinate_not_designated`, `transition_state_reaction_coordinate_ambiguous` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0012, 0008 |
 
 **Why this tier.** Definitional, and narrower than what it replaced. ADR 0008's worked example was `n_imag == 1`; ADR 0012 retired that, because 'exactly one negative eigenvalue' is a statement about the exact Hessian at the exact stationary point on a smooth surface and a deposit contains none of those. Two scientifically correct calculations of the same saddle point can return `n_imag == 1` and `n_imag == 3`, so a gate a depositor passes by switching to `Int=UltraFine` is not a gate on science — and its cheapest workaround is deleting a line from the frequency list, which turns visible ambiguity into invisible falsehood. What survives the translation into a database row is a *contract*: no imaginary mode at all means there is no reaction coordinate and the structure is not a transition state; more than one with no designation means the record cannot answer the question every transition-state-theory code asks it; and an undeclared mode at least as stiff as the designated one means the designation is an assertion the record does not support. None of the three can be produced by a correct calculation that has been honestly described.
 
 **Enforced at.**
 
-- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:698`
+- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:699`
   *A transition state carries no `stationary_point_kind` column — the entity *is* the claim — so the rule needs no kind argument. Upload schemas call `raise_for_blocking_findings` from a `model_validator`, so the contradiction becomes a 422 before the route body opens a submission. The designation is then persisted on `calc_freq_result.reaction_coordinate_mode_index`, which is what lets the read-time trust rubric cite this judgement instead of re-deriving it.*
 - `_check_ts_reaction_coordinate_designated` and `_detect_transition_state_entry_hard_fail` (`backend/app/services/trust/rubrics.py`, `backend/app/services/trust/evaluator.py`) ask at read time whether the record carries the designation this blocking tier required of it — a question about persisted state, not a second opinion about physics. They cannot disagree with the verdict above, which is the collapse ADR 0008 section 9 asked for.
 
@@ -296,13 +324,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `n_imag_contradicts_minimum` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. A covalently bound minimum whose own frequency evidence reports an imaginary mode is mislabelled: the correct response is to re-optimise on a tighter integration grid or to declare it as something else, so refusing the deposit rejects no correct calculation.
 
 **Enforced at.**
 
-- `evaluate_species_entry_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:560`
+- `evaluate_species_entry_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:561`
   *One imaginary mode and two-or-more are folded into a single blocking message that names `n_imag_higher_order_saddle` for the higher-order case. A stationary-point kind the module has not been taught about produces no findings — adding an enum member must be a deliberate decision, not a default.*
 
 **Escape hatch.** Declare `species_entry_kind='vdw_complex'`, which records the same mode with a warning instead, or deposit the structure through a transition-state payload if the single imaginary mode is real.
@@ -313,13 +342,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `n_imag_contradicts_minimum`, `n_imag_higher_order_saddle`, `n_imag_suggests_transition_state` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** The carve-out is the scientific content. A van der Waals complex is held together by intermolecular forces and its stretch, bends and hindered internal rotations sit below roughly 50 cm-1 — the region where numerical noise in a finite-difference or quadrature-grid Hessian is comparable to the true curvature. A small imaginary mode there is usually a grid artifact, so refusing it would force an expensive re-run for a physically meaningless mode. This is what earns `vdw_complex` a separate enum member: it is the only place the two minimum kinds behave differently.
 
 **Enforced at.**
 
-- `evaluate_species_entry_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:560`
+- `evaluate_species_entry_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:561`
   *Same entry point as the blocking minimum rule; the declared kind decides the tier while the code names the finding. A mode at or above 100 cm-1 additionally raises `n_imag_suggests_transition_state`, because that is far too stiff to be intermolecular.*
 
 **Escape hatch.** This *is* the escape hatch for the blocking minimum rule. Its own cost is that a genuinely mislabelled saddle point deposited as a van der Waals complex is accepted with a warning.
@@ -330,18 +360,19 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `transition_state_extra_imaginary_modes_below_tau`, `transition_state_extra_imaginary_mode_above_tau`, `transition_state_extra_imaginary_modes_not_assessable` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0012 |
 
 **Why this tier.** The extra modes cannot be classified from the frequency list, so refusing the deposit would assert a determination the deposit does not contain the information to support — an expectation about numerical quality wearing the costume of a definition. They can also be simply correct: a harmonic model is inapplicable to a torsion, a ring pucker or an intermolecular mode in a loose complex, and a transition state can sit at a maximum of a torsional profile while being a perfectly correct reactive bottleneck, in which case the extra negative eigenvalue is not an artefact but exactly right. Warning rather than blocking is also the only choice that preserves evidence: a record carrying all three frequencies and the full protocol can be reassessed under a better rule in five years, while a refused deposit leaves nothing behind.
 
 **Enforced at.**
 
-- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:698`
+- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:699`
   *Above tau the record is flagged as well as warned: the flag is ADR 0012's answer to 'warnings get ignored', excluding the record from default transition-state consumption without creating the incentive to edit the frequency list that a hard block creates. Below tau it is warned only. The flag and the tau that decided it are persisted on `calc_freq_result` rather than recomputed, so a later parser improvement cannot silently re-label historical records.*
 
 **Thresholds.**
 
-- `tau` — **not a constant.** Resolved per record, in cm-1, by `resolve_tau` (`schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:223`) from the recorded execution provenance `freq.hessian_method`, `grid.quality`, `opt.convergence`.
+- `tau` — **not a constant.** Resolved per record, in cm-1, by `resolve_tau` (`schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:224`) from the recorded execution provenance `freq.hessian_method`, `grid.quality`, `opt.convergence`.
   The Hessian noise floor is flat in omega-squared, not in omega, so the uncertainty in a frequency diverges as omega goes to zero: at 300 cm-1 the sign is never in doubt, at 20 cm-1 it is indeterminate. Where the crossover sits depends on how the second derivatives were built, on what integration grid, and how tightly the geometry was converged. The same -42 cm-1 is real negative curvature under an analytic Hessian on a tight grid and indistinguishable from zero under a numerical one on a default grid, so it cannot be classified from the frequency list at all — only against the protocol that produced it. A constant here would be a claim about physics that is false.
 
   | recorded protocol | `tau` / cm-1 |
@@ -364,20 +395,21 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `transition_state_imaginary_frequency_too_small` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0008, 0012 |
 
 **Why this tier.** ADR 0008's worked counter-example, and the sharpest statement of the whole rule. A very soft imaginary mode is suspicious — often an under-converged geometry or a coarse integration grid — but it can be perfectly real, because flat barriers and variational transition states genuinely produce them. Magnitude is therefore a quality expectation, never a definition, and a check that could fire on a correct novel result must not block.
 
 **Enforced at.**
 
-- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:698`
+- `evaluate_transition_state_frequency` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:699`
   *ADR 0012 changed what this fires *on* without changing what it fires at. It used to read the single imaginary mode of a record that had passed the `n_imag == 1` gate; it now reads the designated reaction coordinate of a record that may carry several. Both thresholds are declared above because both reach the same message: the warning quotes the protocol's tau alongside its own constant, so a reader who is told a reaction coordinate is soft can see immediately whether that calculation could resolve a small mode at all.*
 
 **Thresholds.**
 
 - `TS_IMAGINARY_FREQUENCY_MIN_CM1` = **100 cm-1** — a constant fixed in code.
   A starting point rather than a physical constant: reaction coordinates for hydrogen transfers run to thousands of cm-1, while genuinely flat barriers fall well under 100. Unlike tau it really is fixed in code, because it is a statement about chemistry — what a reaction coordinate looks like — rather than about numerics. It is also the scale that separates a van der Waals complex's soft intermolecular modes from a real reaction coordinate, and is reused for that judgement.
-- `tau` — **not a constant.** Resolved per record, in cm-1, by `resolve_tau` (`schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:223`) from the recorded execution provenance `freq.hessian_method`, `grid.quality`, `opt.convergence`.
+- `tau` — **not a constant.** Resolved per record, in cm-1, by `resolve_tau` (`schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py:224`) from the recorded execution provenance `freq.hessian_method`, `grid.quality`, `opt.convergence`.
   The Hessian noise floor is flat in omega-squared, not in omega, so the uncertainty in a frequency diverges as omega goes to zero: at 300 cm-1 the sign is never in doubt, at 20 cm-1 it is indeterminate. Where the crossover sits depends on how the second derivatives were built, on what integration grid, and how tightly the geometry was converged. The same -42 cm-1 is real negative curvature under an analytic Hessian on a tight grid and indistinguishable from zero under a numerical one on a default grid, so it cannot be classified from the frequency list at all — only against the protocol that produced it. A constant here would be a claim about physics that is false.
 
   | recorded protocol | `tau` / cm-1 |
@@ -398,13 +430,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `transition_state_missing_irc_evidence` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Absence, not contradiction. Refusing a transition state without an IRC would lose the saddle point entirely, and a saddle point with no IRC is an incomplete record rather than a false one. The evidence is recommended, not required.
 
 **Enforced at.**
 
-- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:39`
+- `persist_transition_state_validation_evidence` — `backend/app/services/transition_state_validation.py:44`
   *Every path that can carry a transition state routes through this seam — the PDep bundle, the computed-reaction bundle and the standalone transition-state upload — so all three write identical rows and report an identical gap. Before the seam existed only the PDep bundle could deposit the evidence, so a TS uploaded any other way always read back as `irc: absent` even when the depositor had run one.*
 
 **Escape hatch.** None needed — the warning is the accommodation. Note the warning fires on absence of a *passing* record, so evidence that was run and failed is stored and still warns.
@@ -416,35 +449,35 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `atom_map_element_not_conserved` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Definitional. A map asserting that an element transmutes is a record that cannot be what it says it is, not an unusual result.
 
 **Enforced at.**
 
-- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:302`
   *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
 - `ck_reaction_atom_map_pair_element_matches` (check on `reaction_atom_map_pair`)
   `upper(element) = upper(ts_element)`
 
 **Escape hatch.** Case is not load-bearing. The comparison is deliberately case-insensitive because the two ends quote two different geometries, and a geometry stores the symbol its depositor's XYZ wrote — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
-
 ### 18. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `atom_map_not_a_bijection` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Definitional. A map is a bijection or it is not a map; an atom claimed twice describes no mechanism at all.
 
 **Enforced at.**
 
-- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:302`
   *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
 - `uq_reaction_atom_map_pair_ts_atom_index` (unique on `reaction_atom_map_pair`)
   `(atom_map_id, side, ts_atom_index)`
@@ -453,21 +486,20 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Per leg, not globally: the reactant and product legs each claim the whole saddle point, which is the point of storing two maps both pointing at it. A `side` column exists on the pair row purely so this can be a unique constraint, because SQL cannot dereference the participant to find its role.
 
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
-
 ### 19. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
 
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `atom_map_indices_not_geometry_relative` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Definitional, and it is where ADR 0011's central choice is cashed out. Atom indices are not a property of a species — `geometry_atom.atom_index` is a property of a *geometry* — so 'reactant atom 3' is meaningless until the geometry being counted is named. An index counted against the wrong geometry silently means the wrong atom, which is the failure mode geometry-relative indexing was chosen to make impossible.
 
 **Enforced at.**
 
-- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:302`
   *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
 - `fk_reaction_atom_map_pair_geometry_id_geometry_atom` (foreign_key on `reaction_atom_map_pair`)
   `(geometry_id, atom_index, element) -> geometry_atom(geometry_id, atom_index, element)`
@@ -478,26 +510,23 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None, and the cost is stated in ADR 0011: the map is welded to the geometries it names, so depositing a second conformer or re-optimising at another level of theory does not carry it across. Canonical-order-relative indexing would be portable, and was rejected because its failure mode is a map that looks fine and refers to a different atom order than the depositor intended. Portability can be added later as a derived view; correctness cannot be retrofitted onto records nobody can verify.
 
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
-
 ### 20. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
 
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `atom_map_atoms_unaccounted_for` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Definitional, but only under a precondition that has to be checked first. A reactant atom unaccounted for in the products is a contradiction *when no species is missing*. When the declared reaction is not atom-balanced a species genuinely is missing, and the same discrepancy is incompleteness rather than contradiction — so the rule is gated on the map being complete over every participant and on the reaction balancing, and warns instead otherwise.
 
 **Enforced at.**
 
-- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:228`
+- `validate_reaction_atom_map` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:302`
   *Wire boundary only. This one has no database counterpart: it is a statement about a whole map rather than about one pair row, and a per-row constraint cannot see it.*
 
 **Escape hatch.** Leave the map incomplete, or deposit an unbalanced reaction — either drops the rule to the warning tier by design rather than by accident.
-
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
 ### 21. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
 
@@ -505,13 +534,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `block` |
 | **Code** | `atom_map_contradicts_irc_mapping` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Definitional, because the two surfaces are one claim at two resolutions rather than two claims. An IRC participant mapping partitions the saddle-point atoms among the declared participants; an atom map is, in this schema's own words, 'the refinement of that partition into a bijection'. A refinement that contradicts what it refines is not extra detail, it is a record asserting that one saddle point is two incompatible things at once, and no correct calculation produces both halves of it — the depositor followed one intrinsic reaction coordinate, not two. This is the same class of claim as `CHECK_TS_IRC_MAPPING_ELEMENTS` and `CHECK_ATOM_MAP_ELEMENT_CONSERVED`, which already block, and leaving it advisory would let the pair assert together what neither is allowed to assert alone.
 
 **Enforced at.**
 
-- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:304`
+- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:310`
   *Called from *both* seams — `persist_reaction_atom_map` and `persist_transition_state_validation_evidence` — and reads both surfaces from the database rather than from either caller's payload, so whichever a deposit writes second delivers the same verdict. Today the second is always the atom map: the computed-reaction bundle is the only payload with an `atom_map` field and writes it after the evidence, and no path can attach a map to a saddle point deposited earlier because every transition-state entry is created fresh by the deposit that writes it. Both are incidental orderings, so neither is relied on.*
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction.
@@ -524,13 +554,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `reaction_atom_map_absent` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Absence, not contradiction. An unmapped reaction is an incomplete record rather than a false one — the rate constant is still the rate constant and what is missing is the mechanistic detail. Blocking would reject correct science over evidence the depositor may not have, and would make every reaction already in the database undepositable.
 
 **Enforced at.**
 
-- `_warn_absent` — `backend/app/services/reaction_atom_map.py:560`
+- `_warn_absent` — `backend/app/services/reaction_atom_map.py:573`
   *A reaction with no transition state is not warned about: both legs of a map run toward the saddle point, so a barrierless channel has nothing to map onto and a warning it could never satisfy would train depositors to ignore the one that matters. The PDep bundle has no `atom_map` field yet, so on that path the warning carries a different remedy sentence rather than naming a field that does not exist.*
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
@@ -541,13 +572,14 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `warn` |
 | **Code** | `reaction_atom_map_participants_incomplete`, `reaction_atom_map_atoms_incomplete` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0011, 0008 |
 
 **Why this tier.** Absence again, at finer grain. A partial map is a true-but-partial record; only a map that contradicts *itself* is refused, and that is handled at the blocking tier by `validate_reaction_atom_map` and by the constraints on `reaction_atom_map_pair`.
 
 **Enforced at.**
 
-- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:591`
+- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:604`
   *Two codes from one seam: `reaction_atom_map_participants_incomplete` when a declared molecule is missing from the map entirely, `reaction_atom_map_atoms_incomplete` when a mapped participant leaves its own atoms unmapped or a leg leaves saddle-point atoms claimed by nobody.*
 
 **Escape hatch.** None.
@@ -557,21 +589,22 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | Field | Value |
 | --- | --- |
 | **Tier** | `structural` |
-| **Code** | *(none — prose only)* |
+| **Code** | `atom_map_inferred_requires_note` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0011 |
 
 **Why this tier.** Not a runtime check but a shape. ADR 0011 permits inference only as a labelled and separable thing, because an atom map is a scientific claim about a mechanism and picking one by algorithm and storing it unlabelled would manufacture provenance — the same failure ADR 0009 identified when a network-wide energy-transfer value was duplicated across wells. The immutability trigger closes the laundering path a check constraint cannot see: `UPDATE reaction_atom_map SET source='declared', note=NULL` satisfies both existing constraints, and a CHECK cannot read `OLD`.
 
 **Enforced at.**
 
+- `ReactionAtomMapIn.validate_inferred_names_its_algorithm` — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py:232`
+  *The wire half of the rule, and it was missing from this entry until the codes were audited: the register listed only the two schema objects, so it read as enforced by the database alone when in fact an inferred map with no note is refused at the payload boundary first. Only the note half is stated here — the immutability of `source` is a statement about an UPDATE, which no payload validator can see.*
 - `ck_reaction_atom_map_inferred_requires_note` (check on `reaction_atom_map`)
   `source <> 'inferred' OR (note IS NOT NULL AND btrim(note) <> '')`
 - `trg_reaction_atom_map_source_immutable` (trigger on `reaction_atom_map`)
   `BEFORE UPDATE FOR EACH ROW: refuse any change to the source column`
 
 **Escape hatch.** `note` and `equivalent_map_count` stay mutable on purpose, so a depositor can correct a description or record newly counted symmetry-equivalent maps without touching the attribution. Symmetry means a valid map is often not unique; ADR 0011 declines to canonicalise among equivalent maps and leaves reaction-path degeneracy to a later decision.
-
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
 ## Rate coefficients
 
@@ -580,19 +613,18 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | Field | Value |
 | --- | --- |
 | **Tier** | `block` |
-| **Code** | *(none — prose only)* |
+| **Code** | `arrhenius_a_units_molecularity_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** Definitional. The dimensionality of A follows from the rate law, so an A in cm3/mol/s on a unimolecular reaction is not an unusual result but a number that cannot mean what it says. A mis-declared unit is also silently catastrophic downstream, since nothing later in the stack can recover the intended order from the value alone.
 
 **Enforced at.**
 
-- `validate_a_units_for_molecularity` — `backend/app/chemistry/units.py:49`
+- `validate_a_units_for_molecularity` — `backend/app/chemistry/units.py:62`
   *Called from the kinetics upload schema, so it refuses at the wire boundary. The order is not simply `len(reactants)`: a simple `+M` third-body reaction carries a `[M]` term on the main line and validates one order higher, while a falloff reaction's main line is the high-pressure limit k-infinity and keeps `len(reactants)`, its low-pressure limit k0 being validated separately one order up.*
 
 **Escape hatch.** None, and the refinements are the reason it can block without firing on correct science: PLOG and Chebyshev are refused the `is_third_body` flag outright, because both already encode the full pressure dependence and the flag would otherwise inflate the expected order by one — rejecting a PLOG entry carrying the *correct* units and accepting one carrying the units of the next order up.
-
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
 
 ## Statistical mechanics
 
@@ -602,6 +634,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `structural` |
 | **Code** | *(none — prose only)* |
+| **Code reaches a client via** | *nothing carries a code* |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** A modelling position rather than an arithmetic bound. Canonical transition state theory needs the saddle point's own partition function, so a transition state has to be a first-class subject of a statmech row. The alternative — encoding a transition state as a pseudo-species — would make every partition function's subject ambiguous and would put saddle points into a kind reserved for lumped and phenomenological constructs that the conservation laws deliberately exempt.
@@ -613,7 +646,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by a database constraint alone surfaces as a generic integrity conflict, and one held by schema shape or by a stored evidence row never surfaces as a refusal at all.)*
 
 ## Pressure-dependent networks
 
@@ -623,6 +656,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `structural` |
 | **Code** | `reported_network_solve` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0010, 0008 |
 
 **Why this tier.** The blocking half is definitional: a computed solve with *zero* state energies contradicts its own kind, and a reported solve with no literature would assert rates carrying neither a derivation nor a source. The accepting half is why the token exists at all — published PLOG and Chebyshev fits are correct, common, citable science, so the coverage rules that are right for a solve run here could fire on a correct result and must not block. They warn instead, on every read path that reaches a rate.
@@ -644,6 +678,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `structural` |
 | **Code** | `network_wide_energy_transfer_scope` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | **Governing ADR** | 0009, 0008 |
 
 **Why this tier.** A network-wide ⟨ΔE⟩down is correct, common, published science — Arkane, RMG and MESS inputs routinely specify a single `SingleExponentialDown` applied network-wide — so a check demanding one entry per (well x collider) pair could fire on a correct result and must not block. It is an expectation about *resolution*, not a definition. What stays definitional still blocks: a `per_well` entry naming no well contradicts itself, a `network_wide` entry naming one contradicts itself, and a payload mixing the two is genuinely ambiguous.
@@ -663,6 +698,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `label` |
 | **Code** | `artifact_integrity_failed` |
+| **Code reaches a client via** | a read-time trust label (`HardFailReason`), not any refusal |
 | **Governing ADR** | 0014, 0004, 0002 |
 
 **Why this tier.** It cannot block, because the fact does not exist at upload: the artifact hashed correctly when it was accepted, and the break happened afterwards, in TCKDB's own custody. It cannot be a warning either, because a warning annotates the payload for whoever deposited it, while the party who needs to know here is every future reader of a record the depositor got right. So the consequence is a read-time label. It is a *hard* fail rather than an advisory one because the alternative is to keep publishing an evidence-completeness score computed over bytes TCKDB cannot produce — and note what this reason does not say: unlike every other hard fail, it does not claim the record is wrong, only that the evidence behind it can no longer be shown. The label fires on recorded detections only, so its absence is never a verification claim; an artifact nobody has read has been checked by nothing.
@@ -690,6 +726,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | --- | --- |
 | **Tier** | `structural` |
 | **Code** | *(none — prose only)* |
+| **Code reaches a client via** | *nothing carries a code* |
 | **Governing ADR** | 0002, 0005 |
 
 **Why this tier.** Not a check that fires but a position about what may never be collapsed into a single verdict. Reproducibility is graded under append-only, rubric-versioned assessments rather than as a field on a scientific row or an alias for review status, so a rubric can be revised without rewriting history and an old judgement stays interpretable. This is the same reasoning that made ADR 0005 record execution environments rather than grade them, and it is what lets the warning tiers elsewhere in this register be defensible: an incomplete record is accepted precisely because a separate layer exists to say how incomplete it is.
@@ -700,7 +737,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-*(This check raises prose with no machine-readable code. Recorded as a gap rather than invented, because a code that appears in no message is a code no client can match on.)*
+*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by a database constraint alone surfaces as a generic integrity conflict, and one held by schema shape or by a stored evidence row never surfaces as a refusal at all.)*
 
 ---
 

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -541,7 +541,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:310`
+- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:345`
   *Called from *both* seams — `persist_reaction_atom_map` and `persist_transition_state_validation_evidence` — and reads both surfaces from the database rather than from either caller's payload, so whichever a deposit writes second delivers the same verdict. Today the second is always the atom map: the computed-reaction bundle is the only payload with an `atom_map` field and writes it after the evidence, and no path can attach a map to a saddle point deposited earlier because every transition-state entry is created fresh by the deposit that writes it. Both are incidental orderings, so neither is relied on.*
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction.
@@ -561,7 +561,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_absent` — `backend/app/services/reaction_atom_map.py:573`
+- `_warn_absent` — `backend/app/services/reaction_atom_map.py:608`
   *A reaction with no transition state is not warned about: both legs of a map run toward the saddle point, so a barrierless channel has nothing to map onto and a warning it could never satisfy would train depositors to ignore the one that matters. The PDep bundle has no `atom_map` field yet, so on that path the warning carries a different remedy sentence rather than naming a field that does not exist.*
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
@@ -579,7 +579,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:604`
+- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:639`
   *Two codes from one seam: `reaction_atom_map_participants_incomplete` when a declared molecule is missing from the map entirely, `reaction_atom_map_atoms_incomplete` when a mapped participant leaves its own atoms unmapped or a leg leaves saddle-point atoms claimed by nobody.*
 
 **Escape hatch.** None.

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.20.0"
+version = "0.21.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/coded_error.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/coded_error.py
@@ -1,0 +1,77 @@
+"""A refusal that carries its own machine-readable code.
+
+:class:`UploadWarning` gave the *warn* tier a ``code`` field years before
+the *block* tier had one. A warning arrives as structured data with a code
+a consumer can switch on; a refusal arrived as English prose, and the only
+codes it carried were spelled inside the sentence — ``"Reaction is not
+element-balanced (reaction_mass_balance_failed)."`` — where nothing parses
+them. A client that has to tell "your geometry disagrees with your SMILES"
+(fix the payload and retry) from "your reaction does not balance" (stop and
+think) was left matching English substrings, which breaks the first time
+somebody improves a sentence.
+
+:class:`CodedValidationError` is the block-tier counterpart of
+``UploadWarning``: the code travels as an attribute of the exception, never
+as a substring of its message, so improving the prose cannot change the
+contract and translating the prose cannot break it.
+
+Why this lives in the wire package
+----------------------------------
+``schemas/python/tckdb-schemas/tests/test_import_boundaries.py`` forbids
+``tckdb_schemas`` from importing anything under ``app``, so a wire-schema
+check — the atom-map rules, the stationary-point rules — cannot reach the
+backend's error type. The code a refusal reports is part of the wire
+contract in the same sense a field name is, so the type belongs here and
+the backend subclasses it (``app.api.error_contract.CodedValueError``).
+
+How the code reaches a client
+-----------------------------
+Two paths, both typed:
+
+* raised inside a Pydantic validator — the exception object itself is
+  preserved in ``ValidationError.errors()[i]["ctx"]["error"]``, and the
+  backend's ``validation_detail_code`` reads ``.code`` straight off it;
+* raised from service code — the backend's ``ValueError`` handler sees the
+  exception directly and reads ``.code``.
+
+Neither path inspects the message. ``message_prefix`` exists only so that
+attaching a code to an *existing* refusal can leave its published prose
+byte-identical: the machine-readable ``code`` field of the response body is
+new information, and no consumer already matching on the sentence is
+disturbed by it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["CodedValidationError"]
+
+
+class CodedValidationError(ValueError):
+    """A refusal carrying a stable code and machine-readable context.
+
+    :param code: Stable ``snake_case`` identifier for *what was wrong*.
+        This is the contract; the message is not.
+    :param detail: Human-readable explanation, already formatted.
+    :param context: Optional structured facts about the refusal.
+    :param message_prefix: Whether ``str(exc)`` repeats the code ahead of
+        the detail. ``True`` keeps the legacy ``"code: detail"`` shape that
+        the read API's published details already carry. ``False`` makes
+        ``str(exc)`` exactly *detail*, which is what an existing refusal
+        gaining a code for the first time wants: the ``code`` field appears,
+        the ``detail`` field does not move.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        detail: str,
+        *,
+        context: dict[str, Any] | None = None,
+        message_prefix: bool = True,
+    ) -> None:
+        self.code = code
+        self.detail = detail
+        self.context = dict(context or {})
+        super().__init__(f"{code}: {detail}" if message_prefix else detail)

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py
@@ -50,6 +50,7 @@ from typing import Self
 
 from pydantic import Field, model_validator
 
+from tckdb_schemas.coded_error import CodedValidationError
 from tckdb_schemas.common import SchemaBase
 from tckdb_schemas.enums import AtomMapSource, ReactionRole
 from tckdb_schemas.utils import normalize_optional_text
@@ -58,9 +59,56 @@ __all__ = [
     "AtomMapParticipantGeometry",
     "ReactionAtomMapIn",
     "ReactionAtomMapParticipantIn",
+    "W_ATOM_MAP_ATOMS_UNACCOUNTED_FOR",
+    "W_ATOM_MAP_ELEMENT_NOT_CONSERVED",
+    "W_ATOM_MAP_GEOMETRY_UNPARSEABLE",
+    "W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE",
+    "W_ATOM_MAP_INFERRED_REQUIRES_NOTE",
+    "W_ATOM_MAP_NOT_A_BIJECTION",
+    "W_ATOM_MAP_PARTICIPANT_NOT_DECLARED",
+    "W_ATOM_MAP_WITHOUT_TRANSITION_STATE",
     "parse_xyz_elements",
     "validate_reaction_atom_map",
 ]
+
+# ---------------------------------------------------------------------------
+# Codes
+# ---------------------------------------------------------------------------
+#
+# One code per refusal, so a client can tell "your map transmutes an
+# element" (a mechanism error — stop) from "your map counts against the
+# wrong geometry" (a payload error — fix the key and retry) without
+# reading English. The four that correspond to a register entry are named
+# after that entry, so the code and the registered check are visibly the
+# same thing; the rest are payload shape rather than chemistry and are
+# named for what they are.
+
+#: An atom changed element on the way across the reaction.
+W_ATOM_MAP_ELEMENT_NOT_CONSERVED = "atom_map_element_not_conserved"
+
+#: One saddle-point atom was claimed twice on the same leg.
+W_ATOM_MAP_NOT_A_BIJECTION = "atom_map_not_a_bijection"
+
+#: An index names a geometry the participant does not own, or an atom the
+#: named geometry does not have.
+W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE = "atom_map_indices_not_geometry_relative"
+
+#: A complete map of a balanced reaction leaves saddle-point atoms
+#: unaccounted for.
+W_ATOM_MAP_ATOMS_UNACCOUNTED_FOR = "atom_map_atoms_unaccounted_for"
+
+#: An inferred map does not name the algorithm that produced it.
+W_ATOM_MAP_INFERRED_REQUIRES_NOTE = "atom_map_inferred_requires_note"
+
+#: A map was supplied for a reaction that declares no saddle point.
+W_ATOM_MAP_WITHOUT_TRANSITION_STATE = "atom_map_without_transition_state"
+
+#: The map names a participant the reaction does not declare, names the
+#: wrong species for one, or names the same participant twice.
+W_ATOM_MAP_PARTICIPANT_NOT_DECLARED = "atom_map_participant_not_declared"
+
+#: A geometry the map has to count into is not a readable XYZ block.
+W_ATOM_MAP_GEOMETRY_UNPARSEABLE = "atom_map_geometry_unparseable"
 
 
 def parse_xyz_elements(xyz_text: str) -> list[str]:
@@ -74,16 +122,27 @@ def parse_xyz_elements(xyz_text: str) -> list[str]:
 
     lines = xyz_text.strip().splitlines()
     if len(lines) < 1:
-        raise ValueError("geometry is not a valid XYZ block.")
+        raise CodedValidationError(
+            W_ATOM_MAP_GEOMETRY_UNPARSEABLE,
+            "geometry is not a valid XYZ block.",
+            message_prefix=False,
+        )
     try:
         declared = int(lines[0].strip())
     except ValueError as exc:
-        raise ValueError("geometry is not a valid XYZ block.") from exc
+        raise CodedValidationError(
+            W_ATOM_MAP_GEOMETRY_UNPARSEABLE,
+            "geometry is not a valid XYZ block.",
+            message_prefix=False,
+        ) from exc
     body = [line for line in lines[2:] if line.strip()]
     if len(body) != declared:
-        raise ValueError(
+        raise CodedValidationError(
+            W_ATOM_MAP_GEOMETRY_UNPARSEABLE,
             f"geometry declares {declared} atoms but carries {len(body)} "
-            "coordinate lines."
+            "coordinate lines.",
+            context={"declared_atoms": declared, "coordinate_lines": len(body)},
+            message_prefix=False,
         )
     elements: list[str] = []
     for line in body:
@@ -117,10 +176,17 @@ class ReactionAtomMapParticipantIn(SchemaBase):
     def validate_indices_are_one_based(self) -> Self:
         for atom_index, ts_atom_index in self.atom_to_ts.items():
             if atom_index < 1 or ts_atom_index < 1:
-                raise ValueError(
+                raise CodedValidationError(
+                    W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                     f"atom_map participant '{self.species_key}' "
                     f"[{self.side.value} {self.participant_index}] uses 1-based "
-                    "atom indices on both sides."
+                    "atom indices on both sides.",
+                    context={
+                        "species_key": self.species_key,
+                        "side": self.side.value,
+                        "participant_index": self.participant_index,
+                    },
+                    message_prefix=False,
                 )
         return self
 
@@ -173,10 +239,12 @@ class ReactionAtomMapIn(SchemaBase):
         assertion.
         """
         if self.source is AtomMapSource.inferred and self.note is None:
-            raise ValueError(
+            raise CodedValidationError(
+                W_ATOM_MAP_INFERRED_REQUIRES_NOTE,
                 "atom_map.source='inferred' requires atom_map.note naming the "
                 "algorithm that produced the map. An inferred map is recorded "
-                "only as a labelled, separable thing (ADR 0011)."
+                "only as a labelled, separable thing (ADR 0011).",
+                message_prefix=False,
             )
         return self
 
@@ -187,10 +255,16 @@ class ReactionAtomMapIn(SchemaBase):
         for participant in self.participants:
             slot = (participant.side, participant.participant_index)
             if slot in seen:
-                raise ValueError(
+                raise CodedValidationError(
+                    W_ATOM_MAP_PARTICIPANT_NOT_DECLARED,
                     f"atom_map names {participant.side.value} "
                     f"{participant.participant_index} more than once. Each "
-                    "participant molecule is mapped at most once."
+                    "participant molecule is mapped at most once.",
+                    context={
+                        "side": participant.side.value,
+                        "participant_index": participant.participant_index,
+                    },
+                    message_prefix=False,
                 )
             seen.add(slot)
         return self
@@ -270,18 +344,27 @@ def validate_reaction_atom_map(
         return
 
     if ts_xyz_text is None or ts_geometry_key is None:
-        raise ValueError(
+        raise CodedValidationError(
+            W_ATOM_MAP_WITHOUT_TRANSITION_STATE,
             f"{field_path} was supplied for a reaction with no transition "
             "state. Both legs of an atom map run toward the saddle point "
-            "(ADR 0011), so a reaction without one cannot carry a map."
+            "(ADR 0011), so a reaction without one cannot carry a map.",
+            context={"field_path": field_path},
+            message_prefix=False,
         )
 
     if atom_map.ts_geometry_key != ts_geometry_key:
-        raise ValueError(
+        raise CodedValidationError(
+            W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
             f"{field_path}.ts_geometry_key='{atom_map.ts_geometry_key}' is not "
             f"the transition state's geometry ('{ts_geometry_key}'). Atom "
             "indices are geometry-relative; a map written against a different "
-            "geometry refers to different atoms."
+            "geometry refers to different atoms.",
+            context={
+                "declared_geometry_key": atom_map.ts_geometry_key,
+                "transition_state_geometry_key": ts_geometry_key,
+            },
+            message_prefix=False,
         )
 
     ts_elements = parse_xyz_elements(ts_xyz_text)
@@ -304,23 +387,44 @@ def validate_reaction_atom_map(
         slot = (mapping.side, mapping.participant_index)
         declared = by_slot.get(slot)
         if declared is None:
-            raise ValueError(
+            raise CodedValidationError(
+                W_ATOM_MAP_PARTICIPANT_NOT_DECLARED,
                 f"{field_path} names {mapping.side.value} "
                 f"{mapping.participant_index}, which this reaction does not "
-                "declare."
+                "declare.",
+                context={
+                    "side": mapping.side.value,
+                    "participant_index": mapping.participant_index,
+                },
+                message_prefix=False,
             )
         if declared.species_key != mapping.species_key:
-            raise ValueError(
+            raise CodedValidationError(
+                W_ATOM_MAP_PARTICIPANT_NOT_DECLARED,
                 f"{field_path} names species '{mapping.species_key}' as "
                 f"{mapping.side.value} {mapping.participant_index}, but that "
-                f"participant is species '{declared.species_key}'."
+                f"participant is species '{declared.species_key}'.",
+                context={
+                    "side": mapping.side.value,
+                    "participant_index": mapping.participant_index,
+                    "declared_species_key": declared.species_key,
+                    "mapped_species_key": mapping.species_key,
+                },
+                message_prefix=False,
             )
         if mapping.geometry_key not in declared.geometry_keys:
-            raise ValueError(
+            raise CodedValidationError(
+                W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                 f"{field_path} maps {mapping.side.value} "
                 f"{mapping.participant_index} against geometry "
                 f"'{mapping.geometry_key}', which does not belong to species "
-                f"'{mapping.species_key}'. Atom indices are geometry-relative."
+                f"'{mapping.species_key}'. Atom indices are geometry-relative.",
+                context={
+                    "geometry_key": mapping.geometry_key,
+                    "species_key": mapping.species_key,
+                    "permitted_geometry_keys": sorted(declared.geometry_keys),
+                },
+                message_prefix=False,
             )
 
         elements = parse_xyz_elements(
@@ -334,35 +438,64 @@ def validate_reaction_atom_map(
 
         for atom_index, ts_atom_index in sorted(mapping.atom_to_ts.items()):
             if atom_index > natoms:
-                raise ValueError(
+                raise CodedValidationError(
+                    W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                     f"{field_path} maps atom {atom_index} of {label}, but "
-                    f"geometry '{mapping.geometry_key}' has {natoms} atoms."
+                    f"geometry '{mapping.geometry_key}' has {natoms} atoms.",
+                    context={
+                        "atom_index": atom_index,
+                        "geometry_key": mapping.geometry_key,
+                        "geometry_atom_count": natoms,
+                    },
+                    message_prefix=False,
                 )
             if ts_atom_index > ts_natoms:
-                raise ValueError(
+                raise CodedValidationError(
+                    W_ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
                     f"{field_path} maps atom {atom_index} of {label} onto "
                     f"transition-state atom {ts_atom_index}, but geometry "
-                    f"'{atom_map.ts_geometry_key}' has {ts_natoms} atoms."
+                    f"'{atom_map.ts_geometry_key}' has {ts_natoms} atoms.",
+                    context={
+                        "ts_atom_index": ts_atom_index,
+                        "geometry_key": atom_map.ts_geometry_key,
+                        "geometry_atom_count": ts_natoms,
+                    },
+                    message_prefix=False,
                 )
 
             element = elements[atom_index - 1]
             ts_element = ts_elements[ts_atom_index - 1]
             if element != ts_element:
-                raise ValueError(
+                raise CodedValidationError(
+                    W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
                     f"{field_path} maps atom {atom_index} of {label}, which is "
                     f"{element}, onto transition-state atom {ts_atom_index}, "
                     f"which is {ts_element}. An element does not change across "
-                    "a reaction."
+                    "a reaction.",
+                    context={
+                        "atom_index": atom_index,
+                        "element": element,
+                        "ts_atom_index": ts_atom_index,
+                        "ts_element": ts_element,
+                    },
+                    message_prefix=False,
                 )
 
             claimed = claimed_ts_by_side[mapping.side]
             if ts_atom_index in claimed:
-                raise ValueError(
+                raise CodedValidationError(
+                    W_ATOM_MAP_NOT_A_BIJECTION,
                     f"{field_path} claims transition-state atom "
                     f"{ts_atom_index} twice on the {mapping.side.value} leg: "
                     f"from {claimed[ts_atom_index]} and from atom "
                     f"{atom_index} of {label}. One saddle-point atom is one "
-                    "atom."
+                    "atom.",
+                    context={
+                        "ts_atom_index": ts_atom_index,
+                        "side": mapping.side.value,
+                        "first_claim": claimed[ts_atom_index],
+                    },
+                    message_prefix=False,
                 )
             claimed[ts_atom_index] = f"atom {atom_index} of {label}"
 
@@ -382,22 +515,31 @@ def validate_reaction_atom_map(
     if reactant_claims != product_claims:
         missing_in_products = sorted(reactant_claims - product_claims)
         missing_in_reactants = sorted(product_claims - reactant_claims)
-        raise ValueError(
+        raise CodedValidationError(
+            W_ATOM_MAP_ATOMS_UNACCOUNTED_FOR,
             f"{field_path} is complete over every declared participant of an "
             "atom-balanced reaction, yet its two legs do not cover the same "
             "saddle-point atoms: "
             f"{missing_in_products or 'none'} appear only on the reactant leg "
             f"and {missing_in_reactants or 'none'} only on the product leg. "
-            "No species is missing, so those atoms are unaccounted for."
+            "No species is missing, so those atoms are unaccounted for.",
+            context={
+                "reactant_leg_only": missing_in_products,
+                "product_leg_only": missing_in_reactants,
+            },
+            message_prefix=False,
         )
 
     unclaimed = sorted(set(range(1, ts_natoms + 1)) - reactant_claims)
     if unclaimed:
-        raise ValueError(
+        raise CodedValidationError(
+            W_ATOM_MAP_ATOMS_UNACCOUNTED_FOR,
             f"{field_path} is complete over every declared participant of an "
             "atom-balanced reaction, yet transition-state atom(s) "
             f"{unclaimed} are claimed by neither leg. No species is missing, "
-            "so the saddle point cannot hold atoms the reaction does not."
+            "so the saddle point cannot hold atoms the reaction does not.",
+            context={"unclaimed_ts_atoms": unclaimed},
+            message_prefix=False,
         )
 
 

--- a/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
@@ -1018,7 +1018,12 @@ def raise_for_blocking_findings(findings: list[StationaryPointFinding]) -> None:
     raise CodedValidationError(
         codes.pop(),
         message,
-        context={"codes": sorted({f.code for f in blocked if f.code})},
+        # Which records the contradiction was found on. One code can be
+        # reported for several of them at once — a bundle depositing four
+        # transition states, three of them fine — and the locations are
+        # the part of that a client would otherwise have to read out of
+        # the joined message.
+        context={"locations": sorted({f.location for f in blocked if f.location})},
         message_prefix=False,
     )
 

--- a/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
@@ -93,6 +93,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 
+from tckdb_schemas.coded_error import CodedValidationError
 from tckdb_schemas.enums import (
     HessianMethod,
     ImaginaryModeDisposition,
@@ -988,15 +989,38 @@ def has_structural_flag(findings: Sequence[StationaryPointFinding]) -> bool:
 
 
 def raise_for_blocking_findings(findings: list[StationaryPointFinding]) -> None:
-    """Raise ``ValueError`` if any finding is at the blocking tier.
+    """Raise if any finding is at the blocking tier.
 
     Upload schemas call this from a ``model_validator`` so a definitional
     contradiction becomes a 422 naming the contradiction, before the
     route body opens a submission.
+
+    Every finding already carries a ``code``; until the refusal did too,
+    that code reached a client only as a substring of an English sentence
+    and the response body said ``validation_error``. It is now the
+    exception's own attribute, so the 422 names the contradiction in a
+    field a client can switch on.
+
+    A refusal reports one code only when the blocking findings agree on
+    one. Two different contradictions in one payload are two things to fix,
+    and naming either of them would tell the client the other is not there;
+    the joined message still names both, and the envelope falls back to the
+    generic code. ``message_prefix=False`` keeps the message exactly what it
+    has always been.
     """
     blocked = blocking_findings(findings)
-    if blocked:
-        raise ValueError(" ".join(f.message for f in blocked))
+    if not blocked:
+        return
+    message = " ".join(f.message for f in blocked)
+    codes = {f.code for f in blocked if f.code}
+    if len(codes) != 1:
+        raise ValueError(message)
+    raise CodedValidationError(
+        codes.pop(),
+        message,
+        context={"codes": sorted({f.code for f in blocked if f.code})},
+        message_prefix=False,
+    )
 
 
 __all__ = [


### PR DESCRIPTION
Essentially every chemistry rejection reached a client as the generic `validation_error`. ARC could not distinguish "your geometry disagrees with your SMILES" (fix and retry) from "your reaction does not balance" (abort and investigate) without string-matching English prose.

**Codeless register entries: 11 → 3.** All 30 rows now declare where their code reaches a client.

## Why the codes existed and still didn't work

Six-plus checks embedded a parenthesised code — `Reaction is not element-balanced (reaction_mass_balance_failed).` — while `_NESTED_CODE_PATTERN` required `code: ` **with a colon**. Two correct components, one unwritten convention between them, and nothing tested the seam because each side's tests pass in isolation.

**The fix: the code travels as an attribute of the exception, never as a substring of its message.** Nothing is parsed.

Three things forced that shape rather than extending the regex:

1. **The wire package cannot import the backend** — `test_import_boundaries.py` bans it, and four of the eleven codeless entries are wire-schema rules. `CodedValidationError` lives in `tckdb_schemas`; `app.api.error_contract.CodedValueError` subclasses it, so both sides raise the same type. An error code is part of the wire contract in the same sense a field name is.
2. **Pydantic preserves the exception object** — a `ValueError` from a validator arrives as `errors()[i]["ctx"]["error"]`, the live exception. Verified empirically; `.code` is read off it with precedence over both prose paths.
3. **`message_prefix=False` keeps `detail` byte-identical.** Verified mechanically by an AST diff of every string literal in the seven touched modules against `35bd6ed`: the only user-facing message that changed is the PK-leak fix.

`context` is also lifted into the envelope's own field — the structured facts were previously reachable only by parsing the sentence that named them.

## Checked the consumers before changing anything

- **No ARC adapter in this repo** — only file parsers under `backend/scripts/arc_ingestion/`, no HTTP. Nothing here to break.
- **`clients/python/.../client.py:528`** parses `code` into `TckdbHTTPError.code`, but the only production branch on a code *value* is `idempotency_conflict`. Nothing matches chemistry codes or chemistry prose.
- Backend tests match prose via `pytest.raises(ValueError, match=...)` on the exception; `CodedValueError` is a `ValueError` and `str(exc)` is unchanged, so all still pass.

**Purely additive.** A client matching prose keeps working; a client matching `code` gets something useful for the first time. `clients/python/` untouched, so no client bump; `tckdb-schemas` 0.20.0 → 0.21.0.

## Two checks I did not ask about, with the same defect

Rows 24-25 (stationary-point blocks) also arrived as `validation_error`: `raise_for_blocking_findings` **joined finding messages and discarded their codes**. It now raises coded when the blocking findings agree on one code, and plain `ValueError` when they do not — because naming one of two contradictions would tell the client the other isn't there.

## The register now guards code coverage

`ScientificCheck` gains `channel: CodeChannel` (`error_envelope` / `upload_warning` / `trust_label` / `database_constraint` / `none`), and `__post_init__` refuses a code with no channel or a channel with no code. Three new guards:

1. A `block`-tier check enforced from Python **must** be `error_envelope` — this is the guard that would have caught the original gap.
2. **AST**: the code must be the *first argument* of a coded-error construction in a module defining an enforcing function. This separates a code the module **mentions** from one it **reports** — the old convention satisfied the former while reaching nobody.
3. Every envelope code must be named in the proof file, because nothing above proves it survives Pydantic, the handler and the JSON encoder — and that path is exactly where the codes were being lost.

## The proof

22 tests over 20 codes, real HTTP, each asserting `response.json()["code"] == <code>` — **never** `code in detail`. That distinction is the entire point. Plus 7 tests pinning the two decisions: a code may be attached without moving the message, and two simultaneous failures report neither code.

## The PK leak, and the sweep

`_element_counts_for_species` now names the species by `public_ref` and SMILES; the row id goes to the log. The sweep found four more on scientific upload paths (`statmech.py`, `transport.py`, `conformer.py`, `calculation_resolution.py`), all fixed.

## Verification

Baselines established by running the **full suite twice with the same seed** — once on a pristine `git archive 35bd6ed`, once on the branch:

```
base 35bd6ed:  69 failed, 6533 passed
branch:        68 failed, 6566 passed
failure-set diff: zero tests fail on the branch that do not fail on base
```

The one base-only failure is the register sync test, an artifact of the archive copy having no `.git`.

Also green: `test-scientific.sh` 1983, `test-api.sh` 2468, tckdb-schemas 38, `clients/python` 1337, register guards 31, `ruff` clean. OpenAPI golden unaffected.

**Note on those 68 shared failures:** they are pre-existing order-dependent pollution under a random seed. #111 fixed the leaks it found and took the suite from 876 failures to single digits in fixed order, but the suite is still order-dependent under other seeds — tracked as #64.

## Findings tracked

**#64** the suite is still order-dependent under random seeds. **#65** `map_http_status` in the MCP integration discards the server's `code`, so this entire change is invisible over MCP. **#66** `_integrity_error_handler` collapses named chemistry constraints to a generic 409. **#67** ~40 further row-id leaks in read-layer 404/422 bodies and one in a *stored* assessment snapshot. **#68** no client-side constants for the new codes.

No check's behaviour changed — the same deposits are refused, only the refusals now say which rule refused them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)