### PR TITLE
Run the suite in parallel, and make the order stop mattering

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -77,6 +77,12 @@ jobs:
       # only for names beginning ``tckdb_test``. Keeping CI inside that
       # pattern preserves the guard rather than widening it.
       DB_TEST_NAME: tckdb_test_${{ matrix.gate }}_${{ github.run_id }}_${{ github.run_attempt }}
+      # The gate scripts default to 8 xdist workers, which suits a 20-core
+      # workstation. A GitHub standard runner has 4 vCPUs and one Postgres
+      # container, so 8 workers would pay 8 per-worker `alembic upgrade head`
+      # costs to contend over 4 cores. Each worker still gets its own database
+      # (DB_TEST_NAME above gains a `_gw<n>` suffix).
+      TCKDB_TEST_WORKERS: "4"
       AUTH_ALLOW_OPEN_REGISTRATION: "true"
       DEPLOYMENT_MODE: local
       EXPOSE_API_DOCS: "true"
@@ -126,6 +132,7 @@ jobs:
         if: matrix.gate == 'api'
         run: |
           git diff --check
+          bash -n backend/scripts/lib/pytest_run_args.sh
           bash -n backend/scripts/test-fast.sh
           bash -n backend/scripts/test-api.sh
           bash -n backend/scripts/test-scientific.sh

--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -57,6 +57,9 @@ jobs:
       DB_NAME: tckdb_test_ci
       DB_CLIENT_ENCODING: utf8
       DB_TEST_NAME: tckdb_test_${{ github.run_id }}_${{ github.run_attempt }}
+      # See the note in backend-ci.yml: 4 vCPUs on a standard runner, and each
+      # worker creates and migrates its own database.
+      TCKDB_TEST_WORKERS: "4"
       AUTH_ALLOW_OPEN_REGISTRATION: "true"
       DEPLOYMENT_MODE: local
       EXPOSE_API_DOCS: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,12 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# Anchored to the repo root: these are setuptools build output from the
+# standard Python template. Unanchored, they match *any* directory named
+# lib at any depth -- which silently swallowed backend/scripts/lib/ and let
+# a committed-looking file never reach the branch.
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -135,34 +135,38 @@ make test-fast ARGS="path/to/test_file.py::TestClass::test_case -vv -s"
 
 If a test is flaky, run it three times in a row before concluding.
 
-Test isolation here is **two-tier**, and knowing which tier a test is in
+Test isolation here has **two tiers**, and knowing which one a test is in
 matters when diagnosing cross-file failures (see
 [`tests/conftest.py`](../tests/conftest.py)):
 
 - `db_session` / `db_conn` / `client` roll back per test. Rows written
   through these never outlive the test.
-- The session-scoped `db_engine` fixture does **not**. Test files that
-  use it with `with session.begin():` commit, so the shared test
-  database genuinely accumulates committed rows for the whole pytest
-  session. Those files must delete what they wrote, in a fixture
-  `finally` — see "Isolation contract" below.
+- The session-scoped `db_engine` fixture does **not**. A test that uses
+  it with `with session.begin():` commits, so it must delete what it
+  wrote, in a fixture `finally` — see "Isolation contract" below. The
+  files still in that position are the `*_isolation.py` family, the
+  upload-worker tests and the bundle-export CLI test; every one of them
+  is there because it needs two genuinely concurrent transactions or a
+  subprocess on its own connection, and every one of them cleans up.
 
-All of `tests/workflows/` is now in the first tier and is held there by a
-tripwire in [`tests/workflows/conftest.py`](../tests/workflows/conftest.py)
-that fails any test in that tree which commits. It used to be in the second:
-running `test_network_pdep_upload.py` before `test_computed_reaction_upload.py`
-left fifteen committed `type=irc` calculations behind and five tests that
-locate "the" IRC calculation with an unqualified query then asserted against
-the wrong row — deterministically, under `-p no:randomly`, with no seed
-involved. The same residue accounted for every one of the 75 failures and 47
-errors that `pytest tests/workflows/ tests/services/` produced; that
-combination is green now.
+The whole suite is now in the first tier, and is held there by the
+`_refuse_committed_rows` tripwire in [`tests/conftest.py`](../tests/conftest.py),
+which fails any test that commits without cleaning up. `tests/workflows/` was
+the first tree moved (PR #111): running `test_network_pdep_upload.py` before
+`test_computed_reaction_upload.py` left fifteen committed `type=irc`
+calculations behind and five tests that locate "the" IRC calculation with an
+unqualified query then asserted against the wrong row — deterministically,
+under `-p no:randomly`, with no seed involved. That residue accounted for every
+one of the 75 failures and 47 errors that
+`pytest tests/workflows/ tests/services/` produced. ~50 more tests across 16
+files in `tests/services/`, `tests/invariants/` and `tests/workers/` had the
+same habit and were the bulk of the 69 failures the full suite produced at
+`--randomly-seed=424242`; they are on `db_conn` now.
 
-Two consequences worth remembering. Committed rows from tier two are
-visible to every later test file in the same run. And rollback does not
-undo everything even in tier one: PostgreSQL sequences are
-non-transactional, so a `setval` (as `restore_archive` performs when
-repairing primary-key sequences) survives a rollback and leaks into the
+One consequence worth remembering: rollback does not undo everything.
+PostgreSQL sequences are non-transactional, so a `setval` (as
+`restore_archive` performs when repairing primary-key sequences) survives a
+rollback and leaks into the
 rest of the session — see
 [`tests/services/archive/conftest.py`](../tests/services/archive/conftest.py)
 for the containment fixture and the failure it prevents.
@@ -514,10 +518,12 @@ the matrix result is `success`, while leaving both detailed gate checks visible.
 Each CI job owns an isolated Postgres service and MinIO service. Its
 `DB_TEST_NAME` and `S3_BUCKET` include both the GitHub run id/attempt and the
 job role, so concurrent jobs and workflow runs do not share test resources.
-The workflow does not enable pytest-xdist: an explicit `DB_TEST_NAME` takes
-precedence over `PYTEST_XDIST_WORKER`, so adding `-n` would still make workers
-race on one recreated database. The scientific test factories also need
-worker-aware isolation before xdist can safely be added.
+
+The gates run under xdist, at `TCKDB_TEST_WORKERS=4` rather than the local
+default of 8, because a GitHub standard runner has 4 vCPUs and one Postgres
+container. `DB_TEST_NAME` is still set per job; `_resolve_test_db_name` appends
+the worker id to it, so each worker gets its own database instead of four
+workers racing on one recreated one.
 
 The full Tier 4 suite is intentionally not part of this v0 PR workflow.
 Keep running `make test-full` locally before push/merge until a

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -29,13 +29,18 @@ backend directory before invoking pytest. They forward extra arguments
 through, so `-k`, `-x`, `--maxfail=...`, and named-test selectors all
 work as you'd expect:
 
-| Script                                   | Default pytest call                                                                |
-|------------------------------------------|------------------------------------------------------------------------------------|
-| [`test-fast.sh`](../scripts/test-fast.sh)             | `pytest -v -x --tb=short "$@"`                                         |
-| [`test-scientific.sh`](../scripts/test-scientific.sh) | `pytest -q --tb=short tests/api/scientific/ tests/services/scientific_read/ "$@"` |
-| [`test-api.sh`](../scripts/test-api.sh)               | `pytest -q --tb=short tests/api/ "$@"`                                 |
-| [`test-full.sh`](../scripts/test-full.sh)             | `pytest -q --tb=short tests/ "$@"`                                     |
-| [`test-profile.sh`](../scripts/test-profile.sh)       | `pytest -v --durations=50 [<path>|tests/]`                             |
+| Script                                   | Default pytest call                                                                | Workers |
+|------------------------------------------|------------------------------------------------------------------------------------|---------|
+| [`test-fast.sh`](../scripts/test-fast.sh)             | `pytest -v -x --tb=short "$@"`                                         | 0 |
+| [`test-scientific.sh`](../scripts/test-scientific.sh) | `pytest -q --tb=short tests/api/scientific/ tests/services/scientific_read/ "$@"` | 8 |
+| [`test-api.sh`](../scripts/test-api.sh)               | `pytest -q --tb=short tests/api/ "$@"`                                 | 8 |
+| [`test-full.sh`](../scripts/test-full.sh)             | `pytest -q --tb=short tests/ "$@"`                                     | 8 |
+| [`test-profile.sh`](../scripts/test-profile.sh)       | `pytest -v --durations=50 [<path>|tests/]`                             | 0 |
+
+Every script additionally passes `--randomly-seed=424242` and `-n <workers>`,
+via [`scripts/lib/pytest_run_args.sh`](../scripts/lib/pytest_run_args.sh).
+See [Pinned order and parallel workers](#pinned-order-and-parallel-workers)
+for why, and how to override either.
 
 Tier 0/1 (`test-fast.sh`) keeps `-v` so each test name prints live while
 you iterate. Tiers 2/3/4 use `-q --tb=short` to keep CI and pre-push
@@ -213,27 +218,73 @@ The session fixture derives a test-DB name with the following
 precedence (see `_resolve_test_db_name` in
 [`tests/conftest.py`](../tests/conftest.py)):
 
-1. **Explicit `DB_TEST_NAME`** — used verbatim. Backward-compatible
+1. **Explicit `DB_TEST_NAME` *and* `PYTEST_XDIST_WORKER`** — the
+   explicit name with the worker id appended, e.g.
+   `tckdb_test_api_991_gw3`. This case comes **first**, and that
+   ordering is load-bearing: every gate script and every CI job sets
+   `DB_TEST_NAME`, so while the explicit name won unconditionally,
+   turning on `-n` pointed all workers at one database. They raced to
+   drop and recreate it during session setup, and whichever survived
+   was then written concurrently by every worker — reintroducing
+   exactly the cross-test visibility the per-test rollback exists to
+   prevent. Asking for a specific database name *and* N workers is
+   asking for N databases. Over-long names have the base trimmed, not
+   the suffix, because Postgres truncates identifiers silently and
+   `…_gw10` / `…_gw11` must not collapse onto one name.
+2. **Explicit `DB_TEST_NAME`** alone — used verbatim. Backward-compatible
    with existing CI configs that pin a job-specific name. Explicit
    names are **single-tenant**: only one pytest process at a time may
    use them. For CI runners that share one Postgres host, set
    `DB_TEST_NAME` per job (e.g. include the runner / job id) so
    parallel jobs do not collide.
-2. **`PYTEST_XDIST_WORKER`** — when pytest-xdist is invoked, each
-   worker exports its id (`gw0`, `gw1`, …) and the fixture maps it to
-   `tckdb_test_<worker>` (e.g. `tckdb_test_gw0`, `tckdb_test_gw1`).
-   Worker ids are sanitized to safe identifier characters, so each
-   worker owns its own database and the drop-and-recreate sequence
-   cannot race.
-3. **Fallback** — `tckdb_test_<pid>` so two ad-hoc pytest processes
+3. **`PYTEST_XDIST_WORKER`** alone — each worker exports its id
+   (`gw0`, `gw1`, …) and the fixture maps it to `tckdb_test_<worker>`
+   (e.g. `tckdb_test_gw0`, `tckdb_test_gw1`). Worker ids are sanitized
+   to safe identifier characters, so each worker owns its own database
+   and the drop-and-recreate sequence cannot race.
+4. **Fallback** — `tckdb_test_<pid>` so two ad-hoc pytest processes
    on one host (e.g. two terminals running `make test-fast`) never
    share a database, even without xdist.
 
 The resolved name is exported back into `os.environ["DB_TEST_NAME"]`
 so subprocess-based tests (e.g. the contribution-bundle CLI smoke
-test) inherit the same database. xdist is **not** wired up by
-default; this is forward-looking infrastructure that activates the
-moment a caller sets `PYTEST_XDIST_WORKER`.
+test) inherit the same database.
+
+The xdist controller process never creates a database: it collects but
+does not execute tests, and `PYTEST_XDIST_WORKER` is unset there.
+
+### Pinned order and parallel workers
+
+Both are applied by [`scripts/lib/pytest_run_args.sh`](../scripts/lib/pytest_run_args.sh),
+which every `test-*.sh` script sources.
+
+**The random-order seed is pinned to `424242`.** `pytest-randomly` is installed
+and active, and left alone it seeds itself from the clock — so every gate
+invocation ran the suite in a different order, a red gate could not be told
+apart from bad luck, and a green one proved nothing about the next run. Two
+different agents reported `3 failed` and `69 failed` for the *same commit*
+purely because they drew different orders. A pinned seed does not make the
+suite order-independent; the rollback fixtures and the committed-row tripwire
+below do that. It makes a gate *result* reproducible.
+
+**Workers default to 8**, not to core count. Each xdist worker creates its own
+database and runs `alembic upgrade head` into it, so raising the count buys
+test throughput while paying a fixed per-worker migration cost and pushing the
+single Postgres server toward being the bottleneck. Tier 0/1 (`test-fast.sh`)
+and `test-profile.sh` default to 0 workers: one file does not need eight
+databases, and durations measured under eight-way contention describe the
+contention rather than the tests.
+
+```bash
+TCKDB_TEST_SEED=7 bash backend/scripts/test-full.sh        # a different order
+bash backend/scripts/test-full.sh --randomly-seed=last     # caller wins
+TCKDB_TEST_WORKERS=16 bash backend/scripts/test-full.sh    # more workers
+TCKDB_TEST_WORKERS=0  bash backend/scripts/test-full.sh    # serial
+```
+
+An explicit `--randomly-seed=…`, `-n …`, or `-p no:randomly` on the command
+line always beats the default, because the caller's arguments are appended
+after the script's.
 
 ### Test-database cleanup and the startup sweep
 
@@ -289,7 +340,22 @@ psql -h 127.0.0.1 -U tckdb -d postgres -c "
 
 - Reproduce in isolation first (Tier 0/1). If it passes alone but
   fails in the full suite, it's a test-isolation bug, not a unit
-  bug — bisect by running an ordered subset of files.
+  bug — and the tripwire below should already have named the culprit.
+  If it did not, the pollution is not committed rows: look at
+  sequence counters (non-transactional, so `setval` survives a
+  rollback), process-global state, and session-scoped fixtures.
+- The order is pinned, so a failure reproduces. Confirm order
+  *independence* by varying it on purpose:
+
+  ```bash
+  TCKDB_TEST_SEED=1 bash backend/scripts/test-full.sh   # a different order
+  bash backend/scripts/test-full.sh -p no:randomly      # declaration order
+
+  # Declaration order, reversed. No plugin needed: hand pytest the node ids.
+  cd backend
+  pytest -q -p no:randomly --collect-only tests/ | grep '::' > /tmp/nodeids.txt
+  pytest -q -p no:randomly -n 8 $(tac /tmp/nodeids.txt)
+  ```
 - The pytest fixture creates a fresh `tckdb_test` database via
   `alembic upgrade head` once per session (see
   [`tests/conftest.py`](../tests/conftest.py)) and rolls each test
@@ -323,20 +389,50 @@ itself**, in a fixture `finally` so it also cleans up when the test fails.
 `tests/services/test_concurrent_deposit_isolation.py` and
 `tests/services/test_record_review_write_isolation.py` show the shape.
 
-The one thing a test cannot clean up is an append-only table.
+#### The tripwire
+
+The contract above is enforced, not merely documented.
+`_refuse_committed_rows` in [`tests/conftest.py`](../tests/conftest.py) is an
+autouse fixture that counts a curated set of tables before and after every
+test that touches the database, and **fails the test that committed** — by
+name, wherever it lives. Without it, a single committing test surfaced as an
+inexplicable failure in whatever unrelated file `pytest-randomly` scheduled
+next, hundreds of tests later.
+
+It started in `tests/workflows/conftest.py` and now covers every tree, because
+~40 other files had the same habit. Tests that legitimately commit satisfy it
+by cleaning up: the counts match again by teardown. There is no exemption
+marker, deliberately. `TCKDB_TEST_COMMIT_TRIPWIRE=0` disables it for bisecting
+an unrelated failure, never as a way to land a committing test.
+
+It watches a curated ~35-table union rather than all ~110 public tables
+because counting everything costs ~90 ms per probe (~12 minutes over the
+suite) against ~2 ms for the union. `app_user` and `api_key` are deliberately
+excluded: the session-scoped `_api_test_user` fixture commits exactly one user
+and key on first use, and watching those tables would blame whichever test
+happened to run first.
+
+#### Append-only tables
+
+An append-only table cannot be cleaned up through the ordinary path.
 `record_review_event` and `scientific_record_supersession` carry a
 `BEFORE UPDATE OR DELETE` trigger (`tckdb_reject_mutation`, revision
-`c6f2a9d4e7b1`), and the scientific tables additionally refuse `TRUNCATE`, so
-the rows the record-review race tests commit cannot be removed by any
-test-level code. Deleting them would require the harness to disable a
-production integrity guard — which would leave that guarantee unenforced in
-the very suite meant to enforce it. **The harness answer is the per-run
-disposable database**: `_recreate_test_database` at session start and
-`_drop_test_database` at session end, plus the startup sweep above. Tests in
-that position must confine themselves to a reserved, non-colliding id band
-(as `test_record_review_write_isolation.py` does) so the residue can never be
-mistaken for another test's data, and no test may make an *absolute*
-unqualified count over those tables — before/after deltas only.
+`c6f2a9d4e7b1`), and the scientific tables additionally refuse `TRUNCATE`.
+
+The narrow escape hatch is `SET LOCAL session_replication_role = replica`,
+which suppresses user triggers **for one transaction only**. Three teardowns
+use it — `tests/services/test_record_review_write_isolation.py`,
+`tests/workers/test_upload_worker.py`,
+`tests/services/archive/test_archive.py` — each confined to row ids the test
+itself created (a reserved id band, or an `id >` high-water mark taken before
+the test ran). It appears only in test teardown; no production code path and
+no test *body* may use it, because the guard it suspends is the thing those
+tests exist to protect.
+
+The per-run disposable database remains the backstop — `_recreate_test_database`
+at session start, `_drop_test_database` at session end, plus the startup sweep
+above — but it is no longer the *primary* answer, and "the database gets
+dropped eventually" is not an acceptable substitute for a teardown.
 
 The other thing that outlives a test is **the schema itself**. The migration
 round-trip tests in `tests/db/` run `alembic downgrade` against the per-run
@@ -500,28 +596,42 @@ smoke         # opt-in liveness/sanity tests (already a directory)
 Do NOT tag hundreds of files in one PR. Tag a single suite at a
 time and validate the deselection behavior end-to-end.
 
-## Parallelization (follow-up, not in this slice)
+## Parallelization
 
-[`pytest-xdist`](https://pypi.org/project/pytest-xdist/) can cut the
-wall time of the Tier 3/4 suites substantially once test isolation
-under parallel workers is proven safe.
+[`pytest-xdist`](https://pypi.org/project/pytest-xdist/) is installed (a `dev`
+extra in `backend/pyproject.toml`) and **on by default** in the Tier 2/3/4
+scripts. See [Pinned order and parallel workers](#pinned-order-and-parallel-workers)
+for the flags and how to override them.
 
-Things to verify before enabling xdist by default:
+Order-independence was the prerequisite, not a separate nicety: xdist
+distributes tests across workers in arbitrary groupings, so a suite that only
+passed in particular orders could not survive it. What made it safe:
 
-- The test DB is named per worker (`tckdb_test_gw0`, `tckdb_test_gw1`,
-  ...) so workers do not race on the same `alembic upgrade head` /
-  drop-and-recreate sequence in [`tests/conftest.py`](../tests/conftest.py).
-  This requires omitting `DB_TEST_NAME` (or making it worker-specific),
-  because explicit names intentionally take precedence over
-  `PYTEST_XDIST_WORKER`.
-- The rate-limit middleware in-memory store is disabled per test
-  (already the case via `_disable_rate_limit_by_default` autouse
-  fixture) so two workers do not poison each other's bucket counters
-  when they happen to land on the same IP.
-- The MinIO/artifact-storage tests that skip on `not _minio_available()`
-  do the right thing under parallel workers, including worker-isolated object
-  keys/buckets and subprocess inheritance.
-- The process-global scientific-read factory counters use worker-distinct
-  prefixes or another isolation mechanism.
+- **A database per worker.** `_resolve_test_db_name` appends the worker id even
+  when `DB_TEST_NAME` is set explicitly, which every gate script and CI job
+  does. Without that, all workers dropped, recreated and then wrote one
+  database concurrently.
+- **No test commits to the shared database.** ~50 tests across 16 files did;
+  they now persist through `db_conn`, and the tripwire above keeps it that way.
+- **Advisory locks are per-database.** The only one in the app
+  (`pg_advisory_xact_lock` in `app/services/conformer_resolution.py`) is
+  transaction-scoped and lives in each worker's own database, so workers cannot
+  contend.
+- **Migration round-trip tests own their databases.** The `tests/db/` tests that
+  run `alembic downgrade` create a `uuid4`-named database of their own rather
+  than downgrading the session database.
+- **Worker-local process state is harmless.** Each worker is a separate process,
+  so the in-memory rate-limit store and the module-level factory counters in
+  `tests/services/scientific_read/_factories.py` are already isolated.
 
-Until that work is done, the scripts run pytest single-threaded.
+Things still worth knowing:
+
+- Worker count is a tuning knob, not a core count — the Postgres server is
+  shared. 8 is the measured default; see the header of
+  [`scripts/lib/pytest_run_args.sh`](../scripts/lib/pytest_run_args.sh).
+- The MinIO bucket is **not** per worker. Artifact tests key objects by content
+  hash or by row id from their own worker-local database, so they do not
+  collide today, but a future test that writes a fixed object key would.
+- `--dist load` (the default) may split one file across workers. Nothing in the
+  suite depends on file grouping; if something appears to, that is a leak to
+  fix rather than a reason to reach for `--dist loadfile`.

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -641,3 +641,10 @@ Things still worth knowing:
 - `--dist load` (the default) may split one file across workers. Nothing in the
   suite depends on file grouping; if something appears to, that is a leak to
   fix rather than a reason to reach for `--dist loadfile`.
+- **`tmp_path` usage multiplies by the worker count.** The CCCBDB importer tests
+  write snapshot trees into `tmp_path`, and pytest retains the last three
+  `basetemp` directories per worker. On a host where `/tmp` is a small tmpfs
+  shared with other workloads this exhausts it, and the whole band of tests
+  running at that moment fails with `OSError: [Errno 122] Disk quota exceeded` —
+  which looks nothing like a disk problem in the summary. Point `TMPDIR` (or
+  `--basetemp`) at real disk if `df -h /tmp` is tight.

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -16,7 +16,7 @@ narrowest tier that proves the change you're making.
 | 1    | One affected module / feature                 | < 1 min if poss.  | `test-fast.sh <dir>` (`-k`)   |
 | 2    | Scientific read + service confidence          | 1–3 min           | `test-scientific.sh`          |
 | 3    | Full API surface regression gate              | several minutes   | `test-api.sh`                 |
-| 4    | Full backend suite — pre-push / release       | longest, reliable | `test-full.sh`                |
+| 4    | Full backend suite — pre-push / release       | ~6 min (`-n 8`)   | `test-full.sh`                |
 
 Tier 0 and Tier 1 use the same script with different arguments — the
 distinction is intent (single failure debug vs. validating a focused
@@ -272,12 +272,22 @@ suite order-independent; the rollback fixtures and the committed-row tripwire
 below do that. It makes a gate *result* reproducible.
 
 **Workers default to 8**, not to core count. Each xdist worker creates its own
-database and runs `alembic upgrade head` into it, so raising the count buys
-test throughput while paying a fixed per-worker migration cost and pushing the
-single Postgres server toward being the bottleneck. Tier 0/1 (`test-fast.sh`)
-and `test-profile.sh` default to 0 workers: one file does not need eight
-databases, and durations measured under eight-way contention describe the
-contention rather than the tests.
+database and runs `alembic upgrade head` into it (~6 s), so every extra worker
+costs a database, a migration and a connection pool against one shared
+Postgres. Measured on a 20-core host, full suite (6,618 tests) at seed 424242:
+
+| Workers | Wall clock |
+|---------|------------|
+| 4       | 586 s      |
+| 8       | 369 s      |
+| 16      | 302 s      |
+
+4 → 8 is a 1.6× gain; 8 → 16 buys only a further 1.22× for eight more
+databases and no headroom left on the machine. 8 is where the returns flatten.
+
+Tier 0/1 (`test-fast.sh`) and `test-profile.sh` default to 0 workers: one file
+does not need eight databases, and durations measured under eight-way
+contention describe the contention rather than the tests.
 
 ```bash
 TCKDB_TEST_SEED=7 bash backend/scripts/test-full.sh        # a different order

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -354,12 +354,23 @@ psql -h 127.0.0.1 -U tckdb -d postgres -c "
   ```bash
   TCKDB_TEST_SEED=1 bash backend/scripts/test-full.sh   # a different order
   bash backend/scripts/test-full.sh -p no:randomly      # declaration order
-
-  # Declaration order, reversed. No plugin needed: hand pytest the node ids.
-  cd backend
-  pytest -q -p no:randomly --collect-only tests/ | grep '::' > /tmp/nodeids.txt
-  pytest -q -p no:randomly -n 8 $(tac /tmp/nodeids.txt)
   ```
+
+  For declaration order *reversed*, write a throwaway plugin outside the repo
+  and load it by name — deliberately not a supported flag, because the suite
+  should never have a way to pin an order:
+
+  ```bash
+  mkdir -p /tmp/po && printf 'def pytest_collection_modifyitems(items):\n    items.reverse()\n' \
+      > /tmp/po/revorder.py
+  cd backend
+  PYTHONPATH=/tmp/po pytest -q -n 8 -p no:randomly -p revorder tests/
+  ```
+
+  Do **not** try to do this by collecting node ids and reversing the list:
+  several parametrized ids in this suite embed newlines (ESS log fragments used
+  as parameters), so a line-based `--collect-only | tac` silently mangles them
+  into unrecognised arguments.
 - The pytest fixture creates a fresh `tckdb_test` database via
   `alembic upgrade head` once per session (see
   [`tests/conftest.py`](../tests/conftest.py)) and rolls each test

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -113,6 +113,11 @@ dev = [
     # Without this installed, "-p no:randomly" is silently accepted and does
     # nothing -- reading like an ordering guarantee the suite never had.
     "pytest-randomly>=3.15",
+    # Parallel execution. The suite is ~6,600 tests and was single-threaded:
+    # ~100 minutes on a 20-core machine. Each worker gets its own database
+    # (see _resolve_test_db_name in tests/conftest.py), which is why this is
+    # safe only now that no test commits to the shared one.
+    "pytest-xdist>=3.6",
     "httpx>=0.27",
     "jsonschema>=4.22",
     "ruff>=0.4",

--- a/backend/scripts/lib/pytest_run_args.sh
+++ b/backend/scripts/lib/pytest_run_args.sh
@@ -1,0 +1,78 @@
+# Shared pytest invocation policy for the test-* gate scripts.
+#
+# Sourced, not executed. Defines ``tckdb_pytest_run_args`` which populates the
+# array ``TCKDB_PYTEST_ARGS`` with the two things every gate needs and no gate
+# should have to remember: a pinned random-order seed, and parallel workers.
+#
+# ---------------------------------------------------------------------------
+# Why the seed is pinned
+# ---------------------------------------------------------------------------
+# ``pytest-randomly`` is installed and active, and by default it seeds itself
+# from the clock. Every gate invocation therefore ran the suite in a *different*
+# order, which means a red gate could not be told apart from bad luck and a
+# green one proved nothing about the next run. Two agents reported wildly
+# different failure counts for the same commit (``3 failed`` vs ``69 failed``)
+# purely because they drew different orders.
+#
+# A pinned seed does not make the suite order-independent — the per-test
+# rollback fixtures and the committed-row tripwire in ``tests/conftest.py`` do
+# that. It makes a *gate result* reproducible, so a regression is a regression.
+#
+# 424242 is the seed the order-dependence audit was conducted against; it is
+# deliberately a known-hostile order rather than a lucky one.
+#
+# Run a different order on purpose:
+#   TCKDB_TEST_SEED=1 bash backend/scripts/test-full.sh
+#   bash backend/scripts/test-full.sh --randomly-seed=last   # (caller wins)
+#
+# ---------------------------------------------------------------------------
+# Why the worker count is 8 and not 20
+# ---------------------------------------------------------------------------
+# Each xdist worker creates its own PostgreSQL database and runs
+# ``alembic upgrade head`` into it (~6 s), so every extra worker costs a
+# database, a migration and a pool of connections against one shared Postgres.
+# Full suite (6,618 tests), 20-core host, seed 424242:
+#
+#   -n 4 ....... 586 s
+#   -n 8 ....... 369 s   <- default
+#   -n 16 ...... 302 s
+#
+# 4 -> 8 is a 1.6x gain; 8 -> 16 is only a further 1.22x. Returns have flattened
+# by 8, and the second half of that curve is bought with eight more databases,
+# eight more migrations, and a box with no headroom left for the developer who
+# is running the tests. 8 is the point where the suite is fast enough that the
+# gate stops being something to avoid.
+#
+# Override for a machine with a different shape:
+#   TCKDB_TEST_WORKERS=16 bash backend/scripts/test-full.sh  # dedicated box
+#   TCKDB_TEST_WORKERS=4  bash backend/scripts/test-full.sh
+#   TCKDB_TEST_WORKERS=0  bash backend/scripts/test-full.sh  # serial
+#
+# ---------------------------------------------------------------------------
+# Caller precedence
+# ---------------------------------------------------------------------------
+# The gate scripts append "$@" *after* these args, so an explicit
+# ``--randomly-seed=...`` or ``-n ...`` on the command line wins. Passing
+# ``-p no:randomly`` disables the plugin, which would make ``--randomly-seed``
+# an unrecognised argument, so it is detected and the seed is dropped.
+
+tckdb_pytest_run_args() {
+    TCKDB_PYTEST_ARGS=()
+
+    local caller_args=" $* "
+    local seed="${TCKDB_TEST_SEED:-424242}"
+    # ``TCKDB_DEFAULT_WORKERS`` is the *script's* default (the inner-loop
+    # runners set 0: one file does not need eight databases). ``TCKDB_TEST_WORKERS``
+    # is the *operator's* override and outranks it.
+    local workers="${TCKDB_TEST_WORKERS:-${TCKDB_DEFAULT_WORKERS:-8}}"
+
+    if [[ "$caller_args" != *" -p no:randomly "* && "$caller_args" != *"--randomly-seed"* ]]; then
+        TCKDB_PYTEST_ARGS+=("--randomly-seed=${seed}")
+    fi
+
+    # ``-n0`` is xdist's own "run in this process" mode; asking for it via the
+    # flag rather than omitting it keeps the plugin's reporting consistent.
+    if [[ "$caller_args" != *" -n "* && "$caller_args" != *"-n"[0-9]* && "$caller_args" != *"--numprocesses"* ]]; then
+        TCKDB_PYTEST_ARGS+=("-n" "${workers}")
+    fi
+}

--- a/backend/scripts/test-api.sh
+++ b/backend/scripts/test-api.sh
@@ -15,8 +15,13 @@
 #   conda run -n tckdb_env bash backend/scripts/test-api.sh
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Resolve the script directory *before* changing directory. "$0" is relative
+# to the invoking cwd, so re-deriving it after the cd resolves against the
+# new one -- which works from backend/ and fails from the repo root, the way
+# CI invokes these.
+TCKDB_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$TCKDB_SCRIPT_DIR/.."
 # shellcheck source=lib/pytest_run_args.sh
-source "$(dirname "$0")/lib/pytest_run_args.sh"
+source "$TCKDB_SCRIPT_DIR/lib/pytest_run_args.sh"
 tckdb_pytest_run_args "$@"
 exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" tests/api/ "$@"

--- a/backend/scripts/test-api.sh
+++ b/backend/scripts/test-api.sh
@@ -3,9 +3,11 @@
 #
 # Runs every test under ``tests/api/`` — the cross-surface regression
 # gate for any backend change that touches a route, middleware, or
-# request/response shape. Slower than the scientific tier (10+ minutes
-# on a cold machine); pair with ``-x`` if you want fail-fast on a
+# request/response shape. Pair with ``-x`` if you want fail-fast on a
 # suspected regression.
+#
+# Runs with a pinned random-order seed and parallel workers; see
+# scripts/lib/pytest_run_args.sh for why, and how to override either.
 #
 # Examples:
 #   bash backend/scripts/test-api.sh
@@ -14,4 +16,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-exec pytest -q --tb=short tests/api/ "$@"
+# shellcheck source=lib/pytest_run_args.sh
+source "$(dirname "$0")/lib/pytest_run_args.sh"
+tckdb_pytest_run_args "$@"
+exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" tests/api/ "$@"

--- a/backend/scripts/test-fast.sh
+++ b/backend/scripts/test-fast.sh
@@ -20,8 +20,13 @@
 # overhead when the target is one file.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Resolve the script directory *before* changing directory. "$0" is relative
+# to the invoking cwd, so re-deriving it after the cd resolves against the
+# new one -- which works from backend/ and fails from the repo root, the way
+# CI invokes these.
+TCKDB_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$TCKDB_SCRIPT_DIR/.."
 # shellcheck source=lib/pytest_run_args.sh
-source "$(dirname "$0")/lib/pytest_run_args.sh"
+source "$TCKDB_SCRIPT_DIR/lib/pytest_run_args.sh"
 TCKDB_DEFAULT_WORKERS=0 tckdb_pytest_run_args "$@"
 exec pytest -v -x --tb=short "${TCKDB_PYTEST_ARGS[@]}" "$@"

--- a/backend/scripts/test-fast.sh
+++ b/backend/scripts/test-fast.sh
@@ -13,7 +13,15 @@
 #
 # Conda is intentionally NOT invoked here so the script is composable
 # with whatever python the caller has on PATH (uv, venv, conda).
+#
+# The random-order seed is pinned (see scripts/lib/pytest_run_args.sh) so a
+# failure you are chasing reproduces on the next invocation. Workers default to
+# 0 here: each xdist worker creates and migrates its own database, which is pure
+# overhead when the target is one file.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-exec pytest -v -x --tb=short "$@"
+# shellcheck source=lib/pytest_run_args.sh
+source "$(dirname "$0")/lib/pytest_run_args.sh"
+TCKDB_DEFAULT_WORKERS=0 tckdb_pytest_run_args "$@"
+exec pytest -v -x --tb=short "${TCKDB_PYTEST_ARGS[@]}" "$@"

--- a/backend/scripts/test-full.sh
+++ b/backend/scripts/test-full.sh
@@ -16,8 +16,13 @@
 #   conda run -n tckdb_env bash backend/scripts/test-full.sh
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Resolve the script directory *before* changing directory. "$0" is relative
+# to the invoking cwd, so re-deriving it after the cd resolves against the
+# new one -- which works from backend/ and fails from the repo root, the way
+# CI invokes these.
+TCKDB_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$TCKDB_SCRIPT_DIR/.."
 # shellcheck source=lib/pytest_run_args.sh
-source "$(dirname "$0")/lib/pytest_run_args.sh"
+source "$TCKDB_SCRIPT_DIR/lib/pytest_run_args.sh"
 tckdb_pytest_run_args "$@"
 exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" tests/ "$@"

--- a/backend/scripts/test-full.sh
+++ b/backend/scripts/test-full.sh
@@ -5,11 +5,19 @@
 # pre-push and pre-release confidence gate, NOT the edit loop —
 # expect a multi-minute runtime. Forwards extra pytest args.
 #
+# Runs with a pinned random-order seed and parallel workers; see
+# scripts/lib/pytest_run_args.sh for why, and how to override either.
+#
 # Examples:
 #   bash backend/scripts/test-full.sh
 #   bash backend/scripts/test-full.sh --maxfail=3
+#   TCKDB_TEST_SEED=7 bash backend/scripts/test-full.sh     # a different order
+#   TCKDB_TEST_WORKERS=0 bash backend/scripts/test-full.sh  # serial
 #   conda run -n tckdb_env bash backend/scripts/test-full.sh
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-exec pytest -q --tb=short tests/ "$@"
+# shellcheck source=lib/pytest_run_args.sh
+source "$(dirname "$0")/lib/pytest_run_args.sh"
+tckdb_pytest_run_args "$@"
+exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" tests/ "$@"

--- a/backend/scripts/test-profile.sh
+++ b/backend/scripts/test-profile.sh
@@ -12,15 +12,23 @@
 #   bash backend/scripts/test-profile.sh tests/api/scientific/
 #   bash backend/scripts/test-profile.sh tests/api/ -k upload
 #   conda run -n tckdb_env bash backend/scripts/test-profile.sh tests/services/
+#
+# Deliberately serial (workers default to 0): durations measured while eight
+# workers contend for one PostgreSQL server describe the contention, not the
+# tests. Pass ``TCKDB_TEST_WORKERS=8`` if you want to profile the parallel run
+# itself.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+# shellcheck source=lib/pytest_run_args.sh
+source "$(dirname "$0")/lib/pytest_run_args.sh"
+TCKDB_DEFAULT_WORKERS=0 tckdb_pytest_run_args "$@"
 
 # Use ``tests/`` as the default target when the caller passed no path.
 # Pytest treats ``--durations`` as a top-level option, so additional
 # flags can ride along on the same command line.
 if [[ $# -eq 0 ]]; then
-    exec pytest -v tests/ --durations=50
+    exec pytest -v "${TCKDB_PYTEST_ARGS[@]}" tests/ --durations=50
 fi
 
-exec pytest -v --durations=50 "$@"
+exec pytest -v "${TCKDB_PYTEST_ARGS[@]}" --durations=50 "$@"

--- a/backend/scripts/test-profile.sh
+++ b/backend/scripts/test-profile.sh
@@ -19,9 +19,14 @@
 # itself.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Resolve the script directory *before* changing directory. "$0" is relative
+# to the invoking cwd, so re-deriving it after the cd resolves against the
+# new one -- which works from backend/ and fails from the repo root, the way
+# CI invokes these.
+TCKDB_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$TCKDB_SCRIPT_DIR/.."
 # shellcheck source=lib/pytest_run_args.sh
-source "$(dirname "$0")/lib/pytest_run_args.sh"
+source "$TCKDB_SCRIPT_DIR/lib/pytest_run_args.sh"
 TCKDB_DEFAULT_WORKERS=0 tckdb_pytest_run_args "$@"
 
 # Use ``tests/`` as the default target when the caller passed no path.

--- a/backend/scripts/test-scientific.sh
+++ b/backend/scripts/test-scientific.sh
@@ -15,9 +15,14 @@
 #   conda run -n tckdb_env bash backend/scripts/test-scientific.sh
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Resolve the script directory *before* changing directory. "$0" is relative
+# to the invoking cwd, so re-deriving it after the cd resolves against the
+# new one -- which works from backend/ and fails from the repo root, the way
+# CI invokes these.
+TCKDB_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$TCKDB_SCRIPT_DIR/.."
 # shellcheck source=lib/pytest_run_args.sh
-source "$(dirname "$0")/lib/pytest_run_args.sh"
+source "$TCKDB_SCRIPT_DIR/lib/pytest_run_args.sh"
 tckdb_pytest_run_args "$@"
 exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" \
     tests/api/scientific/ tests/services/scientific_read/ "$@"

--- a/backend/scripts/test-scientific.sh
+++ b/backend/scripts/test-scientific.sh
@@ -6,6 +6,9 @@
 # ``app/api/routes/scientific/`` or ``app/services/scientific_read/``.
 # Extra pytest args (``-k``, ``-x``, ``--maxfail=...``) are forwarded.
 #
+# Runs with a pinned random-order seed and parallel workers; see
+# scripts/lib/pytest_run_args.sh for why, and how to override either.
+#
 # Examples:
 #   bash backend/scripts/test-scientific.sh
 #   bash backend/scripts/test-scientific.sh -k species
@@ -13,4 +16,8 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-exec pytest -q --tb=short tests/api/scientific/ tests/services/scientific_read/ "$@"
+# shellcheck source=lib/pytest_run_args.sh
+source "$(dirname "$0")/lib/pytest_run_args.sh"
+tckdb_pytest_run_args "$@"
+exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" \
+    tests/api/scientific/ tests/services/scientific_read/ "$@"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -90,27 +90,68 @@ def _database_url(db_name: str) -> str:
     )
 
 
+#: PostgreSQL truncates identifiers at ``NAMEDATALEN - 1`` bytes and does it
+#: silently, which would collapse two long per-worker names onto one database.
+_MAX_IDENTIFIER_BYTES = 63
+
+
+def _sanitize_identifier(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]+", "_", value)
+
+
+def _with_worker_suffix(base: str, safe_worker: str) -> str:
+    """Append the xdist worker id to ``base``, keeping the result distinct.
+
+    Postgres truncates over-long identifiers rather than rejecting them, so
+    naively concatenating could hand ``gw10`` and ``gw11`` the same database.
+    The base is trimmed instead — the suffix, which is what makes the name
+    unique, is always preserved intact.
+    """
+    suffix = f"_{safe_worker}"
+    budget = _MAX_IDENTIFIER_BYTES - len(suffix)
+    if budget < 1:
+        # Pathologically long worker id: the suffix alone is the identity.
+        return f"tckdb_test{suffix}"[:_MAX_IDENTIFIER_BYTES]
+    return f"{base[:budget]}{suffix}"
+
+
 def _resolve_test_db_name() -> str:
     """Derive a test-DB name that won't collide across concurrent runners.
 
     Precedence:
 
-    1. Explicit ``DB_TEST_NAME`` — used verbatim for backward compatibility.
-       Explicit names are single-tenant; do not point two concurrent pytest
-       runs at the same value on one Postgres host (see ``docs/testing.md``).
-    2. ``PYTEST_XDIST_WORKER`` — pytest-xdist worker id (e.g. ``gw0``),
+    1. ``DB_TEST_NAME`` **plus** ``PYTEST_XDIST_WORKER`` — the explicit name
+       with the worker id appended, e.g. ``tckdb_test_api_991_gw3``. This case
+       comes first deliberately. Every gate script and CI job sets
+       ``DB_TEST_NAME`` (see ``.github/workflows/backend-ci.yml``), and while
+       the explicit name won unconditionally, turning on ``-n`` pointed all
+       workers at one database: they raced to ``DROP``/``CREATE`` it during
+       session setup, and whichever survived was then written concurrently by
+       every worker — reintroducing exactly the cross-test visibility the
+       per-test rollback exists to prevent. An operator asking for a specific
+       database name and asking for N workers is asking for N databases.
+    2. Explicit ``DB_TEST_NAME`` alone — used verbatim. Single-tenant: do not
+       point two concurrent pytest runs at the same value on one Postgres host
+       (see ``docs/testing.md``).
+    3. ``PYTEST_XDIST_WORKER`` alone — pytest-xdist worker id (e.g. ``gw0``),
        producing ``tckdb_test_<worker>``. Sanitized so any value Postgres
        would reject becomes safe identifier characters.
-    3. Fallback — ``tckdb_test_<pid>`` so two ad-hoc pytest processes on
+    4. Fallback — ``tckdb_test_<pid>`` so two ad-hoc pytest processes on
        one host never share a database, even without xdist.
+
+    The xdist controller process has ``PYTEST_XDIST_WORKER`` unset and never
+    creates a database (it collects but does not run tests), so only the
+    workers reach cases 1 and 3.
     """
     explicit = os.environ.get("DB_TEST_NAME")
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    safe_worker = _sanitize_identifier(worker) if worker else None
+
+    if explicit and safe_worker:
+        return _with_worker_suffix(explicit, safe_worker)
     if explicit:
         return explicit
-
-    worker = os.environ.get("PYTEST_XDIST_WORKER")
-    if worker:
-        safe_worker = re.sub(r"[^A-Za-z0-9_]+", "_", worker)
+    if safe_worker:
         return f"tckdb_test_{safe_worker}"
 
     return f"tckdb_test_{os.getpid()}"
@@ -385,6 +426,171 @@ def db_conn(db_engine) -> Iterator[Connection]:
             yield connection
         finally:
             transaction.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Committed-row tripwire
+#
+# One database is shared by the whole pytest process, so anything a test
+# *commits* is visible to every test that runs after it.  Hundreds of tests in
+# this repo locate "the" row they just wrote with an unqualified query —
+# ``session.scalar(select(Calculation).where(Calculation.type == irc))`` — which
+# is only correct while the database holds nothing but the current test's own
+# writes.  A single committing test therefore turns the suite order-dependent,
+# and the failure surfaces in whatever unrelated file ``pytest-randomly``
+# happens to schedule next.
+#
+# This fixture blames the test that commits instead.  It started life in
+# ``tests/workflows/conftest.py`` (PR #111) and now covers every tree: a
+# committing test is named wherever it lives.
+#
+# Tests that genuinely need two concurrent transactions (the ``*_isolation``
+# family, the upload-worker tests) take ``db_engine`` directly and delete their
+# rows in a fixture ``finally`` — they satisfy the tripwire because the counts
+# match again by teardown, not because they are exempt.
+# ---------------------------------------------------------------------------
+
+#: Tables watched for committed growth.  Deliberately a tripwire rather than an
+#: audit: counting all ~110 public tables costs ~90 ms per probe (~12 min over
+#: the suite), while this curated union costs ~2 ms.  Any commit big enough to
+#: confuse a later test lands in at least one of these.
+#:
+#: ``app_user``/``api_key`` are intentionally absent: the session-scoped
+#: ``_api_test_user`` fixture commits exactly one user + key on first use, and
+#: watching those tables would blame whichever test happened to be first.
+_WATCHED_TABLES: tuple[str, ...] = (
+    # identity
+    "species",
+    "species_entry",
+    "chem_reaction",
+    "reaction_entry",
+    "transition_state",
+    "transition_state_entry",
+    # calculations and artifacts
+    "calculation",
+    "calculation_artifact",
+    "calculation_parameter",
+    "geometry",
+    "calc_sp_result",
+    "calc_opt_result",
+    "calc_freq_result",
+    # conformers
+    "conformer_group",
+    "conformer_observation",
+    "conformer_selection",
+    # scientific products
+    "statmech",
+    "thermo",
+    "kinetics",
+    "transport",
+    "network",
+    "network_solve",
+    # provenance
+    "software",
+    "software_release",
+    "workflow_tool",
+    "workflow_tool_release",
+    "level_of_theory",
+    "literature",
+    "author",
+    "execution_environment_manifest",
+    # submission / review / curation
+    "submission",
+    "submission_record_link",
+    "upload_job",
+    "idempotency_record",
+    "record_review",
+    "record_machine_review",
+    "species_entry_review",
+    "dataset_release",
+    "release_selection",
+)
+
+_COUNT_SQL = text(
+    " UNION ALL ".join(
+        f"SELECT '{table}' AS t, count(*) AS n FROM public.{table}"
+        for table in _WATCHED_TABLES
+    )
+)
+
+#: Fixtures whose presence means the test can reach the shared database.
+#: ``request.fixturenames`` is the resolved closure, so a test that only takes
+#: ``client`` still lists ``db_engine``.  Pure unit tests list none of them and
+#: must not be made to create a database.
+_DB_FIXTURE_NAMES = frozenset({"db_engine", "db_conn", "db_session", "client"})
+
+
+@pytest.fixture(scope="session")
+def _committed_row_probe(db_engine) -> Iterator[Connection]:
+    """A connection that always reads the latest *committed* state.
+
+    ``AUTOCOMMIT`` matters: a pooled connection holding an open transaction
+    would keep returning its first snapshot and the tripwire would never fire.
+    """
+    connection = db_engine.connect().execution_options(isolation_level="AUTOCOMMIT")
+    try:
+        # Fail loudly at session start if the watched list has drifted from the
+        # schema, rather than silently watching nothing for the whole run.
+        connection.execute(_COUNT_SQL)
+        yield connection
+    finally:
+        connection.close()
+
+
+def _committed_counts(connection) -> dict[str, int]:
+    return dict(connection.execute(_COUNT_SQL).all())
+
+
+@pytest.fixture(autouse=True)
+def _refuse_committed_rows(request) -> Iterator[None]:
+    """Fail the test that commits, not the test that trips over the residue.
+
+    Autouse, so it is set up before the test's own fixtures and therefore torn
+    down after them — the second count is read once ``db_conn``/``client`` has
+    rolled back, so only a genuine commit shows up.
+
+    The baseline is taken per test rather than once per session on purpose. A
+    session-wide baseline would be perturbed by any *other* test committing in
+    between, and the next test would be blamed for a leak it did not cause. A
+    tripwire that reports order-dependent false positives would be a strange
+    thing to install here.
+
+    Set ``TCKDB_TEST_COMMIT_TRIPWIRE=0`` to disable — for bisecting an
+    unrelated failure, never as a way to land a committing test.
+    """
+    if os.environ.get("TCKDB_TEST_COMMIT_TRIPWIRE", "1") == "0":
+        yield
+        return
+    if _DB_FIXTURE_NAMES.isdisjoint(request.fixturenames):
+        yield
+        return
+
+    # Resolved here rather than as a parameter so that a test which never
+    # touches the database never pays for a connection.
+    probe = request.getfixturevalue("_committed_row_probe")
+    before = _committed_counts(probe)
+
+    yield
+
+    after = _committed_counts(probe)
+    if after == before:
+        return
+
+    grew = {
+        table: (before[table], after[table])
+        for table in after
+        if after[table] != before[table]
+    }
+    raise AssertionError(
+        f"{request.node.nodeid} committed rows into the shared test database: "
+        + ", ".join(f"{t} {was}->{now}" for t, (was, now) in sorted(grew.items()))
+        + ". Tests must persist through the `db_conn`/`db_session` fixtures, "
+        "whose transaction is rolled back at teardown — committed rows are "
+        "visible to every later test in the process and are what makes this "
+        "suite order-dependent. If a test genuinely needs two concurrent "
+        "transactions, take `db_engine` and delete its rows in a fixture "
+        "`finally`."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/invariants/test_thermo_invariants.py
+++ b/backend/tests/invariants/test_thermo_invariants.py
@@ -276,7 +276,7 @@ def test_nasa_schema_enforces_t_low_lt_t_mid_lt_t_high() -> None:
 
 
 def test_repeated_thermo_uploads_for_same_species_append_not_overwrite(
-    db_engine,
+    db_conn,
 ) -> None:
     """Two thermo uploads for the same species entry must create two
     distinct ``thermo`` rows. Identity dedup happens at ``species_entry``
@@ -288,7 +288,7 @@ def test_repeated_thermo_uploads_for_same_species_append_not_overwrite(
     covered indirectly in the thermo-upload tests.
     """
     unique = {"smiles": "COC", "charge": 0, "multiplicity": 1}
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         first = persist_thermo_upload(
             session,
             _thermo_request(species_entry=dict(unique), note="run 1"),

--- a/backend/tests/invariants/test_workflow_regressions.py
+++ b/backend/tests/invariants/test_workflow_regressions.py
@@ -55,7 +55,7 @@ _THERMO_POINTS = [
 
 
 def test_thermo_upload_preserves_nasa_coefficients_and_tabulated_points(
-    db_engine,
+    db_conn,
 ) -> None:
     """Push a full thermo payload through ``persist_thermo_upload`` and
     verify that every invariant-carrying field survives unchanged.
@@ -80,7 +80,7 @@ def test_thermo_upload_preserves_nasa_coefficients_and_tabulated_points(
         note="invariant-regression",
     )
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         thermo = persist_thermo_upload(session, request)
 
         # NASA block — every coefficient must round-trip exactly.
@@ -121,7 +121,7 @@ def test_thermo_upload_preserves_nasa_coefficients_and_tabulated_points(
 
 
 def test_two_calculations_with_equivalent_lot_share_one_level_of_theory_row(
-    db_engine,
+    db_conn,
 ) -> None:
     """Two calculations uploaded with the same level-of-theory payload must
     resolve to the same ``LevelOfTheory`` row, and the persisted row's
@@ -157,7 +157,7 @@ def test_two_calculations_with_equivalent_lot_share_one_level_of_theory_row(
         "sp_result": {"electronic_energy_hartree": -79.86},
     }
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry = resolve_species_entry(
             session,
             SpeciesEntryIdentityPayload(

--- a/backend/tests/services/test_artifact_storage.py
+++ b/backend/tests/services/test_artifact_storage.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import re
 from pathlib import Path
 
 import pytest
@@ -27,8 +29,21 @@ GAUSSIAN_OPT_LOG = FIXTURES / "gaussian" / "opt_g09.log"
 GAUSSIAN_FREQ_LOG = FIXTURES / "gaussian" / "freq_g09.log"
 ORCA_OPT_LOG = FIXTURES / "orca" / "opt_orca.out"
 
-# Dedicated test bucket so tests don't pollute the dev bucket.
-TEST_BUCKET = "tckdb-artifacts-test"
+# Dedicated test bucket so tests don't pollute the dev bucket — and one bucket
+# per xdist worker, because the ``s3_test_bucket`` fixture below is
+# function-scoped and *deletes the bucket* at teardown. Sharing one name across
+# workers means one worker's teardown drops the bucket, and its objects, out
+# from under another worker's test. Unlike the database, MinIO is a single
+# shared service, so the isolation has to be in the name.
+#
+# S3 bucket names allow only lowercase alphanumerics, hyphens and dots, so the
+# worker id is normalised rather than interpolated raw.
+_XDIST_WORKER = re.sub(
+    r"[^a-z0-9-]+", "-", os.environ.get("PYTEST_XDIST_WORKER", "").lower()
+).strip("-")
+TEST_BUCKET = (
+    f"tckdb-artifacts-test-{_XDIST_WORKER}" if _XDIST_WORKER else "tckdb-artifacts-test"
+)
 
 
 class _BytesBody:

--- a/backend/tests/services/test_calc_hessian.py
+++ b/backend/tests/services/test_calc_hessian.py
@@ -98,8 +98,8 @@ class TestHessianPayloadValidation:
 # ---------------------------------------------------------------------------
 
 
-def test_persist_hessian_binds_geometry_and_natoms(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_hessian_binds_geometry_and_natoms(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_entry_id = _create_species_entry(
                 session.connection(), inchi_key=_next_inchi_key("HESS")
@@ -126,10 +126,10 @@ def test_persist_hessian_binds_geometry_and_natoms(db_engine) -> None:
             assert geom.natoms == 2
 
 
-def test_hessian_geometry_is_deduped_with_calc_input_geometry(db_engine) -> None:
+def test_hessian_geometry_is_deduped_with_calc_input_geometry(db_conn) -> None:
     """The Hessian's geometry resolves through the content-addressed seam,
     so re-uploading the same XYZ does not create a duplicate geometry row."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             se1 = _create_species_entry(
                 session.connection(), inchi_key=_next_inchi_key("HESSDEDUPA")
@@ -162,12 +162,12 @@ def test_hessian_geometry_is_deduped_with_calc_input_geometry(db_engine) -> None
             assert g1 == g2  # same XYZ → same deduped geometry row
 
 
-def test_db_check_rejects_wrong_cardinality(db_engine) -> None:
+def test_db_check_rejects_wrong_cardinality(db_conn) -> None:
     """The DB CHECK is the last line of defence if a row is inserted
     outside the validated payload path."""
     from sqlalchemy.exc import IntegrityError
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             connection = session.connection()
             species_entry_id = _create_species_entry(

--- a/backend/tests/services/test_calculation_parameter_extraction.py
+++ b/backend/tests/services/test_calculation_parameter_extraction.py
@@ -134,10 +134,10 @@ def _make_calculation(
 # ---------------------------------------------------------------------------
 
 
-def test_gaussian_dispatch_via_software_release(db_engine) -> None:
+def test_gaussian_dispatch_via_software_release(db_conn) -> None:
     """When software_release.name='gaussian', the Gaussian parser runs."""
     text_data = GAUSSIAN_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name="gaussian")
 
         rows = extract_and_store_calculation_parameters(
@@ -154,10 +154,10 @@ def test_gaussian_dispatch_via_software_release(db_engine) -> None:
         assert stored.parameters_extracted_at is not None
 
 
-def test_orca_dispatch_via_software_release(db_engine) -> None:
+def test_orca_dispatch_via_software_release(db_conn) -> None:
     """When software_release.name='orca', the ORCA parser runs."""
     text_data = ORCA_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name="orca")
 
         rows = extract_and_store_calculation_parameters(
@@ -177,10 +177,10 @@ def test_detect_software_from_text_recognises_molpro() -> None:
     assert _detect_software_from_text(MOLPRO_MRCI_LOG.read_text()) == "molpro"
 
 
-def test_molpro_dispatch_via_text_sniff(db_engine) -> None:
+def test_molpro_dispatch_via_text_sniff(db_conn) -> None:
     """A Molpro ``.out`` is sniffed as molpro and routed to its parser."""
     text_data = MOLPRO_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name=None)
 
         rows = extract_and_store_calculation_parameters(
@@ -200,10 +200,10 @@ def test_molpro_dispatch_via_text_sniff(db_engine) -> None:
         assert stored.parameters_parser_version == "molpro_v1"
 
 
-def test_text_sniff_fallback_when_no_software_release(db_engine) -> None:
+def test_text_sniff_fallback_when_no_software_release(db_conn) -> None:
     """No DB-linked software_release → sniff log markers."""
     text_data = GAUSSIAN_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name=None)
 
         rows = extract_and_store_calculation_parameters(
@@ -213,9 +213,9 @@ def test_text_sniff_fallback_when_no_software_release(db_engine) -> None:
         assert all(r.parser_version == "gaussian_v1" for r in rows)
 
 
-def test_extraction_raises_when_software_unknown(db_engine) -> None:
+def test_extraction_raises_when_software_unknown(db_conn) -> None:
     """No software_release and unrecognised text → ParameterExtractionError."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name=None)
         with pytest.raises(ParameterExtractionError):
             extract_and_store_calculation_parameters(
@@ -223,7 +223,7 @@ def test_extraction_raises_when_software_unknown(db_engine) -> None:
             )
 
 
-def test_psi4_raises_instead_of_falling_through_to_orca(db_engine) -> None:
+def test_psi4_raises_instead_of_falling_through_to_orca(db_conn) -> None:
     """Psi4 is sniffed, but has no parameter parser — so nothing is emitted.
 
     ``_run_parser`` used to treat ORCA as its catch-all, so a newly
@@ -232,19 +232,19 @@ def test_psi4_raises_instead_of_falling_through_to_orca(db_engine) -> None:
     dispatch is now exhaustive and raises instead.
     """
     text_data = PSI4_LOG.read_text(errors="replace")
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name=None)
         with pytest.raises(ParameterExtractionError, match="psi4"):
             extract_and_store_calculation_parameters(session, calc, text_data)
 
 
-def test_psi4_extraction_failure_never_aborts_an_upload(db_engine) -> None:
+def test_psi4_extraction_failure_never_aborts_an_upload(db_conn) -> None:
     """The opportunistic wrapper downgrades the raise to a logged skip.
 
     An unsupported program must never fail an artifact upload.
     """
     text_data = PSI4_LOG.read_text(errors="replace")
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name=None)
         assert (
             _extract_safe(session, calc, text_data, source="psi4 fixture") is None
@@ -256,10 +256,10 @@ def test_psi4_extraction_failure_never_aborts_an_upload(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_seeded_vocab_keys_link_through_fk(db_engine) -> None:
+def test_seeded_vocab_keys_link_through_fk(db_conn) -> None:
     """At least one parser-emitted canonical_key links to seeded vocab."""
     text_data = GAUSSIAN_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name="gaussian")
         extract_and_store_calculation_parameters(session, calc, text_data)
 
@@ -280,10 +280,10 @@ def test_seeded_vocab_keys_link_through_fk(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_reparse_replaces_only_parser_rows(db_engine) -> None:
+def test_reparse_replaces_only_parser_rows(db_conn) -> None:
     """Re-parsing wipes parser rows but preserves upload + curated rows."""
     text_data = GAUSSIAN_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name="gaussian")
 
         # First parse.
@@ -343,7 +343,7 @@ def test_reparse_replaces_only_parser_rows(db_engine) -> None:
         )
 
 
-def test_empty_reparse_clears_stale_parser_rows(db_engine) -> None:
+def test_empty_reparse_clears_stale_parser_rows(db_conn) -> None:
     """A re-parse with no observations still wipes prior parser rows.
 
     This guards against drift: if an artifact is re-uploaded with a
@@ -351,7 +351,7 @@ def test_empty_reparse_clears_stale_parser_rows(db_engine) -> None:
     must not silently linger.
     """
     text_data = GAUSSIAN_LOG.read_text()
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         calc = _make_calculation(session, software_name="gaussian")
         extract_and_store_calculation_parameters(session, calc, text_data)
 
@@ -377,9 +377,9 @@ def test_empty_reparse_clears_stale_parser_rows(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_upload_payload_parameters_default_to_source_upload(db_engine) -> None:
+def test_upload_payload_parameters_default_to_source_upload(db_conn) -> None:
     """Existing upload flow continues to write source='upload' by default."""
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("DEFSRC")
         )

--- a/backend/tests/services/test_calculation_parameter_persistence.py
+++ b/backend/tests/services/test_calculation_parameter_persistence.py
@@ -122,8 +122,8 @@ def _opt_upload(
 # ---------------------------------------------------------------------------
 
 
-def test_parameters_persist_through_resolve_and_persist(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_parameters_persist_through_resolve_and_persist(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PARAMS")
         )
@@ -180,8 +180,8 @@ def test_parameters_persist_through_resolve_and_persist(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_canonical_key_does_not_block_persistence(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_unknown_canonical_key_does_not_block_persistence(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PARAMSUNK")
         )
@@ -223,8 +223,8 @@ def test_unknown_canonical_key_does_not_block_persistence(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_known_canonical_key_links_when_vocab_exists(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_known_canonical_key_links_when_vocab_exists(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PARAMSKNOWN")
         )
@@ -262,7 +262,7 @@ def test_known_canonical_key_links_when_vocab_exists(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_snapshot_and_relational_persistence_coexist(db_engine) -> None:
+def test_snapshot_and_relational_persistence_coexist(db_conn) -> None:
     extracted_at = datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc).replace(
         tzinfo=None
     )
@@ -271,7 +271,7 @@ def test_snapshot_and_relational_persistence_coexist(db_engine) -> None:
         "sections": {"opt": {"tight": "tight"}},
     }
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PARAMSSNAP")
         )
@@ -314,8 +314,8 @@ def test_snapshot_and_relational_persistence_coexist(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_indexed_repeated_observations_persist_in_order(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_indexed_repeated_observations_persist_in_order(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PARAMSIDX")
         )
@@ -354,11 +354,11 @@ def test_indexed_repeated_observations_persist_in_order(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parameters_persist_for_additional_calculations(db_engine) -> None:
+def test_parameters_persist_for_additional_calculations(db_conn) -> None:
     """``persist_additional_calculations`` delegates to the shared helper, so
     parameters on per-child uploads must end up on the right calculation."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PARAMSADD")
         )

--- a/backend/tests/services/test_calculation_scan_resolution.py
+++ b/backend/tests/services/test_calculation_scan_resolution.py
@@ -48,8 +48,8 @@ def _create_scan_calculation(connection, *, inchi_key: str) -> int:
     ).scalar_one()
 
 
-def test_persist_calculation_scan_persists_nested_scan_rows(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_calculation_scan_persists_nested_scan_rows(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             calculation_id = _create_scan_calculation(
                 session.connection(),
@@ -153,8 +153,8 @@ def _scan_payload_with_point_geometries(*, geometries: list[str | None]) -> dict
     }
 
 
-def test_persist_calculation_scan_resolves_inline_point_geometry(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_calculation_scan_resolves_inline_point_geometry(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             calculation_id = _create_scan_calculation(
                 session.connection(),
@@ -182,9 +182,9 @@ def test_persist_calculation_scan_resolves_inline_point_geometry(db_engine) -> N
             assert len({p.geometry_id for p in points}) == 3
 
 
-def test_persist_calculation_scan_dedupes_repeated_inline_geometry(db_engine) -> None:
+def test_persist_calculation_scan_dedupes_repeated_inline_geometry(db_conn) -> None:
     """Two scan points with the same XYZ collapse to one geometry row."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             calculation_id = _create_scan_calculation(
                 session.connection(),
@@ -217,9 +217,9 @@ def test_persist_calculation_scan_dedupes_repeated_inline_geometry(db_engine) ->
             assert geom_count is not None
 
 
-def test_persist_calculation_scan_allows_points_without_geometry(db_engine) -> None:
+def test_persist_calculation_scan_allows_points_without_geometry(db_conn) -> None:
     """Mixed geometry-present / geometry-absent points: absent stays NULL."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             calculation_id = _create_scan_calculation(
                 session.connection(),
@@ -293,11 +293,11 @@ def test_calculation_scan_create_rejects_unknown_coordinate_reference() -> None:
         )
 
 
-def test_persist_scan_persists_stepped_and_held_fixed_coords_together(db_engine) -> None:
+def test_persist_scan_persists_stepped_and_held_fixed_coords_together(db_conn) -> None:
     """A scan can carry both a stepped coordinate and held-fixed
     constraints; the two land in distinct tables and do not duplicate.
     """
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             calculation_id = _create_scan_calculation(
                 session.connection(),

--- a/backend/tests/services/test_conformer_resolution.py
+++ b/backend/tests/services/test_conformer_resolution.py
@@ -47,7 +47,8 @@ def test_resolve_conformer_group_takes_advisory_xact_lock(db_conn) -> None:
     with Session(db_conn) as session:
         with session.begin():
             # Set up a real species_entry (and its first conformer group) so the
-            # FK targets exist and the resolve below runs against committed rows.
+            # FK targets exist and the resolve below runs against rows that are
+            # visible to it — flushed within this transaction, not committed.
             persist_conformer_upload(session, _hydrogen_request(label="conf-a"))
             session.flush()
 

--- a/backend/tests/services/test_conformer_resolution.py
+++ b/backend/tests/services/test_conformer_resolution.py
@@ -36,7 +36,7 @@ def _hydrogen_request(*, label: str | None = None) -> ConformerUploadRequest:
     )
 
 
-def test_resolve_conformer_group_takes_advisory_xact_lock(db_engine) -> None:
+def test_resolve_conformer_group_takes_advisory_xact_lock(db_conn) -> None:
     """resolve_conformer_group must acquire a transaction-scoped advisory lock.
 
     The lock serializes basin resolution per species_entry to close the
@@ -44,7 +44,7 @@ def test_resolve_conformer_group_takes_advisory_xact_lock(db_engine) -> None:
     conformer_group rows. Here we assert the guard is present by capturing the
     SQL emitted during a resolve call and checking for pg_advisory_xact_lock.
     """
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             # Set up a real species_entry (and its first conformer group) so the
             # FK targets exist and the resolve below runs against committed rows.

--- a/backend/tests/services/test_contribution_bundle_export.py
+++ b/backend/tests/services/test_contribution_bundle_export.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.db.models.common import KineticsDegeneracyConvention
@@ -34,7 +35,6 @@ from app.services.contribution_bundle_export import (
     export_kinetics_bundle,
     export_thermo_bundle,
 )
-from app.services.record_review import ReviewPolicy
 from app.workflows.kinetics import persist_kinetics_upload
 from app.workflows.thermo import persist_thermo_upload
 
@@ -67,19 +67,8 @@ def _isolated_session(db_engine) -> Iterator[Session]:
 # ---------------------------------------------------------------------------
 
 
-def _seed_thermo(
-    session: Session,
-    *,
-    smiles: str,
-    note: str,
-    review_policy: ReviewPolicy | None = ReviewPolicy(),
-) -> int:
-    """Persist one thermo row via the real upload workflow and return its id.
-
-    ``review_policy`` mirrors ``persist_thermo_upload``'s own default so
-    callers that seed inside a rolled-back transaction exercise the full
-    workflow. The committing CLI fixture passes ``None`` — see the note there.
-    """
+def _seed_thermo(session: Session, *, smiles: str, note: str) -> int:
+    """Persist one thermo row via the real upload workflow and return its id."""
     request = ThermoUploadRequest(
         species_entry={"smiles": smiles, "charge": 0, "multiplicity": 1},
         scientific_origin="computed",
@@ -91,7 +80,7 @@ def _seed_thermo(
         tmax_k=3000.0,
         note=note,
     )
-    thermo = persist_thermo_upload(session, request, review_policy=review_policy)
+    thermo = persist_thermo_upload(session, request)
     session.flush()
     return thermo.id
 
@@ -449,26 +438,29 @@ def _seeded_thermo_for_cli(db_engine) -> int:
     """Commit one thermo row so the CLI subprocess can see it.
 
     The CLI opens its own DB session against the dev/test database, so the
-    fixture must commit (not roll back) and clean up after the test.
+    fixture must commit (not roll back) and clean up after the test. The seed
+    goes through the real upload workflow with its real default review policy —
+    the point of this fixture is that the CLI reads a row produced the way rows
+    are actually produced.
 
-    ``review_policy=None`` keeps that cleanup possible. The default policy
-    would also write ``record_review`` rows plus their ``record_review_event``
-    log, and the log carries an append-only database trigger that refuses
-    ``DELETE`` — so those rows could never be removed again and the committed
-    seed would outlive the test in the shared database. The exporter under
-    test never reads review state, so opting out changes nothing it asserts.
+    That means it also writes ``record_review`` rows and their
+    ``record_review_event`` log, and the log is append-only at the database
+    level (``tckdb_reject_mutation``), so teardown suppresses user triggers for
+    its own transaction with ``session_replication_role = replica`` — scoped to
+    the review ids created after the high-water mark taken below. Same escape
+    hatch, same scoping discipline as
+    ``tests/services/test_record_review_write_isolation.py`` and
+    ``tests/workers/test_upload_worker.py``.
     """
     from app.db.models.species import Species, SpeciesEntry
     from app.db.models.thermo import Thermo
 
     with Session(db_engine) as session:
         with session.begin():
-            thermo_id = _seed_thermo(
-                session,
-                smiles="C#N",
-                note="cli-test-thermo",
-                review_policy=None,
+            before_review_id = (
+                session.scalar(text("SELECT max(id) FROM record_review")) or 0
             )
+            thermo_id = _seed_thermo(session, smiles="C#N", note="cli-test-thermo")
 
     yield thermo_id
 
@@ -477,6 +469,18 @@ def _seeded_thermo_for_cli(db_engine) -> int:
     # back session here would leave the seed row in the test DB and
     # pollute later tests.
     with Session(db_engine) as session, session.begin():
+        session.execute(text("SET LOCAL session_replication_role = replica"))
+        session.execute(
+            text(
+                "DELETE FROM record_review_event WHERE record_review_id IN "
+                "(SELECT id FROM record_review WHERE id > :before_review_id)"
+            ),
+            {"before_review_id": before_review_id},
+        )
+        session.execute(
+            text("DELETE FROM record_review WHERE id > :before_review_id"),
+            {"before_review_id": before_review_id},
+        )
         thermo = session.get(Thermo, thermo_id)
         if thermo is None:
             return

--- a/backend/tests/services/test_contribution_bundle_export.py
+++ b/backend/tests/services/test_contribution_bundle_export.py
@@ -34,6 +34,7 @@ from app.services.contribution_bundle_export import (
     export_kinetics_bundle,
     export_thermo_bundle,
 )
+from app.services.record_review import ReviewPolicy
 from app.workflows.kinetics import persist_kinetics_upload
 from app.workflows.thermo import persist_thermo_upload
 
@@ -66,8 +67,19 @@ def _isolated_session(db_engine) -> Iterator[Session]:
 # ---------------------------------------------------------------------------
 
 
-def _seed_thermo(session: Session, *, smiles: str, note: str) -> int:
-    """Persist one thermo row via the real upload workflow and return its id."""
+def _seed_thermo(
+    session: Session,
+    *,
+    smiles: str,
+    note: str,
+    review_policy: ReviewPolicy | None = ReviewPolicy(),
+) -> int:
+    """Persist one thermo row via the real upload workflow and return its id.
+
+    ``review_policy`` mirrors ``persist_thermo_upload``'s own default so
+    callers that seed inside a rolled-back transaction exercise the full
+    workflow. The committing CLI fixture passes ``None`` — see the note there.
+    """
     request = ThermoUploadRequest(
         species_entry={"smiles": smiles, "charge": 0, "multiplicity": 1},
         scientific_origin="computed",
@@ -79,7 +91,7 @@ def _seed_thermo(session: Session, *, smiles: str, note: str) -> int:
         tmax_k=3000.0,
         note=note,
     )
-    thermo = persist_thermo_upload(session, request)
+    thermo = persist_thermo_upload(session, request, review_policy=review_policy)
     session.flush()
     return thermo.id
 
@@ -438,6 +450,13 @@ def _seeded_thermo_for_cli(db_engine) -> int:
 
     The CLI opens its own DB session against the dev/test database, so the
     fixture must commit (not roll back) and clean up after the test.
+
+    ``review_policy=None`` keeps that cleanup possible. The default policy
+    would also write ``record_review`` rows plus their ``record_review_event``
+    log, and the log carries an append-only database trigger that refuses
+    ``DELETE`` — so those rows could never be removed again and the committed
+    seed would outlive the test in the shared database. The exporter under
+    test never reads review state, so opting out changes nothing it asserts.
     """
     from app.db.models.species import Species, SpeciesEntry
     from app.db.models.thermo import Thermo
@@ -445,7 +464,10 @@ def _seeded_thermo_for_cli(db_engine) -> int:
     with Session(db_engine) as session:
         with session.begin():
             thermo_id = _seed_thermo(
-                session, smiles="C#N", note="cli-test-thermo"
+                session,
+                smiles="C#N",
+                note="cli-test-thermo",
+                review_policy=None,
             )
 
     yield thermo_id

--- a/backend/tests/services/test_freq_modes.py
+++ b/backend/tests/services/test_freq_modes.py
@@ -151,8 +151,8 @@ def _freq_calc_payload(modes: list[dict] | None = None) -> CalculationWithResult
     return CalculationWithResultsPayload.model_validate(base)
 
 
-def test_persist_freq_result_without_modes_keeps_existing_behavior(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_freq_result_without_modes_keeps_existing_behavior(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_entry_id = _create_species_entry(
                 session.connection(), inchi_key=_next_inchi_key("FREQNOMODE")
@@ -176,8 +176,8 @@ def test_persist_freq_result_without_modes_keeps_existing_behavior(db_engine) ->
             ).all() == []
 
 
-def test_persist_freq_result_with_modes_persists_rows(db_engine) -> None:
-    with Session(db_engine) as session:
+def test_persist_freq_result_with_modes_persists_rows(db_conn) -> None:
+    with Session(db_conn) as session:
         with session.begin():
             species_entry_id = _create_species_entry(
                 session.connection(), inchi_key=_next_inchi_key("FREQMODES")
@@ -253,9 +253,9 @@ def test_freq_modes_round_trip_via_read_endpoint(client: TestClient, db_session)
     assert body["modes"][1]["is_imaginary"] is False
 
 
-def test_freq_modes_check_constraint_blocks_inconsistent_sign(db_engine) -> None:
+def test_freq_modes_check_constraint_blocks_inconsistent_sign(db_conn) -> None:
     """The DB CHECK is a backstop if the Pydantic validator is ever bypassed."""
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             species_entry_id = _create_species_entry(
                 session.connection(), inchi_key=_next_inchi_key("FREQCHECK")

--- a/backend/tests/services/test_geometry_validation.py
+++ b/backend/tests/services/test_geometry_validation.py
@@ -247,7 +247,7 @@ class TestValidationService:
 class TestValidationPersistence:
     """Test storing/reading CalculationGeometryValidation rows."""
 
-    def test_persist_validation_result(self, db_engine):
+    def test_persist_validation_result(self, db_conn):
         """Create a validation row and verify it reads back."""
         from sqlalchemy.orm import Session
 
@@ -263,7 +263,7 @@ class TestValidationPersistence:
         )
         from app.db.models.species import Species, SpeciesEntry
 
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             species = Species(
                 smiles="[N]=NCCC",
                 inchi_key="TEST_INCHI_KEY_001",
@@ -311,7 +311,7 @@ class TestValidationPersistence:
             assert calc.geometry_validation.rmsd == pytest.approx(0.05)
             assert calc.geometry_validation.atom_mapping == {0: 0, 1: 1, 2: 2}
 
-    def test_fail_status_persists(self, db_engine):
+    def test_fail_status_persists(self, db_conn):
         """A fail validation row persists correctly."""
         from sqlalchemy.orm import Session
 
@@ -327,7 +327,7 @@ class TestValidationPersistence:
         )
         from app.db.models.species import Species, SpeciesEntry
 
-        with Session(db_engine) as session, session.begin():
+        with Session(db_conn) as session, session.begin():
             species = Species(
                 smiles="CCO",
                 inchi_key="TEST_INCHI_KEY_002",

--- a/backend/tests/services/test_irc_path_search_resolution.py
+++ b/backend/tests/services/test_irc_path_search_resolution.py
@@ -89,10 +89,10 @@ def _xyz(comment: str, z: float) -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_persist_irc_result_with_points_and_geometries(db_engine) -> None:
+def test_persist_irc_result_with_points_and_geometries(db_conn) -> None:
     """IRC result row plus forward/reverse/TS points with geometry links."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("IRCPATH")
         )
@@ -168,10 +168,10 @@ def test_persist_irc_result_with_points_and_geometries(db_engine) -> None:
         assert by_role[CalculationGeometryRole.irc_reverse].output_order == 4
 
 
-def test_persist_irc_result_rejected_for_non_irc_calc(db_engine) -> None:
+def test_persist_irc_result_rejected_for_non_irc_calc(db_conn) -> None:
     """The defensive type check in ``persist_calculation_result`` fires."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("IRCBAD")
         )
@@ -205,11 +205,11 @@ def test_persist_irc_result_rejected_for_non_irc_calc(db_engine) -> None:
 
 
 def test_persist_path_search_neb_result_with_points_and_geometries(
-    db_engine,
+    db_conn,
 ) -> None:
     """NEB-method path-search result plus per-point output-geometry links."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PSNEB")
         )
@@ -282,10 +282,10 @@ def test_persist_path_search_neb_result_with_points_and_geometries(
         assert {link.output_order for link in links} == {2, 3, 4}
 
 
-def test_persist_path_search_gsm_result_persists(db_engine) -> None:
+def test_persist_path_search_gsm_result_persists(db_conn) -> None:
     """A GSM-method path-search row persists with method='gsm'."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PSGSM")
         )
@@ -327,10 +327,10 @@ def test_persist_path_search_gsm_result_persists(db_engine) -> None:
         assert result.selected_ts_point_index == 1
 
 
-def test_path_search_result_dedupes_shared_point_geometry(db_engine) -> None:
+def test_path_search_result_dedupes_shared_point_geometry(db_conn) -> None:
     """Two points with the same geometry produce only one output-geometry row."""
 
-    with Session(db_engine) as session, session.begin():
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("PSDEDUP")
         )

--- a/backend/tests/services/test_literature_resolution.py
+++ b/backend/tests/services/test_literature_resolution.py
@@ -72,14 +72,14 @@ def test_resolve_literature_submission_manual_fallback() -> None:
 
 
 def test_resolve_or_create_literature_reuses_existing_row(
-    db_engine, monkeypatch
+    db_conn, monkeypatch
 ) -> None:
     monkeypatch.setattr(
         "app.services.literature_resolution.fetch_doi_metadata",
         lambda doi: {"title": "Should Not Be Used"},
     )
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             existing = Literature(
                 kind="article",

--- a/backend/tests/services/test_record_review_write_isolation.py
+++ b/backend/tests/services/test_record_review_write_isolation.py
@@ -37,7 +37,7 @@ import threading
 import time
 
 import pytest
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -64,9 +64,7 @@ MARKER = "revrace"
 #: can never be mistaken for a fresh identity by the next. ``record_review``
 #: is polymorphic over ``record_type`` and carries no FK on ``record_id``, so
 #: these need not resolve to live rows for the uniqueness race to be exactly
-#: the real one. ``record_review_event`` is append-only at the database level
-#: (``tckdb_reject_mutation``), so these rows are deliberately never deleted —
-#: the per-run test database is dropped wholesale instead.
+#: the real one.
 _record_ids = itertools.count(900_100)
 
 
@@ -84,22 +82,56 @@ def _species_kwargs(suffix: str) -> dict:
 
 @pytest.fixture
 def committed_scratch(db_engine):
-    """A committing scratch space with guaranteed payload cleanup.
+    """A committing scratch space with guaranteed cleanup of everything it wrote.
 
     Every other fixture in the suite isolates by rolling a transaction back,
     which is precisely the thing under test here: the loser's rollback is the
     bug. So these tests commit for real.
 
-    Yields a fresh ``record_id`` allocator. Payload species rows are deleted
-    on the way out, whether the test passed or failed.
+    Yields a fresh ``record_id`` allocator. Both the payload species rows and
+    the ``record_review``/``record_review_event`` rows the test committed are
+    removed on the way out, whether the test passed or failed — a committing
+    test that does not clean up is what makes the suite order-dependent, and
+    ``tests/conftest.py`` fails any test that leaves rows behind.
+
+    ``record_review_event`` is append-only at the database level
+    (``trg_append_only_record_review_event`` calling ``tckdb_reject_mutation``;
+    see ``alembic/versions/c6f2a9d4e7b1_...``), so its rows cannot be deleted
+    through the normal path. ``session_replication_role = replica`` suppresses
+    user triggers for this transaction only — the same narrowly scoped
+    test-only escape hatch already used by
+    ``tests/workers/test_upload_worker.py`` and
+    ``tests/services/archive/test_archive.py`` for their committed teardown.
+    It is confined here to the record ids this fixture handed out.
     """
+    handed_out: list[int] = []
+
+    def _next_record_id() -> int:
+        record_id = next(_record_ids)
+        handed_out.append(record_id)
+        return record_id
+
     try:
-        yield lambda: next(_record_ids)
+        yield _next_record_id
     finally:
         with Session(db_engine) as cleanup:
+            cleanup.execute(text("SET LOCAL session_replication_role = replica"))
             cleanup.execute(
                 delete(Species).where(Species.smiles.like(f"[He]{MARKER}%"))
             )
+            if handed_out:
+                cleanup.execute(
+                    delete(RecordReviewEvent).where(
+                        RecordReviewEvent.record_review_id.in_(
+                            select(RecordReview.id).where(
+                                RecordReview.record_id.in_(handed_out)
+                            )
+                        )
+                    )
+                )
+                cleanup.execute(
+                    delete(RecordReview).where(RecordReview.record_id.in_(handed_out))
+                )
             cleanup.commit()
 
 

--- a/backend/tests/services/test_software_reconciliation_ingest.py
+++ b/backend/tests/services/test_software_reconciliation_ingest.py
@@ -90,8 +90,8 @@ def _gaussian_log_text() -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_declared_only_recorded_at_primary_seam(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_declared_only_recorded_at_primary_seam(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("RECDECL")
         )
@@ -113,8 +113,8 @@ def test_declared_only_recorded_at_primary_seam(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_matched_after_parser_seam(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_matched_after_parser_seam(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("RECMATCH")
         )
@@ -146,8 +146,8 @@ def test_matched_after_parser_seam(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_enriched_after_parser_seam(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_enriched_after_parser_seam(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("RECENR")
         )
@@ -174,8 +174,8 @@ def test_enriched_after_parser_seam(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_mismatch_after_parser_seam_is_non_blocking(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_mismatch_after_parser_seam_is_non_blocking(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("RECMIS")
         )
@@ -205,8 +205,8 @@ def test_mismatch_after_parser_seam_is_non_blocking(db_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parsed_only_when_no_declared_software(db_engine) -> None:
-    with Session(db_engine) as session, session.begin():
+def test_parsed_only_when_no_declared_software(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
         species_entry_id = _create_species_entry(
             session, inchi_key=_next_inchi_key("RECPARSED")
         )

--- a/backend/tests/services/test_software_resolution.py
+++ b/backend/tests/services/test_software_resolution.py
@@ -9,9 +9,9 @@ from app.services.software_resolution import resolve_software_release_ref
 
 
 def test_resolve_software_release_ref_consolidates_same_software_and_release(
-    db_engine,
+    db_conn,
 ) -> None:
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             first = resolve_software_release_ref(
                 session,
@@ -65,12 +65,12 @@ def test_resolve_software_release_ref_consolidates_same_software_and_release(
 
 
 def test_resolve_software_release_ref_reuses_software_but_splits_versions(
-    db_engine,
+    db_conn,
 ) -> None:
     first_version = "test-9.9.1"
     second_version = "test-9.9.2"
 
-    with Session(db_engine) as session:
+    with Session(db_conn) as session:
         with session.begin():
             existing_software = session.scalar(
                 select(Software).where(Software.name == "ORCA")

--- a/backend/tests/test_db_harness_lifecycle.py
+++ b/backend/tests/test_db_harness_lifecycle.py
@@ -91,6 +91,24 @@ def _dead_pid() -> int:
     return proc.pid
 
 
+@pytest.fixture(autouse=True)
+def _name_the_database_exactly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let these tests choose the database name they then assert about.
+
+    ``_resolve_test_db_name`` appends the xdist worker id to an explicit
+    ``DB_TEST_NAME`` so that ``-n 8`` gives eight databases rather than eight
+    workers fighting over one. The tests below drive the ``db_engine`` fixture
+    body directly and check for a database under the exact name they set, so
+    under xdist they would look for ``tckdb_test_regress_1234`` while the
+    fixture created ``tckdb_test_regress_1234_gw3``.
+
+    Clearing the worker id is the honest fix: what these tests pin is the
+    *lifecycle* (create, migrate, drop on every failure path), not the naming —
+    which ``tests/test_db_name_resolution.py`` covers on its own.
+    """
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # 1. The leak itself
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_db_name_resolution.py
+++ b/backend/tests/test_db_name_resolution.py
@@ -21,11 +21,55 @@ def _clean_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
 
 
-def test_explicit_db_test_name_wins(monkeypatch: pytest.MonkeyPatch, _clean_db_env: None) -> None:
+def test_explicit_db_test_name_used_verbatim_without_xdist(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
     monkeypatch.setenv("DB_TEST_NAME", "ci_job_42_db")
-    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")  # must be ignored
 
     assert _resolve_test_db_name() == "ci_job_42_db"
+
+
+def test_explicit_db_test_name_is_still_per_worker_under_xdist(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
+    """An explicit name must not collapse every worker onto one database.
+
+    Every gate script and CI job sets ``DB_TEST_NAME``. When the explicit name
+    won unconditionally, ``-n auto`` had all workers drop, recreate and then
+    write the same database concurrently.
+    """
+    monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_api_ci")
+
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    first = _resolve_test_db_name()
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    second = _resolve_test_db_name()
+
+    assert first == "tckdb_test_api_ci_gw0"
+    assert second == "tckdb_test_api_ci_gw1"
+    assert first != second
+
+
+def test_long_explicit_name_keeps_workers_distinct(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
+    """Postgres truncates over-long identifiers silently rather than failing.
+
+    A 63-byte cap applied to the concatenation would give ``gw10`` and ``gw11``
+    the same database. The base is trimmed so the worker suffix survives.
+    """
+    monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_" + "x" * 80)
+
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw10")
+    first = _resolve_test_db_name()
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw11")
+    second = _resolve_test_db_name()
+
+    assert len(first) <= 63
+    assert len(second) <= 63
+    assert first.endswith("_gw10")
+    assert second.endswith("_gw11")
+    assert first != second
 
 
 def test_xdist_worker_derives_suffix(monkeypatch: pytest.MonkeyPatch, _clean_db_env: None) -> None:

--- a/backend/tests/workers/test_upload_worker.py
+++ b/backend/tests/workers/test_upload_worker.py
@@ -804,6 +804,17 @@ def test_abandoned_claim_recovers_real_thermo_workflow_exactly_once(worker_db, d
 
     with worker_db.begin():
         before = worker_db.scalar(select(func.count()).select_from(Thermo)) or 0
+        # High-water mark for the review bookkeeping this workflow will create.
+        # The upload writes a `record_review` row per reviewable record — the
+        # thermo *and* its species_entry — and only the thermo one used to be
+        # cleaned up, so this test committed one review row into the shared
+        # database on every run. Primary-key sequences are non-transactional and
+        # only ever advance, so "id greater than this" is exactly the set of
+        # review rows this test is responsible for, whatever record types the
+        # workflow decides to review.
+        before_review_id = (
+            worker_db.scalar(text("SELECT max(id) FROM record_review")) or 0
+        )
         existing_species_entry_id = worker_db.scalar(
             select(SpeciesEntry.id)
             .join(Species)
@@ -874,17 +885,19 @@ def test_abandoned_claim_recovers_real_thermo_workflow_exactly_once(worker_db, d
             persisted = cleanup.get(UploadJob, job_id)
             thermo_id = persisted.result["id"] if persisted and persisted.result else None
             species_entry_id = persisted.result.get("species_entry_id") if persisted and persisted.result else None
+            cleanup.execute(
+                text(
+                    "DELETE FROM record_review_event "
+                    "WHERE record_review_id IN "
+                    "(SELECT id FROM record_review WHERE id > :before_review_id)"
+                ),
+                {"before_review_id": before_review_id},
+            )
+            cleanup.execute(
+                text("DELETE FROM record_review WHERE id > :before_review_id"),
+                {"before_review_id": before_review_id},
+            )
             if thermo_id is not None:
-                cleanup.execute(
-                    text(
-                        "DELETE FROM record_review_event WHERE record_review_id IN (SELECT id FROM record_review WHERE record_type = 'thermo' AND record_id = :thermo_id)"
-                    ),
-                    {"thermo_id": thermo_id},
-                )
-                cleanup.execute(
-                    text("DELETE FROM record_review WHERE record_type = 'thermo' AND record_id = :thermo_id"),
-                    {"thermo_id": thermo_id},
-                )
                 cleanup.execute(
                     text("DELETE FROM thermo_source_calculation WHERE thermo_id = :thermo_id"), {"thermo_id": thermo_id}
                 )

--- a/backend/tests/workflows/conftest.py
+++ b/backend/tests/workflows/conftest.py
@@ -16,100 +16,14 @@ calculations behind and five computed-reaction tests then asserted against the
 wrong one — deterministically, with no random seed involved.
 
 The tree now takes ``db_conn`` (per-test transaction, rolled back at teardown;
-see ``tests/conftest.py``). The fixture below is the enforcement: it fails the
-individual test that commits, rather than letting the damage surface as an
-inexplicable failure in whatever file happens to run next.
+see ``tests/conftest.py``).
+
+The enforcement — the fixture that fails the individual test that commits
+rather than letting the damage surface as an inexplicable failure in whatever
+file happens to run next — used to live here. It now lives in
+``tests/conftest.py`` (``_refuse_committed_rows``) and covers every tree, not
+just this one, because ~40 other files had the same habit. This module is kept
+for the history above; the tree needs no fixtures of its own.
 """
 
 from __future__ import annotations
-
-from typing import Iterator
-
-import pytest
-from sqlalchemy import text
-
-#: Tables a workflow upload writes to. Not exhaustive by design — it is a
-#: tripwire, not an audit. Any commit big enough to confuse a sibling test
-#: lands in at least one of these.
-_WATCHED_TABLES = (
-    "species",
-    "species_entry",
-    "chem_reaction",
-    "reaction_entry",
-    "transition_state",
-    "transition_state_entry",
-    "calculation",
-    "geometry",
-    "conformer_group",
-    "conformer_observation",
-    "statmech",
-    "thermo",
-    "kinetics",
-    "transport",
-    "network",
-)
-
-_COUNT_SQL = text(
-    " UNION ALL ".join(
-        f"SELECT '{table}' AS t, count(*) AS n FROM public.{table}"
-        for table in _WATCHED_TABLES
-    )
-)
-
-
-@pytest.fixture(scope="session")
-def _committed_row_probe(db_engine) -> Iterator:
-    """A connection that always reads the latest *committed* state.
-
-    ``AUTOCOMMIT`` matters: a pooled connection holding an open transaction
-    would keep returning its first snapshot and the tripwire would never fire.
-    """
-    connection = db_engine.connect().execution_options(isolation_level="AUTOCOMMIT")
-    try:
-        yield connection
-    finally:
-        connection.close()
-
-
-def _counts(connection) -> dict[str, int]:
-    return dict(connection.execute(_COUNT_SQL).all())
-
-
-@pytest.fixture(autouse=True)
-def _refuse_committed_workflow_rows(_committed_row_probe, request) -> Iterator[None]:
-    """Fail the test that commits, not the test that trips over the residue.
-
-    Autouse, so it is set up before the test's own fixtures and therefore torn
-    down after them — the second count is read once ``db_conn`` has rolled
-    back, so only a genuine commit shows up.
-
-    The baseline is taken per test rather than once per session on purpose. A
-    session-wide baseline would be perturbed by any *other* tree committing
-    between two workflow files — which is exactly what happens under
-    ``pytest-randomly``, since it shuffles file order — and the next workflow
-    test would be blamed for a leak it did not cause. A tripwire that reports
-    order-dependent false positives would be a strange thing to install here.
-    """
-    before = _counts(_committed_row_probe)
-
-    yield
-
-    after = _counts(_committed_row_probe)
-    if after == before:
-        return
-
-    grew = {
-        table: (before[table], after[table])
-        for table in after
-        if after[table] != before[table]
-    }
-    raise AssertionError(
-        f"{request.node.nodeid} committed rows into the shared test database: "
-        + ", ".join(f"{t} {was}->{now}" for t, (was, now) in sorted(grew.items()))
-        + ". Workflow tests must persist through the `db_conn` fixture, whose "
-        "transaction is rolled back at teardown — committed rows are visible "
-        "to every later test in the process and are what made this suite "
-        "order-dependent. If a test genuinely needs two concurrent "
-        "transactions, take `db_engine` instead and delete its rows in a "
-        "fixture `finally`."
-    )


### PR DESCRIPTION
Two problems that turned out to be one job: the gate picked a fresh test order every run, and it ran single-threaded on a 20-core machine. You cannot parallelise an order-dependent suite — xdist hands arbitrary subsets to arbitrary workers, which is harsher than any sequential order — so determinism was the prerequisite and speed came almost free.

**Full suite: ~36 min serial → 369 s at `-n 8`. Roughly 6×.**

**Failures at seed 424242: 69 → 1**, and that one is the pre-existing `test_identifier_lengths` (now tracked as #69 with the exact offenders named).

## The leaks, with the evidence that found each

**1. ~50 tests across 16 files committed to the shared database.** The bulk of the 69.

#111's tripwire was generalised out of `tests/workflows/conftest.py` into `backend/tests/conftest.py:544` as an autouse fixture: it counts 38 watched tables before and after every DB-touching test and fails **the test that committed**. Run over the 46 files mentioning `db_engine`, it named 53 tests individually — `test_calculation_parameter_extraction.py` (11), `test_calculation_parameter_persistence.py` (6), `test_software_reconciliation_ingest.py` (5), `test_irc_path_search_resolution.py` (5), `test_calculation_scan_resolution.py` (5), and 11 more files.

Mechanism in every case: `with Session(db_engine) as session, session.begin():` commits on exit, and hundreds of later tests locate "the" row they just wrote with an unqualified query.

**2. `test_upload_worker.py` cleaned up half its review rows.** The tripwire said exactly `record_review 0->1`. The workflow reviews the thermo *and* its species entry; teardown deleted only the thermo one. Now an `id >` high-water mark, so it covers whatever record types the workflow decides to review.

**3. The MinIO bucket was shared across workers.** `s3_test_bucket` is function-scoped and **deletes the bucket** at teardown, so one worker's teardown dropped it out from under another's test. Only parallelism can produce this — no sequential order has two teardowns at once. Invisible locally when MinIO is down; CI runs MinIO and would have flaked.

**4. `DB_TEST_NAME` collapsed every worker onto one database.** The harness already derived `tckdb_test_<worker>` from `PYTEST_XDIST_WORKER`, but explicit names won — and every gate invocation set one. Now the worker id is appended even to an explicit name, with the base trimmed on overflow so `_gw10`/`_gw11` cannot truncate into one identifier.

**5. The "permanent residue" claim is retired.** `record_review_event` refuses DELETE via `tckdb_reject_mutation`, and `docs/testing.md` documented the leftover rows as irreducible. Three teardowns now use `SET LOCAL session_replication_role = replica`, scoped to ids the test itself created — the same hatch `test_archive.py` already used.

## Worker count: 8, measured not guessed

| Workers | Full suite |
|---|---|
| 4 | 586 s |
| 8 | **369 s** |
| 16 | 302 s |

4→8 is 1.6×; 8→16 buys a further 1.22× for eight more databases and no headroom left. Per-worker migration is only ~6 s, so **migrations are not the limiter** — Postgres and cores are. CI pins `TCKDB_TEST_WORKERS=4` for 4-vCPU runners. Tier 0/1 and `test-profile.sh` default to 0 workers, since one file does not need eight databases and profiling under eight-way contention measures the wrong thing.

## Seed pinned

**424242**, in a new `backend/scripts/lib/pytest_run_args.sh` sourced by all five `test-*.sh`. Override via `TCKDB_TEST_SEED` or an explicit flag; `-p no:randomly` is detected and the flag dropped. A gate that picks a different order each run cannot tell a regression from bad luck — which is exactly how I came to repeat a "3 failed" figure that was one seed's result.

## Order-independence

**1 failed / 6603 passed / 14 skipped** in every configuration, the one failure being #69 each time, and **0 tripwire errors in every run**:

seed 424242 at `-n 8`, `-n 4`, `-n 16` · seed 1 · seed 987654 · **reversed declaration order**

Post-rebase targeted verification: 938 passed, including #115's new test files. `ruff` clean.

## No product bugs

Unlike #111 — which surfaced a non-deterministic `ORDER BY` in a public read — every failure here traced to fixture leakage or the environment.

## Findings tracked

**#69** the two over-long identifiers, now the only failing test. **#70** migration scratch databases outside the reclaim sweep, the bucket-vs-objects teardown, `tmp_path` exhausting tmpfs at eight workers (96 tests failed as `Disk quota exceeded`, which reads as a test failure rather than a disk problem), and two incidentally-safe module-level counters. **#71** mypy passes against the *installed* `tckdb_schemas` and fails against the repo's own — the same two-copies ambiguity that has bitten every agent from the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)