### PR TITLE
Tour reactions, saddle points and k(T,P) in the explore notebook

### DIFF
--- a/examples/clients/explore_tckdb.ipynb
+++ b/examples/clients/explore_tckdb.ipynb
@@ -2,52 +2,84 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "00d27a16",
+   "id": "82f5f36d",
    "metadata": {},
    "source": [
     "# Exploring TCKDB\n",
     "\n",
-    "**A guided tour of a live Thermochemical & Kinetics Database deployment.**\n",
+    "**A guided tour of a live Thermochemical & Kinetics Database.**\n",
     "\n",
-    "TCKDB stores computational-chemistry results — species, thermodynamics, kinetics,\n",
-    "and the quantum-chemistry calculations behind them — together with the provenance\n",
-    "needed to judge how much to trust each number.\n",
+    "TCKDB stores computational-chemistry results — species, thermodynamics, reactions,\n",
+    "rate coefficients, pressure-dependent networks — together with the quantum-chemistry\n",
+    "calculations behind them and the provenance needed to judge how far to trust each\n",
+    "number.\n",
     "\n",
-    "This notebook queries a running deployment and reconstructs real thermodynamic\n",
-    "functions from it.\n",
+    "This notebook queries a running deployment and *reconstructs* things from it:\n",
+    "thermodynamic functions from NASA polynomials, k(T) from Arrhenius parameters,\n",
+    "and k(T,P) from a master-equation Chebyshev fit. Reading values back is easy;\n",
+    "rebuilding the physics from them is the point.\n",
     "\n",
-    "> **Read-only.** Every call here is an anonymous `GET`. Nothing in this notebook\n",
-    "> can modify the database. You do not need an account or an API key.\n",
+    "> **Read-only.** Every call is an anonymous `GET`. Nothing here can modify the\n",
+    "> database. No account, no API key, no local install.\n",
     "\n",
-    "### The deployment this talks to\n",
+    "### Run it as-is\n",
+    "\n",
+    "It points at Calvin's live instance by default:\n",
     "\n",
     "```\n",
     "https://tckdb.homecalvin.com\n",
     "```\n",
     "\n",
-    "That is Calvin's live TCKDB instance. The notebook points there by default, so you can\n",
-    "run it as-is — no signup, no key, no local database. Set `TCKDB_BASE_URL` if you want to\n",
-    "aim it somewhere else (your own local instance, say).\n",
+    "Set `TCKDB_BASE_URL` to aim elsewhere (your own local instance, a colleague's server).\n",
+    "Everything below degrades gracefully — a section whose data is absent says so and\n",
+    "moves on, so this also runs against an empty deployment.\n",
     "\n",
-    "### What you need\n",
-    "\n",
-    "Only `requests` and `matplotlib`. There *is* a proper Python client\n",
-    "(`pip install tckdb-client`) which is the better choice for programmatic work —\n",
+    "**Requirements:** `requests` and `matplotlib`. There is a proper typed client\n",
+    "(`pip install tckdb-client`) which is the better choice for real programmatic work,\n",
     "but it pins a contract version, so a client newer than the server it talks to will\n",
-    "fail on endpoints that server doesn't have yet. Plain HTTP keeps this tour working\n",
-    "against any deployment, which matters when you're handing it to someone else."
+    "fail on endpoints that server doesn't have yet. Plain HTTP keeps this tour portable.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Contents\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **1** | [What's in this deployment?](#1) — inventory before you know what to ask for |\n",
+    "| **2** | [Finding a molecule](#2) — by identity, and by substructure |\n",
+    "| **3** | [Thermodynamics](#3) — NASA polynomials, rebuilt and checked against JANAF |\n",
+    "| **4** | [Reactions and rate coefficients](#4) — equations, families, k(T) with uncertainty |\n",
+    "| **5** | [Transition states](#5) — the saddle points, and what evidence backs them |\n",
+    "| **6** | [Pressure-dependent networks](#6) — k(T,P), falloff, and a self-consistency check |\n",
+    "| **7** | [How much should you trust this?](#7) — review, trust and reproducibility |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95db15a0",
+   "metadata": {},
+   "source": [
+    "## 0. Setup\n",
+    "\n",
+    "One cell. Everything below uses `get()` (raises on failure) or `try_get()`\n",
+    "(returns `None` when this deployment simply doesn't have that thing).\n",
+    "\n",
+    "A full run is a few hundred requests, which is enough to trip a public\n",
+    "deployment's rate limiter. `get()` handles that by reading the `Retry-After` the\n",
+    "server sends and waiting exactly that long — so a cell may pause and print\n",
+    "`rate limited; waiting Ns`. That is the notebook behaving correctly, not hanging."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "88ab9fa8",
+   "id": "30b8db93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T07:59:36.879545Z",
-     "iopub.status.busy": "2026-08-08T07:59:36.879449Z",
-     "iopub.status.idle": "2026-08-08T08:00:07.310994Z",
-     "shell.execute_reply": "2026-08-08T08:00:07.310693Z"
+     "iopub.execute_input": "2026-08-10T07:02:17.491839Z",
+     "iopub.status.busy": "2026-08-10T07:02:17.491690Z",
+     "iopub.status.idle": "2026-08-10T07:02:17.901072Z",
+     "shell.execute_reply": "2026-08-10T07:02:17.900620Z"
     }
    },
    "outputs": [
@@ -55,26 +87,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "deployment: https://tckdb.homecalvin.com/api/v1\n"
+      "deployment : https://tckdb.homecalvin.com/api/v1\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "health    : {'status': 'ok'}\n"
+      "health     : {'status': 'ok'}\n"
      ]
     }
    ],
    "source": [
     "import math\n",
     "import os\n",
-    "\n",
+    "import time\n",
     "import requests\n",
     "\n",
-    "# Point this anywhere: a colleague's server, or your own localhost instance.\n",
     "BASE_URL = os.environ.get(\"TCKDB_BASE_URL\", \"https://tckdb.homecalvin.com/api/v1\").rstrip(\"/\")\n",
     "TIMEOUT_S = 30\n",
+    "\n",
+    "# A full run of this notebook is a few hundred requests, which is enough to trip\n",
+    "# a public deployment's rate limiter. The server does not leave a client\n",
+    "# guessing: it answers 429 with a Retry-After header and a retry_after_seconds\n",
+    "# context field saying exactly how long the window has left. Reading that is the\n",
+    "# whole of correct behaviour -- a fixed sleep would be either too short (and\n",
+    "# hammer a limiter that is already refusing) or needlessly long.\n",
+    "RATE_LIMIT_RETRIES = 3\n",
     "\n",
     "# One connection, reused for every call below.\n",
     "#\n",
@@ -87,48 +126,234 @@
     "SESSION = requests.Session()\n",
     "\n",
     "\n",
+    "class TCKDBError(RuntimeError):\n",
+    "    \"\"\"An error the server described in its own typed envelope.\"\"\"\n",
+    "\n",
+    "    def __init__(self, status, code, detail, context=None):\n",
+    "        self.status, self.code, self.detail, self.context = status, code, detail, context or {}\n",
+    "        super().__init__(f\"{status} {code}: {detail}\")\n",
+    "\n",
+    "\n",
     "def get(path, **params):\n",
-    "    \"\"\"One anonymous GET, surfacing TCKDB's typed error envelope when present.\"\"\"\n",
-    "    r = SESSION.get(f\"{BASE_URL}/{path.lstrip('/')}\", params=params, timeout=TIMEOUT_S)\n",
-    "    if not r.ok:\n",
+    "    \"\"\"One anonymous GET, waiting out any rate limit.\n",
+    "\n",
+    "    Raises TCKDBError carrying the server's own code and message.\n",
+    "    \"\"\"\n",
+    "    url = f\"{BASE_URL}/{path.lstrip('/')}\"\n",
+    "    for attempt in range(RATE_LIMIT_RETRIES + 1):\n",
+    "        r = SESSION.get(url, params=params, timeout=TIMEOUT_S)\n",
+    "        if r.ok:\n",
+    "            return r.json()\n",
     "        try:\n",
-    "            e = r.json()\n",
-    "            raise RuntimeError(f\"{r.status_code} {e.get('code','?')}: {e.get('detail', r.text[:200])}\")\n",
+    "            envelope = r.json()\n",
     "        except ValueError:\n",
     "            r.raise_for_status()\n",
-    "    return r.json()\n",
+    "\n",
+    "        if r.status_code == 429 and attempt < RATE_LIMIT_RETRIES:\n",
+    "            delay = float(r.headers.get(\"Retry-After\")\n",
+    "                          or (envelope.get(\"context\") or {}).get(\"retry_after_seconds\")\n",
+    "                          or 1.0)\n",
+    "            # Say so. A silent sleep is indistinguishable from a hung cell.\n",
+    "            print(f\"  rate limited; waiting {delay:.0f}s before retrying {path}\")\n",
+    "            time.sleep(delay)\n",
+    "            continue\n",
+    "\n",
+    "        raise TCKDBError(r.status_code, envelope.get(\"code\", \"unknown\"),\n",
+    "                         envelope.get(\"detail\", r.text[:200]), envelope.get(\"context\"))\n",
     "\n",
     "\n",
-    "print(\"deployment:\", BASE_URL)\n",
-    "print(\"health    :\", get(\"health\"))"
+    "def try_get(path, **params):\n",
+    "    \"\"\"Like get(), but None when this deployment cannot answer.\n",
+    "\n",
+    "    Only 404/405 are swallowed -- \"no such endpoint or record\". A 422 still\n",
+    "    raises, because that means the *request* was wrong (a missing filter, a bad\n",
+    "    include token), and quietly returning None for a mistake in the query is how\n",
+    "    a tour ends up showing nothing and looking like an empty database.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        return get(path, **params)\n",
+    "    except TCKDBError as exc:\n",
+    "        if exc.status in (404, 405):\n",
+    "            return None\n",
+    "        raise\n",
+    "\n",
+    "\n",
+    "def records(path, **params):\n",
+    "    \"\"\"The `records` list of a search response, or [] if unavailable.\"\"\"\n",
+    "    payload = try_get(path, **params)\n",
+    "    return list(payload.get(\"records\", [])) if payload else []\n",
+    "\n",
+    "\n",
+    "def table(rows, headers):\n",
+    "    \"\"\"Print aligned columns. Keeps the output readable without pandas.\"\"\"\n",
+    "    rows = [[(\"\" if c is None else str(c)) for c in row] for row in rows]\n",
+    "    widths = [max(len(h), *(len(r[i]) for r in rows)) if rows else len(h)\n",
+    "              for i, h in enumerate(headers)]\n",
+    "    line = \"  \".join(h.ljust(w) for h, w in zip(headers, widths))\n",
+    "    print(line)\n",
+    "    print(\"-\" * len(line))\n",
+    "    for row in rows:\n",
+    "        print(\"  \".join(c.ljust(w) for c, w in zip(row, widths)))\n",
+    "\n",
+    "\n",
+    "print(\"deployment :\", BASE_URL)\n",
+    "print(\"health     :\", get(\"health\"))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "75d971dd",
+   "id": "59868b07",
    "metadata": {},
    "source": [
-    "## 1. Finding a species\n",
+    "<a id=\"1\"></a>\n",
+    "## 1. What's in this deployment?\n",
     "\n",
-    "The search endpoints are **lookup-by-identity**, not list-everything. You must supply\n",
-    "at least one of `smiles`, `inchi`, `inchi_key`, `formula`, `species_ref`, or\n",
-    "`species_entry_ref`.\n",
+    "Every `/search` endpoint is **lookup-by-identity**: it requires a filter and answers\n",
+    "`422` without one. That is deliberate — you ask a scientific database for a molecule,\n",
+    "not for a page of rows.\n",
     "\n",
-    "That's deliberate for a scientific database: you ask for a molecule, not a page of rows.\n",
-    "Asking without an identifier returns a helpful `422` rather than dumping the table —\n",
-    "try it by deleting the `smiles=` argument below."
+    "Which leaves a chicken-and-egg problem: *how do you find out what's here before you\n",
+    "know what to ask for?* The **analytics** surfaces are the answer, and the only\n",
+    "endpoints that will list without a filter."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "c47e1422",
+   "id": "2d8a3ca4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:07.311950Z",
-     "iopub.status.busy": "2026-08-08T08:00:07.311863Z",
-     "iopub.status.idle": "2026-08-08T08:00:07.460237Z",
-     "shell.execute_reply": "2026-08-08T08:00:07.459884Z"
+     "iopub.execute_input": "2026-08-10T07:02:17.902314Z",
+     "iopub.status.busy": "2026-08-10T07:02:17.902227Z",
+     "iopub.status.idle": "2026-08-10T07:02:18.457864Z",
+     "shell.execute_reply": "2026-08-10T07:02:18.457348Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "surface       records  approved  under review\n",
+      "---------------------------------------------\n",
+      "thermo        65       0         65          \n",
+      "kinetics      17       0         17          \n",
+      "statmech      101      0         83          \n",
+      "calculations  572      0         494         \n"
+     ]
+    }
+   ],
+   "source": [
+    "SURFACES = (\"thermo\", \"kinetics\", \"statmech\", \"calculations\")\n",
+    "\n",
+    "rows = []\n",
+    "for surface in SURFACES:\n",
+    "    payload = try_get(f\"scientific/analytics/{surface}\", limit=1)\n",
+    "    if payload is None:\n",
+    "        rows.append([surface, \"not served here\", \"\", \"\"])\n",
+    "        continue\n",
+    "    review = payload.get(\"review_summary\", {})\n",
+    "    rows.append([\n",
+    "        surface,\n",
+    "        payload[\"pagination\"][\"total\"],\n",
+    "        review.get(\"approved\", 0),\n",
+    "        review.get(\"under_review\", 0),\n",
+    "    ])\n",
+    "\n",
+    "table(rows, [\"surface\", \"records\", \"approved\", \"under review\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aaff83b",
+   "metadata": {},
+   "source": [
+    "The controlled vocabularies say what a deployment is *about* — which levels of theory\n",
+    "it was built from, which codes produced it, which reaction families it covers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cea89a3b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:02:18.459207Z",
+     "iopub.status.busy": "2026-08-10T07:02:18.459025Z",
+     "iopub.status.idle": "2026-08-10T07:02:18.975249Z",
+     "shell.execute_reply": "2026-08-10T07:02:18.974636Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "methods            CCSD(T)-F12 (1), MRCI+Davidson (1), b3lyp (1), wb97xd (1)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "basis-sets         def2tzvp (2), aug-cc-pV(T+d)Z (1), cc-pVTZ-F12 (1)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "software           Arkane (1), Gaussian (1), Molpro (1), ORCA (1)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reaction-families  R_Addition_MultipleBond (4), 1+2_Cycloaddition (1), Cyclic_Ether_Formation (1), HO2_Elimination_from_PeroxyRadical (1), H_Abstraction (1), Intra_Disproportionation (1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for name in (\"methods\", \"basis-sets\", \"software\", \"reaction-families\"):\n",
+    "    payload = try_get(f\"scientific/meta/{name}\")\n",
+    "    if payload is None:\n",
+    "        print(f\"{name:18s} not served here\")\n",
+    "        continue\n",
+    "    entries = payload.get(\"results\") or []\n",
+    "    summary = \", \".join(f\"{e['value']} ({e['count']})\" for e in entries[:6])\n",
+    "    print(f\"{name:18s} {summary or '-'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc27ae69",
+   "metadata": {},
+   "source": [
+    "<a id=\"2\"></a>\n",
+    "## 2. Finding a molecule\n",
+    "\n",
+    "Two complementary questions:\n",
+    "\n",
+    "- **identity** — \"do you have *this* molecule?\" → `scientific/species/search`\n",
+    "- **substructure** — \"what do you have that *contains* this?\" → `scientific/species/structure-search`\n",
+    "\n",
+    "Identity search takes any of `smiles`, `inchi`, `inchi_key`, `formula`, `species_ref`\n",
+    "or `species_entry_ref`. Substructure search takes a SMARTS pattern and is served by\n",
+    "the RDKit cartridge inside PostgreSQL, so matching happens in the database rather\n",
+    "than by pulling every structure across the wire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fb22917c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:02:18.976774Z",
+     "iopub.status.busy": "2026-08-10T07:02:18.976589Z",
+     "iopub.status.idle": "2026-08-10T07:02:19.124330Z",
+     "shell.execute_reply": "2026-08-10T07:02:19.123804Z"
     }
    },
    "outputs": [
@@ -138,31 +363,30 @@
      "text": [
       "matched 1 species\n",
       "\n",
-      "species_ref     : spc_bzlnvjru7in32c2gz7peczhlwi\n",
-      "canonical SMILES: C=C\n",
-      "InChIKey        : VGGSQFUCUMXWEO-UHFFFAOYSA-N\n",
-      "charge / mult   : 0 / 1\n",
-      "entries         : 1\n",
+      "species_ref      spc_bzlnvjru7in32c2gz7peczhlwi\n",
+      "canonical SMILES C=C\n",
+      "InChIKey         VGGSQFUCUMXWEO-UHFFFAOYSA-N\n",
+      "charge / mult    0 / 1\n",
+      "entries          1\n",
       "   spe_5nr24y2ssxokxlhsvymdwbpwmm  kind=minimum  state=ground  review=under_review\n"
      ]
     }
    ],
    "source": [
-    "species = get(\"scientific/species/search\", smiles=\"C=C\")[\"records\"]\n",
-    "print(f\"matched {len(species)} species\\n\")\n",
+    "species = records(\"scientific/species/search\", smiles=\"C=C\")\n",
+    "print(f\"matched {len(species)} species\")\n",
     "\n",
     "sp = species[0]\n",
-    "print(\"species_ref     :\", sp[\"species_ref\"])\n",
-    "print(\"canonical SMILES:\", sp[\"canonical_smiles\"])\n",
-    "print(\"InChIKey        :\", sp[\"inchi_key\"])\n",
-    "print(\"charge / mult   :\", sp[\"charge\"], \"/\", sp[\"multiplicity\"])\n",
-    "print(\"entries         :\", len(sp[\"entries\"]))\n",
+    "print(f\"\"\"\n",
+    "species_ref      {sp['species_ref']}\n",
+    "canonical SMILES {sp['canonical_smiles']}\n",
+    "InChIKey         {sp['inchi_key']}\n",
+    "charge / mult    {sp['charge']} / {sp['multiplicity']}\n",
+    "entries          {len(sp['entries'])}\"\"\")\n",
     "\n",
-    "# A \"species\" is the chemical identity; each \"entry\" is one physical\n",
-    "# interpretation of it (a minimum, a particular electronic state, ...).\n",
-    "for e in sp[\"entries\"]:\n",
-    "    print(f\"   {e['species_entry_ref']}  kind={e['species_entry_kind']}  \"\n",
-    "          f\"state={e['electronic_state_kind']}  review={e['review']['status']}\")\n",
+    "for entry in sp[\"entries\"]:\n",
+    "    print(f\"   {entry['species_entry_ref']}  kind={entry['species_entry_kind']}  \"\n",
+    "          f\"state={entry['electronic_state_kind']}  review={entry['review']['status']}\")\n",
     "\n",
     "SPECIES_REF = sp[\"species_ref\"]\n",
     "SPECIES_SMILES = sp[\"canonical_smiles\"]"
@@ -170,27 +394,122 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3666b6ed",
+   "id": "acd09511",
    "metadata": {},
    "source": [
     "### Species vs. species *entry* — the distinction that matters\n",
     "\n",
     "TCKDB separates **identity** from **interpretation**:\n",
     "\n",
-    "- a **species** is *what the molecule is* (deduplicated by InChIKey),\n",
+    "- a **species** is *what the molecule is* — deduplicated by InChIKey;\n",
     "- a **species entry** is *one physical reading of it* — a particular minimum, a\n",
     "  specific electronic state.\n",
     "\n",
     "Thermo, kinetics and calculations attach to an **entry**, never to the bare identity.\n",
-    "So two conformers, or a ground and excited state, never silently blur into one number."
+    "So a ground and an excited state, or two distinct conformational wells, never silently\n",
+    "blur into one number. Section 6 shows a case where this matters concretely: two entries\n",
+    "of the same species appear as separate wells in one reaction network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8f3018de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:02:19.125436Z",
+     "iopub.status.busy": "2026-08-10T07:02:19.125341Z",
+     "iopub.status.idle": "2026-08-10T07:02:19.953987Z",
+     "shell.execute_reply": "2026-08-10T07:02:19.953675Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SMARTS \"[OX2H]\" matched 9 species\n",
+      "\n",
+      "SMILES        InChIKey                     charge  mult  review      \n",
+      "---------------------------------------------------------------------\n",
+      "CC=CCO        WCASXYBKJHWFMY-UHFFFAOYSA-N  0       1     under_review\n",
+      "C[CH]C(CO)OO  RBEFRDGSQCPKTD-UHFFFAOYSA-N  0       2     under_review\n",
+      "[CH2]C(O)Cl   VRBFIUCRSFREGQ-UHFFFAOYSA-N  0       2     under_review\n",
+      "O[CH]CCl      GUOHZIQQHGUOMV-UHFFFAOYSA-N  0       2     under_review\n",
+      "OC[S]         VAFVFEZXJXCCEN-UHFFFAOYSA-N  0       2     under_review\n",
+      "[CH2]SO       UKSAJZRKAPLHAR-UHFFFAOYSA-N  0       2     under_review\n",
+      "CCC(=O)O      XBDQKXXYIPTUBI-UHFFFAOYSA-N  0       1     under_review\n",
+      "C=CO          IMROMDMJAWUWLK-UHFFFAOYSA-N  0       1     under_review\n",
+      "[O]O          OUUQCZGPVNCOIJ-UHFFFAOYSA-N  0       2     under_review\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  any carbon           [#6]               44 species\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  carbonyl             [CX3]=[OX1]         2 species\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  hydroxyl             [OX2H]              9 species\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  trivalent nitrogen   [NX3]               4 species\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  halogen              [F,Cl,Br,I]         6 species\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Substructure search: every stored species containing an -OH group.\n",
+    "hits = records(\"scientific/species/structure-search\", query_smarts=\"[OX2H]\")\n",
+    "print(f'SMARTS \"[OX2H]\" matched {len(hits)} species\\n')\n",
+    "table(\n",
+    "    [[h[\"smiles\"], h[\"inchi_key\"], h[\"charge\"], h[\"multiplicity\"], h[\"review\"][\"status\"]]\n",
+    "     for h in hits[:10]],\n",
+    "    [\"SMILES\", \"InChIKey\", \"charge\", \"mult\", \"review\"],\n",
+    ")\n",
+    "\n",
+    "# A count-only sweep: how much of the database contains each motif?\n",
+    "print()\n",
+    "for smarts, description in [\n",
+    "    (\"[#6]\",           \"any carbon\"),\n",
+    "    (\"[CX3]=[OX1]\",    \"carbonyl\"),\n",
+    "    (\"[OX2H]\",         \"hydroxyl\"),\n",
+    "    (\"[NX3]\",          \"trivalent nitrogen\"),\n",
+    "    (\"[F,Cl,Br,I]\",    \"halogen\"),\n",
+    "]:\n",
+    "    n = len(records(\"scientific/species/structure-search\", query_smarts=smarts))\n",
+    "    print(f\"  {description:20s} {smarts:16s} {n:4d} species\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9ddfc228",
+   "id": "a0a2457e",
    "metadata": {},
    "source": [
-    "## 2. Thermodynamics\n",
+    "<a id=\"3\"></a>\n",
+    "## 3. Thermodynamics\n",
     "\n",
     "Each thermo record carries its model (`nasa`, `nasa9`, `wilhoit`), the standard-state\n",
     "values, and its review status."
@@ -198,14 +517,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "fbeb7e6a",
+   "execution_count": 6,
+   "id": "b3fbc7e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:07.461305Z",
-     "iopub.status.busy": "2026-08-08T08:00:07.461193Z",
-     "iopub.status.idle": "2026-08-08T08:00:07.633205Z",
-     "shell.execute_reply": "2026-08-08T08:00:07.632912Z"
+     "iopub.execute_input": "2026-08-10T07:02:19.955189Z",
+     "iopub.status.busy": "2026-08-10T07:02:19.955092Z",
+     "iopub.status.idle": "2026-08-10T07:02:20.131699Z",
+     "shell.execute_reply": "2026-08-10T07:02:20.131286Z"
     }
    },
    "outputs": [
@@ -215,39 +534,44 @@
      "text": [
       "7 thermo record(s) for C=C\n",
       "\n",
-      "  thm_kehnhu3mmaxhm55xrjreryphhy  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
-      "  thm_gk74mw4vyergttszkxgtjnyfwe  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
-      "  thm_3xldk7zoo7fgqpfeydev2e4q5y  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
-      "  thm_ry3rnspliwtmueeth7pitbinpy  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
-      "  thm_nqtvuodj6trobe6rmv4ixtmxva  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
-      "  thm_opilwohiutrg26h5xx6g5ib3r4  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n",
-      "  thm_lzteqmvad6fzdz2cdejssxdlgu  model=nasa   origin=computed  H298=    62.84 kJ/mol   S298=  218.8 J/mol/K   [under_review]\n"
+      "thermo_ref                      model  origin    H298 kJ/mol  S298 J/mol/K  review      \n",
+      "----------------------------------------------------------------------------------------\n",
+      "thm_kehnhu3mmaxhm55xrjreryphhy  nasa   computed  62.84        218.8         under_review\n",
+      "thm_gk74mw4vyergttszkxgtjnyfwe  nasa   computed  62.84        218.8         under_review\n",
+      "thm_3xldk7zoo7fgqpfeydev2e4q5y  nasa   computed  62.84        218.8         under_review\n",
+      "thm_ry3rnspliwtmueeth7pitbinpy  nasa   computed  62.84        218.8         under_review\n",
+      "thm_nqtvuodj6trobe6rmv4ixtmxva  nasa   computed  62.84        218.8         under_review\n",
+      "thm_opilwohiutrg26h5xx6g5ib3r4  nasa   computed  62.84        218.8         under_review\n",
+      "thm_lzteqmvad6fzdz2cdejssxdlgu  nasa   computed  62.84        218.8         under_review\n"
      ]
     }
    ],
    "source": [
-    "thermo = get(\"scientific/thermo/search\", species_ref=SPECIES_REF)[\"records\"]\n",
+    "thermo = records(\"scientific/thermo/search\", species_ref=SPECIES_REF)\n",
     "print(f\"{len(thermo)} thermo record(s) for {SPECIES_SMILES}\\n\")\n",
     "\n",
-    "for t in thermo:\n",
-    "    th = t[\"thermo\"]\n",
-    "    h, s298 = th.get(\"h298_kj_mol\"), th.get(\"s298_j_mol_k\")\n",
-    "    print(f\"  {th['thermo_ref']}  model={th['model_kind']:6s} origin={th['scientific_origin']:9s} \"\n",
-    "          f\"H298={h if h is None else round(h, 2)!s:>9s} kJ/mol   \"\n",
-    "          f\"S298={s298 if s298 is None else round(s298, 2)!s:>7s} J/mol/K   \"\n",
-    "          f\"[{th['review']['status']}]\")"
+    "table(\n",
+    "    [[t[\"thermo\"][\"thermo_ref\"],\n",
+    "      t[\"thermo\"][\"model_kind\"],\n",
+    "      t[\"thermo\"][\"scientific_origin\"],\n",
+    "      None if t[\"thermo\"].get(\"h298_kj_mol\") is None else round(t[\"thermo\"][\"h298_kj_mol\"], 2),\n",
+    "      None if t[\"thermo\"].get(\"s298_j_mol_k\") is None else round(t[\"thermo\"][\"s298_j_mol_k\"], 2),\n",
+    "      t[\"thermo\"][\"review\"][\"status\"]]\n",
+    "     for t in thermo],\n",
+    "    [\"thermo_ref\", \"model\", \"origin\", \"H298 kJ/mol\", \"S298 J/mol/K\", \"review\"],\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3a14ba84",
+   "id": "c4d05882",
    "metadata": {},
    "source": [
     "### Reconstructing Cp(T), H(T), S(T)\n",
     "\n",
     "A NASA-7 fit stores two coefficient sets meeting at `t_mid`. Evaluating them is what\n",
-    "turns a stored record back into thermodynamic functions — and it's the reason to query\n",
-    "thermo at all rather than just read a summary table.\n",
+    "turns a stored record back into thermodynamic functions — and it is the reason to\n",
+    "query thermo at all rather than read a summary table.\n",
     "\n",
     "$$\\frac{C_p}{R} = a_1 + a_2T + a_3T^2 + a_4T^3 + a_5T^4$$\n",
     "$$\\frac{H}{RT} = a_1 + \\frac{a_2T}{2} + \\frac{a_3T^2}{3} + \\frac{a_4T^3}{4} + \\frac{a_5T^4}{5} + \\frac{a_6}{T}$$\n",
@@ -256,14 +580,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "dc3e237d",
+   "execution_count": 7,
+   "id": "e7a462d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:07.634113Z",
-     "iopub.status.busy": "2026-08-08T08:00:07.634024Z",
-     "iopub.status.idle": "2026-08-08T08:00:07.637254Z",
-     "shell.execute_reply": "2026-08-08T08:00:07.636977Z"
+     "iopub.execute_input": "2026-08-10T07:02:20.132948Z",
+     "iopub.status.busy": "2026-08-10T07:02:20.132803Z",
+     "iopub.status.idle": "2026-08-10T07:02:20.137115Z",
+     "shell.execute_reply": "2026-08-10T07:02:20.136796Z"
     }
    },
    "outputs": [
@@ -273,9 +597,9 @@
      "text": [
       "valid 10-3000 K, switching at 770.8 K\n",
       "\n",
-      "Cp(300 K) = 42.93 J/mol/K\n",
-      "H (300 K) = 62.92 kJ/mol\n",
-      "S (300 K) = 219.06 J/mol/K\n"
+      "Cp(300 K) =   42.93 J/mol/K\n",
+      "H (300 K) =   62.92 kJ/mol\n",
+      "S (300 K) =  219.06 J/mol/K\n"
      ]
     }
    ],
@@ -302,34 +626,38 @@
     "    return R * (a[0]*math.log(T) + a[1]*T + a[2]*T**2/2 + a[3]*T**3/3 + a[4]*T**4/4 + a[6])\n",
     "\n",
     "\n",
-    "nasa = next(t[\"thermo\"][\"nasa\"] for t in thermo if t[\"thermo\"].get(\"nasa\"))\n",
-    "print(f\"valid {nasa['t_low']:.0f}-{nasa['t_high']:.0f} K, switching at {nasa['t_mid']:.1f} K\")\n",
-    "print(f\"\\nCp(300 K) = {cp(nasa, 300):.2f} J/mol/K\")\n",
-    "print(f\"H (300 K) = {h(nasa, 300):.2f} kJ/mol\")\n",
-    "print(f\"S (300 K) = {s(nasa, 300):.2f} J/mol/K\")"
+    "def first_nasa(thermo_records):\n",
+    "    return next((t[\"thermo\"][\"nasa\"] for t in thermo_records if t[\"thermo\"].get(\"nasa\")), None)\n",
+    "\n",
+    "\n",
+    "nasa = first_nasa(thermo)\n",
+    "print(f\"valid {nasa['t_low']:.0f}-{nasa['t_high']:.0f} K, switching at {nasa['t_mid']:.1f} K\\n\")\n",
+    "print(f\"Cp(300 K) = {cp(nasa, 300):7.2f} J/mol/K\")\n",
+    "print(f\"H (300 K) = {h(nasa, 300):7.2f} kJ/mol\")\n",
+    "print(f\"S (300 K) = {s(nasa, 300):7.2f} J/mol/K\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a61f6b11",
+   "id": "619421ff",
    "metadata": {},
    "source": [
-    "### Sanity-checking against literature\n",
+    "### Checking against literature\n",
     "\n",
-    "Recomputed values are only worth anything if they agree with known ones. This is the\n",
-    "check to run before trusting anything else in the database."
+    "Recomputed values are only worth something if they agree with known ones. This is the\n",
+    "check to run before trusting anything else in a database."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "41e6bab1",
+   "execution_count": 8,
+   "id": "6740beb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:07.638057Z",
-     "iopub.status.busy": "2026-08-08T08:00:07.637970Z",
-     "iopub.status.idle": "2026-08-08T08:00:08.865604Z",
-     "shell.execute_reply": "2026-08-08T08:00:08.865146Z"
+     "iopub.execute_input": "2026-08-10T07:02:20.138438Z",
+     "iopub.status.busy": "2026-08-10T07:02:20.138293Z",
+     "iopub.status.idle": "2026-08-10T07:03:00.609870Z",
+     "shell.execute_reply": "2026-08-10T07:03:00.609200Z"
     }
    },
    "outputs": [
@@ -337,36 +665,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "species    S298 db  S298 lit      Δ%    Cp300 db  Cp300 lit      Δ%\n",
-      "--------------------------------------------------------------------\n"
+      "  rate limited; waiting 38s before retrying scientific/species/search\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "H2O         188.66     188.8   -0.1%       33.59       33.6   -0.0%\n"
+      "  rate limited; waiting 1s before retrying scientific/species/search\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C2H4        218.80     219.3   -0.2%       42.93       43.6   -1.5%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CH3         194.40     194.2    0.1%       38.93       38.7    0.6%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OH          178.19     183.7   -3.0%       29.10       29.9   -2.7%\n"
+      "species  S298 db  S298 lit  delta  Cp300 db  Cp300 lit  delta\n",
+      "-------------------------------------------------------------\n",
+      "H2O      188.66   188.8     -0.1%  33.59     33.6       -0.0%\n",
+      "C2H4     218.80   219.3     -0.2%  42.93     43.6       -1.5%\n",
+      "CH3      194.40   194.2     +0.1%  38.93     38.7       +0.6%\n",
+      "OH       178.19   183.7     -3.0%  29.10     29.9       -2.7%\n"
      ]
     }
    ],
@@ -378,39 +696,42 @@
     "    \"[OH]\":  {\"name\": \"OH\",   \"S298\": 183.7, \"Cp300\": 29.9},\n",
     "}\n",
     "\n",
-    "print(f\"{'species':8s} {'S298 db':>9s} {'S298 lit':>9s} {'Δ%':>7s}   {'Cp300 db':>9s} {'Cp300 lit':>10s} {'Δ%':>7s}\")\n",
-    "print(\"-\" * 68)\n",
-    "for smi, ref in REFERENCE.items():\n",
-    "    recs = get(\"scientific/species/search\", smiles=smi)[\"records\"]\n",
-    "    if not recs:\n",
-    "        print(f\"{ref['name']:8s} not present in this deployment\")\n",
+    "rows = []\n",
+    "for smiles, ref in REFERENCE.items():\n",
+    "    found = records(\"scientific/species/search\", smiles=smiles)\n",
+    "    if not found:\n",
+    "        rows.append([ref[\"name\"], \"not in this deployment\", \"\", \"\", \"\", \"\", \"\"])\n",
     "        continue\n",
-    "    ts = get(\"scientific/thermo/search\", species_ref=recs[0][\"species_ref\"])[\"records\"]\n",
-    "    n = next((t[\"thermo\"][\"nasa\"] for t in ts if t[\"thermo\"].get(\"nasa\")), None)\n",
+    "    n = first_nasa(records(\"scientific/thermo/search\", species_ref=found[0][\"species_ref\"]))\n",
     "    if n is None:\n",
-    "        print(f\"{ref['name']:8s} no NASA polynomial stored\")\n",
+    "        rows.append([ref[\"name\"], \"no NASA polynomial stored\", \"\", \"\", \"\", \"\", \"\"])\n",
     "        continue\n",
     "    s_db, cp_db = s(n, 298.15), cp(n, 300)\n",
-    "    print(f\"{ref['name']:8s} {s_db:9.2f} {ref['S298']:9.1f} {100*(s_db-ref['S298'])/ref['S298']:6.1f}%   \"\n",
-    "          f\"{cp_db:9.2f} {ref['Cp300']:10.1f} {100*(cp_db-ref['Cp300'])/ref['Cp300']:6.1f}%\")"
+    "    rows.append([\n",
+    "        ref[\"name\"],\n",
+    "        f\"{s_db:.2f}\", f\"{ref['S298']:.1f}\", f\"{100*(s_db-ref['S298'])/ref['S298']:+.1f}%\",\n",
+    "        f\"{cp_db:.2f}\", f\"{ref['Cp300']:.1f}\", f\"{100*(cp_db-ref['Cp300'])/ref['Cp300']:+.1f}%\",\n",
+    "    ])\n",
+    "\n",
+    "table(rows, [\"species\", \"S298 db\", \"S298 lit\", \"delta\", \"Cp300 db\", \"Cp300 lit\", \"delta\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "f58b2ef4",
+   "execution_count": 9,
+   "id": "7978f3bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:08.866786Z",
-     "iopub.status.busy": "2026-08-08T08:00:08.866674Z",
-     "iopub.status.idle": "2026-08-08T08:00:09.307516Z",
-     "shell.execute_reply": "2026-08-08T08:00:09.307180Z"
+     "iopub.execute_input": "2026-08-10T07:03:00.611599Z",
+     "iopub.status.busy": "2026-08-10T07:03:00.611385Z",
+     "iopub.status.idle": "2026-08-10T07:03:01.588745Z",
+     "shell.execute_reply": "2026-08-10T07:03:01.588265Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWoAAAF7CAYAAABLi7JfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtLxJREFUeJzs3Qd0VNXWB/A/6b2HkJAAobdQDF2khqY0QVCxgA+VTxDlARawPPApCBbwoeJTeYAgggqIiFSliAjSIfQSSiAhvffyrX3CDJmQQEgmmfb/rTVrZu7cmbl37mROzr7n7F2jsLCwEERERERERERERERkMFaGe2siIiIiIiIiIiIiEgzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERGR0Tt27BieeeYZBAcHw8HBAS4uLrjvvvswd+5cJCQk6OU9srOz8emnn6Jr167w9PSEnZ0dateujZEjR2Lnzp3Qt3/84x/o37//XdfbsWMHatSooa6rQo8ePdCyZUtUB9mPGTNm3HGdS5cuqfWWLFmiXSa3ZZk8Zspk32U/atasidTU1Nser1evHgYOHFjqc+Pi4mBvb6+ef+DAgVLXKSwsxMqVK/HAAw+o95C/lcDAQPTr1w9ff/11mdslf0vyuh9++GG59+X69etqf44cOQJDkM9qzJgxFfr7eeqppzB06NAq3kIiIiKie8dALRERERm1r776CqGhodi/fz9eeeUVbNq0CWvXrsWIESPwxRdfYOzYsZV+DwmC3X///Zg8ebIKWkpg8LfffsNHH30Ea2tr9O7dG0ePHoW+HD58GEuXLsW7776rt9c0Zw899BD++usv+Pv7wxzExsaqkwz3YtmyZcjJyVG3Fy1aVOo606ZNw+OPP45mzZqpwOzGjRvVd8zPzw/r1q0r9TkSaJXv451et6xA7cyZMw0WqJXfgLfeeqtCz5UA84YNG/D777/rfbuIiIiIKsOmUs8mIiIiqkISnHvhhRfQp08f/PTTT2pEoYYsmzJligrcVtbTTz+tArGbN29Gr169dB577LHHVABXRtnqy/vvv48OHTqgXbt2entNc+br66su5kJGUs+bNw8TJkxArVq1yvWc//3vf2qUbN26dfHdd9/h448/hqOjo/bxzMxMzJ8/X32Xv/zyS53nysjTgoKCUl9XM9JWguESvNyzZw+6dOkCY9e2bdsKP7dBgwbqGMjfYcm/dyIiIiJD4ohaIiIiMlqzZs1S05Yl8FQ8SKsh6QkGDx5cqfc4ePCgGnkoI3PLCtq0b98ederUgT7cuHFDjQaU6dclnT59WgWQnJyc4OPjg//7v/8rdYr81q1bMWTIEDWtXaa3N2zYEOPGjVMjg0uO3Hz++ecRFBSkPj8JdsrI4W3btt32mjJiWabMy3vXr19fBbFKBvdSUlIwdepUlYJCkxpi0qRJSE9Pv2295557Dt7e3ipNhezT2bNnK/yZlZb6QJOyQZ/bXV1klGteXt5d00Bo7Nu3D+Hh4eo7I59rcnIyVq9erbOO7Iuk7yhr1LGV1e3/9mdlZWHFihVqxLoEjjUB4buRNALyNyEkJYkcm/KktSj+fFlf3vu1115T2yzfk0GDBqm/D/nOy/dW/gbkIu+RlpZ219QH5f37EfJZyt/BhQsXyrXNRERERNWBgVoiIiIySvn5+WpqsgSRJNBYHhKgkwDY3S7y2hpbtmxR19WVs1LeLzc3Fz179tRZLgGq7t27q4Dc559/rqa6S3DqxRdfvO01JLjUuXNnLFy4UL3e22+/rYJ5kl9XXrt4MEpGIsvjsp6MngwLC0N8fLzO60VHR+OJJ57Ak08+iZ9//hkDBgxQ0+iXL1+uXScjI0Ntn6RseOmll1RwW4JsEkSVYLnkRxVyLZ+lbL+MeJagdKdOndRr6ps+t1uf36m7kVGx48ePV6kGyhPA1qQkkLzGMsJbApEl0xRIYFIC9vLdkdG2ErS8276tWbMGiYmJ6nUbNWqkvj+rVq26LShaWk7bxYsXq9tvvvmmGvkul2effRb3Yvr06YiJiVHHQtKMSABXUjcMHz4c7u7uauTwq6++qr5Lsu6d3MvfjybQL5/Pr7/+ek/bTERERFSlComIiIiMUHR0tESZCh977LFyP2f06NHqOXe7dO/eXfuc//u//1PLTp8+XVgdXnjhhUJHR8fCgoICneWvvfZaYY0aNQqPHDmis7xPnz5q+7Zv317q68nr5ObmFl6+fFmtt27dOu1jLi4uhZMmTbrj9shnIc/bt2+fzvLmzZsX9uvXT3t/9uzZhVZWVoX79+/XWe/HH39Uz//111/V/Y0bN6r7n3zyic567733nlr+r3/9647bExERodZbvHixdpnclmXyWFVtd1lke8vznapbt+4dX6f4a8XGxhbGxcUVuru7Fw4fPlz7uLzGQw89pPOc9PT0Qjc3t8JOnTrpfM/lu3L+/Hmddf/+++/COnXqaLfJ1dW1cODAgYXffPPNbd830atXr0IHB4fCxMREnc950aJFd90X+TxLHqfyku+yPHfQoEE6y+W7KstfeuklneVDhw4t9PLy0lkmn5V8DpX5+6ldu3bho48+es/bT0RERFRVOKKWiIiIzIZMvZap8He7/Pe//zXYNkoRJklBIFO/i9u+fTtatGiB1q1b6ywfNWrUba8hoxBlWreMNLaxsYGtra0apSlOnTqlXU/y4MpoRZlqv3fvXp3RtsVJnlRZt7hWrVrh8uXL2vu//PKLSjXQpk0bnZGk/fr1U/sioyE1+yFkpOvd9qOy9LndZZEp+OX5Tq1fv/6etl3SQsjIXklhIKOhy/L999+r1A0y6lVDbstoUM2oVg1JR3D+/HmVt1lGoMqoaymKJ3lrS44ejoiIUMdq2LBh8PDwUMukQJ+rq2u50h/ow8CBA3XuSxE0Tb7ckssTEhLuONL3Xv5+NCTn77Vr1yq49URERET6x2JiREREZJRkKrdM8ZaAUnlJHlnJ23o3xYOkmtyz8j5NmjRBVZOiT5JXtiRJRyA5VEsqWWxKpuL37dtXBXyl6n1ISAicnZ3VckkxIK+vIdPYJUgrKQ9kXckD+vDDD2Pu3Lk6rytBw5Ikp23x15Kp5RIElKBwaTT5cWU/JHhc8jXLWzTrXuhzu8si2y0BvbspGXgvD8mT++mnn6rp/Tt37ix1HUlxIN8Xyb2alJSkDUZLjlYJws+cORPW1tba9WU/JQgtF83xeOSRR1TAWtI+PPjgg2q5BGMlcCuPaV5XSED322+/VakTmjZtiqrk5eWlc1/yB99pueTUle9wacr791OcfK7FvytEREREhsZALRERERklCT717t1bBZciIyPLFYCVkYaSi/RuJJelZiSlBLRk9KHkcpVgWHUEoA8dOlRq0FFyrpZUcpnk4Dx69KgK0o0ePVq7XIKRpb3X/Pnz1eXKlSsqj+vrr7+uRuTKqMt73W5HR8cyR1vK45r9kBGrEjgrHkgtbd+qQ3m3uyzvvPOOCobejYxoLl7srDxku2QUuIza3bBhw22PS/7a3bt3q9tlFbPbvHmzNvhaGjkGEhCW77t8d2RdCerL90fIiNrSyOclAX1TUd6/n+JklK4EvImIiIiMBQO1REREZLSkMJQU+5FK9+vWrdOOrNOQqfwScJRq8UKCXmUVDypOpncXL4wkRahk5OLIkSPRq1ev29Y/cOCAGlVZVrDsXsgoRSmSlJycrAomaUhxMQmMSRC2+PTtFStWlDpyU0aOFne3dA6y7fLZyFT4P//8s0LT1GfNmqUCYqWNXCy5HzIqU4p3lbUf1aW8210WCaKWnKJfmpLHo7zk5MK8efNUAF0CqMVpCoZ99dVXqlBYcTISdMiQISqgKsFX+VuQFAmljTLWpMMICAjQBnfl5MeECRPUiNqS5HvyzTffqM9NRkffaX+NZURqef9+NORkwtWrV+8Y5CYiIiKqbgzUEhERkdGSHJsLFy7E+PHjERoaihdeeEHloZSg1OHDh/Hll1+q/KOaQK2MjqvICDkJSsloWgnYSuBMrj09PREVFaVyj0pg9eDBg3oJ1GqqzUteUklhoCGjHiXoJvk5JV2Bn5+fdgp6yUBvgwYNVGBPXkemics2bt26VWc9CQRL8EpydMpzJDgtuVQlsF3WKMo7ke2TfKrdunXDP//5TzX9XgKLMlJ3y5YtmDJlCjp27Kj2SdaR6fzp6elo166dCgwvW7YMhlDe7S6LBDc1Ac6qGjkuAVFJSSFk+zSBRPleSn7WZ599ttTnyvdeRknHxsaqAL589yXPbFhYmMpfLDldZSTtJ598ol5Hc9wlACwBWBlJXtq+jRs3TgXZZZSvBINLI99BGREs31F5bUlJUNWf1Z2U9+9H49ixY8jIyFB/I0RERETGgsXEiIiIyKjJaFoZ0SqB2jlz5qhA4NChQ1XwVIKQEqytLJn+LlPMP/zwQzUi76mnnlIjayWwJ8EcCYaVLFJUUffff78KqMkI4ZK5NCVPafPmzVVA+sknn1Q5NCWHaXGSg1QCs40bN1YBtccff1ylMti2bZvOevJcCUBKgFQKe0nwWXLVSgErGaF5ryQP7h9//IExY8aoz1wCYjIC+T//+Y9KS6EJkFtZWanPS95TRjjKsdqzZ48aGW0I5d1uQ5LPqEuXLjrLJEgq0/blGN9ptK+ctJBj7ObmplI0SE5eCcDK38nw4cNVbloJYsr3W3I+S05e+f7IKOGygqry/ZcgrGZEb2nktSQwKiku5L2kkJk+/hYrqrx/PxqS6kT+7oufLCEiIiIytBqFxcu/EhEREVGV++ijj/Dee++pivMSECOi6pOfn69SSciJHvk7JCIiIjIWHFFLREREVM0kN6jkp/3ss8/42RNVs+XLl6u0EK+88go/eyIiIjIqDNQSERERVTOZki3T1StagIrIGMlEPcmte6eLMUzmkxzFkr/Ww8PD0JtCREREpIOpD4iIiIiIqNKkcNndinMtXrxY5QsmIiIiotsxUEtERERERJWWmpqKM2fO3HGd4OBgeHt789MmIiIiKgUDtUREREREREREREQGxhy1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREREREREREREZGAO1RERERERERERERAbGQC0RERERERERERGRgTFQS0RERERERERERGRgDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUElGVycjIQNeuXeHp6Yl69epV+yf93//+F40aNYKNjQ2WLFlS7e9PRERkSe0uERFRVZkxY4Zq26ysrLBjx45q/aAjIiLQoUMHuLq6okePHtX63mR5GKgls3bs2DE888wzCA4OhoODA1xcXHDfffdh7ty5SEhIqLZtqFGjBg4fPnzPDZE8Ly4uDsZCtke2q7zs7OywYMECrFq1qtzPGTNmjDpOJe3fvx8+Pj5o3LgxLl++XK7XCgsLw65du1SnlYiIqo6cDJM24sCBA6U+PnDgwEoHDvPz81GzZk3MmzdPr9tm6e0uERHp1759+/Dwww+jTp06sLe3h5+fHzp37owpU6ZU+rWlL/vyyy/f03MuXbqk2pMPP/wQxkL6fPf6f8Fjjz2GQ4cOqc+1PCSYK/v9448/3nZSc8CAAbC1tcU333xTrteSfujixYsxf/78e9pmoopgoJbM1ldffYXQ0FAV4HvllVewadMmrF27FiNGjMAXX3yBsWPHVst2rF69WgWK27ZtC0sjI1llv6XjWBnbt29H7969ERQUhN27d6Nu3brlel6DBg3g7+9fqfcmIiLjICfeYmNjMWzYMENvitm3u0REVDEbNmxAly5dkJKSogYHbdmyBZ988gnuv//+Sp9Ek1GdMvhn+PDhFnl4mjZtCi8vr0q9RnJyMvr27av6lxLAffrpp8v1PBlJ26JFC1hbW1fq/YnKw6ZcaxGZmL/++gsvvPAC+vTpg59++kmdydSQZXI2UwK31UEaAEttTPVh3bp1ePTRR9G+fXv88ssvcHd3N/QmERGRAUh72q5du3KfrCMiIqpuEpyVQTqbN29WJ8+KjwaVxyrbDsrMEs4WrJiYmBj069cPFy5cwMaNG9GzZ89KHQ+iqsIRtWSWZs2apaY5fPnllzpBWg0ZaTJ48GDtfZl2IdMyZcRtq1atVJqE+vXr4z//+U+ltuP06dM4efJklQZqNVM1JcWCjBaWQKacaZw8eTLy8vJw5swZ9O/fX50FlP0s7R+EK1eu4Mknn1QNv3xezZo1w0cffYSCgoI7vvfEiRNVjp6Sl2effVYv+7Zs2TI88sgj6NWrlzobXTxIe/DgwVLfWy4y6paIiMxHYWGhaqP11Z5GRUWpWTeSx/zcuXP39FxzbneJiKhy4uPj1TT54kFaDcmtWtmZmpJSobKvc7cUCR988AHmzJmj2jBHR0fVzpw9exa5ubl4/fXXERAQoNo+2RYJfhYn7Zi0ezL6Vdo3aedk1GpkZORdRyKX1bc7f/58pfdNUudJgFu24/fff78tSCvteWnv/eabb1b6vYnuFUfUktmRHHby4ysdMJkqX15HjhzBpEmTVAesVq1a+Pbbb1X+n5ycHEydOrXCjWnt2rXRsWNHVLWRI0eqTt+4ceOwdetW1UBKY7pt2zaMHz9e7cOKFSvw2muvoWHDhtqpozKNVKbnyH7++9//Vg2yjFyV9eVs4+eff17me0oevKoiQXI5HjKaVnIHSQ6h4uT4VncSeSIiunsbLMHK0gKtlbFnzx4VXNVHoDY8PBwPPvggAgMD1Qwc6VBXhLm1u0REVHmSi/brr7/GSy+9hCeeeELllC3Zj6kICTD+/fffqt2oap999pkavCTXSUlJajbqoEGDVJ9W9uV///ufCnxKuyUnCn/++Wftc2VWqwyWevHFF9VAKAn+vvXWW6rfJvlly2pzH3roIXWpCqdOncI///lPbRolOTla0g8//FAl701UIYVEZiY6Olp6g4WPPfZYuZ9Tt27dwho1ahQeOXJEZ3mfPn0K3dzcCtPT0yu0LW3atCmcOHFihZ77r3/9S+1HbGxsudb76KOPbntvWb5mzRrtstzc3EJfX9/CYcOGaZe9/vrrar19+/bpPP+FF15Qn8mZM2e0y2Q9eb970bx5c/UZWllZFXp7exe+/fbbd1x/9OjR6n3k0rVr18L8/PzCilqyZIl6Txsbm0IXFxd1Oy0trcKvR0REpVu8eLH2t7usi7S1FTVp0qTCkJCQSm3b/v37C7du3arapEceeaQwMzNTZz1LbXeJiEh/4uLiVB9G0/bZ2toWdunSpXD27NmFqampFX7d+fPnF3p6eqp25V5FRESobfnggw/KtV7r1q11+mDy3rJ88ODBt7XNsjw5OVndP3XqlLo/fvx4nfWkvZPl06dP1+nz3ev/Be+8845q16R9k3aucePGd1x/+/bt2uNgbW1dePLkycKKysrKUu8tfUrpW8rtr7/+usKvR3QnTH1AdJMkB2/durXO5zFq1CiVCF7O/t2rixcvqlG61ZWfVs5YFidnCmXqilS01JApODKqR86Aasjo4+bNm6NDhw63VeKUPqI8XhknTpxQSdtllJVU0p45c+ZdnyNTbCSX8J9//qkKv1XU6NGj1XvKCKfU1FR129nZucKvR0REdyYzIKSIZ8lLZfPprVmzptLt6dKlS9VIWhn98/3336s0R5VhTu0uERHph7e3N/744w/V9r3//vsYMmSIShswbdo0hISEqN/lis7UlNcqLaWCvklbWTy9gmYEaskRr5rlks5HSIEuTXtWnLR3su5vv/1Wqe2Skbny+Un7Ju2cpBoqb3stKRkmTJiAjIyMCr23pHGQ95Y+pfQt5XZ1FScny8NALZkdmU7h5OSkqmLeC0l3UNYyyTVk7MneS1bAlDy88jmU7IjK8qysLO192Td/f//bXk9yD2ker27yj4FMoZFgrTSoMu2GiIiMn3TEpOBXyUtlCkHKVE/pBFY2ULty5Up1IlACtRJQrSxzaneJiEi/pO2T1Dcypf769etq6r2kAahIQbHo6Gg1gKW6BgCV1r7dabmmjdO0X2W1cYZq32TwzldffaXSL0iwOT093SDbQVReDNSS2bG2tkbv3r1Vsam7JS0v2QCWtUzOjFbkrOfQoUPV9hgz2TfJ+1eS/EMhKpq7r7Kko7tu3TpVkEVyHDEvHxGRZZL2tHHjxmjZsmWlXkdyz0txk+7du6sZL4ZirO0uERFVDcnr+q9//UubJ/1eSTFNmRUog1iMmabPXFYbZ8j2TUa/Llq0SOWolRHDDNaSMWOglsySTC2R6YPPPfecKtZRkkxXWL9+/W1TBY8ePaqzTIqASNVmSQJ/L65evaqmu1TXWc/KkKD2yZMnb0vvINNXZcRRyYqY1R2s/emnn9Q0UknI/8knnxhsW4iIyHCBWn20pzISSAp9yahfadv27t0LQzDmdpeIiCqntCClpqBV8dkT99oOyvR9mX5vzHr16qWuly9frrNc+sWy/9L+GdIzzzyjgrW7d+9W/cu0tDSDbg9RWao+wQmRgaptLly4UFVdDg0NVdUnJQetBGgPHz6sKlHKyBypXqkhjebgwYMxY8YMNV1DGhip4jxnzhw1lfFeG1MPDw+9dLb0MT3zTmQajnQOZRrIO++8g7p162LDhg2q6rR8bjKKyZDkHxI5iyyd9EmTJqn8QpqqnUREZN5k5OuFCxf0duJTTr5u2rQJw4YNUyOTJM1Oybba0ttdIiKquH79+iEwMFD1M2UWh/RdpC376KOP4OLigpdffvmeXk/SBezcuVOl76msqm7fmjRpgueff17NhJRUdhIMlXQPkls2KCjIKPpwkj9Xtk2CtrJ9GzduVMeFyJgwUEtmS0bTSuLyefPmqWCrpDGQaSfSAZIiYTKdvrg2bdqoH2yZlnLu3DkVuP34448r1KBIoFaCvvJ+FaVJdF7VZ059fX2xZ88eNQpZLlI8rX79+ip/0uTJk2EM5DOQQjKPPPKI2ib5h2fKlCmG3iwiIqpi0p5KIFNOuuqL5KmV1Dryv4BMf5T3kGu2u0REVFlvvvmmamOkDyqja7Ozs9UgoLCwMNXX0hTgKi+ZXSi5YIsXqrxX1dW+CRks1aBBAzVyVeqMSI56SWU3e/bsCqUTrApPP/20CtZK0FYC63ICV07kEhmLGoUyP5zIwtWrV0+NsP3ll18q/VoSEK5du7ZqVIuP2L1XUtXzr7/+QkxMTKW3iYiIyBQ1b95cdU5lJFJVY7tLRETGRk4kyglGOalYUTI7UWaSyOwNeT0iMm4cUUukZ7Vq1UJ+fn6Fny85c2SE66+//nrbqF8iIiJLIrlcqxrbXSIiMlbSJ6woSR0kaRemT5+u+qiaHLJEZNwYqCUyMt26dVPpCCS/z6xZswy9OURERGaN7S4REZmjf//73/j+++/RsWNHrFq1ShVqJiLjx9QHRERERERERERERAZmZegNICIiIiIiIiIiIrJ0DNQSERERERERERERGRgDtUREREREREREREQGZpLFxAoKCnD9+nW4urqiRo0aht4cIiIyA4WFhUhNTUVAQACsrMzrPCbbTSIi0je2m0RERFXQbhaaoKtXrxbKpvPCz4DfAX4H+B3gd0Df3wFpY/Tl888/LwwJCSl0dXVVl06dOhX++uuv2sdHjx592/t37NhR5zWysrIKX3zxxUJvb+9CJyenwkGDBt3zNrLd5N8Jfyv5HeB3gN8BU2g3jQXbTf698DeT3wF+B/gdgIHaTZMcUSsjacXVq1fh5uZWqRFGsbGx8PX1NbvRU8a+z4mJidixYwd69OgBT09Pi9nv6sb95vG2BPr6nqekpCAoKEjbxuhDYGAg3n//fTRs2FDdX7p0KYYMGYLDhw+jRYsWaln//v2xePFi7XPs7Ox0XmPSpElYv349Vq5cCW9vb0yZMgUDBw7EwYMHYW1tXW3tJn9P2G5aAn7P2W5aAmNuN40F203T/h2t7r6msey3IVjiflviPgvut2+lj3d5202TDNRq0h1IZ7OygdqsrCz1GpbyB2Ys+5yTk4Ps7Gw4OztX6hia2n5XN+43j7cl0Pf3XJ8pdQYNGqRz/7333sPChQuxd+9ebaDW3t4etWrVKvX5ycnJWLRoEZYtW4awsDC1bPny5aqB37ZtG/r161dt7SZ/T9huWgJ+z9luWgJjbjeNBdtN0/4dre6+prHstyFY4n5b4j4L7reb3o733dpNkwzUEhERmZr8/Hz88MMPSE9PR+fOnbXLZcRHzZo14eHhge7du6tgrtwXMmo2NzcXffv21a4vOY1atmyJPXv2lBmolc6JXIqfvdX8gyWXipDnSV6lij7fVBnLfmvevzLH0BT3u7pxv3m8LYG+vueW9vtARERUHRioJSIiqkLHjx9XgVk58+7i4oK1a9eiefPm6rEBAwZgxIgRqFu3LiIiIvDWW2+hV69eKkArI22jo6NVKoSS0/b8/PzUY2WZPXs2Zs6cedtymaYl21HRDrmM8JXOvaWNHjCG/U5KSlLXCQkJ1RaoNYb9rm7cbx5vS6Cv77kURCEiIiL9YqCWiIioCjVp0gRHjhxRgbbVq1dj9OjR2LlzpwrWPvroo9r1ZJRsu3btVNB2w4YNGDZsWJmvKZ3rO02ZmTZtGiZPnnxbPiTJpVWZ1AfynpaYj8sY9lvz3l5eXvDx8bGY/a5u3G8eb0ugr++5g4ODXreLiIiIGKglA5HkyTKV1xyLDxARFScjYjXFxCQQu3//fnzyySf473//e9sH5e/vrwK1586dU/cld63kWZOiGMVH1cbExKBLly5lftAyGlcuJUmHvDKdcunYV/Y1TJEx7Le7u7tqN+W6urbDGPbbELjfPN6WQB/fc0v7bSDTwb4mEZkytq5kEBJAqFevXqmBBCIicyajYYvnjy0uPj4eV69eVQFbERoaCltbW2zdulW7TlRUFMLDw+8YqCXzw3aTiIiIbSYRmT8GaskgMjIycPjwYXVNRHSv8gsKkZiegyvxGTh5PQWHIlORnJlrdB/k9OnT8ccff+DSpUsqV+0bb7yhioc98cQTSEtLw9SpU/HXX3+px2X5oEGD1LT2hx9+WD1fRk+OHTsWU6ZMwW+//aZ+N5988kmEhIQgLCzM0LtH1YjtJhHpq/38fMcFXEsu/YQhkTlgm0lE+pKQnoNdF5JwPiYN1YU5aslgjadM/5WciU5OTjwKRBbeaYxPz0Zsajbi0nIQn5aNxIxcJGfkICkzF0kZuUjMyFGBWLmdlJGDlKy8215n6TPu6N6kJozJjRs38NRTT6lRsBJ0bdWqFTZt2oQ+ffogMzNTBW+/+eYblb9WRtH27NkTq1at0kkLM2/ePNjY2GDkyJHqOb1798aSJUtgbW1t0H2j6sV2k4gqKyY1C/9cdQR/no9Hcz8nrJlQGw52HLdD5odtJhFVdObjpfgMHLiUgAOXEnHgcgIuxKarxyb0AF7pX7FaH/eKgVoiIqoSWbn5iErOQlRyJm6kZGkDsUXXmsBsNuLTc1BYWPn3S80yvhG1ixYtKvMxR0dHbN68uVzFWhYsWKAuREREFbH7XBwmrTqi2l1xOiYD+yISjO4EJxERUXXJySvAievJOHg5EfsvJahr6a+W5sDlxGrbLgZqiYjonmXm5CM6JQtRSZkqGCu3rydlIjo5C9flfnKmGhWrT1Y1AHdHW3g42alrubg62MDV3gZWBTmo5+3MI0lERFRMXn4BPvntHD7dfl57UtTPzR7/6lsXDzTy4WdFREQWIzkzF4euJOLgpaLA7NHIJGTlFpS5vq11DbQIcENzXwf0ahlYbdvJQC0REZV6dvFaUiauJmTgamIGriZkqutIdT9T5eqpLDtrK/i62sPHxQ4+LvY3bxfd93S2UwFZDxWYtYWHo50KylpJtLaEgoICxMTEoGbN6pmKQkREZApkRsvL3x3B35cStMu6N/bFh4+EID8j2aDbRkREVNUiEyWNwa3RsmdupN5xJqf0N0PreqJ9PS913TrQA/Y2NW72NatvBgoDtWQQdnZ2CA4OVtdEZJj8OzGp2bgUl64Cr5qAbOTNgKyMkK1oOgIbqxrwc3NAgIcDark7IsDdQd2v6aYJxBYFZd0cbFCjxu2BVyK6HdtNIroXv5++gSnfH9XObrG2qoGpfZtgXLf68l8AYljPl8wY20wiy+zfRsSl4++IBJXaR65l4NGdBHo6ol1dT7Sr54V29TzRuKbrbQODZFBQdWOglgzCzc1NFdMhoqptrGTk66X4dETEZSAiLg2X1HW6WpaRk3/Prylx1VpuDqjt4Qh/j6IgbC13B/i7O8Jfrj0c4ONsX+rIVyKqOLabRFTeGTEfbD6Nr/6I0C6TtnrBqLYIreul7hcU6CExPJERY5tJZP4KCgpxNia1KDB7sSg4q8nDXhrpnjYPcEO7ukVBWbmWfqwxYqCWDCI/P19VL5diOqxcTlQ56dl5uBCbhgsxaThxJQYxmddxOb4oIJuSlXfPr+flbIcgT0cEejkhyNMJQV6ON6+d1ChZextrHjKiasZ2k4juRmbHvPjdYRy9mqRdFtbMDx+OaKXSCRFZCraZROaZc/1kVIp2xKykM0i6Q00UB1sr3FenKI2BXNrU8YCLvWmEQE1jK8nsJCYmYs2aNRg2bBh8fFjIgKhcfzfpOTgXk4bzNy/nYlJVcFaKd90Lmf4ogdh6Ps6qAFcdCciqiyMCPZ1MpgEjsiRsN4noTjYej8Krq48h9eYJWimAMv3BZhjTpR7TDJHFYZtJZB4zRI5fS8Lei0VpDCTHbFp22YOQpA8rI2U7BHuhY7AXQmp7wM7GCqaIvXEiIiNLVyD5Yc/rBGSLRsvG30MBL0lREODuiGAJxvo4IdjHBcE+TiowK0FZW2vTbLSIiIjolqzcfLy34RSW7b2sXSYnYD8d1RatAj34URERkcm0Z4evJGFfRLxKZXD4aiKycsvODysFp2WkrARlOwZ7o5m/K2zMpI97z4HaXbt24YMPPsDBgwcRFRWFtWvXYujQoeqx3NxcvPnmm/j1119x8eJFuLu7IywsDO+//z4CAgK0r5GdnY2pU6fiu+++U9Pfe/fujc8//xyBgYH63TsiIiOWkpWLM9GpOB2dijPRKTgdlaoqUWpGw5SHFORqWNNFXSQo62WTh9YN/FHPxwUOtkxRQEREZK4uxqZhworDOBWVol32UCt/zB4WAjcHW4NuGxER0Z3k5heoVD1/XYjHXxfj1YjZ7LyyA7NSjFpGy3YK9kKHYG80qulitnVR7jlQm56ejtatW+OZZ57B8OHDdR7LyMjAoUOH8NZbb6l1ZMrBpEmTMHjwYBw4cEC7nixbv349Vq5cCW9vb0yZMgUDBw5UwV/mKyUic5y2cTEurVhQNhWno1LuKWWBNEwNfV3QyK8oKCu35VqW15DhszcrUsbExKCmqlZpHmcTiYiI6HY/Hb6G6WuPawuD2ttY4V+DWuDxDkFMdUBEREYnv6AQ4deSVVB2z4V4HLiUcMfi1rU9HNVoWZXKoL436nk7WUz7ds+B2gEDBqhLaWQE7datW3WWLViwAB06dMCVK1dQp04dJCcnY9GiRVi2bJkabSuWL1+OoKAgbNu2Df369avovhARGVxSRg5OXE9RjZAkO5egrBT6ys0vX4VlqczcuJarOkNYNFLWVQVl3Z04MoaIiMjSZeTk4V/rTuCHg5HaZQ18nfHZE/ehaS03mJPZs2dj+vTpePnllzF//nxtiqiZM2fiyy+/VIOCOnbsiM8++wwtWrTQPo+zN4mIDK+goFANUpLA7F8X4lQBsDvNHJXAbJcG3uhU3xsd63up2imWqspz1EpgVqLeHh5FOZJk1KykSOjbt692HUmL0LJlS+zZs4eBWgshI6nHjh3LUX9ksqSjcCMlGyeuJyP8Woq6lgDttaTMcj3f1d4GTWq5qktTufi7obGfK9wdGZAlotux3SQiOfk7YcUhlb9e45HQQLwzpAWc7Myr9Mj+/ftVMLZVq1Y6y+fOnYuPP/4YS5YsQePGjfHuu++iT58+OHPmDFxdXdU6nL1JbDOJDNM/lgFKMlpW0hnsvRiPxIzcMtf3c7NH5/re6NzAG10a+Kg6KlSkSlv0rKwsvP766xg1ahTc3IrO8EZHR8POzg6enp466/r5+anHSiNnReWikZKSop3mK5eKkufKl6kyr2FqjGmfJYAv2yIXS9rv6sT9LtDb2cAriRk4eV0Csrcu5SnuZWNVA/V9ndHE71ZQVq5l5GxpUzf4m2a4v29L+30g0yK/F0wPRWSZpI1btf8q/vXzCW3+Pic7a7w7tCWG3Wd+NT7S0tLwxBNP4KuvvlKB2OKfg4ysfeONNzBs2DC1bOnSpaofuWLFCowbN46zN0lhm0lUPWSQ0u5zsfjzfFGe2djUW3G7kryc7bSBWbnU93G2mFQGRhOolVGzjz32mOr4SqGwu5GGt6yDJNNeZIpLSbGxsSoYXFGybTLiV97bUvI5Gss+yz9gR48eVbmMXVxcLGa/qxv3u2LHOy49Fyej03EiOh0nb6TjVHQG0u6QP0fDydYKjXyd0KSmExr7Oqrrel4OsC1ZfTInFbGxqdA3Hu/K/X2npur/mBDpS1JSEv744w888MAD2llKRGT+UrNyMX1tONYfva5dJid9JdVBA9+q/x/aECZMmICHHnpIpckrHqiNiIhQA3uKz8y0t7dH9+7d1cxMCdRWdPZmVQwM4oAJw50Al36fps2U9IzVgcfbcgY8WPKxlmLYh8Oj8OeFBPx5IR4Rcel3LHotOWY730xn0LhE8a/qGrRnTMe7vK9RJYFaaRxHjhypGtPff/9dO5pW1KpVCzk5OSqnUPFRtVIAp0uXLqW+3rRp0zB58mSdhlNy2vr6+uq8dkU+JAkOy+tYSvDOWPZZ3js+Pl4dPx8fH4vZ7+rG/b778U7LzlP5ZI9GJquqk3IdVY4iX55OtmgR4IbmAW5oGeCurut5ORm08iSPd+X+vh0cHPR6PIj0KS8vD1FRUeqaiCyD/H8iqQ4ux2dolz3ZqQ7efKg5HGytYY6k2LQUp5bUByVpZl/KCNri5P7ly5crPHuzqgYG8QS64QbIyMlNOd43btzQCcBXJR5vyxkQZUnHOje/AOFR6dh/NRX7Lifj1I0MFBSWPWipTW0XhAa5IjTIDY18HGGt7RtnIi6ufCkCzfl4l3dgkE1VBWnPnTuH7du3q/wwxYWGhsLW1lYVHZP1hHQ8wsPDVc6h0siZUrmUJB9SZT8oCd7p43VMiTHss+a9q3M7jGG/DYH7baVTafLsjVQcvJx4MyibhHMxabjbiTxfV3u0DnRHiwB3tKwt127wLyN1gaHxeFf879vSfhuIiMg4SWdw6Z5LmPXraeTkF2hz278/vBUeauUPc3X16lVVOGzLli13PHla8v+vO83MLO86VTEwiCfQDTdARvO+Xl5e1TIoSPB4W86AKHM+1vJbKf3j3efjsPt8PP6OSEBGGTNLJcVfmyAPdG3ojfsb+qBVoPvtM0nNQIEej3d5BwbZVGTK+vnz57X3ZdTskSNH1I+gTCt55JFH1FnQX375Bfn5+dozl/K4nN2UqQdSRGrKlCkqiCvLp06dipCQEDW9hYhIn5WRj0Wm4MDlRHU5fDkRqdl3Ho3mbGeNVoEeaB3kgTZB7uq6lptxBmWJiIjIvCRn5OKVH49iy8kb2mVysnjB4/ehjrd5F1qRtAUyy1IG9mhIf3LXrl349NNPVcEwIf1Lf/9bAWt5jmaUbUVmb1blwCCeQDdsoLa6B+nweJtfkM4SjvWNlCzsPheHP1VwNg4xd8gzG+zlgO5N/PBAY190rO8NF3vzKmRZ1ce7vM+/50/1wIED6Nmzp/a+5szj6NGjMWPGDPz888/qfps2bXSeJ6Nre/TooW7PmzcPNjY2akRtZmYmevfurSp3skgGEVVGdHIWDlxOwIGIBOy9EItzcZlqFG1Z5CxgU39XtNYGZj1UvrdbUzSIiIiIqofM+Hnpu8OqOIvGs12D8Wr/prCzMf1gwN1In/D48eM6y5555hk0bdoUr732GurXr68CsTIzs23btupxCcru3LkTc+bMqfDsTSIiS5Kdl48DlxKx82wsdp6JxZkbqXecWdq1oY8aMdulvhesslNQs2ZNswhQG7N7DtRKsPVOCX/LkwxYhvsuWLBAXcgySQGxbt26VUshMTJP8lsTmZipqkvuvRiPfRcTdDo2pfFxsUe7up5oV88Tbet4qFQG5prjjYjMC9tNIvNVUFCIL/+4iA82n9GeYPZwssWHj7RGWHPdfKzmzNXVVRX9Ks7Z2VnNwtQsnzRpEmbNmoVGjRqpi9x2cnLCqFGj1OOcvUmCbSaRrsvx6drA7J4L8cjMLT2dgaOtNTrW91LB2a6NfNDEz1U7s1RSAMTEFBVapKplGeOUyehIsF7OjhPdi6sJGfcUmJXKkqH1vLTB2TpeTkxhQEQmie0mkXmKT8vG5O+Pqg60Rvt6nvjksbYI8HA06LYZo1dffVXNyBw/frxKb9CxY0eV01aCvBqcvUlsM8nSSQpA6TNLYFbal0vFilIWJzFYSfv3wM3A7H11PC1iBoexY6CWDEKqp166dAn16tVjpXUq0/WkTJUrZ+/FBNXQ3Ckw6yBVJoM80K6uF+6r44FAx1w0rBPAaRlEZBbYbhKZn78uxOPllYe1+QClwzyhR0NMCmsEGzMsyFIRO3bs0LkvI7sk3Z5cysLZm8Q2kyyNpgiYJjArRcA0xShLm2XavbEvujfxVSNnvZztqn176c4YqCWDkKJ0UhhAqnCWt/IdWcaZPxkpu+tcLP44F4fzMWllrmtvY6VGyXYK9kanBt4qz6zm7F/RtIyYatxyIqKqxXaTyHxIeoMFv5/Df347B00qfR8XO8x7tA0eaORr6M0jMnlsM8kSpGTl4s9zcUUpDc7GIio5q8y6LKF1PVVgVgK0zWq5wYo1WYwaA7VEZNCcbCeup9wMzMaqIhq5+YVlBmalgelcvygw2yrQHfY2zC9LREREplVde9LKIyqVk8b9Db1VkLamKwcvEBFR2aNmL8Sm4/fTN/D76Rjsv5RYZuHs2h6O2sBslwbecHWw5cdqQhioJaJqlZCeg51nY/D76ViV1kDul0ZO8rWt46mtMtk6iIFZIiIiMl0y4mnyqiOIv/m/j/yvM7lPY7zQoyGsObqJiIhKyM7LV2kMfjsVg+1nYnC5jFyzMrO0U33vopQGjX3RwNeZtVlMGAO1RFTlZ/7O3kjDb3Lm71QMDl1J1E7zKynIyxHdGvmqaX+dG3jD3ZFn/oiIiMi05eYX4KMtZ/HFzgvaZbXcHPDJY23Qsb63QbeNiIiMS0xKlgrKyqjZ3efikJ6TX+p69byd0KNJTfRo4ouOwd5wtONsU3PBQC0Z5otnYwN/f391TeYnKzdfFf+SxkXO/pVVBMzV3kYFZB9o7ItujXxQ19u52reViMgUsN0kMk2RiRl46bvDOHQlSbusV9Oa+HBEaxZwIaoibDPJ1NIBhl9PVv1m6T8fv5ZcZq7Z9vW80LtZTdWO1Pd1qfZtperBKBkZhIeHBwYNGsRP34ykZedh++kYbDoRra4zyjjz17CmC3o3LWpc7qvrCVtWNSYiuiu2m0SmZ1N4FF798RhSsvK0nezX+jfF2K7BLORCVIXYZpIpFNHedTbuZr7ZWMSlZZe6npeznRox27upHx5o7AM35pq1CAzUksGmwxcUFMDKyoq5U0xYUkYOtp68gc0norHrXBxy8gpuW8fWuobKlyOBWblw1CxZkoULF6rLpUuX1P0WLVrg7bffxoABA7S/hTNnzsSXX36JxMREdOzYEZ999plaTyM7OxtTp07Fd999h8zMTPTu3Ruff/45AgMDDbZfVP3YbhKZ1syidzecxPK9V7TLAj0dseDxtir/PhFVLbaZZIxiU7Px26kbqv/8x/nS+86iub+bGjXbs2lNtA70YA5zC8RALRlEfHw81qxZg2HDhsHHx4dHwcQaGAnMbgqPVhWLS6s06elki97N/BDWrCa6NvKFiz1/asgySTD1/fffR8OGDdX9pUuXYsiQITh8+LAKxs6dOxcff/wxlixZgsaNG+Pdd99Fnz59cObMGbi6uqrnTJo0CevXr8fKlSvh7e2NKVOmYODAgTh48CCsrZmLylKw3SQyDedupGLid4dxOjpVu+yhEH/MGhbC3PtE1YRtJhmLC7FpKjArF6nVUlhKrRYHWytVQLtXUz/0bOoLf3dHQ2wqGRFGT4jorlKzcrH5xA2sO3INf56PK7UYWE1Xe/RvWQv9W9RCh2Av2DClAdFtKV7ee+89NcJ27969aN68OebPn4833nhDnbTSBHL9/PywYsUKjBs3DsnJyVi0aBGWLVuGsLAwtc7y5csRFBSEbdu2oV+/fvyUiYiMZATfqv1XMWP9CWTlFo2Ssrexwr8GtcDjHYI4g4yIyELyzR6+mnQzOBuNC7Hppa4nfeew5n7o08xP1WxxsOXgC7qFgVoiKnPa3o4zMVh35Dp+Ox1T6tQMmcY3QIKzLf3RNsiD+daI7iA/Px8//PAD0tPT0blzZ0RERCA6Ohp9+/bVrmNvb4/u3btjz549KlAro2Zzc3N11gkICEDLli3VOmUFaiVdglw0UlJS1LWknJFLRcjzNFMJLYmx7Lfm/StzDE1xv6sb95vHuyJSsnLx5toT+OV4lHZZ45ou+M/jbdDYz1X9LcnF3L7nlvb7QERUVr95z4W4m8HZmDLzzTaq6YK+LfzQp3kttKrtzr4zlYmBWiLSkjQGf12IVyNnJbVBanZR8YuSwdnBrQPwYIg/WgS4cYQI0V0cP35cBWazsrLg4uKCtWvXqtG0EmgVMoK2OLl/+fJldVsCuXZ2dvD09LxtHXmsLLNnz1a5b0uKjY1V21HRDrmM8JXOveQXtxTGst9JSUUV4xMSEqotUGsM+13duN883vcqPCodb2+8iOspOdplD4f44OXuQXCokYmYmEyY6/c8NfVWegciIkuSmpWHPYevYeupGOw8G1tqIW2rGkBoXU/0bV4LfZr7oZ6Ps0G2lUwPA7VEhMvx6fjhQCRWH4pEVPLtQRxvZzsMbOWPwW1q4746HgzOEt2DJk2a4MiRIyrQtnr1aowePRo7d+7UPl6jRg2d9aXjXHJZSXdbZ9q0aZg8ebLOiFpJl+Dr6ws3N7cKd+zlPeU1LC1wZwz7rXlvLy+vasntbiz7Xd243zze5f+uFOKr3RH4aMtZ5N3MCeXqYIPZD7dUJ7Mt4Xvu4OCg1+0iIjJmCek52HIiGhvDo/Dn+Xjtb3/JfLMPNPJVgdneTWvC28XeINtKpo2BWjIIGR02atQoODoyUbahZOTk4dfj0fjhwFXsi0i47XEpANavRS0MaROALg28mXOWqIJkRKymmFi7du2wf/9+fPLJJ3jttdfUMhkZ6+9/q1MfExOjHWVbq1Yt5OTkIDExUWdUrazTpUuXMt9TUijIpSTpkFemUy4d+8q+hikyhv2WQnKadrO6tsMY9tsQuN883uUprDr5+yP441ycdpmcyP7ksbYI8nKCpXzPLe23gUwH+5qkLzEpWaqQ9sbwaOy9GF9qrRYvZzv0aloTfZv7qSCtox3zzVLlMFBLBiGVymUKMFUvGYUnyc1X/X0Vvxy7jvQSUzRkekbPJjUx7L5A9G5Wk0nNiaro71DyxwYHB6tA7NatW9G2bVv1mARlZbTtnDlz1P3Q0FDY2tqqdUaOHKmWRUVFITw8HHPnzuXxsSBsN4mMwx/nYvHPVUe1OQhlcsP4Hg0wKawxbFlIlcgosM2kyriWlKnSAG48HoWDVxJRWopxP1dbPNiqtiqk3a6eF6ylI02kJwzUkkHINNx9+/ahY8eOFZ6GS+WXnp2H9ceisXzvZZyMKioqVFx9X2eMbBeEYW1ro6Ybp7ER6cv06dMxYMAAlXZAcvmtXLkSO3bswKZNm9RopkmTJmHWrFlo1KiRushtJycnNXJSuLu7Y+zYsZgyZYoaUSnT3qdOnYqQkBCEhYXxQFkQtptEhpWbX6DSHHyx84J2ma+rPeY/2gb3N6z6dCREVH5sM+leXYpLV6NmN4VH4Whkcqnr1PV2Qn8ppN3cD7XsstUMOM4soKrAQC0ZhIwak4rnmlFkVDXO3UjFVzuuYNPpo0grURhMUhtI3tkR7YKYd5aoity4cQNPPfWUGgUrQddWrVqpIG2fPn3U46+++ioyMzMxfvx4ld5ATl5t2bIFrq6u2teYN28ebGxs1IhaWbd3795YsmSJGi1CloPtJpHhXE3IwMTvDuPI1aKifqJ7Y198NLI1fJh/kMjosM2k8rgYm4YNx6Lwa3g0TpUymEk0rOmCAS1rYUBLfzTzd1UDLSTPt6QhI6oqDNQSmeGID5mqIaNnS8s92zrIA092rIOHWvnDyY4/AURVadGiRXd8XP7ZmzFjhrrcqVjLggUL1IWIiKqXpIqatvo4Um+e8LaxqoHX+jfF2K7BsOJUVyIikzvx9suxKPXbfuJ66cHZZv5ueFCCsyG10LDmrcETRNWFURoiM5GcmYuVf1/Bkj2XEJWcdVv1ySGta+PJTnUREuhusG0kIiIiMgWZOfl455cT+O7vq9pldbycsODxtuqkNxERmYbo5CxsOB6F9Uev68yMKK51oDsGhPirnLP1fJyrfRuJimOglsjEXYnPwP/+jMD3B64io0RxsPo+zhjSwhOjuzWFh/PtFeCJiIiISNeZ6FS8uOIQzsWkaZcNbh2A9x5uCVcHW35cRERGTgo+SjGw9ceisP9SQqkFwVoFumNQqwA1cjbQ08kQm0lUKgZqySCkWE779u3VNVXMwcsJ+PqPCGw+EY2CEg1PWLOa+Mf9wegY7InY2Fi4ObJTQURkythuElW9wsJCfLvvCv79y0lk5xWoZY621pg5pAVGhAaqdDVEZPzYZlqmpIwc1TdefzQKey7E3dZHFk1ruWJQ6wBVq6WuN0fOknFioJYM1niykFjFOhA7zsTi0+3ncfBy4m3pDR4JDVQB2vq+LmqZJDonIiLTx3aTqGolZ+Ti9TXHVNXv4h36T0fdp4rJEJHpYJtpOdKz87DlZFFw9o9zscjNvz06W9/XWY2cHdTanzlnySQwUEsGkZ2draqg+/v7w96eU/LvpqCgUDVAC34/f1vSc19Xe4zpUg+jOtSBp7NdFR41IiIyFLabRFVHTn5PWnUU15IytctGd66LaQ82g4OtNT96IhPDNtO85eUX4I/zcfjp8DVsOXEDmbm66f9EkJejCs4ObBWAZv6unBFBJoWBWjKI1NRUbNmyBcOGDWOg9i6NkFSl/Gz7eZ08aaJRTReM695AnRm0t2EngojInLHdJNK//IJCLPk7Cl/tjVK3hbujLeY+0gr9WtTiR05kothmmufM0qORySo4K0XB4tNzblvH390BD4X4q9QGkn+W6WrIVDFQS2SEcvMLsOZQJD7fcQGX4zN0Hgup7Y4JPRuib3M/WFkxVxoRERHRvYpJycKkVUew50K8dln7ep745LG2CPBw5AdqAAsXLlSXS5cuqfstWrTA22+/jQEDBqj7Y8aMwdKlS3We07FjR+zdu1dnJOXUqVPx3XffITMzE71798bnn3+OwMDAat4bItKHy/Hp+Onwdfx05Boi4tJve1xOrkm+2SFtaqNdXU/2j8ksMFBLZERkNIecIZy37extAVppeF7s1RDdG/vy7CARERFRBW0/E4Op3x/VjsiSGmETezXCS70awsbaip+rgUgw9f3330fDhg3VfQnKDhkyBIcPH1ZBW9G/f38sXrxY+xw7O920X5MmTcL69euxcuVKeHt7Y8qUKRg4cCAOHjwIa2vOQCMyBfFp2dhwPAprD1/D4StJtz1uZ2OlimcPbVMbPZrUVPeJzAkDtURGMpVj84kb+HjrGZy9oZvioGtDHxWg7RjsxQAtERERUQVl5+VjzsYz+N+fEdplvs62+OTxtujS0Jefq4ENGjRI5/57772nRtjKiFlNoFZqW9SqVXpaiuTkZCxatAjLli1DWFiYWrZ8+XIEBQVh27Zt6NevXzXsBRFVRFZuPraduoE1h65h19lY5N1MR6MhJ9Q6BXvj4ba10T+kFtwcbPlBk9lioJYMQs5oe3p6WvyZbQnQ/nEuDh9uOYNjkck6n1GXBt6Y0rcxQut68VtKRGTh2G4SVc75mDS89N1hnIy6VZS1V1NfvNo9AI3revPjNTL5+fn44YcfkJ6ejs6dO2uX79ixAzVr1oSHhwe6d++ugrlyX8io2dzcXPTt21e7fkBAAFq2bIk9e/bcMVArKRPkopGSUvQ9KSgoUJeKkOfJ//oVfb6pMob9ltyk8h2R6+raDmPYb0OozH7L845dS8bqg9ew/lgUkjNzb1unaS1XDGkTgEGt/HXS0hjyc+ax5ne8osr7vWWglgxCgrQjRoyw6E//xPVkzPr1FP48fys3mmhbxwOv9G2CLg19DLZtRERkXNhuElWMBAJW7b+KmetPaiuDyzTZ6QOa4qlOdRAbG8uP1ogcP35cBWazsrLg4uKCtWvXonnz5uoxyVUr/Ye6desiIiICb731Fnr16qUCtDLSNjo6WqVCkN/L4vz8/NRjdzJ79mzMnDnztuXy/ZBtqWiHXEb5ynfQyspypmYby35369ZNBe5jYmIsar+rW0X2Oz49FxtPxWPDyXhEJNz+9+XrYot+TbzQr6kXGvk6FS3MSUVMTCqMAY81v+OVKXRYHgzUElWz6OQsNYJ29aFIFBbqni18pV8T9GpakykOiIiIiCopOSMX09Yew6/HbwXpGtZ0wYLH26KZv5vFjXwzBU2aNMGRI0eQlJSE1atXY/To0di5c6cK1j766KPa9WSUbLt27VTQdsOGDRg2bFiZrykBpLtVf582bRomT56sM6JWUib4+vrCzc2tQvsi3y95X3kNSwvccb95vEtLPfPbqRisltQG5+JUbZbiHGyt0L9FLQy/rzY61/c26qJg/I7zN62iHBwcyrUeA7VkEHFxcSrRv+Si8vGxjJGj6dl5+O/OC/jyj4vIyr3VMQjycsQr/ZpiYIi/UTdIRERkOJbYbhJVxt8RCZi08jCuJ98arfVExzp486HmcLRjUSljJSNiNcXEJBC7f/9+fPLJJ/jvf/9727r+/v4qUHvu3Dl1X3LX5uTkIDExUWdUrYyo7NKlyx3fV0bkyqUkCbBWJsgqAcvKvoYpMvR+G6rNNPR+G0pZ+y0nScKvpeDHg1ex7uh1JGXcntqgfT1PPBIaiAdD/OFqQnlneaz5Ha+I8v42MFBLBiNTUSxBQUEhfjwUibmbziAu7VbuKzcHG1Vh+OkudWFvww4DERHdmaW0m0SVkZdfgP/8fh6f/n4OmgFb7o62mDO8Ffq3LL0IFRkvCfQUzx1bXHx8PK5evaoCtiI0NBS2trbYunUrRo4cqZZFRUUhPDwcc+fOrdbtJsNjm2k48WnZWHv4Gn48GInT0bdP9fZ3d8Dw+wIxPDQQwT7OBtlGImPGQC1RFToemYy3fw7H4StJt/7orGrgqc518VKvRvB0tuPnT0RERKQHVxMyMGnVERy8nKhd1jHYC/MfawN/91tFaMg4TZ8+XeWhlZQDksdv5cqVqnjYpk2bkJaWhhkzZmD48OEqMHvp0iW1voyWfPjhh9Xz3d3dMXbsWEyZMgXe3t7w8vLC1KlTERISgrCwMEPvHpHZD07acyEO3+2/gi0nopGbr5vawN7GSp0sGxEahM4NvGHNmaREZWKglqgKJGXk4IPNZ7Di7ys6eWj7tfDD6wOa8cwhERERkR6tP3od09ceR2pWnrovQYB/hjXCCz0aMiBgIm7cuIGnnnpKjYKVoGurVq1UkLZPnz7IzMxUhca++eYblb9WgrU9e/bEqlWr4Orqqn2NefPmwcbGRo2olef07t0bS5YsgbU1Z68RVcnfbUoWlv4dhQ2nTuJqYuZtj4fWLUpt8FArf7iZUGoDIpMK1O7atQsffPCBqq4pjahU4hw6dKjO9BSpmPnll1+q/EAdO3bEZ599hhYtWmjXkekrcnbzu+++0zagn3/+OQIDA/W3Z0QGIEnRpbLwB5tPI7FYDp4Gvs6YMbgFHmjky+NCREREpMcaADN+PoEfDkZqlwV6OuKTx9qqAAGZjkWLFpX5mKOjIzZv3lyuQi0LFixQFyKquj7vjjMx+O7vq9h+Jua2wmDeznYqODuyfRAa+LrwMBBVdaA2PT0drVu3xjPPPKOmnpQk+X8+/vhjdeaycePGePfdd9VZ0DNnzmjPdk6aNEkl95bpLDItRaanDBw4UAV/ebbTMnh4eKjqrHJtLk5Hp+D11cdx5OqtNAdOdtZ4uXcjPHN/MOxsLCvhNhER6Y85tptElRV+LRkvfXcYF+PStcsGtw7Auw+35MgtIgvGNrNqRCZm4Pv9V/H9gUhEp9wq1Chq1AC6NvTB4x3qIKyZH/u+RNUZqJW8QXIpjYymnT9/Pt544w3VmRBLly6Fn58fVqxYgXHjxiE5OVmdLV22bJk2V9Dy5ctVLqJt27ahX79+ldkfMhEyJclcqlZn5eZjwe/n8N+dF5FX7GyidBSmP9gMtdwdDLp9RERk+syp3STSRy7ERbsjMHfzaW0eRGc7a7wzpCWG3VdbVeMmIsvFNlO/BRp/Ox2Db/ddwR/nYnXS+gk/N3s82NQTz3RvgjreHD1LZHQ5aiMiIhAdHY2+fftql9nb26N79+7Ys2ePCtTKqFmpwFh8nYCAALRs2VKtU1qgVlIlFK/2mZKSoq4LCgrUpaLkuRJcrsxrmBpj2WcpCHD06FE1OtvFxcVk93vfxXhMWxuOS/EZOmkO/j2kBTrV99a+t6Uf7+rG/ebxruj3hshYSbt55MgRtGnTplraTSJjFZOahSnfH8Uf5+K0y1oFuuM/j7VFPVYPJyK2mfr5rU3Jwsr9V/Hd31cQlaw7elbqgPVqWhOPta+Dbo28kRAfh5qeTvzuERljoFaCtEJG0BYn9y9fvqxdx87ODp6enreto3l+SbNnz1Z5b0uKjY1FVpbuj8a9dsplhK8EsqysLGNaurHssxQBOHXqFHx9fatlGqe+9zslKw+f7r6Gn8NvdRJsrGpgdPta6mJnk4+YmBgYmrEc7+rG/ebxrgipME1krOT/nZMnT6Jp06YM1JLF2n46BlN/OIr49BztsnHd62NKnyacZktEWmwzK0b6jPsiErBs72VsDo/WmS0qans44rH2QRjRLkg7a5QDHYiMPFCrUXK6kfzB320K0p3WmTZtGiZPnqwzolZSJUiQz83NrcLbKT8q8p7yOpYSxDKWfda8t5eXV7VM5dTnfkvC9GlrTiMm9dYo7/vqeGDWwy3R2O9W1VljYCzHu7pxv3m8K0IKkBARkfHJzsvH+xtPY/Gfl7TLarra4+ORbdC1EVOCEBFVRkpWLtYeuobley/jXExaqaNnn+hUF90bSR+DqWWITCpQW6tWLXUtI2P9/f21y2VkoWaUrayTk5ODxMREnVG1sk6XLl1KfV1JnyCXkiTwVNngkwSx9PE6psQY9lnz3tW5HZXd77TsPLy34aSqbqkh+dBeG9AUT3asa7SNljEcb0PgfvN43ytL+xshIjIF52NSMfG7IzgVVZT6TPRuWhNzH2kFb5fb+wdERFQ+J6+nYPm+y/jp8DVk5OTrPObtbIfHOgSp4mCBTGtAZLqB2uDgYBWI3bp1K9q2bauWSVB2586dmDNnjrofGhoKW1tbtc7IkSPVsqioKISHh2Pu3Ln63Bwivdl7MV5NtYtMzNQu697YF7OHhSDAw5GfNBEREZEeyWw7yY84c/0JZOUW5RC3s7HCGw82w9Od67JgGBFRBeTkFWBjeBSW/XUZBy4n3vZ4+3qeeLJTXfRvWQv2Ntb8jIlMIVArxSzOnz+vU0BMilvIFPY6depg0qRJmDVrFho1aqQuctvJyQmjRo1S67u7u2Ps2LGYMmUKvL291fOmTp2KkJAQhIWF6XfvyGjJFGM55sY+1TgrNx8fbD6D//0Zoa1w6WRnjTcfao7HOwSxk0BERNXCVNpNIn1IysjBtDXHsTH8Vv2KRjVd8J/H26KZf8XTnhGRZWCbebu4tGys2HdFpTconsJPM0v04ftqqwBt01r8jSUyuUDtgQMH0LNnT+19Te7Y0aNHY8mSJXj11VeRmZmJ8ePHq/QGHTt2xJYtW+Dqeit357x582BjY6NG1Mq6vXv3Vs+1tuYZG0shFas7d+4MY58K8tLKwzhfLE9Ph3pe+HBEa9TxZlVLIiKqPqbQbhLpw76L8Zi06ohOlfEnOtZRJ8kd7dhXIKK7Y5t5y4nrySq/989Hr6vRtMU19nPBU53qYmjb2nB1sOVXi8hUA7U9evRQU5HulBdyxowZ6nKnM1wLFixQF7JMubm5SEhIUCOqJRWGMZHv9zd/XcZ7v57SNmYy1e6Vvk3wj67BsDbSXLREZHxmz56NNWvW4PTp03B0dFS52CUVUJMmTbTrjBkzBkuXLtV5npzk3Lt3r/Z+dna2mn3y3XffaU9wfv755wgMDKzW/SHDMeZ2k0gfcvMLMH/bWXy+44J2FpOHky3mDG+Ffi2K6mAQEZXr98TC28z8gkJsPRmN//15CX9HJOg8Jl3Zvs1rYcz99dAx2IszRImMECunkEEkJydj3bp16trYpto9v+wg/vXzCW2QtkWAGzZM7IrnutVnkJaI7onkaJ8wYYIKukpu9ry8PPTt2xfp6ek66/Xv31/la9dcfv31V53HJa3Q2rVrsXLlSuzevVulIRo4cCDy83ULP5D5MtZ2k0gfLsamYfjCPfhs+60gbaf6Xtj48gMM0hLRPbPUNjM5Ixdf7rqAbnO34/+WH9IJ0ro52OD5bvWx85We+OKpUHSq780gLZElFBMjMmXSkL288rDOVLt/3B+M1wY0YSJ1IqqQTZs26dxfvHgxatasiYMHD6Jbt27a5fb29qoYZ2mkk7Fo0SIsW7ZMm8t9+fLlCAoKwrZt29CvXz8eHSIySTKLaZUqGHYSmblFJ55srGpgSt8mKqDAWUxERHcnqfqW7InA6oPXtL+lGg18nTHm/mAMv682nOwY/iEyBfxLJYsnU0M+/f08PvntLApujuLwdLJVuWh7N/Oz+M+HiPRHM7JDpuIVt2PHDhXA9fDwQPfu3fHee++p+0KCujKFT0biagQEBKBly5bYs2dPqYFaSZUgF42UlBR1XVBQoC4VIc+ToEpFn2+qjGW/Ne9fmWNoivtd3bjf1Xe8E1XBsHBsOXlDuyzYxxnzH22NkNruEsZFgeYfsyrC4125421pvw9ExkTa6L8uxuOrXRex/UzsbY/3aOKLZ+4PxgMNfWDF1H1EJoWBWrJoCek5eOm7w9h9Pk67TKbazX+0LWq5s7I2Een3H2opwNm1a1cVZNUYMGAARowYgbp16yIiIgJvvfUWevXqpQK0MtI2OjoadnZ28PT01Hk9Pz8/9VhZuXFnzpx52/LY2FhkZd2aNXCvHXIJNMt+WFlZTuYkY9nvpKQkdS0596orUGsM+13duN/Vc7z/vpKCf2++hNj0XO2yh0N88FK3QDjaZiMmJgbVgce7csc7NTVVr8eDiO4uL78Av4ZHqwDt8Wu6qR2c7KzxSGggRnephwa+Lvw4iUwUA7VkEFJ0TorKybWhHL2ahPHfHsK1pEx1X040/jOsMcb3bMipdkSkdy+++CKOHTumcswW9+ijj2pvSwC3Xbt2Kmi7YcMGDBs2rMzXkwBaWb+h06ZNU0Hh4iNqJVWCr68v3NzcKhzQkPeT17C0wJ0x7Le1tbVqN729vdXFUva7unG/q/Z4Z+fl46Mt5/D17gjtMpnF9P6wEPRpXv2zmHi8K3e85TeJyBgZQ19T39Ky81SqmP/tjtD2XzVqezjimfvrYUS7ILg7Wl7xNCJzw0AtGYR0Mp9++mmDffor/76Ct9edQE5+0agkHxc7fDrqPpVUnYhI3yZOnIiff/4Zu3btQmBg4B3X9ff3V4Hac+fOqfuSuzYnJweJiYk6o2plxFmXLl1KfQ0ZiSuXkqRDXplOuXR4KvsapsgY9lsCptXdbhrDfhsC97tqjve5G6l4aeURnIoqSsUiHmjko1JN+bkZLuDH413x421pvw1kOgzd19SnGylZWLLnEr7dexkpWXk6j7Ws7YbnuzXAgy1rwcaaf49E5oKBWrIo2bn5mLE+HKsOXNUuu6+OBz5/IpSpDohI72TUqwRp165dq/LQBgcH3/U58fHxuHr1qgrYitDQUNja2mLr1q0YOXKkWhYVFYXw8HDMnTuXR42IjP53cPney3h3wylk5xWdILeztsJrA5rimS71mDuRiKgUZ6JT8dUfF7HuyDXk5uvm6+7ZxBfPdauPzvW9zWrUMBEVYaCWDEJy7G3ZskUVxylZVKeqRKfk4Nkf9iL82q2RHKM718UbDzWHnQ3PQBKR/k2YMAErVqzAunXr4Orqqs0p6+7uDkdHR6SlpWHGjBkYPny4CsxeunQJ06dPh4+PDx5++GHtumPHjsWUKVPUCBH5zZw6dSpCQkIQFhbGw2YhDNFuElVWXFo2Xv3xGH4/fSvnbGM/F3zyWFs0869YGhYiInNuMw9cSsDnOy7o/G5qTnANbRuAZx+oj8Z+rgbbPiKqegzUkkFITjDJmVhd1WIPXUnEcytPITGjaLqIg60VZg8LwcNt7zwFmYioMhYuXKiue/ToobN88eLFGDNmjMo7evz4cXzzzTeqWJQEa3v27IlVq1apwK7GvHnzYGNjo0bUZmZmonfv3liyZIl6PlmG6m43iSpr+5kYvPLDUcSl5WiXjelSD68PaAoHW/52EVHVMbU2U2Ye7DoXh8+2n8ffEQk6j7k52ODJTnXV72dNA6aJIaLqw0Atmb2fDl/Dqz8eRc7NKSN1vJzwxZOhaB7AkRxEVPX/eN+JjKrdvHnzXV9HCmIsWLBAXYiIjFlWbj7e33ha5VTUkFoAHzzSGj2b1jTothERGZP8gkJsPhGtArQnrt+a9akpEDa2azAebR8EZ3uGbYgsCf/iyWwVFBTi461n8en289plnet7YeGTofBwsjPothERERGZGykU9vLKwzh7I027rFfTmpj7SCv4uNxe4JCIyBLl5BXgpyPX8MXOC7gYm67zWANfZ7zQoyGGtAmALQuEEVkkBmrJLGXk5GHyqqPYdKIoH6QY2tIHcx4Nhb0tv/ZERERE+jw5/r8/IzB30xnk5BdNNba3scKbA5vjyY51WOyGiAhAZk4+Vu2/gi93XcT15CydzySktjsm9GyAvs1rscgikYVjxIoMws3NDQMGDFDX+hadnIVnv9mvLRpmVQN486FmGNDAkWcliYjIJFVlu0lUGTdSsjD1h6P441ycdpkUCvvPY23QiAVviMgAjK3NTMvOw9I9l/C/3RGIT7+Vt1t0qu+F8T0a4oFGPjypRUQKS92TQdjZ2SEoKEhd69OZ6FQM/exPbZDW1d4G/xvTXiVfr1Gjhl7fi4iIyNTbTaLKkNyK/efv0gnSPvdAMH6a0IVBWqpQAc5WrVqp4JpcOnfujI0bN+rkfZ8xYwYCAgJUjncp1HnixAmd18jOzsbEiRPh4+MDZ2dnDB48GJGRkTwaFsZY2szUrFyVf7brnN/xweYzOkHa3k1rYvULnbHy+c7o1tiXfVUi0mKglgwiIyMDBw4cUNf6svdiPB75Yg+iU7K0RcPWjO+CHk1YuIKIiExbVbSbRBWVnp2HaWuOY9yyg0jMyFXL/NzssXxsR7zxUHPY21jzw6V7FhgYiPfff1/91smlV69eGDJkiDYYO3fuXHz88cf49NNPsX//ftSqVQt9+vRBamqq9jUmTZqEtWvXYuXKldi9ezfS0tIwcOBA5Ofn84hYEEO3mRKgXfDbOXSds10FaJNu/k7KTM/BrQOw8eUHsGhMe4TW9TLI9hGRcWPqAzIIaTQPHTqEevXqwcnJqdKv9+vxKExaeUSbF611oLsaSevNwhVERGQG9N1uElXUoSuJmLzqCC7F3wqA9Gvhh/eHtYKnM0d8U8UNGjRI5/57772nRtnu3bsXzZs3x/z58/HGG29g2LBh6vGlS5fCz88PK1aswLhx45CcnIxFixZh2bJlCAsLU+ssX75cjazctm0b+vXrx8NjIQzVZqZl52PV7+fxvz8vITmzKDirCdAObVMbL/ZqiPq+LtW2PURkmhioJZO35M8IzPzlJAoLi+73bOKLz564D052/HoTERER6UNufgEW/H5eTePNLyj6p8vJzhpvD2yOR9sHcdou6ZWMgP3hhx+Qnp6uUiBEREQgOjoaffv21a5jb2+P7t27Y8+ePSpQe/DgQeTm5uqsI2kSWrZsqda5U6BWUibIRSMlpSiNWkFBgbpUhDxP0jVU9Pmmyhj2W/PelTl+9yIlMxeL/4xQAdrU7Fujt62tamBomwCM79EAwT7OOttmLozheFc3S9xnwf0u0MtnWB6MZJHJkh/HOZvO4IudF7TLRoQGYtawEBYNIyIiItKTi7Fp+OeqIzgamaxd1raOB+aNbIN6N4MPRPpw/PhxFZjNysqCi4uLSmMgo2kl0CpkBG1xcv/y5cvqtgRyJSepp6fnbevIY3cye/ZszJw587blsbGxalsq2iGXUb7SZ7GyspyMg8aw30lJSeo6ISGhSoNpqVl5WHUkBisPxSAtp1iAtgbQv5k3xnSohSAPB6AgHTEx6TBHxnC8q5sl7rPgfhdW+ngXT9VzJwzUkknKyy/Aq6uPYc2ha9plL/ZsiCl9G3NEBxEREZEeSCf0231X8N6GU8jMzdeOEHu5dyM1QszG2nI6qFQ9mjRpgiNHjqhA2+rVqzF69Gjs3LlT+3jJ4sDyHb1bweDyrDNt2jRMnjxZZ0StpEzw9fVVhc0qGtSQ95XXsLRgjqH3W/O+Xl5eqrBcVeTpXvLXZXy16yJSsvJ0ArQPt62NCT0boK63ZZzEMobjXd0scZ8F99u30sfbwcGhXOsxUEsGIWe7GzZsWKFKnNl5+Zi44jC2nLyh7sv/Xe8MaYmnOtWtgi0lIiIy7XaTqCJiUrPw+urj+P10jHZZfR9nzHu0DVoHefBDpSr9rRPt2rVTRcM++eQTvPbaa2qZjIz19/e/9T2NidGOspXiYjk5OUhMTNQZVSvrdOnS5Y7vK2kU5FKSdMor0zGXYE5lX8MUGXq/JRgi3yO51uc2ZOXmY8W+K/h8x3nEpeVol9tY1cCw+2rj0RAPtG0UxONtAQz9HTcU7rdVpT6/8n5fGKglg5Az01LJ9V5l5uTj+WUH8Me5OHXfztoK/3m8Dfq3vPUPGxERkbmpaLtJVBFbTkTj9TXHkZB+KxDxZKc6mP5gM9YAoGolo2Eld2xwcLAKxG7duhVt27ZVj0lQVkbbzpkzR90PDQ2Fra2tWmfkyJFqWVRUFMLDwzF37lweOQui7zZTcnT/eDAS//ntHKKSs3SKhA2/LxAv9W6E2h4O6qQAEVFlMVBLBpGXl6eKAzg7O8PGpnxfw9SsXIxdcgB/X0pQ9x1trfHl06F4oJFvFW8tERGR6bWbRPcqLTsP7204jVUHrmqX+bjY44NHWqFn05r8QKlKTZ8+HQMGDFApBySP38qVK7Fjxw5s2rRJjeKaNGkSZs2ahUaNGqmL3HZycsKoUaPU893d3TF27FhMmTIF3t7eatr71KlTERISgrCwMB49C6KvNrOgoBDrj13HvK1ncSk+Q+exga388c8+jdHA1+XmupZVWIqIqg7/0yeDkLxTa9aswbBhw8qVNygxPQdjFv+tLWLham+D/z3THu3reVXD1hIREZlWu0l0r45dT8O735zElYRM7bK+zf0we1gIvF1unxJOpG83btzAU089pUbBStC1VatWKkjbp08f9firr76KzMxMjB8/XqU36NixI7Zs2QJXV1fta8ybN08F5mRErazbu3dvLFmyBNbW1jxgFqSybaaM5N568gY+3noWp6N1i//0bloTk/s2RosAdz1uMRHRLQzUktGLT8vGE1/v0zaSnk62+OYfHRESyMaRiIiIqLJTeudvPYuFOy+goLBombOdNf41uAVGhAaySCtVm0WLFt3xcRlVO2PGDHUpi+QkXbBggboQVcSf5+Mwd/MZHL2apLO8U30vvNKvKULr3sp/TERUFRioJZMK0vq62uPbZzuisd+tM+dEREREdO/Ox6Thn6uO4Pi1ohlLol1dT3w8sg3qeDvxIyUii3HiejLe33haWwtFQ4onvtK3Ce5v6M0TV0RULRioJZMJ0tZyc8B3z3dCsI+zoTeNiIiIyGTJtN5ley9j1q+nkJVblFfR2gqYFNYY43s0hLVUyCEisgCRiRn4eMtZrD1yDYU3ZxWIJn6umNqvCcKa1WSAloiqFQO1ZJSkyjCDtERERET6FZOShVd+PIadZ2O1yxr4OuOtsCB0CwmGFYO0RGQBkjNy8fmO81i85xJy8m4VAqvt4Yip/RpjSOva/D0kIoNgoJYMQpK6P//882UGaUd9tVc7ktbPzZ4jaYmIyKLdqd0kKq9N4VGYtuY4EjNytctGd66LV/s1QWpSPD9IIjL7NjMrNx/L/rqMT7efR3Lmrd9Cd0dbTOzVEE92qgsHWxafIyLDYaCWjO7MZvGRtBKkXfl8Z6Y7ICIiIqqg1KxczFx/Ej8ejNQuq+lqjw9GtEb3xr4oKCiAbl1zIiLzUlBQiJ+PXscHm8/gWlKmdrmdjRWeub8exndvCHcnW4NuIxGRYKCWDCIpKQk7duxAjx494OHhoZalZedh9OK/cSoqRd1nkJaIiKjsdpOoPPZejMfUH44iMvFWYOLBkFp4b2gIPJ3t+CESkdm3mfsuxuPfG04i/FpRP1PUqAEMaxuIyX0bq3QHRETGgoFaMoi8vDzExMSoa80UlOeWHsCRq0nqvo+LPb57joXDiIiISms3ie5G/rf6cPMZLPozQlsgx8XeBjMHt8Cw+2qzOA4RmX2beTUuFdN+uYCN4dE6j3dr7IvX+zdF8wA3g20jEVFZGKglg8vNL8D4bw/hr4vx2vxAy8Z2QH1fF0NvGhEREZHJOR6ZjH9+fwTnY9K0yzoEe+GjEa0R5OVk0G0jIqpq6dlFuWdf+PYQIjNvhTya+bvhjQeboWsjHx4EIjJaDNSSQeUXFOKfq47g99Mx6r6znTWW/qODakSJiIiI6N5Ofn+2/Tw+/f088goKtfkXpVjYP+4PZgVzIjL7vuX3B65iye/HMNyr6DdRM1vzlX6N8UhoEKytahh6M4mI7oiBWjIo6Uz8cixB3ba3scLXo9ujTRBz7xERERHdi/MxqZj8/VEci0zWLgup7Y6PR7ZGIz9XfphEZNb2XIjDO+tPqqLUfna5gBdga22FF3o0wPgeDeDqwEJhRGQaGKglg3BxcUGmT1N8fyAOgBVsrWvgiydD0bmBN48IERFRKe1mz5491TVRyUrmi/dcwtxNp5GdVzR6TEaMvdizIV7s1VAFKoiIzNWluHTM+vUUtpy8oV2WnGeDy/bBWDquHRrU8jTo9hER3Surqkjc/eabbyI4OBiOjo6oX78+3nnnHRQUFP3jKAoLCzFjxgwEBASodaQa44kTJ/S9KWTEfjgcjXl/pyKrwEpV3Jz3aBv0bFrT0JtFRERklBwcHNCoUSN1TaRxNSEDo77ei3//clIbpG3g64w1L3TBP/s0ZpCWiMxWRk4ePth8Gn3n7dIJ0spMgm+eux/vje7DIC0RmSS9B2rnzJmDL774Ap9++ilOnTqFuXPn4oMPPsCCBQu068iyjz/+WK2zf/9+1KpVC3369EFqaqq+N4eM0MbjUZj9yzGEuqXBySof/xrYHANbBRh6s4iI9G727Nlo3749XF1dUbNmTQwdOhRnzpzRWac8Jy+zs7MxceJE+Pj4wNnZGYMHD0ZkZCSPmAXJzMxU3wu5JpLfDcnDOOCTP7D3YlEKKTG2azA2vPQAWjONFBGZ8e/fr8ejEPbRTny2/QJybuahrelqjw9HtMa6CfcjpJYj20wiMll6D9T+9ddfGDJkCB566CHUq1cPjzzyCPr27YsDBw5of1jnz5+PN954A8OGDUPLli2xdOlSZGRkYMWKFfreHDIyey/G4+WVR+BqnY9+PskY28kfY+4PNvRmERFViZ07d2LChAnYu3cvtm7dqmadSJuYnp5+TycvJ02ahLVr12LlypXYvXs30tLSMHDgQOTn5/PIWQj5zvz555863x2yTDGpWXjumwN49cdjSMvOU8tqezhixXMd8dbA5nCwtTb0JhIRVVku7qcW/Y3x3x7C9eQstUxS6Eke2u1Te+CR0EBVNJFtJhGZMr3nqO3atasaUXv27Fk0btwYR48eVZ1KCc6KiIgIREdHq46qhr29Pbp37449e/Zg3Lhxt72mjCSSi0ZKSoq6lnQKxVMq3Ct5rgSOK/MapsaQ+yyJ3aVjoc563uxDPNmxTrVsiyUea8H95vG2BPr6nlfF78OmTZt07i9evFiNrD148CC6det228lLIScv/fz81MlLaROTk5OxaNEiLFu2DGFhYWqd5cuXIygoCNu2bUO/fv30vt1EZLyzkqavPY7EjFztspHtAlWAloVyiMhcyUmp//x2Dv/bHYG8gkLt8m6NfTFjUHPU92X+diIyH3oP1L722muqU9m0aVNYW1ur0T7vvfceHn/8cfW4BGmFdEKLk/uXL18uc+rozJkzb1seGxuLrKyiM2kV7ZTLtkpH2crKMgotGGqfY9NyMHblaaRmFY38aBXgLEuRmJiotqWqWeKxFtxvHm9LoK/veXWk35HtFF5eXuU+eSlB3dzcXJ11JE2CzEiRdUoL1FbFCU6e+DHsiR/NcavsSep7eT+e4DQeKZm5mLH+JH46cl27zNvZDu8Pa4nezYr+p+bghXvH77nxneAkKk7aoZ+PXsd7G04hJvXW/zWBno54e2Bz9GnuhxpS8ISIyIzoPVC7atUqNdJHRgK1aNECR44cUVM2pVM5evRo7Xolf1DlR7isH9lp06Zh8uTJOh1OGUnk6+sLNze3Sv1zIe8pr2MpwTtD7LMken/2h32ISSsa/dEq0B1vDWqATRsuqWCF5FysapZ4rAX3m8fbEujre17VRZqknZO2TGaeSJC1vCcvZR07Ozt4enreto7m+dVxgpMnfgx74icpKUldJyQkVFuglic4jeP/hX2XU/Du1kuIvfl/lOjR0AOv9aoDT6caiImJqfR78HjzxG5FsL4IVaUz0al4a104/o64lYfbzsYKL3RvoFIdMM0LEZkrvQdqX3nlFbz++ut47LHH1P2QkBDV2ZROowRqJfeekM6lv7+/9nnyT2bJjmrx0UVyKUk6TJXtNEnnXh+vY0qqc58LCgox+ftjCL+Wos2htmh0e9gVZCEwMFAd1+r67C3xWAvuN4+3JdDH97yqfxtefPFFHDt2TKUDKuleTl4a6gQnT/wY9sSPtJe1a9dW/yu5u7tX+fvxeBv+RJ+c6H5/4xks33dFu8zVwQYzBzXHkDYBeh1FxuNt+ONdnUzlBCdZJvnt++S3c1j0h26ag7BmfmoUbR1vp7u+hq2trepryjURESw9UCtFwUo2+JICQTP6Izg4WAVrpahK27Zt1bKcnBxVcGXOnDn63hwysDmbT2PLyRvqtou9Df43pj18XSXobo8HH3zQ0JtHRFQtJk6ciJ9//hm7du1SHQeN8py8lHWknZRUMcVH1co6Xbp0qdYTnDzxY7hAjhx7KdRanXi8DXe8D15OwJTvj+JSfIZ22QONfDD3kVbwd3eskvfk8bacQK2pnOAky/P76Rt466cTuJaUqV1W19sJMwa1QM+mNcv9OnJCk31NIjJVeg/UDho0SOWkrVOnjkp9cPjwYVXN+h//+If2nwJJhTBr1iw0atRIXeS2k5MTRo0ape/NIQNatf8K/rvzorptbVUDnz1xH5rUclX3JXAv1c9tbGz4Tx4RmS0Z9SpB2rVr12LHjh3qZGVx5Tl5GRoaqkaEyDojR45Uy6KiohAeHo65c+caYK/IENhuWoas3Hx8vPUsvvrjIjQp/B1srfDGg83wZKe6zMVIRGYpOjkLM9efwMbwWymd7KytML5nA/xf93tPc8A2k4hMmd4DtQsWLMBbb72F8ePHq9E+kptWiqG8/fbb2nVeffVVZGZmqnVkhFDHjh2xZcsWuLoWBfHI9O05H4c31oZr70s1zu6NfbX3JcfemjVrVJXz6shRS0RkCBMmTFA529etW6faOE1OWRnp4ejoWK6Tl7Lu2LFjMWXKFHh7e6vc3lOnTlWphcLCwnhgLQTbTfN3+Eoipv5wFBdi07XL2tbxwMcj2yDYR4qwEhGZl/yCQnzz1yV8tOUs0rKLik6LLg288e7Qlqjv61Kh12WbSUSmTO+BWumIzp8/X13KIh3TGTNmqAuZn6sJGRi/4pA2p9CYLvXwVOd6ht4sIqJqt3DhQnXdo0cPneWLFy/GmDFjyn3yct68eWoGgoyolXV79+6NJUuWqNRCRGT6o2jnbzuHL3ddgCYdoxTMmdKnMZ59oL6alUREZG6ORyZj+trjOH4tWbvM29kObw5shqFtanMGARFZLCYWIr3KzMnH88sOIimjqDJxjya+eGtgc37KRGSxqQ9Ku2iCtMVPXko6g6ysLJX2oGXLlrcVbJEZK/Hx8SoX/Pr161VxMCIybccikzBowW58sfNWkLZ1oDs2TOyKcd0bMEhLFkWKT7dv316dqKxZsyaGDh2KM2fO6Kwj7ae0m8UvnTp10lknOztbpR2SWXvOzs4YPHgwIiMjq3lvqCwyclbSHAz5bLdOkPbxDkH4bUp3PNw2kEFaIrJoeh9RS5ZLgg+vrzmGU1Ep6r5M0/vksbbsZBAREREVk52XjwW/ncfCnRfU1F9ha10Dk8IaY1y3+rCx5lgKsjxyolJSBkmwVmpZvPHGG+jbty9OnjypAq4a/fv3VzNTNOzs7HReR1IKyQnNlStXqpRBkjpo4MCBOHjwIGeiGNj20zF4Y+1xXE/O0i5r4ueK9x5uiXb1vAy6bURExoKBWtKbRbsjsO7IdXXb2c4aXz4VCndHW37CRERERDeFX0tWuWhPR6dqP5OWtd3w4YjWaFrLjZ8TWaxNmzbp3JdgrIyslQBrt27dtMvt7e1VIc7SJCcnY9GiRVi2bJk2j/vy5cvVLJRt27ahX79+VbwXVJqE9Bz8+5eTWHv4mnaZFEp8ubekeAmGLU9OERFpMVBLeiseNnvjae39j0a2RiO/sovDSTGcp556Sv2jRURERHfGdtP05eQV4LPt59VFk8ffxqoGXurdCC/0aMBABVEpQVfN719xO3bsUAFcDw8PdO/eHe+99566LySom5ubq0biakhxa0kptGfPnjIDtZIuQS4aKSlFMwQLCgrUpSLkeTLjsKLPN1XF91uuNxyPxsz1JxGfnqNdp2tDb7w3tCWCvJy0z9En+W488cQTqq9ZXZ8/j7flfM95rC3nWOv7eJf3NRiopUqLTMzAi98d1k7de7FnQ/Rv6X/H51hZWamK50RERHR3bDdN28nrKWoU7cmb6aFEM383fDSiNZoHcBQtUUnSKZ48eTK6du2qk7d9wIABGDFiBOrWrYuIiAi89dZb6NWrlwrQSlAuOjpapULw9PTUeT0/Pz/12J3y486cOfO25bGxsSp/fEU75BJsln2R33BLodnvmNRsfLgjEn9cvJWH1tXeGi93C8RDzb1RIy8NMTFpVbotqam3Zi5UNUs/3pa035a4z4L7XVjp413e3yQGaqnSOdbGf3tITWfRFA/7Z5/Gd32enKWWs9pdunSBmxs7KERERGw3zU9ufgEW7riA//x2TjuK1tqqBib0bKhObNvZWE4Hj+hevPjiizh27Bh2796ts/zRRx/V3pYAbrt27VTQdsOGDRg2bFiZrycBFSk8VpZp06apwHDxvoqkS/D19a1wX0WCGvKe8hqWFMzJy8vHuvB4fPbnGVU4TKN/Cz/MHNwCvq5VP6NSjt/evXtVobnq6mta6vG2xP22xH0W3G/fSh9vKRBdHgzUUqW8v/E0jkUWnSWt6+2ETx4tX/GwnJwcXLlyRf1zRURERGw3zc2Z6FRM+eEIwq+l6BTNkfRQLWu7G3TbiIzZxIkT8fPPP2PXrl0IDAy847r+/v4qUHvu3Dl1X3LXSj8jMTFRZ1RtTEyMGiBSFhmNW1pKNumUV6ZjLsGcyr6GKbkUl47XVx/D3ogE7TIfF3v8e0gLDAi584xLfZJidJq+ZnV+9pZ2vC15vy1xnwX326pSn195vy8M1FKFbQqPxuI/L6nbMiLks1H3wd2JxcOIiIjIcuXlF+C/uy7ik23nkJNflItMTmK/0L0BJvZuCHsba0NvIpFRklGvEqRdu3atykMbHBx81+fEx8fj6tWrKmArQkNDYWtri61bt2LkyJFqWVRUFMLDwzF37twq3wdLJSnwFv8ZgQ82n0F23q0cjCNCA/HmQ83ZRyQiugcM1FKFXE3IwKs/HtXef2tgc44OISIiIlj6KFr5/+jozdlGolFNF3w4ojVaB3kYdNuIjN2ECROwYsUKrFu3Dq6urtqcsu7u7qq2RVpaGmbMmIHhw4erwOylS5cwffp0+Pj44OGHH9auO3bsWEyZMgXe3t6qENnUqVMREhKCsLAwA++hebocn65ycO+/lKhd5u9mh/eHt0b3JkVF3oiIqPwYqKUKVS1+ccUhpGQV5Rx6KMQfT3asw0+SiIiILDoX7YLfzyE3vygXrWSCer5bA0wKawQHW46iJbqbhQsXqusePXroLF+8eDHGjBkDa2trHD9+HN988w2SkpJUsLZnz55YtWqVCuxqzJs3DzY2NmpEbWZmJnr37o0lS5ao55P+FBQU4tt9lzHr19PIzM1XyyQN8OhOdfF0W0/UC/Thx01EVAEM1NI9m7PptHakiOSlnT085I7J+Uvj5OSkkrvLNREREbHdNFXh15Lxyo/HcCrqVi7aBr7O+GBEa9xXR7fyPBHdOfXBncio2s2bN5erWMuCBQvUharGtaRMNXvgz/Px2mVBXo748JHWaF/PU+UENiT2NYnIlDFQS/dk68kbWLQ7Qt22sy7KS+vmYFuhxrNVq1b89ImIiNhumqSs3Hw1gvaLnRdVfkZNLtpx3erjpd4cRUtE5hlM/+FAJN755STSsotmV4onOtbB9AebwdneRlWGNzT2NYnIlDFQS+V2IyULrxTLS/vmwGYVzkubnZ2Na9euoXbt2qVWWCUiIiK2m8bq0JVEvPrjMZyPSdMua1rLVeWirej/RkRExt4XfH31MWw/E6td5u/ugDnDW6FbY18YE/Y1iciUWRl6A8h0chBJkvikjFx1v18LPzzVqW6FXy81NRXbtm1T10RERMR20xRk5uTj3V9OYvjCPdogra11DfwzrDF+frErg7REZJZ+OXYdfeft0gnSPhIaiE2TuhldkFawr0lEpowjaqlcvvnrEv44F6du13S1x/vDWt1zXloiIiIiU7X3YjxeW30Ml+MztMtaBbpj7iOt0LSWm0G3jYioKqRm5WLGzyex+lCkdpmv6guGoHczP37oRERVgIFauqtzN1Ixe+Np7X2Z1ufpbMdPjoiIiMye5GF8f+MpLN97RbvMzsYKk/s0xrNdg2FjzQlqRGR+Dl5OwKRVR3A1IVO77KFW/nh3SEv2BYmIqhADtXRHOXkFeHnlEWTnFSWFf+b+ekY5vYWIiIhI33adjcW0NcdVhXON0LqeahRtA18XfuBEZHby8guw4PfzqljizTqJcLG3wTtDWuDhtrU5q5KIqIoxUEt39PHWszgZlaJuN/ZzwWv9m+rlE7O2toa3t7e6JiIiIrabxiQlMxezNp7G9wduTfd1tLXGq/2b4OnO9WBtxfRPRGR+Lsenq1G0h68k6Zycmv9oGwR5OcFUsK9JRKaMgVq6Yy62/+66oG7bWVth/qNt4WCrn8Cqp6cnhg8fzk+fiIiI7aZR2XUhCR/uCEdMarZ2Wef63qqyeR1v0wlUEBHdi9UHI/H2unCk5+Sr+3JC6uXejTC+RwOTS/HCviYRmTIGaqlU6dl5mPrDURTenO4ytV9jNA9goQwiIiIyTzGpWZj58wlsOB6tXSbTfac/2AyPdwjidF8iMksZOXl466cTOgXD6no7qVG0bet4GnTbiIgskWmdGqNqM3vjKUQmFuVj6xjshWe71tfr68fFxeHrr79W10RERMR201AKCwvx/f6rCPtop06QtkcTX2z5ZzeM6liHQVoiMktnolMx+NM/dYK0I0IDseGlB0w6SMu+JhGZMo6opdvsOR+nrWzsZGeNDx5pDasqyMVWUFBUoIyIiIjYbhrCpbh0TF97HHsuxGuXuTtY4+1BLTDsvkAGaInIbE9Qrdp/Ff/6+YS2aLSznTVmDQvBkDa1YQ7Y1yQiU8VALd2W8uDV1ce0918f0JT52IiIiMjsqpp/vTsC87ae1QYpxNA2ARjXwQdN6rGyORGZp7TsPLyx9jjWHbmuXdbM3w2fjWqL+r4uBt02IiJioJbukPKgU30vPNmxLj8jIiIiMhvh15Lx2upjOHE9Rbustocj3nu4Jbo18kFMTIxBt4+IqKqcu5GKccsP4mJsunbZk53q4M2HmuutaDQREVUOR9RSqSkPHG2tMXd41aQ8ICIiIqpumTn5mLftLL7+4yIKbhZLrVEDeKZLMKb0bQxnextOlSUis7XxeJQqFp2ek68tlvj+8BAMbBVg6E0jIqJiGKglg6Q88PDwwCOPPAI3NzceASIiIrabVWr3uTiVi/ZKQoZ2WdNarpg9LMSkC+YQEd1NfkEhPtxyBgt3XND5/fviyVDU83E2yw+QfU0iMmVWht4AMg5zNp3WpjzoGOyFpzpVbcoDGxsbeHl5qWsiInO1a9cuDBo0CAEBAaoo0U8//aTz+JgxY9Ty4pdOnTrprJOdnY2JEyfCx8cHzs7OGDx4MCIjb1VnJsvAdrNiEtNz1AiyJxft0wZp7Wys8Eq/Jlg/sSuDtERk9r+BYxb/rROkHdImAGvH32+2QVrBNpOITBkDtYSDlxOxbO/lWykPHmlV5SkPUlNTsXPnTnVNRGSu0tPT0bp1a3z66adlrtO/f39ERUVpL7/++qvO45MmTcLatWuxcuVK7N69G2lpaRg4cCDy84umLpJlYLt57xXNfz56HX3m7cSPB2+d2OgQ7IWNLz+ACT0bwtaa/wYTkfk6H5OKwZ/txh/n4tR9a6saeHtgc8x/tA0c7cw7Hy3bTCIyZRzOaOFy8gowbc0xFN7M1SY52up6V/3ZVRkhdubMGbRo0QKurq5V/n5ERIYwYMAAdbkTe3t71KpVq9THkpOTsWjRIixbtgxhYWFq2fLlyxEUFIRt27ahX79+VbLdZHzYbpbf1YQMvL0uHNvPxGqXuTrYYPqDzfBouyDm3ycii0j38sK3B5Galafu+7jY4dNR96FTfW9YAraZRGTKOJTAwn256wLO3khTt0Nqu2NMl3qG3iQiIouyY8cO1KxZE40bN8Zzzz2nU3H+4MGDyM3NRd++fbXLJI1Cy5YtsWfPHgNtMZFxys0vwBc7L6hRtMWDtP1b1MK2yd3xeIc6DNISkdn77u8rGL34b22Qtrm/m0r1YilBWiIiU8cRtRbsYmwa/vP7ee1UGCmoYcNpgERE1UZG244YMQJ169ZFREQE3nrrLfTq1UsFaGWkbXR0NOzs7ODpqVvsyM/PTz12p5EkctFISUlR1wUFBRWuai/Pk+nkFX2+qTKW/da8f2WOoSnu972kcXpz3Qmcib6VUsnPzR7/Gtgc/VsWjVgvz76Y2n7rC/ebx7ui3xsyrqJhUnfky10XtcvCmvnhk8fawNme3X4iIlPBX2wLJZ2QaWuOq9QHYmzXYLSs7W7ozSIisiiPPvqo9raMkm3Xrp0K2m7YsAHDhg2742+4FB4ry+zZszFz5szblsfGxiIrK6vCHXJJxSDvbWVlORNyjGW/k5KS1HVCQkK1BWqNYb/vJiUrD5/vvoafwotyMAr5y3ikjS/+r3NtONtb6YxSN5f91jfuN493RbDWhPHIys3HpJVHsOnErZO4z3YNxrQHm6kBOUREZDoYqLVQPxyMxL6IBHU7yMsRk8IaVev7Ozo6ok2bNuqaiIiK+Pv7q0DtuXPn1H3JXZuTk4PExESdUbUSeOrSpUuZH9u0adMwefJknRG1ktfW19cXbm5uFQ7kSHBYXsPSAljGsN/Ozs6qMF3t2rXVbUvZ7zsXC4vCuxtOIT49R7u8ZYAb3h3aEq0C3c1yv6sK95vHuyIcHBz0/l2ke5eWnYfnvzmAPRfi1X0JzL4zpAWe6FjXYj9O9jWJyJQxUGuB4tNzMXvjGe39d4eGwMmuer8K0sns0KFDtb4nEZGxi4+Px9WrV1XAVoSGhsLW1hZbt27FyJEj1bKoqCiEh4dj7ty5Zb6OpE2QS0kSeKpM8EkCWJV9DVNkDPsthTc7duxocftdmktx6Xjzp3DsPn9rFK2znTWm9G2CpzvXrXQaJ2Pd76rG/ebxvleW9jdijBLTczBm8d84Gpms7jvZWWPhk6Ho3tgXlox9TSIyZVXSul67dg1PPvkkvL294eTkpEZOSr694qMgZsyYoQqiyNmuHj164MSJE1WxKVSK+TuvIjkzV90e2ibAIA25jBC7fv26uiYiMldpaWk4cuSIugjJQyu3r1y5oh6bOnUq/vrrL1y6dEkVFRs0aBB8fHzw8MMPq/Xd3d0xduxYTJkyBb/99hsOHz6s2teQkBCEhYUZeO+oOrHdBLLz8vGf386h7/xdOkFaVSxsSnf8o2swc+0TmTBJ29O+fXt1YkqKbA4dOhRnztwaXFLefqTkaJ84caJqTyVgN3jwYERGRsLcRCdnYeR//9IGad0dbbH82Y4WH6QVbDOJyJTpPVAr0zPvv/9+NQJo48aNOHnyJD766CN4eHho15FRQB9//DE+/fRT7N+/X03t7NOnD/McVYPtZ2Kw9Wyiuu3hZIu3BjaHIcg03F9++UVb4IaIyBwdOHAAbdu2VRch6Qjk9ttvvw1ra2scP34cQ4YMQePGjTF69Gh1LYFb6aRqzJs3T3VWZUSttK9yAnT9+vXq+WQ5LL3d3HsxHgM++QMfbz2rza9f28MRi0a3wxdPhcLfnamUiEzdzp07MWHCBOzdu1fNJMnLy0Pfvn2Rnp5+T/3ISZMmYe3atVi5ciV2796tTowOHDgQ+fn5MBcxqVkY9dVenItJU/d9Xe2xalwn3FdHt/iopbL0NpOITJve57vPmTNH5cFbvHixdlm9evV0zoLOnz8fb7zxhrZQytKlS1UF6xUrVmDcuHH63iS6KTMnH//6+aT283jzoebwdrl9aiwREemHjPSRdq8smzdvLlcOwAULFqgLkaWJT8vG7I2n8ePBW6PhJP+iFEGV/PrVnbqJiKrOpk2bdO5Lf1JG1srMzG7dupWrHynFABctWoRly5ZpZ54sX75c9U+3bduGfv36mcXv4hNf7cPFuHRtvZFvx3ZCHW8nQ28aERHpgd7/u/35559VAzhixAh1VlSKXowfPx7PPfecdtpndHS0OjuqIXn0unfvjj179pQaqJXpK3LR0JwZk8IHlal8LM+VBr86qicbg09/P4fIxEx1u3N9Lzzcxt9g+65538oew3t5P0s61hrcbx5vS6Cv77ml/T4QGbP8gkJ89/cVfLD5jDZdk2gT5IFZD4egeUDFiuIRkemQoKvw8vIqdz9Sgrq5ubk660iahJYtW6p1ygrUVkV/syr+D0/KyMFTi/7WjqQN8HDAirEdUdvTwWj+jzGG/kd19zWNZb8NwRL32xL3WXC/C/TyGRokUHvx4kUsXLhQTe+cPn06/v77b7z00kuqEX366adV4yrkzGdxcv/y5ctl5iuaOXPmbctjY2ORlZVVqQ9J/gGQPzJzT4Z/OSEL/911Ud22sQJeut9PfX6GkpSUpK4TEhKqLVBrKce6OO43j7cl0Nf3vPi0SSIynKNXk/DWunAcu5l3Ubg62OC1/k0xqkMdWFnV4OEhMnPSpkt/smvXrirIKsrTj5R17Ozs4Onpeds6mudXV39T3/+Hp+fkY+Lqszh5I0Pd93WxxX+GNoRtbipiYoznfxhj6H9Ud1/TWPbbECxxvy1xnwX3u7DSx7u8/U2bqjh47dq1w6xZs9R9ycUnCd4leCuB2uKVZYuTL3nJZRrTpk1TDXXxM5wyfcXX1xdubm6V2lZ5T3kdc/4DU//orN+PvIKi6bdPhPqhfZM6Bt1nGxsblWdRkvxrzpJXJUs51iVxv3m8LYG+vueSYoDIWMl3W4rimHMbJtXL524+g5X7r6B4xpBhbWvj9QeboqYr/0aJLMWLL76IY8eOqRyzJd1LP7K861RFf1Of/4fn5hfg1W8OaoO0Pi52+O65jqjv6wJjYwz9j+ruaxrLfhuCJe63Je6z4H77Vvp4l7e/qfdArb+/P5o31y1Q1axZM6xevVrdloTvQs5oyroaMTExt50d1ZDRuHIpST6kyn5Q8gemj9cxZuuPXseeC/HawhvPdAgw+D5LoymVy6uTJRzr0nC/ebwtgT6+55b220CmRTqaTzzxBMxRQUEhVh24ijmbTiMp41aagyZ+rnhnSAt0rO9t0O0jouo1ceJElU5v165dCAwM1C4vTz9S1snJyVEFrouPqpV1unTpUuZ7VlV/Ux//n0iQWeqM7DoXp+67O9ri22c7oaHfrcKjxsbQ/Q9D9DWNYb8NxRL32xL3WXC/rSr1+ZX3+6L3b5VUpD5z5ozOsrNnz6Ju3brqdnBwsGpApZKnhjSmks/2To0nVUxqVi7+/cutAmIzBjWDg61l/ZgQERGRcToemYyHF+7BtDXHtUFaF3sbvPlQM/zyUlcGaYksiAQkZSTtmjVr8Pvvv6t+Y3Hl6UeGhobC1tZWZ52oqCiEh4ebbF9z4c4LWLn/qrptZ22Fr55uhya1jDdIS0RElaP3EbX//Oc/VSMoqQ9GjhypctR++eWX6qKJwE+aNEk93qhRI3WR2zI1YdSoUfreHIs3b+s5xKQWJcYPa1YTvZv5qTPKhib5gjZu3IgBAwZU23QUIiIiU2Vu7WZyRi4+2HIa3+7TTXMwuHUA3nioGfzcmOaAyNJMmDABK1aswLp16+Dq6qrNKevu7g5HR8dy9SNl3bFjx2LKlCnw9vZWv5dTp05FSEgIwsLCYGp2nY1VRRU1PhzZGh2CTb8NqGrm1mYSkWXRe6C2ffv2WLt2rcrz884776gzn/Pnz9eZrvfqq68iMzMT48ePV9NSOnbsiC1btqgGmfTn5PUULP3rkroto2j/NaiFUeU3SU9Pt7hKiURERJbcbkqagx8PReL9jaeRkJ6jXd6wpotKc9ClgY9Bt4+IDEdqmogePXroLF+8eDHGjBlT7n7kvHnzVI5SGTQk6/bu3RtLliyBtbU1TElkYgZeXnlYezLrn2GN1cksspw2k4gsk94DtWLgwIHqUhY5Gzpjxgx1oarrCEnF5PybBcQm9mqEIC8nNlZERERkEEevJmHG+hM4fKWoGrdwsrPGpLBGGNMlGHY2TM1EZOmpD+6mPP1IKdayYMECdTFV2Xn5GP/tISTeTAnTu2lNTOzV0NCbRUREphqoJcP78WAkDl5OVLfr+zjj2Qd0czwRERERVYfY1GzM3XQaPxyM1Fn+UCt/lYvW392RB4KIqET6umORyep2HS8nfDyyDaysavAzIiKyAAzUmqHE9BzM3nhKe/+dIS1hb2NaU32IiIjItOXkFWDJngj857fzSMvO0y5v4OuMGYNb4IFGvgbdPiIiY3ToSiK+3HVB3ba1roHPn7gP7k62ht4sIiKqJgzUmqG5m89op8kMbOWPro2ML9+bm5ubSo8h10RERGRe7eb20zH49y8ncTEuXbvM1cEGk8Ia4+nOdWFrzTQHREQlZebkY+r3R3Eze536zWxZ250flJm3mURExTFQa2YOX0nEyv1X1G0Xexu8NbA5jJGdnR0CApgMn4iIyJzazYuxaSpAu/1MrHZZjRrAY+2DMKVvE/i42Bt0+4iIjNlHW85oT3C1DvLAuG71Db1JJslU2kwiotIwUGtGpHDYmz+F36oM2qcx/NwcYIykCueJEyfQokULODs7G3pziIiIjJqxt5upWblY8Pt5LP4zArn5twoCtavrqdIccEQYEdGdnY9JxeI9l9RtexsrfDSiNWw4+8As20wiojthoNaMLN97GSeup6jbTWu5YnTnujBWmZmZOHLkCOrXr8/Gk4iIyETbzYKCQvx4KBJzN51BXFq2dnktNwdMe7ApBrcOUFXaiYjozt7dcEoNvBHjezREw5ou/MjMrM0kIioPBmrNqKLyh1vOaO+/O7Qlz8ASERFRlTlwKUGlOTh6szK5sLOxUlN1X+jRAE52/DeTiKg8tp+JwY6bKWMC3B3wPFMeEBFZLP4HbSZmbzyF1KyiisojQgPRrp6XoTeJiIiIzNDl+HS8v/E0NoZH6yzv36IW3nioGYK8nAy2bUREpiY3vwDv/nJSe/+1AU3haGdt0G0iIiLDYaDWDPwdkYA1h66p224ONnh9QFNDbxIRERGZmeQMyUN7Dkv/uqSTh7aJnyveHtQc9zf0Mej2ERGZojWHInEhtqiA2H11PFTKGCIislwM1JrBGdi3fgrX3n+lf1N4m0BFZXt7ezRp0kRdExERkfG2mzl5BSoP/n9+P4ekjFztch8XO0zu0wQj2wUy3RIRUQXk5Rfgs+0XtPdlVgLzelce+5pEZMoYqDVxS/dcwpkbqep2q0B3jOpQB6bA1dUV3bt3N/RmEBERmQRDtJuFhYXYcvIG5mw6g4i4otFemmrkzz1QH//XowFc7PmvJBFRRf1yLApXEjLU7fsbeiO0LtPX6QP7mkRkyvjftQm7kZKF+dvOqdtSUPnfQ1rC2so0Kivn5eUhJSUFbm5usLHh15CIiMiY2s3j15Ix46ezOHwtTWf5w21r45V+TRDg4Vjl20BEZM7kZNii3RHa+xN7NTLo9pgT9jWJyJRZGXoDqOLe23AKadlFBcQea18HrYM8TObjTEpKwo8//qiuiYiIyDjazWtJmZi86giGfLZHJ0jbIdgLP794P+Y92oZBWiIiPTh0JVGdFBMhtd3RMZijafWFfU0iMmUcymii9pyPw89Hr6vbnk62eLVfE0NvEhEREZmoxPQcfLb9PL7Ze1nlpNWo6+2E6Q82Q9/mfsybSESkR0v2XNbeHtOlHn9jiYhIYaDWBEkH6q11twqIvda/KTyd7Qy6TURERGR6MnLysPjPS/hixwWk3pylI9wdbfGPDn4Y17sFHOz47yIRkT4lZ+Ric3i0uu3lbIeBrf35ARMRkcL/vE3Q//6MwIXYoqIebet4YGS7IENvEhEREZmQ3PwCfH/gqsp1H5uarVMo7Jn7gzGuWzCyUxNhZ8MsWURE+rb+2HXk5BfNXhjapjbsbaz5IRMRkcJArYm5npSJT24WELO6WUDMykQKiJVkZcXOHxERUXW2m1K85tfj0fhwyxlExKXfeu0awKPtg/By78ao5e6AgoICxKTy2BARVYXVhyK1t4eH1uaHXAXY1yQiU8VArYn59y8nkZmbr24/2akuWtZ2hyny8fHBs88+a+jNICIisph2U/Lbz9l0Gkcji4rXaPRvUQtT+zVBw5ouldxKIiK6m8jEDBy+UlQYsmktV7QIMM3+nDFjX5OITBmHNJqQnWdjsfFmLiMfFztM6csCYkRExmzXrl0YNGgQAgICVJGQn3766bbRjTNmzFCPOzo6okePHjhx4oTOOtnZ2Zg4caLqdDg7O2Pw4MGIjLw1Eofobg5eTsCor/Zi1Nf7dIK0UmF8zfgu+OKpUAZpiYiqydaTN7S3B7ZibloiItLFQK2JyM7Lx4yfb3Xepw1opgp9mKrExESsXr1aXRMRmav09HS0bt0an376aamPz507Fx9//LF6fP/+/ahVqxb69OmD1NRbc84nTZqEtWvXYuXKldi9ezfS0tIwcOBA5OcXza4gy1CRdvNYZBLGLP4bwxf+hT0X4rXLZQTX4mfaY+XznXBfHc8q2mIiIirN5hNFA29E3xa1+CFVAfY1iciUMfWBifh8+wVtLrn29Twx7D7TzmUkAYb4+HgGGojIrA0YMEBdSiOjaefPn4833ngDw4YNU8uWLl0KPz8/rFixAuPGjUNycjIWLVqEZcuWISwsTK2zfPlyBAUFYdu2bejXr1+17g+ZRrt5KioFH289qzNqS9TzdsLLYY0wpHVtk81vT0RkyhLTc/B3RIL2N7kRU85UCfY1iciUMVBrAs7HpGHhjgvqto1VDfx7aEs1hZaIiExXREQEoqOj0bdvX+0ye3t7dO/eHXv27FGB2oMHDyI3N1dnHUmT0LJlS7VOWYFaSZcgF42UlBR1LQWi5FIR8jwJLlf0+abKWPZb8/53Ooby/8Inv53DhuO3RmuJ2h6OmNirAYa1rQ0ba5lMJftTaBL7Xd243zzelkBf33NL+33Qhz/Ox0Hz8yujadmnIyKikhioNXLyT9Qba48jJ7/oH6HnutVH01puht4sIiKqJAnSChlBW5zcv3z5snYdOzs7eHp63raO5vmlmT17NmbOnHnb8tjYWGRlZVW4Qy4jfKVdsqRKysay30lJRYVnEhISbguORCZlY9G+69h8OkEbABC+zrYY08Efg1t6w9baCgnxcSa339WN+83jbQn09T0vnqaHyuevYmloujb04cdGRES3YaDWyP1wMBL7bk6PqePlhJd6NTL0JhERkR6VHE0jHee7jbC52zrTpk3D5MmTdUbUSroEX19fuLm5VbhjL+8pr2FpgTtj2G/Ne3t5eanCcuKCzLjZeRHrjl5HfrEIrbezHV7oUR+jOtSBg621Se93deN+83hbAn19zx0cHFAVRTg/+OADNaMkKipK5WgfOnSo9vExY8aoNEHFdezYEXv37tXelxklU6dOxXfffYfMzEz07t0bn3/+OQIDA2Foey8WBWptrWugXT3mCCciotsxUGvE4tOyMevXU9r77w5tCUe7inW4jI2rq6vKtyjXRESWSAqHCRkZ6+9/q+pzTEyMdpStrJOTk6OKYhQfVSvrdOnSpczXlhQKcilJOuSV6ZRLx76yr2GKjGG/3d3dVbsp12dupOHT7efx6/EoFBYbQevhZItx3RpgdJe6cLKzMYv9NgTuN4+3JdDH97wqfhs0RTifeeYZDB8+vNR1+vfvj8WLF2vvy8yT4qQI5/r161URTm9vb0yZMkUV4ZTgr7W14fpS0clZ2pojrQM99PI7TaVjX5OITBlbByP23oZTSMrIVbeHtAlAt8a+MBcSQKhfv76hN4OIyGCCg4NVIHbr1q1o27atWiZB2Z07d2LOnDnqfmhoKGxtbdU6I0eOVMtkhFF4eDjmzp3Lo2dBpN1Ms/PCi6uO31YkTAK0/7g/GM/cXw+uDrYG20Yioqoswln891BzsrMkYy7C+dfFW+lnOjfwNth2WAL2NYnIlDFQa6T+PB+HNYevqdtuDjZ486HmMCcZGRk4f/48GjZsCCcnJ0NvDhFRlUhLS1O/dcULiB05ckRNX69Tp44a9TNr1iw0atRIXeS2/CaOGjVKrS+jJ8eOHatGA8moIHmeTOcMCQnRdkDJ/B28nICF204hJeYqTqRJm1k0IszHxQ7PPlAfT3aqCxd7/ktHRJZhx44dqFmzJjw8PFQBzvfee0/dF8ZchPPQ5UTtY+3reZptMTZjKMoofc0LFy6gQYMG1dbXNIb9NgRL3G9L3GfB/S7Qy2dYHvyv3ghl5earAmIa0x9sBl/X26ewmjJpPCWXlPzjxEAtEZmrAwcOoGfPntr7mryxo0ePxpIlS/Dqq6+q/Hnjx49X6Q0kz96WLVt00sLMmzcPNjY2akStJteePNeQ0zep6kkHQIrOLPj9PP66GA8/uxyMDUzB5Ux7uDo7Y1z3+nisfR2zSYlERFQeMtp2xIgRqFu3rjr5+dZbb6FXr14qQCujKI25COeRy7cKifnb5ag0RubIGIoySgHOffv2qe+EBPQtZb8NwRL32xL3WXC/Cyt9vMtbhJOBWiP08dazuBSfoT3bOrJdkKE3iYiIKqBHjx7qn7g75QicMWOGutypWMuCBQvUhcxfXn4BNoZH48tdF3H8WvJtj0/o2RCPPtAc9jYM0BKR5Xn00Ue1t2WUbLt27VTQdsOGDRg2bJjRFuEsRA2cizusltfxckSDOgEwV8ZQlLG0ApyWsN+GYIn7bYn7LLjfvpU+3uUtwslArZE5fCURX/9xUd22s7HC7GEhsLK6c/VvIiIiMm0ZOXn44UAkvt59EVcTMnUeC/ZxxvMd6iL1dCweDPFnkJaI6CYpximB2nPnzhl1Ec7zsenIyi2a8hpS28PsgzuGLsqoed/q3gZD77ehWOJ+W+I+C+63VaU+v/J+XxioNSLZefl49cdjKLg5+GpSWCM0rHlr+isRERGZl/i0bCz96zKW/XUJiTcLiGq0rO2G57s1wEMh/khMiMea0wbbTCIioxQfH4+rV6+qgK0xF+EMLzZDokXtio3QJSIiy8BArRH5z2/ncC4mTd1uFeiO5x+oD3MluaOkkI5cExERWZqIuHQs2n1RjaLNztMtLNCtsS/GdauPLg28tVN12W4SkaUX4ZSLpAoaPny4CsxeunQJ06dPV1PbH374YaMuwhl+rag4mWgZ4G6w7bAUbDOJyJQxUGskjkcm44udRSkPbK1rYO4jrWBjbb7D6CXXU//+/Q29GURERNWmoKAQf5yPw5I/I7D9TKzOY9ZWNTC4dQCee6A+mgfcPtqK7SYRWXoRzoULF+L48eP45ptvVLEoCdbKuqtWrTL6Ipynom4FaluU8htP+sU2k4hMGQO1RiArNx9TfziK/Js5D17s2QhNa7mZfSLq7OxslQvK0vK6EBGRZUnLzsOaQ5FYsucSLsam6zzmZGeNxzvUwT+6BqO2h2OZr8F2k4gswd2KcG7evPmur2GMRTgvxxf99ns42cLb5fZcuKRfbDOJyJQxUGsEPtx8BmdupKrbzfzdML5nA5i7hIQErFmzRlVnra5KnERERNXdMV+65zJ+OHAVqdl5Oo9JUPbpznXxWPs6cHeyvetrsd0kIjLdOiRRKVnqdl0vJ0NvjkVgm0lEpqzKhzLOnj1b5VebNGmSdpmcJZX8QgEBAXB0dFRnTk+cOAFL9Of5OHy9O0LdtrOxwrxHW8PWjFMeEBERmTOZHbP9dAzGLtmPHh/uwP/+jNAJ0naq74UvngzFzld6YFz3BuUK0hIRkemKTMiEZpBwHW9nQ28OERFZ8oja/fv348svv0SrVq10lkvFzY8//ljlCmrcuDHeffdd9OnTB2fOnNHJL2TukjJyMOX7o9r7r/VvavYpD4iIiMxRdHIWVu2/ilX7r+B6ctHIKQ17Gys83LY2Rnepp2bOEBGR5bickKG9zRG1RERksECtVOx84okn8NVXX6lAbPHRtPPnz8cbb7yhpr2LpUuXws/PDytWrMC4ceNgCeRzeGNtOKJvToPp2tAHz3SpZ+jNIiIionKS0bM7z8Zgxb6r+P30DdxMNa/l7+6Ap26mN/BytuPnSkRkgS7HFwvUejP1ARERGShQO2HCBDz00EMICwvTCdRGREQgOjoaffv21S6TglLdu3fHnj17Sg3UStEpuWikpKRok4TLpaLkuRIwrcxrVNSPByOx4XiUuu3haIu5w0MkfKsqQlclQ+5zye3QXFfHthjLflc37jePtyXQ1/fc0n4fqHK5Z1cfuoYfD1y9bfRsjRpAzyY1VYGwnk18YcN0RkREFu1K8RG1TH1ARESGCNSuXLkShw4dUqkPSpIgrZARtMXJ/cuXL5eZ53bmzJm3LY+NjUVWlm4H6V475cnJyaqDb2VVfXlhz8Vm4K2fTmvvv9orCFbZKYiJKQpAVyVD7XNJ8v4DBgxAfn4+YmJiLGa/qxv3m8fbEujre56aWlTUkag0KVm52BR+A6sPRWL/pcTbHq/l5oCR7YPwaPsgVShM37y8vDBmzBjY2LAOLBGRyaY+4IjaasE2k4hMmd7/27969SpefvllbNmyBQ4ODmWuJwXGipMOdsllGtOmTcPkyZN1RtQGBQXB19cXbm5ulercy3vK61RX8E46em8uO4Xs/KKRs4+3D8Jj9zdBdTHEPhsD7jePtyXg97xy3/M7tVlkuakNdp2NxYo9F7HrYjKy8woMNnpWvtt2dkyfQERkqqkPHGytUNPV3tCbYxHYZhKRKdN7oPbgwYNqhGRoaKh2mYya3LVrFz799FNVMEwzstbf31+7jjyn5Cjb4qkR5FLaD3Blg40StNTH65SHBKNf/fG4trFuWdsN/xrcotoDptW5z2WR0W9//vkn7r//fri7u1vMfhsC95vH2xLo43tuab8NVDpJQXToSiJ+ORaFX49HISb1VuoljYY1XTD8vkBVIKyWu4PZtptERFT5/t+1pEx1O8jTqcyBSaRfbDOJyJTpPVDbu3dvHD9+XGfZM888g6ZNm+K1115D/fr1UatWLWzduhVt27ZVj+fk5GDnzp2YM2cOzNlXf1zElpM31G13R1ssfCIUDrbWsES5ubmIjIxU10RERIbuSB+NTMYvR6+r4GzJvLPC08kWg1sHYHhoIEJqu1d7Z5vtJhGR6cnIKUDOzdkYvhxNW23YZhKRKdN7oNbV1RUtW7bUWebs7Axvb2/t8kmTJmHWrFlo1KiRushtJycnjBo1CuZq97k4zNlUNJpYzHu0NYK8WPWTiIjIUCNnj11LxqbwaGw4fh1XE4pGPBVnZ22FHk180au+M4Z2aAQHO+aHJSKi8kvKytPe9nJm+hoiIro7g/Q4Xn31VWRmZmL8+PFITExEx44dVU5bCfKao3M3UvHCtwdVrjsxoWcD9GpaepoHIiIiqhpZufn460K8mt3y26kbpaY1sLGqgQca+WBgqwD0aeEHFztrlZ7JzoapMYiI6N4kZjBQS0RERhio3bFjh859mS44Y8YMdTF3cWnZ+MfS/Ui9eTY1rJkfJvepvuJhREREliwhPQe/n47BtpM3sOtcLDJy8m9bx9qqBro08MagVgHo28IPHk52OkX6iIiIKiKZI2qJiOgecQ5fFUrNysU/luzXTqdsEeCGTx5rozqElk7SYUhBFLkmIiLSF8kFePhKogrK/nEuDsevJaOwaEKLDnsbKzVyVk6g9mnuB28X467EzXaTiMj0JGVyRK0hsM0kIlPGQG0VyczJx9ilB3AsMlnd93Ozx6LR7eFsz49cODo6okWLFlX18RMRkQUVArscn6ECs7vOxuGvC3FIL2XUrPB2tkOvpjVVYPaBRr5wtDOdgp5sN4mITE9S5q3CyZ7FZmtQ1WKbSUSmjFHDKsqB93/LD+LviARtpehlYzuilrtDVbydScrKysLVq1cRFBQEBwd+LkREVP7A7MW4dOy7mIB9EfHqOjolq8z1m/m7oVtjH/Rp5oe2dTxNdlYL200iItMeUSsnC6l6sM0kIlPGQK2epWTl4rmlB7DvZpDWxd4G3/yjIxr7mWehtIpKS0vD9u3bMWzYMAZqiYioTLn5BTh7IxUHLyeqtlUCs5L/vSzSEZaUBt0a+6JrQx/UdDOPk4FsN4mITDtQ68lAbbVhm0lEpoyBWj2KTc3GmMV/48T1FHXf2c4a/xvTHiGB7vp8GyIiIrOUl1+AczFpOB6ZrHLLHruWjFNRKSrvbFkcba3Rrp4nujTwUQHa5v5usDLRUbNERGReOKKWiIjulcUHao9eT0M3T2842luhMg5dScT45Ye00y8l3cGSZzqgdZBHpV6XiIjIHOUXFOK8BGWvJeN4ZJI2KJuVW3ZQVjNTRQKzHYO90bG+F0Jqu8PWunJtOBERUVUHaj2Yo5aIiMrBogO1RyOT8NLqs2i6JxpfPt0OfhWYHllQUIilf13CrF9PITe/qKy0v7sDlo3tgIY1me6AiIhIgrIRcWmqwKZcwq8lq9kn/9/evQBXVZ0LHP8SCEkISUjCIy8CiFKvQFKKijBU5WGAEZALHSN2esFHb22LUwcYB/VOoXOdan2gjkUdwSqoiJ1CFKS0QIFQBREfXAhSLl4QiQQCMS8gvMy+8y3MMQESojmc/Vj/38yeJOfsJOfba5/znfWtddauPX3hi341dFmnBOmblSy52cmmOPtvGYnSlsIsAMBHhdrE2LbSri2DigCAi2trc6dx2p+3ycmvHfmfkioZ98d35albfyiDL+/U4r+x40CV/NdbxfLJF5Wh267tkSp/vL1/YNbEu1Tatm0rXbp0MV8BAMGhA5h7y4+Fli/Qr8UHquT4qYsXZXuktQ8VZftldZQ+WUmSFBcTkcftdeRNAPCfqm8KtakduJBYJJEzAfiZtVUyverzs7f9UO5esEUO1pySQ9Un5fb5m+Xf+2fJvcMul8s6d2jyatO6zMGf3vtcVm4vlbqzk2iNu4b0lJmjr+QjmC3QsWNHGT9+fNjaEwDgTlF231fHZVtJpZklq7Nldabs0ZPfftSzKd1S4yU3q6NZx12XL+ibmSzJ7SnKNoW8CQD+W3e9+uTZQcoUlj2IKHImAD+ztlCrrspMkj9NulL+e82XsmlPubmt8JMvzXZ19xQZ1CtNeqQlSFxMG6msPSW7Dx2Vdz87YtbUa+iyzgny8Pi+5kImAAB8F7Nnz5bf/e53jW7r2rWrHDx4MDRAqPe/+OKLUlFRIQMHDpS5c+dKnz59Inqg9XGUVJ6ULQdLpfhA9dklDA5USc2JixdlszrGm1my9bNltSjL1a8BAEFWcfx06Pu0BGbUAgBaxupCrUptHyOv3nmNLNqyX+as/l+p/CahfrivwmzN6dShndw5pKeZSRvbtk2EHnEwHDlyRJYuXSoTJkyQTp0ocAOwmxZd16xZE/q5TZtvc8pjjz0mc+bMkVdeeUV69+4tDz/8sNx0002ya9cuSUyM3FroJ8/UScGCYvlmOfYmZSbHhWbJ9svuaL6m0kFtNfImABts2LBBHn/8cfnoo4+ktLRUCgsLG30KryWDlydPnpQZM2bIG2+8IbW1tTJ8+HB57rnnJDs7O6KxVBw/FfqewcnIImcC8DPrC7UqOjpK/mNQD7nlh1ny5pYv5M0t++X/Dh+74AGLjhLpn5Mik67NkbF5GRRoAQCtT8Zt20p6evp5t2uH9Omnn5aHHnrIDGypBQsWmBm3ixYtkl/84hcRO/r66ZKeafHy2ZHa0G3pSXHfrin7TXG2U4fYiD0mAECwHDt2TPLy8uSOO+6QiRMnnnd/SwYv77vvPlm+fLksXrxY0tLSZPr06TJmzBhT/G04EHqpVRz7tlDLgCUAoKUo1DaQHB8j/3l9L7OVVByXTw9Uy4HKWjn1dZ10iI2R7mntpU9mknRkjSEAQBjt3r1bMjMzJTY21swO+v3vfy+XXXaZ7N271yyBkJ+fH9pX97nhhhtk48aNTRZqdTaRbvWqq6vN17q6OrN9H/p7Y/ukyddtYs/OlM1MuuCFM7/v3/cqjUcL5m7HVf//W9OGfow70oib9rZBuM7zS/H6MHr0aLNdSEsGL6uqquSll16SV199VUaMGGH2ee2116Rbt27mkysjR46USMlJay8zhnaTM9GxcnWPtIj9XwCAv1GobUJ2SnuzAQBwKWlhduHChWZm0KFDh8zsoMGDB8uOHTtC69RqJ7Qh/Xnfvn1N/s1HHnnkvHVv1eHDh+XEiRPfu0Oe36OdJCcnSXS0iJyolrITZwvAQaZxa8dfCwTRJnB3VFZWmq9fffVVxAq1Xog70oib9rZBuM7zmpoaiaSWDF7qrNnTp0832kcHQvv27Wv2aapQeykGOLsmxsrE3M7SuXNnc5xtGfjywoBXpAc3vRK3G2yM28aYFXHXheUYtgSFWgAAXNRw5lC/fv1k0KBB0qtXLzNL6LrrrjO3R0VFNfodfXN47m0NPfDAAzJt2rRGHU6dTaSdxaSkpO/9xkL/Z32H0xZeibv+f6empkZkbXevxB1pxE172yBc53lc3PmfqriUWjJ4qfu0a9dOUlJSztun/vcjOcDJgFe0FYObiva2Z6CPtranrcPd3i0d4KRQC1d07NhRCgoKJCEhgRYAgAb0dVELtrocQv0FVLRzmZGREdqnrKzsvI5qQzrDSLdz6ZuL1rzB0I59a/+GH3khbi3Q1ufNSD0OL8TtBuKmvW0QjvPcrdeG7zp42ZJ9GOAM1oCX5kx9n6Q5U68DYEvcbrAxbhtjVsTdudXt3dIBTgq1cIUmzOTkZI4+AJxDP3q5c+dO+fGPfyw9e/Y0FxlbvXq19O/f39x/6tQpKSoqkj/84Q8cO4uQNwHYrv6im80NXuo+micrKioazarVfXRZoaYwwBmsAS+dVa2bbXG7xca4bYxZEXd0q45fS88Xu84qeIZ+DHft2rWh9Z8AwFYzZswwhVdde2/z5s3yk5/8xLw2Tp482bwZ0qtX68XFCgsLpbi4WKZMmSLt27eX22+/3e2HjggibwKwXcPBy3r1g5f1RdgBAwZITExMo31KS0tN/myuUItgIWcC8DNm1MIV+qbqs88+k9zcXFoAgNVKSkpk0qRJcuTIEfMRKl2X9v3335fu3bub+++//36pra2VX/3qV2aGkF58bNWqVZKYmOj2Q0cEkTcB2ODo0aOmj1BPBzG3bt1qPsqek5MTGry84oorzKbfNxy81E/s3XXXXTJ9+nRJS0szv6cDorqk0IgRI1yMDJFEzgTgZxRqAQBw0eLFi5u9X2fVzp4922wAAATZhx9+KEOHDg39XH9hTP2UySuvvNKiwcunnnrKLBdz6623mn2HDx9ufrdNmzauxAQAwHdBoRYAAAAA4Lobb7zRXPirNYOXerGWZ5991mwAAPiNLwu19cm7teub6lXrampqTDK3ZRFor8Ssj0FHuPVrJBZ690rckUbctLcNwnWe1+eU5jqIfhWOvMnrCXnTBpzn5E0bkDcvjrzp/vnlp76mV+J2g41x2xizIu64Vrd3S/ubUY4Pe6S6nl+3bt3cfhgAgADav3+/ZGdnS5CQNwEAlwp5EwCA8OVNXxZqtZJ/4MABsxaRfvylNdVsLfjqQUpKShIb2BizIm7a2wac5607zzUd6uh4ZmZm4EbHw5E3Ob94HbUB5znnuQ3CdZ6TNyNznP2GuGnvoOMc5xy/1HnTl0sfaEDhnO2kidOm5GlrzIq47UJ72yUc7a1Xiw6icOZNnld2ob3tQnvbhbzZNPKmN84vPyJue9DWdkkK02taS/qbwZoyBAAAAAAAAAA+RKEWAAAAAAAAAFxmdaE2NjZWZs2aZb7awsaYFXHT3jbgPLfrPI80zi+7zi/am/a2Aee5Xed5pHF+2XV+0d72tDdtbU9bu9XevryYGAAAAAAAAAAEidUzagEAAAAAAADACyjUAgAAAAAAAIDLKNQCAAAAAAAAgMso1AIAAAAAAACAy6wt1D733HPSs2dPiYuLkwEDBsg///lP8avZs2dLVFRUoy09PT10v14vTvfJzMyU+Ph4ufHGG2XHjh2N/sbJkyfl3nvvlU6dOklCQoKMGzdOSkpKxEs2bNggY8eONXFojG+99Vaj+8MVZ0VFhfzsZz+T5ORks+n3lZWV4tW4p0yZcl77X3fddb6O+5FHHpFrrrlGEhMTpUuXLjJ+/HjZtWtX4Nu7JXEHsb2ff/55yc3NlaSkJLMNGjRIVq5cGei29iPyJnnTL88t8iZ5syHyJnnTDUHKmYr+ZnDfk9qYMxX9TfqbK73c33QstHjxYicmJsaZN2+e8+mnnzq/+c1vnISEBGffvn2OH82aNcvp06ePU1paGtrKyspC9z/66KNOYmKis2TJEmf79u1OQUGBk5GR4VRXV4f2ueeee5ysrCxn9erVzscff+wMHTrUycvLc86cOeN4xV//+lfnoYceMnHoqVtYWNjo/nDFOWrUKKdv377Oxo0bzabfjxkzxvFq3JMnTzaPuWH7l5eXN9rHb3GPHDnSefnll53i4mJn69atzs033+zk5OQ4R48eDXR7tyTuILb3smXLnBUrVji7du0y24MPPmheo/U4BLWt/Ya8Sd7003OLvEneJG+SN90UtJyp6G86gX1PamPOVPQ36W/GeLi/aWWh9tprrzUHuaErr7zSmTlzpuPXxKknyIXU1dU56enp5sSrd+LECSc5Odl54YUXzM+VlZXmJNU3FfW+/PJLJzo62vnb3/7meNG5SSRcceqbKf3b77//fmifTZs2mdv+9a9/OW5rKnnecsstTf5OEOLWgQd9LEVFRVa197lx29LeKiUlxZk/f741be115E3ypl+fW+RN8iZ5k7wZaUHLmYr+ph39D1tzpqK/SX/zUQ89t61b+uDUqVPy0UcfSX5+fqPb9eeNGzeKX+3evdtM09aP2Nx2222yZ88ec/vevXvl4MGDjeKNjY2VG264IRSvHo/Tp0832kf/Vt++fX1zTMIV56ZNm8wU9YEDB4b20Y926G1ePhbr1683H5Xv3bu3/PznP5eysrLQfUGIu6qqynxNTU21qr3PjduG9v76669l8eLFcuzYMbMEgi1t7WXkTfJmEJ9bQX4dVeRN8iZ50x1BzZmK/qa970mDnjMVeZO8me+h57Z1hdojR46YQkDXrl0b3a4/6wuvH+mJsHDhQvn73/8u8+bNM3EMHjxYysvLQzE1F69+bdeunaSkpDS5j9eFK079qknoXHqbV4/F6NGj5fXXX5e1a9fKk08+KVu2bJFhw4aZNVSCELcO7k6bNk2GDBliXghtae8LxR3k9t6+fbt06NDBJMV77rlHCgsL5aqrrrKirb2OvHkWeTM4z62gvo7WI2+SNxV50x1BzJmK/qYd/Q8bc6Yib5I3vfbcbiuW0kWwz31ynnubX+iLZ71+/fqZWWi9evWSBQsWhBb6/j7x+vGYhCPOC+3v5WNRUFAQ+l4LeldffbV0795dVqxYIRMmTPB93FOnTpVt27bJu+++a1V7NxV3UNv7Bz/4gWzdutUstr5kyRKZPHmyFBUVWdHWfkHeJG8G5bkV1NfReuRN8qYib7orSDlT0d8Ua59bQc+ZirxJ3vTac9u6GbV6hbY2bdqcV9HW6fvnVtD9Sq9ApwVb/XhKenq6ua25eHUf/ZiOXqGuqX28Llxx6j6HDh067+8fPnzYN8ciIyPDJE9tf7/HrVdVXLZsmaxbt06ys7Otae+m4g5ye+sI5eWXX27e/OlVWPPy8uSZZ54JfFv7AXnzLPJmcJ9bQXkdVeRN8iZ501025ExFf9Pe96RBypmKvEneTPdgf9O6Qq0WAwYMGCCrV69udLv+rMsFBIF+DGHnzp3mRVTXrNUTpmG8eoLpTLX6ePV4xMTENNqntLRUiouLfXNMwhWnzkbW9Wk++OCD0D6bN282t/nlWOiSF/v37zft79e4ddRJRzaXLl1qPmaj7WtDe18s7qC2d1PHQl/LgtrWfkLeJG8G/bkVhNdR8iZ5k7zpDTbkTEV/0973pEHImYq8Sd50vNzfdCykV2rTK7a99NJL5sps9913n5OQkOB8/vnnjh9Nnz7dWb9+vbNnzx5zhbkxY8Y4iYmJoXj06nV6xbqlS5c627dvdyZNmuRkZGQ41dXVob+hVybNzs521qxZ43z88cfOsGHDnLy8POfMmTOOV9TU1DiffPKJ2fTUnTNnjvl+3759YY1z1KhRTm5urrlCn279+vUzx9SLcet92v4bN2509u7d66xbt84ZNGiQk5WV5eu4f/nLX5q21PO6tLQ0tB0/fjy0TxDb+2JxB7W9H3jgAWfDhg0mpm3btjkPPviguYLmqlWrAtvWfkPeJG/66blF3iRvkjfJm24KWs5U9DeD29+0MWcq+pv0N6M93N+0slCr5s6d63Tv3t1p166d86Mf/cgpKipy/KqgoMCcRPqGIDMz05kwYYKzY8eO0P11dXXOrFmznPT0dCc2Nta5/vrrzcnXUG1trTN16lQnNTXViY+PNyfTF1984XiJJgZNHudukydPDmuc5eXlzk9/+lNT7NZNv6+oqHC8GLd2RPLz853OnTub9s/JyTG3nxuT3+K+ULy6vfzyy6F9gtjeF4s7qO195513hl6PNbbhw4eHkmZQ29qPyJvkTb88t8ib5E3yJnnTbUHKmYr+ZnD7mzbmTEV/k/7mKg/3N6O+OUkBAAAAAAAAAC6xbo1aAAAAAAAAAPAaCrUAAAAAAAAA4DIKtQAAAAAAAADgMgq1AAAAAAAAAOAyCrUAAAAAAAAA4DIKtQAAAAAAAADgMgq1AAAAAAAAAOAyCrUAAAAAAAAA4DIKtQAAAAAAAADgMgq1gA9ERUU1u02ZMqXZ39f7Z86c2eR948ePb3TbX/7yF4mLi5PHHnssrHEAABAJ5E0AAMibgB+1dfsBALi40tLS0Pdvvvmm/Pa3v5Vdu3aFbouPj2/yd+vq6mTFihWybNmyFh3q+fPny69//WuZO3eu3H333TQPAMB3yJsAAJA3AT+iUAv4QHp6euj75ORkM1Oo4W3Nee+99yQ6OloGDhx40X11Bq0WgRctWiQTJ05s1WMGAMAt5E0AAMibgB9RqAUCTmfSjh071hRrm6NLI+gs2nfeeUdGjBgRsccHAICXkDcBACBvAm6hUAtY0OF84oknmt1n5cqV8vbbb8s//vEPGTZsWMQeGwAAXkPeBACAvAm4hYuJAQG2c+dOKSkpuegM2dzcXOnRo4dZ9qCmpiZijw8AAC8hbwIAQN4E3EShFgj4rKCbbrqp2YuNqaysLCkqKjIXXxk1ahTFWgCAlcibAACQNwE3UagFAkyXMxg3blyL9s3JyTHF2rKyMsnPz5fq6upL/vgAAPAS8iYAAORNwE0UaoGA0oLrli1bZMyYMS3+nezsbFm/fr2Ul5ebYm1VVdUlfYwAAHgFeRMAAPIm4DYKtUBALV++XAYOHChdunT5Tr9XvwxCZWWlWTZBvwIAEHTkTQAAyJuA26Icx3HcfhAAwk+XPBgyZIjcf//9HF4AAMibAADQ3wQ8jhm1QEBpkXbSpEluPwwAAHyBvAkAAHkTcBszagEAAAAAAADAZcyoBQAAAAAAAACXUagFAAAAAAAAAJdRqAUAAAAAAAAAl1GoBQAAAAAAAACXUagFAAAAAAAAAJdRqAUAAAAAAAAAl1GoBQAAAAAAAACXUagFAAAAAAAAAJdRqAUAAAAAAAAAcdf/A04oXPGyFn4sAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWoAAAF7CAYAAABLi7JfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAArBRJREFUeJzs3Qd0VNXWB/A/6b13Ugi9JLTQBKSGpjRBUbGAovIJ+kTAgljAJyA8BSxP3tOHgCBioVtoKiAiUgOEXkIJJCQhvddv7RNmyECAAJlM+//WmjUzd+5M7py5kzN33332qVVWVlYGIiIiIiIiIiIiIjIYK8P9aSIiIiIiIiIiIiISDNQSERERERERERERGRgDtUREREREREREREQGxkAtERERERERERERkYExUEtERERERERERERkYAzUEhERERERERERERkYA7VEREREREREREREBsZALREREREREREREZGBMVBLREREREREREREZGAM1BIREZHRO3DgAJ566imEh4fDwcEBLi4uaN26NWbNmoXU1NRq+RsFBQX49NNP0blzZ3h6esLOzg61a9fGsGHDsGXLFlS3p59+Gn379r3leps3b0atWrXUtT5069YNERERqAnyPqZMmXLTdc6cOaPWW7hwoXaZ3JZl8pgpk/cu78PPzw9ZWVnXPV6nTh3079+/0uempKTA3t5ePX/37t2VrlNWVoZly5bh3nvvVX9DvivBwcHo06cP/ve//91wu+S7JK/7wQcfVPm9XLx4Ub2fmJgYGIK01ciRI+/o+/PEE09g8ODBet5CIiIiotvHQC0REREZtS+++AJRUVHYtWsXXnnlFaxbtw4rV67EQw89hP/85z8YNWrUXf8NCYJ16tQJ48ePV0FLCQz++uuv+PDDD2FtbY2ePXti//79qC779u3DokWL8N5771Xba5qz+++/H3/99RcCAwNhDpKTk9VJhtuxePFiFBYWqtvz58+vdJ1Jkybh0UcfRZMmTVRg9pdfflH7mL+/P1avXl3pcyTQKvvjzV73RoHaqVOnGixQK/8D3nrrrTt6rgSYf/rpJ/z222/Vvl1EREREd8Pmrp5NREREpEcSnHv++efRq1cvrFq1SmUUasiyCRMmqMDt3XryySdVIHb9+vXo0aOHzmOPPPKICuBKlm11ef/999GuXTu0adOm2l7TnPn6+qqLuZBM6jlz5mDs2LEICAio0nO+/PJLlSUbFhaGb775BrNnz4ajo6P28by8PMydO1fty59//rnOcyXztLS0tNLX1WTaSjBcgpfbt29Hx44dYexatWp1x8+tV6+e+gzke3jt952IiIjIkJhRS0REREZr+vTpatiyBJ4qBmk1pDzBwIED7+pv7NmzR2UeSmbujYI2bdu2RWhoKKrDpUuXVDagDL++1tGjR1UAycnJCT4+Pvi///u/SofIb9y4EYMGDVLD2mV4e/369TF69GiVGXxt5uZzzz2HkJAQ1X4S7JTM4U2bNl33mpKxLEPm5W/XrVtXBbGuDe5lZmZi4sSJqgSFpjTEuHHjkJOTc916zz77LLy9vVWZCnlPx48fv+M2q6z0gaZkQ3Vud02RLNfi4uJbloHQ+PvvvxEbG6v2GWnXjIwMLF++XGcdeS9SvuNGWcdWVtf/7M/Pz8fSpUtVxroEjjUB4VuRMgLynRBSkkQ+m6qUtaj4fFlf/vZrr72mtln2kwEDBqjvh+zzst/Kd0Au8jeys7NvWfqgqt8fIW0p34NTp05VaZuJiIiIagIDtURERGSUSkpK1NBkCSJJoLEqJEAnAbBbXeS1NTZs2KCua6pmpfy9oqIidO/eXWe5BKi6du2qAnKfffaZGuouwakXXnjhuteQ4NI999yDefPmqdd7++23VTBP6uvKa1cMRkkmsjwu60n2ZHR0NC5fvqzzeomJiXjsscfw+OOPY82aNejXr58aRr9kyRLtOrm5uWr7pGTDP/7xDxXcliCbBFElWC71UYVcS1vK9kvGswSlO3TooF6zulXndlfnPnUrkhU7ZswYVWqgKgFsTUkCqWssGd4SiLy2TIEEJiVgL/uOZNtK0PJW723FihVIS0tTr9ugQQO1/3z77bfXBUUrq2m7YMECdfvNN99Ume9yeeaZZ3A73njjDSQlJanPQsqMSABXSjcMHToU7u7uKnP41VdfVfuSrHszt/P90QT6pX1+/vnn29pmIiIiIr0qIyIiIjJCiYmJEmUqe+SRR6r8nBEjRqjn3OrStWtX7XP+7//+Ty07evRoWU14/vnnyxwdHctKS0t1lr/22mtltWrVKouJidFZ3qtXL7V9v//+e6WvJ69TVFRUdvbsWbXe6tWrtY+5uLiUjRs37qbbI20hz/v77791ljdt2rSsT58+2vszZswos7KyKtu1a5fOej/88IN6/s8//6zu//LLL+r+Rx99pLPetGnT1PJ33nnnptsTFxen1luwYIF2mdyWZfKYvrb7RmR7q7JPhYWF3fR1Kr5WcnJyWUpKSpm7u3vZ0KFDtY/La9x///06z8nJySlzc3Mr69Chg85+LvvKyZMnddbduXNnWWhoqHabXF1dy/r371/21VdfXbe/iR49epQ5ODiUpaWl6bTz/Pnzb/lepD2v/ZyqSvZlee6AAQN0lsu+Ksv/8Y9/6CwfPHhwmZeXl84yaStph7v5/tSuXbvs4Ycfvu3tJyIiItIXZtQSERGR2ZCh1zIU/laX//73vwbbRpmESUoQyNDvin7//Xc0a9YMLVq00Fk+fPjw615DshBlWLdkGtvY2MDW1lZlaYojR45o15M6uJKtKEPtd+zYoZNtW5HUSZV1K2revDnOnj2rvf/jjz+qUgMtW7bUySTt06ePei+SDal5H0IyXW/1Pu5WdW73jcgQ/KrsU2vXrr2tbZeyEJLZKyUMJBv6Rr777jtVukGyXjXktmSDarJaNaQcwcmTJ1XdZslAlaxrmRRP6tZemz0cFxenPqshQ4bAw8NDLZMJ+lxdXatU/qA69O/fX+e+TIKmqZd77fLU1NSbZvrezvdHQ2r+Xrhw4Q63noiIiKj6cTIxIiIiMkoylFuGeEtAqaqkjqzUbb2VikFSTe1Z+TuNGjWCvsmkT1JX9lpSjkBqqF7r2smmZCh+7969VcBXZr2PjIyEs7OzWi4lBuT1NWQYuwRppeSBrCt1QB944AHMmjVL53UlaHgtqWlb8bVkaLkEASUoXBlNfVx5HxI8vvY1qzpp1u2ozu2+EdluCejdyrWB96qQOrmffvqpGt6/ZcuWSteREgeyv0jt1fT0dG0wWmq0ShB+6tSpsLa21q4v71OC0HLRfB4PPvigClhL2Yf77rtPLZdgrARu5THN6woJ6H799deqdELjxo2hT15eXjr3pX7wzZZLTV3ZhytT1e9PRdKuFfcVIiIiIkNjoJaIiIiMkgSfevbsqYJL8fHxVQrASqah1CK9FallqcmklICWZB9KLVcJhtVEAHrv3r2VBh2l5uq1rl0mNTj379+vgnQjRozQLpdgZGV/a+7cuepy7tw5Vcf19ddfVxm5knV5u9vt6Oh4w2xLeVzzPiRjVQJnFQOplb23mlDV7b6Rd999VwVDb0UymitOdlYVsl2SBS5Zuz/99NN1j0v92m3btqnbN5rMbv369drga2XkM5CAsOzvsu/IuhLUl/1HSEZtZaS9JKBvKqr6/alIsnQl4E1ERERkLBioJSIiIqMlE0PJZD8y0/3q1au1mXUaMpRfAo4yW7yQoNeNJg+qSIZ3V5wYSSahkszFYcOGoUePHtetv3v3bpVVeaNg2e2QLEWZJCkjI0NNmKQhk4tJYEyCsBWHby9durTSzE3JHK3oVuUcZNulbWQo/J9//nlHw9SnT5+uAmKVZS5e+z4kK1Mm77rR+6gpVd3uG5Eg6rVD9Ctz7edRVXJyYc6cOSqALgHUijQThn3xxRdqorCKJBN00KBBKqAqwVf5LkiJhMqyjDXlMIKCgrTBXTn5MXbsWJVRey3ZT7766ivVbpIdfbP3aywZqVX9/mjIyYTz58/fNMhNREREVNMYqCUiIiKjJTU2582bhzFjxiAqKgrPP/+8qkMpQal9+/bh888/V/VHNYFayY67kww5CUpJNq0EbCVwJteenp5ISEhQtUclsLpnz55qCdRqZpuXuqRSwkBDsh4l6Cb1OaVcgb+/v3YI+rWB3nr16qnAnryODBOXbdy4caPOehIIluCV1OiU50hwWmqpSmD7RlmUNyPbJ/VUu3TpgpdfflkNv5fAomTqbtiwARMmTED79u3Ve5J1ZDh/Tk4O2rRpowLDixcvhiFUdbtvRIKbmgCnvjLHJSAqJSmEbJ8mkCj7pdRnfeaZZyp9ruz3kiWdnJysAviy70ud2ejoaFW/WGq6SibtRx99pF5H87lLAFgCsJJJXtl7Gz16tAqyS5avBIMrI/ugZATLPiqvLSUJ9N1WN1PV74/GgQMHkJubq74jRERERMaCk4kRERGRUZNsWslolUDtzJkzVSBw8ODBKngqQUgJ1t4tGf4uQ8w/+OADlZH3xBNPqMxaCexJMEeCYddOUnSnOnXqpAJqkiF8bS1NqVPatGlTFZB+/PHHVQ1NqWFakdQglcBsw4YNVUDt0UcfVaUMNm3apLOePFcCkBIglYm9JPgstWplAivJ0LxdUgf3jz/+wMiRI1WbS0BMMpA//vhjVZZCEyC3srJS7SV/UzIc5bPavn27yow2hKputyFJG3Xs2FFnmQRJZdi+fMY3y/aVkxbyGbu5uakSDVKTVwKw8j0ZOnSoqk0rQUzZv6Xms9Tklf1HsoRvFFSV/V+CsJqM3srIa0lgVEpcyN+Sicyq47t4p6r6/dGQUifyva94soSIiIjI0GqVVZz+lYiIiIj07sMPP8S0adPUjPMSECOimlNSUqJKSciJHvkeEhERERkLZtQSERER1TCpDSr1af/973+z7Ylq2JIlS1RZiFdeeYVtT0REREaFgVoiIiKiGiZDsmW4+p1OQEVkjGSgntTWvdnFGAbzSY1iqV/r4eFh6E0hIiIi0sHSB0REREREdNdk4rJbTc61YMECVS+YiIiIiK7HQC0REREREd21rKwsHDt27KbrhIeHw9vbm61NREREVAkGaomIiIiIiIiIiIgMjDVqiYiIiIiIiIiIiAyMgVoiIiIiIiIiIiIiA2OgloiIiIiIiIiIiMjAGKglIiIiIiIiIiIiMjAGaomIiIiIiIiIiIgMjIFaIiIiIiIiIiIiIgNjoJaIiIiIiIiIiIjIwBioJSIiIiIiIiIiIjIwBmqJiIiIiIiIiIiIDIyBWiIiIiIiIiIiIiIDY6CWiIiIiIiIiIiIyMAYqCUiIiIiIiIiIiIyMAZqiYiIiIiIiIiIiAyMgVoiIiIiIiIiIiIiA2OgloiIiIiIiIiIiMjAGKglIiIiIiIiIiIiMjAGaomIiIiIiIiIiIgMjIFaIiIiIiIiIiIiIgNjoJaIiIiIiIiIiIjIwBioJSIiIiIiIiIiIjIwBmqJiIiIiIiIiIiIDIyBWiIiIiIiIiIiIiIDY6CWiIiIiIiIiIiIyMAYqCUiIiIiIiIiIiIyMAZqiYiIiIiIiIiIiAyMgVoiIiIiIiIiIiIiA2OgloiIiIiIiIiIiMjAGKglIiIiIiIiIiIiMjAGaomIiIiIiIiIiIgMjIFaIiIiIiIiIiIiIgNjoJaIiIiIiIiIiIjIwBioJSIiIiIiIiIiIjIwBmqJiIiIiIiIiIiIDIyBWiIiIiIiIiIiIiIDY6CWiIiIiIiIiIiIyMAYqCUiIiIiIiIiIiIyMAZqiYiIiIiIiIiIiAyMgVoiIiIiIiIiIiIiA2OgloiIiIiIiIiIiMjAGKglIiIiIiIiIiIiMjAGaomIiIiIiIiIiIgMjIFaIiIiIiIiIiIiIgNjoJaIiIiIiIiIiIjIwBioJSIiIiIiIiIiIjIwBmqJiIiIiIiIiIiIDIyBWiLSq3nz5qF169awtbXFlClTYOnbQUREpE/s74iIyNwYS99mLNtB5o2BWiLSq8DAQEydOhWDBw82aEsby3YQERHpE/s7IiIyN8bStxnLdpB5szH0BhCRedN0YqtXr+Z2EBERWUi/S0REZG59m7FsB5k3ZtSS2Tpw4ACeeuophIeHw8HBAS4uLmqYwqxZs5Camqr3v19SUgI/Pz/MmTPntp+7cOFC1KpVC7t374Yx0GzPmTNnavTvXfv+U1JS0KZNG/VZbty4sUa2hYiI7q7P6t+/P+rUqWOQPlWGJcq2Sf9hKn2uIfpdIiK6e3///TceeOABhIaGwt7eHv7+/rjnnnswYcIEg/SBlt6/8ZiSTBUzasksffHFFxgzZgwaNWqEV155BU2bNkVRUZHqpP7zn//gr7/+wsqVK/W6DVu3bkVycjKGDBmi179jKeLj49GrVy9cunQJmzZtQocOHQy9SUREVEPYpxIRkTH76aefMHDgQHTr1k0lBskQ+YSEBHX8uWzZMnz44Yd3/NrsA6sPjynJFDCjlsyOBGGff/55REdHY8+ePSpgKx2mBPkmTZqEo0ePqkxbffvhhx9U9mdYWBjMUc+ePVWmcmWXt956q1r/1okTJ9CpUydkZGRgy5YtOkHamtwOIiIyDHPvU6uC/R0RkfGS4KyM5Fy/fj0eeeQRdO3aVV1/8MEHOHfu3F29tjn3gTymJLoeA7VkdqZPn66GU3z++edqyMm17Ozs1NnOikMi9+3bpzJf3dzc4O7ujscff1xlw96psrIylbE7dOhQ6JNm+6XMw0MPPaS23cvLC+PHj0dxcTGOHTuGvn37wtXVVQ07lR8Q19q2bZvqIGUdJycndOzYUZ0RvpVff/0V+fn5lV7++c9/Vtt7jImJQefOnWFjY6O2NTIy0iDbQUREhlHdfaqcsK1bty7at2+PpKSk23quJfS7RER0+y5fvgwfHx91zHItKysroz6utIS+jceUZEoYqCWzIvV7fvvtN0RFRSEkJKTKz5NaQvXr11dnK6WjWrVqFfr06aPKJdyJ7du3q6Eu+g7UagwbNgwtWrTA8uXL8eyzz6r6RS+//LIqdn7//ferzr1Hjx547bXXsGLFCu3zJDtVlkum6vz58/HNN9+oznXAgAH49ttvq2XbpHOXjlY+m4q3q0I6fMmGlppMclsOrA2xHUREdGua/6/XXuQg825UZ58q/Z4cPDZv3hy///676l/uhLn2u0REdGekFq3UqP3HP/6hru/0ONKQx5Xm2rfxmJJMThmRGUlMTJSjwbJHHnmkSuu/8847av2XX35ZZ/nXX3+tli9ZsuSOtmPcuHFlkZGRZXdqwYIF6u/v2rWrStv/4Ycf6ixv2bKlWr5ixQrtsqKiojJfX9+yIUOGaJd16NChzM/PrywrK0u7rLi4uCwiIqIsODi4rLS0VGd74uLibvu9aLax4kVeryrvXy7u7u5lSUlJt/13q2M7iIjo1ir+z77RJSws7I6b8m76VM3//uTk5LLFixeX2dnZlf3jH/8oKykpue0+15z7XSIiujspKSllnTt31v7ftbW1LevYsWPZjBkzdP7n12QfaGzHlHfTv/GYkiwJM2qJADz22GPXnU2UYSuSbXMn5AxjTWXTambUrqhJkyZq+Eq/fv20y+T9SNbw2bNn1f2cnBx1tvfBBx+Ei4uLdj1ra2s88cQTqtC6DHO5W5KhLNlUFS8jR46s0nOlRIWcmR03btxdZwPdzXYQEdGtffXVV9i1a9d1Fylfczeqo0+dNm2a+p///vvv46OPPrqrYajm3O8SEdGd8fb2xh9//KH6PelrBg0ahOPHj6s5UqR0W0pKitEfV5pr38ZjSjI11xdQITJhUhdIauLExcXd1vMCAgJ07ksHJJ2t1Bq6XTt37lQF42syUCs1hK6twyvtIBNqXbs8MzNT3U5LS1MdnMxIeq2goCB1fSfvvzrJZGAtW7bEu+++i9LSUixZskR1+kREZHzkgE4mO7mW1Lo7f/78Hb1mdfWp0n/Url1bTexSHcy13yUiorsj/aCmL5TyB1ImQEoISF3Xymq7GtNxpbn2bTymJFPDjFoyKxLEkyLme/bsUWfvqioxMVHnvtS9kQ5FgrW3S2r6NGzYEBERETBmnp6eKqNIah5d6+LFi9rAt6FNnToV77zzDpYtW4bhw4erz4aIiCxDdfWp69atg62tLe69915tFlBNM5V+l4iIqof0O3IcI2JjY83yuNJU+jYeU5IpYaCWzI4ML5GzelIAvbCw8LrH5czm2rVrdZZ9/fXXOve/++47FRCUiazupEOtyWzaO+Xs7KxmvJbhNHl5edrlmszV4OBg9cPAGMhQF+lc5XNhsJaIyHJUV58aFhamhqTa29urYO2JEydQ00yp3yUiottTWaBSHDlyRCe71NyOK02pb+MxJZkKlj4gs5xxc968eRgzZgyioqLw/PPPo1mzZipAu2/fPnz++efqrKTMQqkhHYuUO+jVqxcOHTqkhkfIjJdSq/Z2xMTE4NSpU9XWoUpNIH2aMWOGes/du3fHxIkT1TCWzz77TJ3xldk69f33b8fbb7+tztbKZyOBeNk++cyIiMg8VXefKsMyZWbqPn36oEuXLti4caNOllJN9Hmm1O8SEVHVSd8iQUk5xmzcuLEKVEo/9uGHH6rarS+99JLB+kAeU17FY0oyBYxykFmSbNp27dqpekAzZ85UpQ1k6ImczZOMzBdeeEFnfQnUyhk2CfBKRyYd7Ny5c9UB1O2e9ZSsHQkQ343c3Fx1LZk/+tS1a1f89ttvakiOFGOXHxQSoF6zZs11xeSNwZtvvqmCtZMnT1bbKuUQ5HMlIiLzU119akUy/FL6vfvvv1/1gevXr6+xPtcU+10iIqr6ccrq1avV8adk1xYUFKgThNHR0WrEp9Rxr+k+kMeUN/6seExJxqxWmaSmEVkozfCH5OTkaqmd07RpUzUrppw5vRtyxvXTTz9Feno6XF1d73q7iIiITE119am3wj6XiIjMsQ9k/0ZkmphRS1SNDh8+fFfPl0nQdu3ahS+//BIDBw5kkJaIiCzW3fapt8I+l4iIzLEPZP9GZNoYqCUyIg8++CAyMjJUkPbjjz829OYQERGZLfa5RERkjti/EZk2lj4gIiIiIiIiIiIiMjArQ28AERERERERERERkaVjoJaIiIiIiIiIiIjIwBioJSIiIiIiIiIiIjIwk5xMrLS0FBcvXoSrqytq1apl6M0hIiIzUFZWhqysLAQFBcHKyrzOY7LfJCKi6sZ+k4iISA/9ZpkJOn/+fJlsOi9sA+4D3Ae4D3AfqO59QPqY6vLZZ5+VRUZGlrm6uqpLhw4dyn7++Wft4yNGjLju77dv317nNfLz88teeOGFMm9v7zInJ6eyAQMG3PY2st/k94T/K7kPcB/gPmAK/aaxYL/J7wv/Z3If4D7AfQAG6jdNMqNWMmnF+fPn4ebmBnMmWVDJycnw9fU1eIbX5cuXsWbNGgwcOBDe3t4W2w6GxHZgO3B/0N/3IjMzEyEhIdo+pjoEBwfj/fffR/369dX9RYsWYdCgQdi3bx+aNWumlvXt2xcLFizQPsfOzk7nNcaNG4e1a9di2bJl6n/vhAkT0L9/f+zZswfW1tZV2g5L6TeN7X+kofpNY2sHQ2E7sB24T5hev2ks2G8aBvtNw2K/yXbg/qDf70VV+02TDNRqyh3IwaY5H3Bqdor8/Hz1Pg19sGVvb68CDIGBgeq2pbaDIbEd2A7cH/T/vajOkjoDBgzQuT9t2jTMmzcPO3bs0AZq5f9pQEBApc/PyMjA/PnzsXjxYkRHR6tlS5YsUR38pk2b0KdPnypth6X0m8b2P9JQ/aaxtYOhsB3YDtwnaua7YY6l6NhvGgb7TcNiv8l24P5QM9+LW/WbJhmoJcN1nHXq1GHzExHdgZKSEnz//ffIycnBPffco12+efNm+Pn5wcPDA127dlXBXLkvJGu2qKgIvXv31q4vNY0iIiKwffv2GwZqCwoK1KXi2VvNDw25mCt5b1L7yVjeo62tLUJDQ9XtmtwmY2sHQ2E7sB24T+j3u2Hp/2Oo+vF4k4iIgVq6Dbm5uTh27BgaNWoEJycnth0RURUcPHhQBWblTKyLiwtWrlyJpk2bqsf69euHhx56CGFhYYiLi8Nbb72FHj16qACtHKwkJiaqUgienp46r+nv768eu5EZM2Zg6tSp1y2XYTuyHeZKggaShSwBCGPIJJW2lnITkgHt4OBgse1gKGwHtgP3Cf1+N2RCFKLqxONNIiIGauk2O85du3apA04GaomIqkZObsXExCA9PR3Lly/HiBEjsGXLFhWsffjhh7XrSZZsmzZtVND2p59+wpAhQ274mnJwfbMhM5MmTcL48eOvq4cktZXMvfSBtIux1GZNSUnBkSNH1D7g4+Njse1gKGwHtgP3Cf1+N2ryBBRZBh5vEhExUEtERKRXkhGrmUxMArFywuujjz7Cf//73+vWlVqmEqg9ceKEui+1awsLC5GWlqaTVZuUlISOHTve8G9KNm5lNVHlgNzcA3cSfDCW96nZBkNsjzG1gyGxHdgO3Cf0992w9P8vRERE+sDelYiIqAZJNmzF+rHXznYsQ+UlYCuioqJUndONGzdq10lISEBsbOxNA7VERERERERkejiZGBERmayC4hJk5hbifHo+XDyK4eJgB2PyxhtvqDq0UnZAavktW7ZMTR62bt06ZGdnY8qUKRg6dKgKzJ45c0atL0PkH3jgAfV8d3d3jBo1ChMmTIC3tze8vLwwceJEREZGIjo62tBvj4iITNCa/RdR17UUV+atJCIiohsoLinF3vgstLR3Q5BnzczVxEAt3dbw3fDwcHVNRFSdGabZBcVIzy1CWm4h0nKLkJ5bqL1fcXlGbiEy84uRlV+krguLr844/dXTTujS0LiOOi9duoQnnnhCZcFK0LV58+YqSNurVy/k5eWpica++uorVb9WgrXdu3fHt99+C1dXV+1rzJkzBzY2Nhg2bJh6Ts+ePbFw4UJYW1sb9L3RrbHfJCJjkpFbhDdXx2Lt/otoF+qKpc/VBqsXkDFhv0lExkCOTbceT8amw5fw29EkpOcV4dU+wJjuDWrk7zNQS1UmE9BIcIGIqCrB16yCYiRnFehesq+/L0HZopKyu27UrPxio/tg5s+ff8PHHB0dsX79+ipN1vLJJ5+oC5kW9ptEZCz+PJmCid/vR0JGvrq/81wW/jiZgu6N/Q29aURa7DeJyFASM/Kx8cglbDx8CTtOXUZhydWEIPHr0WQGasn4lJSUqGwuCS4wk4vIcpWUlqkga0JGnjrgU5d0ze08JF0JwhZUyHatLla1AFcHW7jY28DVwQZuDrZwtreGLUrg53r95FlEhsR+k4gMLb+oBLPWHcOXf8Zpl7k52OCV7iHo2tDXoNtGdC32m0RUk04mZWH9oUvYcPgS9p9Pr3QdF3trtA91w8DWoTW2XcyopSqTWcdXrFiBIUOGqBqKRGSembAZeUWIT8tDfFouLqaXB18vZuSrs4wSkL2UVaCCtXfLxqoWfFzs4eVsB09nW3g42cHTyRaeTnbX3C6/losEZ60kWltBaWkpkpKS4OfnedfbRFSd2G8SkSEdupiBccticCIpW7usU31vzBwSCZvCLINuG1Fl2G8SkT6VlpYhJj4dG1RwNhGnk3MqXa+2hyOim/ghuqk/2oZ5Ij01BX41WNidgVoiIguTW1iM86l5OJ+aq4Kx59PKb8t1fGquKllwNyTA6utqX35xuXLtag8/Vwed5e6OttcFXYmIiOjuyMnUz7eexuyNx7SlhexsrPB638YY2bGOnJZFUhIDtUREZP4Ki0vx1+nLWH8oUZU1kJGflWkS6IbeTf3Ru5k/mga6oVatWtqkoJrGQC0RkRmeKbyUlY8zKbk4czkHZy9LEFaCsuWB2Ms5hXf82t7Odghwd0Cgujiq20EeDghwc1TX/m4OcLDlJFdERESGICdex38Xg11n0rTL5IBz7iMt0dDfVfs7gYiIyFxl5Rdh87FkVdJg89GkShORJF+oTR0vFZzt0ywAIV5OMBYM1BIRmWiJgkuZ+dgXn4WMswU4m5qHMyk5KjArl/yi0jsqRRDk4YgQL0eEeDoh2NMRtT0dGYQlIiIygd8FP+yJx9S1h9Vs1UKSgf6vaz28HN1QZdQSERGZq6SsfGw6nKRKGmw/ef1kYEL6wi4NfNC7WQB6NvaDt4txznHCQC0RkRHLyC3CyeQsnErKQZzKjs1BXEquus4tLLmt15IDNn9Xh6uBWC8nhHhKYLY8KBvg5gAbax7IERERmZLUnEJMWnFATYiiIf367GEt0S7cy6DbRkREpC8X0/OwLjYRv8QmYPfZNJRVMmBEJtCMblJe0uDeBr5wtjf+MKjxbyEZDW9vb4waNQpWVgzkEFV3FoxM1nUqKRsnk7JxKvnqdUp24W1nxYZ6OaGOjzPqeDsj3McJod7OKiAr2bH2NixLQFRT2G8Skb79fjQJr/xwACnZV2vuPRQVjLcHNIWrgy0/ADIp7DeJ6FbOXc5VgdlfYhMRcz690nWkTF95vdkAdcLS1sSSkRiopSqTYsrW1gzyEN1NIXPJhNUNxuao27eTHSvBWMmCDfN2gp9jLTQN8UG4rwvCvZ1VnVhmxRIZB/abRKTPiUGn/3wES3ac05nMc8aQSPSNCGTDk0liv0lElZHjZcmc/flgAg5dzKx0nXq+zugbEaDqzUbWdtdOBmaKbjtQu3XrVvzrX//Cnj17kJCQgJUrV2Lw4MHqsaKiIrz55pv4+eefcfr0abi7uyM6Ohrvv/8+goKCtK9RUFCAiRMn4ptvvkFeXh569uyJzz77DMHBwdX77qhapaen448//sC9994LDw8Pti7RDcgkHTJx19HETBy/lIWjiVnq+nRyDopvYwIPHxd71PdzRj1fF3UJ93VWwVjJjJWzgjIDZVJSEvz8/JjpTmSE2G8SkT5IBtHL38YgLiVHu6xbI1/MerA5/Fwd2OhksthvEpFmxOnxS9nlmbMHE3HsUhYq0zjAFf0iAnFfZAAaXJkw0xzcdqA2JycHLVq0wFNPPYWhQ4fqPJabm4u9e/firbfeUuukpaVh3LhxGDhwIHbv3q1dT5atXbsWy5YtU8MbJkyYgP79+6vgLzM2jVdxcbEKzss1EZV3IMnZBTiWmKUuEowtv85GXlHVMmRltkkpVSCB2Pp+5QHZen4uqO/rAncnDlkkMmXsN4moWv+nlJTi099P4pPfTqLkyolfR1trTL6/CR5rH2rS2UNEgv0mkWUfW0u27C9XyhpIklNlJFu2X2SACtCG+zjDHN12oLZfv37qUhnJoN24caPOsk8++QTt2rXDuXPnEBoaioyMDMyfPx+LFy9W2bZiyZIlCAkJwaZNm9CnT587fS9ERHqTX1SCE5eycehiBo4kZKqzehKUTcstqtLzba1rqSCsnOmrfyUoKxcpX+Bgy5IiREREdGOnk7Px8nf7sb9CPb4WIR6YM6wF6vq6sOmIiMgkg7MHL2TgpwPlwdlzqbmVrtc61EMFZqW0gZQANHd6r1ErgVk5u6sZKi9Zs1IioXfv3tp1pCxCREQEtm/fXmmgVkolyEUjM7O8JoUM+5WLOZP3JzuvMbxPzTYYot2NqR0Mie1QM+2QnluIIwlZOJSQqYKycmZPaslqslduRpJZQj2d0NDfBY0CXNHQ3xWN/F3U5F43KmJ+p++D+0P1toOl/38hIiLjI/3b13+fw7SfjmhH61hb1cKLPepjbPf6JjdBChERWTbp1+RY+8cDF/HjgYRKg7O1agFt63jhPqk5GxGAQHdHWBK9Bmrz8/Px+uuvY/jw4XBzc1PLEhMTYWdnB09PT511/f391WOVmTFjBqZOnXrd8uTkZPU3zJkEDiTYLTuzlZWVwWsGidTUVIMEao2lHQyJ7VC97SDPT8wqxInkPBxLysWJ5FwcT85Ty6rC28kG9XwcUdfbEfWvXId7O6hhiLrykHY5D9WN+0P1tkNWVuW1j4iIiAwhKSsfr/1wAL8fS9Yuk2Ges4e1QKtQ3WMpIiIiY3biUhbWHkhQAdrKyhrIScgOdb1U5mzvZv4WXXNdb4FayZp95JFH1AG0TBR2K3KAfaO6SpMmTcL48eN1MmqlVIKvr682AGyupP2kXeS9GjpAKW3duXNnVcLCwcHBYtvBkNgOd9cOSZn5OHAhAwfiyy8yzKIqpQuk05AyBc0C3dAk0BVNA91UtqyXsx0MiftD9bZDTf9fI/Pn4uKCLl26qGsiotux/lAiJq04iNScqyePpQ6t1KN1stP7oEgig2C/SWRezqTkqMDs2v0JlU4IJvO13FPPG/2bB6FPswCDH18bCxt9BWmHDRuGuLg4/PbbbzrB1ICAABQWFqqJxipm1crM5R07dqz09ezt7dXlWnJAbglBOwlAGMN7dXJyQtOmTWHp7WBobIeqtYOULygPyKZjvwRl4zOQmHnrDHxnO2s0CXRDsyA3NA2Sa3cVpDXWOrLcH6qvHSz9fwtVPwn+N27cmE1LRFWWlV+Ed9cexvd74rXLfFzs8a8Hm6N7Yz+2JJk19ptEpu98ai5+OlieORt7obxsaWVlDQY0l5qzgfB1vT7WZ+ls9BWkPXHiBH7//Xd4e3vrPB4VFQVbW1s16ZisJxISEhAbG4tZs2ZV9+ZQNZIyE2fOnEGdOnWYeUZGN9GXBGVlgo398ekqU/bs5coLkVckZ+xk1siI2m5oGuiugrOhXk6wklN7RER3+7+J/SYR3YZdZ1Lx8rcxiE+7Wi6pd1N/zBgSCW8XyzuQlfJ3b7zxBl566SXMnTtXOwpTSuJ9/vnnKvGnffv2+Pe//41mzZppnydzm0ycOBHffPMN8vLy0LNnTzXCMzg42IDvhqqC/SaRaUrIyFMTgknN2ZgKk15eOyGYZM7e3zwQ/m4cyVitgdrs7GycPHlSe1+yZmNiYuDl5aUmBXvwwQexd+9e/PjjjygpKdHWnZXHpTatu7s7Ro0ahQkTJqggriyXjjQyMhLR0dG3uzlUg+Sz37p1K3x8fBioJYN3BL8fT8WpXZex91w6Dl3IQPEtJvpytbdBRG13NA9xR4tgDxWgDfZ0vGHJFSKiu8V+k4iqorC4FHM2Hcd/tpxCWdnVET7vDGyGh6KCLfK3yq5du1Qwtnnz5jrLJbFn9uzZWLhwIRo2bIj33nsPvXr1wrFjx+Dq6qrWGTduHNauXYtly5ap40057uzfv7+a1Nra2jhHSFE59ptEpkNK8/x04CLW7L+IXWfSKl2nebA7+jcPxH2RgQj2dKrxbbSYQO3u3bvRvXt37X1N7dgRI0ZgypQpWLNmjbrfsmVLnedJdm23bt3U7Tlz5sDGxkZl1GrOckpny46TiK5VVFKKwxczsedsGvacS8O+s2m4mHHzEgb2NlYqO7Z5sAdahLir63BvZ2bKEhERkVE5fikL45bF4HDC1eGhbcI8MefhlgjxcrLYYN1jjz2GL774QgViNSSbVjJrJ0+ejCFDhqhlixYtUpNSL126FKNHj1aTi86fPx+LFy/WJgEtWbJEzW+yadMm9OnTx2Dvi4jI1OUWFmPj4UtYHXMRW48nV5osJWUEJTgrlzBvZ4Nsp8UFaiXYKp3kjdzssYq1Zz755BN1ISKqKLugGLvPpGJnXCp2n0nDgQvpyC8qvWkjSQ1ZGUohMyBLtmxDfxfYWLPeKBERERmn0tIyLNh+BjPXHVUZtcLWuhZe7tUQo7vUUxOZWqqxY8fi/vvvV4HWioFaGckpozV79+6tXSbzmHTt2hXbt29XgVrJmpVSfBXXkVGfERERah0GaomIbj9xavvxFKyOuYANhy8ht7Ck0uPxAVfKGshtujucMpSIDCojrwi74lLxd9xlFZyNvZiJkpuUMXCys1bB2MY+tujcpDaiwrzg4cTZIYmIiMh0SjhN/H4//jx5WbusgZ+LyqKVMk2WTMoVSBk9KX1wLU1JPcmgrUjunz17VruOlNurOGm1Zh3N8ysjdW3lopGZWZ7hXFpaqi7mSt6bJFoZy3vUbEdNt7uxtYOhsB3YDhryfdhzNhXf7jiH304eQFpu0XX7S6C7Awa2CMLAFoFoHOCqLdNjbt+j0mr8/1DV12CglqpMylUEBgaqa6K7qWWzM+4ydpwuz5o9kpiprcdWmRAvR0SFeiIqzFNlzEonIEkmSUlJ8PPzg5UVM2eJyDix3ySia0ktvzdXHkRmfrF22dOdwvFq30ZwsLXs+qnnz59XE4dt2LDhpvNhXFuzVw6gb1XH91bryMRlMknZtZKTk9UEV+ZKggZSLkLaxxh+U0vZC6krLIHymg7UGlM7GArbge0QdzkP64+lYsPRVFzMLLxuH3Gzt0bPhp7o3cgLLWq7wEr9X81HcjL/T1ZFVlZWldZjxI2qzMPDAwMGDGCL0W3JKyzBzjOp2HYiGdtOXsaRCjXYKiNlC9qHe6N9XS+0q+MFv0pmhDS3s3REZJ7YbxKRRkZuEd5eE6vq+mkEuDngg4daoHMDHzYUoMoWyIn4qKgobXvI5NQymfGnn36qJgwTkhkrySMa8hxNlm1AQAAKCwuRlpamk1Ur63Ts2PGG7Txp0iTt3CtCAoVS19bX1xdubm5m+/nIb2oJYMv7NIYApSRh1K1bF5beDobCdrDMdpBRHj8eSFD90+GErErnf4lu4odBLYPQpYEv7GzMv030tT/c7CRkRQzUUpVp0r1l57TE2WepaqRsQeyFDGw7mYJtJ1LUJGCFJZUHVmU3ahLgpoKyEpxtF+4FL2eWMSAi88B+k4jEnydTVKmDhAqToQ5oEYT3BkXA3cmWjXSFTDB98OBBnfZ46qmn0LhxY7z22msqgCeB2I0bN6JVq1bqcQnKbtmyBTNnzlT3Jchra2ur1pGJq0VCQgJiY2Mxa9asG7a11LqVy7XkuMfcAzVyXGcs79OQ/aYxtYMhsR0sox1yCoqxLjYRK/bFY/upy9eNcJURrJ3q+6B7uAsevKcB3Bwt+xi9uvaHqj6fgVqqssuXL2PFihVqllUfH575p6vOXc7F1hPJ6kBE/tFL3dnKyO+tZkFu6FjPB+3DvdCmjhfcHXmAQkTmif0mkWXLLyrBrHXH8OWfcdplrg42eG9wBAa1rG3QbTNGrq6uatKvipydndVQeM3ycePGYfr06WjQoIG6yG0nJycMHz5cPe7u7o5Ro0ZhwoQJ6nleXl6YOHEiIiMj1eRkZNzYbxLpdxLLv05fxvK98SpIW9mkYC1CPDC4ZRD6Nw+Ct7OtGo3gYs+wYU1jixPRbZPZiXedScVvR5Pw+7EknE7OuWmN2c71fdG5vg861vOGJzNmiYiIyMwdiE/Hy9/G4FSF30jyO0hKHQR5OBp020zZq6++iry8PIwZM0aVN2jfvr2qaStBXo05c+aoGuGSUSvrSqbuwoULYW1t2TWAicgynUzKxoq98Vi17wIuVhjZoVHH2wmDW9VWJxDDfZy1y1lu0HAYqCWiKrmUmY/frwRmpaRBTiVn4IRkyHaq762GStxb3xeh3k5sYSIiIrIIRSWl+PfvJ/HJbydVOSgh9fxe7dNITRpmJeNJqco2b9583fDTKVOmqMvNagB+8skn6kJEZInScgqx9sBFLN97AfvPp1/3uJuDDfq3CMLQ1sFoHerB0pZGhoFaIrphjaiDFzKw8fAllTl76GLlk4BZW9VCVKgnujbyxb0NfNAsyF0tIyJg3rx56nLmzBnVHM2aNcPbb7+Nfv36ab9nMsv0559/rs0M+ve//63W0ygoKFDDNr/55httZtBnn32G4OBgNjERkZFlLU34Lgb74zO0yyJqu2HOsJZo4H8145OIiEgfo143H0tSpQ3k+L2oRLfwrByjd2voiyGtg9GziR8cbDnKwFgxUEtEWsUlpdh5JhUbDl3ChkOJlQ6NEDLhl/yT797YT838yIkwiConwdT3338f9evXV/cXLVqEQYMGYd++fSoYKxObzJ49Ww3JbNiwId577z306tVLzWytGcYp9fjWrl2LZcuWqXp7Unevf//+anZsDuMkIjKOun9f/XUGM345ioLiUu0B8dju9fFij/qwtTbPyWiIiMg4kquW74nHmv0XkZZ7/VwxTQPdMDQqGANbBMHX9fpJE8n4MFBLVebp6akK9Ts6sq6WuU108ceJFKw/lIhfj1yq9J+7iKztrgKz3Rv5onmwB7NmiapgwIABOvenTZumMmx37NiBpk2bYu7cuZg8ebKapFETyPX398fSpUsxevRoZGRkYP78+Vi8eLF2EpQlS5YgJCQEmzZtQp8+ffg5GDH2m0Tm72J6Hl75YT/+PHlZu6yujzNmP9wSLUM8DLptRKaG/SZR1VzOLsDKfRfw/e54HLuUdd3jEpCVScEke7ZJoBub1cQwUEtVJplbLi4ubDEzkFtYjF+PJOHngwnYcjy50hkfba1roWM9H/RpFoDoJn7wc3MwyLYSmYuSkhJ8//33yMnJwT333IO4uDgkJiaid+/e2nXs7e3RtWtXbN++XQVqJWu2qKhIZ52goCA1+7Wsc6NArZRLkItGZmamdlIAc54YQN6bZBYYy3uUWooyG7moyW0ytnYwFLYD20Gf+4S8zuqYi3hn7WFk5Rdrl4+4J0zVo3W0szba72B1tYOxvj8yXTzeJLoxqXu+9Xgyvtt9HpuOXLqutIG9jRV6NwvAkNa1cW99H9hwNIfJYqCWqkwO9P/++29VQ9HNjWdlTE1BcQm2HEvG2gMJ2HT4EvKKrg/OOttZo1sjP/Ru5q+yZ90cbA2yrUTm5ODBgyowm5+fr052rVy5UmXTSqBVSAZtRXL/7Nmz6rYEcu3s7FSGybXryGM3MmPGDFX79lrJyclqO8yVBA0kC1kCEFZWhh9qLEH5w4cPq8/b2fnqLLqW1g6GwnZgO+hrn0jPK8bMX8/i95NXJ2jxdbHFm73qoH2YG7LSL+P6/Cbza4esLGN+l2SKeLxJdL0zKTn4fs95LN9zAYmZ1/+OjwrzxINRwbi/eSCP380EA7VUZYWFhSoDrFWrVmw1E5p5+M+TKVi7PwEbDifqZHxUrDcrGbOSOdupvg+LihNVs0aNGiEmJgbp6elYvnw5RowYgS1btuhkXVYkB87XLrvWrdaZNGkSxo8fr3PgI+USfH19zfpEmwQfpF3kfRpDgDIlJQUJCQnqBKePj4/FtoOhsB3YDvrYJ349moRJK44gJbtQu0yGl74zoCncHW0t6rvh4MDRVlS9eLxJdHUE7C8HE/Ht7vPYGZd6XbP4uNhjaFRtPBQVgvp+HPVsbhioJTIzEsCR2YZX7I3H2hsUFPdwskW/iEAMaB6IduFeHBZBpEeSEauZTKxNmzbYtWsXPvroI7z22mtqmWTGBgYGatdPSkrSZtkGBASog5a0tDSdrFpZp2PHjjf8m1JCQS7XkgNycw/cSfDBWN6nZhsMsT3G1A6GxHZgO1TXPpFdUIz3fjyMZbvOa5d5Otli2gORuC/y6v9wS/puWPr/FyKi6j6Ojzmfju92lx/HS79TkUxS2b2RHx5uG4JujXw5UaUZY6CWyEwkZOSpguIy4+Op5JzrHne1t0GvZv4Y0CIInev78B87kQF/hEn92PDwcBWI3bhxo3akggRlJdt25syZ6n5UVBRsbW3VOsOGDVPLJEMzNjYWs2bN4mdIRFQDJJtpwvcxOJ+ap10mk6vOHNqcNfyJiOiupOUUYvneeHy76zxOJGVf93hdX2c83CYED7SuDT9XjmSwBAzUEpn4kIj1hxJVvZo/T6WgTLeeOBxsrdCziT8GtghC14a+LGtAVMPeeOMN9OvXT5UdkFp+y5Ytw+bNm7Fu3TqVzTRu3DhMnz4dDRo0UBe5LZNPDR8+XD3f3d0do0aNwoQJE+Dt7Q0vLy9MnDgRkZGRiI6O5udJRKTn+v6zNxzH53+c1v7GcrKzxlv9m+KRtiG3LFNDRER0o8SNv+NS8c3Oc6rEQWFJ6XVzx/RvHoRhbYPROtST/Y2FYaCWqkyCB23bttXOYE2Gc/BChhp6tybmInIKr58UTMoZPNg6GP0iA+DKCcGIDObSpUt44oknVBasBF2bN2+ugrS9evVSj7/66qvIy8vDmDFjVHkDqWW6YcMGuLq6al9jzpw5sLGxURm1sm7Pnj2xcOFCNTMyGTf2m0Sm6/DFTLz8bQyOXbo6YVabME/MHtYSod78LUykD+w3ydyl5hSqEoVLd57D6UpGwbat44lhbUJUSR1ne4brLBU/ebqtjpMTiRmO1KhZtTcei/+Kw7Gk3OseD/VywpDWtTGkVTAPIIiMxPz582/6uGRjTZkyRV1uNlnLJ598oi5kWthvEpmektIy/HfrKczZeBxFJeVptHbWVhjfuyGevbeuqhFIRPrBfpMsMXtW6p0/GBWMR9qFop4vJwYjBmrpNkhNRckKk0lvKpukhvTjYHwGlu48i9UxF5F7TfasDImQmrNDo4JVlgeH4BERGQ/2m0Sm5UxKDiZ8vx97zqZplzUOcMWch1uiSaCbQbeNyBKw3yRLyp7tUNcLj7YLRd+IANjbcKQcXcWMWqoyqa8oQ3KHDBnCQK2e5ReVYM3+i/jqrzOIvZB53eORtd0xvH2oqj3LIRFERMaJ/SaR6WQ7ff33OUz76QjyispPikvi7Oiu9TAuugEPoIlqCPtNMpfs2aV/n8O6WGbP0p1hoJbIiFzKzMeSHWfVP/bLOYXXZc8ObBmEPvVd0CWiDqysrAy2nURERETm8tvr1R8OYMvxZJ1yUrOHtUCbOl4G3TYiIjINGXlF+GFPPL7++yyzZ+muMVBLZAT2nUvDgj/P4OeDCSguvTKtcCXZs462VkhKSjLYdhIRERGZix8PXMSbq2KRnlukXSa/uSbf14QjloiI6JYOXczA4r/OYlXMBeQX6dae9XK2U7VnH24bwtqzdFsYqCUykOKSUvx0MEEFaGPOp+s8ZmNVC/0iA/FUpzpoHeqpXV5aqvvPn4iIiIhuT3puIaasPaLKTGn4utpj1tDm6N7Yj81JREQ3VFBcoiYFkzKFe8/pHsdras8Obx+GPs38WTqH7ggDtVRl1tbW8PT0VNd05/IKS/DtrnP44o84XEjPu+6s2/B2oXi8QxgC3B3YzEREJoz9JpHx+ftsJqb/GotLmQXaZfdHBuK9wRHwdLYz6LYRWTr2m2TM5Nh96d9nsWzn+evKFLrY22Bo69p44p4w1PdzNdg2knlgoJaqTIK0Dz30EFvsDqXlFOKrv85i0V9n1AyQFcmMwk93Clc1aB1sGQgnIjIH7DeJjEdOQTGm/3xETRqm4eZgg38OjlDlpWrVqmXQ7SMi9ptkfEpLy/DnqRR1HP/rkUu4pkohGvm7quDsA61qs2QOVRsGaon07GJ6Hv73RxyW7TqH3MLymYQ1ujXyxXNd6uKeut48QCAiIiLSg51xqZj4/X6cS83VLru3gQ9mPdgcge6ObHMiItKRlV+MH/+Mw9K/z+N0Ss51ZQr7RgTgyXvqoG0dTx7HU7VjoJaqLCUlBWvXrsWAAQPg4+PDlqvC0IjPfj+J73afR1HJ1VNv1la10L95IEZ3qYemQW5sRyIiM8V+k8iw8otK8OGGY/jftjiUXfkp5mBjhdf7NcaIjnV4cE1kZNhvkqEdS8zCwj/jsHLfBeQX684PE+DmoCacfKRtCPzcWKaQ9IeBWrotRUVXZ8WlysWn5eKzzafw/TUBWgdbKzzcJgTP3FsXIV5ObD4iIgvAfpPIMPafT8f472JwKvlqJlRUmCde7x6EqIahDNISGSn2m2SI8ga/HU3Cgu1x+PPk5ese71jPG090CEN0U3/YWlvxAyK9Y6CWqBoDtP/+/RR+2KMboJXC4iM6hqkatN4u9mxvIiIiIj0pLC7FJ7+dUCfNS64UE7SzscLE3g3xVMc6uJySzLYnIiJk5Rfh+93xag6Zs5evlsYRTnZWeLB1CJ7syMnBqOYxUEt0l5Ky8vHxryfw7a7rA7RPdaqDUZ3D4eHEWYSJiIiI9OloYibGf7sfhxMytcsia7vjw2Et0NDfFaWlusNYiYjI8pxJycHC7Wfww554ZBcU6zxWx9sJI+4JQ5dQe4QHB8LKihm0VPMYqCW6Q5n5Rfh8y2nM3xaHvKKrk4QxQEtERERUc4pLSvHfracxd9Nx7UlzmezlxR4NMKZ7PQ5VJSKycGVlZdh+6jIW/BmHX48maeuWa3Su74OnO9dBt4Z+sjaSkpIMtalEDNRS1Xl4eGDIkCHq2tInplj811n8e/NJpOderdnrbGeNpzuHM4OWiIgU9ptE+ncqORsTvtuPmPPp2mUN/V0we1hLRNR250dAZELYb5I+jt1lYrCFf57BsUtZOo/JHDIPtApWo2Bl1EXFmrVEhsSMWqr6zmJjAx8fH4ttMalztnxvPOZsPI6EjHztclvrWnisfRhe6FEfPqxBS0REV1h6v0mkT3IgLUNXZ647ioIrM3Nb1QJGd62HcdENYG9jzQ+AyMSw36TqkpxVgK/+OoMlO84irUJylQh0d8CT99TBI21D4OnMEoVkfBiopSrLzs5GTEwMWrZsCRcXF4tqub9OXcY/fzysU/OsVi3ggZa18XKvhgjxcjLo9hERkfGx5H6TSJ/Op+Zi4vf78XdcqnZZuI8zPnioBaLCPNn4RCaK/SbdrZNJWfjfH3FYse+CmlyyIukfZILvPs38YWPN2rNkvBiopSrLz8/H4cOH0bhxY4s54Dx3ORfTfz6CdYcSdZb3bOyHiX0aoUmgm8G2jYiIjJsl9ptE+q4xuGzXebz342HkFF6dH2Bkxzp4rW9jONoxi5bIlLHfpDvtG3acTsUXf5zGb0d1a8tKvfL+zQNVicLmwZZdwpFMx22fRti6dSsGDBiAoKAg1KpVC6tWrbruSzJlyhT1uKOjI7p164ZDhw7prFNQUIAXX3xRDQd0dnbGwIEDER8ff/fvhqiaZOUXYcYvRxA9e4tOkLZZkBuWPdcB80e2ZZCWiIiIqIYkZuRj5IJdmLTioDZIW9vDEUufbY8pA5sxSEtEZIETSa7ZfxEDP/0Tj36xQydI62pvg9Fd6uKP17pj7iOtGKQl886ozcnJQYsWLfDUU09h6NCh1z0+a9YszJ49GwsXLkTDhg3x3nvvoVevXjh27BhcXcsLNI8bNw5r167FsmXL4O3tjQkTJqB///7Ys2cPrK15JpwMW+/shz3xmLX+KFKyC7XLpfbsq30aYWhUMKylABoRERER6Z0kgayKuYB3Vh9CZn6xdvmj7ULwxn1N4Opgy0+BiMiCZBcUY9nOc1jw5xlcSM/TeUxO4MnkYA+3DWH/QJYTqO3Xr5+63OiH1Ny5czF58mQMGTJELVu0aBH8/f2xdOlSjB49GhkZGZg/fz4WL16M6Ohotc6SJUsQEhKCTZs2oU+fPnf7nojuyJGETLy5KhZ7zqZpl9lZW2HUveEY270+XOxZKYSIiIiopqRkF2DyyoNYf+iSdpmfqz1mDm2O7o39+EEQEVnYyIoF2+Ow9O9zyKpw4k5E1HbDs/fWxX2RgbBl/VkycdUaeYqLi0NiYiJ69+6tXWZvb4+uXbti+/btKlArWbNFRUU660iZhIiICLUOA7XGy8HBAZGRkera3M7Izd14HAu2n0FJaZl2eb+IAJWpwYnCiIjoTphrv0lUE9bFJuCNlbFIzbk6wmlQyyBMHdgMHk6cpZvIHLHfpMqcTMrGf7acwqp9F1Bc4Xhd9GjspwK0Hep6qdKcROagWgO1EqQVkkFbkdw/e/asdh07Ozt4enpet47m+deSmrZy0cjMzFTXpaWl6mLO5P1JprIxvE8nJye0b99eu12m3g7yer/EJuK9n44gMbNAZ9bgqQObonN9H+3fNhbGtD8YEtuB7aCP/cHSv1dU/WQCsXvuuYdNS3QbMnKL8M6aWKyKuahd5uVsh2mDI9AvMpBtSWTG2G9SRfvPp+OzzSex4fAllFWIz8qo1yGta+OZe8NR36+8vCaROdHLWO5rz2TIAfStzm7cbJ0ZM2Zg6tSp1y1PTk5WM0OaMwkcSLkIaR8rq9ue+61aFRcXqyC5m5sbbGxsTLodLmYUYNZv57DjbHnQX9hb18KIdoF4PMofdjalSErSnTHSGBjT/mBIbAe2gz72h6ysrLveN4kqkhFEqamp8PLygq0t62gS3crvx5Lw+vIDuFThBHrvpv6YPiRSzRdAROaN/SbJ7/k/T17GvC0n1XVF7o62eKJDGJ7sGAY/V45WIvNVrdG2gIAAdS2ZsYGBV894S8BLk2Ur6xQWFiItLU0nq1bW6dixY6WvO2nSJIwfP157X4KFUtPW19dXBQ3NPQAhAWx5r4YOzKWkpGDbtm0YPHgwfHzKs01NrR1ksrDFO85i1vrjyCsqnzFYdG3oq7JoQ72cYMyMaX8wJLYD20Ef+wOHp1N1kxMIq1evVnX7a7rfJDK1MlTTfjqMb3ae1y5zdbDBu4OaYXDL2hzOSmQh2G9aLjlOX38oEfO2nMKB+Aydx/zd7PFM57p4tH0o540hi1Ctgdrw8HAViN24cSNatWqllklQdsuWLZg5c6a6HxUVpbJKZJ1hw4apZQkJCYiNjcWsWbMqfV2pcyuXa8kBuSUEqyQAYQzvVfP3DbUtd9sOp5Kz8doPB7C7wmRhge4OeGdAU/RpFmAyBwHGsj8YGtuB7VDd+4Olf6eIiAzhz5MpePWHAzozd3dp6IuZQyMR6O7ID4WIyIwVFpdiVcwFVYP2dHKOzmN1vJ3wf13r4YHWtWFvY22wbSQy+kBtdnY2Tp48qTOBWExMjBrWFxoainHjxmH69Olo0KCBushtqW06fPhwtb67uztGjRqFCRMmwNvbWz1v4sSJarKN6Ojo6n13RFKyoaQUX/wRhzmbjquOQOPxDqF4rW9juDpwOCoRERFRTcopKMaMX45gyY5z2mXOdtZ4s39TPNI2xGROoBMR0Z31Act2ncf//jiNhAzdcpbNgtzwfLd66BcRCGsr9gVkeW47fWj37t0qW1aTMSslCeT222+/re6/+uqrKlg7ZswYtGnTBhcuXMCGDRvg6nq1yPOcOXPU8HnJqO3UqZMK5K5duxbW1jxLQtXraGImHvhsO2auO6oN0oZ5O2HZcx3w3uBIBmmJSK+kxnrbtm1VH+jn56f6vmPHjumsM3LkSBWQqHjp0KGDzjoyoeaLL76ohs87Oztj4MCBiI+P56dHRCZp+6kU9Jm7VSdIKzN2rxvXBY+2C2WQ1kLNmzcPzZs3V6Xt5CKTMf7yyy/ax9lfEpm+jLwifPzrCXSa+Rv++eNhnSBt+3AvLHq6HX58sTP6Nw9ikJYs1m1n1Hbr1k0VeL4ROcCcMmWKutysDuAnn3yiLmQ65LOVz84UMhxKSsvwxR+n8eGGYygqKd9f5WTcqM7hGN+rERzteFKAiPRPSv+MHTtWBWtlQsbJkyejd+/eOHz4sAq4avTt2xcLFizQ3rezs9N5HTkBKic0ly1bpkajyKiU/v37Y8+ePTzJacRMqd8kqqkMqvd/OarmC9BwtLXGpPsa4/H2YbBi5pRFCw4Oxvvvv4/69eur+4sWLcKgQYOwb98+NGvWTC1jf2ne2G+ar/TcQny5LQ4Ltp9BVn6xzmPRTfxVBm1U2NU5jIgsWbXWqCXzJsGBJ598EsYuPi0XE77bj7/jUrXL6vu5YNaDzdE6lP/8iajmrFu3Tue+BGMls1YCrF26dNEulzrsmgk5K5tYY/78+Vi8eLG2RNCSJUvUpJqbNm1Cnz599PwuyNz7TaKasOP0Zbzyw36cT71ai7ZduBf+9WBzhHlfPXFFlmvAgAE696dNm6aybHfs2KEN1LK/NG/sN81Pak6hKm+waPsZ5BRencxbShoMbBGkatA2Crg6+pqIGKglMyKZ3qtjLuKtVbHIKig/SydJTM91qYvxvRqyADkRGZwEXYXUZ69o8+bNKoDr4eGBrl27qoNTuS8kqFtUVKQycTWCgoIQERGB7du3VxqolVIJctHIzMxU16WlpepiruS9SV9gzu+xKtgObAdj2h9yC4sxa91xfFUhi9bB1gqv9WmEJzqUZ9HW1LYZui2MRXW1gz7bsaSkBN9//z1ycnJUCQR99ZdEpB/JWQVqhOuSHWeRWyFAa2NVCw9GBWNMt/oI9XZi8xNVghm1VGWpqamq3rD8+Lk2yGBoGblFmLzqIH48kKBdVtvDER8Oa4EOdb0Num1EREIOiqWue+fOndVBo0a/fv3w0EMPISwsTE3Q+dZbb6FHjx7qgFMyhxITE1UpBE9P3REB/v7+6rEb1cadOnXqdcuTk5ORn687YYM5kaCBBMOlra2sbrsMf7WTAPnOnTvRrl07VW/RUtvBUNgOhm+HffFZeG/jGVzIKNQua1nbBZN7hSHEwwEpKck1uj3cJ6q3HbKyslDdDh48qAKz0le5uLhg5cqVaNq0qd76Sw2e4DSOkxdpaWnYuHEjevXqdd3nqE88iVN97XApMx+f/xGHb3aeQ37R1dexta6Fh6KC8XzXeqjt6aj9e8aI+wPbQV/7Q1Vfg4Fauq2dSg46je0f6l+nLmP8dzE6hcgfaFUbUwc1g5uDrUG3jYhI44UXXsCBAwewbds2nUZ5+OGHtbclgCsTccpB6E8//YQhQ4bcsAHlB8ONap9OmjRJBYU15H+3lErw9fWt0YBhTZP+SdpE3qcxBChlG3Jzc1Xml0wEZ6ntYChsB8O1g2TRfrD+OBb+pZtF+0rvRhhxj+Fq0XKfqN52kBrc1a1Ro0aIiYlBeno6li9fjhEjRqh67xKs1Ud/qcETnMZxYk8+d/nNIieWJTu6pvAkzt23w6WsQizenYg1sSkovDJHjLCzroVBkT54IioAfq52QFEWkpKq/yRPdeL+wHbQ1/5Q1ROcDNSSyZIJwz797SQ++vU4Sq/0BW4ONpj2QCQGtAgy9OYREWm9+OKLWLNmDbZu3aomS7mZwMBAdeB54sQJdV9q1xYWFqosk4rZJUlJSejYsWOlryGZRXK5lvy4MIYDMX2Sg3FjeZ+abTDE9hhTOxgS26Hm22FnXKqqRXv2cq52WZswT/zroRYI9zF8LVruE9XXDvrYnyQjVjOZmARid+3ahY8++gj//e9/9dJfavAEp3Gc2NNsg4ze5AlO0ziJk5iRj39vPoXvdp/XTuKtOTk3vF0onrs3HH5u1X9SR594Uo/toK/9oaonOBmoJZOteTPu23348+Rl7bKO9bxVqYNA9/KhFEREhiZnXiVIK0M3pa5eeHj4LZ9z+fJlnD9/Xh2AiqioKNja2qqhgMOGDVPLEhISEBsbi1mzZun9PRARVUVeYQn+tf4YFmyPQ9mVY3V7Gyu80qcRnuoUriaOIbqTfrRizXV99Zc8wWkcJ/Z4gtN0TuIkZeVj3uZT+Prvcygsvjri1snOGk/cE4Zn760LH5frkwZMBU/qsR30sT9U9fkM1JLJ2X4qBS8ti1HBWiG/+2WyMClIbqihdERElRk7diyWLl2K1atXw9XVVVsjz93dHY6OjsjOzsaUKVMwdOhQdaB55swZvPHGGyqL5IEHHtCuO2rUKEyYMEHNhixZJhMnTkRkZCSio6PZ8ERkcLvPSBbtAcSl5GiXRUkW7YPNUdfXxaDbRqZD+j+pQyulemR46LJly9RJznXr1rG/JDISl7ML8N+tp/HVX2d0atA621ljRMc6eObeuvBytjPoNhKZOgZqqcqkrqH8eDJUfUMpdfDxryfw8W8ntaUO/Fzt8fGjrThhGBEZpXnz5qnrbt266SxfsGABRo4cCWtrazVxyldffaXqskmwtnv37vj2229VYFdjzpw5sLGxURlCeXl56NmzJxYuXKieT8bL0P0mkb7lF5Xgg/XHMP9P3Szaib0b4enOzKKl23Pp0iU88cQTKgtWTlI2b95cBWllYinp+9hfmj/2m8YrPbcQX/xxGgv/PIOcwhLtckdbazzZMQyju9RjgJaomjBQS7dVM0rOcBvqzN24VSew69zV4sv3NvDBnIdbmvSQCiIy/yGbNyNZtevXr69SPaNPPvlEXch0GLLfJNK3PWfT8Mr3+3G6QhZtq1APfPBQC9RjFi3dgfnz59/wMfaXloH9pvHJzC/Cl9viMP+POGQVFGuX29lY4fH2YXi+Wz34uvJ4nKg6MVBLVSYzVx8+fFjNuurk5FRjLRd7IQPPLd6Ni+n56j5LHRARkSkwVL9JpO8s2tkbj+N/f5zWjnCSA/YJvRqqIa+sRUtEd4r9pvHIKSjGwu1n8PnW08jIK9Iut7WuhUfahmJs9/oIcDetScKITAUDtXRbHefevXtRp06dGjvgXLXvAl5bfgAFVwqUy9m6jx9phXvqedfI3yciIjKlfpNIn/aeS8NEyaJNvppF2zJEsmibo77f1XItRER3gv2m4cnEYF/+GYd5m0/jck6hdrmchHsoKhgv9KiPYE/+piHSJwZqySgVl5Ti/V+O4n/b4rTLIgKc8cXIdgj0YMdAREREVJNZtHM2HccXWytk0VpbYXzvhnimczhsrA0/WzwREd3dfDAr9sbjw/XHkJh1NUAro1kfaBWMf/SsjzBvZzYxUQ1goJaMTmpOIV78Zi/+PHlZu+zhNsEY28EX/m4cXkFERERUU/acTcUrPxzQyaJtEeyuatE28GcWLRGRqc+nsPHwJfxr/TGcSMrWeWxAiyCMi27AuuNENYyBWjIqhy9mqnq08Wl56r6NVS1MGdgMj7YNRnJysqE3j4iIiMgi5BWW4IMNx9QQ2LIKWbTjejXAc/fWZRYtEZGJ+/v0ZcxcdxR7z6XrLO/WyBev9GmEZkHuBts2IkvGQC3d1iyc9evXV9f6sOFQIl5aFoO8ohJ138fFHvMeb422dbxQWlpeo5aIiMhU6LvfJNKXHacvqzkCzl7O1cminfVgCzQKYBYtEekH+82aS46atf4oNh/TTYRqHeqBZ9v5oU/rerCyYkkbIkNhoJaqzM3NDT169NDLcIv52+Iw7ecj2oyNFiEe+M/jrRHo7shPiIiITJK++k0ifckuKMbMX45i8Y6z2mV2NlaY0KshRrEWLRHpGftN/Tp7OQezNx7H6piLOssb+rvglT6N0aORD0exEhkBBmqpyoqLi5GTkwNnZ2fY2FTPrlNUUoopaw7h67/PaZcNbBGEWQ82h4OtNT8dIiIyWfroN4n05Y8TyXh9+UFcSC8vPyXahHli5oPNWZ+QiGoE+039SMkuwMe/nsDSv8+hWDMjJIDaHo54uVdDPNCqNqytanEUK5GR4FEDVVl6ejpWrFiBIUOGwMfH565bLjO/CGO/3os/TqRol/2jZwO8HN0AtWrV4idDREQmrbr7TSJ9kN9j0386gmW7zmuXOdpa49W+jfDkPXXUwTsRUU1gv1n9tcalzvi8zafUiAkNL2c7jO1eH493CIW9DZOjiIwNA7VkEJKt8dSCnTh+KVs7OcXMByPxQKtgfiJERERENeC3o5fwxopYJGbma5d1qOuFmUObI8zbmZ8BEZEJKi0tw8p9F9SEkAkZV/+/O9tZ45l76+KZe8Ph6mBr0G0kohtjoJZq3LHELIz4cqf2oMDTyRb/faIN2oV78dMgIiIi0rP03EK8u/YwVuy7oHMAP+m+JhjeLhRWzKIlIjJJ20+m4L2fjuBwQqZ2mYyMeKRtCMZFN4Svq71Bt4+Ibo2BWqpRf5++jGe+2o2s/PKhF3W8nbDwqXao48OsDSIiIiJ9WxebiDdXxaqahRr3NvDB+0Obq3qFRERkek5cysKMX47it6NJOst7NvbD6/0ao4G/q6E2jYhuEwO1VGN+OZiAl76NQWFxqbrfItgdX45sC28XntUjIiIi0qfL2QWY8uMR/HQgQbvM1cEGb/Vvioeigjk/ABGRCUrOKsCcTcexbOc5VJgnDM2C3DD5viboWJ818olMDQO1VGUyEcpzzz13Ry22+K8zeHvNIZRd6Ty6NfLFv4e3hrM9d0EiIjJPd9NvElWXsrIybDyWijlbDiA1t0gny2raA5EIcHdgYxORUWC/eXsThc3fdlpNFJZTWKJdHujugFf6NMLglrVZxobIRDFKRno/OPjo1xOYu+mEdtnQ1sF4f2gkbK2t2PpEREREepKUma/KHGw4fEm7zMPJFlMHNsPAFkHMoiUiMsHj69UxF/H+L0d1JoKUOuNjutfH053C4WhnbdBtJKK7w0AtVVl6ejo2b96Mbt26wcPDo0qdyLSfjuB/2+K0y8Z0q6fO8NWqVYstT0REZu12+02i6iK/wVbsvYB3fzyMjLyrWbT3RQZg6sAITiZDREaJ/ebN7T+fjqlrD2HvuXTtMk4URmR+GKilKisuLkZSUpK6vpWS0jK8ueogvtl5Xrvszfub4Jl767LFiYjIItxOv0lUXRIy8vDGioP4/Viydpmnkw3+OSgC/VvUZkMTkdFiv1m5pKx8zFp3DD/siddZ3r2RL964rwknCiMyMwzUUrUrKinFhO/2Y83+i+q+JM++PyQSD7cNZWsTERER6SmLdtmu85j+0xFkFVw9OTCoZRCeb++LhmGBbHciIhNSUFyCBX+ewSe/ntCpQ1vP11lNBNmtkZ9Bt4+I9IOBWqpW+UUleGHpPmw6Ul4LzcaqFuY83BIDWgSxpYmIiIj04ExKDiatOIi/Tl/WLvNztVeThfVs7Ksyu4mIyHROvG06koT3fjqMs5dztctdHWzwcnRDPHFPGOd7ITJjDNRStQZpn/1qN/44kaLu29lY4bPhrRHd1J+tTERERFTNiktK8eWfcfhww3EUFJdqlz8UFYw3+zeFu6MtSkuvLiciIuN2/FIW/vnjYe0xtWaE6qPtQjGhV0N4u9gbdPuISP8YqKUqc3FxQffu3dV1ZUHaZxbtxraT5R2Kk501vniyDTrV92ELExGRRbpZv0l0tw5fzMRryw/g4IUM7bLaHo6YMSQSXRr6soGJyORYcr8pEz/O2Xgci3ecVfO9aLQP98LbA5qiWZC7QbePiGoOA7VUZQ4ODmjQoMF1y/MKyzNpNUFaF3sbLHq6LaLCvNi6RERksW7UbxLdDTk5/ulvJ/GfLadQfOVgXrKtRnasg4m9G8HZnj/vicg0WWK/KWUOVu67gOk/H0VKdoHOibfJ9zdBv4gA1JJ/8kRkMfhLjqosLy8Pp0+fRt26deHo6Fi+jEFaIiKiKvebRHdj15lUvL78AE4l52iXNfBzwftDmyMqzJONS0QmzdL6zSMJmXh7dSx2nUnTLnOwtcKYbvXxXJe6cLC1Nuj2EZFhMFBLVZaTk4M///wT/v7+quOsPEjbjgcKRERElfSbRHcqu6AYs9YdxVd/ndUus7WupQ7mx3SvB3sbHswTkemzlH4zM78IczeewKK/zuiUOejbLABv9m+CYE8ng24fERkWA7V0VxOHMUhLREREpD+/H03C5JUHcTEjX7usRYgHZg1tjkYBrmx6IiITKnOwOuYipv18BMlZV8sc1PF2wpSBzdCtkZ9Bt4+IjAMDtXTbiopLMebrvQzSEhEREelJak4h3l17CKtiLmqXOdpaY2KfRqoerbUVaxYSEZmKY4lZeGt1LHbGpeqUOXihe308cy/LHBDRVVYVbhNVyYcbj+G3o0nqtrOdNcsdEBHdwIwZM9C2bVu4urrCz88PgwcPxrFjx67LrpgyZQqCgoLUML9u3brh0KFDOusUFBTgxRdfhI+PD5ydnTFw4EDEx8ez3YnMNuPqAqJnb9EJ0nau74MNL3fBqM7hDNISEZlQ6Zr3fjyM+z7+QydI27upPza+3BUv9GjAWrREpN9AbXFxMd58802Eh4erA04pBP7uu++itLT0tg5KyfhYW9sgx8Ydvx4r72DsbazwvxFtWZOWiOgGtmzZgrFjx2LHjh3YuHGj6iN79+6tarBpzJo1C7Nnz8ann36KXbt2ISAgAL169UJWVpZ2nXHjxmHlypVYtmwZtm3bhuzsbPTv3x8lJSVseyNma2uL4OBgdU1UFRfT8zBq0W68tCxGZdQKNwcb/OvB5lg8qh1CvFi3kIjMl7n1mxsOJaLX7C3437Y4bS3aMG8nLBjZFp8/2Yb/04moZkofzJw5E//5z3+waNEiNGvWDLt378ZTTz0Fd3d3vPTSSzoHpQsXLkTDhg3x3nvvqYNSyTKSrCMyPhJc/+iPC1h43EU7gcV/nojCPfW8Db1pRERGa926dTr3FyxYoDJr9+zZgy5duqj/rXPnzsXkyZMxZMgQtY70nzKJxtKlSzF69GhkZGRg/vz5WLx4MaKjo9U6S5YsQUhICDZt2oQ+ffoY5L3Rrclvn/vuu49NRbdUWlqGr3eew8xfjqrsK437IgNU3UI/Vwe2IhGZPXPpN+Wk25Q1h7Dh8CXtMklyGtu9Pp7rwjIHRFTDgdq//voLgwYNwv3336/u16lTB998840K2IqqHJSS8fnX+mNYtD0OdrXKUIJa+PiR1ujOYudERLdFgq7Cy8tLXcfFxSExMVFl2WrY29uja9eu2L59u+oTJahbVFSks46MSImIiFDrVBaolVIJctHIzMxU1zK6peIIF3Mj701+ZxjLe5TtkCxqGxsbWFlZWWw7GIqptMPplBxMWnEQu86kaZf5utrj3YFN0adZgLp/N+/BVNqhJrAtqrcduE+RufSb1UWyZhdtP4MPNxxDTuHVUU9dGvrivUERCPXmqAgiMkCgtnPnziqj9vjx4ypbdv/+/WqYpgRnq3pQei1LPeA0lh+UX/xxGp9tPgV/uyKMCk6GW+OO6NPMv0a3yRjawRiwHdgO3B/0973Q9/8X2cbx48erflKCrEL6QyEnKyuS+2fPntWuY2dnB09Pz+vW0Ty/stq4U6dOvW55cnIy8vOvzhxvbuQzlGC4tLUxHOClp6dj69atKnvaw8PDYtvBUIy9HYpLyvD1nkTM/zsBhSXlQ2LFwAgfvNi5NlwdrJCUVD4ngDm3Q01iW1RvO1Qs0UNUHVJTU7FixQqV0CV1+U1J7IUMddLt4IXyk/LCx8Ue7wxoiv7NA1GrFieAJCIDBWpfe+011fE3btwY1tbWqn7etGnT8Oijj1b5oPRalnrAaQw/KH85chkz1p/RWdbSz6ZaDhxMqR2MBduB7cD9wXQPOF944QUcOHBAnby81rU/3uW93OoH/c3WmTRpkgoKVzzBKaUSfH194ebmBnPeF6RN5H0aQ1+h2QbJoK7JA05jawdDMeZ2OBCfgTdWHsThhKv/d0K9HDH9gUh0rOayUsbcDjWNbVG97eDgwJIcRDkFxZi98TgW/BmHK2VoleHtQ/Fa38ZwdzSPertEZMKB2m+//VbVzpMyBlKjNiYmRk2CIsM0R4wYcUcHpZZ6wGnoH5R/nEjGtI1Xg+ePtw8FLiTX+AGn4A9rtgP3B34vTPmA88UXX8SaNWtUdqVMkqEhE4dpTmIGBgZql8vJMM0JTVmnsLAQaWlpOlm1sk7Hjh0r/XsyUkUu15L2MfdAjewLxvI+NdtgiO0xpnYwJGNrh8oO6K1qAc/cWxcvRzeEo521RbSDIbEtqq8duD+Rpdt4+BLeWR2LixlXk8ca+rtgxpBIRIWVl7kiIjJ4oPaVV17B66+/jkceeUTdj4yMVJmykhUrgdqqHJRey5IPOA31g/JAfDqe/3ofiq8cRTzRIQyPtPPHypV7DNbu/GHNduD+wO+FPv8/6OP/mpyElCDtypUrsXnzZoSHh+s8LvelX9y4cSNatWqllklQdsuWLWpyThEVFaVmP5Z1hg0bppYlJCQgNjZWTc5JRKbh96NJeHNVLC6k52mXNQ5wxcyhzdEipOZKYxAR0d1JyszHO2sO4ZfYRJ3Jwl6KboBnOteFnY35xyiIyIQCtbm5udcd7EoJBE3tv6oclJJhnUnJwVMLdiH3SgH0vs3KZxxOS73Mj4aI6DaMHTtWjTBZvXo1XF1dteV/ZFZjR0dHFWCWUSfTp09HgwYN1EVuOzk5Yfjw4dp1R40ahQkTJsDb21uNapg4caI6ERodHc3Pg8jIJWXl4921h/HjgQSdA/px0Q3xzL3hsLXmAT0RkSmQE/A/7InHP388jMz8Yu3yexv44L3BEQjzdjbo9hGReaj2QO2AAQNUTdrQ0FBV+mDfvn2YPXs2nn76afV4VQ5KyXCSswrw5Jc7cTmnUN1vF+6FuY+0hLVVLRUceOKJJyrNbiYiouvNmzdPXXfr1k1n+YIFCzBy5Eh1+9VXX0VeXh7GjBmjyhu0b98eGzZsUIFdjTlz5qgZkCWjVtbt2bMnFi5cqE6EkvFiv2nZSkvL8N3u85j+8xGdA/rO9X0w7QEe0BMRmVK/GZ+WizdWxmLr8WTtMm9nO7w9oCkGtgjiZGFEZLyB2k8++QRvvfWWOuCUcgZSm3b06NF4++23tetU5aCUal5eYQmeWbQL51Jz1f1G/q744sk2cLAtDwRIprRkgBERUdUzL25FTmBOmTJFXW5WP1f6V7mQ6WC/ablOJmWrycJ2xqVql3k62eKt/k3xQKvaPKAnIjKRflNOui3ecRYz1x3VjjgV8r9c/qd7OdsZdPuIyPxU+1grCbbOnTtX1aWVYOypU6fw3nvvwc7O7rqDUqmxl5+fr8oeREREVPem0G12QBO+j8H++Ax1P8jdAQufbqszS6VM4rZu3Tp1TURERDfHftPyFBSX4KNNJ3DfR3/oBGmHtK6NXyd0w5DWwQzSEt1kFErz5s3VZNFyueeee/DLL7/onPyUY0hJBJJgnoxWOXTokO53sKBA1YaXiY+dnZ0xcOBAxMfHs81NhLH1m6eTs/Hw53+perSaIG2guwO+HNkGcx5uySAtEekFi2KRIjMQ/3ywvHais501vnyqLQLddc9mSi3hc+fOqWsiIiK6OfablmXXmVTc//E2zNl0HIUl5XMzhHo5Ycmo9pg9jAf0RLcSHByM999/H7t371aXHj16YNCgQdpgrEygKSX1Pv30U+zatUvNe9KrVy9kZWVpX0NK7MkEnsuWLcO2bduQnZ2N/v37o6TkaiYkGS9j6TeLS0oxb/Mp9P3oD+w6k6ZdPrx9KDa83AU9Glc+CToRkVGWPiDTs2JvPD79/aS6bVUL+GR4KzQOcDP0ZhEREREZvYy8IjUkdunf57TLpLb/c13q4h89GsDRjrWkiao610lFMu+JZNnu2LEDTZs2VaM2J0+ejCFDhqjHFy1aBH9/fzVpp5Tay8jIwPz587F48WLtZJtLlixBSEgINm3ahD59+vCDoFs6fDETry0/gIMXykeaijBvJ8wYEomO9XzYgkSkdwzUWjjJ/nh9+UHt/Tfvb8ozhERERES3IMOwf4lNVENiZTJWjRYhHnh/SCSaBPKkN9GdkgzY77//Hjk5OaoEQlxcHBITE9G7d2/tOjLhVNeuXbF9+3YVqN2zZw+Kiop01pEyCVJiT9ZhoJZuprikDHM3ncBnm0+huLRMm8T0dKdwTOjdiCfdiKjGMFBrwc5ezsFzX+3WDs97rH0onupUx9CbRURERGTULqbn4e3Vsdh0JEm7TEpHvdKnEZ64p47KqCWi23fw4EEVmJV5TFxcXFQZA8mmlUCrkAzaiuS+zI0iJJAr86J4enpet448djNS21YuGpoaqaWlpepiruS9yUknY3mPmu2o6XY/mpCBccuO4HhynnZZAz8XzBwaiZYhHjrbZs6MbX8wFLYD20Ff+0NVX4OBWguVlV+EUYt2Iy23SN2/t4EPpgxsdtMJLpycnNChQwd1TURERDfHftP8lJSW4au/zuCD9ceQU2H27+gmfnh3UASCPIxrtnIiU9OoUSPExMQgPT0dy5cvx4gRI9TE0xrXHqvIwfPNjl+qus6MGTMwderU65YnJyeroLG5kqCBlIyQNrKyMvz0NdLWzZo1Q25uLpKSrp4I0+f/9KV7L+Hz7RdRdCWL1roW8GTbADzVLhB2NoU1sh3Gwtj2B0NhO7Ad9LU/VKypfjMM1Fqg0tIyTPx+P04mZav79Xyd8enw1rC1trrlAafMxEpERES3xn7TvMReyMDklQexP/5q3UI/V3tMHdgMfSMCbhkIIqJbk4zY+vXrq9tt2rRRk4Z99NFHeO2119QyyYwNDAzUri9BNE2WrUwuJpNQpaWl6WTVyjodO3a86d+dNGkSxo8fr5NRK7VtfX194ebmZtYBCPnfJe/TWAJzoaGhNfJ34lJy8MqKA9h7Ll27rL6fMz58qAUia7vDEhnj/mAIbAe2g772BwcHhyqtx0CtBZq35RTWH7qkbrs52GD+iLZwd7S95fNkONCFCxdQu3ZtVROKiIiI2G9awiik2RuPY9H2M7iScKUtGfVq38ZV+g1FRHdGMpjkGCQ8PFwFYjdu3IhWrVqpxyQoK9m2M2fOVPejoqJga2ur1hk2bJhalpCQgNjYWMyaNeumf0eObSo7vpGDcnMPWEkAwljeZ00cb5ZeGRnx/rqjyC8qH4Ys59kea+2PyQNbwNHesv+nG9P+YEhsB7aDPvaHqj6fgVoLs+V4Mj7YcEzbIX30SCvU8XGucpq2zJgqM60yUEtERMR+0xImC5u69hAuZV6tXdnQ3wXTH4hEmzpeBt0+InPzxhtvoF+/fiqTVY47li1bhs2bN2PdunXqIHncuHGYPn06GjRooC5yW0YuDB8+XD3f3d0do0aNwoQJE+Dt7Q0vLy9MnDgRkZGRiI6ONvTbIyM43oxPy8Ur3x/AX6cva5fV8XbCrAebI9SxCPa21vyciMjgGKi1IOcu5+If3+xD2ZVskHE9G6J7Yz9DbxYRERGRUTmfmqsmC/v9WLJ2mYOtFV7q2RDP3Bt+y3JRRHT7Ll26hCeeeEJlwUrQVUquSZC2V69e6vFXX30VeXl5GDNmjCpv0L59e2zYsAGurq7a15gzZw5sbGxURq2s27NnTyxcuBDW1gzAWfqJt+92n8c/fzyC7IJi7fIR94ThtX6N4WBjZVG1aInIuDFQayHyCksweskeZOSVTx4W3cQfL/Yor/9EREREREBhcSn+t+00Pv71hHZIrOjR2E/Vog3x4oSqRPoyf/78mz4uWbVTpkxRl5vV//vkk0/UhUgkZeXj9eUH8dvRq4HY2h6OKou2U30fdb86ZnMnIqouDNRayBnE11ccwJGETHW/ro8zZj/cAlZWnPSCiIiISOyMS8Wbqw7i+KXyyVZFgJsDpgxsij7NOFkYEZGp2XT4El5dfgCpOYXaZQ+3CcGb/ZvA1cGya9ESkfFioNYCLNlxFqtjLqrbznbW+O8TUXC7g45JhgxJvScOHSIiImK/aS7kAP79X47gu93x2mVyLntkx3CM790QLvb8uUxEVBOq63gzt7AY7/10BEv/Pqdd5uNij5lDI9GziX81bCkRkf7wl6eZi72QoWrxaHzwUAs08L9ax+l2eHp6YujQodW4dUREROaL/abxjzj6YU88pv98BGm55aWhRPNgdzVZWERtd4NuHxGRpamOfvNAfDrGLYvB6ZQc7bJeTf3x/pBIeLtU/wRlRETVjYFaMyaF0l9YuheFJeU1d57qVAf9IgMNvVlEREREBnUyKQtvrIxV5Q40XO1t8ErfRnisfRisWR6KiMiklJSW4T9bTmHOxuMoLi2fPdvR1hrvDGiKh9uGqBrHRESmgIFaM84SeWPFQZy5nKvNDpnUr8ldvWZKSgpWrVqFwYMHw8envPA6ERERsd80pclVP/39BD7fehpFJeUH8qJ/80C83b8p/NwcDLp9RESW7E6PN+PTcjH+2/3YeebqybcWwe6Y+0grhPs462lriYj0g4FaM/XtrvNYs/+iNkPk00dbw87G6q5flzNiEhERsd80Rb8fS8Lbq2NxPjVPuyzUywn/HByBrg19DbptRER0Z8ebq/ZdwFurYpFVUKzuy4CIMd3q46XoBrC1vvvjXyKimsZArRk6mpiJd9Yc0t5/f2hzhHo7GXSbiIiIiAzhQnqemlRm/aFL2mW21rXwf13rYWz3+nCwvbtJa4iIyDBl/iRAu3LfBe2y2h6OmPtIS7St48WPhIhMFgO1ZkZmuBz79V4UFJefiXy8Qyjub866tERERGRZCotLsWhnAhbs2of8oqsZWu3DvTDtgUjU93Mx6PYREdGdT5gtc7FoyvyJIa1qY8qgZnBzsGWzEpFJY6DWzExZcwinkstnuGwS6IY3729q6E0iIiIiqlHbTqSoMgcVZ/32cbHH5PsbY3DL2pxUhojIROdhWfDnGcz45Yi2zriLvQ2mPRCBQS1rG3rziIiqBQO1ZmRdbAK+2x2vbjvZWePfw1tV63A+Dw8PPPjgg3Bzc6u21yQiIjJX7DdrXkJGeZmDnw4kaJdJvcIn76mDl3s1hLsjM62IiEyx30zNKcQr3+/Hr0eTdCYM++TR1izzR0RmhYFaM3EpMx+vrziovT9lYDPU9a3eIX02Njbw8mK9HyIiIvabxqWopBQL/ozD3E0nkFtYol0eGeiMGUNbIiLYw6DbR0REd368ueP0Zby0bB8uZRZolz3XpS4m9m5ULRNmExEZEwZqzUBpaRkmfr8f6blF6n6/iAA8FBVc7X8nKysLe/fuRevWreHq6lrtr09ERGRO2G/WjL9OXVZlDk4kZWuXeTnb4bW+jXBvsC0C/DkSiIjIFPvN4pJSfPLbSXzy2wmUllc6gLezHT4Y1gLdG/kZenOJiPSCgVozsOivM/jjRIq67edqj+kPROql9lpBQQGOHTuGZs2aMVBLRETEftOgkjLzMf3nI1gVc1G7TH7+PNY+VGVZuTnYICnp6hBZIiIybhWPN7NLbfDSshjsjEvVPt6xnjfmPtwSfm4OBt1OIiJ9YqDWxB1LzMKMX45q73/wUAt4OtsZdJuIiIiI9EUyrL766yzmbDyOrIJinVqF/xwcgeZXyhyUlpbyQyAiMkF7zqbh9Z/2Iu3KiFFrq1oY36sh/q9rPXWbiMicMVBrwgqKS1StnsLi8gORpzrVQZeGvobeLCIiIiK92H0mFW+uisXRxCztMg8nW7zWtzEebhMCKx7AExGZrJIr9Q3eWROLtILy5KPaHo746JGWaFOHc6UQkWVg5W0T9uGG49oDlYb+LuoghYiIjMfWrVsxYMAABAUFqZI0q1at0nl85MiRannFS4cOHa4bBvjiiy/Cx8cHzs7OGDhwIOLj42v4nRAZVlJWPiZ8tx8P/ucvnSDto+1C8NuEbni0XSiDtEREJiwluwDvrI5Vt8uu1KPt2dgPP/2jM4O0RGRRmFFronadScUXf5xWt+2srTD34VZwsLXW6990dHREy5Yt1TUREd1aTk4OWrRogaeeegpDhw6tdJ2+fftiwYIF2vt2drrla8aNG4e1a9di2bJl8Pb2xoQJE9C/f3/s2bMH1tb6/b9Pd4f95t2TUUMLt8fh419PIrtCmYOI2m7456AItAr1rIa/QkREhj62fWHpXuTk5CLfzQV5pdYqCWl0l7o8CUdEFoeBWhOUV1iCV77frz3TOL53QzQN0v+MxpLJ1a5dO73/HSIic9GvXz91uRl7e3sEBARU+lhGRgbmz5+PxYsXIzo6Wi1bsmQJQkJCsGnTJvTp00cv203Vg/3m3dlyPBlT1x7C6eQc7TKZIGxin0Z4rH0Y6xQSEZm4srIyfL71NGatP3al7IE1DhX74fOnW6FDXW9Dbx4RkUEwUGuC/rX+GM5czlW3W4V64Nl769bI3y0sLERKSooafnttxhcREd2ZzZs3w8/PDx4eHujatSumTZum7gvJmi0qKkLv3r2160sZhYiICGzfvv2GgVoplyAXjczMTO3kSuY8wZK8NznoM5b3aKh+09ja4XadS83FtJ+OYOORJO2yWrWAR9qGYEKvhvBSk6bK+7tyxtpM26G6sB3YFvraJyz9u0V3JyOvCBO/34+Nhy9pl3Wu64FJPWqjQbArm5eILBYDtSZmZ1wqFmyPU7ftbKzwrwdb1FhGiRzo//jjjxgyZIg66CQiorsj2bYPPfQQwsLCEBcXh7feegs9evRQAVrJtE1MTFQBPk9P3eHd/v7+6rEbmTFjBqZOnXrd8uTkZOTn55vtxyZBA8lClgCElZXhy/Cnp6erOsVdunRRgXhLbYeqyisqwaJdiVi65xIKS64GYSMDnTGheyga+zmhOCcdSVcTbM2yHaob24Ftoa99Iivrar1ootsReyEDz3+9B+dT87TLXuheH0+08sLqVSvhz+NNIrJgDNSaWMmDV3+4WvJgYu+GqO/nYujNIiKiO/Twww9rb0uWbJs2bVTQ9qefflInxW5EDq5l4rEbmTRpEsaPH69zok3KJfj6+sLNTf+lcgwZfJB2kfdpDIE5zTZ4eXnV6AlOY2uHW5H9+aeDiZjxy1EkZFw9keDnao/X+zXCoBblk/GZezvoC9uBbaGvfcLBweGu9k2yTN/tPo83V8WqGuTCw8kWc4a1RPfGfmoUChGRpWOg1oTMWn9UW/KgdagHRnWumZIHRERUMwIDA1Wg9sSJE+q+1K6V4fNpaWk6WbVJSUno2LHjDV9HsnHlci05IDf3gJUEH4zlfWq2wRDbY0ztcDNHEjIxZc0h/B2Xql1ma11L/cZ5oUd9uNjbWEQ76BvbgW2hj33C0r9XdHskMPvuj4ewZMc57bKWIR7492OtUduDk1UTEWkwUGtCJQ8Wbj+jbttLyYOHaq7kARER1YzLly/j/PnzKmAroqKiYGtri40bN2LYsGFqWUJCAmJjYzFr1ix+LGSy0nMLMXvjcSzZcRYVS812b+SLtwc0Q7iPsyE3j4iIqtGlzHw8v2QP9p5L1y57okMY3urfVJXzIyKiqxioNZGaba8tP1Kh5EEj1POt+ZIHctZcZrDm2XMioqrJzs7GyZMntfelDm1MTIwaCi+XKVOmYOjQoSowe+bMGbzxxhtqiPwDDzyg1nd3d8eoUaMwYcIEeHt7q+dMnDgRkZGRiI6O5sdg5NhvXk9m9V626xw+WH8MablF2uV1vJ3w9oCm6NHYv0Y/IyIi0q9dZ1Ix5uu9SM4qn+RUArPTBkfgoTYh163LfpOIiIFakzDvz4s4m1pe8iAqzBNPdw43yHZIgOCxxx4zyN8mIjJFu3fvRvfu3bX3NXVjR4wYgXnz5uHgwYP46quv1KRTEqyVdb/99lu4ul6d7XjOnDmwsbFRGbV5eXno2bMnFi5cCGtra4O8J6o69pu6tp9Mwbs/HsbRxKsTEDnZWasSB6M6h8Pehvs0EZG5kPrji3ecxbtrD6P4ytCJIHcH/OeJKDQPrnyCTfabREQM1Bo9KXnwXUzS1ZIHDzZnyQMiIhPRrVs3daByI+vXr6/SZC2ffPKJuhCZoriUHEz/+Qg2Hr6ks3xQyyBM6tcEAe6ckIiIyJzkF5Vg8spYLN8br13WsZ43Pnm0Fbxdrq+hT0REV+mlIMyFCxfw+OOPq2GaTk5OaNmyJfbs2aN9XA5aZbhnUFAQHB0d1YHsoUOH9LEpJt/BvbEyVnv/lT6NUNcAJQ80UlNT8fXXX6trIiIiYr95Mxl5RZj202H0nrNFJ0gbWdsd3//fPfjokVYM0hIRmZn4tFw8+J/tOkHa57rUxVdPt7tlkJbHm0REesiolZmpO3XqpIZv/vLLL/Dz88OpU6fg4XF1eINMgDJ79mw1dLNhw4Z477330KtXLxw7dkxnuKel+2zzKZxOyVG3W4a446lOhil5oFFaWoqcnBx1TUREROw3K1NcUoplu86rycJScwq1y/1c7fFa38Z4oFVtWHFCVCIis/PXqcsY8/UebQ1yR1trzHqwOQa0CKrS83m8SUSkh0DtzJkzERISggULFmiX1alTRyebdu7cuZg8eTKGDBmili1atAj+/v5YunQpRo8ezc8FwIlLWZi3uXwCGmsrYPoDkSx5QEREREbtjxPJ+OePh3H8UrZ2mZRuGt2lLkZ3rQdne85jS0RkjqQe7dQ1h7T1aMO8nfD5E23QKICJWEREt6Pafy2vWbMGffr0wUMPPYQtW7agdu3aGDNmDJ599lntjNeJiYno3bu39jn29vbo2rUrtm/fXmmgtqCgQF00MjMztWfczDG7s7S0DK8vP4CikvJO7vEofzT0czb4e9X8fUO0u/w9CfIbug0Mje3AduD+oL/vhaX/fyG6G6eSszH9pyP49Wh5XX2NgS2C8Fq/xqjt4cgGJiIyQ0UlpZi69hCW7DinXda1oS8+frQV3B1tDbptRESmqNoDtadPn1YzWcvM1m+88QZ27tyJf/zjHyoY++STT6ogrZAM2ork/tmzZyt9zRkzZmDq1KnXLU9OTkZ+fj7MzYoDydhzLl3dDna3xwMNHZGUlAQrK72UFK4ymZVcUzvIEIHajIwMFYwxdDsYEtuB7cD9QX/fi6ysqzPRE1HVZOQW4aNfT+Crv85os6hEixAPvN2/CaLCvNiURERmKi2nEGO+3ou/Tl/WqUcrZW6sWeKGiMg4ArVywNymTRtMnz5d3W/VqpWaKEyCtxKo1ahVq5bO8+QA+9plGpMmTVKB34oZtVJewdfXF25ubjAnlzLz8dmf+7X3ZwyJhL9bqXqvhg5QSp1hFxcX+Pj4wM7Orkb/tuxXsn8YQzsYEtuB7cD9QX/fCwcHzjxP1Ut+o/Tv39/sfquIwuJSfP33WXz86wltLUIR4OaA1/o1wqAWrENLRGTOjl/KwqhFu3A+NU/dt7O2wvQhkXgwKviOX9Oc+00iIoMFagMDA9G0aVOdZU2aNMHy5cvV7YCAAHUtmbWyroZkjF6bZash2bhyuZYckJtb0O7dH48gu6BY3ZZOrlMDX202raHfqwQxgoPvvOO9WxKIMYZ2MDS2A9uB+4N+vheW/r+Fqp+c1AwKqtoEKqZCTqz/EpuIWeuO4szlXO1yB1sr/F/XeiqTysmOdWiJiMzZpsOX8NKyfcgpLFH3fVzs8fmTUWgd6nlXr2uO/SYR0e2q9qPSTp064dixYzrLjh8/jrCwMHU7PDxcBWs3btyofbywsFDVs+3YsSMs2YZDiergR3g522HyfU1gTHJyclQpC7kmIiIiy+o395xNxdB529Uw14pB2sEtg/D7xG4YF92QQVoiIjMmJ+v+/ftJPLt4tzZIG1HbDWtf7HTXQVpz7DeJiO5Etac8vPzyyyrgKqUPhg0bpv7Rfv755+qiyXoaN26cerxBgwbqIrednJwwfPhwWKqs/CK8vfqQ9v7b/ZvC09nOqCa3ycvLQ0xMDOrWrQtnZ2dDbw4REZFRM5d+My4lR2XQak4ma3So64U37muC5sEeBts2IiKqGflFJXht+QGsjrmoXda/eSD+9WALONpZV8vfMJd+k4jIqAK1bdu2xcqVK1Vd2XfffVdl0M6dOxePPfaYdp1XX31V/RMeM2YM0tLS0L59e2zYsAGurq6wVB9uOI7EzPKJ0e5t4INBLTnkg4iIiAwnNadQ1aBdsuOszkRh9f1c8MZ9jdG9kd8N5xcgIiLzkZxVgGe/2o2Y8+WTS4uJvRtibPf67AeIiKqZXoqISQFwudyI/KifMmWKuhCw71waFv11RlvjbdrgSHZ4REREZLCsqS//jMO8308h60rdfE0NwvG9GmJYm2DYWLOmMxGRpUwa9vTCXYhPK580zMnOGnMebok+zcrnniEiourFX9kGVlRSikkrDqLsSqKKHACFejsZerOIiIjIwpSWlmH5nnj0+GAzZq07pg3SOtpa46WeDbDllW4Y3j6UQVoi0osZM2ao0ZkyytLPzw+DBw++bu6TkSNHqoSWipcOHTrorFNQUIAXX3wRPj4+avj8wIEDER8fz0/tDvxxIhlDP9uuDdIGujvg+/+7h0FaIiI94rS8BvbFH6dxNDFL3W4a6IanO4XDWNnb26NRo0bqmoiIiMyj35TJYbadTMGMn4/icEKmdrlVLeDhtiF4Oboh/NwcDLqNRGT+ZHLpsWPHqmBtcXExJk+ejN69e+Pw4cM69Ur79u2LBQsWaO/b2dnpvI7Mh7J27VosW7YM3t7emDBhghrtuWfPHlhbV08tVUuw9O9zeGt1LEqulL6RScPmj2gLfz32B6bSbxIR6RMDtQZ0JiUHH206oT0Yen9opFFnqcjZ7a5duxp6M4iIiEyCKfSbUm9QJgrbfuqyzvIejf3wer/GaOhvufMHEFHNWrdunc59CcZKZq0EWLt06aJdLkG8gIDKh91nZGRg/vz5WLx4MaKjo9WyJUuWICQkBJs2bUKfPn30/C7MY3TFjF+O4Is/4rTLejX1x0ePtISTnX7DB6bQbxIR6RsDtQbMXpm86iAKikvV/ac6hRv9rMlyZjszMxNubm6wseGuQ0REZKr95smkLHyw/jjWHUrUWS4ZU2/0a4KO9X0Mtm1ERJqgq/Dy8tJpkM2bN6sAroeHhwrqTZs2Td0XEtQtKipSmbgaQUFBiIiIwPbt228YqJVyCXLRkP/dorS0VF3Mlbw3OS7VvMfcwmKM/+4ANhy+pF1nVOc6eL1vY1hb1dJ7W0i/mZWVpQK2NdlvXtsOlortwHbg/qDf70VVX8O4jhosyIq9F/DnyfLsldoejqo2rbFLT0/HihUrMGTIEFXziYiIiEyr37yQnoe5G49j+d54XBnNqoR5O2FC70boHxkIKxnmQ0RkQHJQPH78eHTu3FkFWTX69euHhx56CGFhYYiLi8Nbb72FHj16qACtZNomJiaqUgienp46r+fv768eu1l93KlTp163PDk5Gfn5+TBXEjSQgLi09+XcYryy5hSOJuWqx6xrARO6h2JIc29cTkmusX5z69atKoNaAvGGaAcrK+Md4apvbAe2A/cH/X4v5ERUVTBQawCXswvw3k+HtfffGxwBZ3t+FERERKS/3x6fbT6FxX+dRWHJ1bP5fq72+EfPBqoWra0Rl18iIsvywgsv4MCBA9i2bZvO8ocfflh7WwK4bdq0UUHbn376SZ0UuxE5wJaJx25k0qRJKjBcMaNWyiX4+vqqURHmHICQdrlc4oDnvt+LhIzyoLSLvQ3+Pbwl7m3gW6PbowmCSBZ1TZ7g1LSDfN6WHqhlO7AduD/o73vh4FC1Gt+MDhrAtJ+OIC23SN3u3zwQ3RuXD9UhIiIiqk7ZBcWY/0ecmrxUbmu4Odjg+W71MbJjHTjacXIdIjIeL774ItasWaMyK4ODg2+6bmBgoArUnjhRPu+H1K4tLCxEWlqaTlZtUlISOnbseMPXkWzcyiawkoNycw/c7T6fhUk/7Ud2QYl2tOeXI9uiUUDN1yjXtLUh2l0CMZbwed8K24HtwP1Bf9+Lqj6fgdoa9seJZKzYd0F7kPT2gKY1vQlERERk5gqLS7HgzzMqi/ZyTqF2uYOtFZ7uFI7RXerB3cnWoNtIRHRt1qsEaVeuXKnq0IaHh9+ygS5fvozz58+rgK2IioqCra0tNm7ciGHDhqllCQkJiI2NxaxZs9jg11gVcwGvrjqJ4iu1cFqEeOCLJ6Pg51q1rC8iIqp+DNTWoLzCEkxeGau9/8Z9TUyuE7T0M4xERETG3G9KgPa7Xefw8a/HkZRdPnpH2FjVwiPtQvCPHg3g52Zavz2IyDKMHTsWS5cuxerVq9VkUpqasu7u7nB0dER2djamTJmCoUOHqsDsmTNn8MYbb6gh8g888IB23VGjRmHChAnw9vZWQ+gnTpyIyMhIREdHG/gdGldQ/D9bTmPmuqPaZdFN/PHJo60MPsqCx5tEZOkYqK1BH/16AudSy4uztwv3wrA2ITAl8iPomWeeMfRmEBERmYSa7DeLSkqxcu8FfPzbCcSn5ek8NrBFkJq0tI6Pc41sCxHRnZg3b5667tatm87yBQsWYOTIkbC2tsbBgwfx1VdfqUmnJFjbvXt3fPvttyqwqzFnzhzY2NiojNq8vDz07NkTCxcuVM8noKS0DFPXHsJXf53VNsfwdiF4d1AEbAxcq5zHm0REDNTWmMMXM1V9OGFnbYXpD0RyVmUiIiK66wPuVfvKA7RnL5efDNbo2dgP43s3RLMgd7YyEZlElufNSFbt+vXrqzRZyyeffKIupCu/qAQvLduH9YcuaZf9X8cgvHJ/M1hzQkkiIqPAjNoaOoiatOKAuhZju9dHfT8XmBopyv/bb7+hR48eOsX5iYiIqGb7TflN8eOBi2q0zunkHJ3Hujb0wYjWPujWPJxDSImIqLxPyinEM1/txp6zadqSOO8PiUTnYFs1UY4x4PEmEREDtTXiq7/OYH98hrrdwM8Fz3erZ5L7XklJiSrYL9dERERU8/1maWkZ1h1KxNxNx3H8UrbOY53qe6sSB61CPNQM50REROJ8ai5GLNipPbHnbGeNeY9HoXN9b6PqL3i8SUTEQK3eXUjPw7/WH9PenzEkEnY2nJCLiIiIbj9A+/GvJ3A0MUvnsXZ1vFSJgw51va+sW8qmJSIiJfZCBp5auAvJWQXqvq+rPRaMbIuI2u7sL4iIjBBLH+i5ztKbKw8it7A8k+ax9qFoU8dLn3+SiIiIzEhxSSl+PJCAT38/iZNJuhm0rUI9MKFXI5VJayzDVomIyHhsP5WCZxftRs6V49G6vs5Y9FQ7hHg5GXrTiIjoBpjaqUdrDyTg92PJ6rafqz1e7dtYn3+OiIiMzNatWzFgwAAEBQWpQNqqVauuO6E3ZcoU9bhMkiIzXR86dEhnnYKCArz44otqJmRnZ2cMHDgQ8fHxNfxOqKYVlZTiu93nET17C8Z9G6MTpG0e7I4FT7XFiuc7onMDHwZpiYjoOusPJWLkl7u0QdqoME8s/7+ODNISERk5Bmr1WKx96pqrB9vvDoqAu6MtTJmrqyuio6PVNRER3VpOTg5atGiBTz/9tNLHZ82ahdmzZ6vHd+3ahYCAAPTq1QtZWVeHto8bNw4rV67EsmXLsG3bNmRnZ6N///6sF26m/WZBcQm+/vssun+wGa/+cABnLudqH5OD7IVPtcXqsZ3QvZEfA7RERFQpOdH3/JI9KCwpL4UT3cQPXz/THp7OdkbdYjzeJCJi6QO9mfbzEVzOKVS3+zTzR9+IAJPf3+zt7VG3bl1DbwYRkcno16+fulRGsmnnzp2LyZMnY8iQIWrZokWL4O/vj6VLl2L06NHIyMjA/PnzsXjxYhXwE0uWLEFISAg2bdqEPn361Oj7If31m/lFJVi28xz+u/U0EjLydR67p643XuxZX12zxAEREd3MF1tPq2NRjSGtamPmg81ha238OVo83iQiYqBWL7adSMEPe8qHpbra26hsWnOQm5uLkydPon79+nByYl0jIqK7ERcXh8TERPTu3VvnAKVr167Yvn27CtTu2bMHRUVFOutImYSIiAi1zo0CtVIuQS4amZmZ2kmmzHmiKXlvEgA3lvco/eapU6dQr169G/abWflF+GbnefxvWxxSsstP8Gp0aeCDF3rUR5swT3Vf3ptcTK0dDIXtwHbgPqHf74al/48xNvKZzlp/DPM2n9Iue7pTON68vwmsrEyjjjmPN4mIGKitdnmFJXhj5UHt/Un3NYG/m4NZ7GvSce7YsUMFCRioJSK6OxKkFZJBW5HcP3v2rHYdOzs7eHp6XreO5vmVmTFjBqZOnXrd8uTkZOTn62ZrmhMJGkgWshysWlkZPnMoPT0df//9twrAe3h46DyWklOEb/ddwooDycgp1A123FvXHSPbBaJZgLNUq0VSUpJJt4OhsB3YDtwn9PvdqFimhwyrpLQMb646qE78aUzo1VCd7DOlkRg83iQiYqC22s3ddBznUsvrybWr44VH2oZwPyMiohu69gBKDpxvdVB1q3UmTZqE8ePH62TUSrkEX19fuLm5mXXwQdpF3qcxBCg12+Dl5aUmgxOnU3LUsNSV+y6gsORqdqx8nH2bBWBst3poGuRmVu1gKGwHtgP3Cf1+NxwczCMZxdRJbfOXv43BzwcTtf2JjOh8okOYoTeNiIjugM2dPIkqF3shQw1dFHbWVpgxNNJkhpkQEVHNkonDhGTGBgYGapdL9qQmy1bWKSwsRFpamk5WrazTsWPHG762ZHDK5VpyQG7ugTsJPhjL+9Rsg1zvj8/Af7ecxvrDiahYvUB+LwxpXRvPdqmLer4uZtkOhsR2YDtwn9Dfd8PS/78Yg9zCYoxevAd/nEhR922samH2wy0xsEWQoTeNiIjuEHvXalJcUorXlh9Qw07EP3rWr9YDLiIiMi/h4eEqELtx40btMgnKbtmyRRuEjYqKgq2trc46CQkJiI2NvWmgloyDpp7s68sP4IHPtmPdoatBWqlhP7prXfzxWne8P7Q5fzMQEdFtyS4oxsgvd2mDtI621vjfiDYM0hIRmThm1FaTL/+Mw6GL5ZO1NPJ3xXNd6sHcSJ3E0NBQdU1ERLeWnZ2tJmGsOIFYTEyMGgov/0/HjRuH6dOno0GDBuoit6UG+PDhw9X67u7uGDVqFCZMmABvb2/1vIkTJyIyMhLR0dH8CIxUflEJ1uy/iG//PIbwUgfsvpyl/cnl52qPpzuHY3j7ULg52Bp6U4mIyARl5BVhxJc7EXM+XXvyb+HTbREV5gVTxuNNIiIGaqvF6eRszN54XFsT6P2hkbCzMb9kZalr2LdvX0NvBhGRydi9eze6d++uva+pGztixAgsXLgQr776KvLy8jBmzBhV3qB9+/bYsGEDXF1dtc+ZM2cObGxsMGzYMLVuz5491XOtra0N8p7oxpKy8rFkxzl8veMsLucUqmV74K2u6/o6Y3SXuhjcqjbsbfjZERHRnUnNKcQT8//WJgl5ONli8dPtERnsbvJNyuNNIiIGau+alDp45YcDyC8qn7F5ZMc6aBWqOzu3OU08UFBQoOoesiYVEdGtdevWTTv8/UY1AqdMmaIuN5us5ZNPPlEXMk6HLmbgy21nsHb/RRSWlP8eEFYoQ9tQV4zs3AB9IgJZt56IiO76hOAT/9uJY5dkpAbg42KHxaPao0mgeUwUyuNNIiLWqL1rX26Lw56zaep2HW8nvNKnkdnuV6mpqVi8eLG6JiIisvQTtesPJeLh//6F+z/ehuV747VBWmurWujfPBCLHmuKnjbH0DbIjkFaIiK6KwkZeXjkvzu0QVp/N3sse+4eswnSCh5vEhExo/aunEzKxr82HNOWPPjXQy3gZMeyv0REROYqLacQP+yJx+IdZ3EuNVfnMXdHWzzaLhRP3hOGIA9HpKSk4IjBtpSIiMzF+dRcDP/fDpxPzVP3a3s4Yumz7RHm7WzoTSMiomrGqOJdZNJM/H4/CovLs2ee7hSOtnVMu3g7ERERXU/KV+yPz8Div87ixwMXUXCl79eQ+rNPdQrH0Na1ecKWiIiqVXxaLh75fAcupJcHacO8nfD1M+0R7OnEliYiMkMM1N6hL/44rZ1ls66PMyb2Nt+SB0RERJYot7AYa2IuYsnfZxF7oXzSlorubeCDpzuHo2sDX5Y2ICKiaifB2Ue/uBqklRODS5/pgAB3B7Y2EZGZYqD2Dpy4lIXZG46r21ZXSh442nEGZyIiInMpbbRkx1lVdzYrv1jnMTcHGzwYFYLHOoSinq+LwbaRiIjMvybto59fLXcgyUHLnu0APzcGaYmIzBkDtbepuKQUE6TkwZUJQ569ty6iwjxhCby8vDBy5EjY2HC3ISIi85JXWIJfYhPw7a7z+Dvu+kkzmwe74/H2YRjQIqjKJ2fZbxIR0Z1IzMhXQVpNLfRwH2d885z5B2nZbxIRMVB72z7+7SQOxGeo2/V8nfFyr4YWsx9ZWVnBzs7O0JtBRERUrbVnv9t9HmtjLiKrQDd71t7GCgNbBOHxDmFoEeJx26/PfpOIiG5XUmY+hn+xA2cu52pr0n7zbAf4m3mQVrDfJCJioPa27DqTik9/O6FuW1vVwofDWsLB1nJKHmRkZODPP/9Ep06d4O7ubujNISIiuiOXswuwct8FfL87HscuZV33uNQAHN4uFA9GBcPD6c5PULLfJCKi25GaU4jh//sbp1Ny1P1Qr/IgraXUpGW/SUTEQG2VZeQVYdyyGJSWld9/OboBWt5Bdo0pKyoqQnx8vLomIiIyJflFJfj9aJIK0P5+LAlFJVc69Cuc7KzRv3kgHm4bgtahnqhVq9Zd/032m0REVFVZ+UUY8eVOVSddBHs6qnIHQR6OFtOI7DeJiAArfTfCjBkz1MHOuHHjdIYaTpkyBUFBQXB0dES3bt1w6NAho/08ZHvfXBWrnW2zXbgXnu9W39CbRURERDdRWlqG7adS8NoPB9B22iY8//VebDh8SSdI2ybME7OGNseuydGY9WALRIV5VUuQloiI6HZOJj6zaDcOXigvsefvZq8yaWtbUJCWiIjK6XVWqF27duHzzz9H8+bNdZbPmjULs2fPxsKFC9GwYUO899576NWrF44dOwZXV1cYmxV7L2Dt/ova2Z7nPNxSlT4gIiIi43MkIRNr9idgzf6LSMjIv+5xX1d7DGlVGw+1CUF9PxeDbCMREZEoKinFC0v3aiey9HCyxeJR7RHi5cQGIiKyQHoL1GZnZ+Oxxx7DF198oQKxFbNT586di8mTJ2PIkCFq2aJFi+Dv74+lS5di9OjRMCank7Px9upY7f3pQyJ5ZpOIiMiIyG+Lo4lZ+PnARazdfwFnUq8PzjrbWaNPRAAeaFUbHev58IQrEREZxciPV384gE1HkrR91cKn2qGhv/ElLxERkYkHaseOHYv7778f0dHROoHauLg4JCYmonfv3tpl9vb26Nq1K7Zv325UgdrcwmI8v2QvcgpL1P2HooLRv3kQLJWzs7OaSEyuiYiIDB2cPXQxEz8fTMAvsYmIuzLxSkU2VrXQtaEvBrWqjV5N/OFoV7MTgLLfJCKim/VjU9ceUrXThZ2NFb54so3FzYNSEftNIiI9BWqXLVuGvXv3qtIH15IgrZAM2ork/tmzZyt9vYKCAnXRyMzMVNelpaXqoq+O8/XlB7SzQTfwc8Hb/Zvo7e/diPw92Zaa/ruVkYB6kyZNtNtlqe1gSGwHtgP3B/19Lyz9/4spKCktQ8z5NGw4dAk/xybgfGp57fiKpDBRVJgnBrUMwv3Ng+DlbAdDkTr8zZo1M9jfJyIi4zVvyyks+qv8+FfK6n36aCt0rO8DS8Z+k4hID4Ha8+fP46WXXsKGDRvg4OBww/WunahDDrJvNHmHTEg2derU65YnJycjP//64Y3V4fuYJFXfTjjZWeG9vmHIyUjF9fk6+iWBg4yMDNU+VlZ6n/vtpgoLC3Hp0iUVVLezs7PYdjAktgPbgfuD/r4XWVnlJ+bIuGTmF+GP4yn49cgl/H4sCWm5RdetI2XjZaLPvs0CEOVvjWZ1g42ir5DfKPK7KCQk5Ka/iYiIyLKsjrmAWeuOae/LpJa9mwXA0rHfJCLSQ6B2z549SEpKQlRUlHZZSUkJtm7dik8//VRNGKbJrA0MDNSuI8+5NstWY9KkSRg/frxORq0c9Pj6+sLNza3aP8e959Lw8R/x2vv/erAF2jYOMFgAQgLY8l4NfdCZkpKCffv2YfDgwfDx8bHYdjAktgPbgfuD/r4XDKQZjzMpOfj1aJIKzu6MS0Vxadl160j20T11vdEvMgC9mwaoCcJkX5DfE8ZC6vX//vvvqiY/9y8iIhJ/n76MV74/oG2MV/o0wtCoYDYO+00iIv0Eanv27ImDBw/qLHvqqafQuHFjvPbaa6hbty4CAgKwceNGtGrVSpupuWXLFsycOfOGQ+7lci05IK/uoF1SZj5eWBqDopLyg8Jn7w1XQycNSQIQ+nivt0vz9w21LcbSDobGdmA7cH/Qz/fC0v+3GFJ6biG2n7qMP06k4M+TKTiXmlvpejLJSpeGvujR2A89m/gbtKwBERHR7TqZlI3nFu9BYUl5uaVH24VgTLd6bEgiItJfoNbV1RURERHXFQX39vbWLh83bhymT5+OBg0aqIvcdnJywvDhw2FIeYUleOar3UjMLC+nIMMoX+vb2KDbREREZG4Kikuw52watl0JzB64IKUrKl83xMsRPRv7o2cTP9Uv29vU7IRgRERE1SE1pxBPLdyJjLzyEj4y2eU/B0XcsPwfERFZJr1MJnYrr776KvLy8jBmzBikpaWhffv2qqatBHkNpbS0DC9/G4MD8Rnqfm0PR3w6vBVsrJlhRUREdDdyC4ux71y6KmOw60yqKjGUX1T55G221rXUZGBdG/ohuokf6vu58CCWiIhMWnFJKcZ+vVc7CWaTQDf8+7HWPNYkIiLDBGo3b96sc1/OGk6ZMkVdjMXMdUex7lCiuu1ib4P5I9vAz5UTf1RkY2MDPz8/dU1ERHSzUga7zqSpoKwEZ2MvZFRaZ1ajcYArOtf3QecGPipr1snOPPoZ9ptERCSm/3wUf52+rG5LTfUvR7ZRx5zEfpOI6FrsHQDM23wK/916WjtztGTSNg6o/knKTJ2Hh4eaSIyIiKhiGYMjCVmIOZeG/fEZiDmfjriUnJs2kIxaaV/XC/c28EGn+j5me2KU/SYRES3fE48v/4zTjhr5z+OtEejuyIZhv0lEVCmLD9R+/fdZlU2r8c/BEejWyK/y1iIiIrJgZWVlKgi7Pz4dMefSEROfgSMXM7WTotxIPV9ntAv3RrtwT7St44VgT6ca22YiIiJD2X8+HZNWXp1o+91BEYgK8+IHQkREN2TRBVjX7L+IN1fFau+/0qcRHmsfZtBtMmYpKSn4/PPP1TUREVlendlW/9yIHh9uwcvf7seiv86qA9Brg7R21lZoGeKBpzuF4z+PR2HPm9H4dUI3zBgSiQdaBVtUkJb9JhFR1c2YMQNt27ZV85ZIuTUZyXfs2LHrThhK+bygoCA4OjqiW7duOHTokM46BQUFePHFF+Hj46MmtR44cCDi4+Nr/KNIysrH6MV7UFhc3k8+1j4Uj7YLrfHtMCXsN4mILDijVgq6f/b7Se0s06O71MWYbvUMvVlERERGSerGejjaIj23fLZqjbq+zmgZ7IGWoR5oEeyhJkixs7Ho88BERHQHtmzZgrFjx6pgbXFxMSZPnozevXvj8OHDKuAqZs2ahdmzZ2PhwoVo2LAh3nvvPfTq1UsFdDUTU48bNw5r167FsmXL4O3tjQkTJqB///7Ys2cPrK2ta+yzWfzXWSRm5qvbbet44p0BzWrsbxMRkemy2ECtjbUVlj7bASO+3ImI2m54vV9jzipNRER0E1IaKD4tVwVkJTDbvLYH3J1s2WZERHTX1q1bp3N/wYIFKrNWAqxdunRR2bRz585VAdwhQ4aodRYtWgR/f38sXboUo0ePRkZGBubPn4/FixcjOjparbNkyRKEhIRg06ZN6NOnT419Ui9HN0QtAD/sicdnj0XxJCYREVWJxQZqhZezHZY91wEOttYM0hIREd3ClIHMBiIiopohQVfh5VVe0zUuLg6JiYkqy1bD3t4eXbt2xfbt21WgVoK6RUVFOutImYSIiAi1zo0CtVIuQS4amZmZ6rq0tFRd7tS46AYY1bkOXB1s7+p19EW2SQLgxrJtmu2423Y39XYwFLYD24H7g36/F1V9DYsO1Apne4tvAiIiMiCptTd16lSdZZIdJAejQn4YyONSIzwtLQ3t27fHv//9bzRrxqApERGZJ+n7xo8fj/9v7/5jqirDAI6/OAGpgDA1EILMfmwlsKYNcVSGRrjAmG0RtQbrx0aJW8vm0rbwr36tH2ut2ZYby61GW0pSZEklMEPLMsePiFmaSSMxEqHSzHjb87p74yIXjnm55977fj/bicu5Bzvnuc85zz3PPfc9eXl5pskqPHVRauRI8vuhQ4e8y8TExKikpKSzlvH8vb/xcUfXYnH06FF18uSZ4QvOx4kzfd+QI00DaYhLvKdMcX/YooGBAfPzt99+C3qjNpTi4BbiQBzIh8ndL4aGhhwtR5cSjl188cWqtLTUO0YUACAwpOkqX8n0GDmGnpPx+BCaqJsA8P9UVVWptrY2tXPnzrOei4qSAQX+IyfPo+eNNtEya9euNY3hkVfUynAJM2fOVAkJCSqSGxASF9nOUGhQytXT0lSX882pU6daGwe3EAfiQD5M7n4xbdo0R8vRqIVjUiwTExOJGABMwvE1OTn5rPlOxuND6KJuAsC5W7Vqlaqvr1ctLS0qLS3NO99TJ+XK2JSUFO/8vr4+71W2ssypU6fMN1BGXlUryyxatMjv/1OGUJBpNDkpj/TGnTQgQmU75WpomWyPg5uIA3EgHyZvv3D69zRq4Zh8svzVV1+pBQsWRPQnywAQbPv37zdj6MlJogxt8PTTT6srrrjC0Xh8wRxrL9SF2thq8vUmT90M5tXPoRYHtxAH4kBOTO6+EehjjKyTNGnr6upUU1OTmjNnjs/z8rs0YhsbG9X1119v5klTtrm5WT333HPm9/nz56vo6GizzF133WXm9fb2qo6ODvMNFYQ2zjcBgEYtzoG8Efr+++9VVlYWcQOAAJHG7KZNm8ywBkeOHDFDG8hVP52dnY7G43NjrL1QFYpj7f3www8qNTVVnThxwto4uIU4EAdyYnL3Dadj7Tm1cuVK822RrVu3mg+3PDVQvtEXFxdnrmh69NFHzYeZV111lZnk8QUXXKDuuece77IPPPCAWr16tbrkkkvMV+kff/xxlZmZqZYuXRrQ9UXgcb4JADRqAQBw1bJly7yP5UQyNzdXzZ071wxxsHDhwv81Hh9j7YXGGHOedZBGwYwZM4L2/2WMOeJAPrBvBOMY4XSsPac2bNhgfi5evNhnfk1NjaqoqDCP16xZYz74euSRR7w32Ny+fbvPtxZefvllM/SMXFEryy5ZssSM8z5y/HcAAEIVQx8AABBC5AYa0rCV4RBKSkomHI9vLIy1FxpjzHnWwY0x7xhjjjiQD+wbk32MCPRxTT6EdLLe69evN9N4DeRXX33VTAAAhJuwbNR6irhnzL1I/8RbvlYkbzjcPumU9ZBPpeVnsAd5D6U4uIk4EAfyYfL2C09NcXKiOJlkbNmuri514403OhqPzwlb6maoHSPdqpuhFge3EAfiQE7YUTcnA3XTHdRNd1E3iQP5MLn7hdO6GaXDsLL29PSoyy67zO3VAABEoMOHD/vcZXqyydh5xcXFKj093VwpK2PUSiO2vb1dZWRkmIasjDkrX/30jMcnN1np7u52fIMq6iYAIFLqZjBQNwEAbtXNsLyiVu6MLRsmJ6jjjdEXCaTjLk1p2d6EhARlK+JAHMgH9ovJPj7I55byaanUmGCfDJaVlalff/3VjBco49Lu3r3bNGmdjsc3EVvqJrWCOJAP7BccIyK/bgYDddMuvH8gDuQD+0Uwjg9O62ZYNmrlcuNI+9R2IpIQNjdqPYgDcSAf2C8m8/ggd4sOttra2vMej28ittVNagVxIB/YLzhGRG7dDAbqpp14/0AcyAf2i8k+Pjipm/YOXAYAAAAAAAAAIYJGLQAAAAAAAAC4jEZtiIuNjVXV1dXmp82IA3EgH9gvOD6AWkHN5L0D76F4P8n7anCOxbkm59z0HujBRHIvKkrLaLYAAAAAAAAAANdwRS0AAAAAAAAAuIxGLQAAAAAAAAC4jEYtAAAAAAAAALiMRi0AAAAAAAAAuIxGbZCtX79eRUVF+UzJycne5+XebrLM7NmzVVxcnFq8eLHq7Oz0+Tf++usvtWrVKjVjxgx14YUXquXLl6uenh4VylpaWlRxcbHZLtnm9957z+f5QG33sWPH1H333acSExPNJI8HBgZUuMShoqLirPxYuHBhxMXhmWeeUTfccIOKj49Xs2bNUiUlJaq7u9u6nHASBxtyYsOGDSorK0slJCSYKTc3V23bts2qXIB/1E3qJnWTuulB3TyDuonxUDepm7bXTc41ncfBhnwIy7qpEVTV1dX6uuuu0729vd6pr6/P+/yzzz6r4+Pj9ebNm3V7e7suLS3VKSkpenBw0LtMZWWlTk1N1Y2NjXrv3r36lltu0dnZ2fr06dMh+2p++OGH+sknnzTbJWlXV1fn83ygtruwsFDPmzdPt7a2mkkeFxUV6XCJQ3l5udmGkfnR39/vs0wkxOG2227TNTU1uqOjQ+/bt0/ffvvtOj09Xf/+++9W5YSTONiQE/X19bqhoUF3d3ebad26dTo6OtrExZZcgH/UTeomdZO66UHdPIO6ifFQN6mbttdNzjWdx8GGfAjHukmj1oXCKS/mWIaHh3VycrJJEo+TJ0/qxMRE/frrr5vfBwYGTELV1tZ6l/n555/1lClT9EcffaTDweiCEajt/vbbb82/vXv3bu8yu3btMvO+++47HWr8Fc477rjD799EYhyEfFgh69fc3Gx1ToyOg805kZSUpDdu3GhtLuA/1E3qpgd18z/UzbHjIKib1E3bUTepmx7UzTOomWPHweaaGernmwx94IL9+/ebS6rnzJmj7r77bnXgwAEz/+DBg+qXX35RBQUF3mVjY2PVzTffrFpbW83vX3/9tfr77799lpF/a968ed5lwk2gtnvXrl3m8vKcnBzvMnLZvswLp9g0NTWZryZcffXV6qGHHlJ9fX3e5yI1DsePHzc/p0+fbnVOjI6DjTnxzz//qNraWvXHH3+Yr6TYmgvwRd30xX6hrD1GelA3x46DjTlB3cRYqJu+qJvK2mOkoGaOHQdb8+GfMDjfpFEbZPKibdq0SX388cfqjTfeMAmxaNEi1d/fbx6LSy+91Odv5HfPc/IzJiZGJSUl+V0m3ARqu+WnHGBGk3nhEptly5apt956S3322WfqxRdfVHv27FH5+flmPJRIjYN82PvYY4+pvLw8c6CzNSfGioNNOdHe3q4uuugiUxQrKytVXV2duvbaa63MBfiibp6N/UJZd4wcibrpPw425QR1E/5QN89G3VTWHSM9qJn+42BbPrSH0fnm1HPeOpwX2RE8MjMzTQd/7ty56s033/QO2iwDOI/eqUbPG83JMqEuENs91vLhFJvS0lLvYzmALliwQGVkZKiGhga1YsWKiIxDVVWVamtrUzt37rQ6J/zFwZacuOaaa9S+ffvMYOubN29W5eXlqrm52cpcgC/qpn/sF/YcI0eibo4fB1tygroJf6ib/lE37TlGelAzx4+DTflwTRidb3JFrcvkbnHSsJWvpyQnJ5t5o7vtcum5p7svy5w6dcrcTc7fMuEmUNstyxw5cuSsf//o0aNhG5uUlBRzoJT8iMQ4yF0T6+vr1Y4dO1RaWpq1OeEvDjblhHxCeeWVV5o3B3KH0uzsbPXKK69YlwuYGHXTvmPkuYjUY6QHdXP8ONiUE9RNOEXdpG7aeIwU1Mzx42BbPsSE0fkmjVqXySXlXV1dZoeQMWvlxW1sbPQ+L8kgXX4ZHkHMnz9fRUdH+yzT29urOjo6vMuEm0Btt1ydLOOufPnll95lvvjiCzMvXGMjQ2IcPnzY5EckxUE+VZJP9bZs2WK+ZiE5YGNOTBQHm3JirNjI8dGWXIBz1E17jpH/R6QeI6mbzuJgU06MRt2EP9RN6qZtx0hqprM42JIPYVk3z+nWYzhvq1ev1k1NTfrAgQPmbnBFRUU6Pj5e//jjj+Z5udOc3F1uy5Ytur29XZeVlemUlBQ9ODjo/TcqKyt1Wlqa/uSTT/TevXt1fn6+zs7O1qdPnw7ZV2hoaEh/8803ZpK0e+mll8zjQ4cOBXS7CwsLdVZWlrm7nkyZmZkmxuEQB3lO8qO1tVUfPHhQ79ixQ+fm5urU1NSIi8PDDz9sXm/ZF3p7e73Tn3/+6V3GhpyYKA625MTatWt1S0uL2ca2tja9bt06cwfN7du3W5ML8I+6Sd2kblI3PaibZ1A3MR7qJnXT9rrJuaazONiSD+FYN2nUBllpaal5waOjo/Xs2bP1ihUrdGdnp/f54eFhXV1drZOTk3VsbKy+6aabTKKMdOLECV1VVaWnT5+u4+LizAv/008/6VAmO70UitFTeXl5QLe7v79f33vvvab5LZM8PnbsmA6HOMgBs6CgQM+cOdPkR3p6upk/ehsjIQ5jxUCmmpoa7zI25MREcbAlJ+6//36dkZGhY2JizLYuWbLEWzRtyQX4R92kblI3qZse1M0zqJsYD3WTuml73eRc01kcbMmHcKybUfKfc7sGFwAAAAAAAAAQSIxRCwAAAAAAAAAuo1ELAAAAAAAAAC6jUQsAAAAAAAAALqNRCwAAAAAAAAAuo1ELAAAAAAAAAC6jUQsAAAAAAAAALqNRCwAAAAAAAAAuo1ELAAAAAAAAAC6jUQsAAAAAAAAALqNRC4SBqKiocaeKiopx/16ef+KJJ/w+V1JS4jPv3XffVdOmTVPPP/98QLcDAIBgoG4CAEDdBMLRVLdXAMDEent7vY/feecd9dRTT6nu7m7vvLi4OL9/Ozw8rBoaGlR9fb2jUG/cuFGtXLlSvfbaa+rBBx/k5QEAhB3qJgAA1E0gHNGoBcJAcnKy93FiYqK5UmjkvPF8/vnnasqUKSonJ2fCZeUKWmkCv/322+rOO+88r3UGAMAt1E0AAKibQDiiUQtEOLmStri42DRrxyNDI8hVtB988IFaunRp0NYPAIBQQt0EAIC6CbiFRi1gwQnnCy+8MO4y27ZtU1u3blWffvqpys/PD9q6AQAQaqibAABQNwG3cDMxIIJ1dXWpnp6eCa+QzcrKUpdffrkZ9mBoaCho6wcAQCihbgIAQN0E3ESjFojwq4JuvfXWcW82JlJTU1Vzc7O5+UphYSHNWgCAlaibAABQNwE30agFIpgMZ7B8+XJHy6anp5tmbV9fnyooKFCDg4OTvn4AAIQS6iYAANRNwE00aoEIJQ3XPXv2qKKiIsd/k5aWppqamlR/f79p1h4/fnxS1xEAgFBB3QQAgLoJuI1GLRCh3n//fZWTk6NmzZp1Tn/nGQZhYGDADJsgPwEAiHTUTQAAqJuA26K01trtlQAQeDLkQV5enlqzZg3hBQCAugkAAOebQIjjilogQkmTtqyszO3VAAAgLFA3AQCgbgJu44paAAAAAAAAAHAZV9QCAAAAAAAAgMto1AIAAAAAAACAy2jUAgAAAAAAAIDLaNQCAAAAAAAAgMto1AIAAAAAAACAy2jUAgAAAAAAAIDLaNQCAAAAAAAAgMto1AIAAAAAAACAy2jUAgAAAAAAAIBy17/6Xm1L3Cv1PQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1400x360 with 3 Axes>"
       ]
@@ -422,9 +743,12 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "T = [t for t in range(int(nasa[\"t_low\"]) or 200, int(nasa[\"t_high\"]) + 1, 10) if t > 0]\n",
-    "fig, ax = plt.subplots(1, 3, figsize=(14, 3.6))\n",
-    "for axis, fn, label in zip(ax, (cp, h, s), (\"Cp  /  J mol⁻¹ K⁻¹\", \"H  /  kJ mol⁻¹\", \"S  /  J mol⁻¹ K⁻¹\")):\n",
+    "T = list(range(max(int(nasa[\"t_low\"]), 200), int(nasa[\"t_high\"]) + 1, 10))\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(14, 3.6))\n",
+    "for axis, fn, label in zip(\n",
+    "    axes, (cp, h, s),\n",
+    "    (\"Cp  /  J mol$^{-1}$ K$^{-1}$\", \"H  /  kJ mol$^{-1}$\", \"S  /  J mol$^{-1}$ K$^{-1}$\"),\n",
+    "):\n",
     "    axis.plot(T, [fn(nasa, t) for t in T], lw=2)\n",
     "    axis.axvline(nasa[\"t_mid\"], ls=\"--\", c=\"0.6\", lw=1)\n",
     "    axis.set_xlabel(\"T / K\")\n",
@@ -437,26 +761,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2c1499c",
+   "id": "4b90d665",
    "metadata": {},
    "source": [
-    "## 3. The calculations behind the numbers\n",
+    "<a id=\"4\"></a>\n",
+    "## 4. Reactions and rate coefficients\n",
     "\n",
-    "This is what distinguishes TCKDB from a table of values: every thermo record traces\n",
-    "back to the quantum-chemistry calculations that produced it, each with its level of\n",
-    "theory and software provenance."
+    "Reaction search needs `reactants`, `products` or a ref to scope it — so, as in\n",
+    "section 1, it cannot itself tell you which reactions exist. The kinetics analytics\n",
+    "surface can, and every row carries the `reaction_entry_ref` the reaction endpoints take."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "bec77ed6",
+   "execution_count": 10,
+   "id": "e9d074f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:09.308853Z",
-     "iopub.status.busy": "2026-08-08T08:00:09.308700Z",
-     "iopub.status.idle": "2026-08-08T08:00:09.687867Z",
-     "shell.execute_reply": "2026-08-08T08:00:09.687320Z"
+     "iopub.execute_input": "2026-08-10T07:03:01.590982Z",
+     "iopub.status.busy": "2026-08-10T07:03:01.590695Z",
+     "iopub.status.idle": "2026-08-10T07:03:04.084813Z",
+     "shell.execute_reply": "2026-08-10T07:03:04.084252Z"
     }
    },
    "outputs": [
@@ -464,64 +789,78 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "32 calculation(s) for C=C\n",
-      "\n",
-      "by calculation type: {'sp': 7, 'freq': 7, 'opt': 18}\n",
-      "by level of theory : {'b3lyp/def2tzvp': 32} \n",
-      "\n",
-      "  calc_c3pgshx34sw7uaqfimxe2qeo6e  sp    raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
-      "  calc_uzdtyaspttrufuapeljaibbf54  freq  raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
-      "  calc_mxhadodv3hsdead3rnmofh3xyi  opt   raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
-      "  calc_j4my2yvcqowtzfdaufvpoqu3z4  opt   raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
-      "  calc_u7j7kghz7wxdi7odncrfwml7im  opt   raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n",
-      "  calc_j2rgfjta4ycv3k3wamogup2t6u  sp    raw  b3lyp/def2tzvp   Gaussian Gaussian 16, Revision C.02\n"
+      "17 kinetics record(s) across 17 reaction entries\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "equation                                     family                              k records  TS   atom map\n",
+      "---------------------------------------------------------------------------------------------------------\n",
+      "C1=C[C]2C=CCC2C=C1 <=> C1=Cc2ccccc2C1 + [H]  R_Addition_MultipleBond             1          yes  no      \n",
+      "C[CH]C(CO)OO <=> CC=CCO + [O]O               R_Addition_MultipleBond             1          yes  no      \n",
+      "O + [CH3] <=> C + [OH]                       H_Abstraction                       1          yes  no      \n",
+      "C=CCCCCCCC <=> C=CC + C=CCCCC                Retroene                            1          yes  no      \n",
+      "F[C]F + C=C <=> FC1(F)CC1                    1+2_Cycloaddition                   1          yes  no      \n",
+      "[CH2]SO <=> OC[S]                            intra_OH_migration                  1          yes  no      \n",
+      "C[N+](=O)[O-] <=> CON=O                      intra_NO2_ONO_conversion            1          yes  no      \n",
+      "[CH2]CC <=> C[CH]C                           intra_H_migration                   1          yes  no      \n",
+      "C=C + [CH3] <=> [CH2]CC                      R_Addition_MultipleBond             1          yes  no      \n",
+      "C=CO <=> CC=O                                Ketoenol                            1          yes  no      \n",
+      "[CH2]CC=C <=> [CH2]C1CC1                     Intra_R_Add_Exocyclic               1          yes  no      \n",
+      "[CH2]CCC <=> C1CC1 + [CH3]                   Intra_R_Add_ExoTetCyclic            1          yes  no      \n",
+      "[CH2]C=C <=> [CH]1CC1                        Intra_R_Add_Endocyclic              1          yes  no      \n",
+      "C=C(C)CC <=> CC1(C)CC1                       Intra_RH_Add_Exocyclic              1          yes  no      \n",
+      "[CH2]C[CH2] <=> C=CC                         Intra_Disproportionation            1          yes  no      \n",
+      "CCO[O] <=> C=C + [O]O                        HO2_Elimination_from_PeroxyRadical  1          yes  no      \n",
+      "[CH2]C(C=C)OS <=> C=CC1CO1 + [SH]            Cyclic_Ether_Formation              1          yes  no      \n"
      ]
     }
    ],
    "source": [
-    "calcs = get(\"scientific/calculations/search\", species_ref=SPECIES_REF)[\"records\"]\n",
-    "print(f\"{len(calcs)} calculation(s) for {SPECIES_SMILES}\\n\")\n",
+    "kinetics_rows = records(\"scientific/analytics/kinetics\", limit=50)\n",
+    "entry_refs = list(dict.fromkeys(r[\"reaction_entry_ref\"] for r in kinetics_rows if r.get(\"reaction_entry_ref\")))\n",
+    "print(f\"{len(kinetics_rows)} kinetics record(s) across {len(entry_refs)} reaction entries\\n\")\n",
     "\n",
-    "# level_of_theory and software_release sit alongside `calculation` on the record,\n",
-    "# not inside it -- provenance is a peer of the result, not a detail of it.\n",
-    "by_type, by_lot = {}, {}\n",
-    "for rec in calcs:\n",
-    "    cal, lot = rec[\"calculation\"], (rec.get(\"level_of_theory\") or {})\n",
-    "    by_type[cal[\"type\"]] = by_type.get(cal[\"type\"], 0) + 1\n",
-    "    key = f\"{lot.get('method','?')}/{lot.get('basis','?')}\"\n",
-    "    by_lot[key] = by_lot.get(key, 0) + 1\n",
+    "reactions = []\n",
+    "for ref in entry_refs:\n",
+    "    found = records(\"scientific/reactions/search\", reaction_entry_ref=ref)\n",
+    "    if found:\n",
+    "        reactions.append(found[0])\n",
     "\n",
-    "print(\"by calculation type:\", by_type)\n",
-    "print(\"by level of theory :\", by_lot, \"\\n\")\n",
-    "\n",
-    "for rec in calcs[:6]:\n",
-    "    cal, lot = rec[\"calculation\"], (rec.get(\"level_of_theory\") or {})\n",
-    "    sw = (rec.get(\"software_release\") or {})\n",
-    "    print(f\"  {cal['calculation_ref']}  {cal['type']:5s} {cal['quality']:4s} \"\n",
-    "          f\"{lot.get('method','?')}/{lot.get('basis','?'):10s} {sw.get('software','?')} {sw.get('version','')}\")"
+    "table(\n",
+    "    [[r[\"equation\"][:52], r.get(\"family\") or \"-\",\n",
+    "      r[\"availability\"][\"kinetics_count\"],\n",
+    "      \"yes\" if r[\"availability\"][\"has_transition_state\"] else \"no\",\n",
+    "      \"yes\" if r[\"availability\"][\"has_atom_map\"] else \"no\"]\n",
+    "     for r in reactions],\n",
+    "    [\"equation\", \"family\", \"k records\", \"TS\", \"atom map\"],\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4ab23ed9",
+   "id": "b5fff932",
    "metadata": {},
    "source": [
-    "## 4. Statistical mechanics\n",
+    "### One reaction, in full\n",
     "\n",
-    "Frequencies, rotors and symmetry — the inputs a partition function is built from.\n",
-    "These are what make a thermo value *recomputable* rather than merely *quoted*."
+    "`/scientific/reaction-entries/{ref}/full?include=all` assembles the reaction, its\n",
+    "participants, its rate coefficients and its transition states in a single response."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "c62f016a",
+   "execution_count": 11,
+   "id": "a6c4211f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:09.688819Z",
-     "iopub.status.busy": "2026-08-08T08:00:09.688714Z",
-     "iopub.status.idle": "2026-08-08T08:00:09.897953Z",
-     "shell.execute_reply": "2026-08-08T08:00:09.897442Z"
+     "iopub.execute_input": "2026-08-10T07:03:04.086492Z",
+     "iopub.status.busy": "2026-08-10T07:03:04.086296Z",
+     "iopub.status.idle": "2026-08-10T07:03:04.308724Z",
+     "shell.execute_reply": "2026-08-10T07:03:04.308040Z"
     }
    },
    "outputs": [
@@ -529,46 +868,750 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7 statmech record(s)\n",
+      "O + [CH3] <=> C + [OH]\n",
       "\n",
-      "  sm_ub3tbslev5twt7btwtzcgouckq\n",
-      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
-      "     frequency scale factor: 0.999\n",
-      "  sm_4hxeerk7n4oslcjt4ivgk3rdiq\n",
-      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
-      "     frequency scale factor: 0.999\n",
-      "  sm_df3deeaphwtqeaj5btfsesds7e\n",
-      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
-      "     frequency scale factor: 0.999\n",
-      "  sm_pq5k4zcwhhzpzv7i2anuvnocw4\n",
-      "     treatment=rrho  point_group=D2h  symmetry=4  linear=False  optical_isomers=1\n",
-      "     frequency scale factor: 0.999\n"
+      "family      H_Abstraction\n",
+      "reversible  True\n",
+      "review      under_review\n",
+      "atom maps   0\n",
+      "\n",
+      "participants\n",
+      "   reactant O                        spe_evwhah63tpbcfopksky6ji2diu\n",
+      "   reactant [CH3]                    spe_bcbdjwkip75yoziblpntwzblzu\n",
+      "   product  C                        spe_bg76km6tw34gcbraa75vkwkyli\n",
+      "   product  [OH]                     spe_2lq3jupc22nwanghcqtshffoxu\n"
      ]
     }
    ],
    "source": [
-    "sm = get(\"scientific/statmech/search\", species_ref=SPECIES_REF)[\"records\"]\n",
-    "print(f\"{len(sm)} statmech record(s)\\n\")\n",
+    "# Pick a bimolecular reaction if one exists -- its rate constant has the more\n",
+    "# familiar cm3/mol/s units and a clearer Arrhenius shape than a unimolecular one.\n",
+    "def pick(reactions):\n",
+    "    for r in reactions:\n",
+    "        if len(r[\"reactants\"]) > 1 and r[\"availability\"][\"kinetics_count\"]:\n",
+    "            return r\n",
+    "    return reactions[0]\n",
     "\n",
-    "for rec in sm[:4]:\n",
-    "    b = rec[\"statmech\"]\n",
-    "    print(f\"  {b['statmech_ref']}\")\n",
-    "    print(f\"     treatment={b['statmech_treatment']}  point_group={b['point_group']}  \"\n",
-    "          f\"symmetry={b['external_symmetry']}  linear={b['is_linear']}  \"\n",
-    "          f\"optical_isomers={b['optical_isomers']}\")\n",
-    "    rot = [b[f\"rotational_constant_{x}_cm1\"] for x in (\"a\", \"b\", \"c\")]\n",
-    "    if any(r is not None for r in rot):\n",
-    "        print(f\"     rotational constants /cm-1: {rot}\")\n",
-    "    if b.get(\"frequency_scale_factor_value\") is not None:\n",
-    "        print(f\"     frequency scale factor: {b['frequency_scale_factor_value']}\")"
+    "\n",
+    "chosen = pick(reactions)\n",
+    "RXN_REF = chosen[\"reaction_entry_ref\"]\n",
+    "\n",
+    "full = try_get(f\"scientific/reaction-entries/{RXN_REF}/full\", include=\"all\")\n",
+    "entry = full[\"reaction_entry\"]\n",
+    "\n",
+    "print(f\"{entry['equation']}\\n\")\n",
+    "print(f\"family      {entry.get('family') or '-'}\")\n",
+    "print(f\"reversible  {entry['reversible']}\")\n",
+    "print(f\"review      {entry['review']['status']}\")\n",
+    "print(f\"atom maps   {len(entry.get('atom_maps') or [])}\")\n",
+    "\n",
+    "print(\"\\nparticipants\")\n",
+    "for side in (\"reactants\", \"products\"):\n",
+    "    for p in full[\"species\"][side]:\n",
+    "        print(f\"   {side[:-1]:8s} {p['smiles']:24s} {p['species_entry_ref']}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bb1178b5",
+   "id": "bfa97323",
    "metadata": {},
    "source": [
-    "## 5. Review status — how much should you trust this?\n",
+    "### The rate coefficient, and what backs it\n",
+    "\n",
+    "A kinetics record is more than `A`, `n`, `Ea`. It carries the temperature range it was\n",
+    "fitted over, its uncertainty, and an **evidence checklist** — a deterministic tally of\n",
+    "which supporting records exist. That checklist is what lets you decide for yourself,\n",
+    "rather than taking a status word on faith."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b8822ee2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:04.310083Z",
+     "iopub.status.busy": "2026-08-10T07:03:04.309869Z",
+     "iopub.status.idle": "2026-08-10T07:03:04.458914Z",
+     "shell.execute_reply": "2026-08-10T07:03:04.458368Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "model            modified_arrhenius   (computed)\n",
+      "A                3025.44 cm3_mol_s\n",
+      "n                3.11242\n",
+      "Ea               39.9711 kJ/mol\n",
+      "tunneling        eckart\n",
+      "fitted over      300 - 3000 K\n",
+      "A uncertainty    1.24736 (multiplicative)\n",
+      "\n",
+      "evidence         7/9\n",
+      "   + has_source_calculations\n",
+      "   + has_transition_state_entry\n",
+      "   + has_ts_opt_evidence\n",
+      "   + has_ts_freq_evidence\n",
+      "   + has_ts_sp_evidence\n",
+      "   + has_path_search_or_irc_evidence\n",
+      "   + has_uncertainty\n",
+      "   - has_geometry_validation\n",
+      "   - has_scf_stability\n"
+     ]
+    }
+   ],
+   "source": [
+    "kinetics = records(f\"scientific/reaction-entries/{RXN_REF}/kinetics\")\n",
+    "k_record = kinetics[0]\n",
+    "params = k_record[\"parameters\"]\n",
+    "\n",
+    "print(f\"model            {k_record['model_kind']}   ({k_record['scientific_origin']})\")\n",
+    "print(f\"A                {params['A']:.6g} {params['A_units']}\")\n",
+    "print(f\"n                {params.get('n')}\")\n",
+    "print(f\"Ea               {params.get('Ea_kj_mol')} kJ/mol\")\n",
+    "print(f\"tunneling        {k_record.get('tunneling_model') or '-'}\")\n",
+    "\n",
+    "coverage = k_record[\"temperature_coverage\"]\n",
+    "print(f\"fitted over      {coverage['record_min_k']:.0f} - {coverage['record_max_k']:.0f} K\")\n",
+    "\n",
+    "uncertainty = k_record.get(\"uncertainty\") or {}\n",
+    "print(f\"A uncertainty    {uncertainty.get('A_uncertainty')} \"\n",
+    "      f\"({uncertainty.get('A_uncertainty_kind')})\")\n",
+    "\n",
+    "evidence = k_record.get(\"evidence_completeness\") or {}\n",
+    "print(f\"\\nevidence         {evidence.get('score')}/{evidence.get('max')}\")\n",
+    "for name, present in (evidence.get(\"checklist\") or {}).items():\n",
+    "    print(f\"   {'+' if present else '-'} {name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "9f3aa2e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:04.460060Z",
+     "iopub.status.busy": "2026-08-10T07:03:04.459925Z",
+     "iopub.status.idle": "2026-08-10T07:03:04.696844Z",
+     "shell.execute_reply": "2026-08-10T07:03:04.696346Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABQkAAAGZCAYAAAAq17elAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2DlJREFUeJzs3Qd4W+XVB/B/vCQPSd57ZE8nzmKEQEgIWSQkAcJqS4HSUkoLFAotdDH6tdBCGaXMUmiBssMIEEISCElIgExn7+W9lzxkeeh7zjEytrPsxENX/v+e57ZYku2ra8U6Pu97zunjcrlcICIiIiIiIiIiol7Lp6dPgIiIiIiIiIiIiHoWk4RERERERERERES9HJOEREREREREREREvRyThERERERERERERL0ck4RERERERERERES9HJOEREREREREREREvRyThERERERERERERL0ck4RERERERERERES9HJOEREREREREREREvRyThETk0f7zn/+gT58+evzyl7/s0XOZPHly87mkp6f36LkYTXf+HO+7777m7/X444936fciIiIiIiLyFkwSElG7ZGZm4oYbbkB8fDwCAgKQkpKC2267DcXFxV1+Ba1WK3Jzc/GnP/2p1e379+/H9ddfj8TERJhMJvTr1w9XX301NmzY0PwYSRS9//77R33N6667DvPnz2/++JlnnsGoUaP0e8kxYcIEfPLJJ60+591338W6detgdBUVFfjd736HoUOHwmw2IzY2FhdeeKE+P5fL1e0/xx07duCKK65AVFSU/hwHDRqEP/zhD6iurm71uL59+x4z6SdJwdGjRzd/fOedd+r3kdcFERERERERtQ+ThER0UgcPHsT48eOxd+9evP7665qce/bZZ/HZZ59pMq2kpKTdV1ESOpKg6whJ9Ekiy2KxNN8micBx48bpOT333HPYuXMn3nvvPU18/epXv+rwT1USSg899JB+XTkuuOACzJs3TxNYbuHh4ZrIOl0ZGRmn/LmFhYVwOByn/PllZWU455xz8PLLL+Oee+7Bpk2bsGrVKlx55ZX49a9/jfLy8m79OX799dc466yz4HQ68fHHH+vP8y9/+Qv++9//Ytq0aXp7R4WEhOj38fX17fDnEhERERER9VZ+PX0CROT5fv7zn+vuwaVLlyIwMFBvS05OxpgxYzBgwADdlSY78bqL7HaTBJXsOFu9ejV8fL5b75AdZbLDsaMuvvjiVh//+c9/1uckSawRI0Z0yu69t99+W5Nf27dv71BitaXFixdrua4k9a699lpN0nbEb3/7Wxw+fFiTcbIr1G3w4MG6C1N2Fnbnz1F2pw4bNkx3Mbp/jrJLVc5HXl+PPfYYfvOb33TbOREREREREfVW3ElIRCckyaxPP/0UN998c3OC0E12a33/+9/Hm2++2aVlqm1JP0DZ4Sc7BlsmCN1CQ0NP6+s3NDTgjTfeQFVVVYeTcC01NjZi2bJl+MEPfqDXSnYqTp06tVU5tOwqlJ1vJzpuuumm5sfL9X711VdRWlqqux2HDBmiCU0pB2/P+cjzkq/RMkHoJt/Lz8+vW3+OsgP0jjvuOOrnmJaWpiXQsnOViIiIiIiIuh53EhLRCe3bt08TgLLb61jkdklYSRlsdHR0t52TkNLi9pAdcm1LT2trazF79uxWt23btk2TglLOKwkzKV8ePnx4h89PdunJoI5XXnlFE43Sb0+ShRMnTjzqsZKsO9kQFOnl5yZJPDlvOaQ0WHYnSunwvffeq4NVZHfhggULjkroiqKiIv1Ztfe6dTW5TuJEr60vv/yy1W2yq/D3v/99q9ukJPlUfk5ERERERET0HSYJiei0uHcQSr+5Y5Fy4FmzZrVK6MjnvPPOO61KYOXorO/ZlpSsyq60tskm2THYkuzKk4Sd9O1buHChJtxWrlzZ4QTUjTfeqJ8nOwAfffTRYybsWib9Bg4ciFNhs9nw4x//WA8ZqCLJ0B/+8Ifa86/lUJZTvW5d/XM8Gfn6bc/1rrvuOqoX4j/+8Q/tq0hERERERESnjklCIjohSWBJokbKQo+VeNq9ezfCwsIQGRl5zM+XgSctd8pJQic7Oxt//etfWw0E6QjpVyd27drVaqrt8Uipb9tEnCTSJBnYkvRddD9Oznv9+vV44okndDBKR8gE3n//+99aKvvRRx9pee8111xzzN6GUm58siSklCvLoJi2ZMfjhx9+qDsWlyxZoj38pARbSpqPRYauyM9KrltHdeXPUV5bx/o5ymtL+k62JK+ztj/Ljn5fIiIiIiIiOhqThER0QhERETpl9umnn8btt9/ealdcXl4e/ve//+nutePtTpPHt0zqSEJHhnic6u45IQklSaz9/e9/1wEebfvZSfLvdPsSuneySVnyqZzfk08+qecnSUIZViIJvNTUVE0Wyo4/SVyeSrmxnJOU4Epi8K233tKyaEki/u1vfztpGbFcJ7le8rlSnty2L6GURptMpmP2Jeyqn6Ocs+z0vOqqq1r9HLds2YLly5fjwQcfPOWvT0RERERERO3HwSVEdFL//Oc/NVk2Y8YMLeuUIRmyc02ShwkJCTo4oztJQvKll17SnnaTJk3Sib8HDx7E1q1b9VzmzZvX4a8pZbJSUiuTf6U3oUxs/uKLL3QX4KmSnYmXXnopPvjgA911J8lU6R/Yckehu9z4REfLXo8ytER+DpLQkySh7ESUgSjt7TP4l7/8BUlJSTjrrLP0XGQXn/R4fPHFFzVpV1lZie78Ob7wwgt6DpdddpmWTMvzkT6LMm1a+kPKJGciIiIiIiLqetxJSEQnJSWfMpH3vvvu051oxcXFuhNOyo9lR1pPlHueeeaZek6SFPzJT36iQzni4uJwzjnnaLlvR+Xn5+suv9zcXO31N2rUqOZEaGeQUl9JeMkhZbSnSkqJZQdny92FHSHlxl9//bUmFv/v//4PR44c0dtGjhyJhx9+WJ97d5JhLnI+999/Py666CLdnZicnKz9IO+55x7d2UhERERERERdr4/L3cmeiMgDyZRgSay17R/YU2SnYb9+/bB58+Z29UOknvs59u3btzkxS0RERERERCfGcmMi8njl5eXae08mEvckme57rOEj5Fk/Rymplu8jpctERERERETUPtxJSEQezW63aymwkGEkx5ui3B2kr2BNTY3+t5TESs9B8ryfY0lJiR7uMu/uLqEmIiIiIiIyIiYJiYiIiIiIiIiIejmWGxMREREREREREfVyTBIS0SmTuUc33nijTjfu06cP0tPTMXny5G4dFCEDMaR8lYiIiIh6t/vuuw8xMTEal77//vu47rrrMH/+/J4+Leoi/DuAqPMxSUhEp2zJkiX65vzRRx8hNzcXqampePfdd/GnP/2p1YTZxx9/vNXn8Q39xIqLizFz5kzEx8fDZDIhKSkJv/jFL1BRUdHqcdu2bcP555+PwMBAJCQk4IEHHtDEbUsrV67EuHHjYDab0b9/fzz77LMn/bk+88wzGDVqFKxWqx4TJkzAJ5980uox8n0kEJdzlO8vyeEdO3a0ekxtbS1uueUW7T8YHByMuXPnIisrq9VjSktLcc0112jfQDnkv082AflYiegnnnhCr9Vrr7120udHRERE3mfXrl24//778dxzz2lcKgPnJD6QuNPtdBazn3rqKQwbNkzjniFDhuDll18+6jELFy7E8OHDNSaR/3/vvfeOeszTTz+Nfv36aWwmMdrq1atP+r2ff/55PXeJyyQB2jZWOnz4MG644Qb9unJ+AwYMwL333gun09nqcTLU7eKLL9a4TOKzW2+99ajHtCe+bMudlHWrq6vDVVddhbi4OGzduvWkz4+IPAeThER0yg4cOKBv/ueccw5iY2Ph5+enuwotFotHX1UJXDyZj48P5s2bh0WLFmHv3r0a3C5fvhw33XRT82MkYTht2jRN0q1fvx5PPvkkHnnkETz66KPNjzl06BAuuuginHfeedi8eTN++9vfajAoAeyJJCYm4qGHHsKGDRv0uOCCC/R8WiYB//a3v+n3+uc//6nfX37+cj4yoMRNgnAJjt944w18+eWXqKysxJw5c9DQ0ND8mO9973u6A1USznLIf0uisCMkCL7nnnv0e8nXIyIiot4ZlwqJWSQukUSdLEB2RsWJLKBKrCELpBIPSTLy5z//OT788MPmx3z11Ve48sorNY7ZsmWL/v8VV1yBb775pvkxb775psZHv/vd7zQ2kxhNkpmSvDuR6upqXUCWWO5Ydu/ejcbGRk2Qyvk99thjujDc8vESf82ePRtVVVUal0l8JjHhr371qw7Flycj5yoLw/L58n1k4ZmIDMRFRHQKrr32WllSbD5SUlL09vPPP9912223Nf93y8fIsWLFiqNuu/fee/XxtbW1rrvuussVHx/vCgoKcp155pn6+JZeeuklV1JSkiswMNA1f/581yOPPOKy2WzHPc9Dhw7p93jzzTf1fEwmk+vFF190FRUVua666ipXQkKCfq3U1FTXa6+91upz5fG33HKLnlNYWJgrJiam+Vzddu3a5Zo4caJ+3WHDhrmWLVum3++9995rfkxWVpbriiuucIWGhrrCw8Ndc+fO1fPqiCeeeMKVmJjY/PHTTz+tz9vhcDTf9uCDD+q1a2xs1I9//etfu4YOHdrq6/z0pz91nX322a6Okuf/wgsv6H/L14+NjXU99NBDzffLecj5PPvss/pxWVmZy9/f3/XGG280PyY7O9vl4+PjWrJkiX68c+dOvVZff/1182O++uorvW337t3HPRf3a0zO4xe/+IV+39WrV3f4OREREdHJvf322xonmc1mjWOmTp3qqqys1PvWrVvnuvDCC10REREuq9XqmjRpkmvjxo2tPl/e1yU+mD17tsZcEpusXbvWtW/fPn1Pl5hPYpP9+/e3+rxFixa5xo4dqzFWv379XPfdd5+rrq7umOco8Vnb+NIdr86bN6/5v9s+pr3x2IQJE1x33nlnq9skFpEY0E1ivZkzZ7Z6zIwZMzTedJPY9qabbmr1GLked999d7vOwx1Hl5aWnvSxf/vb3/S6uS1evFjjMInH3F5//XW9vuXl5e2OL4/FHfvKeck1GTlypCsnJ+eE59fQ0OC6//77NRYPCAhwpaWluT755JOjYviFCxe6Jk+erK+dUaNG6Wun5d8F7r8D5PF9+vRxrV+/vtX3+cc//uFKTk4+4fkT0Xe4k5CITomUb0j5gew6k5IOWS1sS0qP5X55nDxGDtl1KOXHUi7hvu3OO+/Ux19//fVYs2aNrmxKacLll1+uq6b79u3T+2Ul9kc/+hFuvvlm3XE2ZcoU/N///V+7zvc3v/mN7qKTUpQZM2bA4XBoiYeUSm/fvl17K8qKb8vVXvHf//5XSzLkdtk9J89l2bJlep+s2Eqfm6CgIL1fSkFkZbjtaqqcZ0hICFatWqUrqvLf8rzalnccT05Ojl5LKf1ouVotH8squZs8L3mslJy4HzN9+vRWX0seI7sD27ubUlad5echq85SduzeoZiXl9fqa8t5yPmsXbtWP964caN+j5aPkVVpKUl3P0bOT1b4zzrrrObHnH322Xqb+zHHU19frz+vt99+W0uqzz333HY9HyIiImo/idOuvvpqjb8khvriiy9w6aWXNpefSgXBtddeqyWzX3/9NQYNGqRVDC0rC4S0ovnhD3+o8dvQoUN15/9Pf/pT3Z0ncYmQ1ipun376KX7wgx9o7LZz507dISeVFX/+85+PeZ4SS7700kvN5yzHsWJXiWV+8pOfND9GWrq0h7RQkfLglqQcd926dc0x1fHiLndMI3GfxEdtHyMfnyzuORXl5eVa4eMm5ydxmMRjLc9PnpucV3vjy+OR2FA+V+Jjic2k2uhE5Ofx97//XXcqStwv30d2ILrjfjeJreXnK6+dwYMH6+tR4sC2pMXRhRde2Pw6cJOPpTellEQTUTu0SBgSEXXIY4891ryD0K3lTkIh98vjWmq56ucmq8ey+tdydVPIavU999yj/3311VcftUJ75ZVXtmsn4eOPP37S53PRRRe5fvWrX7V6Lueee26rx5xxxhmu3/zmN/rfstrp5+fnys3Nbb6/7U7Cf//7364hQ4a0Wr2UHZOyGvrpp5+e8Hxk5VkeJ1/v4osvdtXU1DTfN23aNNdPfvKTVo+XayePda+wDho0yPXnP/+51WPWrFmjjznZ6u7WrVtdwcHBLl9fX72+H3/88VFfo+3PSs5n+vTp+t//+9//dFW4LTnvG2+8Uf9bzk3OsS257S9/+ctxz01+LvK15ZCdnERERNQ1ZFegvOcfPny4XY+vr693WSwW14cffth8m3z+73//++aP3VUDEiO13NEmOxXdzjvvvKNigVdeecUVFxd33O8tsVfbP29b7iQ8VpzaXhKLShXFhg0bNKaT3WrR0dGtYiqpoJD4p6WW8ZA7TpM4qiWJhwYPHtypOwklrpadnf/6179axWkSh7Ul5+eupmlPfHkscr98HdkVWVVV1a7nIrsT28apEmfffPPNrWJ4dyWL2LFjh97mjv/a/k0hlUNS/eLeCZmenq5/X3S0goeoN+NOQiLyCJs2bdJVaVkhlJ127kNWIt09ZmQF272bza3tx8czfvz4o3bIyWq09EmJiIjQ77V06dKjesK07aMiq6IFBQX633v27NEVaOl743bmmWe2eryszO7fv1/7NLqfk6zqyk5G9/M6HuknI9dFGkHLY++4445W97ddEXWv6re8/USPkVX/ltf6f//7X/PjpCG3rNjKroCf/exnuktAVvJP9v1Ptkrb9jHHenx7vo7sHJRz/v3vf3/M1WQiIiI6fWlpaZg6dSpGjhypFR7/+te/dOiYm8RE0jNZ4jf3EDLpQXyieEqmDwv5mi1vk9jIPaRN4iep3mgZp7h3AEqVRnf7wx/+oL0DpeLB399f+x7K7jTh6+vbodjoRI/5y1/+0uo5n6xX4bHIrj+pWJGf149//OMTfu9jnWN74stjkYEo0ktbdn2ejPyc5TwnTpzY6nb5WOL947123LsT3bF4W1LhIz3S3QNjXnzxRa3okV2GRNQ+fu18HBFRl5LSBAmyJChsGWwJCZLEySarnYiUDLck5Q2ShJPSZwlS5X5pJN22BFgCwZYkQJJzdZ/PyQImeayUNbdMwLlFRUWd8HMl+SiHlOVIIlOaW0uQKgGS3C5lHS25AyZ38H28x0jwJF9PAnlJBLq5P08EBARg4MCBzQlWKSeXshAJ/NxJUfnaLUtJ5Gu3/N5yLeUPibCwsFaPkZJz92Py8/OPet6FhYWtzuVY5GcmP0MpK5Gm4NIIvO3PioiIiE6PxGTSZkXKYWUxVQZZSPmntFmRSbqSKJP3bYmnUlJStExVFnBPFE+5Y6dj3eaOseT/ZTiIlDa31bbstztIabEknCQOkthF4h9pMyOLwDIl+ERxlzumkcfJ9TzRYyThKnGNW8vS4PaQxJskxeRnIOfXkpxf27Y6EqdJufTJYkdxsthMysOlXFhK02Ux3t1O6ETak1Q90eukLYlfpR2NlBjLa+e1117T1yYRtR93EhJRl5I365bTbI9325gxY/Q2CUQkOdXycCelhg8frjvbWmr7cXvJLjpZBZaARlbJ+/fvf1QPlJOR5J2s8LZMdLXtzTh27Fj9utHR0Uc9L0nStZc7QSp9Y4QEf9LjsGUQLsG7BJPu1VJ5jLt/YsvHSNJPAi4JeFuez4mmUsv3d39v+aNAfiYtv7ach+z6dCcAJTEq36PlY2T1X/o/uh8j5yf9cqSfj5sEr3Kb+zEnMnr0aHz++efa51FWyz19ajUREZERSWJGdnhJ0k4m8koc596pJfGU9A2UPoQjRozQJGFRUdFpf0+Jn6Rio23sJIePz6n/CXusGLQjJLaRftuS7JOezXPmzGk+n+PFXe6YRr63xEdtHyMfux8j1SYtn6ss7LZXdnY2Jk+erNdOkmRtr5Ocn8RhLfs1yvnJz0zOq73x5YlI30np53333XdrL+/jkd7k8jUlhmtJktHDhg3D6ZDdk8uXL8fTTz+tseGxEs1EdHxMEhJRl5KAQoINCVzcQaPcJqUon332md4mZSNSpvL9739fgwsZ0iHDMSTh9te//hWLFy/Wz5MgdMmSJRp0SDnDP//5T/34VEjg5V4Zl7IGaZ7dduX0ZKZNm4YBAwZoKa40XJahK+7BJe6VTnlOsnIsCUkJpOV5STLttttuQ1ZW1jG/rjxfCe4kkJMm0fKxlPxKgO4O0KThtwR1soIvj5NgXUpUpCTZ/b1lNfrIkSN6mzxHWQH/97//fdKV3d/+9rd6rvK9t23bps9JGpXLc3E/N9l1Kd9Pvq98fzkPGeAi5yUkAXrDDTfgV7/6lf6c5Y8KScjKDkDZ/SckCJRyGCkfkmSvHPLfEnBLuXN7SAnKihUrtNH2ggUL2j0MhoiIiE5OFu/k/V6Gi8jCqMRosnPQnciReOqVV17ROEMeK7GCLEKerj/+8Y94+eWXcd9992HHjh369aVqQNqMnA6Jo+Q8JcaRGPR4O9Lakrjz1Vdf1YVfWdy86qqrNP6Ra+MmsZ0k1CR23b17t/6/JKskZnKTmOyFF17QmEye0+23367XVWK2E5EYVao/pIWNkPhMPi4pKWneQSgJQmmDI4NA5Gckn9MytpUBKbLgLjvtJC6T+ExiQom9JGnX3vjyZOQ1IK8JiScfeuih4z7urrvu0mskP1dJCEtiUZ6TXMfTIa9NKQuXoYUy5KQzXo9EvUpPN0UkIu8eXCLNqUeNGuUymUytmknfdNNNroiICL3t3nvv1ducTqfrj3/8o6tv377a/FkaRF9yySU6RMNNmlwnJibqQA8Z5vHII4+0a3DJ5s2bW91eXFysjaxDQkK08bQ01P7hD3940ubWcr80wXaTxskTJ05sbtYsjbrl+y1ZsqT5MTLYRL52ZGSkXof+/ftrU+jy8vJjnvPnn3/umjBhgj4vaeItgzxkWErbJtVyXaSxt3xNuVb33XdfqwEp4osvvnCNGTNGz0+u6zPPPOM6mR/96Ef6c5XPiYqK0uExS5cubfUY+T7yc5PvK99/0qRJrm3btrV6jAxa+cUvfuEKDw/Xn9ecOXNcGRkZR/0cvv/972uTcznkv0/WjPtYPxdpZC3nIt9DBsMQERHR6du5c6drxowZGg/I+70M2HjyySeb79+0aZNr/Pjxep/EK2+//fZRQ+taDnQ7Xmx2rIEcEkudc845GkPIEI4zzzzT9fzzz5/W4JI9e/a4zj777ObBcO6BFnLO7nj0eNdh9OjRzeciX3P37t1HPU6evwyskzhW4sKFCxce9ZinnnqqOc4aO3asa+XKla6TkXOT8217yOAOIf9/rPvbXo8jR464Zs+erc9D4jOJ09xDPjoSX7bV9mfsHiIiA/7aDidxa2hocN1///2uhIQEvV5paWk6FPBErxN5fcht8npxP+9j/R0gfy/I49atW3fC8yaio/WR/+npRCURkbeQ3YQyVENWemWXIRERERF5rpqaGi3zlcoN6edHxifDCaUcXHZcElHHcHAJEdFpkDIMGawyaNAgTQxKiYSUBTNBSEREROT5pA3MBRdcwAShF5B2RlLGLQN2/vSnP/X06RAZEncSEhGdBumXI0FIZmam9h6UfnsydVemBxMRERERUfeQXoqvv/465s+fr5ONZcAMEXUMk4RERERERERERES9HKcbExERERERERER9XJMEhIREREREREREfVyTBISERERERERERH1cpxufByNjY3IycmBxWJBnz59uvenQkRERNTJXC4X7HY74uPj4ePDdeITYRxIREREvTEOZJLwOCRBmJSU1FU/HyIiIqIeIdPYExMTefWP4amnntLD6XTiwIEDvEZERETUq+JATjc+jvLycoSGhuoFtFqt8KaV8cLCQkRFRXEXAa+rx+PrldfVSPh65XX1dBUVFboAWlZWBpvN1tOnY4g48MiRI14VB7b9nVVUVITIyEjGhLzmXomvcV7z3oCvc17zjsSBKSkpJ40DuZPwONwlxhIYelNwKL9EHA6HPieWGvG6ejq+XnldjYSvV15Xo2AblfZfI0kUelMc2PZ3luyYlOfImJDX3BvxNc5r3hvwdc5r3l7u9/qTxYFsSENERERERERERNTLcSchERFRF2poaEBdXR2v8WmskMv1k13w3O3UPv7+/vD19eVrjoiIyAOGRdTX12s82BUYJ3W/Rg+PTU83DmSSkIiIqItUVlYiKytLA0Q6NXLtJBiTaWwsk20fuU7SkDokJIQvOyIioh4iLR1yc3NRXV3dZd+DcVL3c3l4bHq6cSCThERERF1AVowlQRgUFKTDojwxiDDSCryfnx+vYTuvlwwok9feoEGDuKOQiIioB0gS6dChQ/o+HB8fj4CAgC6JYxgndT+XB8emnREHMklIRETUBaQMQd6oJUEYGBjIa+yFgZinktfc4cOH9TXIsmMiIqKe2UUoicKkpCRdMO4qjJO6n8vDY9PTjQM9r4CaiIjIi3hi8EDeja85IiIiz+CJPevIu/U5zb89+IolIiIiIiIiIiLq5ZgkJCIiIiIiIiIi6uWYJCQiIurFpGfJ888/3y3fq2/fvti+ffsx77vhhhswYsQIXHLJJVi0aBHuuuuu5vN74YUXuuX8iIiIiHobI8SC3XV+xMElREREvZo78Lrxxhs7/Lnups2nKz8/H2+//TbKysqae/fMnTu3VZLwpptuOu3vQ0RERETGiwVP9fyo4zjduIfVOBtg9vdhk3EiIi938ZNfotBe26XfI8piwoe3nHvM+2pqanDddddh27Zt8Pf3R0xMDJYuXarJt4yMDIwePRrJycm6crthwwbccsstqKqqgtlsxmOPPYaJEydqkDZ+/HjceuutWLZsGS699FJcffXV+rHc53A4MH/+fDzwwAP6PVevXo2bb75ZpzufeeaZOg2uLQkGp0yZgurqaowdOxZXXXUVYmNj8dFHH+Gdd97Bz372Mz2/MWPGNJ8fkbeQfxPFVU5EBAcwFiQi8nJdFQu64EIf9DlhHGjkWPBY50ddh0nCHlTX0IiHP92NS8cmIDUhtCdPhYiIupgEhXkVjh67zkuWLEFpaSl27typH5eUlOj/P/vss7jzzjs1GBROp1MDvn/961+YMWMGvvzySyxYsAD79+/X+4uLizFw4ED88Y9/1I/lMb/73e8wadIkXU2eM2cO3nvvPVx00UUa5P3vf//D5MmT8dZbb+Gpp5466rxCQ0OxePFiDTjT09P1tv/85z/N9z/zzDPN58epveSN9uVXIivAF/GhZkSFmPg6JyLyUowFTy0WbBurUtdikrCH1NY34BevbcaynflYs78Yj105GsPjrT11OkRE1MVkdbcnv0daWhp2796tq7nnn3++JvGOZc+ePQgICNDknzj33HMRHR2NrVu3Ii4uTleTZcVYyOry559/riUibpWVlfp9BgwYgKCgIE0QiiuuuIJlIkQnqCw5UFCFrNIaxNsCEW0xwcenD68XEZEX6apYsOVOwhNhLEjtwSRhD8kurcH6w027OPbk23Hn21vw6BVpGBrHRCERkTc6UflHd+jfv7/uIpSk3vLly/HrX/+6ebW2JSkDOdaOPfdtwcHBzf/d2Nio/71+/XotW2lpy5YtXfZciLxVbV0jDhVVIbusGrG2QMRYTPDz5ZxBIiJv0BWxoMRt7r6AJ6u4YCxI7cGoo4f0jwrBqzecBYupKU+7M7cCv35nK/bkVfTUKRERkRfLysrS4FGaQD/yyCMaVGZmZsJqtaK8vLz5cUOHDkVtba0mE8XatWtRUFCAkSNHHvU1LRYLzjvvPDz00EPNt+Xk5Oj3kq8jvW9WrVqlt0tPmZbfp73k/Coq+N5IvYuz3oWM4mpszixDZkm1tqghIiLqrbHgqXwenRruJOxBqQk2LTO+5fXNqKlrwNbsctz59lb8bcEoDOOOQiIi6kTSpPruu+/WgFB2AF5zzTUYNWqUrj4PGTIEqampusIszaAXLlyoDajdzapl2pzsICwsLDzq60rPwTvuuKM5cAwJCdHeMYmJiXj99debm1VL2bE0m+4oOcfBgwfr13efH1FvUd/g0hLk3HKHliDHhZph8vPt6dMiIiIDMnIs2Pb8qOv0cR1rvAzprgWbzaYZa8lcd2Vvwnc3ZuH+j3bCUde0Sjwi3qqJwuFx1k5vXi2/DGQVQPpLuUeLE6+rp+LrldfVyK9Xme526NAh9OvXT4Mr6voyGmpyvNded8U23qC7rpW8vr8+2NR+pj2kTaH0nIoPDYTZ//SShXyP7X685rze3o6v8e90VxzIOKn7uTw8Nj3dOJBZoh4mq8GXjE3EH+cMR+C3wd6OnAr86q0t2J5dccwR4URERETU+zS6gPyKWqRnlmF/gR3VzvqePiUiIiLyIkwSegBZCb50bCLunTscQQFNicLdeU3DTLZklaFRIkIiIiIiIt3FABTandiSWY49eXbYHXW8LkRERHTamCT0oETh/NEJuG/uCASbfJunHt/19lZszixlopCIiIiIjlJS5dTqk505FSivZrKQiIiITh2ThB6WKJybFo/7545AyLdTj/cVVOowk68PFqOek+2IiIiI6BjKa+qwM7cC27PLNXHIljVERETUUUwSemCicM6oeNw/bwQs5qZE4aGiKi09XrW3CHVMFBIRERHRcdgd9VqCvDWrHIX2WiYLiYiIqN2aslDkgYnCOPj79MF9H+7U1eCccgfuemcLHpg3AlOHxZz2RDsiIup+Xx0o7rKvPWFARJd9bSIynmpnA/YXVCKz1AcJoYGICjHBR8YjExGRF8WCLjQ0NGDioOhO/rrUW3EnoQdPPZ6ZGoeHLh2JWGvT2OriKifufncbPtySw2l2RER0Sux2O0JCQvDjH//Yo6/gfffdB6fT2a7HXnTRRThw4MBJH/f+++9j3bp1p3Q+Uro5ceJEHDly5KSPXbBgAeLj49GnTx9UVlYe93FvvvkmxowZg9TUVIwcORJPPvlk831ffPEFgoKCMHr06OajpqZG78vLy8NZZ52F+npOtqWTq61rxMHCKu1xnVNWgwYOxCMi6tUYCzIWPBEmCT1YgJ8PpgyNxt8WjEJKRFBzCckfP9iBtzZkooKT7IiIqIPeeOMNjB07FgsXLjxhAqunuBNf999/f7uThIsXL8aAAQO6NEn49ttvY8iQIUhJSTnpY2+66Sakp6ef9HGJiYn45JNPsH37dnz55Zd44oknsGbNmub7hw8frl/HfQQGBurtsbGxmiR89dVXT+m5UO/krHfhSHE1NmWUIrOkmi1siIh6KcaCjAVPhElCD+fv64NzBkTgr5eNwpAYi95WU9eAP3+8C6+sPaylyERERO3173//G7/5zW9w3nnn4a233jru4/r27avJK7fx48fr7jYxefLk5q8hyTlJirmVl5frLkXZGZeWloYf/ehHentdXR3uvvtunHnmmbor7qqrrkJZWZned9111+HWW2/FzJkz9XPcX++cc87RnXYFBQV47bXXNDEmH8vnS2LwWOd6vHOTxy9atAgPPfSQfv4LL7yA2bNn4/XXX2/+Op9++ql+j2N57rnn8P3vf7/pfbimRs/znXfe0Y+/+uor9OvXD0VFRfrxhRdeiOjok5f9yM5ESfgJm82GoUOH4tChQ2iP733ve/jXv/7VrscStVTf4EJWaQ3SM8uRX+FAbX0DLxARUS9itFhQHuuJseDo0aO9Mhb0ip6El1xyib5Yp06d2vxDki20F1xwgb4QpUZfXnA/+clPYER+vj44o284/rpgJO5btBPpmWWoa3DhkWV7UVJdh5+c1x+xtqaSZCIiouPZsWMHMjMzNQCTHXt/+9vfmgO3jpLyXnnvld1+suNNgqMJEybgl7/8pZYzb9myBT4+PigsLNTHP/zww3q7eyffn/70J9x77726e07ITrpVq1bpY9yB2Nq1axEcHKznOmPGDA2GpIT38OHDGjRK6a+/v3+7zk1KkufOnasB7i9+8Qt9nOwKlB2LV199tX78z3/+s/m+liSWkHOR5ydkR5/sLJS4Q77GD37wA7zyyiuIjIw85Rffzp079Tyff/755tv27Nmjuz59fX1x/fXX4+abb26+b9y4cdi8eTOqqqr0GhF1lJQdl1Y5NVkYbTVr30L2vCYi8m5GjAXdH0ssKDGbp8SCb731liYDvS0W9IqdhJIAfPnll1vdJn18Vq5cqeU533zzDR588EEUF3ddw/iu5uvTB6MSQvHgJamY+G1zepcL+PeXh/DgJ7twuKiS0+uIiOikK8c//OEPNdCQldODBw9i165dp3TVZPVXvo4ESbKS6u4J+NFHH+Guu+7SoFBERUU1l/pKeay7v56s2sr3d7viiiuag8BjkVXVWbNmaf+++fPn60rt8foDHu/c2po2bRpKS0s1iJWvv2HDBj2PtuR7BQQEaGzhNnjwYPz1r3/VYFFWy88991ycqqysLMybNw/PPvus9jIUEhDK7Zs2bcJ7772n97Vc7ZeAODQ0FLm5uaf8fYnc8WRBRS02Z5Rhb74dVbXsdUlE5K0YC7bGWNBLdxJOmTKledurm/xx4A7mHQ6H7iaUpuNGJhPphsZZ8cD8VDy2bC8+2tr0h8EH6TkoqnTitxcNxbBYKyfXERHRMVdAJUknySV3WUV1dTVefPFFXdlty8/PT9873eS9tCWz2dzqPfdkQzTkPfjpp5/WXf7HcqIEoZAV3kceeUQThCI8PPyoczqVc5OFxqeeekpLPGQl3WQyHfUYiSeO9b0kgSdJ0IyMDJyqnJwcXYX+/e9/j8svv7z5dqvV2qp3oTz/1atXt0piyjm5+xQSdYbiSqceoUH+iA8NhC3w6N0ZRERkTEaPBWURmLHg6i6PBXt8J6FsJ7344oubpwDKToO25IUk9d3yIpQtlRIkt4fUt0s9uwTXv/71r09r66enkGs0ICoEd88aiuvO6Ys+396+Zn8Rfv3OVqw/XAJnfWMPnyUREXmaDz74AP3790d2draWaMghQzJkJ74EjW1JDxfZiS+kLETKHdpDyjgk0GxsbHovcpeYyO2PPvqoBqNC/l9KXo7HYrFoTxs32fEn/WaEBLjycUdJ4q3l1xTXXHONDg/573//26qfTkuSQIyLi2u181F2TErfGnkOX3/9tU4q7ijZBSgly9I359prrz3qPvc1lBYq8v2kB49bfn6+Bu/unYdEnamsug47cyqwPbtcS5KJiMj4GAsyFjTETkKpn5ZEntRXX3bZZUfdL0G31LRLolCaOkpdupQbSb12cnLyCb+2lOFICZEE0pdeeikWLFiAmJiYYz62trZWD7eKigr9fwnQ3UG6J4m3mfGzSf0QHuSPJ1fs1x6FO3IqcOfbW/D7OcNw7oBIBAb4HvV58lwkg++Jz8nIeF15XY2Er9fuua7uj92HOLt/eBd996bV2ZOVl0hPv5aPGzFihCaZpImzvE+29H//93/aRFo+T5JT8tiWz6Xlf7f8WBKBt99+u5YFS4mu9H2RpsqSCJOeL9IMWha8hCzgSZ+YY329O+64Q1eaZXVUEmSPP/649iBOSEjA2WefrTHA8c7neOcm/WIk3pB+gj//+c+1TFi+vpT6SlJOFhWPdx3l+kjDa/k82TkoPWEkuRgWFqaxipyrXKdBgwbp15NdhkImIsttK1as0I+lzFuug1yXP/zhD/q1pBePux+P7GyUc5Qey1JiLIlAWZmXGEZ+Hu7zk+/t3lXZ9pzdz7dtDMP3fuoou6Meu/PsCDb56s7CiOCA5n+/RETUcRO+bR3WWeT9/mQ7+NwkpnMP3nCTeE1iwQ8//PCoWPDPf/6zLmLK50kbFIkF2+Oxxx5rFQueccYZGgvK0JK2saDEh8f7ur/61a+aY8GlS5dqrOSOBaXdy8nyQccii8MST0ksKL0HJRaUihGJqaS6Iykp6bifK/kqib8kBpT4TWLCJUuWaHWLtISRCle5ThL3yeJ421jQXf0qvREfeOABjQX/+Mc/HhUL3nbbbRoLLly4EM8880xzLCgVJ3K7m3xvuR6d/b7cx+VBNbjy5KTvjjvoFfICkgstF8dt2LBh+hjpM+gmF1yaTLoHl7T1s5/9TF9gLUt5Wrrvvvv0BdvW3r17dTeDp6p01GHlgVI8tjIblc6mPwRCA31x5/kJmNAvDMGm1nlg+QNBdlHIrgh3vyg6fbyuXYPXldfVyK9X2Z0nH0sz45blGNQxEqZIqYuUsXRFckK+tkzZk8DsRH0Fpf+hlLnI7ktPeP+UQFRiI5mC15aUnsj5ymuxZTNv2ZEovRTlddmynJmOJovFcv26+lp9daAI9Y0u+PXAa0r+bTntJQiwhLf735bZ30eThVEhJra3OcX3CZnQKRMvPeH3iLfj9eY170nyXiz9jt0VkV3FnSSURBIXcU49FpSck+STzjvvvOM+TmIrWbSVChL5/dLT11zOVZKvbWPB47322hvb9PhOwhORSTQbN27UjHNL06dP18kyJyK7ByXjLE9eLoaUNUui8Hjuuece3bXgJp8jWWTpNeTJgbQM1Y6OiUF0RDj+b/Fu5FfUoqymAX9anoWfTzHhinGJOrHOTV7M8kKW58XgpPPwunYNXldeVyO/XuUNWpIyEkDIQafnWJPrTpfsoJSde1KhMHny5BM+VsqvZbVb/sCXHYc9SWIciWlkhf5Y5PUmr8GIiIhWwSGT1Z7lUFEVvv/CNwgPDsDFo+IxeUg0Avw8O3HkqGvEwcIqZJVWI84WiBirWYfrERERGZHEgrfccovu7jtRglDIwr/EgrLjMDY2Fp4QCx5rsfh0efRfLTJNULK6bUuE5eO8vLzmj2UUtmzllNJlCdxlN6IExzfccENzyY1sJR01atRxv5c0Kj9Ws3L5Op6eTLMGBmDaiDhYg0z4v492Yl9BJWrrG/Hosn3ILnPgp5P6o19kcHOWW/7fCM/LaHhdeV2NhK/Xrr+ucsjH7oNOjbyHt3z/6kxSFixHex2vGqG7SWDatlyoJfdrru17Pd/3PctzKw+g0QUdPvfS2sNYuDkbs1NjceHwGAQFeHSIDme9C0eKq5FdVoNYqxmxNjP8fRlXEhGRsUhZsBzttWDBgg6VeHcVyYlJG6Gu4NkRyLfa/lHQ8g8GIY3DjyU9PR29hdnfFxMHROBvC0bhkU/3YM2BYr39zfWZyC6twZ3Th2BEghW+/DuViKhbeVBXD+ol+JozhsvHJ6KgwoHP9zQN96moqcPr6zOxaEsOZoyIxYzUWFjNnj1duL7BhazSGuSU1WjlSpzNrDEpERE14XsyGe0159FLfjKNWHoQtdw1KKTU53gDSHozP18fpCWG4r65I3DF+O8abn65vwh3vbMFX+4rRLWzZzPeRES9hbx/uVtnEHUn92vO/RokzzQuJRz/vu4MPHjpSB1q5F7HrXI24N3N2bj19c145avDKDHAdGHZEZlX7kB6Zhn2F1SixtnQ06dEROQRbVKqq6v5kyBDxYEevZNQJuGMGzcOy5Yt06ktbvJxR8qDehMfnz4YFGPBrVMHIj7UjGe+OKClx1KCfOfbW/HrmUMwNqqP9jIkIqKuI33hZFpaYWGhBoos9Tw1bMjd8d6Y8pqT1x57YRpD34hg3DZ1MHLH1eguwtX7itDgcmn8tnh7HpbuzMf5g6NwcVq89gD0ZLJ5odBeq4f0WpRY1OLhuyGJiLqCJGhCQ0N1g5OQ9+WuaD/DOKn7uTx4WExnxIE9niSsrKzE/v37mz+WKSxSJixjpGWktQwTkTHVMh5axlw///zzOiL6pptu6tHz9nSJYUG45uwUDSYf/nSPrkIXVznxxw924MazYnC5JQxJ4d/1KSQios4lv1/j4uL0fU2modGpB2IS8Lh7PNLJybWSGIrXy1jiQgPx0/MH4LJxifhoay4+352PugaXTj/+bHcBPt9TgHP6R2Du6AQkhwfB00nsKYct0B8JoYGwBTFZSES9i3u4hTtR2BUYJ3U/l4fHpqcbB/Z4knDDhg2YMmVK88fuCcPXXnst/vOf/+DKK69EcXExHnjgAeTm5uokv8WLF+tkGTqxiBCTrjpHhQTgwU9240Bhla5KP7kmF1nVPrhxUn8Mig7RMmUiIuqaHfGDBg1iyfFpkCBM4gCZ1MvdmO1/3fFadd7rT46u4h6w11JEcACunZCC+aPj8cn2PCzbmY+augbdpSc9p+UYlxyKeaMTMDA65LS/d1f3yyqrduoRYvJFvM2MsOAAj/yjqjvIa8n9xyXxensjvsaPJm3SpI1aXV1dl13zkpIS3WTF9/7u0ejB11zeX90VTG3fa9r73tPjScLJkyefNDi5+eab9aCOCzH54bzBUQgNCsCjy/Zi7bcDTd7bnI1DRVW4c8YQjE0O9fgpekRERiVv0mazZ5cIejIJaCTYkWvoaYEYeZ+nnnpKj4aGpp56UrLjcDi67PtJDOy02495XyCAS4cGY0b/FHy2vxzL9pbBXtt0XhszyvQYHhOIOcPCMSw6sMOJN4m+62sq5S+K5n6IXanEDpQUAQF+PlqKLENZpE1Ob/t9Vl5erj93/j7j9fZGfI33zDWvqqrS0lL+XuE1PxH7ceKNtvq4OG7nmCoqKmCz2fSN3Gq1wugaG13YX2DHf9YewevrM3Q1WsRYTbhrxlBMGRKlOw/pVK9vo24jj46O5i/nTsTr2jV4XXldjYSv187jbbFNd1yr0tLSLr1WEoZ/c6i0XY911DVgxZ5CfLw1ByXVrXekDIwKxtzR8RibHAafdiYLmxKUJQiwhPfIzj5JFsbbTIiymOHbS5KF7l5RUVFRjBd5vb0SX+O85r1Bo0F/l0tsExYWdtI4kNvHeglZqR0ca8XNU/ojIbABz3ydj8raeuRX1OJ3723DTydJD5ymHje9tQSEiIiIqCUJ/rvyDwBJ1LU37goM8MNFI+MwbXiMDjdZtCVb4zixv7AKjy7bh8SwQMxNi8c5AyLblXiT7+0+upv0WzxS4kBOea320I61meHfC1rgyLXu6tcV8Xr3JL7Gec17gz4G/F3e3nM1zjOiThFvC8SMYRF46LJU9I1oanotfQr/8fk+PPLpHmzLLoeznn1SiIiIiDyRJNIuGBqNv18+GrdcMBBJLYaYZJXW4OkvDuD2N9OxdGeeIWI6SRbKeW/OKMPhIumf3VRSTURERN2POwl7oRCzP6bERiDaYsaTn+3H6v1FevuHW3NxqLgad0wbhHEp4TqNjoiIiIg8j+wUlB2DZ/ePQHpGGd5Pz8a+gkq9r7CyFi+tOYx3N2XjotRYXDg8xuP7Tzc0upBb7kBehQORISadiBwY4NvTp0VERNSrcCdhLyVBlyQCfz9nGK6d0Be+35aZbM8ux51vb8X7m7ORXVbT5RPviIiIiOjUSQ/CsSlhuH/uCPxhznCMSrQ131deU4fX12filtc34831Gfqxp5PQs9Bei/TMMuzJs8Pu8PxzJiIi8haevaRIXb4CPSTWihvP74++kUF4fPk+DR5Lqpy4/8Md2Jtvxw/OTsbAaEuv6BFDREREZOT+SMPjrHocKqrCB+nZWHeoRKcYVzsb8H56DhZvy8OUodGYMyoOEcEB8HQSk8phDfTTnYWhQZ5/zkREREbGJCFp0HXpmEQkhgbi0eV7sSvXjkYX8L9vMrA7z47bpg7CmORQWMwsPyYiIiLydP0ig/HLCwcjp6wGH27J0dYyUs7rbGjEpzvysHxnPiYOjMDMgcHoa4HHq6ipR0WNHcEmX8SHBmqCk4P2iIiIOh+3h5GyBfnjvMFReOjSUZg/Or75qmw8UopfvbUFi7bkaKDJ8mMiIiIiY5CE2k/PH4AnrhyNWamxMPk1hf4NLhdW7SvC7z45gseW7cWBwqZehp6uqrYB+/IrtRQ5v8KBRlnVJiIiok7DnYTUzOzvi5EJNtx24WAMibXgqRUHUFlbr82v7/1gB/afXYkrzkhk+TERERGRgUSEmPDDCX0xf0wCPt2ep7sJq5wNWoq8/kipHqkJNsxLi8eIeKvH79Jz1DXiYGEVskqrEWsLRIzFBD+2xiEiIjptTBJSKz4+fbREZcG4JKREBOvqskzKq2904aW1h7ErrwI3Tx6ItKRQTj8mIiIiMhCr2R+Xj0/CnFHxWL4rH4u3ZqPM0dA8vE6OAVHBmD86QYehyFAUT+asdyGjuFqrXWIsZsTazAj4drckERERdRyThHRMURYTpgyJRrTFhBfXHMbibbl6+9cHS3CwcAtuuWAgJg+JRmJYoMevNhMRERHRdwIDfHV4yeRkf3yT14iPtuYgv6JW7ztQWIW/L9urPavnjY7HhAER8PPx7MRbfYML2WU1yC2v0RhWyqylQoaIiIg6xrPf8anHA8gxyWG4Y9pg3HHhYAQFNAVbBfZa3LdoJ55esR/bssvhqGtagSYiIiIi4wjw9cHUodH4++WjdQE4OTyo+T5Juj39xQHc/mY6lu7Ig7O+EZ5OWhRKslN6Fu7Lt6Oqtr6nT4mIiMhQuJOQTsjXpw8GRofgqrOS0C8qCP/4bL+WH0vD69fXZ2JbTgVuvWCglqREhph4NYmIiIgMGO+dMyASE/pHYHNmGRal52BPvl3vK6p0asuZhZuzcVFqLKYNj0FQgGf/CeFyNZ23HKFB/rqz0Bbo39OnRURE5PE8+x2ePEa0xYypw2IQbwvEK19n4IP0bG12Lb1rfvX2Fvzs/AGYPiJW+xlKoElERERExiItZMYmh+mxO7cCH2zJ0V15oqKmDm+sz8QH6TmYPiIGs1LjDJF4K6uu0yPE5If4UDPCgwPYKoeIiOg4mCSkdpNV49HJYQgNDkBqghVPrdiP0uo62B31+Nune7T0+PqJfTE83qaBGBEREREZ09A4qx6HiqqwaEs2vjlYogvENXUNmiiUftXSv1qGoEgfQE9XWVuPvfmV2k4n3mbWChgZ2EdERETfYSaHOkR2CQ6ICtGVY9k1+NSKA9iUUar3fbI9DztzK3Db1EE4s1+4NrzmUBMiIiIi45J477apg5E7vgYfbsnFqn2FaGh0oa7BhaU78/HZrgKcMzACc9PikRj2XU9DT1XjbNDhLJmlNYizmXVIn58v27QTEREJviPSKZHV14kDI3H/3OG47py+8PdtWok9UlyNe97dhhe/PKylyBxqQkRERHR8sguvjwE2tMXZAnHjpP74x1VjcNHIOJj8mv6MkD7Vq/cV4a53tuLvS/dgf0EljEAGsUjcKj0YM0uqDTGYhYiIqKtxJyGdMrO/L1ITbLAFBmBorAVPfr5fJ+HV1jfixTWHdIfhzZMHYHRSKKKtZl5pIiIiohak4kIGxCWGBSK33IGCCodO6PVk0tPvmrNTMH90PD7dkYclO/JQVdug9204UqpHarwV80YnYES81eOrSuobXMgqrUFOWY0mbGXIicS4REREvRGThHRaJPBLjgiCLSgOyeFBeHHNYSzfla/3SaPrO97aghvP648ZqbHoHxUMf5ZzEBEREbUiSSkp65VWLXnlDuRVOLSk15NZzP5YMC5JexJKyfHH23K0V7XYnlOhx4CoYMxLS8C4vmHw8fBkoVzu/IpaFNhrEREcoMnCYPbYJiKiXoZJQuoU0qPwjH7hiLSYMC4lFM+tPIiymjptEv3o8r3YmFGKH5/XF6nxoQgLDuBVJyIiImojwM9HF19lCq8kCiVhKL3/PD3BOXtUnE48lrLjD7fk6LkL6f0ncaAkP6VnofQu9PPx7G5HLhdQVOnUIzTIH/G2QNiCPH+KMxERUWdgkpA6jewSHBxjQWigPwZFW/DcqgNYf7hpqMnKvYXYmVOBm6cMwHmDotA3IohNoomIiIiOFaD7+ugQEOkDWGB3IKfM4fE98yQOvGBoNCYPjsI3h4p1AvKRkmq9T9rRPLPyAN7emKk7D2UqsiREPV1ZdZ0eISY/TdxKqbWnl08TERGdDiYJqdNJ/8FzB/kjxmrCx9vy8N+1h1FT14DCylo88OFOXJwWj++fnYyhMVauzBIREREdh69PH00UxljMKKqs1WSbo86zk4U+Pn0wYUAkzu4fgS1ZZZos3J1n1/tkd95/1h7Gu5uyMCs1DtOGxxiipFcqY/bmV8Ls76NlyFEhJn2eRERE3sbz35XJ0ENNQoMCMDzOgqdWHMCefDukYGbRlhwNGn92/gCc1T9CexlKEExERERER5OElCzCymANSbTJkI1qZ9OwEE8lO+5GJ4XpsTuvQpOF0q9aVDjq8eaGTI0JLxwWjVkj4xAW5PntaCRBe7CwClml1YjV5K2JlTFERORVmCSkLg0Ok8KDmvq5hAZi4cYsvLUxSxtxHymuxu/e345LxyTgivGJGBJnhdXMfi9EREREJ4qtJFEYGRKgQ0IkWWh31Hv8BRsaa8XQmVYcKa7CB1ty8PXBYu39J5UmH27NxSfb8zBpcBTmjIrTnZOezlnvQkZxNbJLa7RyJtZmhsmPE5GJiMj4mCSkbpl+NyY5TPu4jEoKxdMr9iOztEaThW9vzMKGI6W6q/DMfuGaVOSuQiIiIqITJwslrpKjvLpOy5DLa5omC3uylIhg3HrBIFwxLgkfbc3Bqn2FOpilvtGFz3cXYMXuAo0HZchJ/6gQeDqJZaVfZG65Q5O3MuQkMIDJQiIiMi4mCalbSOJPgj0JZvtFBuONdRm6kiyryIeKqnDPe9uwYGwiLh+fiMGxFu4qJCIiImoHmbwrh90hOwsdKKlyevx1k513Pz6vPxaMS9RdhMt25uuuQmlL882hEj2kbc28tHiMiLd6/LAQiWcLKmr1kFhXhpzIIjkREZHRMElI3Up6FI5LCdMymfF9w/HMFwd09VtWYqU3zfrDJbiJuwqJiIiIOkSSUkNi/VHtrNcyZOldKMkrT48Lrz4zGfNGx2P5znws3p7XvCNye3a5Hv0jgzF3dDzOSAk3xLAQSdLKYTH7ISE0EGHBnt9rkYiIyI1JQup2/r4+GBht0QbVEvi9sT4TH25t2lV4sKgKv5VdheMS9RgUY4EtkCuxRERERO0RFOCncVZiWIMmCwvttWh0ef45zx2dgJmpcVi9r1DjwvyKWr1PYsPHl+9DrNWMi9Picd6gSI0lPZ30ipSpzkEBvtqbWxbIiYiIPB2ThNRjIkJMGN/XX///jL5heGblAS2Tkb40kjiUXYU/O38gxqaEag8b9iokIiIiah+zv6+2ekkMC0JueY0m3aRyw5MF+Plg6rAYTBkSrSXHi7Zk43Bxtd6XV+HAv1YfxNsbMzF7ZBwuGBqtyUVPJ1Oo9xdUIqPEB3HWAHh8xpaIiHo1z39nJa8mweCQWIv2b5FA9vV1Gfh4W67uKjxQKL0Kt2qvwkvGJmJwTIiWpRARERFR+2MtWWyV3Wx55Q7kVzh0WIgnk7LiCQMicHb/cGzLLseiLTnYkVOh95VV1+F/32Tg/c3ZmDY8BjNGxBoiPnTWN+JwcQ0aqipRb7Ig1hakPxsiIiJPwiQheQSZCCdlxZG6qzAcz648oJPiJIh9fX0mvj5Ughsn9dcdhxLoGqHMhIiIiMhTSOyUFB6kycICuwPZpTXw9BEnMrBkVGKoHrIb78MtOVppIinOKmcD3k/P0cXlyUOidXdhjNUMTye7ObNKZSJybdNE5NBA3fVJRETkCZgkJI/cVTgwOhivfZOJxbKrEE0TkH/33jbMGRWPK89IxJBYqyYUiYiIiKj9pH1LnC0QUcEB2N9YiWpfH9TWe/bOQjEwOgS3TxusfRY/2pqDVfuKNOEmC8oyHXn5rnxM6B+BuWnxuqDs6aTqWErAC+y1iAgOQFxoIEJM/NOMiIh6Ft+JyEN3FUYgymLGWf3C8fzqg8gqrdFgSspN1h0qwU8m9cfEgRHoFxkMkx9XX4mIiIg6WtIrZbqDomworWmaiFxV2+DxF1F23t04aQAWjEvSxeTPdufDUdeorWrWHijWY3RSqCYLh8ZadDeiJ5PzlknUckhVTXyo2RDl00RE5J2YJCSP3VU4OKZpV+GgmBAs3JSN9zZn64qxNK7+00c7MXVoNH5wdgqGxVkRYzV5fBBIRERE5GkkfpLqDDlKq5zILqvRybyeTmJEiQPnj0nQnYRLtuei4tvzTs8s02NQdIgmC8emhMHHAHFieU2dHsEmX93tKRORGd8SEVF3YpKQPJoErLKqKrsLdVfhqoPYV1Cp9322uwAbM0rxo4n9dMJd/6hgQ0y5IyIiIvJEYcEBelQ46nRnYWlVHTydlOheMiYBF42Mxco9hfhoay4KK2v1PokZ/75sLxJCA3FxWhwmDoiEnwH6WsuOTunBmFnqg3gpDbeYtEyciIioqzGjQoZotD0w2oKIYBP6Rgbj4625eGN9hpaWyIS7R5ftxZr9Rbh+Yl+MiLdpICglNERERETUcVazP6yx/qiqbSpDLq5yalmsJ5P2M9NHxGLqsBh8fbAYH2zJQWZJtd4nuyOfXXkQb23I0gEnsrhshGEhtXWN2pc7q7Rah7LE2swc3kdERF2KSUIyDFnZHmMO1ebO41LC8O8vD2kpifjmUAm2Z5fj+2enYOaIGAyIssAW5N/Tp0xERERkWMEmPwyKsSCprkGThYX2Wu0R7clkx93EgZE4Z0CExonSz3p3nl3vK6ly4pWvj2gLmxkjYjSpKAlRTyfDWaQ/t/wMoq1mxNnMhkhyEhGR8TBJSIYiJSL9o0IQEWJCYlggPttVgP9+dVh751Q5G7Qc+ct9RfjRuf0wOsmm0+1kJyIRERERnRpJSEn8lRAWiLxyh07llT7Rnkx6+Y1JDtNjb75dk4Ubj5TqfZW19drvWkqTpwyJxuxRcdrixtPJJW+6/g5ORCYioi7BJCEZkvQpTEsM1YBuVJINL689gi/3F+l9O3Mr8JuFWzEvLR6XjUvUptXSy4WNn4mIiIhOr6RXFmBlwrA7WSW73DydDMO7c/oQLT/+aGsO1uwvRoPLhdr6RizZkaeDT84ZGIGLR8UjKTwIno4TkYmIqKswSUiGJX0HJZCLCAnQps6r9xXhpTWHUGBvWt1+d3M21h4o1l6FUnbCwSZEREREp0+qNCQGk2Rhgd2BnDIHnPWNHn9p5Zx/NnkgLh+fhI+35WLF7gJNFErCUOJIOcYmh2He6HhNLBoBJyITEVFnYpKQDE8mGo+It+quwtR4K97ZlIWPtuRqwJdX4cCDn+zWvjQ/nJCC4XE2LZXhhDgiIiKi0yPxVJwtEDEWM4oqa5FT7kCNs8HjL6vEjNdO6ItLxyTg0x35+HRHnpYgi00ZpXoMjbXg4rR4jEkKNUQ1SsuJyNKzMNpiZrxLREQdxiQheQUJ3mTiW1iwvzZ0njggUgeb7MlvalQtOwqlefVVZyTjolGx6B8ZgvDggJ4+bSIiIiKvqO6Q+Evau8hwENlZ6E66eTKL2R8LxiVizqg4rNhTgI+35uokZyHDTnbn7dHdh3PT4jGhf4Qhkm4yEflwUbUOOom1mnUqcoAf+3MTEVH7MElIXtcrZ0isRYPUflHB2mPmtW8yNFCtdjbgxTWHsHpfIW44t582sk6JCOJ0OCIiIqJOWrSV4XJylFfXIbusRsthjTCYZVZqHKYNj8Ha/cU65ETOXUgfw6dW7Mdb6zN1wMnkIVEab3q6+hYTkSUulh2fgQGef95ERNSzmCQkryS7BK3mUESFmDA+JQyvfn0Eq/Y1DTbZV1CJ3763TYPBK8YnYkB0iPY0lFVwIiIiIjp9tiB/PeyOOt1ZKDsMPZ2fjw8mDY7CuYMiteR4UXqOxo2isLIW/1l7GAs3ZWHGiFhMHx6jOxGNMBFZplHLIX28pRTZCOdNREQ9wyv2nl9yySUICwvDggUL2nU79Q5+vj7oGxmMcwZG4q4ZQ/GH2cMQH2puDpikYfUdb23Bwo3Z2JJVpiveRERERNR5JCElVR6jk0J1R5sB2vvBp08fjE8Jx/1zR+DeOcP13N3sjnq8szELt7y+Gf9dexiFdgeMorjSie3ZFdiRU47SKidcMiaZiIjI25KEt956K15++eV23069S4jJD6kJVsweFY+HF6Th8nGJ8PdtilCl78xjy/fi3kU78NmufOzLt6O23vMbbhMREREZiZS6DowO0YSb7GYzQgGHlE8PjbPiNzOH4qFLR2LiwMjm85apyEt25OGXb6bjn5/vw5HiKhhFRU299lzcmlWu06kbZfWciIjIW5KEU6ZMgcViafft1HsHm4zvG4YbJ/XH3y5Lw6gEW/P9EiT9euFW/HPFfnxzsET7tzBgIiIiIur8/n9S6TE2JQyJYYHw+3bh1tOlRATjF1MG4vErx2DmiFiYvh0GIvm1NQeKcfe72/DgJ7uwPbvcMDv0pF/3gYIqbM4s0x6M9Q2NPX1KRETU25OEq1atwsUXX4z4+HhN5Lz//vtHPebpp59Gv379YDabMW7cOKxevbpHzpWMTxpND4qxYMrQKNw3dzhuv3AwIr6dclzf6MIH6Tm4/c10vLUhkyXIRERERF3E39dHJweP/XaQnFEm8ErJ9LXn9MWTV4/R6hSL2a/VovOfF+/C79/fjq8PFhtmwdlZ34iM4mpsyijTHZGsqiEi6r16fHBJVVUV0tLScP311+Oyyy476v4333wTv/zlLzVROHHiRDz33HOYNWsWdu7cieTk5E47j9raWj3cKioq9P8bGxv18BbyXGR105ue06mwmv10J2FkSADSEq14b3OO9iiURKGUID++fJ+WH187oS9GJlqRFHbiKci8rl2D15XX1Uj4euV19XS9/b2fPJOvTx/EhwYi1mpGUWWt7mhz1DUaotfipWMTdeLxyr2F+HhrLgrsTX9LHCyqwhOf7UOM1YTZI+Nx/uAoQyRBGxpdOmQmt9yByBCT9vIOCujxPxeJiKgb9fhvfUn4yXE8jz76KG644Qb8+Mc/1o8ff/xxfPrpp3jmmWfw4IMPdtp5yNe6//77j7q9sLAQDodxGhK35w+E8vKmMggfH88PVrqa7CHsH9KIa0bbMCHBH69uKsT2vGq9b1t2BX7z7lbMGByG+akRGiiFBwUccwoyr2vX4HXldTUSvl55XT2d3W7v6VMgOi6Jr6KtZt2pJ5OQJVlVWVtviCqV6cNjMXVoDNYdKsaiLTk4XNwUS8pE4RfXHMI7GzN1IvK0YTEae3o6qZYutNfqERrkr0lcWyAnIhMR9QY9niQ8EafTiY0bN+Luu+9udfv06dOxdu3aTv1e99xzD+64445WOwmTkpIQFRUFq9UKb/ojVsq65XkxSfidRAD9Ep0YmByHNfuL8crXR1BU6YS0Zlm8uxRfZ1bhB2cl4/zBIegXEYzQb0uUeV35ejUi/h7gdTUSvl47j7RtIfJ0EqdGhJj0KK+u052F5TV1MMKOyAkDInF2/whsz6nAh1tysC27XO+rcNTj7Y1ZmkA8v78Vc8YGI8pijH+PZdV1esggwLhQs7bpkZ8RERF5J49OEhYVFaGhoQExMTGtbpeP8/Lymj+eMWMGNm3apKXLiYmJeO+993DGGWcc9/ZjMZlMerQliTRvS6bJG7s3Pq/TFWExIzTYhBhrIMYkh2oJsgR4UoIsK9r/+Hw/Pt9dgOvO6YcRCVb0jQjWSX1uvK5dg9eV19VI+HrldfVkfN8no7EF+ethd9TpzkKJx4zwPjAywabHoaIqfLg1R/sTyu48mYi8dG8ZPtu3BecMiMCctHgkhwfBCGRX5778SmT4+yDeFqg7PiUxSkRE3sWjk4RubVerpFS25W1Sfnwsx7ud6Hgk2JEm2tKHRVZ4Jw2Kwn+/Ooz0zDK9X1aGf7NwK2aNjMVlYxPRPyoYCaGBYIxERERE1HX9/4bE+qPG2YCc8hotgzXCAOF+kcG49YJBuGp8kva+/mJPIZwNjWhwubB6f5Eeo5NCcXFaPIbFWgyxQ6+2rlGTn1ml1YixmvUwQr9FIiLygiRhZGQkfH19W+0aFAUFBUftLiTqTLJDcFicVQOf5IhArN1fjJe/OoLCyloN7D7amosv9xXhqjOTMXVYFJLDAjV5TURERERdF58NiApBYlgg8sod2vNPhm14Oum1eP3Efrh0TAI+ST+Mz/ZXNPdblIVoOQZEBWNuWgLGp4Qds/+1p6lrcCGrtAY5ZTW6q1D6Fp5oyB8RERmDRycJAwICMG7cOCxbtgyXXHJJ8+3y8bx583r03Kh3CA8OgC0wDNEWs670vpeerSXIEhiV1dTh2ZUHsGxnHn44IQVDbY0IstXBFnR02ToRERERdd6wkJSIYE1M5Vc4NGEosZmnswb645LUCMwb3x8r9xbh42052gNbHCiswmPL9+qU5zmj4nDeIGNMRJYcrSRr5ZC4WQb9yc5PIiIyph5PElZWVmL//v3NHx86dAjp6ekIDw9HcnKyDhO55pprMH78eEyYMAHPP/88MjIycNNNN/XoeVPvK0GWVVJZCZYS5P99cwTrD5c2B3X3LtqJCSkWfL8+EEPjLPp4CWCJiIiIqGv4+/ogMSwIcbZALUGWUmQph/V0suNuZmosLhwejW8OlugC9JGSponIeRUOvPDlIR10Io+RicjBph7/k61dpGekHBaznyZww4L8DVFCTURE3+nxd5wNGzZgypQpzR+7Jwxfe+21+M9//oMrr7wSxcXFeOCBB5Cbm4vU1FQsXrwYKSkpPXjW1BtJQDck1oIYqwl9I4Ox/lAJXv7qMDJLa/T+r47YsSl7C+aPTtDeMn0jg7SxsxFKRoiIiIiMvKAba5P+eCbdmSclsNXOBng6Px8fTBwYqUNMtmaV6/TjnbkVep9MdH5zfSY+SM/G1KExmJUaqxOfjcDuqMeePLuWh8fZzIgKMTEeJiIyiB5PEk6ePPmkvdxuvvlmPYg8QWhQAEaZ/RFtMSE1wYalO/Lw1sZMVNU26NS6Nzdk6hTkH5ydgnMHRegUZKMEdURERERGJbvWpPJDjtIqJ7LLajRhZYTzTksK1eNAYaXuLFx3uESHszjqGnXoyZLteZg4MAJzRsVrxYoRyKCZg4Wth5zI7k8iIvKiJGFmZqa+kSUmJurH69atw2uvvYbhw4fjxhtv7IpzJPI4sjtQyiiapiCbcHb/cLz19QGsOFCuvVlkwIn0lfl0h1X7FY5MtGnvnBCDlIsQEREdD2NBMoKw4AA9Khx1urOwtKoORiCDWX554WDtsyg9C1fuLdR+izI4b9W+Ij3GJjdNRB4SY4yJyM56FzJLZMiJQ+Nm2V3IISdERJ6pw0s53/ve97BixQr9b5k6PG3aNE0U/va3v9WSYKLeRBpKD4wO0SThjRPi8OAlI5Eab22+X0pG7nlvGx5btg9r9hfp6rCz3vN75RARER0PY0EyEqvZH0NjrUhLsmmCygA5NSXl0zec2x//uGqMtrIJDviu1/WmjDLc/+FO3LtoB9YfLkHjSaqyPIVMopbkp0xz3pdvb57wTEREBk4Sbt++HWeeeab+91tvvaU9AteuXau7CaWHIFFvJFPcksODMHlIJO6bOxy/mjZYy5GFxG3Ld+XjjjfT8fLaw9hwuETLLhplyyEREZHBMBYkIwoK8NOF3dFJobqTTfoYGqXNzZVnJOHJq8fimrNTdIKw276CSjy6bC/uensLVuwuQF2DMRaiJTaW3pHbssqxI6dcS8NP1n6KiIi6R4drH+vq6mAyNSU/li9fjrlz5+p/Dx06VAeLEPXuPjhmRFoCEW0JxJjkUHy0NRfvbc7WXoVVzgb896sjWLYrH98/MwVnDwjXEmQpWSYiIjIKxoJkZFLmKgPoEsICdVdbfoVDy3k9nQwBuWhkHKaPiMFXB4q1b6F7eF5OuQPPrz6oPbJnpcbhwmHRmhQ1goqaelTU2BH07ZATiYs59I+IyEA7CUeMGIFnn30Wq1evxrJlyzBz5ky9PScnBxEREV1xjkSGIivTyRFBGN83HD86tx8evWI0Jg2KbL5f+rE8vHQP/vjBDizbmY/t2eWwO4zRJ4eIiIixIHkDGaAhA0DGJIehb2QQTP7GGKghE5HPGxSFv142Cr+eMQRDYy3N95VV1+H1dRn4xWub8do3R1BS5YRRyDTqA4VV2JxZqgNn6g2yK5KIyNt0eInpr3/9Ky655BI8/PDDuPbaa5GWlqa3L1q0qLkMmYiaVqoHx1h0kltSeCCmDY/FK18fxt78Sr08O3Iq8Nt3t2HS4ChcMT4Jg2NCNFhlI2ciIvJkjAXJ2xZ342yBiLWatQRWhpxIwsoIFSyS4JRD+vtJ9Yr0J5Q9kTV1Dfhway4Wb8/DeQMjdSKy7Jw0AhlyklFcjezSGm3dI70ZGRsTEXlwknDy5MkoKipCRUUFwsLCmm+XycZBQUHNH69Zswbjx49vLk0m6q1sgf4YmWDT4HNYXAi+3FeM19ZloMBeq4GcTK37+mCxBnBz0+LQLzIE8aFm+PkaY0WbiIh6F8aC5L1tY0x6SI882c1mdxhjsMagGAtun2bRBOfH23Kxam8h6htdOijki72FeoxNDsPFo+IwJNYYE5Hl3HPLHcircCAiOABxoYEIMRmjhJqIyMhO6Tetr69vqwSh6Nu3b6uPZ82ahfT0dPTv3//0zpDIC0gwFm01a7Np6Vc4vm8YPtmep/0KZbVaehYu3JSFz3fn667CC4ZGa7/CGKvJEIEcERH1LowFyZuFBQfoUeGoQ26ZwzBlu/GhgfjJef2xYFwilmzP08F57l2RmzJK9ZDhLXNGxeGMlHBD9P5zDzmRwxroh3hbIEKD/BkfExF1kS7bqsQJVURHk92B7n6F157TF49dORozRsTC99tEYGl1HZ5bdRC/XrhVG1JvySo3TGBKRETUE7GgtMGRxesFCxa063ai9rKa/XXnXVqSTXcYGmXdNiwoAFefmYwnrx6D75+V3Goi8v6CSjy+fB9+9fYWLNuZB2e9cXr/yZCT3Xl2bM0qR4HdgcZGzx84Q0RkNKxnJOrBfoUTBkTgF1MG4m8LRmFcyne7c48UV+PPi3fhgQ934vPdBdiRU47KWmOUvBAREXWnW2+9FS+//HK7byfqKJkULDvwxiSHaksY6WNolPOWdjZPXDkaPzt/gPa+dpMy3hfXHMYvXt+EdzZm6a5JQw05KeCQEyKirsDGDkQ9vEKdmmDVpsx9I4OxOaMUr359BIeLq/V+KQtJzyzFhcNicNnYRAyIDkZiGIebEBERuU2ZMgVffPFFu28nOlUmP19tByNlvfkVDuSVO1DX4DJEJYsMyjtvUKRWqXy0NUcH6Anpuygtb6SCZfKQKFw0Mk6H7hkBh5wQEXU+7iQk8pBG2aOTQjEzNRYPXTYKN50/oLk0RCoplu7Mxy/fTMeLXx7G+kMlOFJchfoG45SHEBERHcuqVatw8cUXIz4+Xt8P33///aMe8/TTT6Nfv34wm80YN24cVq9ezYtJPcrf10cXbWUYSP+oYJj9jfEnlfwbk3jz97OH4y+XjNSKFvemSGdDo8abt7+VjseX78WBwkoYhXvISXpmmU56ZvUNEZEH7iTksAWijpHSFQk4oy1mTRpOGBCOj7bkYtGWHB1sUlPXoFORl+3Mx1VnJuHcQZFICgvSqclGaDxNRES9S3tiwaqqKqSlpeH666/HZZdddtT9b775Jn75y19qonDixIl47rnndDjezp07kZyc3GnnWltbq4dbRUXTLqvGxkY9vJE8L+kb6a3Pr7tEhQQgMthfe0hLoqqytmlQyLHI9XYfPa1vRBBumTIQV41PwuLtufhiT6HGm3Jq3xwq0WNYrEWHnKQlhcLHAA0Z5dwL7bV6WAN9ERdi8up/w56Iv1d4zXuDRoO+f7b3fLssSegJb35ERhTg54MBUSGIs5k1YThlaDTe3pCpwZv8qyqsrMWTn+/HR1tz8b0zkzGub5gmCyNDApicJyIij9GeWFASfnIcz6OPPoobbrgBP/7xj/Xjxx9/HJ9++imeeeYZPPjgg512rvK17r///qNuLywshMPhgDeSPxbKy8v15+TjY4ydcJ4u2h8IbqxHcZUT1cfoJS3/IuprKiWDDk9JudkAXJ1qxcWDgvH5gXIs31uGim8Tnbvy7HrEWwMwa0gozk6x6C5KIyiyA4UFsgJQhYrqOliDArio3g34e6X78ZrzmreX3W7v2SRhe0+AiI7fbHpYnFWThQmhgToF+dVvMrA9u1zvP1RUpcNN0hJtOsFuRLwNyeFBsAX585ISEVGPO91Y0Ol0YuPGjbj77rtb3T59+nSsXbsWnemee+7BHXfc0WonYVJSEqKiomC1WuGtf1hqy5OoKCYJO1k/QEte88prUFxVpzvcmhPnLhcCQsI8bmE33AIsiIzC3HGN+HJ/ET7elqs7I0VOhRP/Xl+AhTtKMXNELKYOjUawyfNb28v1drpcKHYFodLpgxirSRfgjZLoNCL+XuE17w0aDfr+KW1b2qNdv93HjBnT7jeyTZs2tetxRNQ+oUEBsAX6a7JQJuttOFyK19dl4EhJ03ATaUC9NWublh9fMT5JHyPJQiMEb0REZAw9EQsWFRWhoaEBMTExrW6Xj/Py8po/njFjhn5PKV1OTEzEe++9hzPOOOO4tx+LyWTSoy0J/o30B0BHyc/U259jT7EGBujhqGtATlmNlsBKO2m55u7DE5n8fTF1WIxWsmw6UqqVK3vymxL+ZdV1eGN9Jj5Iz9H7L0qNRUTI0f9uPIn7Wtc1AFmltcgpq0W01axxtdnft6dPzyvx9wqveW/Qx4Dvn+0913ZlEebPn3+650NEp/lLSAIaCcRkEvLo5FCs2luItzZkoqjSqeUrq/cV4euDxbrjcN7oBPSLDOIkZCIi6hQ9GQu2TabI7qCWt0n58bEc73ai7iSJqP5RIRqT5ZVX40iVZyYH25IehOP7huuxN9+uE5FloVpiTumTvXhbLj7dnqfDT6RvoUx9NgIZCChTqeWQIYFxoWZYzazCISLqUJLw3nvvbc/DiKgbh5vEWM04u38EPt2Rh/fTs1FV24C6Bpeu+K7YXaCJwlmpsUiOCEJ8aCBLK4iI6JT1RCwYGRkJX1/fVrsGRUFBwVG7C4mM0HNaYji/2hAgMBC5FU44643R9H5wjAV3TBuC3LIaLUNeta9QY84Gl0tLk+UYlWDDnLR4pMZbPXaXZFsybEYOi9lPdxZK0tAo505E1FVOuR5ResTs2rVLf5EOHz5cy1CIqPsCzX6RwTrZWJKFk4dEY1F6NpbsyNOgrcrZNAlZEohSgnz+kCgkhTdNQpZEIxER0enq6lgwICAA48aNw7Jly3DJJZc03y4fz5s3r1O/F1F38fHpg2hbIOJCg7QaREqRq53Hn4jsSeJCA/Hj8/rj8vFJWLojD0t35mvvRbE1u1wPmZo8Z1S8LmQbJea0O+phd1TC7O+DOFsgoiwmw5w7EVGPJwll9faqq67CF198gdDQUC35kMloU6ZMwRtvvKHNG4moewQG+GJIrEVLJWQFdPqIWJ2ELKXHUg4i0/WeWXlAV31luMkZfUORFB6MaIuJK6VERHRKOjMWrKysxP79+5s/PnToENLT0xEeHo7k5GQdJnLNNddg/PjxmDBhAp5//nlkZGTgpptu4k+PDE2b3ltMepRWOZFTXoOKmqMnInsi6ZUticKL0+Kxcm+hlh4X2Gv1vsPF1fjniv14Y30GZqXG4YKh0Ybp/eeoa9TBgFml1boIL4cszBMR9SYd/q13yy236MS3HTt2oKSkBKWlpdi+fbveduutt3bNWRLRCUkvldQEGyYOjMQd04fgwUtHYnRSaPP9GSXV+OuS3bh30U4s35mvw06KK5uCOSIiop6KBTds2KA7EN27ECUpKP/9xz/+UT++8sor8fjjj+OBBx7A6NGjsWrVKixevBgpKSn8oZHXCAsOwIh4G1ITrFryahSS/JNe2I9eMRq3XjAI/SO/60souyRf+foIfvHaJk0YllU7YRRSlZNVWoPNGaU4UFiJaqcxkrdERJ2hj0uWfzvAZrNh+fLlR02HW7duHaZPn46ysjJ4Awl05bnKyrjVaoU3jeuWHQDR0dGGmsTj6Tzpuso/aVnNlVXQzRlleO2bDBwsqmr1GGkyfcW47yYh24I8s2GzJ11Xb8LryutqJHy9el5s0xtiQW+NA1vivy3PveY1zgbkljdNRJZBG0YhMeiu3Ap8uDUX6Zmtfw/4+fTBeYOiMHtUHBJCA7vtfJz2EgRYwk+7giY0yB/xtkCPjZk9BX+v8Jr3Bo0G/Ru1vbGN36lcEH//o385ym1yHxH1LAmCpDwiMsSk/y87DNfuL8Ib6zObS0G+OlCMdQdLMGVoFC4Zk6j9DWXASYjplNuUEhFRL8FYkKjr28l8NxHZgXy7A/UNnp8t1P6k8TY9MkuqdSLymgPFaGh0ob7RhRV7CvQYlxKmE5GHxFgM0/6mrLpOj2CTr/YtjAzhkBMi8k4dzghccMEFuO222/D6668jPj5eb8vOzsbtt9+OqVOndsU5EtFpTEKWRKEMLDmzXziW7SzAu5uztEGzTKRbvqsAq/YWYcaIGMxNS0BKZBCSwoI0OCUiIurtsaAkRL11EVyel+y08tbn5w3XXNrhJYZJ32kTCuwO5JbXGmYicmJYIG46f4AO0FuyPQ+f7S5ATV3TgJaNR0r1kIqWOSPjMD4lTAe6dDa51u6js1Q66rHPYceRYhlyYkJUiAl+vsbZSdTV+HuF17w3aDTo+2e733s6+oX/+c9/6kS5vn37IikpSVd/pIH0yJEj8eqrr57KuRJRF/L39UFfmYRsM+sxaXAkFm/L0ybTEqw5Gxq1LEQShtKA+qKRsToJWYI7kx+ThURE1HtiwaeeekqPhoamZEZhYSEcDge8kfyxICVH8oeOkcqleus1l4gsPsCFClcdSiudqDVIsjAEwILhIZg9KBBfHKjA0r1lKP12QMv+gko8/tk+xIT4Y8aQUJzb19qpg0IkNVhfUylbHNHZKUjpsLivFDjg00cHuYQFBXDICX+v9Aj+Luc1by+73d41PQndli1bht27d+ub3PDhw3HhhRfCm3hrLxqj1s97OiNd16raeh1kIscH6TlYtjNPGzS7WQP9ccnoBEwbHq3JwvjQQE009gQjXVcj4XXldTUSvl49N7bx5ljQfa1kKIs3xYFt/21JElSmUfM91ljXXCeKV9chp0ImIjcltI2ivqERaw8W4+OtucgsrWl1n9Xsh+nDYzBteAwsZn+P6kl4MvLlI4L9EWsL7NXte/h7hde8N2g06PunxDZhYWGd35PQbdq0aXoQkbEEm/wwLM6qyT9pHH1RaiwWbsrGyr0F2hy7oqYO//3qMD7eloMF45IweXAUEsICEWczs5yCiIh6VSwowb+R/gDoKEmcePtz9NZrHm7xRbjFDLujDrnlDhRXGmN6sL+fL84fHI1Jg6KwJatc+xbuyKnQ+yoc9XhnUzYWbcnF5CFRuGhknLbNOd3r7T66WnFVPYqr7LCY/TTODgvyN0zPxc7E3yu85r1BHwO+f7b3XE8pSSjT67744gvd4dO2rvnRRx89lS9JRN1MSiNsCTYNYhLDg7SB9NsbM/H1wRK9v6jSiWdXHsCHW3Jw5fgkTBgQjoSwIO1v2BV9Y4iIyDgYCxJ5BtlxJ4cjvAE5ZcaZiCx/YI9OCtXjUFEVPtyag28OFuu5SyucpTvzsWxXPs7sG67tcAZESeGyMUjv7z15du3xLYvs0reQsTMRGUWHk4R/+ctf8Pvf/x5DhgxBTExMq9WR3rhSQmR04cEButIZH2rW3oUS1LyxPgNbs8r1/uyyGjy6fC8GbAnGVWckY2xKmPYrjLaY+G+eiKgXYixI5HnM/t9NRM6vcCCvwhgTkUW/yGDcesEgFJ6RpH2zZQKy9FyUpljfHCrRY2isBXNGxWNMcih8DPI3Z42zAQcLq3TSs+yIlKMzey4SEXlEkvCJJ57Aiy++iOuuu65LToiIup8k+KMtZkQGmzRZODgmREtA3liXgX0FlfqYA4VV+PPiXUiNt+KqM5MxIt6qgWhkSACThUREvQhjQSLPJUkod0/pponIDtTWGWPISZTFjGvP6YvLxibqLsIlO/K0DY7YnWfH7rw9iLeZcdGoOJw3MMowCTfp/Z1VWqM7PSMtJsTbAnWXIRGRVyQJpY554sSJXXM2RNSjpBQizhaoZRGy2ikJwfWHS/HmhkxdBRXbcyrw+/e344y+YbhifBIGx1g0GJUdiURE5P0YCxJ5Pt9vYzppEyMtZHLLa1BVa4whJyFmP1wyJgGzR8Zh9f5CLN6Wi5yypinjOeUOvLD6EN5an4npI2J1yIm1E4acdAcppS6oqNUjLNgfcdZA2IKMce5E1Ht0ePnl9ttvx1NPPdU1Z0NEHsHPt2kVWkqLpVfh3y4diZ9PGaglxm6SPPz1wq14dNlefLmvCNuyylFWbYym2UREdOoYCxIZq1okymLCqMRQDIuzaE9qo5CdglOHxuDhBWm4a/oQPX83HXKyMQu3vLYZ//7yIHLLWk9K9nSlVXXYmVuBrVllTX0kjdBIkoh6hQ7vJLzzzjsxe/ZsDBgwAMOHD4e/f+s3mnfffbczz4+IepC/r4/2KYwLNSPaZsaE/uH4bHcB3tuUjbKaOu0Vs3JvIb7cX4SpQ6Mxb3QCUiKCNMFopCCUiIjaj7EgkTGFBgXoUVlbr0m14iqnxnKeTnoQysK1HAcKK/HxttxWQ06W7yrAZ7sKME4Xt+O1bY5ReuXL7s79BZXI8PNBrM2MGItJF+uJiAyTJLzllluwYsUKTJkyBREREYb5BUxEp87k56tT5RJCA7UMedKgKCzdkYdFW3JQ5WxAQ6NLp9BJo+lpw2MxNy0eyeGSLAzUiXtEROQ9GAsSGVuIyQ+DpF1MXQPyyh0osNdqLGcEEo+6h5x8sr1pyImjrhFy9huOlOoxMDoEc0bGYXxKGIzCWd+IjOJqZJfWaOWOJAxlGA0RkccnCV9++WUsXLhQdxMSUe8iwYoEldIMW3YXTh0Wg4+25miQJlPopDGz9I35bFc+ZqbGYs7IeCRFBCIpLAjBpg7/uiEiIg/EWJDIe+I6qRhJCAtsmohc7tBYzihDTn44oWnIiVS5LNmei9LqpiEnsjPv8c/2aZn19IFWTB1lQ2CAMeJQSdbKsBmZTi39vuNsZi64E1G36vBvy/DwcC01JqLeSxJ+Q2OturNQkoWzUuN0V+HSnXkaXErC8IP0HCzdkY+LRsbhopGxWoKcGBaIIIMEaUREdGy9KRZsbGzUwxvJ83K5XF77/DyRp15z3z7QqcGxFhOKKmt1OIjszjOCoABfXDwqDrNGxGDtwWIs3paHjG+H7Umvv/9tLsT7O0pw4bAYTB8Rg7AgYwzakzLwInutHhazL+KsZoQFB3h8FZ+nvsa9Ga85r3l7tfffZYf/Wr/vvvtw77334qWXXkJQUFBHP52IvIiUEo+ItyExNEhXoWePisP7m7Px+e4C1De6UFPXgIWbsvDpjjwdgDJjhCQLA5EYFsQSCiIig/LmWFCG88nR0NA0BbawsBAOR9NUVW8jfyyUl5frH/QysZp4zd3iAlywN9ajtNqJGqcxJiKLs2N9cVZMPHbkV2PJnjJsz2tKFkprnA+25GgvwwkpFswcEooE23fD+DxdsR0oLgT8/XwQFuSP0MAA+Ph4ZrKQv1d4zXuDRoO+f9rt9nY9ro9LnlkHjBkzBgcOHNAL0rdv36MGl2zatAneoKKiAjabTX/4VqsV3vSCLigoQHR0tKFe0J6O17VJaZUTmaXVOFJcjfc2Z+OLPQXaVNrNGuiPeWnxmDY8RkuWZWfhifqt8Lry9WokfL3yuvaW2KY3xILua1VaWupVcWDb31mSBI2KimJMyGt+XBWOOuSW16C0qh5Gc6S4Ch9tPoKvMyqP6rmYlmjD7JFxGBFv9fjdeW35+fbRASfRVpP2Dfck/L3Ca94bNBr0/VNim7CwsJPGgR3eSTh//vzTPTci8lJSBhEa5K8JQCkvlgEmspNQph/LckRFTR1e+fqI9jGcPyZBJyLLY+Vgc2YiImPoTbGgBP9G+gOgoyQ54u3P0dMY7ZqHBpn0qHbWa688KX81yIwTpEQE4ydnxeLqCSE6YG/5rnxUf7szcktWuR4pEUE6Efns/uHwM8jPpKERyCmvRW5FLSJDAhBrC9RhNJ7CaK9xb8BrzmveHu39N9nh3yZSXtIer7/+OubOnYvg4OCOfgsiMvibVGSICRHBAYgPNSM5IgjzRidg4cYsfHWwWB8jjaVfWnMYH27JwaVjEzF5cBTiNFlo9rgVUSIiao2xIFHvIz2lZbKwDKOTASf5dgfqDTLkRAaAXH1mMuaPTsAXewt0yF5RpVPvk+qXp1bsx+vrAjArNRYXDI02TP9sWYAvtDv1sAb6Id4WqIv1RtsZSUSepct+A/70pz/FWWedhf79+3fVtyAiDyYBSrTFjKgQkw446RcZjH35dryzMQsbjpTqYyRAe37VQSxKz8Fl4xJx7oCIb5OFgQjw4+ojEZGRMRYk8j4Sn8kCsPSiLrA7kFPmgLPeGEMqAgN8ddje9OGxWHeoRCtbDhZV6X0lVU7875sMvLspWxOFkjCMCDFO38KKmnpU1Nj1OcpEZFmw9/XQvoVE1EuThB1sdUhEXpwsjLF+lywcFBOCXblNycL0zDJ9TF6FQ1dxZejJgnGJWvIhiULpt0JERMbEWJDIe0kCKs4WiFirWRd9pW9hVW2DYc59woAIjTd359nx0dZcbMpoWsCWoXsy4OST7bmY0D8Cs0fF60K3UcigmYOFVcgsqdb4Ww4uvBNRRxhjLzURGZ5MYYu1mRFlMWlQOTTWgh05FXhrQ6b+v8guq8ETn+3Du5sCcdnYRJzVPxwhDbUIi2iEiX1NiIiIiDxuMVhiOznKq+s0liuvqYNRzn1YnFUPOe9PtuVi1b5C1DW4tO/imgPFeshwExlykpYUCh+DlPLKc8gqrUFOWY3uiJSWPkYpoyainsXfFETU7au3ukvQatbS4uHxVqRnlOHtjZnYm1+pj8ksrcHjn+1D0qZAzB1mQ6VvMBJCgxAXaoa/L8uQiYiIiDyNLchfj6paGXJSozsMjVJcJtUuPz6vPy4fn4SlO/OwdEc+KmubJjrLYrYc8pjZo+Jw7sBIw8SjkuwstNfqYQuU4YJmhAYF9PRpEZEH8+ok4SOPPIKXXnpJV4nuvvtu/OAHP+jpUyKiFsnChG9LiqV3SlqSDZuOlOGdTVnYX/BdsvCptTVYtKtcexae3T9CP0d2JBolOCMiIiLqTYJNfhgYbUFiWIMOOSmw16LBICORJZF2+bgkzE2Lx6q9RTrkRNriCNltKL2031yfiRkjYnHhsGhYzP4wCtnhKUdQi76FUulDRNQrkoTbtm3Da6+9ho0bN+rHU6dOxZw5cxAaGtrTp0ZELfj5+iAxLEh72kgZ8pjkUGzKKMPCNsnCx5fvQ3J4dnMZMpOFRERERJ7L7O+LvpHBSAwLRL69FnnlNXDWGyNZaPLzxbThMZg6NBobM0rx8dZc7Mm3632SaJN2OR+kZ+P8wVG4aGScVsgYRbWzAQcKq5DBvoVE1J1JwpSUFPj799zKyq5du3DOOefAbG76hT169GgsWbIEV111VY+dExGdOFmYFB6kuwSlHHmsJAuPlOLt9YdxsKRWHyPBzGPL9yIlPEiThWcyWUhE5LF6OhYkIs+J8WRxN06GnFTVIrfMoYkqI5Cddmf0DddjX75dh5qsO1yiZdS19Y1YujMfy3bm44x+4ZgzMg6DYiwwipZ9CyO/rexh30Ii8umMyXWNjUePvd++fTuSkpJO+euuWrUKF198MeLj47Vc+P333z/qMU8//TT69eunicBx48Zh9erVzfelpqZixYoVKCsr0+Pzzz9Hdnb2KZ8PEXUP/2+ThWNTwnDRyFjcOz0Zv54xBAOivpssd6SkGo8u34vfLNyK9zZnazJRprjVNRz9u4iIiLpWV8WCRORdJOEWbTFjVKJNB9hZA41V1CYJwF9eOBiPXTFay41Nfk1/SsveyHWHSvDHRTtw36IdWH+oBI0GKa8WcqoFFbXYklmOXbkVOoCGiHqvdv9mrq+vx3333aeJuMmTJ+P+++/Hww8/rLfJfbJD71//+hcCAjqnEWpVVRXS0tJw/fXX47LLLjvq/jfffBO//OUvNVE4ceJEPPfcc5g1axZ27tyJ5ORkDB8+HLfeeisuuOAC2Gw2nHHGGfDzO/7Tra2t1cOtoqJp2qoEvccKfI1KnsvxgnnidfUkvn2kibQZfRzBSE4IwRjpWZhZrmXIBwur9DFHiqvx6LK9SIkIwqVjEnBWv3BtyCwlH+xZeHz8PdA1eF15XT3d6b73d3csSETeSTaAhAUH6CHDQXLLalBcZZwhJxJnXndOXywYm4jlu/KxZEde80RnKUmWQ9royGL3pMFRWrpsFGXVdXpo38JQMyKD2beQqLfp45KMUTv84Q9/0MDv+9//vpbtTpo0CR9//DEefPBBDTp/+9vf4pZbbsGvf/3rzj/JPn3w3nvvYf78+c23nXXWWRg7diyeeeaZ5tuGDRumj5FzauvHP/4xLrnkEsyePfuY30MCXAl229q7dy8sFuNsGz8Z+VmVl5dr4tTHh4MfeF2N83ptcAElVU6UVtUiPacaH2wvxqHS7xL7IiXUhHmp4RiXGILwIBPCQvzhx9f5Ca8rfw90zeuV15XX1RPZ7XYMHjxYX6dWq7XDn9+TsWB3k8Vi+bdcWlp6StfKCORnVlhYiKioKP7O4jXvcY66Bh0QUmh3dtqQE/kz12kvQYAlXP+e7CpSybLmQLH2LZThJi2FmPy0t+H0YTE6+dloAvz6IMZq0h2g7VmA5++V7sdrzmvekdgmLCzspHFgu5OEAwYMwBNPPKHDP/bv348hQ4boYJArr7xS73/77bfxwAMP6MCQrk4SOp1OBAUF6feUxJ/bbbfdhvT0dKxcuVI/LigoQHR0NPbs2YPLL78cmzZtOu5uwmPtJJQSGW8LDvlLhNfV6K9XZ30jcstrdFpe04CTbBwsatpZ6NY3oqln4Rl9w7S/Cqchn/y6Ute8XonX1YjBoSfGgt3lqaee0qOhoUEXir1tsbglLmzwmnui+sbGb3ezOVEvK8SnQT67vtoOvyALumOGr/xZvS2vGkv2lGJnfutkoZ9PH0xIsWDmkFAk2EwwGsmxWgP9dRHe5H/8GIe/V7ofrzmveWcvFre73DgnJ0fLf8XAgQO1lMT9sRg/fjyOHDmC7lBUVKTBW0xMTKvb5eO8vLzmjyWpKP0Ig4OD8dJLL52w3NhkMunRlvyh521/7EnS1RufV0/jde2e62oO8EG/KAsSwoIRFxqEcSlh2HikDO9sysKhb5OFh4ur8fdle9EvMrg5WSiJQpmeHPBt/5jejq9XXlcj4eu1c5zu+74nxYJd5ec//7ke7p2EkvT3psXitn9Yyr8tLmzwmnuaeH19ulBcWYucilrUnOKQE90L43IhICSsS3cStjTeGoHxg5NwuKhKh5x8dbBYe/7VN7qw+lCFHtKTcXZqHFITrN12Xp1B0p7ZtUCorx/irIHH3BnJ3yvdj9ec17y93EN9T6bdSUIJlCTh5m5ALaW+LVdWZRded/+Sa/v95I2g5W1r167t1vMhou4jyb6+kcE6CTnWFohxKaHYcER2Fn6XLJT/f2TpHk0WXjo2AWekhCFOpusxWUhE1GGeGAt2NW9fVGUCntfcU8k/u5jQIETbAnVnYU55DSpq6k/pNe4+ulO/qBD84oJBuPrMZO1Z+PnuguaJzluzyvVICgvERSPjMHFgpKF6aZfXNKC8pvK4fQv5e6X78ZrzmrdHe+OZdicJZRCIlOuOHDlSP16zZk2r+6W0ZNCgQegOkZGR8PX1bbVr0F1e3HZ3IRH1rmTh+JRQrD9SioUbs3RHoTtZ+PelTQNOLvl2wIkkCiWwMVIzaSKinuRJsSAR9Q5GH3ISEWLC989KwaVjEvHF3gJ8si0PhZVNLa4yS2vw3KqDeGN9JqYPj9HehRazcfoWStLzQEEVMv2qtWehVO3I4EEiMrZ2JwmfffZZ+Psf/5dWXV1dtzWqlvKWcePGYdmyZa16EsrH8+bN65ZzICLPThbKrsG2yUKZhvz48n1IDAvUZOE5/SMQGxqoE5GZLCQiMk4sSES9jwwBGRRjQZIMOSl3oMBe22lDTrpaYIAvZqXGYfrwWGw4XKKlyPsKKvU+mYz89sYsfJCeg0mDI3FRapxWvhiFs96FrNIa5JTVICLEH/51p1YeTkQGSxJKg8MT+d73vofOVFlZqU2x3Q4dOqRDScLDw5GcnIw77rgD11xzjfa/mTBhAp5//nlkZGTgpptu6tTzICLjJgslwJJkoZQhv7spq3nAiQQyT36+XxOI80Yn4NxBkTrgRD7H7M+dhUREnhALEhEdi8RqEuslhAUiv8KhhySqjMDXpw/O6h+hx958OxZvy8W6wyW6M9LZ0Ijluwrw2a4CjEkOw+xRcRgWazFMGwfJ1xZUOOG0V6HKtwIJocGGnOhM1Nu1O0nYlpT2yiGNMlsaNWpUZ5wXNmzYgClTpjR/LElBce211+I///mPTtIrLi7WKXq5ublITU3F4sWLkZKS0infn4iMnyxMiQj+tqw4UIeXyDTk9zZnYW9+08ptTrkDz6w8oH0MJVl4/uBIfWwCk4VERD0eCxIRnYj08UsMC0K8LRBFlbXILXc09/0zgsExFj0kySl9C1fsLkBtfaNOZd6UUaqH9NWePTIOZ/UPh5+B+qOWVdejvKaiqW+hzYzIkNZ9C4nIc/Vx6din9tu4caMm6nbt2tU0MerbXhHuoSEyddgbuKfanWw8tNFIIC8BfXR0tFc34u5uvK6ef12d9Y1ampJbXqPNot/dnIVdufZWj4kMCcDctHhMGRqtAU1CaJCWh3gbvl55XY2Er1fPi216QyzorXFgS/y3xWvubeR3kJTuZpc1DTmRj532EgRYwg2xG6+qtl4HnEjCsKTK2eq+8OAAzBwRiwuGRiPYdMr7fLrc8a55gF8f7VsYYzXrQj51Hv4u736NBs2ptDe26fBvmOuvv17LTf7973/rkBAj/MIlIpKAJDkiSIeVSFlxWlIodmRLsjAb27LL9QIVVTrx4prDeG9zNi5Oi9dATHYVSjlLUIDnBmRERN2JsSAReSL5uzQ0KEAPGXKSU1qF3KbiEUOQ5J/En7NGxuKbg019C2X4npCk4WvrMnSRe/KQaMwaEYtoqxlG7FsYaTHpYjxjayLP1OG/eqU34LvvvouBAwd2zRkREXVxaUpSeJBOYJMAJTXRhl05FZosTM8s08eUVtfh5a+O4P30HFw8Kg4XDovRxKIkC6VpNhFRb8ZYkIg8ncRrA6MtMNdXocFkQmFlnWGGnEhZ8cSBkThnQAR25TX1Ldx0pFTLkB11jViyPQ+f7sjDmX3DcdHIOC1ZNoqmvoW1etgC/XV4oPw/Nx4ReY4O/7U7depUbNmyhUlCIvKKZKEkCuUYFm/F3jy77iLccKRUH1NRU4f/fZOh0+akH8z0ETGaKJTdhRYzGzETUe/EWJCIjFRJEh0RjKRwIN9eq61npAWNEUjibHicVY/cshos3p6HVXsLdcCJdHr45lCJHoOiQzROPaNvuKH6/klpuBzS2kdi8Sj2LSQyZpLwhRde0D4027dv12Eh/v6t/1CeO3duZ54fEVGX8vu26XWstakMeUisBfsLKjVZuO5Qia7aSsnKmxsy8dHWHMxMjcPM1NjmMmRZ/SQi6k0YCxKREeM9id3irGYUVzm1R3VVrXH6p8pgvRvO7YfLxyfq9GPZSSgJNrGvoBKPf7YP0RaTxqiTB0cbqqd2jbMBBwurkFlSrT0L2beQyGBJwrVr1+LLL7/EJ598ctR93tKsmoh6b/DoThYOignRgEVKjtceKNIV2ypng05ClrKPGSNiMGtknH5OYlig9r8hIuoNGAsSkVHJTrsoi0mP8uo65JTXoKy6KdlmBFazPy4Zk4A5o+I0Pv14W54m10SBvVbb5byzMUv7asugk4gQE4yirqGpb6EMnpFpyLK70JOHtBB5qw6PYrn11ltxzTXXIDc3V6e6tDyYICQio/P16aNJwjFJYTh3UCTumDYYf788DecPjoK7gqOmrkGTh7e+vhnPrjyArw4UY1tWuTaV7uDAeCIiw2EsSETewBbkj2FxVoxKtGnS0EjzOKVtzvmDo/HXS0finllDkZZoa76v2tmAj7bm4rY30vHPz/c1Dz8xCgmlC+212JpVjh055ShlfE3UrTqcmi8uLsbtt9+uk42JiLx5pTnOFogYi1l3CvaNDMalYxKwaEsOvthbqM2va+sbNQhbuiMfFwyLxsWj4vWxUoYcERzAJsxE5JUYCxKRN5HdagOjQ5AUHoj88lrk2x2obzDGoq9U8o1KDNVDdhR+sj0Xq/cVob7RhQaXC2sOFOsxLM6iQ07GJofBx0DZ0IqaelTU2GH299G4XJK5sqBPRB6UJLz00kuxYsUKDBgwoGvOiIjIw5KF0htFmiknhgYiOSJIyzwkWbhiT4GWRkgDaZk0t3xnPiYPicbctDgdiiKlyFIuYaQm0kREJ9ObYkF3tYw3kuclu9+99fl5Il5zz77e/j59kBgmA+1MKLQ7kFtRi9o64/z7kIXqn5zXH1eMS8KyXfl62B31et+uXLse0lZnVmosJg2OhMmv8/sWyvV2H53ft7ASGSVViLGYEG01dcn5GxF/r/Cat1d7fxd2OEk4ePBg3HPPPdqXcOTIkUcNLpESFCIibyOJvmhJFlpMOugkMTwI80Yn4OOtOVi+q0AThbJqu3xXPj7fnY+JAyMxLy0B/aKCNVkozaSZLCQib+DNseBTTz2lh7uFTmFhIRwOB7yR/LFQXl6uf8z7+HS4AxHxmnv1a1weHR/ggr2xXtvJOOqM03c/UIaJDg7CzP4pWHvEjiV7SpFnb+q7mFfhwEtrD+OtDRm4YKANUweGIjSw8/r+SWqwvqZStjiiK5bInQAOlQGH+wAWsz/CgvwRGNC7+xbydzmveXvZ7fZ2Pa6Pq4Np/n79+h3/i/Xpg4MHD8IbVFRUwGaz6RuL1WqFN/0SKSgoQHR0NANCXleP58mvV/nVKUGjNFfOKXPoMJOlO/PgaLHiLMHRGf3CMX90AobEhiDW1jQYpafLJDz5uhoZryuva2+JbXpDLOi+VqWlpV4VB7b9nSVJ0KioKL4X8Jp7pc58jVc46pBX7kBJlXGGnLg1ulzYklmmQ0525la0us/Ppw/OGRChpcjJ4UGdEh877SUIsIR3W9sdi9lXp1aH9dJWP/xdzmvekdgmLCzspHFgh9Puhw4d6uinEBF5HQlCZGKcHElhTi3xkJ6ES3bkYcmOXFTVNuhq6rpDJXpIQ2lJFqYm2jRRGGsza9NpIiKj6U2xoCQWvHkxRd7LvP05ehpec2Ne79Agkx5S9ppbXqODNRqN0bYQvn36YGxKuB4yxOSTbblYe6BYexZKFcyqfUV6jEywYfbIOB3kcjrJNvlc99EdKmsbsa+wGqYyh8bYUr3j18tibP5e4TVvj/b+Huzde3OJiDqBrFzKkRQWhPgwswZYn+3Ox8dbc1FW07TivCWrXI+hsRYtUx6bHKqJQmnCHODXuwIZIiIiIiMKDPBF/ygZchKkOwvzKxzan9oo+kUG4+YpA3HVmcn4dEcePtuVjypnUyn1tuxyPWThW3YWThwQaagYVfpHHimuRlZpjSYKJc42+7NvIVFHdfhf/YIFC/DQQw8ddfvDDz+Myy+/nD8BIuq1bEH+GBFvw/h+YfjB2Sl44qox+NHEvogMCWh+zO48O/66ZDfufncb3tucjY1HSrQRs5F63RBR78ZYkIh6O6kGkUShTAseEBWsyUMjCQ8OwNVnJuOf3xuL687pq0k1N0myPb/qIG55YzPe3ZSFim8XvI2iodGF3HIHNmeUYU+eHeUGO3+intbhnYQrV67Evffee9TtM2fOxCOPPNJZ50VEZFhWsz+scf5ICq9HXKgZU4ZGY+3+YnywJVv7Fwop93h8+T4dajI3LR4TB0VoiUR8aCCCenkDZiLybIwFiYiOHmxXVl2HnPIaVNQ0TRQ2AtlpN2NELKYNi8HGI6X4eFsu9uQ3DTeQ5ODbG7Pwfno2Jg2KwqyRcRq3Gon0D5cj2OSr1TsRwQEcJEh0Eh3+S7SyshIBAd/tinGTyXbSCJGIiJqEmPwwOMaiZRtxNjPOGxyp/Qnf35yNw8XV+hgZfPLMygN4Z2MWLk6Lw/mDo7U8IiEsUD+fiMjTMBYkIjq6J5y7/UxlbT3yymtQVOlEx0aE9myyU4btybG/wK7Jwm8Olej5Szn1Z7sL9BiTFKqlyCPirYYaEiK9wvcXVCLDrw9irGY92BucqJPKjVNTU/Hmm28edfsbb7yB4cOHd/TLERF5PdkZODDaoiUpsmvwoUtH4jczh2JIjKX5MYWVtXhxzWHc9sZmvPzVYaw/VIKdORUskSAij8NYkIjo+GSRV+K+McmhiA81w8/XOMk0Ied+29TBeOLK0ZoQDGzR129zZhn+vHiXts1ZubcAdQ2NMBJnvQuZJTXYdKQUBworUe00zq5Pou7S4W0qf/jDH3DZZZfhwIEDuOCCC/S2zz77DK+//jrefvvtrjhHIiKvICUd0uxadgnGhQZiXEoYdmSXaxmHDDURMujkf99k4IP0HMxMjcWM4bFasixlyGFB/oZatSUi78RYkIjo5Ex+vkiJCNYSXVkMlj55MlzDKKIsZlxzdgouG5uAFbsLsWRHru6OFBkl1Xh25UG8vi4T04bHaLmyNdAfRiGTqQsqavUIDfLXih9bIONsolNKEs6dOxfvv/8+/vKXv+Cdd95BYGAgRo0aheXLl+P888/nVSUiamfQKIk/CUpSE23Ym2fHB1tydAehVKZIqYqUIH+0NUcDL1nJlcfLIYNQmCwkop7CWJCIqP38fH20H570ni6uciK3zKFxnpEqYmaPitPFa2mb88n2XOwrqNT7ZCiIxKsfpGfj3IFRmJUag2iDdcuRXpJyyPAZicsjQ0zw9eGiPPVep/RPePbs2XoQEdHpT8aTgESSf0PjLDhYWIVFW3KwZn+RrnI66hrx4dZcLNmRh8lDojFnZBySIoIQbwvUSXTSQ4aIqLsxFiQi6hhZ4JUElBySXMsrd+hQDaOQxNmEARF67M23Y/G2XKw7/F3fwhV7CvRIjQ3C7DQfpCWFGmpRu8bZoHG47JKMsZgRYzPpwj5Rb2OwPD8RkXeuMEspSpzVjITQIAyIDsGCsYmaHGzq9+LSY9nOfHy2Kx8T+kdg7ugEDIwORqwtEDEWk34NIiIiIvJ8UtoqhySmcstrUGiv1cVho5DBfHLIeX+6Iw+f7y5ATV2D3rc9rxrb8/ZobDtrZCzOGxiFAD/jxKn1DS4dLCiTqqV6R4acWMzGKaUmOl1MEhIReQjZFSiTjWOsJp2InBIZjEvHJuhKrSQIa+sbNYBcc6BYD5kwN3d0PFITbLriKZ9rpCCMiIiIqDeTElfpVy2VJfkVDj1kuIZRRFlM+IH2LUzUhe3F2/M0cSgk0fbC6kN4c32mts6R3oWhQQEwCtkhWWh36mEx+2nlT3gwW/6Q92OSkIjIw0hpRrTFjKgQE5LCApEUFoR5aQlYujMPn2zPa+5jIxPm5JApyTI1eVxKKKKtTaXLMiSFiIiIiIzRgiYxrKmdTNG3Q06qnU0784yS7JyZGqfJwG/2ZGLZgUrszrPrfXZHPd7dnK3tdM4ZEKF9tqU3t5HIc7A7KmHy99HektLyh1U85K2YJCQi8uBkYUSISY+k8EDEh5k1sPpiTyE+3pbTPGFuT74dDy/dowlFKUOWAEyCF0kWBpv4a56IiIjIKFUlsuArR1m1EzllDu1faKTzH5cYggnDknGwqAqfbMvF1wdL0OByob7RhVX7ivQYHmfVmHZMcih8DNS3UKZTHymuRlZpje6ilN2FXJgnb8O/HomIDEDKM+RIDq/T5N+Fw6Oxdn+xrspKOYfILK3BUyv24631mZgzKg7nD4nSEmR5vJW9VIiIiIgMF/tV1dbrzkLZYSglsEYxICoEv7hgEK4+sxZLpa/27nxU1TbtjtyZW6GHJNlkavKkQVGGSrY1NLp08IwcYcH+iLMGwhbEvoXkHZgkJCIyEGmcPCTWX3cWSmB13uBIbDxSikXpOdhXUKmPKaysxUtrD2Phpqym0o/hMfpYaSAdygCGiIiIyDCkKmRgdAiSW/QtlIF2RiEVMVefmYxLxiRg1b5CfLItD3kVDr1Pkp8vrTmMtzZkYurQGEwfHqOPN5LSqjo9ggJ8Nd6W6dWyo5LIqJgkJCIyoKAACRgt2r8mzhaIM1LCsDPXrjsL0zPL9DEVjnoNuhZtycaFw2IwKzVOB6LEWgPgMtJSNBEREVEvJ8PpZMCJVIjIcBCZiuyoa4RRyE7B6cNjNSZNzyjD4u252JFToffJDkOJYT/emouz+4dj1sg43YloJNJD8kBhFTJKqnUishwcKEhGxCQhEZGBScDVLzJYdwnGhwZhZKINBwoqNdD66mCxlqVIAPnR1lws2Z6H8wZFaSlyjL8DLnMNYmxB8OVqJxHRMTU2NurhjeR5yYKRtz4/T8RrzuvdGWSPWrQlAFEh/iirrkNuRQ0qajxjyIn8TnEfJzp/6UUox5HiKh3Kt+ZAsZbwSu9C+W85ZDDfrNRYjE8JM9TOPJlOnVkifQurERnijxhrIEK6sEc4f690v0aDvn+293zb/Wp9/vnnMXfuXMTGxp7OeRERUReQlcrkCFldbiorHhQTgsySGk0OrtxboGUp0jB6xZ4CfLGnAOOTQjBvnD+Gxlp0pVN6F8pkPSKi3hwLPvXUU3o0NDT9wV1YWAiHo6ksztvIHwvl5eX6h46PD3//85p7n97yGo/0lZLkBpRWOWF31PVo30L51vU1lTJ9T5OBJxMXAPxobBguHWbB5/vLseJAOezf9i2UwXxyRAX7YdrgUJzXz4ZAf2P9HLMrgOycpunPYUEBsJj9dDBhZ+otr3NP0mjQa263N00cP5k+rnbWnE2ZMgVfffUV0tLSMG/ePD1GjBgBb1VRUQGbzaY/fKvVCm96QRcUFCA6OtpQL2hPx+vK6+ppGhtd2pswp6xGmyrLKu2ynfmoqWu90jwywYa5afEYmWBFjK2pz6GRGkd7Ev4e4HX19timN8WC7mtVWlrqVXFg299ZkgSNiopiTMhr7pV642vcUdeAArsDBXYn6nugb6GkFpz2EgRYwk8pGeasb8SX+4s0bnUP5nML9PfFlCFRmDEiVicLG5HJ3wexVhOiQkzw66TF+d74Ou9pjQa95hLbhIWFnTQObPdOwhUrVmig9PHHH2PRokX461//isjISA0QZVV50qRJhrpARETeTMoyZIdgtMWE4nAnEsICMW90PJbvzMfi7Xkor6nTx23LLtdjQFQw5qYl4Ix+Yfo50u9G+h4SEfXmWFCej7c9p5bkj3hvf46ehtec17srBZl80NckA+5cmiyUwSC13dy3UF7j7qOjTP6+mDosBhcMjcbWrHLtWyj/L2ShW2LYT3bk4cy+4bhoZBwGx1hgJFKKnFHiQHZZrSY6O2txnr9Xul8fA75/tvdc272TsC2n04nPP/9cg8QPP/wQ1dXVmD17tgaJs2bNQnBwMIyMOwmpI7iDqGvwunausmqnrsoWVtRixbYj+GRvOQrsta0eE28zY05aPM4bGInIb5OFtkD/Tj4T78TXK69rb4ttvDkW9NY4sCX+zuI193Z8jTft7Cupcmqy0O6o9/idhMci/f1kZ+GX+wuPmuosU58vSo3Fmf0iDNtjOyzYH3HWQNiCTi3e5uu8+zUatDqzvbHNKScJ29qwYYMGiR988AEWLFiAP/zhDzAybw0OjfqC9nS8rryuRlJeXYv9GTmo9gnB+sMl+CA9B0dKqls9JizIX6chTx0WrTsSZaUzPDig0/uoeBP+HuB17e2xjTfFgt4aB7bE31m85t6Or/HWpF+hJAsladhVfQu7IknoVlFTh+W78rF0Z35zRYxbZEiAliFPGRKN4C4cEtKVggJ8Nd6ODDF1aFALX+fdr9GgOZVuTxK2VFdXB39/Y+888dbg0KgvaE/H68rrasTXqyU0Ann2WhRUOJCeWY5FW7KxK9d+VP+XC4dFY2ZqnJYsx59C8NJb8PcAr6un687YxuixoLfGgS3xdxavubfja/z4fQulX7VUk8hEYaMkCd3qGhqx9kAxFm/LRUabRW6Tnw8mD4nWqciyyG1E/r7ftgyymmDyO3kpMl/n3a/RoDmV9sY2XZJmN3JQSETUW8iktQFRIUiU5F9oIMalhGFXbgU+2pqDDYdLdUKd9H/5cGuu9oA5d2Ak5oyKQ/+oYMTaAhFj6bymy0TkXRgLEhF5JumB1zcyWOM/SRTK7kIZGGIU/r4+OH9wFCYNisSOnAp8sj0XmzLK9L7a+kZ8uiMPS3fkaVwrfQuHxloMVQkjJdVZpTXaIkh2SErMHWLQ3ZFkTHy1ERH1crJKmRIRjITQQN0tmJpgxeGiany8LRer9haivtGlK80r9xbqMTY5DBenxWF4nBWxNrMe7VnpJCIiIiLPIAu9skgsJa7F0rewzIHK2q7vW9hZJPGXmmDTI6esRvsWStzqbGjUhe4NR0r16BcZrDsLJ/SPMNTittR7FtqdeljMfmz9Q92GSUIiImp6Q/D10URhnNWMxLAg3TF4+bhELNmRp1ORq5wN+rhNGaV6DIoOwcWj4jG+bxiirWbEh5o5EZmIiIjIQCTZJq1k5KiQvoVlTX0LjUSSnTec2w9Xjk/CZ7vzdTdhaXVT38JDRVV4+osDeH1dBqYPj9V+2xazsSofZeiM3VGJAD8fXZyPtph0RyVRV2CSkIiIWpF+g9oLxWJCSbhTE4bz0hKwYk+B7i50B477Cirx6PK9urI5e1QczhsYhRibCXE2TkQmIiIiMhqr2R/WWP8u7VvYlULMfpg3OgGzR8bh60Ml2rdQkoRCkoZvbsjEe5uzMWlwpA7ok+SikUhZeEZxNbJKqhFlaYq5TX7GKaUmY2CSkIiIjruyHBFi0qO8ug5xoWZMHxGDrw4Ua5/CzG+bRUsvmxdWH8LbG7Iwc0QsLhweo4lDTkQmIiIiMnbfwnx7rSYMjdS3UKpjpJf2xAER2JNnx+Ltuc39tqUcefmuAj1GJ4VqKfLIBJuh+hZK3ja/olYPW6AvAurqENVVI6up12GSkIiITsoW5K9HVW29Jv/OGxSpE5E/3JKDnbkV+pjymqYV2vfTs3HB0GhtFu0eihLFichEREREhmxFE28zo6jSqclCo/UtHBpn1SO/woEl2/Pwxd4COOqaEp7pmWV6yHOUZOG5gyIN12e7rLoeTnsN7H0qdGeh7DD09TFOwpM8D5OERETUbsEmPwyMtmgJskxbG5scqmXHMhH5m0Ml2mRZJstJ82jpB3POgKaJyAOjQ7SHipQxs4cKEREREQyVbJPkkxxG7VsoMei15/TFgnGJ2kJH4lRJfAqZJPzCl4fwxvpM7VkovQvDgwNgJDXOBi2tziyt1pZB8nxlRyhRRzFJSEREHSZBh0yLc+8UHBprQVZpjfYsXLmnabKclEJ8ub9Ij1GJNh1yIv8vQ05kNyIDFyIiIiLj9i2UljOFButbKAvec0bFa0/CDUdK8Mm2POzJt+t9skvyg/QcfLQlF2f3D8fM1KaFbiOpb3Ahp8yhPxtJdMoivfzMiNqrwyNxXn311ePed9ddd3X0yxERkYHJrsCk8CCMSQ7DhAERuHnyADx59RhcNjYBIabv1qG2ZpXjz4t34e53t+G9TVnYeKQU+/LthipZIaImjAWJiMi9YCxVJSkRQTp510ikJPesfhG4b+4I/N/8VO1h6C7TbXC5sOZAMf7wwXbcu2g7vj5YbKhEqJDqnuJKJ3ZkV2BbVjkK7A40Guw5UM/o8L/kX/ziF/joo4+Ouv32228/YdBIRETeS4IqKWuQBtDj+4bhunP6abLwunP6asmDm5RB/OPz/bj9zXS89k0GNhwuwY6ccpRWOeFiw2UiQ2AsSERELfsWSlWJJAsHRQcbslJkQFQIfj5lIP5x1RhcMiYBFvN3C9178yvxxGf7cNsbm7UXtxEXuOWcDxRUYXNmqQ4eNNIQGjJAufEbb7yBq666CosWLcKkSZP0tltuuQXvvvsuVqxY0RXnSERERpyIXFOnJQ4XDovBukNNE5ElSSgK7LV4ae1hvL0xCzNGxGD6iFjEShlyqBmRwSb4sOEykcdiLEhERMeLARsig2G2WlBgd+pONiOR8twrxidh/ugErNlfhE+25yKztEbvK65y4rV1GVi4KQuTBkdh5ohYTY4aibPepe2BcspqEBEipciBrSp/iESHXxEzZ87Es88+i/nz52Pp0qV48cUX8cEHH2iCcPDgwR5zVffs2YMrr7yy1cevv/66njcREXU9W6C/HjIROdZm0nLk7dkV+HBrjpYfu1c2F27KxodbcjF5SJRORJbyZR1yYjHp6jQReRajxIJERNQzpAdeaJAJjvAGnYgsi8NGKteV0ukpQ6M1Nt2RU6HJwk0ZZXqfDOhbtjNfD6mgkanIIxNsmiQ1CvlRFNqdesiuSekVLglSIz0H6jqnlDaWnYSlpaU499xzERUVhZUrV2LgwIHwJEOGDEF6err+d2VlJfr27Ytp06b19GkREfXaiciS/JMV17SkUBwslInIuVh7oEgDFRl0slQCrl35OKtfuDaUHhxj0VJlSRgasXSFyJsZIRYkIqKeJfFb328H3UmiUIZpGKnUVZJmqQk2PXLLarBkRx5W7i3URKFIzyzTIyE0ELNGxuK8gVGG681od9TD7qiEyd9HWwdJ7C09x6n3aleS8I477jjm7dHR0RgzZgyefvrp5tseffRReBopjZ46dSqCg4N7+lSIiHotk58vUiKCNZBKCAvEoBiLlnTI6uznuws04JK2hF8fLNFDJibPHhWHcSlhiAoxIS6UJRFEPcXosSAREfV830LZsSZlu7K7UJJTRiJx6PUT+2nsumJPAT7dkYeib8ups8tq8MLqQ3hjXSYuHBaNacNjdWeekdTWNSKjuBrZpTWIDAlAnC0QgQFcpO+N2pUk3Lx58zFvHzBgACoqKprv78ztqatWrcLDDz+MjRs3Ijc3F++9995RpcISkMpj5P4RI0bg8ccfx3nnnXfU13rrrbfwwx/+sNPOjYiITi9QlERhnNWMpPBAnYh36ZhELN+Vj0925KGipk4ftzvProcElFKGPGlQFCItAYi3BSLMYIEXkdH1RCxIRETeRd4jIkNMetgddbqzsESH18FQFTJS8TIrNQ4bjpTgk2152JNvb26j8356jrbRObt/OGamxmFgdAiMRMrC8ytq9QgN8tee4fL/fH/vPdqVJOyJgSRVVVVIS0vD9ddfj8suu+yo+99880388pe/1EThxIkT8dxzz2HWrFnYuXMnkpOTmx8ngeuaNWu0yfaJ1NbW6tHy80RjY6Me3kKei0wQ9abn5Al4XXldjcSTXq+RwQF6lIU6ERcaoH1dpFH0x9tykVPu0MdIAPnvLw/hrQ2ZmDYsBtOGx2jiMM5mQoQHDTnxpOvqTXhdO/danioOpyMios5kMfvr4agzZt9CX58+OKtfhB4HCiuxZHsevjpYrM+hweXCmgPFegyOCdGE4hl9w/VzjKSsuk4Ps7+P7iyMspgM9xyo4/q45C8aDydZ67Y7Cc866yyMHTsWzzzzTPNtw4YN08c8+OCDzbe98sor+PTTT/Hqq6+e8Hvcd999uP/++4+6fe/evbBYLPCmPxDKy8ths9ng48NeA7yuno2v1953XWvqGlBa5UR5jRNbcqrx6Z5S7Cpomirn5ufTBxP7WjBjSBiSw0wICwqALcgffj38XDz5uhoZr2vnsdvtOlhEXqdWq7UTv7L3kcVi+bcsfRe99VrJv63CwkLtKcnfWbzm3oivcWNd8/qGRhRV1iK3olZLX41IYljpr/3Z7oKjyqkjggMwfUQMpgyJ7tSJwpLOcdpLEGAJ7/Ldfn6+fRAVEqC9C3tzv/BGg75/SmwTFhZ20jjQkPOunU6nliHffffdrW6fPn061q5de1Sp8Y033njSr3nPPfe06rcjFzApKUl/8N4UHMoLWn55GO0F7el4XXldjcTTX68pgK4q9010YMIwJ/YXVOrOwq8PFuuQk/pGF1YerNBjTFIo5oyKw4j4YERbTVoS0VNBi6dfV6Pide08ZrO5E7+ad3rqqaf0aGho0I/ljwCHo2lXs7cm4OUPTP7O4jX3RnyNG++ay2fEB7hgb6xHabUTNc6m38VGIRMQ5g8JxkUDUvBVhh3L9pYhq7ypb6H0Ynx9XSYWbszCuf2smDYoFHHW02+fIzu+6msqZWcVunqPnzyTI2XAEQAhZn+EBflr+XVv02jQ909ZLG4PQ/5Ei4qKNHiLiYlpdbt8nJeX1/yx/ODWrVuHhQsXnvRrmkwmPdqSH7qRfvDtIX/EeuPz6mm8rryuRuLpr9cgkw/6RfkjMbwRieFBGBpnQU6ZQ0s5ZMiJ7DgUmzPL9OgXGYzZI+Nw9oBwRFukFNmsJSzdzdOvq1HxunYOvi5P7uc//7ke7p2E3rZY3BIT8Lzm3o6vceNec/df+dLjL6+8BsVVdYbqWyipv2lhkbhwlAs7cirwyfY8jVeFs8GFz/eX6zE6KRSzRsQiNcF6yrsAtTDU5UJASFi39g2UhGF+HRDUxxdxVhMiQjynBVBXazToxoD2LhYbMkno1vYfgfwDaXmbBHf5+fk9cGZERNQZ/FsNOalFcngQLh2boIlCSRjKqqw4VFSFf67YjzfWB2DmiDhMGRqlpRCSLJTpcmy2TESnwtuT/kzA85p7O77GjX3NrYEBetTWNyC/vBb5dgfqG1yGuhYjE0P1yC2rwZIdeVi5txC19U3l1OmZZXpIrDtrZCzOGxiFAD+fU/o+7qO71dQ14mBxDTLLHLpQH2MzweTn/aXIfQy4MaC952rIJGFkZCR8fX1b7RoUBQUFR+0uJCIi45OVSQk8okJM2kA51mbGzNRYfHOwREuRJUkoiiqdePWbI1i4KQtTh0Vj5ohYJIQFstkyERERkUFJ0ik5IkhjukJ7LXLLa+AwWN/CuNBAXD+xH64Yn4QVewrw6Y48jVtFdlkNXlh9CG+sy8SFw6IxbXisLnIbSV2DS59HTnmNnrvE6tYeqOqh02fIJGFAQADGjRuHZcuW4ZJLLmm+XT6eN29ej54bERF17apdWHCAHlKCIj0IJw6MwM6cCny0Nbe5lEPKkeXjT7bl4ewBEVqKLNPlZHehHKeySktEREREPUcm60ryKcbatGicW+5AeU2doX4k0sNvzqh4nXi84UiJxqp78pt6xUls+356Dj7ckouz+4dj1sg4DIgKgZFI9XNxpVMPGdAiOwsjg3tPKbI38NgkYWVlJfbv39/88aFDh5Ceno7w8HAkJyfrkJFrrrkG48ePx4QJE/D8888jIyMDN910U4+eNxERdQ8JPAbFWJAUHqQ7BaWUI6O4Gou352L1vkJd0WxwubBmf5Eew+OsOuRkTHIooixmxIeaERTgsW+DRERERHSSReOq2npNFhZX1uqAOyMlPM/qF6HHgcJKbaPz1YFijV01fj1QrIcscktC8Yy+4fo5RiJJz8qCemT6VTeVInOh3hA89q+jDRs2YMqUKc0fuycPX3vttfjPf/6DK6+8EsXFxXjggQeQm5uL1NRULF68GCkpMheTiIh6C5lm3DcyGIlhgXr0iwrG5eMSsWxXPpbuyNcARezMrdBD+r5cNDIO5w6M1InI0rcwNMhYJR1ERERE1LQzb2B0iPatzq9w6CELxUYiuwV/PmUgrj4zGct35ethdzTFr3vzK7E3fx8iggMwY0QspgyN1oVyI3HWu5BVWqPlyJEhUoocaLjn0Jt47E9m8uTJTZN6TuDmm2/Wg4iIyM/XB/Ey5MRm1h4v0rdmblo8Vu0twuJtucircOhFkgDlX6sP4s0NmZgxPAYXDo/RsuW4UDPLIYiIiIgMSFrJSHWJLAYXVUrfQgeqnQ0wEunlJz0L549O0CqYT7bnIrO0Ru+TYX2vrcvQvtuTBkdp322Je41E0juFdqceFrOflo5L8pMDBj2LxyYJiYiIToUEGlEWkx7l3w45kSEmm46U6pCT3XlNfV8qaurw9sYsfJCeo8HWRSNj8f/t3Qd0nOWV8PGrPmqjPipWccFdGFzBmGaKjSkxfCQ4mxyWsJvvwCa7WcKX5UByNkuSs4e0k11IgCzHJGyyJBAgkBCavcbYphg3DO7dlmSrt1EbldF8515Ziotsy7LKvDP/3zkPtqRX8uiZB+mZ+z733qKMhL66hdpZGQAAAA5rdud22dB9YLm3TepbOh0X8NQTg9dOzpIdx7wWLNxS0lN3Wzsjr9xZaePSglRZMj1HJrmddXJS6UnJJl+zHImOtBqT7L2DB0FCAEDISkmIsdHa0WXBwnnj0i1t441tx+TjQ3V2R7PD321pHat2VcrsojS5ZUauTM1Jts2l3qHVdGYAAAA4cx/Y1uG3jsjaGdlJdQv1xnfxmBQb5Q1t8vaOClmzt9oChWpraYONPHes3DzDL1dNzHJcc76Orm4prWuTo/VtkpHUUwZIU8gxeph9AEDI0wYlWu+lIC3BAn9Tc5NtM/LWjgpZvbvKNlu6Z9x0pN6G1rbRjshaJFpPJGqAMSU+ZrS/DQAAAJyn+NgoGa/7wPQEqWpql4pGnwWnnCQ3NV7uXTDO0pFX76mSd3ZUWHkddczbIcvfPyQvbCy17Jkbp2ZbwM1JNHirQVwd7vhoKwWk6dekIo88goQAgLCrV6OBQv2zKDNRPj8rX1btrpK3t5dLfWtPOsr+qmZ5fNU+yUqKszTkayd7JDOpJ1ioBZfZsAAAADiLlpLRmoV5KS6r8Vfe4OtrcOcUesru1hl51vF405E6eWtbheyp7Cmlo9+LltF5/dNj1jX5puIcmehJcty+1dvWJd62ZomL0VRkl3iS4ygDNIIIEgIAwk5UZETfpqOhtdOaltxcnCMfHayVNz4rlyN1rXZddXO7/PdHR+TlzWVy/dRs6yqngUId2clx1iwFAAAAzqFBM735q8Pr67SThXUtHVaGxkl7WQ0EzhubLnuOHJNVh1rlowN14g8E7FSe7ml1TMhKlJuKc+XycemO27e2d3ZLSW2rlNW1SmZyTyqyZgdheDHDAICw3iSmJcba0LuvGvy7amKmbDvqlTc+OyafljXadS0dfvnzp8csgHj5hAwLKE7MTrZUZN2wULcQAADAedyuGBu+Tr9Uen2Wjtzld1C0UETGpbvka0V58jfzOq3Gttba9vp6TkgeqG6RJ1fvl+fXx8gN07LlhqnZjiuho0HPKm+7DX3sul9PS4hx3AlJpyBICACAiCTFRVvgrzCjJx15ZmGqHKpusY7IH+yvka7ugN2d1b/rmJKTLDdfnCuzC9Ps7ma2O5Z5BAAAcCC94VuUkSj5aQlWF08bnfg6nVW3UGv4fWFOgSy9dIx8dLBG3tpeIUdqe7JjGto6LTPmtU+OyhUTNBU5V8ZlJorTNLZ12tBU5JzjWUFOOyEZ7AgSAgBwgrjonk2i1qzJT4uXi7KTZNncAlm5s9JGb+2a3RVNNrLdcXLT9Fy5ZlKmJPhbJCqhXTKTXdzdBAAAcBhN47WyMu6ekjTljT4LSjmtBvc1kzxy9cQs2VPRZI36Nh6us3Rqvem9dl+NDb3hrXUL5xSl2/fttFRkDYCW1bdZvfDclHhrUIMLR5AQAID+fkFGRdqGQ+9S1qZ3SGF6giy9NE/e31cjb24vl2MNPruu0qt1Cw/LS5tL5Zrxbrm5yyV5aQnULQQAAAiBkjQt7V0WLKxtbrfUVyd9D1Ny3Tb0dOSKnRWyeneVldE58Ya3BtlunJYj1032SJLLWSEif3fA9uKVx1ORtQxQKqnIF8RZKwAAgFEubq2pyNdN9cinpQ3y5rYK2Xa0p25ha4df3tpdL+/sqZfLxmvdwlyZnEPdQgAAACfTjsIXeZLshnFP3UKfdHQ5KFooYnW0v3xZkdw5K1/W7auRd3ZUyNGGNvtYTXOH/H5Dibyyucxqc+vpQk27dmoqsktTkVNckpVEKvJgECQEAOA8i1vrJjEvJV5mF6XLoZoWeWtbubx/vG6hdZQ7UGtjUnaS1S2cW5RudQt1w+K0YtEAAADoSeMtSE+wkjQ1Le3WFbmlvedUnpNqL95oDUw8dqP77e0V8klpg32sw98tq3ZX2bh4TIoFCy8tSJVIhzUI0VqSh2tapbSuzYKjmhVEKvLAESQEAGAQG6yxmVrcuqdu4UStWzinQN7+9LCsPuDt6yi3t7JZ9lbuszuZutG6dnLW8Y7I8ZKRGCuRDqv/AgAAEO50/+ZJ1qYZLju5psHCupYOcVqmzIz8VBvapOWdHZWyZm9VX7MWDSDq0ADb4unZVuPQaYE2TUXW50aHpiDr90Iq8rkRJAQA4ALqFmr6sdY/qUn1SXqUR+6YO0E+PFBrdQu1mLKqbm6X364/Yl3lFk7OsoDhmLR4yXZrYWyXxNCVDQAAwHE0Q0SHr9NvwaiqpnYLTjmJ3rz+yhVj5a45+fLenmpLRdbvQ1V4ffLfHx2RP2wqk2t0Dzs9x/auTqNNaHSQinxuBAkBABiCu7EZSXHiz0gUlztF8tLiZeGULPmsrFHe3FYun5b11C1s6/TLm9srrMvcvLHploqsneV6Txc67Q4tAAAATs4y0ZvD2uhEO/A6SUJstO1NNRCoKchvby+X7ce8fXtYTU1+Z3uFzCxMkyXFOTI9z217YCchFfncCBICADCEtGZhakKc+NITLPCnG6kjtS3y1vYKWbevWjr9AQkERD4+VGdDC2HfXJwj88ZlSEZS7PGubLE8JwAAAA7MMtH9n6a21rd2yrGGNmk6XobGSenUs4vSbJTWtcrbO07Yw4rIlpJ6GxoQ1YDilRMzJS7a2anIuv/WE6ERDgt6DgeChAAAjEDdwgmenrqF/7urUlbsrLQaNmp/VbM88e5+yUwqkcXTc2ThZM/xk4Uu66hM3UIAAABn0WBTemKsjZb2LjtZWNvcbg3unEQbtfzfq8bLF+cWyLu7q2wP21t/UcvqLH//kLywsVSum+KRRdOyLbPGyanIuSnxkpkUa8HecEWQEACAEapbqJsqrUV42yV5PXULt5VLSV2rXVfT3CHPf1wir2wpk2sneaxuYf4JdQu1ox4AAACcJTEu2jJHCtMTpNKrdQt90tHlrGhhsitGll46Rm6ZkSubDtdb6vGeyib7WHN7l/z502Pyl8+Oydyx6bKkOFcmZSc5MhX5UE2L7c3DuSsyQUIAAEawbqGOJl+nBQ2vmZQp2496LViotV96Nyia1qFFo+eMTZObi3NlSq7WLXTZ5+hGEwAAAM6iN3z1ZN6Y1HipaWm3VNeWdr84SXRkpFw+PsPGwepmCxZ+eLDW0ne7TyinMy4z0VKR50/IcFyDPn+YpyLzSgMAgFG4G6tDN4p6yvDSwlQpqW21uoVr91ZLh7/bar5sPFxvQzdaWiB6/vgMSbe6hfGSlhA+mxUAAIBQoaVkPMkuG1p+RoNRvSm8TjI+K0m+tvAi+dJlhVZOZ+WuKvEeL6ejJ/KeXnNAfrehRG6Y6pEbpmY7suZ2Qz9dkSNDfPtNkBAAgFGsW1iUoXULE6QgLUHGZyXKXXPyZdXuKjtJqJuS3o3WU+8dkN99XCI3TsuW66dmi8fdU7dQNyvhXDcFAADAqfSEmg5fp9+ChVVN7XaSzUk0+Pf52QWWjvzRgVrLiNG9q9Ig6CtbjsprW4/JFeMzrJyOBhedxtfZLYdrWqW0rk0yk2IkymGdq88HQUIAAEZZVGSE3Z3MdsdZJzytW3jrxbny0cFaO13Yu9FqaOuUlzaXyWtbj8qCCZl9Gy2P1k1JcVnQEQAAAM5teFfd3JOKrIEpJ9G04qsnZclVEzNlb2WzvLW9XDYerrM0ZA18rttfY2NydrI165s3Lt32wM5LRW6XjqZmaYnySm5KgqUkh1J2D0FCAACCtBNebmq8bbT2VPRstDYcrpNAQKTTH5D39lbbmJbrliUX58isgjTJPB4s1DvSAC5cd3e3jVCk31cgEAjZ7y8YMefMd6hjjV84jZllJ8eJJynWMkrKvW3ibTtz3UL9Od47gok2LpmUPVFqmttl5c5KWb2n2hqcKG14okP3u9oReeHkLCvD4xSB4/Nd36KpyN6eVGR3nGQGeXbPQH/fEyQEACDIO+FpOnLxGLcca/DJip0V8u7uKmnt6Nkw7iz32tBTiFog+ppJHslMjrVgYWZinNW9ATAwTz75pA2/v+f/r+rqavH5fCE5ffpiobGx0V7oREYG74uaUMKcM9+hjjU+9DKjRJLi/FLf0iFeX6fdLD6RvtnV1qx3miUYd3xuEblzapLcOjFBPjrSJCv3NshRb0/9Ra3D+MLGUvnjljKZX5QsN05MlfzUOAl2gVPmXL8bb53I/sgIu1GfGh8rcTHB93u1qamnG/W5RASCLeQcJLxer6SkpNjmye3WpR06P7irqqrE4/GwIWRegx7rlXl1kuFer93dAbsbW368uLU2ONGaL/r2ieJjouyOrKZx5KfHW1HsbLfLOuo5ET8Hhk6o7m2Gc67q6+tDdq70/y0NgmZlZbEnZM5DEmucOQ81nf5uqWrySaW3XTq6esI4Gs7paKqT2OR0R6S86uPdccxre9hPShos4Hai6Xluu+k9syA1aG90BwYw5ynx0ZLrdklKEKUi694mLS3tnPtAThICAOCUTnhul43G1k7JTXXJDdOy5dPSBqtbuO1oo13X1umXN7dXyFs7KmROUZrcVJwr03OTJTPZZY1O9IQigIH+fxcZ0gE0feES6t9jsGHOme9QxxofPnGRkVKQniRjUhOltqXD6hY2+TptzntHsNPHeHF+qg19/O/srJA1e6pt/6o0gKhD623rDe9rJ2dJQmzw7V0jzjHnXp9fvL4WS0XWm/X6/Yx2KvJAf9cH32wDAICz0ruSOto6/JKXGi9zxqbL4ZoWuyu7bl+11SzUPIGNh+ttFGUkyJLiXLliQoZkJMVKbkq8pAXRnU0AAAAM/MZxVnKcjYbWdjlQ0iQdDtzSaWmce+aPlS/MzrcMmXd2VEqFtydDRrs8/3b9EXlpc6mV0lk8Pdv2r07j6+yWI7WtUlavXZF7ygEFY9DzRMH96AAAwBnFx0bJuMxEKUiLt254F2UnybK5BVazcMWOCuuUrHRz8ss1B+R3G0rkxqnZcsNUj2SnuCQnSO5sAgAA4Py5XTEyJjVe3GkpUt3cYcG1Lr+zKspp0EwzXxZNz5GtpQ3y9gkZMhpke2dHhY1LC1LtdOGM/BSJjHBeV+RKb7sNrVuowcJgvWFPkBAAAIfTIJ+eKNR0Yq1XqJvFW2fkyscH66wr8oHqFrvO29Ypr2wpkz9tPWqnCpdcnCsTspLsTrR+rismarS/FQAAAJwn3cMVZSRas7veGtaaceIkGvibVZhmo6y+1YKF6/bVSIe/pyuvBhB16J510bQcuXpSZtCfyutPY1unDW1uojfsdR8eE0Q37J03owAAoF96NzIjKc6G1qjRTdSCizJkb2WzBQs3HKqT7oBIV3dA1u6rsTE1N9lSkWcXpklGcqzkuuMtlRkAAADOEhUZ0VcDTwNRGixsOJ5Z4iQa7PzqVePli3ML5b29VXaSsKa5pyuyfk///dFh+cMmTUXOkkUOTUVuP56KXFrXKsVjUoKmbnhwPAoAADCkkl0xNgrSE2yjpd3itED0ip2Vsmp3pbS099xd3lXeZOPEAtGZSXGWBqF/6mYTAAAAzrpxnJoQa0NPFGqtv+qmdkt7dZIkV7TcOiNPbi7Olc0l9Xa6cGe51z6mzU60HvfbDk9F7g6I+LWYeJAgSAgAQAiLi46yQKGmIGv6if79jpljLH3j7R3lcqzh9ALR11qB6BwpSI8XT7JLslPi7OsAAADAuTWsdb+nAUM9xea0Zi1zx6bbKKlrtdrb/aUia/qu7mGdmoocDJg1AADCgG6uPJp+4nZJY2un5Ka65PqpHvmsrNFSkfXP3gLRekdW0zpmFaXJkuIcO4Wopwq12YkWyAYAAICza1hrsNDb1iVOU5h+5lRk/Z56U5GvnpQli6dlS26q81KRRxNBQgAAwozWHNTh6/TbCcPZRWlSUttqJwvX7u25K6tJD5uP1NvQzdhNxTmyYEKmpCfGWipyRmKsBR4BAADgzBrWLe1dVuOvtrnd0l5DKRX55K7I2TIjP9VxqcijgSAhAABh3AlvbKZ2wou31OLxnkRZNqdQ3t1dKe/srLS7zErTOp5Ze1B+v6FErp+SLTdOy5aclLieVGS3S2Kjg6cjGwAAAAZGm2Vc5EmyG8KVXp9UNfmko8tZ0UJSkYcWQUIAAMKcpp9oVzit41Lf2il5aS65eUaubDxUJ29tr5B9Vc12XZOvS17belRe//SYzBuXbqcLJ2cnSWayy04XJgVJVzYAAAAMnN7w7a1hXaupyI0+aW4nFTkcsZsHAAB96SeaTqxD00+0bs2CizJlb2WTpXCsP1hn3dd0fHSw1sb4zEQLFl4+PsM+T+vc6J/6tQAAAOCsU3lZyXE2vL5OqdRU5JYOCaLmu4NKRda04x3HSEUeCIKEAACg3/STCVk96Sdj0uJlWp5bKhrbZdWuSvnfXZXi9fXcXT5Y0yJPvXdAnv+4RG6Y6pEbpmZbcxQ9WehJjpOYKFKRAQAAnEab1eko7PJLZWO7pSJ3+p2bilxa12rBQroinx1BQgAAcEYa5MtPS5C8lHipTe+QoowEWXrpGFl/sNa6IB+qabHrGts65ZUtR+W1rcfsVKF2RZ7o0VTkODtdmBDLlgMAAMBp4qKjpDAjwWpY1zS3W6OT1g6/OE3BALoiv7ipRK6Z5Anrrsjs2AEAwHmlnzT5OiUv1SVXT8qUPRXN1hV5w6E664rn7w7IB/trbGiQcPH0HLlsXLp10NPThWkJMaQiAwAAOHAvqNkiOhpbOy2w1tvkLlRSkX2d3WHfFZkgIQAAOC/JrhgbPXeVE6R4jKYi+2TlrkpZtauqr9C1NjzZV7Vf/ufjGLlxarZcPzVbst09wcKspDhrmAIAAABnSUmIseHr9NsesLq5XbpIRQ4JBAkBAMCg0096O+HVtLRb0PD/zMyXDw7UWKOTkrpWu66htVNe2lwmr35yVK6YkCE3FefKRZ4kO5WoHZXjY6N4BgAAABzGFRMlYzMTbT9Y3aSpyG12Gi+UU5EXTfNIRgjf5yZICAAALjz9JFkblbisNmFuqksWTs6SneVN8s72Ctl4pM664nV1B2Ttvhobk7OTrSvynLFpkqmpyG6XpJKKDAAA4DhRkRGWKaIZI7oX1LqFepPYyanIW0rqrf52f6nIF+ckyJJLIuWSglSJjIiQUEKQEAAADJmU+BgbvvQEyUuNlxn5KVLe4JMVOytk9e4qaTle6HpPZZON9MRYuXFatlw3xWPdkElFBgAAcKaIiAhJTYi10dbht1N4esJQa1Y7id4AnzM23UZ/XZG3VbTKtoo9dpN78fRsuXpSVsg06QuN7wIAAARd+klRRqLVLKxJ70lFvnNWvjU00buyZfVtdp0WvH5xY6n8cUuZXHlRpjU6GZ/111TkuOjQujsLAAAQDrSczDhNRU6Ll6qmdgsYtodkKvIReXFTach0RQ7pIGF0dLQUFxfb3+fMmSPLly8f7YcEAEDYpZ9kuzX9pKcTnqYi66lBTd3QYOGWI/Wi95Y7/QFZvafaxtTcZLlpeq7MLkqT9MRoie3olCzNVwYAAICjaKM6zS7JTXFJfaumIreJt62nyZ0TU5GXTM+RDXtLZdXBln5TkS/JT7GSOjPynZmKHNJBwtTUVNm6detoPwwAAHBKJzzdLGodl2MNbbJiZ6W8t6dKWo+nIu8qb7KRmdSTirwgL0a8EY12Z5auyAAAAM5MRdYyMzpaO7qsbmFNU7s4LBNZNBV51pgkuXxKoWXGnJqK/GlZow2npiI755ECAICQ64RXmJ5gf//C7HxZu6/aGp0ca/TZdZrK8fsNpfJKVIRcNbHZUpH1WroiAwAAOJcGzSZkJdk+0FKRG33S0UUqcjAI2sbNa9euldtuu03y8vIs4vzaa6+dds1TTz0l48aNE5fLJbNnz5Z169ad9HGv12vvv/LKK2XNmjUj+OgBAMBAO+FpWsbMwlS5a06B/OQLl8gjS6bIpQWpfdd1+AOyaneVPPTKZ/L913fIXz47ZmnKu8q90tDaIQFSkQEAABwnJipSxqTGy6zCVJmUnSTJLmeeY0s6nor8+LKZ8v9unCTT89x9H+tNRX7wpU/lh2/tkq2l9dIdxHvXoH0GWlpa5JJLLpF7771X7rzzztM+/uKLL8oDDzxggcIFCxbIf/3Xf8mSJUtk586dUlhYaNccPnzYgozbt2+XW265RbZt2yZu91+frBO1t7fbODHAqLq7u22ECv1e9MVUKH1PwYB5ZV6dhPXKvAYjtyta3K4k64SXmxJnQUJN4Vixo0LW7K0SX1fPZmr7Ma8N7YS8aFq2XDMpSzKSYiXHHSeZSXFW9wb943c/AAAIRnowLCMpzkZze5edLKxtdmYq8pyzdEV2QipyRMABt991wbz66qty++23973vsssuk1mzZsnTTz/d976pU6faNY899thpX0MDiD/4wQ+sgUl/Hn30Ufne97532vv37t0rycnJEkovEBobGyUlJUUiI3khxbwGN9Yr8+okrNeh5e/utqLWdS3tUlvXIOsrA7JqX4NUNneedJ12P14w1i03TEyV/NQ4SYmPkdT4WImL4XfcqZqammTSpEm2DzjTTVP89Wax7pVCea70Z1ZVVZV4PB72hMx5SGKNM+fhIJTXuaYfVzX5pNKrqcjBE7YKBALS0VQnscnpFqs6l2Zf12ldkXu5YiKtK/LXF06wRifBsLcJrpDlAHV0dMjmzZvl4YcfPun9ixYtkg8//ND+Xl9fLwkJCRIXFydlZWV2wnD8+PFn/JqPPPKIPPjggydNYEFBgWRlZYXU5lB/iOhC1u8r1H6IjCbmlXl1EtYr8+oUuRos9Pvl8NFymTAxWW6e1WV3X9/eXiHbjjbaNe1dAXl3f6ONi8ek2OnCmQWJkh4VIznJLmuUMpANXDjQ8iwAAABOEBsdKflpCZKXEi91rR12urDJ59yuyDcX58qWknp5e0dFv12Rb5jqkWfunmOnEUeTI4OENTU19qIhOzv7pPfr2xUVFfb3Xbt2yX333WeBMH1x8Pjjj0t6evoZv6YGE3WcSj8/1IJpOh+h+H2NNuaVeXUS1ivz6iTJrljxeFIsIDgmLUHmjk2XktpWeWdnhazdWy3txwtda+BQh6Yia1fkayd7rENytttl7wv3VGR+7wMAAKfRoJmWlNHR5Ou0k4V6Ii/4c2LPLxU5MS561AOEjg0S9jr1ZIAe++x93xVXXGE1CAEAQGiIj42ScdoVOS1eCtLjZYInUZbNKZD39lTLip0V1h1P6Z/Pf1wiL20qkysnZtrpwvFZSRYw1EYpwVb7BQAAAOeW7IqxUZjebcFCTUcOplTkgSpIT5CvXjVevji30FKRV++ukq9cMVaCgSN3yZmZmRIVFdV3arCX5uKferoQAACEFj0RmJsSb0WfG1o7ZUxavCwpzpGtpQ12V/az46nIemf23d1VNqbkJMtN03Ps7m1aYox9fhqpyAAAAI5MRdZAm3ZGrm3pSUXWhidOTUX+1uLJkpYQK8HAkUHC2NhYmT17tqxcuVLuuOOOvvfr20uXLh3VxwYAAEaGZg+kJcba0K7IeWnxMndcTwrHip2Vlorc1um3a3dXNNlIT4yVG6Zmy3VTPOJxx/WlIseEeSoyAACA02h6blZynA1NRbauyC3OS0WOCoI046APEjY3N8v+/fv73j506JBs3brV6goWFhZak5G7777buhXPnz9fnnnmGSkpKZH7779/VB83AAAY3VTkwvQEmeBJslTkdfuqrXbhsQafXVfX0iF/2FQqf9xSJvMnZMji6Tky0ZMkmclxdjJR68EAAADAoanIXX6p8rZbOnKn32HRwiAQtDvhTZs2ycKFC/ve7u08fM8998hzzz0ny5Ytk9raWvn+978v5eXlUlxcLG+++aYUFRWN4qMGAACjnYqsdQez3XHS2NYpeWkua2KiDU30dOGWI/Wi28Wu7oAVi9ZxkSfJgoWXjUu3k4a5KS77k67IAAAAzhIXHdWXilzT0m6nC1vaezJL4OAg4bXXXmuNSM7ma1/7mg0AAIATaYAvNSHWhq/TL3mp8TKrKE2O1bfJyl2VsnpPVd+GcX9Vs+yv2i//sz5Grp/ikeunZvcFGj3JLqt7AwAAAGelIus+TodXuyI7NBV5pAVtkBAAAGAouGKiZKymIqcnWCqy/v3zs/Plg/211uikpK7VrtOTh3/85Kj8aesxmTsuzU4XTs1JlsxklwUNk0hFBgAAcBy3K8YGqcjnRpAQAACEBS0KrY1KdDS2dlqH44WTs2RPRZO8vaNCNh6uk+6AiD8QkPUH62wUZSTI4mk5suCiTMlIirXPzUiMtbvTAAAAcA5Skc+NICEAAAg7KQkxNnydCTImLV6K81MsDWXV7ipZtatSvL4uu+5Ibas8s+6g/G5DiVw7OUsWTcu21GXriuyOs80mAAAAnINU5DMjSAgAAMI6FbkoI1Hy0xKktrndUpLvmDlG1h/sSUU+UN1i1zW3d8lfPiuXN7aVy+zCnlTk4jFuyUiKs4BhSnzMaH8rAAAAOE+kIp+MICEAAAh7morssdOBLqtNqDUIr56UJfsqmy1YqEFD7Yisxa43Ham3oV3zFk3PlqsnZlk3ZP2czKQ4+1oAAABwDlKRexAkBAAAOIGeCtTR3uW3QODU3GSpbiqUd3dXyf/uqpT61k677mhDm/z6g8PywoZSuWZSTypyQUaCZCXFWcBQTynC2bq7u22EIv2+AoFAyH5/wYg5Z75DHWucOQ8VmYmxNrQrcpVXuyJ39nVF1t+dvcNJ+42Bfn2ChAAAAAO4o6wpyZ+7NE82Ha6304W7K5rsurZOvzU+0XFJfoosmp4jlxakWqOTnOOpyBERnC50gieffNKG3++3t6urq8Xn80ko0hcLjY2N9iInMjJytB9OWGDOme9QxxpnzkORW0TiXd3S0NopDa0dllnS1dYsEhEhQ7W7q6vxiS92eMNzTU09+9ZzIUgIAAAwwOLWTT7tiuyS+RMy5HBNi7yzo1I+2F8jHf6eu7OfljXayHbHyaJpOXbC0IKFKS47YRgdRTAmmH3961+34fV6JSUlRbKyssTt1pcHofliXoPX+j0SJGTOQxFrnDkPB6zzkTPG5jsgNU1tcqisQrpdKUN2Ezg9M9lqIw4nl8s1oOsIEgIAAAxQsivGRmF6t+SnxcvE7GT50rxCWb2nSlburJTq5na7rtLbLr9df0T+sKlUrrwo0xqdjM1MlMzjAcOEYb5bjKGhwbNQDqDpi5tQ/x6DDXPOfIc61jhzHsoiI0U8KQki7UnicruluqlDals6+lKRB/91h/938UC/PjtUAACA8xQbHWnpx5qKXNfSIXlpLrnl4lzZUqqpyJWy/WijXdfe1S2rdlfZmJbrtmDh7KI0SUuMsVRkbXhCKjIAAICzuF0xkpoQJ4Vdfqnytkul1yed/qGrUzhaCBICAAAMkgb4MpLibLS0d0luqkvmjU2X0ro2WbGzQtbuqxZfZ08q8s5yr42MxFi5YVq2XDfFY92QNdCopwsBAADg7BrWlY3t0tzeJU5FkBAAAGAIJMZFy/isJClMT7DN4gRPoiybWyBr99ZYwLC8sacBhqalvLixVP64pUzmj8+Q22eOkf8zK5/nAAAAIERqWFc0+oYkFXmkESQEAAAYys1VVKTkpcZbgxPthKd/XzQ9W7aVNVqw8JOSBtH9oqakrN1XY+N/1h+Rby2eLFdMyOS5AAAACIUa1l09qchVTT7p6HJGtJAgIQAAwDClIqclxtrwdfotDWX22DQ5Wq+pyJWyZk+VtHT47dotJQ12DQAAAEIvFbm2pcPqFjb5gjsVmSAhAADAMHPFRFl3Y90oajryuMxE+cLsfPlgf411RZYIkWsneXgeAAAAQjAVOSs5zoamImuwsKY5OFORCRICAACMkKjICMl2u2w0tnXKmLR4+dwleda4RDeQAAAACINU5PRuCxZqKnIwIUgIAAAwClLiY2x0+butjiEAAADCQ2x0ZF8qcjAdKCRICAAAMIoIEAIAAISnyCDLJOG2NQAAAAAAABDmCBICAAAAAAAAYY4gIQAAAAAAABDmCBICAAAAAAAAYY4gIQAAAAAAABDmCBICAAAAAAAAYY4gIQAAAAAAABDmCBICAAAAAAAAYY4gIQAAAAAAABDmCBICAAAAAAAAYY4gIQAAAAAAABDmokf7AQSrQCBgf3q9Xgkl3d3d0tTUJC6XSyIjiREzr8GN9cq8OgnrlXkNdr17mt49DsJvH3gifmYx56GONc6chwPWOXM+1PtAgoRnoIE0VVBQMOBJBwAAcMIeJyUlZbQfRlBjHwgAAMJxHxgR4HbyGSPyx44dk+TkZImIiJBQodFjDXyWlpaK2+0e7YcTMphX5tVJWK/Mq5OwXoeObvl0Y5iXl0c2QZjuA0/E/1vMeahjjTPn4YB1zpwP9T6Qk4RnoJOWn58voUoDhAQJmVenYL0yr07CemVegxknCAcm1PeBJ+JnFnMe6ljjzHk4YJ0z50O1D6QoHQAAAAAAABDmCBICAAAAAAAAYY4gYZiJi4uTf/u3f7M/wbwGO9Yr8+okrFfmFXASfmYx56GONc6chwPWOXM+1GhcAgAAAAAAAIQ5ThICAAAAAAAAYY4gIQAAAAAAABDmCBICAAAAAAAAYY4gIQAAAAAAABDmCBICAAAAAAAAYY4gYQh66qmnZNy4ceJyuWT27Nmybt26M1773nvvSURExGlj9+7dI/qYg93atWvltttuk7y8PJuf11577Zyfs2bNGpt/fR7Gjx8vv/zlL0fksYbqnLJWB+axxx6TuXPnSnJysng8Hrn99ttlz5495/w81uvQzytr9tyefvppmTFjhrjdbhvz58+Xt956i7UKDPP+Tz3//PNyySWXSEJCguTm5sq9994rtbW1fR9/7rnn+t0j+nw+np9BzvmTTz4pU6dOlfj4eJk8ebL85je/Oe2aV155RaZNmyZxcXH256uvvsp8D+Ocs85H/vUPa3xk55w1PrRzXl5eLl/60pfs50lkZKQ88MAD/V7n5HVOkDDEvPjii7ZQv/Od78gnn3wiV111lSxZskRKSkrO+nn6YlcXfO+YOHHiiD1mJ2hpabGN9C9+8YsBXX/o0CG5+eabbf71efj2t78t3/jGN+yHBQY3p71Yq+feKHz961+X9evXy8qVK6Wrq0sWLVpk8816Hdl5Zc2eW35+vvzwhz+UTZs22bjuuutk6dKlsmPHjn6v52crMDT7v/fff1/+9m//Vv7+7//e/n976aWXZOPGjfLVr371pOs0eH/i/lCHvhDF+c+53hR55JFH5NFHH7U5/973vme/V15//fW+az766CNZtmyZ3H333fLpp5/an3fddZd8/PHHTPkwzTnrfGRf/7DGR+c1Jz/Lh27O29vbJSsry34O6ef1x/HrPICQMm/evMD9999/0vumTJkSePjhh/u9fvXq1QFdBvX19SP0CJ1P5+vVV1896zUPPfSQzfuJ7rvvvsDll18+zI8udOeUtTo4VVVVNr9r1qw54zWs1+GZV9bs4KSlpQWWL1/e78dYq8DQ7P9+8pOfBMaPH3/S+5544olAfn5+39u//vWvAykpKUz5EM35/PnzA9/61rdOet8///M/BxYsWND39l133RW46aabTrpm8eLFgS9+8Ys8D8M056zzkX39wxof+TlnjQ/tnJ/ommuusZ8pp3L6OuckYQjp6OiQzZs32+mWE+nbH3744Vk/d+bMmZZqcv3118vq1auH+ZGGPr17cOrzsHjxYjsp09nZOWqPKxSwVs9PY2Oj/Zmenn7Ga1ivwzOvvVizA+P3++WFF16wO7qadtwf1iowNPu/K664QsrKyuTNN9/UAwNSWVkpL7/8stxyyy0nXdfc3CxFRUV26vfWW2+1kyoY3Jzr6ZNTT2FqCuyGDRv69oZn+hl3rn18OBiuOVes86ExkN/RrPGhNdB9EWt8ZH3k8J/lBAlDSE1Njb3Iys7OPun9+nZFRUW/n6OBwWeeecaOJP/xj3+03HoNFGpuPgZP57u/50FTFPV5wvljrZ4/feH34IMPypVXXinFxcVnvI71OjzzypodmG3btklSUpLVbLn//vutZovWbmGtAsO3/9MgodYk1HSo2NhYycnJkdTUVPn5z3/ed82UKVOsltWf//xn+f3vf2/BlgULFsi+ffvC/qkZzJzrC8Tly5dboEt/j+iL+F/96lf2Qr53b3im38dn+prhZLjmnHU+dAayn2SNj/ycs8ZHXoXDf5ZHj/YDwNDTgpsn0l+Kp76vlwYFdfTS0xulpaXy05/+VK6++mqeniF+Hvp7PwaGtXr+/vEf/1E+++wzqz11LqzXoZ9X1uzA6Dxt3bpVGhoa7IbVPffcYzUgzxQoZK0CF77/27lzp9Wt+u53v2uBFK01+C//8i8WqH/22Wftmssvv9xGLw0Qzpo1ywKJTzzxBE/Dec75v/7rv9oLRJ1TvU5fMH7lK1+RH//4xxIVFTWo5zEcDfWcs86H//k59f2s8ZGdc9b46Ihw8M9yThKGkMzMTPuFd2qEuqqq6rRI9tnoDxLuEl8YvSPf3/MQHR0tGRkZF/jV0Yu1emb/9E//ZKc/tHyApomdDet1eOa1P6zZ0+kpposuukjmzJljXaS1CPTjjz/OWgWGcf+n/69p0E8Dg9phXAOF2jVWT1lpwLA/2sVRu7yzRxzcnGuaq85va2urHD582JptjB07VpKTk+3rne338fns40PVcM35qVjngzeQ/SRrfGgNZg/PGh9+OQ7/WU6QMMReaGn7c+28eSJ9W9NKBkrrzWiaHAZPT2Se+jysWLHCXgTHxMQwtUOEtXo6vUulJ920fMC7774r48aNY72O0rz2hzU7sLnWOlL94WcrMDT7Pw2a6AvFE/WerOo9hdLf/5t66pc94oXtuXUfqDeZdL61DqvWeux9Ls70M+589vGharjm/FSs88EbyO9o1vjQGsy+iDU+/OY7/Wf5aHdOwdB64YUXAjExMYFnn302sHPnzsADDzwQSExMDBw+fNg+rt2/7r777r7r/+M//sM6+Ozduzewfft2+7gui1deeYWn5gRNTU2BTz75xIbOz89+9jP7+5EjR/qd14MHDwYSEhIC3/zmN+150OdDn5eXX36ZeR3knLJWB+Yf/uEfrBvle++9FygvL+8bra2tfdewXkdmXlmz5/bII48E1q5dGzh06FDgs88+C3z7298OREZGBlasWMFaBYZx/6fdLqOjowNPPfVU4MCBA4H3338/MGfOHOse2+vRRx8NvP322/Zx/f1877332ud8/PHHPDeDmPM9e/YEfvvb39qeW+dw2bJlgfT0dPv51+uDDz4IREVFBX74wx8Gdu3aZX/qnK9fv545H6Y5Z52P7Osf1vjIzzlrfGjnXPVeP3v27MCXvvQl+/uOHTsCobLOCRKGoCeffDJQVFQUiI2NDcyaNSuwZs2avo/dc8891qq7149+9KPAhAkTAi6XK5CWlha48sorA2+88cYoPfLgtXr1avuhcerQ+exvXpUGE2bOnGnPw9ixYwNPP/30KD360JhT1urA9DenOvQFYS/W68jMK2v23P7u7/6u7/dVVlZW4Prrr+8LELJWgeHb/6knnngiMG3atEB8fHwgNzc38OUvfzlQVlbW93ENwBQWFvb9/7lo0aLAhx9+yNMyyDnXF/CXXnqpzbfb7Q4sXbo0sHv37tPm86WXXgpMnjzZXuhPmTKFG/fDPOes85F//cMaH9k5Z40P/ZxLP9frz6VQWecR+p/RPs0IAAAAAAAAYPRQkxAAAAAAAAAIcwQJAQAAAAAAgDBHkBAAAAAAAAAIcwQJAQAAAAAAgDBHkBAAAAAAAAAIcwQJAQAAAAAAgDBHkBAAAAAAAAAIcwQJAQAAAAAAgDBHkBAAAAAAAAAIcwQJAQADcscdd0haWpp8/vOfZ8YAAADCDHtBIPQRJAQADMg3vvEN+c1vfsNsAQAAhCH2gkDoI0gIACGmtrZWPB6PHD58eEi/7sKFCyU5Ofm09+vJwp/97GdD+m8BAABgcNgLAhgsgoQAHGnt2rVy2223SV5enkRERMhrr7122jVPPfWUjBs3Tlwul8yePVvWrVs3bNf05ytf+Yo8/PDDp71fH+/Zhn7ehXjsscdsbsaOHXvSY7n99ttPuu7ll1+27+nHP/7xBf173/3ud+Xf//3fxev1XtDXAQAAGCj2gmfGXhDAYBEkBOBILS0tcskll8gvfvGLfj/+4osvygMPPCDf+c535JNPPpGrrrpKlixZIiUlJUN+TX+6u7vljTfekKVLl572sfLy8r7xn//5n+J2u0963+OPPz7oeWlra5Nnn31WvvrVr571uuXLl8uXv/xlm7+HHnrI3qcB0OLi4tPGsWPHzvq1ZsyYYQHJ559/ftCPGwAA4HywF+wfe0EAFyQAAA6nP8peffXVk943b968wP3333/S+6ZMmRJ4+OGHh/ya/qxduzbg8XgCfr//rNf9+te/DqSkpASGyiuvvBLIzMw87f333HNPYOnSpfb3H/3oR4G4uLjAyy+/fN5ff/Xq1YE777zztPc/+uijgauuumqQjxoAAGDw2Av+FXtBABeCk4QAQk5HR4ds3rxZFi1adNL79e0PP/xwSK85kz//+c+W8hsZGTniqTdz5sw548c1/fkHP/iB/OUvf5E777xzyP7defPmyYYNG6S9vX3IviYAAMBgsBdkLwhgcKIH+XkAELRqamrE7/dLdnb2Se/XtysqKob0mrMFCX/605/KSNNmJVqnsT9vvfWW/OlPf5JVq1bJddddd95fe/HixbJlyxZL78nPz5dXX31V5s6dax8bM2aMBQh1XoqKii74+wAAABgs9oLsBQEMDkFCACFLm4CcSLNRTn3fUF1zol27dklZWZnccMMNMtK0Do02IzlT7UDdNGujEQ3u9dep+GzeeeedM34sPj7e/mxtbT3PRwwAADA82AuejL0ggHMh3RhAyMnMzJSoqKjTTvtVVVX1nQocqmvOdIrwxhtv7AucjSR9zPX19f1+TE/7rVmzxpqj3HTTTdLU1DRk/25dXZ39mZWVNWRfEwAAYDDYC7IXBDA4BAkBhJzY2Fjr1Lty5cqT3q9vX3HFFUN6TX80pfdzn/ucjIaZM2fKzp07z/jxwsJCCxRqoFNrK3q93iH5d7dv324pyLopBwAAGE3sBdkLAhgcgoQAHKm5uVm2bt1qQx06dMj+XlJSYm8/+OCDsnz5cvnVr35l6b/f/OY37WP3339/39cYqmtOpMG3jRs3yq233iqjQesG7tix44ynCZUG89577z2pra21QGFjY+MF/7vr1q07rcELAADAcGEv2D/2ggAuBDUJATjSpk2bZOHChScF89Q999wjzz33nCxbtsyCYN///vctvba4uFjefPPNk5pqDNU1J3r99dflsssuE4/HI6Ph4osvtu7Gf/jDH+S+++4743W9qcc6h5oavWLFCklNTR3Uv+nz+ayJydlqFgIAAAwl9oL9Yy8I4EJEBLQCPwBgSGia8ZVXXikPPfTQqM2oBjG/9a1vWQpwZOTwHxh/8sknLcVaA40AAADhjL0gACfjJCEADCENEP7N3/zNqM7pzTffLPv27ZOjR49KQUHBsP97MTEx8vOf/3zY/x0AAIBgx14QgJNxkhAAAAAAAAAIczQuAQAAAAAAAMIcQUIAAAAAAAAgzBEkBAAAAAAAAMIcQUIAAAAAAAAgzBEkBAAAAAAAAMIcQUIAAAAAAAAgzBEkBAAAAAAAAMIcQUIAAAAAAAAgzBEkBAAAAAAAAMIcQUIAAAAAAAAgzBEkBAAAAAAAACS8/X9ZXSvnLgqLxwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1300x420 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "k(1000 K) = 5.373e+10 cm3_mol_s\n",
+      "            spanning 4.307e+10 to 6.702e+10 at the stored A uncertainty\n"
+     ]
+    }
+   ],
+   "source": [
+    "def arrhenius_k(parameters, T):\n",
+    "    \"\"\"k(T) = A * T^n * exp(-Ea / R T), in the record's own A_units.\"\"\"\n",
+    "    return (parameters[\"A\"]\n",
+    "            * T ** (parameters.get(\"n\") or 0.0)\n",
+    "            * math.exp(-(parameters.get(\"Ea_kj_mol\") or 0.0) / (R / 1000.0 * T)))\n",
+    "\n",
+    "\n",
+    "t_lo = coverage[\"record_min_k\"] or 300.0\n",
+    "t_hi = coverage[\"record_max_k\"] or 2000.0\n",
+    "\n",
+    "# The stored A uncertainty is multiplicative -- a factor on k, not a +/- offset.\n",
+    "factor = (uncertainty.get(\"A_uncertainty\")\n",
+    "          if uncertainty.get(\"A_uncertainty_kind\") == \"multiplicative\" else None)\n",
+    "\n",
+    "\n",
+    "def arrhenius_panel(axis, lo, hi, title):\n",
+    "    temps = [lo + i * (hi - lo) / 200 for i in range(201)]\n",
+    "    inverse_t = [1000.0 / t for t in temps]\n",
+    "    k_values = [arrhenius_k(params, t) for t in temps]\n",
+    "    axis.semilogy(inverse_t, k_values, lw=2, label=\"stored fit\")\n",
+    "    if factor:\n",
+    "        axis.fill_between(inverse_t,\n",
+    "                          [k / factor for k in k_values],\n",
+    "                          [k * factor for k in k_values],\n",
+    "                          alpha=0.25, label=f\"A uncertainty (x{factor:.2f})\")\n",
+    "    axis.set_xlabel(\"1000 / T   (K$^{-1}$)\")\n",
+    "    axis.set_ylabel(f\"k  /  {params['A_units']}\")\n",
+    "    axis.set_title(title, fontsize=10)\n",
+    "    axis.grid(alpha=0.3, which=\"both\")\n",
+    "    axis.legend(fontsize=8)\n",
+    "\n",
+    "\n",
+    "fig, (full, zoom) = plt.subplots(1, 2, figsize=(13, 4.2))\n",
+    "arrhenius_panel(full, t_lo, t_hi, f\"{entry['equation']}\\nfitted range {t_lo:.0f}-{t_hi:.0f} K\")\n",
+    "\n",
+    "# The band is real but invisible on the left: a x1.25 factor is under a tenth of\n",
+    "# a decade, against an axis spanning nine. Showing it needs a window where the\n",
+    "# temperature dependence does not dwarf it -- which is itself the useful lesson,\n",
+    "# not a plotting trick. Combustion-relevant window, clipped to the fitted range.\n",
+    "z_lo, z_hi = max(t_lo, 900.0), min(t_hi, 1200.0)\n",
+    "arrhenius_panel(zoom, z_lo, z_hi, f\"same fit, {z_lo:.0f}-{z_hi:.0f} K only\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "k_1000 = arrhenius_k(params, 1000.0)\n",
+    "print(f\"k(1000 K) = {k_1000:.4g} {params['A_units']}\")\n",
+    "if factor:\n",
+    "    print(f\"            spanning {k_1000 / factor:.4g} to {k_1000 * factor:.4g} \"\n",
+    "          f\"at the stored A uncertainty\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ce7bda3",
+   "metadata": {},
+   "source": [
+    "<a id=\"5\"></a>\n",
+    "## 5. Transition states\n",
+    "\n",
+    "Saddle points are searched by **what evidence exists for them**, not by identity —\n",
+    "the `has_*` filters. That is the useful question for a transition state: an optimised\n",
+    "geometry with no frequency calculation behind it is not yet a characterised saddle point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e90f541c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:04.698945Z",
+     "iopub.status.busy": "2026-08-10T07:03:04.698748Z",
+     "iopub.status.idle": "2026-08-10T07:03:05.078404Z",
+     "shell.execute_reply": "2026-08-10T07:03:05.077784Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "34 transition state(s) with a frequency calculation\n",
+      "\n",
+      "reaction                                     label  status     calcs  IRC  SP   IRC validation\n",
+      "----------------------------------------------------------------------------------------------\n",
+      "C1=C[C]2C=CCC2C=C1 <=> C1=Cc2ccccc2C1 + [H]  TS0    optimized  4      yes  yes  absent        \n",
+      "C[CH]C(CO)OO <=> CC=CCO + [O]O               TS0    optimized  4      yes  yes  absent        \n",
+      "C#C + [CH3] <=> [CH]=CC                      TS0    optimized  2      no   no   absent        \n",
+      "O + [CH3] <=> C + [OH]                       TS0    optimized  4      yes  yes  absent        \n",
+      "C=CCCCCCCC <=> C=CC + C=CCCCC                TS0    optimized  5      yes  yes  absent        \n",
+      "F[C]F + C=C <=> FC1(F)CC1                    TS0    optimized  5      yes  yes  absent        \n",
+      "[CH2]SO <=> OC[S]                            TS0    optimized  5      yes  yes  absent        \n",
+      "C[N+](=O)[O-] <=> CON=O                      TS0    optimized  4      yes  yes  absent        \n",
+      "[CH2]CC <=> C[CH]C                           TS0    optimized  4      yes  yes  absent        \n",
+      "C=C + [CH3] <=> [CH2]CC                      TS0    optimized  4      yes  yes  absent        \n",
+      "C=CO <=> CC=O                                TS0    optimized  5      yes  yes  absent        \n",
+      "[CH2]CC=C <=> [CH2]C1CC1                     TS0    optimized  4      yes  yes  absent        \n"
+     ]
+    }
+   ],
+   "source": [
+    "ts_records = records(\"scientific/transition-states/search\", has_freq=\"true\")\n",
+    "print(f\"{len(ts_records)} transition state(s) with a frequency calculation\\n\")\n",
+    "\n",
+    "table(\n",
+    "    [[t[\"reaction\"][\"equation\"][:44] if t.get(\"reaction\") else \"-\",\n",
+    "      t[\"transition_state\"][\"label\"],\n",
+    "      t[\"transition_state_entry\"][\"status\"],\n",
+    "      t[\"evidence_summary\"][\"calculation_count\"],\n",
+    "      \"yes\" if t[\"evidence_summary\"][\"has_irc\"] else \"no\",\n",
+    "      \"yes\" if t[\"evidence_summary\"][\"has_sp\"] else \"no\",\n",
+    "      t.get(\"validation\", {}).get(\"irc\", \"-\")]\n",
+    "     for t in ts_records[:12]],\n",
+    "    [\"reaction\", \"label\", \"status\", \"calcs\", \"IRC\", \"SP\", \"IRC validation\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fd0b7c6",
+   "metadata": {},
+   "source": [
+    "`IRC validation` is worth reading carefully. `absent` does **not** mean the IRC is\n",
+    "missing — the `IRC` column above shows the calculation exists. It means no stored\n",
+    "*evidence record* asserts that the IRC actually connects this saddle point to the\n",
+    "reactants and products the reaction claims. The calculation being present and its\n",
+    "conclusion being recorded are two different facts, and TCKDB keeps them separate\n",
+    "rather than inferring one from the other."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2997a17c",
+   "metadata": {},
+   "source": [
+    "<a id=\"6\"></a>\n",
+    "## 6. Pressure-dependent networks\n",
+    "\n",
+    "A master-equation solve produces k(T,P) for every channel in a network of wells and\n",
+    "bimolecular states. This is where a thermochemical database stops being a table of\n",
+    "numbers: the stored object is a *surface*, and reading it back means evaluating a fit.\n",
+    "\n",
+    "Two forms are stored here:\n",
+    "\n",
+    "- **Chebyshev** — a smooth two-dimensional fit in reduced (1/T, log P);\n",
+    "- **PLOG** — Arrhenius expressions at fixed pressures, interpolated logarithmically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4e52d9c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:05.080194Z",
+     "iopub.status.busy": "2026-08-10T07:03:05.079942Z",
+     "iopub.status.idle": "2026-08-10T07:03:05.221207Z",
+     "shell.execute_reply": "2026-08-10T07:03:05.220611Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hydrazine   (Arkane 3.2.0)\n",
+      "   solved over 300-2000 K, 0.01-100.0 bar\n",
+      "   10 species, 7 states, 21 channels, 42 k(T,P) records\n",
+      "   forms stored: Chebyshev PLOG\n"
+     ]
+    }
+   ],
+   "source": [
+    "nets = records(\"scientific/networks/search\", has_channels=\"true\")\n",
+    "if not nets:\n",
+    "    print(\"no pressure-dependent networks in this deployment\")\n",
+    "else:\n",
+    "    for n in nets:\n",
+    "        info, ev = n[\"network\"], n[\"evidence_summary\"]\n",
+    "        tool = n.get(\"workflow_tool_release\") or {}\n",
+    "        print(f\"{info['name']}   ({tool.get('workflow_tool','?')} {tool.get('version','')})\")\n",
+    "        print(f\"   solved over {info['solve_temperature_min_k']:.0f}-{info['solve_temperature_max_k']:.0f} K, \"\n",
+    "              f\"{info['solve_pressure_min_bar']}-{info['solve_pressure_max_bar']} bar\")\n",
+    "        print(f\"   {ev['species_count']} species, {ev['state_count']} states, \"\n",
+    "              f\"{ev['channel_count']} channels, {ev['kinetics_count']} k(T,P) records\")\n",
+    "        print(f\"   forms stored: \"\n",
+    "              f\"{'Chebyshev ' if ev['has_chebyshev'] else ''}{'PLOG' if ev['has_plog'] else ''}\")\n",
+    "\n",
+    "NETWORK_REF = nets[0][\"network\"][\"network_ref\"] if nets else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "555fa199",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:05.222950Z",
+     "iopub.status.busy": "2026-08-10T07:03:05.222748Z",
+     "iopub.status.idle": "2026-08-10T07:03:05.364508Z",
+     "shell.execute_reply": "2026-08-10T07:03:05.363854Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "role      SMILES       species_entry_ref               species_ref                   \n",
+      "-------------------------------------------------------------------------------------\n",
+      "well      NN           spe_wi6mz65sb47vzsyop3tqrqrcai  spc_654ydo5fdsxkzlo3cf7kdle5qq\n",
+      "well      [NH-][NH3+]  spe_zsvxdy7fbktworbhss2da62doi  spc_e5fmssd45p2zkgybqg7kazmbtm\n",
+      "reactant  [N-]=[NH2+]  spe_fvlbwfuoauoeknq6l5esaozqai  spc_js6c4lveb4j7w424qsjntzfjim\n",
+      "reactant  [H][H]       spe_7ioiqvdqm6cyumgnrammbhefum  spc_ci5wbzqmgdyiq6abljksewkef4\n",
+      "reactant  N=N          spe_cft35qrkqphdifcfqlcenqgdau  spc_ajemr6t7nbxrzlhbrnyshdioh4\n",
+      "reactant  [NH]N        spe_c4ty3ixcmyuljgqfs73pdecmte  spc_5tn7bnh3ta4grgkftj5n7kdily\n",
+      "reactant  [H]          spe_knzmwhplnwnpodfp6frphrl7ei  spc_orvolagcqa4ht6ldv2fecs7c7u\n",
+      "reactant  [NH2]        spe_gzk56q4jegyyg7ylbcdqb2xvka  spc_gnaqhl7rxotedn75vxedfcrld4\n",
+      "reactant  N=N          spe_qefrbgmpyryylyocpghhc2ikki  spc_ajemr6t7nbxrzlhbrnyshdioh4\n",
+      "bath_gas  N#N          spe_axwvieje3toq6w5qdc6ly6akca  spc_di22xpjap5ccohkyptkuxvv5je\n"
+     ]
+    }
+   ],
+   "source": [
+    "detail = try_get(f\"scientific/networks/{NETWORK_REF}\", include=\"species\") if NETWORK_REF else None\n",
+    "if detail:\n",
+    "    table(\n",
+    "        [[sp[\"role\"], sp[\"canonical_smiles\"], sp[\"species_entry_ref\"], sp[\"species_ref\"]]\n",
+    "         for sp in detail[\"record\"][\"species\"]],\n",
+    "        [\"role\", \"SMILES\", \"species_entry_ref\", \"species_ref\"],\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9341c7c4",
+   "metadata": {},
+   "source": [
+    "Note the two entries with SMILES `N=N`. They share one `species_ref` — one chemical\n",
+    "identity — but are two distinct `species_entry_ref`s, and the network treats them as\n",
+    "**separate states**. That is section 2's identity/interpretation split doing real work:\n",
+    "diazene has two wells, and collapsing them would merge two channels with genuinely\n",
+    "different rate coefficients.\n",
+    "\n",
+    "It also means a channel label built from SMILES alone is **lossy**: below, three\n",
+    "distinct channels render as two identical-looking strings and one that appears to go\n",
+    "from a state to itself. The composition hashes distinguish them correctly, which is\n",
+    "why the pairing further down uses those rather than the labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a916cd11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:05.367314Z",
+     "iopub.status.busy": "2026-08-10T07:03:05.367141Z",
+     "iopub.status.idle": "2026-08-10T07:03:06.033057Z",
+     "shell.execute_reply": "2026-08-10T07:03:06.032583Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21 Chebyshev fits, 21 PLOG fits\n",
+      "unique channels by composition hash: 21 / 21\n",
+      "\n",
+      "channel                               kind      shape  units    \n",
+      "----------------------------------------------------------------\n",
+      "N=N + [H][H] -> 2 [NH2]               exchange  6x4    cm3_mol_s\n",
+      "N=N + [H][H] -> [H] + [NH]N           exchange  6x4    cm3_mol_s\n",
+      "2 [NH2] -> [H] + [NH]N                exchange  6x4    cm3_mol_s\n",
+      "N=N + [H][H] -> [H][H] + [N-]=[NH2+]  exchange  6x4    cm3_mol_s\n",
+      "2 [NH2] -> [H][H] + [N-]=[NH2+]       exchange  6x4    cm3_mol_s\n",
+      "[H] + [NH]N -> [H][H] + [N-]=[NH2+]   exchange  6x4    cm3_mol_s\n",
+      "N=N + [H][H] -> N=N + [H][H]          exchange  6x4    cm3_mol_s\n",
+      "2 [NH2] -> N=N + [H][H]               exchange  6x4    cm3_mol_s\n",
+      "[H] + [NH]N -> N=N + [H][H]           exchange  6x4    cm3_mol_s\n",
+      "[H][H] + [N-]=[NH2+] -> N=N + [H][H]  exchange  6x4    cm3_mol_s\n"
+     ]
+    }
+   ],
+   "source": [
+    "def channel_key(record):\n",
+    "    \"\"\"Identify a channel by the composition of the states it connects.\n",
+    "\n",
+    "    Two fits of the same channel are two records with two different refs, so ref\n",
+    "    equality cannot pair them. The composition hashes can: they are computed from\n",
+    "    the participating species and stoichiometry, which is what makes \"the same\n",
+    "    channel\" the same -- and they separate states that render identically.\n",
+    "    \"\"\"\n",
+    "    ch = record[\"network_channel\"]\n",
+    "    return (ch[\"source_state_composition_hash\"], ch[\"sink_state_composition_hash\"])\n",
+    "\n",
+    "\n",
+    "def channel_label(record):\n",
+    "    \"\"\"A readable `A + B -> C` label. Lossy where two entries share a SMILES.\"\"\"\n",
+    "    def side(state):\n",
+    "        return \" + \".join(\n",
+    "            (f\"{p['stoichiometry']} \" if p[\"stoichiometry\"] != 1 else \"\") + p[\"canonical_smiles\"]\n",
+    "            for p in state[\"participants\"]\n",
+    "        )\n",
+    "    ch = record[\"network_channel\"]\n",
+    "    return f\"{side(ch['source_state'])} -> {side(ch['sink_state'])}\"\n",
+    "\n",
+    "\n",
+    "chebyshev = records(\"scientific/network-kinetics/search\", has_chebyshev=\"true\",\n",
+    "                    include=\"coefficients\", limit=50)\n",
+    "plog = records(\"scientific/network-kinetics/search\", has_plog=\"true\",\n",
+    "               include=\"plog\", limit=50)\n",
+    "\n",
+    "print(f\"{len(chebyshev)} Chebyshev fits, {len(plog)} PLOG fits\")\n",
+    "print(f\"unique channels by composition hash: \"\n",
+    "      f\"{len({channel_key(r) for r in chebyshev})} / {len({channel_key(r) for r in plog})}\")\n",
+    "print()\n",
+    "table(\n",
+    "    [[channel_label(r)[:46], r[\"network_channel\"][\"channel_kind\"],\n",
+    "      r[\"network_kinetics\"][\"chebyshev_shape\"], r[\"network_kinetics\"][\"rate_units\"]]\n",
+    "     for r in chebyshev[:10]],\n",
+    "    [\"channel\", \"kind\", \"shape\", \"units\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ebc2c21",
+   "metadata": {},
+   "source": [
+    "### Evaluating a Chebyshev fit\n",
+    "\n",
+    "The Chemkin convention, which is what the stored coefficients assume:\n",
+    "\n",
+    "$$\\tilde{T} = \\frac{2/T - 1/T_{min} - 1/T_{max}}{1/T_{max} - 1/T_{min}}\n",
+    "\\qquad\n",
+    "\\tilde{P} = \\frac{2\\log P - \\log P_{min} - \\log P_{max}}{\\log P_{max} - \\log P_{min}}$$\n",
+    "\n",
+    "$$\\log_{10} k(T,P) = \\sum_{i}\\sum_{j} a_{ij}\\, \\phi_i(\\tilde{T})\\, \\phi_j(\\tilde{P})\n",
+    "\\qquad \\phi_n(x) = \\cos(n \\arccos x)$$\n",
+    "\n",
+    "Temperature is reduced in **inverse** T because Arrhenius behaviour is linear in 1/T;\n",
+    "pressure in **log** P because falloff is a decade-scale phenomenon. Both map the fitted\n",
+    "domain onto $[-1, 1]$, where the Chebyshev basis is defined."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0bc5e3ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:06.034782Z",
+     "iopub.status.busy": "2026-08-10T07:03:06.034479Z",
+     "iopub.status.idle": "2026-08-10T07:03:06.041179Z",
+     "shell.execute_reply": "2026-08-10T07:03:06.040626Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def chebyshev_basis(order, x):\n",
+    "    return math.cos(order * math.acos(x))\n",
+    "\n",
+    "\n",
+    "def chebyshev_k(record, T, P_bar):\n",
+    "    \"\"\"Evaluate a stored Chebyshev fit at one (T, P).\"\"\"\n",
+    "    meta, block = record[\"network_kinetics\"], record[\"coefficients\"]\n",
+    "    t_min, t_max = meta[\"tmin_k\"], meta[\"tmax_k\"]\n",
+    "    p_min, p_max = meta[\"pmin_bar\"], meta[\"pmax_bar\"]\n",
+    "\n",
+    "    t_red = (2.0/T - 1.0/t_min - 1.0/t_max) / (1.0/t_max - 1.0/t_min)\n",
+    "    p_red = ((2.0*math.log10(P_bar) - math.log10(p_min) - math.log10(p_max))\n",
+    "             / (math.log10(p_max) - math.log10(p_min)))\n",
+    "\n",
+    "    # Clamp to the fitted domain. Outside it the basis functions diverge, so an\n",
+    "    # unclamped evaluation does not extrapolate -- it produces nonsense, silently,\n",
+    "    # by many orders of magnitude.\n",
+    "    t_red = max(-1.0, min(1.0, t_red))\n",
+    "    p_red = max(-1.0, min(1.0, p_red))\n",
+    "\n",
+    "    return 10.0 ** sum(\n",
+    "        c[\"coefficient\"]\n",
+    "        * chebyshev_basis(c[\"temperature_order\"], t_red)\n",
+    "        * chebyshev_basis(c[\"pressure_order\"], p_red)\n",
+    "        for c in block[\"coefficients\"]\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def plog_k(record, T, P_bar):\n",
+    "    \"\"\"Evaluate a stored PLOG fit at one (T, P).\"\"\"\n",
+    "    entries = record[\"plog\"]\n",
+    "    pressures = sorted({e[\"pressure_bar\"] for e in entries})\n",
+    "\n",
+    "    def arrhenius_sum(p):\n",
+    "        return sum(e[\"a\"] * T**e[\"n\"] * math.exp(-e[\"ea_kj_mol\"] / (R/1000.0 * T))\n",
+    "                   for e in entries if e[\"pressure_bar\"] == p)\n",
+    "\n",
+    "    if P_bar <= pressures[0]:\n",
+    "        return arrhenius_sum(pressures[0])\n",
+    "    if P_bar >= pressures[-1]:\n",
+    "        return arrhenius_sum(pressures[-1])\n",
+    "    lo = max(p for p in pressures if p <= P_bar)\n",
+    "    hi = min(p for p in pressures if p >= P_bar)\n",
+    "    if lo == hi:\n",
+    "        return arrhenius_sum(lo)\n",
+    "    k_lo, k_hi = arrhenius_sum(lo), arrhenius_sum(hi)\n",
+    "    w = (math.log10(P_bar) - math.log10(lo)) / (math.log10(hi) - math.log10(lo))\n",
+    "    return 10 ** (math.log10(k_lo) + w * (math.log10(k_hi) - math.log10(k_lo)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50339904",
+   "metadata": {},
+   "source": [
+    "### Falloff\n",
+    "\n",
+    "The point of a pressure-dependent network: k depends on pressure, and how strongly\n",
+    "depends on the channel. Recombination into a single well rises with pressure as\n",
+    "collisions stabilise the adduct; a bimolecular-to-bimolecular channel is far flatter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "97750b93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:06.043376Z",
+     "iopub.status.busy": "2026-08-10T07:03:06.043256Z",
+     "iopub.status.idle": "2026-08-10T07:03:06.414929Z",
+     "shell.execute_reply": "2026-08-10T07:03:06.414403Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABQkAAAGZCAYAAAAq17elAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAq5NJREFUeJzt3QmcW3W5+P8nyexb21nb0oWtrJWCgMoqBQULslTAqlcoS5ValYsICFevV7gXUdGKslSQq+Dyk4IKeLUKvX+RIqhYoF4QBIqFtnTJLO3se/J/Pd/kZE4ySeacLJNM8nnzCp2c7/ecnDknJ/PkOd/FEwwGgwIAAAAAAACgaHlzvQMAAAAAAAAAcoskIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICAAAAAAAARY4kIVDATjnlFLnqqqvyZjsY7w9/+IN4PB7zOO+88zK2/r777htZvnfvXtfbTXf9XB2PdFmvPX369MiySy65JLL8kUcekalkKu87ACC79G/9bbfdxmGeYuLFKumun268MNXiDf1uY+3vpk2bcrovX/nKVyL7wvWIfECSEChgv/zlL+U///M/XSdoYpNCbreTLW+++abZv+bmZunu7o4qO/LII80f2VTpdisqKuStt96KWq6JKg18su3VV1+V++67L/JcXzNekiz2HB1//PGyc+dO+fCHPzyu7k033WTKpk2bFnfdZF8U/vrXv8ovfvELyZV4x0P3/Wtf+1pUPQ1EdbnFze8Yjx6veHU+8IEPmLIlS5a4fs84PZf6Oy9evFhaWlrMdvfff3/50pe+JMPDw5Kq73znO2a/AQAoRtZNzz//+c9Ry/XmtyaK0k0yPfDAA1HLNYbQ18y2H/7wh/Laa69FnmvMlChpGJu4cxvrxEv6xcY2uYo3Ojo65LOf/awcfPDBUlVVJfPmzZMrr7xSOjs7J1z3E5/4hNnnhQsXuv6ekagBRex50O9Q73//+6WpqUnq6urkuOOOk8ceeyxqnWuuucbsx5w5c1I6BkCmkSQEClh9fb3U1tbmzXYyRf9wf/Ob38z4djUw+PKXv5zWNjQ4SCXo1IAklTvCZWVlMnPmTKmsrBxXpudMy+xJNKc0mNHznoqtW7dKuuIdD02cff3rX5c9e/ZItujxspKqduXl5aZM/830e8ZSWloqF198sTz++OMmYagB/Pe//335j//4j4TraMCaLImtv4vuNwAAxUrjhy984QtZ2W66N/OsxJRbGiNprDQZsY4T6cQb6cSNO3bsMA/9XvDiiy+aOPx3v/udXH755ROuq0lF3eeSkpKsfc/YsGGDSRKuW7dOnnvuOXMz+Oyzz5YXXnghUqempsbsh8/ny8hrAukiSQikSf8QnXjiieaPdUNDg3zwgx+UN954I1I+NDQkn/nMZ2TWrFkmmNC7i7fcckvUl3y966V/kGfPnm3uflk0GaJJgxkzZpg/ZHpn7/XXX496/aefflre+973mnKtd8YZZ0SSKLF3uX7yk5/IMcccE0kefexjHxO/3x8JUvQPl9LtaMBiJR9itzPRfll30fRO2aGHHmr++Fl3JzNB7xiuXr06su+ZotvVY6RBBlK33377yfve9z758Y9/LL29vRk7lLpNfd/ar59cy+R7RlsOXnrppbJo0SKZP3++nHPOOfIv//Iv8tRTT2VkXwEAU0swGJRvfOMb5u+D3gzUvw8///nPI2X6d1HjK/1Zact0jSm/+MUvRrbxq1/9ysR+GoM2NjbKhz70oajX6Ovrk8suu8zEhrruPffcE1WuybWDDjrIxHu6H//+7/8elRTTOFZbWenffI1xNVn0kY98JKollv6sf8+qq6tNPPztb397XGyp8fJ1110n++yzj6n37ne/27S4z4QrrrjCtCTURE0mffSjHzUt1vSGHlK3fPly05rv1ltvdf1dQdfTni+aeDvggAPk1FNPlZtvvln+53/+R0ZGRnL+PUNv+Or7+thjj5UFCxbIV7/6VfOv7h+Qr0gSAmnSJMjVV19tumf+f//f/yder1eWLl0qgUDAlH/3u981AdqDDz5oWgdpQsHqhqCBngZKd999t0myaXP+d7zjHZFta5Ju48aNZv0//elPJgg888wzI8GZjqFx2mmnyeGHH27K//jHP5o/kqOjo3H3VQMw7Tb8t7/9zbzWli1bIonAuXPnRrqX6n7qH2ntOhDPRPtlBZ16F06DRr2LpncJtTl9bFdLTU6mEpQdeOCBpjttIitXrjTJyWSP2DuX2nVXk7w33HCD633CmJdfftkE93p3XZN6+uXjySefjHyJSZXeYdXg6vbbb5ft27fnxSHP5ntm8+bN5iaE3gQAABQf/Tuq3UrXrFkjf//73+Vzn/ucfPzjHzd/UzWGuv/+++XZZ581saYV++iQFVa3yN/85jcmKXjWWWeZlksap2rC0O5b3/qWWablq1atkk996lPyj3/8I1KuyUO9+at/2zUu1ISYxq52enNc48pf//rX5qH7Zx8eRONkvamtceP69evNza/nn38+aht6k0zraPfd//u//5MLL7zQJEDtN6H1d7YPReKUxt16bPRvtRWfx/rpT386Ydyodey0++i//du/mXg0kzdFi41+R/rkJz8pa9euNd9H9DuF/jwwMJDS9jRxq+cmtoVgJr9npErff5o0T7W3DjAZUrtyAEScf/75UUfjv//7v03zfw2m9O6WJqL0jpG2NtTgRlsIWbRMkyh6J1i7Guod3He9612mTIMiDaY0YNJEhNLgRP94aiCmwZPeXdbA7q677opsUxOGiWiyxqJ3gzWo1Nfr6ekxwY/1BytZ11cn+6U0Yfi9733P3NVT2prS/sdW70jr+CH6e7tljU2nCVENmK3XsNPXsicl49GWm7G0ldoRRxxhAtiTTjpJckkDbT0vdokSwG7EG/NEk7qZoudV7+L+13/9l0kG/+hHPzLnSlswaAtUvWOsrQ1ToQl4bbGgXXD1WsvV7+j2PePmXOp1pV+eBgcHTdCcjSAVAJDfNOmkrZl+//vfm3HMrNhNbwjrzWW9gaSt7vTniy66SHbv3m1aJ2myz4qt9G+xtuq78cYbI9vV1oh2mpDR5KDValATgPq3+5BDDokkKu3Jts9//vMmgaOto+yJD03eWUPT6P5oQlJfXxMimsz8f//v/5kb20oTn/YYTJOMP/vZz8wNQGu5xnB6o0zr6g1CK76I103WTcJVY1bdv1jael9vcCajCdhYeuw0earnSltZ5pImx2JjjUzQpFlsV1iNUTT5nAk6xI32pNLHK6+8Yt4vev41sbts2TLTOOE973mPo221t7ebBhHaejRVTr5nKP3+de+990Yt09aL2mo3EU3K67UdbyxxIF+QJATSpIGNBgXajaGtrS1yh1ITgJok1D9sOhaFBjZ6R1RbHZ1++ummjibUtBm6Bn1apoGa/kHSO1/6R1L/tQcs2p1Zt6NlVktCKynnhAaOendZ19OBfu37ethhhznahpP9spKA9j+q2r3E3mxfk5P2O9VuabdqTbzqsdfAM5YmOlMZq0WPgyayNFB+5plnJqwfe+w0ONAEqT1I07v+mjB1S7t/a+sBu7/85S9me+nQZFbsGJOpjKOo3cytrrCa/NZWDrFBlv4O+tAAWlsn6BcVff+lM/Odjkuo3Un0i0qqv6MGntqq16KJ8lQ5ec+4OZf65Uu/VGmL32uvvda0yLW+jOnvZR9QXFsHawtNq/uZ0lYN+gAATF16s1lbUmkMaaef+0cddVTkucaBDz/8sLlhpX9ntGuwRf/e6uQMyehNLvvfbb15bY/X9O+Lxqraul3/Vmqco6207DR5aP+ba4/5/vnPf5q4yLoJrjTRp3GjRW+M6d8y+75biSiNMS3pxI2aiNLEk44jrImnWLr/qYy/rcMF6c08vRmucY4TekPfmvTM6mVhjxvjxVRO6P7HttBU2lghHZo41gYNdhrzuL1xrcleK+Frvce1gYSdDlOkCTqtp/GPJne1dWm8CelidXV1mcSlxmXJxnPOxPcMpV3o7V37rYlK7L+jnSbC9XvYo48+mvJ4ksBkIEkIpEmTetqKTrtf6N1PTbxpclCDOPXOd77TdOv97W9/K//7v/9r7hzpH1oNunQ97dqrXS+0TO9G6ngcybpm6nJrgON4k1UkonetNDmpD02OaLCkCS79I2jtqxNO9kvFthDUsnS7m8bSIELvrmsiJVZsEiieeMGJ0kSWBqpOEll6zjUItwcH2m3b3iUlNph2Ssfk0e4OdpnoZqut+GJbiqbSJUPvnvb395ufE7UI1WBVu5xrgKXvAe1ytGLFCknHySefbN63mghLNGnHRL+jk5ambkz0nnFzLvVzQWmQqwG4tibUhKjexdeWw/b3m7YGfvvtt03i1EIXFgCY+qwbudplWFsM2tknltBW8johgv6NiB232kmcGC9es15bb4BbLRH1764m9zRho62hnG7Div1iJ+ewx4RaV/ff+j3sMtkyTmMQbf1l74Fj0bhtotZn2mpTE0Ox9IafJrS0B4WTmY11bERriB79G643Me1/21PpZaN0yKPYWCMTNHEcu11NSDpJ3MXG5vYWdPF69Gzbts2cC40d9fuTJsG1K/pE9OaqNrjQ94smzVM9hk6/Zyi9HmKPS6Lkn94A1slUHnrooXEJVyDfkCQE0qBN2rX1nAYNVjdD7QYSS5NEetdSHxdccIH5I6Yt+fTLvAZw2sVBH5/+9KdN9w6dBEETBHq3VlsbWd169fVee+01c5fNuvur3Tns3UgS0buv2tJR/+BZSQgdVzB2plyV7M6gk/2aLHpXWsfauf766zPW3Vjp8dE7wpqEStTFwJ54sgcIGhzoOc1GkJZvYr+02JNfGuBpN2NtaauJdO0arO/7VMeHiaXvY+12HNvqwKlUW5om4uY944Z+idIvEtaXqdj3ln6G6J3zYni/AUAx0XhLk4F6QzfZ2LR6E0mTQ3ozWnukaEsqbW1vjxOdJFni0aFltFWbvbWU1QLOKf2bqAkbHTvRij/175YmNK3fS1tGauyprQ+zOdSLJpC0ZZi25tLYJBPdjZUef23JqTGpk9aE9qGHrLioGP6Oa8wS70amJvj0BrsmBrWru36/0G6+mlB0cqNd30+axNbrRYdEStbdN1PfM9zQFoQ65JP+m6ku2kA2kSQE0qCz+2o3CJ0JTrtWaCAX+4dEm+hrmSY0NIjQO0h6R05bOen4LRoUaVCi3XP1j6MmATR40O2ee+65ppuIJiH1jp1uWxMzulzpAMw60Ym2QNS7c5rke+KJJ8xdNx3/zU5bzGm5TvqgdV966SUzZoedvq7e6dXx0zTQ1H2JvYOrXRYm2i8nNFjULpoavCZKNjmh491ot43Y5FO6SSA9tto6VO9ixuuWgsT0faQt3jTprePY6HWSafq+17v5+n7OF+m+ZzSxql+k9HfTQFdbVOg2dVuZSq4CAKYGja/0ZqcmS7SlnXZ91GSIDmuhsZmO76utDH/wgx+YSeS054rGY7pcJ/7Qv73a5VLHAdREnbYI1Ju8mky0jyeYjCauNLbV1oM6O6u+nrbScvt76D5payxNEGlspvulMbHVulBv+OnfdI0LtZWiJg31xraOx6h/EzUmVXojXZNxOj5xqrR1vsbmmrCxJwVT7W5s0eSPbk9j40TJRMR33nnnmW7pOlakfqdyc7NVE4zaS0pb1GoPIr1G9KG011Rsy9RMfc9wSt9n+r7WYXd0XMVdu3aZ5fodK9XxNYFsY3ZjIJ0LyOs1gZN+mdcuxhrIaXdhOw3ktCugJk00wNLZfLWbga6riUJNKpxwwgmRu7066LQ1/ooOsHz00UebcQy1ubu2JtJ1rSb0GlQ9/vjjZuwyvduldXSci3h/yPQPpSYlNUmpd6e1JZZ2jbDTZJ22StQgUwMcbRkVz0T75YT+Mdeu1vYZkVOhx0DvzqU6A1oiGsjqeCuZ3m4x0HF0tKWpJq+zkSC0aJI7013Yc/me0etWPyv0WtbPA23poInW2EGxAQDFQf/O6Rh6mhjT3hraWkrjRB1So7W11XRf1L8VmiBUmnzTXhJ6M1hpN1aN+7R1ld6s1haG+vfZKb35q7GtxoO6viYoU5mcQyf10HhR40btaqlxr/4+9hZfGltqMkVbRup4hdqyT/fVan2oNG7UyTnSobGqHtdsxHf6N5y40T3t/q1JQu0F5LY3hn4H0/eJ9sLSpLY2zLAe2nU5Xel+z9CksSbnNZ6z79u//uu/pr1vQLZ4gvn0DQsAiox2q9BJLfbs2ZNwRmkndGw+HRvGGhNPx8S56qqrzCPX+5bvrxlLk+l63KyxdmKP7VSkrTW09YferQcAIJd0nGy9Ma2tBjXRicn/m56tWGeqxBuaQNfEt07Kky8yEbsDmUBLQgDIA3PmzDFdc93S2W61tap9ohSLtmrTslTuumvXCvssulPleKRLj5fVAsNOu+Brmf47lejvkslB3wEAcOuFF14w3S51nGKd0Mya/MPNMDWIpjGSxkr5EutMxXhDWzDqPmsrxFzS2ZB1P7RrP5APaEkIADmkswPrzHZKAwQdrzIT6+vA4lZX7v333990b3cj3fVzdTzStXnzZvOvjmGj3bmUDqRujW+jXUR0puKpYirvOwCgcJKEK1asMN2FdXxsHbJGuyDreIPITKyS7vrpxgtTLd7QWFNjTvu47bmik1nqwxoeirEKkWskCQEAAAAAAIAiR3djAAAAAAAAoMiRJAQAAAAAAACKXEmud2CqCgQCsmPHDqmtrTWzOAEAAOSzYDAo3d3dMnv27EkbZ7RQEQcCAIBCjANJEqZIE4Rz585NdXUAAICc2LZtW8qzYiKEOBAAABRiHEiSMEXagtA6wHV1dVF3lltbW83MRLHZWbdlyernWrb2Ld3tul3faX0n9Tj36eHcc90Xy3Xvdnk+4DO/MM69zjypNzitGAaTGwfm83ujWD8T3KyT6rlNtYxznx+xgJO6nPv08B2A675YvgPk+jPfaRxIkjBFVhdjDQxjg8OBgQGzLN4bwk1Zsvq5lq19S3e7btd3Wt9JPc59ejj3XPfFct27XZ4P+MwvrHPPMCm5iQOnwnuj2D4T3KyT6rlNtYxznx+xgJO6nPv08B2A675YvgPky2f+RHFg/kQbAAAAAAAAAHKCJCEAAAAAAABQ5EgSAgAAAAAAAEWOJCEAAAAAAABQ5EgSAgAAoOi8+uqrcuSRR0YelZWV8sgjj+R6twAAAHKG2Y0BAABQdA4++GDZtGmT+bmnp0f23Xdfef/735/r3QIAAMgZWhICAACgqP3qV7+S0047Taqrq3O9KwAAADlDkhAAAABTzoYNG+Tss8+W2bNni8fjidtV+K677pL99ttPKioq5Oijj5annnoq7rYefPBBWbZs2STsNQAAQP6iuzEAAACmnN7eXlm0aJFceumlcv75548rX7t2rVx11VUmUXjCCSfI3XffLUuWLJGXX35Z5s2bF6nX1dUlTz/9tDzwwAMJX2twcNA87OuoQCBgHhb9ORgMRi2zS1TudnmuZWu/0t1uKus7XSfVc5tqGefeHbfHy019zn1hXfeZuuYnqsN1n/lzl+76xX7uAw63TZIQAAAAU44m/PSRyOrVq+Xyyy+XFStWmOe33XabPPbYY7JmzRq55ZZbIvUeffRROeOMM0xrw0S0/o033jhueWtrqwwMDEQF4J2dnSbQ93rHd9hJVO52ea5la7/S3W4q6ztdJ9Vzm2oZ594dt8fLTX3OfWFd95m65ieqw3Wf+XOX7vrFfu67u7sd1SvqJGFJSYksXLjQ/HzMMcfIvffem+tdAgAARSA4NCQjbW0y4vfL0O7dMvDPf0rfkUdKzXHH5XrXCsLQ0JA899xzcv3110ctP/300+WZZ54Z19X4k5/8ZNLt3XDDDXL11VdHtSScO3euNDU1SV1dXVSQr12fdXmiRFK88njL+//2Nxl4fbNUdndLeW2teD2exDuYrMyUS/psr6FfYoa7uqWirtbsd6aY7Xb3SEVtrXi87rcbDOj63a7Wd7rORPWSladSFgwEsnKMXQsGY54GZcja3wzul14DY+/1FJIFQXfrx60f87uO1Q0mvQ6TladSNtHr5UrK+zVBXbfnLu76PeHPDQf7lfA9HLNu3M85zwTXr/1z0pR1SUVtXcx175FgMDC2nu13Di3vMa8ZORaeVD7zPQ7qJ9+G/dgEwvtbWVc3du7jbXPC1405fhKUkc4uqZpWF/03M8l5iT3GI12dUj1tWug42sqiVgs/0ffwSKfWny5en/29Fv16wWBARvZ2Ss2M6ZHjEPteCQSCMtrZKTXTp4X2PVIeWl/Laru7Q+vZthFab6/U9vZGrafvt9E9e6V5wYKsJQmT3Qy1K+ok4fTp0yOz2gEAAKQrODwsw36/jLz6qnT/34sy2tZqEoEj/tC/Azt3SFfHHhnds2fcul3LlpEkzJC2tjYZHR2VlpaWqOX6fNeuXZHnetf+2WeflV/84hdJt1deXm4esTSQjw3m9UtAvOUTlccu7/7NOtnzk5+Yn/slP/Xl6Xb7srhOXxrlqZRl6xinqz9Pt9ufxfr9aZSnUpav132xnXsn12CxXPfZ2q/eSV6/N4P1ejJc5n3571lLEjrdblEnCQEAAJwIjozISHt7OOEXav3X/+absqu3T0Zaw0nA1lYZbW+PrOOsU8eY0dZWTkaGxbYq0Tv19mXTpk2T3bt3c9wBAACmcpJQZ7S79dZbTVeSnTt3ysMPPyznnXdeVB0dqFrraPnhhx9uxqI56aSTorqK6Ex3lZWVcvPNN8t73/veHPwmAAAgV4Kjo+Hkn9Xiz29aAvZufUu2d/dEEoAm+RenK9rYaHQOlZRISVOTlDY3S4k+mprE19QkfRUVUn/kokz9WkWvsbFRfD5fVKtB5ff7x7UuzFd1Z54pZQsONGMI1SbrRhe/h6StfKIKTsR0OQ0Ex/bLabdgB/uhXcF6urulJsVulqms73SdieolK0+lLLS8x90xzprorubd3V1Sq10oM9zVvLvHeq+7b0Wj3fvGrhVv6vXj/Eqh3znxdZisPJWyiV4vV1Lar2Dmz9249QMBB+/JoOvPr3H14nyG2a9fj5PjFd5GwnNvfhe97mtCxyLe5+aEn6XBCevr67vaRCAgPT09UlOj+xX/WCR73ajXs34MBs3ynt4eqalOtN1g0u3pfukkZtXV1bZjPO6Xjfo9evt6pbqqKlI/et/Gzk9fb69UVYW3a9WJ1A3tu3ntqqpxu2zW7+uTqsrKOOc+ECrTfbD/Pmad/Gg/XFLMM9q9+eabMnv2bHnppZfkrLPOkhdffDFqXJlMz2rntixfZzVTzG7l7phw7rP/niqU2a247gv/3E+1mSyn6me+BoLapTfS1bfVL8O7d0vvtm2yvbvbtNozy9vadENxtz/kNvnX2GgSf5r0G66pkdp586S0pUVKmhrFp8sbG6V9aEiaW1rGjUenrRDLm5ryYla7QlBWVmZuBK9fv16WLl0aWa7Pzz33XJkKqt55lFQcuUiG/H6Z3tycdxOXZGO/dLuapJ+R4nZTWd/pOhPVS1aeSpm1vJjOfTrbdbu+m/oT1U1WnkpZto5xuort3Dupl63rPtXPwGwxcYrfL/VZOPejfr80pHHuA36/NLo4907qBwIBc1OxaYJzH0xQx1q/2UWZtTwflBTzjHaaIFQ6eclhhx0mr732mpnAJFuz2rkty9dZzRSzW7k7Jpz77L+nCmV2K677wj/3uZzVrBA+87VusLNLAu1tJtHXt2279Pf1iezpkEBbu1mu/wY7OkRGR9NP/nm94qmvF29jo3gbGsTb2CCehgazrL+iUmrmzzPJP48Omm27jns7O2Vk2jQJeL1i3WIMDA9Lp95kDI89l85xyOasdlOFtmrYvHlz5PmWLVvMWNP19fXmhrBONHLRRReZ2O64446Te+65R7Zu3SorV67M6X4DAADkqymbJEx3Rrs9e/aYJp46CPX27dtNC8P9998/q7PauS2baIa8XMrWvqW7XbfrO63vpB7nPj2ce677Yrnu3S4vls98M+NbV1dkbL9QN9+xVoBWd2BNDOrkIHZj7fxd8HpNyz9t9VfS3CQlTdr9V39uFl9Do3SVlkjTQQdJqSYEfb64+643CqfSuXc6q91UsXHjRlm8eHHkuRWnLV++XO677z5ZtmyZtLe3y0033WSGntGbwuvWrZP58+fncK8BAADyV0mxzmj3yiuvyBVXXGGCcQ3Mv/Od75g7z9me1c5t2UQz5OVStvYt3e26Xd9pfSf1OPfp4dxn5jhkE9e9u2PidBbTbB/fTEh130x34N7eyHh/JgFojf232y/9b78tvXv3mudB27Aeaeyo+BoaTMKvNJL4awmP/dcoXSUl0nzIIVKqrf/iJP+spF2/3y9lE3RHmWrnPh/fV+k45ZRTJhxXadWqVeYBAACAIk0SOpnR7vjjjzdjEAIAgNQE+voiST8dQ8c++UckEagt/7Q7cAb4ZswITfZhHk2mm+9AVZVM3/8AKWsJL9eWf6Wl8fc3EJA+v98kDK2uwQAAAAAKOElYCDPaAQCQK4GhoejZfnfvlr4335Sd2iLQ1vU3kKEx7rzTpklppMuv7aGzAFvJP235V1YWvZ/hQZ5r82yAbwAAAGAqKsgkYSHMaAcAQKbpWH4j7e1jyb9Ii7/oFoCje/fGXd9tZ2BvTU1Uy7/SmASgt6lJ9gSD0jJ3Lkk+AAAAIMembJKQGe0AAAgJjo7KaEdHwqTfcLj132h7u469kfZh81RWjkv4jUsGahKwujrpdsyEHX4/pxEAAADIA1M2SciMdgCAQqdj6Wqrvuik3+7x4/+1tYmMjqb9etqdN5L0a2mJJPy8jU3SU1YqjQcdJGUzZ5rkX+y4vwAAAACmtimbJGRGOwDAlE7+dXfLcFtbJNE3pOP+vfWWvN3dI6O2GYC1i3DaSkrCrf103D9N/GkC0D7+XzgZOG1a3OSftvgb9PulnLH/AAAAgII1ZZOEAADko0B/fyTpN/T6ZukYHJDR1jYZ2b07Mg6gPvYODKQ/7p/HI77GBim1T/hhWgGGfjbdfltazKzAzOYLAAAAIBmShAAAOBDUGX9bW6O6+uqsv73btsq2zi5TFm/G394Uj65v+vRwl99QS7+x2X5trQAbGsRTwp9yAAAAAOnjmwUAoKgFR0ZkpL0j1L231TbZx26/9G7fLn1794Qm/dizJ+E2hly8nre2VqS+XipmzZLScIu/kqZm8TU1SndJiTQdcohJBHrLyjLy+wEAAACAEyQJAQCFPelHuJtvpKvvbr/0bd8m/Z2dMrLbLyM6428gkHA7Iw5fz1NRYbr5Wl1/fc3NMlBVKdP331/KtPVfeAZgqagQv98vzTHj++m4f/1+f2hsQNtyAAAAAJgMJAkBAFMu+Rfo6Yma8GPgn1tkd1+fjEZmANZWga1JJ/1wPB1ISUlobL/IjL86zl9zZNbfrhKfNB9yiJTU1UVN+qFJP00G1sVJBgIAAABAviFJCADIG4GBAVt3X20BODbLb2S5Jv/6+sat2+/2xbxeKWlsjJrswz7en7exUfZ6vNKy4EDx+Xzx9zcQkF6/X3y1tXFnBQYAAACAqYIkIQAg67RF30hbW9zkn3YBHtixQzo7OiTQ1ZWR19PZfCOTe4Qn/bASgD5N/nm90nLwweIrLU24DU0Aev1+kn8AAAAAigJJQgBAyoKBgIy2t4dn/B2b9XfEvztqFmCtkwnempqo7r5W0q+3vEIaDlpgxv7zNTUlnfQjkvxL0DoQAAAAAIoRSUIAQPxx/7q6IrP8Wi0A+956S97u7jbj/ZlkYFubyIjTqT2SKCsLtfSzkn/hyT+sh5kFWJN/1dVxk36akKxkwg8AAAAASBlJQgAoMoG+vkg3XzO7b2Sij7GEoD6Cg4Nx14+/NIGSkvCsvk1jyb/IuH+hZd6mJmnr75eWlhZm9QUAAACAHCFJCAAFIjg0ZFr4Dcd0+40kBHXZ7t1mZuBM8DU0hFr+2Vv9tYRb/lldgevrxWOb2TcebQnoGRjIyD4BAAAAAFJDkhAA8lxwdFRGOzqiWvmFEn+hBGBk3L+Ojoy8nreubqzlX/PYbL++pkbpLi2VpoMPlrLmZvEkmfQDAAAAADC1kCQEgFyO+9fdLYOdXTIaHuNv3Lh/OhOwjvs3Opr263kqKqJb/sV0+zXPddy/ysqELf76/X5Td6LWgQAAAACAqYUkIQBkcdy/od27Zej116VjYDCUCIwz7l9nJsb900RfzGQf9hmANQGoMwN7PJ7M/ZIAMiIQDMiewT1SMlAijVWNHFUAAADkBElCAHA77l9b27hZf3u3viXbusZa/8WO+9ebylH2eMy4f5FEX+TRFJoJ2OoGPGMGLfuAPDQaGJWOwQ5p7WuV1v5W8ff6ZUvrFunf0m+et/W1ib/fLx39HTISHJGPH/px+cK7vpDr3QYAAECRIkkIAJr8CwRktL09PMHH2Dh/w7t3Se/27dK3t9MkALVOIkMujqR32jTTtTcwY7pU7TMnnPRrEl9Tk3SXlEjTIYdIWVMT4/4BeZr8a+9vl9e7Xpd/DP1D2gbaTNLPJAPDCcFdPbtk79BeGQ06HypA1wUAAAByhSQhgKIY989q8ReV/Nu2Xfr37g21/tNx/0ZGEm4ncUmScf9aWkzSb6CqUqYfcICU2Vr/eSsqzBh/fr9fmvV5eIw/xv0Dcpv8026/u3t3y+bWzTLUORRKAIYTf1YSsH2g3VXyLxGvxyv1FfXSVNkkdb46Obzh8Iz8HgAAAEAqSBICmLIC/f2Rsf2Gdu2SgX9uEX9f39gkINa4fwMDCbcx7HLcP239V2rN+Gu1/mtskq4SnzQfeqiU1NVFjftnJQLrbIlAAJM/5l/HQEck+TfcOSytA2Pdfa0koLYOzFTyb3rZdGmpbpHmqmZprGwM/VvRKKVDpbJg1gJprm42CcISb0nUDQMAAAAgV0gSAsg7weHh0Lh/u3eHE33hWX71Z534Q//d7TctBGP1pzjuX2TiD6u1X3jSD29jo+z1eqVlwQLxlcT/yNQv+L1+v/hqa5kYBMjBhB8dHR2mdZ8Z969vLOmn/2oSMJPJv4aKBpP009Z/NZ4amVc/T5qqmkwSUP/V5Zog7GjriGolbPbXSgY2cNMAAAAA+YckIYDJHfdvzx5b8m8sAajPB3bskK6ODhnt6NB+wmm/nreuLpT8s1r+NTWFkoAtzab1X6fPKy0HHyy+8vKE29Av9V6/n4lBgElO/u0d3BtK8vX5pa2/LZT8s7r8hpOBmvzTCT8ylfyzknyaBKwKVMm+jfuaFn8mCVgZavnn8/pC+xhnuIDI/gcCae8TAAAAMNlIEgLIzLh/PT2R1n5WSz+rK/CwPzwWYGtr0nH/xM24f82hln6RGX6bmqSvokLqFxwoZTNnmoSgt7Iy4Tb0S3y3Jv9KS9PeHwDOPys6BztN6z7t6ru7b7eZ7bfvzT6TCIy0AOxvlZFABj4rxGMSe5FWfhVNUhWskvmN801XYCspqAlCK/k3UQIQAAAAKFQkCQEkFRgYCE3sEU4ADu3eLX1b3pQdvT0y6m+NJACD/a47+o7n84Vb+4UTgPbuvzoWYEvouTdOt179Uq/7V8WXeiAnyb+uoa6oJJ+926+9NeBwwPFIoBMm/7TF3zTfNJkzfU6oxV9lKOlnjQPYUNlgxvyzkPzDVHL7C7fLI5sfkcBoQLw+74TXRNLymL+ZKW0jpnx0dFR8vrHkuhMT7Ye56agt+L3elIfvSGW/nK4zUb1E5cl+r0RlTo6F1sm2oATTPsbxthGnkpk8ytyw8aT2u1rHy6nY+sn2c6LrMFl5KmVOrvtcSGW/JvpscXLukn4eBEPrT/SetO9HvPew02szln1bsb+rHi9fSczrhOuMjI5Iia9k/HUfXifZcYvdn9i69ueJ9t3NNsz+joxISUmJ6X2RbFtRrx3+2SqPlEX+8cjw8LCUlpYm3Odx+xWzreGhYSktK43ar3ivo//pNa71y8rKxup7bPtpe62hoaGoeqbMtj1932md8vJys09Rv2tQZHBwUCoqKqLLwv8ODAxIZUVl6LXD5XrudZ1vnvpNyTWShEAxj/vX3m5r7Rfd+s9aFujsjLv+oMvX89XXRyb6CLUAtGb6bYq0BGwfGZGWmTNpuQPkCQ1Yeod7zYQfr7W/JsM9w2bsP3vXX+vnwVG3nwrxWbP9Wq38rK6+kXH/KpukvrJeSr2lJP1Q0HqGesz1BQAAioMnxRtkmUSSECjEcf/27o3u+hvb/bfVL6Nt7ZkZ96+mxpb8sxJ/oYdp+ac/NzaKp6ws6Xb0Tp3Hz5chYLL0DffFbfEXO+5f/0gGWgmLyPTy6VEJP6vVn872e+DMA2VmzUzT7bfUxxAAgKotq5WWqpYJW9hM2ErLUSOuoOvy2BZFmWjVpq/jtjXYuP1KYX2n60xUL1l5vDKrVUmi9dI9Fpn6wjmuFanV4i+NbSQ7905ansVbPxgIumrlFq9VXKLXzvS5n6gsE+c+G9zul6NWpBO1UJzwIy444Xsydj+cfn7Zf994v4uup49E11my1qrmu4+u54nZXiAoHq8n8fGLWRRbx/7c/nslOxexv3+8bUQts28r6sfxdeKtj/xGkhCYIkzz897ecMIvydh/rW0iwxnozldebpvsozmSAPQ1NUp3WZk0HXSwlM1sEW9VVUZ+PwCZMTAyEDWzr0n4hX/WcQCtZT3DPRl5vbqyukgLP3vrP6vbr9X1t8w3/kZBpPtvE2P/AbE+c9RnZNWiVXk5Pma2uu6nu91U1ne6zkT1JprMyG1Zvg6PUCjn3k19zn1mzlEmzkUm1s/UNT9RHa775Kzu3Hr8mpqbxpKxcRKbkQRj5J/QD5ocbvW3SmNT47hkbrztaNfw1rZWaWwM1Tc3F2ITpMGgmUCvrbVNGhobxtWztqX7brbV0DiW1NUkb/iGR1tbaH0rgWxtQ8va29uloSFUZv9ddHk+KNok4bZt2+Siiy4yb0rtW//v//7vcuGFF+Z6t1CkgoNDMrRtmwTa2kLj/u3aJX1vviU7enpkNDwe4HBrqwT7+jIz7l9jY6j1nzXOX1QLQF3WYmYGjndXTD/YBvx+KcuzoBUodMOjw6Fx/cJJPqvVX2xLQB0bMBNqS2tDyb6qJmmsaJTqYPXYbL+2cf8qSioy8noAAAAoDmYsvvBDx/2zjxHoVMATMDehNRZ1lCD2BaSvpM+01J8oQTxUNiQzKmYkTRAHygMmTo6XIPb2ek3MHK+srL9MmmvH3xiqHEg86eZkKtokoSYGb7vtNjnyyCNNovCd73ynnHnmmVJdXZ3rXUMBCY6MmHH/NOk39PrrsmdoSEZNq7/WSItAa9y/vZkY92/GjEjX37HZf8cSgJoQ1LEBPS4H9AaQPTqLb8dAhxn373X/6zK0dyg0029MAlDrZEJlSaXpwmhv7afJPqs1oPW8qrQq71u0AOnq6+uTQw891Nwo/uY3cz9YOAAAQC4VbZJw1qxZ5qH0S099fb10dHSQJIQj2lTYPu6fNetv75tvyfaebjPrr1muTYYDgch6vSkeX2919dgsv+GWfmbmX30englYJ/7wTjDuH4DJo10V9gzuMX9b2gbaIgm/3X275e29b0vnaGck+ad101XuKx+b6MOW8Iud+KO6lJthgOXmm2+Wd7/73RwQAACAqZwk3LBhg9x6663y3HPPyc6dO+Xhhx+W8847L6rOXXfdZepo+eGHH25aDp500knjtrVx40bTSmLu3LmT+BsgX4326Lh/Y8m/YW3tt9svvdu2SX9nZ6gloHb9TTDu35CL19LJPDTRF5g+Xar22UdKZ4bH/Wtsku6yUmk6+GAzFqCvhi/1QD7dJNAuvZr009Z/b+x+QwZ3D4bGAeyPHv9vJDiS9uuVeEvijvMXO/Ovjg2YDzOiAVPF66+/Lv/4xz/k7LPPlpdeeinXuwMAAJBzUzZJ2NvbK4sWLZJLL71Uzj///HHla9eulauuusokCk844QS5++67ZcmSJfLyyy/LvHnzIvV0cMiLL75Y7r333qSvNzg4aB6Wrq6usb7otpZi+rM1IGUst2XJ6udatvYt3e0mPcaDgya5p4k/belnJvnY7ZeebdtkoKsrkhRMNu6f4+lAvN7QhB/a7bcp1MpvsLpK6vbbT8oiLQKbxTttmtnf1tZWadKWgOFufLr//a2tZhserzev3gNT8dynU99JPa77wjn3vcO9kSSfv9cvW1q3SN+bfWMtAcNJwKGAm9sB8enYKzqbr5XwM118A1Vm3L+W6pZIElBnBY6M05KENcNeNnDduzsmicrcLs+0fPpbkg83i6+55hpT/swzz+TgNwAAAMg/UzZJqAk/fSSyevVqufzyy2XFihXmuQaGjz32mKxZs0ZuueUWs0yTfkuXLpUbbrhBjj/++KSvp+vceOON45ZrcmdgYCAqAO/s7DTBfrxBKt2UJaufa9nat1S2GxwZleCeDgm0t5tJPvq2b5f+nl4JdrRLoK1dgu36b5sEw4ndeNzMBeypqxNvY6N4dFYknfFI/21oFKmvl77KCqmdP3/cuH9mso/OTimfNk2Grd9raEjfQJz7NM59Ous7re+kHtd9/p/7wdFB6RjskPbBdpPoe7vzbel7tU/ah9qlfaDdLNdH/2i/ZML0sunSUN4gdd46aalpMRN/1JfXS2N5o9SX1UvpYKnMbZwrpb7Scb/HtLppod9jRGSka0TapE1yLZ8+86fyde92eaZ1d3dLoUj3ZvGjjz4qBx10kHk4SRJm4mZxPieQi/XGgZt1Uj23qZZx7vPjZrGTupz7wrlZ7LYe5z49nPvJ/cx3uu0pmyRMZmhoyNxZvv7666OWn3766ZFAUE/AJZdcIqeeeqqZ5Xgimki8+uqro4JD7Z6srb/q6uqiDrx297K3Cku1LFn9XMvWvtm3q/+OjfvXKiOtoZZ+2vov9HO4VWDMuH+pTPgRGfcvPOZfaLKP0OQf2hLQ29QknSU+aT7oICmprEy477EtAuP9Xpz7ic99qskCN+s7re+kHtd97s79cGBYWntbZWfnTtk2uM20+LNaAtpnAM7UjL/apdfe1bepokkqRytlv+b9It2AGyobpNRbmvAzIdnyYv7ML4br3u3yTKuoKJyZqNO9WfznP/9ZHnjgAXnooYekp6dHhoeHTTz35S9/OWs3i/M5gVysNw7crJPquU21jHOfHzeNnNTl3Ken2G4YJivjuneHc5+dm8UFmSRsa2uT0dFRaWlpiVquz3ft2mV+fvrpp81d5iOOOEIeeeQRs+zHP/6xvOMd74i7zfLycvOIpRd17EVvpvGOszyVsmT1cy3VfTMZ8t7eyOy+Zty/8Iy/Ov5f/9tvS8+ePaZVYKJx/ySFcf/GHuGJP8zYf43SWVIiLYccIiW1tUk/gHr9fpMgTPb7cu7TPFdpvt/dru+0vpN6nPv0xB4/nchDJ/SwJvuITfrpv/rYM7BHgpJ+F9uqkqqxsf7C4/xp99/y4XI5YOYBke6/FSUV4z4bks36m+h94XZ5PsjWvhXbdZ/Lc5+P76tc3SzWpJ/Vs+S+++4zYxImShBm6mZxPieQi/XGgZt1Uj23qZZx7vPjppGTupz79BTbDcNkZVz37nDus3OzuCCThJbYAdw1OWUtO/HEE/Ou60YhCAwMRMb2syf/Ist0EhBN/iUZ988xn09KGhujkn86hl9fZaXUH3CAlLbMNMt806cnHMxf3wM9fr9pRQhgcif9sI/991b7W9L9cre09YfG/tN/R4OjGZ/x1yQBK5qik39VTXFn/J0oAQhg6t4sditTN4sL6eZBodw4cLNOquc21TLOfX7cNHJSl3OfnmK7YZisjOveHc69c06vj4JMEjY2NorP5xsXCOqXvdiAEc5oi76RtrZI4s+0+NuyRXb29ppJQLT777C/VQKdnRk5pL4ZM6SkZazLb2lUS8Dw8oaGqHH/rC/1OvtwNV/qgUnXN9wXaem3u293VMs/+886PmC6Sjwl0ljVaFr8affeWqmVfRv2lebq5gln/CX5BxSHZDeL7XT4GQAAABRokrCsrEyOPvpoWb9+vZmYxKLPzz333JzuW74JalKtoyOU/LPG/rO3BAyP/WfG/Ysza+bYKDzOeGtqIsm+0pZw0q9pLAGoswB3BAPSMmdO3t0xB4rV0OhQKPHXs1s279osg+2D0joQSvzpwyQE+1vNzMDp8ohH6ivqI91+tRWg1QLQPhag1rFm/CXpB8COm8UAAABFliTUQaY3b94ceb5lyxbZtGmT1NfXm1nrdNwYnZDkmGOOkeOOO07uuece2bp1q6xcuVKKgRn3r6trrMuvTvZhJf+01Z/1vK1NZGQkM+P+hcf5M2P+mdZ+zdEJQR1zYYJuvWZcAb8/7f0BMLHRwKiZ2dfeyi/SAjA8BqA+9gzuyeikH1ayL5IIrGiSkoESOXifg6WxutFM+gEAqeJmMQAAQJElCTdu3CiLFy+OPLcGk16+fLkZgHrZsmXS3t4uN910k+zcuVMWLlwo69atk/nz58tUp5N+RI/1Fz35h5UMDA6m36VPSkpMck8foUSf1eKvUXrKyqTxoIOlbGaLeOvGd+kDkLubBJ2DnaHx/qyx/2KSgPrQmYB1gpB0VZZUSktVaGy/SPLPlgS0nsdO+mGJtASsZuw/AM5wsxgAACDzpmyS8JRTTjFfhJNZtWqVeUxFwaEh2fOzn0nfli2yo6fXzPRrJf80SZg2j0d8DQ2RyT6iWv61jI0B6KuvF0+CWbwG/X4pZ+w/YFJpl14r8Wd187WSgPaZf4cD6c8Mri367F189d+qQJXs17RfZMIPTQ7Gm/QDALKpmG8WAwAAZMuUTRIWvJIS8d/6TdMV2G17QO+0aVJqkn+a8GsJtQQMj/8XmQCksVE8pXTpA/KFTuZhEn+9Y+P+mZl+w91+rSRg30j6M4PrWH4NFQ1jLf3Ck3zEtgacXh49Mzhj/wHIF4V+sxgAACAXSBLmKW29p4m8EdsMzZ6qqphZfkPj/4W6ArdEEoLeivhd+gBMvpHAiOnW62/zm3+t8f6spN/Orp2yZ3iP7B3cm5HX08SelfizJwEjYwGGJ/0o8fLxDwAAAAAYw7fEPNbyla9IZ1+vNB50kJTNnGkm/WDcPyD/xv3TWX/f2P2GDOwaMInAyOQffX4zMUgmxv3TLr2x4/xZLQCtBGBjZaOU+8oz8vsBAAAAAIoLScI8VnPySdLHuH/ApOsb7osk+rT77z9b/yn9b/VHxvvL6Lh/ntJQV18d40/H/qtskspApezftH9k3D9NADLuHwAAAAAgm0gSAigaQ6NDkYk+NPn3hv8N6d/eb8b+s08EopODZGLcv8aKRpPkq/PWyZwZc0yyT8f90xZ/1oQgg3sHpaWlRbzhCYIY9w8AAAAAkAskCQFMeaOBUWnra5PXOl+TlwdfDo0BGG7xZ7UI1MeewT2ZHfcv3OVXk36VI5VyQMsB0lwd6vprjfuXLOlnyjz+jOwTAAAAAADpIEkIIK/H/esa6opM8mHv6mt+Dk8C0t7fLqPB0bRfr7KkMjLDrz0BWD5cLgfOPDDS/Td23D9a/wEAAAAApjqShAByNu6fPeHn7/XLW+1vSfc/uk33XyshODg6mPZraYs+k/CrajRJQDPJR0WjlI+Uy4EtB0pLTYsprymrGbcuCUAAAAAAQDEgSQggo4ZHh0NJvv5wSz9bC0B719/u4e60X8sjHmmobIhM+FHrqZV5DfNkZvXMqJmAtXuwjhFoR/IPAAAAAIAxJAkBOBIIBqRjoMNM+PG6/3UZ2jsUGfvP3g1Y62RCXVldqMtveIKPSBfgcDdgfa5dgbWVoNm/JGP/AQAAAACA5EgSAkVOx/3rGe6ZcNw/nRhkJDiS9utV+CrGkn+a+Asn/DQRWDpYKgfPPthM/lFRUpGR3w8AAAAAAEyMJCFQwAZGBiJJvtikn9UVWBOC/SP9ab9WiafEjPmnSb9IAjCcDNQWf9ZYgDWlNeLxeMatH2kJWEtLQAAAAAAAJhtJQmAKGg4Mmxl9I2P+hZN+kTH/wuP/dQ+lP+6fqq+oj8z621TRJFXBKtmvaT8z268mADX5p3Vix/0DAAAAAABTA0lCIM/G/ds7uFd29eyS11tfl+HOYWkdCLf4s7X80wRhUIJpv5626ouM8xce+8/eFVgTgw0VDVLqKx3bR8b+AwAAAACg4JAkBCZp3L/ekV7Z0rnFJP3ss/7qY0fXDtkzvMckAEcC6Y/7V+4rH5fwi+0GrOVVpVUZ+f0AAAAAAMDURpIQyMS4f9q9t3e3bN65WQbbBuPO+puJcf98Hp80VDaEuv6GZ/y1ugFbE4BoAlBnBo437h8AAAAAAEA8JAmBBLRFn3br1QSfJgD/6f+n9L/db5J+9tl/u4a6MnIMZ5TPiLT0M638AmPj/lnJQK3j8/o4ZwAAAAAAIKNIEqIou/7uGdwTmuijd7e8sfsNGdgVag1onwk4k+P+adJvesl02Wf6PuPG/2usaJRAT0DmzJwjXm9o4g/G/QMAAAAAAJOJJCEKKvnXM9QjW3u2ypbRLZEuv/ZWf9bMvzo7cLrKvGVR3X3NrL/a+q851PrPPu5fsqSfKevzp70/AAAAAAAAqSJJiCk17p99wg8r+WdPAmZi3D+vxyuNlY1RY/xpsq98pFwOaDkglACsbJZp5dOixv2j9R8AAAAAAJiqSBIip7RFn3brjXTz7fXLlrYt0ru5V9r627Iy7p+V+LO6+laOVsr+zftLS00o+VdfUT9u3D8SgAAAAAAAoJCRJERWBIIB6RjoiHTvtbr6WuP9WS0CtU7Gxv0LT/hR562TuTPmhib8qLQlBCsbpcxXFr2fSboBAwAAAAAAFAuShHA97p+26tMJP15ve12Gu4cjY//ZE4FtfW0yEhxJ++iW+8ojiT4rCWiNAWifAETH/VMk/QAAAAAAANwjSYiIvuG+cZN8aMIvdhzAwdHBtI+az+MLjfsXTvLZx/4rHSyVBbMWyMyamVJXVhc17h8AAAAAAAAyjyRhERgaHYqa9CO2+6+1vGe4JyOvp2P6WQm/SGu/cCtA67mODRg77l9US8AZdP8FAAAAAACYLEWdJFy6dKn84Q9/kNNOO01+/vOfy1QzEhgxY/rFbfkX/lcfewb3ZOT1astqzcQekS6+wSrZt3Hf0Nh/VaFuwA0VDVLqK83I6wEAAAAAAGByFHWS8Morr5TLLrtM7r//fsk3o4FRea3jNXmt9TUZ7hyW1oFQws+eAGwfaDcThKSrsqQyuttvZajlX2Tsv8pmaaxqNPUsjP0HAAAAAABQOIo6Sbh48WLTkjAfBSQgy36zLK2Zf0u9pZFZfe2TfNi7AGsCsLq0mnH/AAAAAAAAiljeJgk3bNggt956qzz33HOyc+dOefjhh+W8886LqnPXXXeZOlp++OGHy2233SYnnXSSFAJN8OnYftpaMN6kHw2VDZEWf+MSf/pzZbNMK59G8g8AAAAAAABTN0nY29srixYtkksvvVTOP//8ceVr166Vq666yiQKTzjhBLn77rtlyZIl8vLLL8u8efNMnaOPPloGB8fPxPv444/L7NmzXe2Pbse+ra6urki3W31Y9OdgMBi1LNWyCw+6UHp6emR+4/xIEjDZpB+xdHv6yIZkv0sut+t2faf1ndTL5LnP1vHNBM69u2PCuc/+e2qqXfdul+cDrnt3xyThOR7qE2/nNgn0/1Okd7dIz27xdO8S6d4pMzq2SfDwsyXw7iuyeh4BAACAKZck1ISfPhJZvXq1XH755bJixQrzXFsRPvbYY7JmzRq55ZZbzDJthZgpus0bb7xx3PLW1lYZGBiICsA7OzvNlwOv1xtV123Z0pal0lnRKdOmTQstGxUJdAekvXt868LJlux3yeV23a7vtL6Tepk899k6vpnAuXd3TDj32X9PTbXr3u3yfMB1n/yY+EYHxNvXKt5ev/j6WsXTu1tK92yXoZFO8fW3mTJfr19KhrqkOc62PCJSLiJ9VS3Std/SrJ3H7u7urG0bAAAAU1/eJgmTGRoaMgnA66+/Pmr56aefLs8880xWXvOGG26Qq6++Oqol4dy5c6WpqUnq6uqivjR4PB6zPN4XRjdlyernWrb2Ld3tul3faX0n9Tj36eHcc90Xy3Xvdnk+KNrP/LoKk+ATbe3Xoy3+domnW1sA7pJg9y5p7nw7lBQc6pFMqAj0SEVzvDRiZlRUVGRt2wAAAJj6pmSSsK2tTUZHR6WlpSVquT7ftWuX4+2cccYZ8vzzz5uuzXPmzDHjHh577LFx65aXl5tHLP2SEftFQ79YxFueSlmy+rmWrX1Ld7tu13da30k9zn16OPeZOQ7ZxHXv7pgkKnO7PB8UzLnXv93DPeLt8Ztuvtrl1yQBoxKBu6Sla6d4R/qSb8fpTpZUitTOlGBNiwyUTpeKpn3FUztTpGamWR6obpbWAZ80zV2Q1XOfj+8rAAAA5I8pmSS0fzGw0y4/scuS0e7JAACgAOgYvINdYwk/W9LPenh6dkmzSf71J92URhJOoolASZV46maFEn72pF9Ns+wdKZfpcw8Vb90skfI6DVokqF2U/X4pb24Wjz1hp2MY+v2mDibX0qVL5Q9/+IOcdtpp8vOf/5zDDwAAitqUTBI2NjaKz+cb12rQ7/ePa10IAAAKJfm3U0S7+5p/Qy3+6ju2imewI1SeoeRfsLxWRisbxTdtn7EEYO2scCKwxfwcqG4Sf2e/NMcm/FQgIEOa9Gts1uZ76f3+yKorr7xSLrvsMrn//vs50gAAoOhNySRhWVmZmbl4/fr15g6wRZ+fe+65Od03AADgMPk30Cm+PW+I9P4j3O3X6v4bnQxMlPzThF+Zi4MdLK8LJf+mzzEtAEMJv+hWgKZbcEmltPn98ROAFjNTcPKkJPLf4sWLTUtCAAAA5HFLwp6eHtm8eXPk+ZYtW2TTpk1SX18v8+bNM5OIXHTRRXLMMcfIcccdJ/fcc49s3bpVVq5cmdP9BgCgqJmWf91jLf8iST9719/Qcu9wnzRl4iUrponHluSLTfpZz4MlFRMn/yIJQOS7DRs2yK233moms9u5c6cZW/q8886LqnPXXXeZOlp++OGHy2233SYnnXRSzvYZAAAgn+VtknDjxo3m7q7Fmll4+fLlct9998myZcukvb1dbrrpJhP4LVy4UNatWyfz58/P4V4DAFDANPnX649O9kWN/Rd+Ppx4wg9XKqaFuvmGu/jGJv10wg//gE+aZ89LnvSzkPwrKDrx3KJFi+TSSy+V888/f1z52rVr5aqrrjKJwhNOOEHuvvtuWbJkibz88svmhrMbg4OD5mHp6uqKzIStD4v+rGNk25fZJSp3uzzXsrVf6W43lfWdrpPquU21jHPvjtvj5aY+576wrvtMXfMT1eG6z/y5S3f9Yj/3AYfbztsk4SmnnGIOUjKrVq0yDwAAkIah3ugkX8zPoQk/dpiWfxlL/mnLvtqZodl+G/cNdf+1xv6zugGXVibfjgY7OvYfipIm/PSRyOrVq+Xyyy+XFStWmOfailAnrVuzZo3ccsstrl5L6994443jlre2tsrAwEBUAN7Z2Wli2HizSScqd7s817K1X+luN5X1na6T6rlNtYxz747b4+WmPue+sK77TF3zE9Xhus/8uUt3/WI/993d3VM7SQgAANI01BfTys/e9deWEBzqzsiEH1KuLf9aYrr72pJ/VivAcPIv4Wy/QJqGhoZMN+Trr78+avnpp58uzzzzjOvt3XDDDZFeLVZLwrlz50pTU5PU1dVFBfkej8csT5RIilfudnmuZWu/0t1uKus7XSfVc5tqGefeHbfHy019zn1hXfeZuuYnqsN1n/lzl+76xX7uKyoqHNUjSQgAwFQzMhinxV+crr8DnRl5udBsv03im66z/c4KJwJnh/+1tfwrq87I6wHpamtrk9HRUWlpaYlars937doVeX7GGWfI888/b7ouz5kzx4xreOyxx47bXnl5uXnE0kA+NpjXID/e8onK3S7PtWztV7rbTWV9p+ukem5TLePcu+P2eLmpz7kvrOs+U9f8RHW47jN/7tJdv5jPvdfhdkkSAgCQL0aHRTq3h8f9i23xZ2v519+RmdcrrRYxs/zaJ/mIaflX0yLB0ipnE34AeUYDbjvtxmNfpt2PAQAAEEKSEACAbBsdGZvwo2uHVO54XTx/77W1+tslnu6dMrOvLTOvV1KZuKuvtvqr01aAM0XKa51tL88mTQAm0tjYKD6fL6rVoPL7/eNaFwIAACCEJCEAAKkKBsSrib2du0R6o8f783TtlIY928Uz0CbSo5NrhCbj0nZ40+JsytGYf77yOMk/+8y/4a6/OjFITAsqoJiUlZXJ0UcfLevXr5elS5dGluvzc889N6f7BgAAkK9IEgIAECsYFOnfIyUdr4l0vRiTABzr+uvp2S3NgZG4x09TdKVOj6y3VIK1LTJc3iCl9fOiZ/q1TwJSOYPkHxDW09MjmzdvjhyPLVu2yKZNm6S+vl7mzZtnJhq56KKL5JhjjpHjjjtO7rnnHtm6dausXLmSYwgAABAHSUIAQHEl/wa7xLfnDZHef4j0xJvtN/Svd3RQGifY3ERt9YIer2nZ57ESfXWzJFAzU7qDVVI7+yDxTtNuv7NEKutNO8MOxv0DHNu4caMsXrw48tyafXj58uVy3333ybJly6S9vV1uuukm2blzpyxcuFDWrVsn8+fP5ygDAADEQZIQAFAYhvvGxv2zEn5dO8a1/vMO90pTJl6vukmCtTNlsKxeyhvmhxKBpgVgqPVfoLpF/L1BaZ45K3qyj0BA+v1+qW1u1mnGopYDcO6UU04xE5Eks2rVKvMAAADAxEgSAgDy28hQuMVfbGu/0MPTvUuaO3eId6grM6+nXXprZ0mwZqb0l06XyqZ9xaMTfdgn/NCffaUSDARkb6LWf5r069exCAEAAAAg/5EkBADkRmBUpLdVpHOHlG//h8i2/rHuv122ZOAEM/5ql19HU3SU15kEnyb/BkqnS4WV/LN1BTb/llaY6poA7PL7pSJeAhAAsq39DZG926Vs7x6R3hkiXuuTLs4n3riJimKeO5rIaII69m0EAlK6Z4/IgO6XN7VtxKPb3btXZEjHX03hczeo+xVe3+nntvW7TLSOvV683yNoL/c6KAtGb3cw5vUTLY/abvKWtM5MsI3Y1wjazr3jc+RgPwOjoXPXPz21c2/eO3tE+uzXSrL6wfH1Ex3PYFDK9oTrxj339vLxrzP+Gp6gLNk6uZRwv9Lcx6A4OHdJPtOsz42J3pPWOpFrqz66fuy5jfd5FFsnGJTSjj0iw+E69uKgSElHh8hI/fjPyWAwVDa6M+a6D0qJ7ltgd+i1ol7P9nNkuSe15/F+l2TrBIPi7W4XKRsQ8fomrh+3LP52PQN7RPpLbcfBWj/Ruraf9ZodHRIZGQzt17h9sNVlQr/sJQl/97vfSU1NjZx44onm+Z133inf//735bDDDjM/z5gxw+0mAQCFRP9g93UkHOtPusNdgDUhqLMDi0g6fzmCJZUyWtUkvun7iMd09Z0Vfwbg8tpQ/UBAOv1+KSf5B6SEWHCS/OVu8T57t9RL/tHP7YY83G4q6ztdZ6J6ycpTKcvWMU5XoZx7N/W1bn2K5amUTfR6uZKt/crXc++k3kTXdqPLsmTr5JLuV3OWttuS5vozXb9eTMIx6l9TIB6PJ7RfkSRybD2tI9Ic1CreceX6X5MmQKMSqlaZSFMgKB6fb9w6jaMBkX99QaZckvDaa6+Vr3/96+bnF198UT7/+c+bgaJ///vfm39/+MMfZmM/AQB5wDPUI9K2N0733x3Rz/WuXrq8peEkn5Xoi5f8mynBslppa22N3+UXQMYRCwIAgKnIY7VstloOx2lA7HG0ncT1dLnPZZknnJwL5EGLR9dJwi1btphWg+oXv/iFfPCDH5SvfvWr8vzzz8uZZ56ZjX0EAGTb8IBIj070YY31N378Px37r0WThGnziNQ0RxJ9OvlHj6dWqmceKF7t/mtN/lEZ2z0jASb8ACYVseAkOWCxBEurpLevT6qrqkzLhrjfZsZ1kQym0CXV3To6YUxfX59URfYrM11fg8HA+O2mur7DLpBBCTpaZ1y9mP2Le0zSKDPL+/ulqjK1YxGR4S+cprNAf194v9y8TvJy/X17+/tt73W3+xWU3j7n64fq268tazc9zusmLPc4WjdR2USvN3mir+mU9svB58LE203++eToc8O2jnkP9/VO+Pk1brtxPmujrt94ZeYarrB9toS2Eb8s9Jr9/f1SGVlue83I68ckuWKPUeTH2HpOthX/ue7XwMCgVJSXhy6RZPXHDVEQTFhP/xscHJTystKx33dc/UQ/h/ZreGhYSktL7Ecx/nr6esGgDI8MS2mJ1rfVi9ovkaAEZGR4WEpMveht2Pd9dGREfD6veGLK9XUCo6PiNWUyviwwKl7TejB6uf4++cB1krCsrMxcCOp///d/5eKLLzY/19fXS1dXhgaNBwBkxuhIeMbfRLP9hh/9eybclKNwUBN7sS3+bDP+mn+rm0V8Y39+tPtvr98v1bGz/QLIS8SCk+TgJRJccIb0+P1SlWctpfVzu9vvl8oM71e6201lfafrTFQvWXkqZdk6xvl87tN5r7td3039ieomK0+lLN1jkS3Z2q9MnHs378lMXfPZuu7zcTzsbA3Vk3QCQIfrd7hY32n9YCAg7RPU0zptCepoWavLMl3u1+UyBZOEOhahdis+4YQT5Nlnn5W1a9ea5a+99prMmTMnG/sIAIhlboO2R7f2i9cKUBOEmbgrVVZrWvwNVTRIWf088UQSf7YEoM74G570A0DhIhYEAAAoTK6ThHfccYesWrVKfv7zn8uaNWtkn332Mct/+9vfygc+8IFs7CMAFA8d5Fa79Lbq7HEx4/7FtgIMDKf/er7ysRZ+sS3+zL+zI5N+6B2uPWnc7QNQGIgFAQAACpPrJOG8efPk17/+9bjl3/72t6Oef+1rX5OVK1fK9OnT09tDACgUw/22JN8O0/Kvdvcb4hntiiT+zLh/w73pv5bHF2rZF5UAjJ30Q8f9m5Hx8YoAFDZiQQAAgMLkOknolE5m8uEPf5gkIYDCFxgRr872O7w91Pov0uJvp3i6dkrD3u3i6fOLDOyNWk3b4lXHbMpRuq6qIdzCzzbz77hx/5pEvInm1QKA7CMWBAAAmFqyliTU2VkAoBDG/Stp+4dI59/CCcDx4/55ev3SnGDcP036lTp9vfK60Lh/5fVS1jBfPFZrP3sCUFsHlpRn8rcEgKwgFgQAAJhaspYkBIC8Ntgtvr3/FOn9h4i2ArTP9GvG/9sp0rNLvKND0jjBpiZq/Rf0lZkkn8dK+NWEZvwN1LTI3pFKmT7vUPHWzRYpr2HcPwAAAABATpAkBFBYRgZDM/pa4/4lmPjDO9QtTem+lsdrWvYFa2fJYNkMKW/U1n+zo8b/C9TMFH/XkDS3tIyf7CMQkCG/X6ShWYSJQAAAAAAAOUSSEMDUEBgV6W2NGu/P3vLP07VDmrt2iDdm3L+UmXH/ZkmwpkX6S6dLZdN+4tHWfpExAGdHxv3TWX/3Jpr1NxAQ6fZnZp8AAAAAAMgSkoQAcj/uX/8ek/wr2/YPkR39pptvpMuv1QpQuwQHR5N2+XU06UdZTSj5VztTBkqnS0Vs8s8a+y887p8mALv8fqmIlwAEAAAAAKBAZC1JeNJJJ0llZWW2Ng9gKhjqixnnL34rQBkZMDP91qfxUkFvqQSqmsU7fXY46Wd1+Q0nAHWZTvpRUReqHwhIp98v5ST/gLw2Ojoqw8PDccsCgYApGxgYEK+DJL7T+k7qJauTqMzt8lSVlpaKz5f72c2JBQEAQDoKKQ6crFgw3TjQUZKwq6vL8Qbr6kJfwNetW5fyTgHIc6PDIp3bQ2P/xUv8mRaAu0QGOzPwYh6RmuZQgi+S/AsnAG0tAIMV06W1tS1+l18AU1JPT49s37494Sy5ulyDqu7ubvF4Jm5L7LS+k3rJ6iQqc7s8VbqNOXPmSE1NjWQKsSAAAJhMhRYHTlYsmG4c6ChJOH369Al3VH8praOZ3qmkr69PDj30ULnwwgvlm9/8Zq53B8gtHT+vry1By7/QRCCe7l3S0tsmHon/Ye1KxfRIwk8n/+j11knVzANCM/1aiUBNDvpKnO07gIKh8YQGhlVVVdLU1BQ3DtHYY2RkREpKShwHh07qO6mXrE6iMrfLU6Hbam1tNcduwYIFGWtRWMixIAAAyC+FGAdORiyYiTjQUZLwiSeekEJ18803y7vf/e5c7waQXXr3ZbArcZdfq+WfjgUYGEm6KUcfWSWV4Rl+ba3+zGQfMc9Lx4Yk0O6/PX6/VDUz0y8AMV0uNNDRwDDR8CVTLTicjCSh0mP25ptvmmOYqSRhIceCAAAgvxRiHDhZsWC6caCjJOF73/teKUSvv/66/OMf/5Czzz5bXnrppVzvDpCa4YGoln6RBKCV+LMSgcN96R9hb4mZ7Xe4olFK6+eGxv6L1w24Ypq2c+aMAkhbJpJmxSYbx6xQY0EAAJC/iAMn/5ilNHHJ3r175b//+7/llVdeMTtw2GGHyWWXXSbTpk2TTNmwYYPceuut8txzz8nOnTvl4YcflvPOOy+qzl133WXqaPnhhx8ut912mxkk26lrrrnGrP/MM89kbL+BjNEWfdrqr3d39Cy/sclAnRk4E6oaba39Ymb6NctnmzraybjD72fsPwAoYpMRCwIAAGByuU4Sbty4Uc444wzT5PNd73qXaRa5evVq02338ccfl3e+850Z2bHe3l5ZtGiRXHrppXL++eePK1+7dq1cddVVJlF4wgknyN133y1LliyRl19+WebNm2fqHH300TI4ODhuXd3Pv/71r3LQQQeZh5MkoW7Hvi1rAG8dXFIfFv3ZGnQyltuyZPVzLVv7lu523a7vtL6Teo7Pr3b97e+ItPYLdu2U6t1viAS6JKjdfbt3iad7p7T0toonmP7xDZbXjs3wa8b4mylBa8IPbQVoJQJ9ZY62x7lP49w7KOO6L9DrPo3l+SAX171VZj0SscqS1Umlfrx6++23n1RUVJiHuvbaa+VjH/uYqeP3+2X58uXyxhtvSHl5udx+++1yyimnmDId/3jFihUm9tCE2te+9jX50Ic+FPf1tFxjDB1suqOjQz74wQ/KcccdZ8ZNdnpn2Dpm8WKUTJisWBAAACCf7LvvvpFYUOOfG264QT7ykY+YMo0FL774YhMLlpWVyfe+971IIzaNBS+//PKoWDBenktpuU5gYsWCZ511lhx//PGuYsFJTRJ+7nOfk3POOUe+//3vm/7SSvtOa/CrSTttAZgJmvDTRyIajOpB1tdV2orwsccekzVr1sgtt9xilmkrxET+/Oc/ywMPPCAPPfSQmTVH+2vrzMxf/vKX49bXbd54443jluugkDpNtT0A7+zsNG+YeNNduylLVj/XsrVv6W7X7fpO6zupZ2Yjatshvj1vSEl/q3h7/eLr3W3+1cc0bRU42C6evlbxBKKnca91/ZuKBH1lMlrVLIHqFhmtbpZAVbOMVrdIIOrnJgmWViff0JCItO91/Lqce3fHhOu+8K97t+fe7fJ8kIvrXv8ua7nGGPqIR9ezJslwOhaNk/rJ6v3sZz+ThQsXRurofmqdL3zhC3LsscfK//zP/5gAUANGHdKktLRUvvGNb5h/9UamBo6LFy82QeOMGTPGvZ7S33fr1q0mKNSJ1f7t3/7N1WQgur4eu/b2dvO6Fg04M2GyYkEAAIB88/Of/9z0ZLXGELRcf/318p73vEd++9vfmnyTxoIa92kdTfDpTWQd8k4fJ598spx66qmRWDCeHTt2mJuyy5Ytky996Uv53ZLQHhSajZSUyHXXXSfHHHOMTIahoSGTANSTYHf66ac77jqsST8rmXjfffeZMQkTJQiVZoivvvrqyHO9yz937lwzKKQmFy0alOuXBV0e7wujm7Jk9XMtW/uW7nbdru+0fmCoX0q635b6wQ7xavdfbe2nSb9wyz9r3L/ZQ72SrqDHK1LTbMb9K5mh4/7NkmBNuBtwTbg1oLYErJguXo9HvKmOG5Ciojv3Dupx3aen2M692+X5IBfXvd6A06SWxhj2mCMeeyLMCaf149WL3R+rjgaM//znP02ZtvxraWmRv/zlL6Y1oZb98Ic/NHUPOOAAExj+5je/kUsuuSTu67311ltywQUXmLjjU5/6lKvfzdpHPZ4NDQ2RVo/K/nM68iEWBAAAyCcPPvigbNmyxfys8ZDGgn/84x9NLKg9YTXvZPVM0Vjw0UcfHRcLWjS5qC0NP//5z6cUC6bDdW5BE2J6d/uQQw6JWr5t2zaprU2lPZR7bW1t5o66HnQ7fb5r166svKZmffURS4Pw2C82+oUn3vJUypLVz7Vs7Vu623W1fmBEfH1+8e7aIV6T8NsZd+IPb3+HNEv6gpX1ock+rK6/tbMlUNMinYFKmTbnEPFO20c81U0SEE/UuH/5Nmx/QZx7F/Wd1OO6T0+xnXu3y4vxutfnWmY9zr79j9LaPX4IkaAExePiUzJR/abacvmfz54YqhMMRloQxrYk/PjHP26Sm9rN9j//8z9l1qxZpiuILtPPbGv9+fPnm3hJ19d/tXuKtT0t07jJ2rb99dT73vc+03X3iiuukFRYxyz2uGbq3OVDLAgAAIpLvFgwU3FgbCyYzL/8y7+YuE97kGi3YY3/tPeGLtMb39YQMhr7abyk9F+N/yxWnJjIaaedllYsOKlJQm3qqN18tbmk9ovWIFSzozouz0c/+lGZTPGmk06lj3ai7C2mML0we9vjz/qr/2orQG0N2OuX5gyM+ydlNRKsnSVD5fVS1jBPPNZEH+FJPwI1M8Xf55Hm2XNN0i9KICCDfr+Ifrm0yvJwTDIAyCUNCnd1jQ3vkQvajVbHPdYuxl/84hdNPLRu3bqEMYmdvXyi8RC1m/EPfvAD000lHycCyadYEAAAFId8igWHhobMcDCaSyq0WNB1ktAaLFEHZLTGCNLuMdoEUrOok6GxsVF8Pt+4VoM6UGRs60IUoIGu6IRfuKuvPjxdO6Wx820z7p+M6mB7yU2YUtbJPGpnmgTgQOkMqWjaN5QAjMwCHJ70o7xWgoGA7Ek0668m/Yb8af3aAFDM9O5uPJlsSTgRa2I0jXt07L2DDz7YPNduvdY4xXoHWendYau+/vvmm2+a+MUqO/PMMxO+zh133GGGVNEWhToRSLLxanIhH2JBAABQXOLFapluSegmFrzyyivN2ISxsaAV7+nwMVMxFnSdJNRZWr7zne+Y8fy0n7RmQA888ECpqqrKzh4m2AeduXj9+vWydOnSyHJ9fu65507afiDDhgdMF9/SnX8XaR0U6dltSwDakoJDPQk34XH6pjbj/rVIsHamDJbVS3njfPFEZgC2JQArZ2jK3yQAO/1+KY+XAAQAZF287h8ag1iDRjuduMRNfbve3l7TgnD69OmRCUyOPPLISLlOMHLnnXfKV77yFTNxye7du+XEE0+MKtNxCXWsmieffNLMeJeI7pvW1+BTg0ONb+rr6yVf5EMsCAAAijsWnMw4MF4sqOMMHnXUUWKx4r3/+I//MOM3a6O2qRgLpjzfgQaC73jHOyRbdMbhzZs3R57rgdy0aZM5MJqF1cG8L7roIjMgpA4Qfs8995hs7MqVK7O2T0jR6LBIj39cq79xrQH795hJOEI5+NQFKmaIZ9rscIu/0Lh/keSf9W+Ndu31meTf3kSt/wAACNOknw4grWMia5C5//77m24glq9//esmLlmwYIFJomkQaE3sod1wL7vsMlOmQZ/eHXYS6H33u981LRat4NC6S50vsh0LAgAA5GssuO+++8r9998/LhY86KCDTEvDH/3oR1MyFnSdJNTZBm+//XZ54oknTPdeHZzR7vnnn8/IjmnmdfHixZHn1szCy5cvN7PC6Hg4OjjkTTfdJDt37pSFCxeavuD2wSCRZTqWX29ruMVfggSgTv6hdSR5n3tHymrDM/vauvnGJAAD1c3i7+gk6QcAyChNCr7wwgvj7kZbdLgT7Q4Sr6y6utrcbbbfwU4kdoya2267Le/O5GTFggAAAPkYCwbjxHRWLBivbCrFgq6ThJr91AzmBRdcYGb2S6WZphM6TfREgzmuWrXKPJBhetwH9sYZ98824Uf3Tmnp2S2ewNiXoJT5yiOJPh37r89XJ5Ut+4vXTPxhJQRbzLh/E2LCDwAAsmqyYkEAAABIficJf/Ob35gWeyeccEJ29gjZNdgTP/kX2wpwJPmsQY6+Dnh8Zty/SMs/+8/2VoDhcf+Udv/t9vul0j7TLwAAyBvEggAAAIXJdZJwn332kdpaBy26MPmTfvTsSpwA7LIm/ejOyMsFq5tkpKJRSurn2sb+sycAZ4lUN5px/wAAQOEolFhw27ZtZuwg7TKt3X7+/d//3QwsDgAAUKxcJwm/9a1vyRe+8AUzEwvj/03SpB+d20V6/Qla/41N+pERFdPHEn2mu+9MWyvA8HOdFdjjk3Ym/AAAoOgUSiyoiUEd50dnqdZE4Tvf+U4588wzzbhBAAAAxch1klBnE9YBq3XQRp3VTmdtsevo6Mjk/hWvkUHxfHuhtPS2iicTk36UVsd09bVP+mGb+be00tn2GPsPAICiVCix4KxZs8xDNTc3m1kGdd9JEgIAgGLlOkn40Y9+VN5++2356le/amZvYbDqLCkpFxkdnDhBaCb9aIme5TcqGRhuBVhRl609BQAARWSyYsENGzbIrbfeKs8995zs3LlTHn74YTnvvPOi6tx1112mjpYffvjhpmXgSSed5Pq1Nm7caGZpnjt3bgZ/AwAAgAJPEj7zzDPypz/9SRYtWpSdPcKYWUfKUO9eKR037p/tX9ukHwAAANk2WbFgb2+veY1LL71Uzj///HHla9eulauuusokCnVCvbvvvluWLFkiL7/8ssybN8/UOfroo2VwcHDcuo8//rjMnj3b/Nze3i4XX3yx3HvvvQn3Rbdh305XV5f5VxOL+rDoz8FgMGqZXaJyt8tzLVv7le52U1nf6TqpnttUyzj37rg9Xm7qc+4L67rP1DU/UR2u+/TOhVVmPRKxypLVSaV+0EG9ZHVSKXP7uyTbL+u4xsYoWUkSHnLIIdLf3+92NaQgeNEj0sG4fwAA5IUrr7xSfvWrX8lbb70l//d//2diIouOaaeJpjfeeEPKy8vljjvukPe+972mrK+vTy6//HL561//alrdfe1rX4skvTRg0+3+9re/NWVXX321rFq1Ku7r77vvvvLrX/9aFi5caLr7Llu2TCorK+XHP/7xuC6/2TRZsaAm/PSRyOrVq81xXbFihXmurQgfe+wxWbNmjdxyyy1mmbZCTEYTf0uXLpUbbrhBjj/++IT1dHs33njjuOWtra3mXFj0fHZ2dprg3Ov1jqufqNzt8lzL1n6lu91U1ne6TqrnNtUyzr07bo+Xm/qc+8K67jN1zU9Uh+s+vXM3PDxsykdGRswjHl1vdHTU/OykV4PT+sEk9T73uc+ZWExjQY3rjjjiiEgdjQUvu+yyqFjwxBNPjMSCn/zkJ03PBf1db775ZhN/WMdBt/u73/3ObEtvgK5cuTLuvi1YsMD0rLBiwY997GMmFrzvvvsisaAeL92m3gS1x4fd3d3ZSRJqYPv5z3/e/FLveMc7xgWldXV0awUAAIXnggsukOuuuy4S8Nldf/318p73vMcEeM8++6yZJXfz5s0mTvrmN79pgsXXX3/dPE4++WQ59dRTZcaMGfKTn/xEXnnlFfn73/9uWs5pyzctsycgY2krtnPOOcfU0VZ0k508yodYcGhoyCQA9bjbnX766aaloxP6JeCSSy4xx1tnOU5Gk4iawLWfA+2a3NTUFPX7alCuAb4uT5RIilfudnmuZWu/0t1uKus7XSfVc5tqGefeHbfHy019zn1hXfeZuuYnqsN1n9650wSYJrV0kjF9JOP2RqnT+qVx6ml8p5O36dAmPp8vqs6XvvSlSCyoPS50eBaNBa2J0jSZp89fe+01cyP5fe97n4kFf/SjH8mrr75qYkFNJmosqGWJYkHdntY799xz5eCDDx4XC2q5Pm9oaJCKiorIcvvPGU0SfuADHzD/nnbaaeMCLT3BVsYVAAAgY+5+r0iPf9ziEjN2r/NhNxLWr2kWueLJpOtqci+RBx98ULZs2WJ+PvbYY81EGH/84x9l8eLFplus3uFV++23n9nOo48+ahJUWnbFFVeYQFMnzvjwhz8sDzzwgHzlK1+J+zracm358uXy/ve/3yTrciEfYsG2tjbzOjomop0+37Vrl6NtPP300+b4ayuARx55xCzTVpma+IylSV59xNIgPPaLjR6DeMsnKne7PNeytV/pbjeV9Z2uk+q5TbWMc++O2+Plpj7nvrCu+0xd8xPV4bpP/Vzocy2zHvFiQY3oSsNxnZNIcML64VgwGI5nrP2zs3qJxP4O6qGHHoqKBTUm0VjjlFNOMXGiFQvqxG8aC2rvFI0FtUxjQU3uWbGgxieJYkGNgXS9RLGgdcxij6vT68N1kvCJJ55wuwoAAEB6NCjs3hG1yO2IvNkawVe7c+jdcL0Tbpk/f75s3brV/Kz/6nMnZdqlWLuiJKJ3sD/xiU9EutPmQj7FgrHBuz2wn4i2CM23sf4AAICzWDBf4sDYWNAaU1BjuqkYC7pOEsbLnMaj4+ncdNNN0tjYmMp+AQAARN/djREe3tnVHeSE9eNsP91kVaJyN2WxzjrrLHOnWuOsXM3Emw+xoG5TW1/GthrU8YBiWxcCAIACEBOrZTQOjLP9Yo0FXScJndIxdq655hqShAAAIH3xugIHg2ZwZjNWjZPWY27rO6Rjvlhdga3WhHpX2JphV/998803IzGRlp155plRZUcddZR5rgNhW+vFc+2118rhhx9uuq5oi75kdXMtm7FgWVmZGbNn/fr1kYG/lT7XMXoAAECBx4J5EgfGxoJW3GOP6aZSLJi1wU3SnbYZAABgqtCuH3feeaf5WWe72717d2SCE3uZjlXz5JNPmolHrLJ77rnHjK/X0dFhxqDRWYuT0clTPvWpT5ngUAPJfJVuLNjT0yObNm0yD+vY6c9W9xydSOTee++VH/zgB2byF50ZUMsSzQgIAACQLRfa4j3tLqy9HaZiLJi1loQAAACF5NOf/rSZcESDPh0suqamxsxWrL7+9a+bGXIXLFhgWrn98Ic/jMzGp3d8L7vsMlOm3UnuuOMOMzC10nV0NmS9I2zVPfTQQyfcF22hpwNQa9dfvYusE6IUGg2wdeIXizW7sE7cooN/awCtYwBpl+adO3fKwoULZd26dVHj+gAAAGQjFlyyZImJBXXGYnsseNBBB5lZj3XW4qkYC5IkBAAAcEDvAFt3gYPhLisWHQfv8ccfj1tWXV1t7gpby62AUem4erpNa3mySTe0K4qdJs2sxFkh0rvjE7VG1PF49AEAADBZsWAwTkxnxYLxyqZSLJi17sYAAAAAAAAApgaShAAAAAAAAECRy1qS8OMf/7jU1dVla/MAAADIY8SCAAAAU4vrMQl1xhXtM235y1/+IoODg3LccceZwRkta9asydxeAgAAIC8QCwIAABR5S0KdNU6nby4vLzezp+zZs0c++MEPmuSgDiytM8ppHQAAABQeYkEAAIDC5jhJ+IUvfMHMxPLwww/LrFmzTIKwq6tLtm3bJm+99ZaZyeXmm2/O7t4CAAAgJ4gFAQAACpvj7sb/+7//K7/85S/lPe95j5xwwgnS2Ngo69evl3322ceU33jjjbJixYps7isAAAByhFgQAACgsDluSajdi62EYH19vVRVVcn8+fMj5QcccADdjQEAQMG68sorZd999xWPxyMvvfRSVJkOvbL//vvLkUceKUcddZR85zvfiZT19fXJRz/6UVmwYIEcdthh5qarJRAIyGc/+1k55JBDTPldd92V8PX1ta3XHRgYkHPPPVc+8pGPyPDwsEwGYkEAAFDMrgzHgl6vN2EsqHHgMcccI9/+9renZCzouCVhc3OzSQLOnTvXPP/MZz5jkoX2wLG6ujpjOwYAAJBPLrjgArnuuuvMGM3xfPe73zXDsejwLCMjI5Hl3/zmN82Yzq+//rp5nHzyyXLqqafKjBkz5Cc/+Ym88sor8ve//116e3vl6KOPNmUaKCaiw72cc845po4GkhqoTgZiQQAAUMwucBALnnXWWSYOLCkpmZKxoOMkod4Z/9Of/iTvete7zPOvfe1rUeV//OMf5YgjjsjYjgEAAFiW/XqZtPW3jT8gQRHxuDhOCeo3VjbK2g+uTbqqBnSpWLt2rdx3333m5/32289s59FHH5VLLrnElF1xxRXi8/nMzdcPf/jD8sADD8hXvvKVuNtqbW2V5cuXy/vf//5xsVi2EQsCAIBciRsLZigOVMSCLpOEGswmo8lDnfV4qnj11Vdl2bJlUc9/9rOfyXnnnZfT/QIAAONpUOjv8+f1obn22mvlhhtuMN1IbrrpJjnooIPM8q1bt0YN0aI/67J4ZdqNZOPGjQlf48ILL5RPfOITcsstt8hkK7RYEAAATB1TKRY85JBDzM1cHZZvqsWCjpOEEzn22GNlKjn44INl06ZN5ueenh5zIvSuPAAAyD96dzeuDLYkTMePf/xjMySLdjW+4447zE3Hl19+OVKu4xhGdiGoOyGOymJpF5aHHnpIVq1aFRkCJl9MtVgQAABMHXFjtQy3JMxELKhjDN5+++1y9tlnT8lYMKUk4dtvvy1PP/20+P1+cwBiB3Kcan71q1/JaaedxpiKAADkqXhdga2x/3TMF3twlYjb+m5YQZpuV8dt1jvJ7e3t0tjYKPPmzZM333zT/GzdMT7zzDPNz1aZDnKt3nrrLbMsEd3u4YcfbgbHfuKJJ5LWzaZCiwUBAMDUigXzKQ6MjQU1gfeFL3zBxIINDQ1TKhZ0nST84Q9/KCtXrpSysjLzy9oPrv6cqcBww4YNcuutt8pzzz1nJkx5+OGHx3UF1gEatY6W60G67bbb5KSTTnL9Wg8++KBcfPHFGdlvAABQXDTg1CCwpaXFPP/FL35hftY4yeoWcuedd5oYasuWLfLkk0/K9773vUjZPffcYwaf1kGodYzC3/3ud0lfTwfM1gGqreDQ3kVlMkxWLAgAADAVY8Ff/vKXUzYWdJ0k/PKXv2we2s86m7Pp6awuixYtkksvvVTOP//8ceV64K666iqTKDzhhBPk7rvvliVLlpjmnFYmVWeFGRwcHLfu448/LrNnzzY/60nQO+E6SHgyuh37tnQ9pXfP7XfQ9WfNUMfeVU+lLFn9XMvWvqW7XbfrO63vpB7nPj2c+8wch2ziund3TBKVuV1erOfeKrMeiVhlE3XNcFs/Xr1Pf/rTpvfBrl27zBAl1dXVsnnzZhkYGDBdPzRO0NhI7xJrotBa/5prrpHLL79cFixYYJJo2h1ZZ7PTso9//OPy7LPPmnEMtUzr6jg2ifbPOh6f//znTX0dA/D3v/+9mRAltk68GCUTJisWBAAAyCef/vSnzRjNGgtq/qmmpsbEghoD2mNBTQ7ax3LW1n+XXXZZVCyoE9apiy66yMSC2vDNqnvooYdOuC8aM+praSyoiUJ7LDipScK+vj75yEc+kvWgUA+4PhJZvXq1CbhXrFhhnmsrwscee0zWrFkTGcBRWyFORE/cGWecIRUVFUnr6TZvvPHGuLMM6pcDewDe2dlpgvPYY+S2LFn9XMvWvqW7XbfrO63vpB7nPj2ce677Yrnu3S4v1s/84eFhU653ZvURj643OjpqfnbazcRJ/UT1vvOd75iHvY7uZ3l5ufzpT38at76W6fpa/pOf/CSyXGcytv9OGsNYy7V+ot/39ddfN/9a5dpiz2q1Z19Hf9Zjp3e0S0tLI8u7u7slEyYrFgQAAMgnd955p3nYuy4rvXFsTTYSW2aVa0O3eGUa/+k2nXSF1m7JdldffbV5ZJLrJKEm5nSQxOuvv15yZWhoyCQAY/fh9NNPl2eeecZ1V+NPfvKTE9bTu+X2g68tCbXPeVNTk9TV1UWWa1CuJ1WXx/vC6KYsWf1cy9a+pbtdt+s7re+kHuc+PZx7rvtiue7dLi/Wz3y9AadJLQ2W7IFUPPZEmBNO6zupl6xOojK3y93S42XdxbbfBJ3ohuhUigUBAACQea6ThNqi7oMf/KDpI/2Od7xjXECrLfyyra2tzdxxt/p7W/S5Nvt0SlsvaLNOq0tQMtoKQB+xNAiP/WKjX3jiLU+lLFn9XMvWvqW7XbfrO63vpB7nPj2c+8wch2ziund3TBKVuV1ejOden2uZ9YhH78ZaZU5bEjqp76ResjqJytwuT5V1zGKPa6bOXT7EggAAAMiDJOFXv/pV06334IMPNs9jB6ueTMmCciemTZsmu3fvzsKeAQAAFKZ8igUBAACQwySh3h3+wQ9+IJdcconkig4Irv22Y1sN+v3+ca0LAQAAkDn5EAsCAAAg81z3O9EutzqbcC6VlZWZmYvXr18ftVyfH3/88TnbLwAAgEKXD7EgAAAA8iBJ+K//+q9y++23S7b19PTIpk2bzENt2bLF/Lx161bzXCcRuffee82d7FdeeUU+97nPmbKVK1dmfd8AAACK1WTFggAAAMjzJKFO9HH//ffL/vvvL2effbZ86EMfinpkik4ffdRRR5mHlRTUn7/85S+b58uWLZPbbrtNbrrpJjnyyCNlw4YNsm7dOpk/f37G9gEAAMCabfm8886Tgw46yMQdS5YskTfffDNqyJMPfOADsmDBAjOZx9NPPx0p6+vrk49+9KOm7LDDDpNf/vKXUTM8f/azn5VDDjnElN91110JD/i+++4rL730UmR/zj33XPnIRz4iw8PDk3qSJisWBAAAyMdY8KijjjKTuMWLBa1Y8Y9//OOUjAVdj0k4ffr0SQkATznlFDMRSTKrVq0yDwAAgGz75Cc/aZKDOjmHtqTTGOTxxx83Zddff7285z3vMTP+ahLtwgsvlM2bN5uZf7/5zW+aLrqvv/66eZx88sly6qmnyowZM+QnP/mJ6RHx97//XXp7e81wKlqmgWIiXV1dcs4555g6GkhO9mzYkxULAgAA5GMsqL773e/KFVdcMS4W/O1vfyt//vOfTfLujTfekJKSkikVC7pOEv7whz/M2IsDAAA4seX8C2SkrW3ccr2h6GZG3UT1SxobZb9f/DzhehUVFXLmmWdGnmsQ+J3vfCfy/MEHHzRDo6hjjz1WmpubzR3kxYsXy9q1a+W+++4zZfvtt58JDB999FEz8YeWaYCpE7LV19fLhz/8YXnggQfkK1/5Stz9aG1tleXLl8v73/9++drXvia5QCwIAADyIRbMVBzoNhYMBoPy7ne/O2r4FXsseMwxx5hJdTUW1AZwUykWdJ0k1F96ZGTENIO002yo3i3X5o8AAACZpEHhyO7deXNQNSg866yzzM/t7e2mq0hTU1OkXIc/scZR1n/tw6EkK9M4SodcSURbKH7iE5+QW265RXKFWBAAABR7LHjHHXeYLsexsaDVI1ZjuqkYC7pOEmqm87LLLhuXJPzLX/5iJhL5wx/+kMn9AwAAMHd348lkS0KnvvrVr5qbo9q12BK7zdghU+zlbspiaWLyoYceMl2d586dK7lALAgAACZbvFgt0y0J3cSCOqzM3XffXXCxoOsk4QsvvCAnnHDCuOXa7eYzn/lMpvYLAAAgIl73Dw2itHeDjvXiJEB0Wz8eHVNGB5tev369VFVVmWUNDQ2R7h9Wa0K9Kzxv3jzzs/6rA1s3hoNPLbO6q1hl1kRtb731VmS9eK699lo5/PDDTdeVJ554ImndbCEWBAAAuY4FcxEHWrHgww8/bMYejBcLWvGePaabSrGg69EN9WB2d3ePW97Z2Smjo6OZ2i8AAIC8snr1avnZz35mEoQ6eUds148777zT/PzXv/5Vdu/eLSeeeOK4Mu2q++STT5rBpq2ye+65x8RQHR0dZlyaZcuWJd2P6667Tj71qU+Z4FADyclGLAgAAIo5Fnz88ceTxoLaXXjXrl1TMhZ03ZLwpJNOMn2f9cDowIpKfxldZh0AAACAQrJ9+3b5/Oc/L/vvv7+ZjESVlZWZ4VbU17/+dbnooovMcCy6XCf30DvV1h1fa6gWTbDpGDY6MLXSdXQ2ZL0jbNU99NBDJ9yfa665xsxk9973vtfcRdZBsCcLsSAAACjmWPDUU081LRN1MpPYWPCggw4y83X86Ec/mpKxoOsk4Te+8Q0zE8vBBx9sgkT11FNPmSmYf//732dkpwAAAPLJnDlzosaIsbqsWHQGO72rHK+surra3BW2d3Ox6A1XvbPspPuLdkWxu/rqq81jshELAgCAYo4Fg3FiOisWjFc2lWJB192NDzvsMPm///s/My2z3+83XY8vvvhi+cc//iELFy7M6M4BAAAgvxALAgAAFCbXLQnV7NmzzWwuAAAAKD6FEAvq3XrrBvcxxxwj9957b653CQAAYOolCQEAACaDvYsvOGaZpAOOb9q0ibcVAAB5ijhw8o+Z6+7GAAAA2WZNjjY0NMTBdsk6ZtYxBAAAmEqIA3MXB9KSEAAA5GVX0KqqKmltbTUzxOnsbbHsgz8nG+TZbX0n9ZLVSVTmdnkqAoGAOWZ67OyDYk81GzZskFtvvVWee+452blzpzz88MNy3nnnRdW56667TB0t1xkBb7vttsikek7opHtHH320VFZWys0332xmBwQAALlXiHHgZMSCmYgDHa/V09MjNTU1Kb0IAACAGxogzZo1S7Zs2SJvvfVW3DoaUGkwpIGj0+DQSX0n9ZLVSVTmdnmqdDvz5s3LyLZyFQv29vbKokWL5NJLL5Xzzz9/XLnOEHjVVVeZROEJJ5wgd999tyxZskRefvll87srTQAODg6OW1dnHtQxFXWGQP33pZdekrPOOktefPFFqauri7s/uh37tjTBqPS86cOiP1vnM55E5W6X51q29ivd7aayvtN1Uj23qZZx7t1xe7zc1OfcF9Z1n6lrfqI6XPfpnwudLVj/VsfO6Bu7jXgJxHTrBxzUS1YnlTK3v0siug1rJmZ712On14jjJGFjY6MsXrxYzjnnHPPYZ599UttjAAAAB8rKymTBggUJuxxrsNPe3i4NDQ2OAz4n9Z3US1YnUZnb5ekct0xsJ5exoCb89JHI6tWr5fLLL5cVK1aY59qK8LHHHpM1a9bILbfcYpZpK8RkNEGodPISnbH5tddeMxOYxKPbvPHGG8ct17v1AwMDUeeys7PTBOWJvgDEK3e7PNeytV/pbjeV9Z2uk+q5TbWMc++O2+Plpj7nvrCu+0xd8xPV4brPzLmbNm2ajI6Oxh1nT5d1d3ebG5hObxY7qR90UC9ZnVTK3P4uiei62s14796948p0+xlNEr766qvyq1/9Sn7xi1+YO7dHHHGECRDPPfdc8zMAAECmadBYUVGRMLjULiha7vSLgZP6Tuolq5OozO3yfJMvsaAmjTUBeP3110ctP/300+WZZ55xtI09e/aYrjjl5eWyfft20wJx//33T1j/hhtukKuvvjqqJeHcuXOlqakpqvWhnksN0HV5okRSvHK3y3MtW/uV7nZTWd/pOqme21TLOPfuuD1ebupz7gvrus/UNT9RHa77zJ+7eOvrzTo3595J/YCDesnqpFLm9ndJRaJ4OuUk4fz58+Wzn/2seWi2d926dfLoo4/Kt771LZkxY0YkSNTxXBgoGwAAoLDkSyzY1tZmWhVoNyQ7fb5r1y5H23jllVfkiiuuiHTx/s53viP19fUJ62syUR+xdP3YYF63F2/5ROVul+datvYr3e2msr7TdVI9t6mWce7dcXu83NTn3BfWdZ+pa36iOlz3mT936a5fzOfe63C7Kb26Nvn86Ec/Kg888IAJ1HQcGM186rgxmvn86U9/mspmAQAAMAXkQywYrwuP0y46xx9/vBmD8G9/+5ts2rRp3KQoAAAAxSjtae90xhTt3qGP22+/XV544QUzKwsAAAAK32THgjo2orZUjG016Pf7x7UuBAAAwCQmCWMdddRRmd4kAAAApohsx4I6MYvOXLx+/XpZunRpZLk+1+7OAAAAyJMkIQAAAJCOnp4e2bx5c+T5li1bTLdgHTdw3rx5ZhKRiy66yMxGfNxxx8k999wjW7dulZUrV3LgAQAAUkSSEAAAAHll48aNsnjx4shza2bh5cuXy3333SfLli2T9vZ2uemmm2Tnzp2ycOFCM5GKTq4CAACA1JAkBAAAQF455ZRTzEQkyaxatco8AAAAkBmuZzf+yU9+krDs2muvTXd/AAAAkMeIBQEAAAqT6yThZz7zGfn1r389bvnnPve5pEEjAAAApj5iQQAAgMLkOkn4wAMPyMc//nHZsGFDZNlnP/tZefDBB+WJJ57I9P4BAAAgjxALAgAAFCbXScIPfOAD8r3vfU/OO+88M6i0jgXzy1/+0iQIDznkEMlHS5culRkzZsgFF1wwrkxbRR588MGyYMECuffee3OyfwAAAFPFVIwFAQAAkKWJSz7ykY/Inj175MQTT5SmpiZ58skn5cADD5R8deWVV8pll10m999/f9TykZERM1ueBrV1dXXyzne+Uz70oQ9JfX19zvYVAAAg3021WBAAAAAZShJqIi2e5uZmOeqoo+Suu+6KLFu9erXkm8WLF8sf/vCHccufffZZOfzww2WfffYxz88880x57LHH5KMf/WgO9hIAACA/TfVYEAAAABlKEr7wwgtxlx9wwAHS1dUVKfd4POKWjm146623ynPPPSc7d+6Uhx9+2HRfsdPAU+touSb1brvtNjnppJMkXTt27IgkCNWcOXPk7bffTnu7AAAAhSSbsSAAAACmUJIwmxOS9Pb2yqJFi+TSSy+V888/f1z52rVr5aqrrjKJwhNOOEHuvvtuWbJkibz88ssyb948U+foo4+WwcHBces+/vjjMnv27ISvHQwGxy0juAUAAIjG5HQAAACFL6UxCTNJE376SES7rFx++eWyYsUK81xbEWqX4DVr1sgtt9xilmkrxFRoK0J7y8Ht27fLu9/97rh1NQlpT0TqXXMVCATMw6I/a/LRvizVsmT1cy1b+5budt2u77S+k3qc+/Rw7jNzHLKJ697dMUlU5nZ5PuDcF8a5z8f3FgAAAPJHzpOEyQwNDZkE4PXXXx+1/PTTT5dnnnkm7e2/613vkpdeeskkCnXiknXr1smXv/zluHU1IXnjjTeOW97a2ioDAwNRAXhnZ6cJ9r3e6Mmj3ZYlq59r2dq3dLfrdn2n9Z3U49ynh3PPdV8s173b5fmAz/zCOPfd3d1Z2zYAAACmvrxOEra1tcno6Ki0tLRELdfnu3btcrydM844Q55//nnTtVnHHdRxD4899lgpKSmRb33rW2ZiEw3Qr7vuOmloaIi7jRtuuCFq0G5tSTh37lwzo58mGC26He2yrMvjfWlwU5asfq5la9/S3a7b9Z3Wd1KPc58ezj3XfbFc926X5wM+8wvj3FdUVGRt2wAAAJj68jpJmGicQL3T7mbsQO2enMg555xjHhMpLy83j1gazMcG9Lpv8ZanUpasfq5la9/S3a7b9Z3Wd1KPc58ezn1mjkM2cd27OyaJytwuzwec+6l/7vPxfQUAAID8kdfRYmNjo/h8vnGtBv1+/7jWhQAAAAAAAAAKMElYVlZmZi5ev3591HJ9fvzxx+dsvwAAAAAAAIBCkvPuxj09PbJ58+bI8y1btsimTZukvr5e5s2bZ8YBvOiii+SYY46R4447Tu655x7ZunWrrFy5Mqf7DQAAAAAAABSKnCcJN27caCYOsViTgyxfvlzuu+8+WbZsmbS3t8tNN90kO3fulIULF5pZiOfPn5/DvQYAAAAAAAAKR86ThKeccoqZiCSZVatWmQcAAAAAAACAIhuTEAAAAAAAAED2kSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAAAAAAAAihxJQgAAAAAAAKDIkSQEAABA0fn2t78thx9+uBx22GFy5ZVXSjAYzPUuAQAA5BRJQgAAABSV1tZWueOOO+S5556TF1980fz75z//Ode7BQAAkFMluX15AAAAYPKNjIzIwMCA+Xl4eFiam5s5DQAAoKjRkhAAAAB5ZcOGDXL22WfL7NmzxePxyCOPPDKuzl133SX77befVFRUyNFHHy1PPfWU4+03NTXJNddcI/PmzTOv8b73vU8OOOCADP8WAAAAUwstCQEAAJBXent7ZdGiRXLppZfK+eefP6587dq1ctVVV5lE4QknnCB33323LFmyRF5++WWT+FOaOBwcHBy37uOPPy6VlZXy61//Wt58803zs66ricmTTz457v7oduzb6urqMv8GAgHzsOjPOrahfZldonK3y3MtW/uV7nZTWd/pOqme21TLOPfuuD1ebupz7gvrus/UNT9RHa77zJ+7dNcv9nMfcLhtkoQAAADIK5q000ciq1evlssvv1xWrFhhnt92223y2GOPyZo1a+SWW24xy3ScwUQeeughOfDAA6W+vt48P+uss8yYhImShLrNG2+8Me7YhlaXZSsA7+zsNIG+1zu+w06icrfLcy1b+5XudlNZ3+k6qZ7bVMs49+64PV5u6nPuC+u6z9Q1P1EdrvvMn7t01y/2c9/d3e2oHklCAAAATBlDQ0MmAXj99ddHLT/99NPlmWeecbSNuXPnmrqa4CstLZU//OEP8slPfjJh/RtuuEGuvvrqqJaEug3ttlxXVxcV5Gv3aF2eKJEUr9zt8lzL1n6lu91U1ne6TqrnNtUyzr07bo+Xm/qc+8K67jN1zU9Uh+s+8+cu3fWL/dxXVFQ4qkeSEAAAAFNGW1ubjI6OSktLS9Ryfb5r1y5H23jPe94jZ555phx11FEmGD/ttNPknHPOSVi/vLzcPGLpurHBvAb58ZZPVO52ea5la7/S3W4q6ztdJ9Vzm2oZ594dt8fLTX3OfWFd95m65ieqw3Wf+XOX7vrFfO69DrdLkhAAAABTjgbTdtpFJ3ZZMjfffLN5AAAAICS/bkkCAAAASTQ2NorP5xvXatDv949rXQgAAADniiJJuHTpUpkxY4ZccMEF4wZuPPbYY+XII4+Ud7zjHfL9738/Z/sIAACAiZWVlZmZi9evXx+1XJ8ff/zxHEIAAIAUFUV34yuvvFIuu+wyuf/++6OWV1VVyZNPPmn+7evrk4ULF8qHPvQhaWhoyNm+AgAAFLuenh7ZvHlz5PmWLVtk06ZNZjbiefPmmUlELrroIjnmmGPkuOOOk3vuuUe2bt0qK1euzOl+AwAATGVFkSRcvHixmbUulnZV0QSh0tntdBBsHc8GAAAAubNx40YTv1msmYWXL18u9913nyxbtkza29vlpptukp07d5obvevWrZP58+fncK8BAACmtpx3N96wYYOcffbZMnv2bDPY9COPPDKuzl133SX77befmbJZu5c89dRTGXv9vXv3yqJFi2TOnDly3XXXmXFuAAAAkDunnHKKuXEb+9AEoWXVqlXy5ptvyuDgoDz33HNy8sknc8oAAACmcpKwt7fXJOnuuOOOuOVr166Vq666Sr74xS/KCy+8ICeddJIsWbLEdCmxaOJQ7yDHPnbs2DHh60+fPl3+9re/mW4s/+///T/ZvXt3Rn8/AAAAAAAAIN/lvLuxJvz0kcjq1avl8ssvlxUrVpjnt912mzz22GOyZs0aueWWW8wyvXucLp0N74gjjjAtGy+88MJx5XqXWh+Wrq4u828gEDAPi/6sd7rty1ItS1Y/17K1b+lu1+36Tus7qce5Tw/nPjPHIZu47t0dk0RlbpfnA859YZz7fHxvAQAAIH/kPEmYzNDQkEkAXn/99VHLTz/9dHnmmWfS3r62GqysrJS6ujqT9NME4ac+9am4dTUheeONN45b3traasYztAfgnZ2dJtj3eqMbarotS1Y/17K1b+lu1+36Tus7qce5Tw/nnuu+WK57t8vzAZ/5hXHuu7u7s7ZtAAAATH15nSRsa2szk4loKz87fb5r1y7H2znjjDPk+eefN12bdezBhx9+WI499ljZvn27aaVojXPzmc98xrQmjOeGG26IDJqtNKk4d+5caWpqMklGe6CvYyvq8nhfGtyUJaufa9nat3S363Z9p/Wd1OPcp4dzz3VfLNe92+X5gM/8wjj3OrYzAAAAMCWThBYNnO00oRe7LBntnhyPjmW4adMmR9soLy83j1gazMcG9Lpv8ZanUpasfq5la9/S3a7b9Z3Wd1KPc58ezn1mjkM2cd27OyaJytwuzwece3fHJNk5HhwJSltvv/i7B8XfpY9+eXP3HjnuYJEPLJyVtXOYj+8rAAAA5I+8ThLqTMM+n29cq0G/3z+udSEAAECu6A3MroERae0ekF2dA7L57XYZfLVHWruHQsnA7gGTENzd1S+9Q/HHBhyU0qwmCQEAAIApmyQsKyszrf3Wr18vS5cujSzX5+eee25O9w0AABS+QCAoHX1DoRZ/mujrHpTW7kHZ3Tkg29o6pWvoDfH3hFoEDo6kNzGIbh8AAAAo2iRhT0+PbN68OfJ8y5YtpgtwfX29zJs3z4wDeNFFF8kxxxwjxx13nNxzzz2ydetWWblyZU73GwAATF0jowFp741O/u3uCv3r7xqQHR09smfg7yYhOBIIZuQ1q8t8MqOqRGZNr5Lmugppri2X5toKaaopk9LRfnnH/rQiBAAAQBEnCTdu3CiLFy+OPLcmB1m+fLncd999smzZMmlvb5ebbrpJdu7cKQsXLpR169bJ/Pnzc7jXAAAgHw2NBKTVtOwbS/hZY//t7g4l/zr6X5SO3iHJUO5PplWWhhJ+dWNJv0rPsBwwu1FaNBkYTghWlnrNkCnNzc3jJi4xyxuqM7NDAAAAwFRMEp5yyilmHJ9kVq1aZR4AAKA4DQyPmlZ9Y2P7DZjH1tZO6Rp+K1w2aJJ/maDTozXUlJmkXyj5Vx71c2NNmXgHe+TQfWdLZXlp1LqRpF+cZCAAAACQr3KeJAQAAMVrYDggb7X3SlvvcCT5F9UCsFuTgYPS2T+ckdfzeUSaTKu/UOu+ptoKaQm3ALRaAzZWl0mgv1Nmz2xJOCNwKBE4LOWlvozsFwAAAJBrJAkBAEDG9Q2NmOSelezT5J/V2s9KBOq/3QMjGXm9Mp83nPwLtfRrsY/5F16m3YBHevfKzJbEyb9IAnCwKyP7BQAAAEwVJAkBAIBjvYMj4yb5sCf9rPH/egYzk/yrKPVGtfIb6/KrY/+VSslwnxyy7yypry4Xj0c7CUvy5F9f8joAAABAsSJJCAAAIi3/4ib/Ogdk595eae8bkZ7B0YwcrcpSn0n21Vd4ZZ/6WtP913T7rSuXlnAiULsC11WUJEz+WWP/zagqmzBBCAAAACA5koQAABRJt9/dtrH+TAIwPONvJlv+VZX5TFdf7fqr/7aEWwDal2mrwJryEjNxWbwJPgAAAABMPpKEAABMQf1Do1HdfKNbAIaSf61dg9KdqeRfqVdaplWGu/2Gkn8m4Rfu+htqBVhhkn9OaZIQAAAAQH4gSQgAQB4ZGB6Vth5t9TcwrrVfNib80KSeNd6ffbIP+/PGmjLp6+ygxR8AAABQwEgSAgAwCQZHRk2ib1dnv7y+fY8MbO6T1p6hsUSgtgDs7JeuDI35Z3X7tWb6NS39YpJ/Tlv+6dh/fRnZKwAAAAD5iiQhAABpGB4NyNt7+03CT5N9/nALwF2dA7K9rVv2DL5qWv/t7RvO2IQfVtfesSTg2Jh/mgicOc1dt18AAAAA4BsEAABxjIwGTOJv11CnrcXf2Hh/1mQg7b1DGTl+FaVeaagqkdkzqsPJv1DrP/u4f/pvbXni2X4BAAAAIFUkCQEARSUQCEp777C07rCSf9bEH4PSGk7+6fO2nkEJZGBejTKfx7T60xZ/2sKvuaZcqrwjcsDsBpk5rdIkAptqK6SmzCutra2M+wcAAAAgJ0gSAgAKgs6Uu6d3KNLKL6rln/4bnvm3tXtQRjKQ/Sv1eUz33voKn8yurzEt/kwSMDwGYFNNmXiHuuXAubPE5/NFje/n9/vHJQN1OQAAAADkCklCAEDeJ/96Bkci3XutJKCO+WfG/+sckB17+0zrwKHR9JN/Xo9ExvabXi4yt7HOtPgzyb9pFdIS7gY8o6pM9y5uwm8sGdhP12AAAAAAUwJJQgBAzgwMj8rOvX3y6tvdMrRr1EzwoQ9NAJqWgN2hVoB9Q5mZ8bexpswk+6aXe0zyryXc3ddM9hGeAbihplx8Xk/CFn+xXZcBAAAAoBCQJAQAZNzQiE76EafLb+Tf0KNrYCQjr1dX4QuP7xea8Tcy4Ue41Z81JmCpz+so+QcAAAAAxYYkIQDAsdFAMDSuX89weJy/sVl+9fmuDM/4qzP5NtWVh1v5hWb3DXX3HUsENlaXSueedpJ+AAAAAJAGkoQAADPu396+4biTfuyK/Bya9CMDw/5JRak3lOirDSX+aktGZb+W+tCYf1ZCsLZcqssn/jPFhB8AAAAAkD6ShABQ4EKTfox18R1LAlqz/oaWaRfhdJV4PTEt/uyTfYx1/a2rKIlM6EH3XwAAAADIPZKEADBFDY6MjiX6Ysb6sz/vzcCkH5rPa6wpl/pKn+xTXy0tdaEJP6K6AddVSH1VmXh1emAAAAAAwJRCkhAA8nDcP9O1t2coafJvT99wRl5velVpqKWfafFXHtXiz0oC6qzAmvtjwg8AAAAAKEwkCQEgB+P+7erUR7/8c2eH9AZaQ5N/dI+N+xfIwLh/VWU+k+RrjmrxNzbhhy5rqi2XilKfo+0x9h8AAAAAFC6ShACQAX1Do/LPtl5p7dbWf9ZMvwOyu3NAtnd0S0f/y6Zr8NBo+uP+lfm8ke69psVfbYXMNBN+hMYBtBKBtRWlnFsAAAAAgCMkCQFggnH/dnQOyrb+Pab7r7YA1JaA1liA1sy/PYPpj/vntY37N6ehJjLLr9Ua0Ho+o6o0MukHACC5pUuXyh/+8Ac57bTT5Oc//7njMgAAgGJDkhBA0Y771947LLvf7gy1/tOuvpoA1ORfuDuwv3tQOnqHMvJ60ytLQ0m+aRXSXBvq/ttcWyYVwUFZMLdZZk+vkoZqxv0DgEy78sor5bLLLpP777/fVRkAAECxIUkIoODG/esMj/tnWvqFk33Wz7v1506dFGTQJAozMe6fad1X4ZE5DbUyc5rO+js27l9zTZnIQJfMnT1TvF7vuDH+QhOBTI+UMe4fAGTW4sWLTWtBt2UAAADFpiiShMm6kmzZssXcQd69e7f4fD7585//LNXV1TnbVwCJ9Q+Njs3yG072WT/rJCA79/RJW9+wDAynP+5fqc9jxvrTZN+0MpF5TdPCs/9a4/+FymrKS0xiMtGsv6FEYA+nFQDi2LBhg9x6663y3HPPyc6dO+Xhhx+W8847L6rOXXfdZepo+eGHHy633XabnHTSSRxPAACADCuKJGGyriSXXHKJ/Nd//ZcJNjs6OqS8vDwn+wgUs+HRgPi7+uUfu3rlhdZdZuy/UMu/sRl/tRVg18BI2q+lQ/k1VGsrv3KZXu6ReY11oeSfrfWfPuqrysTr9dha+41PAFo0SQgAcK+3t1cWLVokl156qZx//vnjyteuXStXXXWVSRSecMIJcvfdd8uSJUvk5Zdflnnz5pk6Rx99tAwODo5b9/HHH5fZs2dn5LTo9u2v0dXVZf7VvxH2FuD6s/5NSNQqPFG52+W5lq39Sne7qazvdJ1Uz22qZZx7d9weLzf1OfeFdd1n6pqfqA7XfebPXbrrF/u5DzjcdlEkCRN1Jfn73/8upaWlkbvR9fX1Odg7oHDpB52O6WeN82cf88/8bBKAg9LWMyiZyLPVlvtMd19t6We1Aozq+mvGASyXUp/XUfIPAJBdmvDTRyKrV6+Wyy+/XFasWGGeayvCxx57TNasWSO33HKLWaatELNNX+vGG28ct7y1tVUGBgYiz/VvS2dnp/n7F+9vS6Jyt8tzLVv7le52U1nf6TqpnttUyzj37rg9Xm7qc+4L67rP1DU/UR2u+8yfu3TXL/Zz393dPTWShLnsZvL6669LTU2NnHPOObJ9+3a54IIL5N/+7d/S3i5QDHoGR0It/mzJvtD4f+Gx/7oGpbV7UIZG078bUl7ijczyG+ryG07+2X5uqimT7r3tJP0AoEAMDQ2Z+PD666+PWn766afLM888M6n7csMNN8jVV18d1ZJw7ty50tTUJHV1dVFBvs4+r8sTJZLilbtdnmvZ2q90t5vK+k7XSfXcplrGuXfH7fFyU59zX1jXfaau+YnqcN1n/tylu36xn/uKioqpkSTMZTeT4eFheeqpp2TTpk0msfCBD3xAjj32WHn/+9+f4d8SmDoGR0bF3xXq5qvdfUNj/tlaAZquv/3Sl4Fx/3xeHfev3Dw00VdXGpD5LTNMMjAy7l9thdRVlpgPzWT0g9XZvREAwFTQ1tYmo6Oj0tLSErVcn+/atcvxds444wx5/vnnTcw5Z84cc0Na472Jyux0OJp4Q9JoIB8bzOvfq3jLJyp3uzzXsrVf6W43lfWdrpPquU21jHPvjtvj5aY+576wrvtMXfMT1eG6z/y5S3f9Yj73XofbLSnmbiYaDGogqHeC1ZlnnmkShvGShJkYi8ZtWb6ORaIYk8LdMcmHc68z+WrX311dA+I3k39YCcDwv5oY7BqQjr7hjLxefVWp6d5ruvnWlstMW9dfXa6JwPrqMpMoVPq7areteHdP9FhMNO5foYxJwXXv3lQ797kciyRVfOYXxrnPx/eWE7E3ifRYTXTjyE7jxlTKAAAAik3Ok4S57GaiCUKd1XjPnj0ybdo00/X5iiuuyNpYNG7L8nUsEsWYFO6OSTbPvdbpHhyVtt5hae3Rx1Dk59C/Q9LaOywdvcMymoFx/ypLvVJf6TPdfJtqy6SxulSa9FFTJo01oZ91WVlJsv0elGD/oLT3Jz8OxTgmBdd94Z/7XI5Fkio+8wvj3DsdiyZfNDY2is/nG9dqUMeTjW1dCAAAgAJPEma7m0lJSYl89atflZNPPtkE5pp8/OAHP5i1sWjcluXrWCSKMSncHZNUz33NtHpp7R0y3X+t1n7W+H/63CzvHpCBDHT9LfV5pMm0+Au1/Iu0+gtPAGKW15VLdZkvYYu/dDAmBdd9sYxHMtXGn1J85hfGuXc6Fk2+KCsrM0PKrF+/XpYuXRpZrs/PPffcnO4bAABAIcrrJOFkdDOZqLtzpseicVuWr2ORKMakcHdM7GXDowEzqYcm+nbu7Zc3drRJX3Cv+Lt1JuCByLh/2kIw/fMk0lijSb9yM76f1dU31O03lAzU5zOqysQb7vqbjPVllvFIUjv3Tsq47gt/PJKpNv6U4rqf+uc+H99XPT09snnz5sjzLVu2mKFf6uvrzdjTeoP2oosukmOOOUaOO+44ueeee2Tr1q2ycuXKnO43AABAIcrrJCHdTDDVBIJBaesZNF18tZXfrkjCb0C2tXXJ3sHXzfP23iGZYIg9R+oqSiITfGiLv5nTym0/h1oEauvAUl/+fTEEAGDjxo2yePHiyIGwem0sX75c7rvvPlm2bJm0t7fLTTfdJDt37pSFCxfKunXrZP78+Rw8AACAYkoS0s0E+UJbr/YMjkqXv8ckAE3iz+ruG/7Z6v47Ekg/+1de4jVj+82eUSUt0yrN+H8m6Wdm+w3/XFshlWW+jPx+AADkwimnnDLhxFSrVq0yDwAAABR4kpBuJsi1gZGAbO3oi+rq6+8eNK3/rJ/1376h9Lv+6ky+2rrPnuzTln6VwUFZMKdZZk2vNC0Ba8q8Zty/5ubmvOweBgAAAAAACkvOk4R0M0G26Lh/2vVXJ/nQhJ/fTPgxNumH9XNn/3BGXq+hukwaqnwyu74mPOaf9Sg3M//6hnrkoPmzpbTEN26MP52psbm5MWriEgAAAAAAgKJJEtLNBG4FAkHp6Au1+ovu7qs/98vbHb3S3vdixsb9qy0vMYm+6RVemdtYKy11lbbZfkNj/zXVlEuJV8LJvvGt/0KJwEHTkhAAAAAAACDf5DxJCFh0TKKu/mHZ0t4vr3a2Rcb+81sJwO5QUlBbBA6PZmbcP0321Vf6ZE59rbSYCUBCE39YD+0aXF1eYmvtl7j7L63/AAAAAADAVEWSEJOib2gkarZfewtA83O4K/DAcPrdbH0eMS387OP+WQk/K/mnrQDrKktMYnKi5B8AAAAAAEChI0mItAyOjEp7b6ilX6jFnyb+wj+bxF8oGdg9MJKxcf+scf7sLf6s5zr230jvXpk1s8VR0m+iGRUBAAAAAACKAUlCxDUyGjBj+tkn+vBHjf03ILs6+2Vvf2aSf3UVJaGWf3XlMq00KPOap5vWftoKMLQ8NO5fmQ78l4TpFtzPuH8AAAAAAABukCQsMvEm/Rgb728sAaizAgcy0MiustQXSvTVlocm+Qi3+LO6AlstASvLQjP+Ohn7DwAAAAAAAJlFkrCgJv0YiYztZ2/9pz+Hxv4bEH/3oIxkIPtX6vNIQ1Wp7DOjykz40Vwb3e1X/9VEoM4M7PHQsg8AAAAAACCfkSScAsm/7oFhae0ZHjfOnzXTr/V8cCT9ST+8HpEmWws/k/Sr1ZZ/0WMATqvwSWtrKy3+AAAAsuAXz22XDa+3ysDAgFRW7IzcdI3cerXdg/XYn+jzmPuzngRl9vXGrTPuHq9tQTAoAwP9UlHpj7oZPNFt4YnuG+tQ0QP9/VJZ2ZrwJnOybWjc3N/fL1WVbRO+lv01+/r7IusEJ9h2on2zl8ceiWTrJioLRC1PvO9Jf7fkxY62EbsV7ZXUb96TuyP7O/F+TLwn+vsO9A9IReWuce/n8XsR5zXM8RqQyspdCd+JUfuh7zV9D1fsGque4EV0Pb0OKyp2xt22vvZY+fj9tso8DsuSrTPZ7O9J+++ZrBFIso+ORPVjz12yz7DYcvO5MaDXym7z3on6jIta0TPu88tr//yK+WyMfJ5UjV2bVpXI7x8MSp+po58f5tUj2wqt3ydVVe1R+2XWDQalt69Pqqs7IutF1unTdfaI1zu2PPLatv3QH+2vN7Zv0ectab3Y/YradmiZtV893T1SVzcQtV9R+2FfJ7If419Df/TattvV1SnTWwOmF2Hc9SPPPSZXYX9tvVr27u2W+t4S8fms9aPXsb+eHvc9e/qkI9AtPn09Tyj/oVsz2w6/hgSD0t45KMNl/aaetb71+3jD+945MCLl/cPmtb22/ZNgQIZHA2YIN59t21MFScI8nhDkjG9vMMm//gzM+Ksaa8rCLf5sXX61xV9taLZf/bmhplx8oSslKe0WDAAAgOx48e1OeXTTDg4vAAAFwGtLYGqy1UoqRpKIwaD87T/en+vdJEmYr8pLfNLWM+QoQTitstQk+cZa+4WTgOGEYLPDST8AAAAAAACQWWbUN6vpdYIh4PKhxSEtCfPYAU3Vsrd3UGbPqA7P8hvq+mtPBGrX4IrS0KQfAAAAKAxXnrZAlh83T9ra26WhoUG8Hm+kN6R2c7LYv2aMLbaVx3wPife1ZHydYNJy7VHS0dEh9fX14vF4HXUpnbhba3i7e/ZI/YwZcSewm2gbo4GA7NnTITNm1JtWGk5o91kn68TWi+0SGwgGZE9Hh8yorzfnykmZfhdM9Dvr8j26vH5G5BjHM9H3yXhdd11vwxNzHMLn3r6/E+9HcqHj0CEN9Q1JzkPirQTD78mGhnrxJJn80GPr3tzR3i715tqyd830xN23dus6DHeJjCoP2srjnPt4Zda5b28P7XPsuY+3fLKNu+7j/C5OuoEnLQ+fO+v31XM3fpXkn0ejcT6PQmvF/xy0Pr/0WvaE32vxdjNSL3zdWtuz6kb2vSN0nVoXQSQHFL6GZ8zQa9jqHBsqt5fpevZ19u7dK9OmTzfrjL1WMPp1g7bfLjj2u2od87Ad/7Gfx46lVSf0b2jb1nbHysdeU6/7zq4uqa2tDfeljl0v+rn+EFlu/9n2GnoN6na7e3qkuro6chxM/XjbjdpOaNloICi9vb1SVVVl1tftRY6x7XWsdbS8r0+7mleOLQuOf53R8LAK5eXlZnvaidIqD+X2QnUGBweltKwsku8L/U6hbQwODYmvpDTyO4+Gd2w0GJTh4RHx+XxRr637NjI6KvmAJGEee3jV8cz0CwAAUITqq8tkemWJVI72SnNDdU6TBbH0i6zfNyDNzXUZ3S+z3dJBaW6eltJ2zfpl7tZ3us5E9ZLteypl6R6LbDH75e2X5ubazJ97j263JuVzXyt90tzkbH2tXxPolebGia8trVudpK6WVyW4Ticqi3d9J1qea8l+l3S3WxN0fu4Sv3ecvSedfn45uQZNnfIhaW6eHv/arhyW5uYZ8cuqR6S5eXyC2O8flebmUEI6X4T2qzTj8xGEtutPebtu13daP+CgXrI6qZRZy/NB/rzzAAAAAAAAAOQESUIAAAAAAACgyJEkBAAAAAAAAIocSUIAAAAAAACgyJEkBAAAAAAAAIocSUIAAAAAAACgyJEkBAAAAAAAAIocSUIAAAAAAACgyJEkBAAAAAAAAIocSUIAAAAAAACgyJEkBAAAAAAAAIpcSa53YKoKBoPm366urqjlgUBAuru7paKiQrxeb1plyernWrb2Ld3tul3faX0n9Tj36eHcc90Xy3Xvdnk+4DO/MM69FbNYMQwmNw7M5/dGsX4muFkn1XObahnnPj9iASd1Offp4TsA132xfAfI9We+0ziQJGGK9ASquXPnproJAACAnMQw06ZN48ineQwVcSAAACikONAT5HZySjTTu2PHDqmtrRWPxxNVduyxx8pf//rXuOu5KdNMrwaf27Ztk7q6Osk3yX6XXG7X7fpO6zupx7lPD+ee675Yrvt4y/nMTw3n3jkN+TQwnD17dl61SiumOLCQPhcKJQ50s06q5zaVMs59/vw9cFKXc58evgOEcN0X/neAXH7mO40DaUmYIj2oc+bMiVvm8/kSnthUynRZvgWGE/0uudyu2/Wd1ndSj3OfHs79GK77wr7uk63DuXeHc+8OLQhzGwcW0udCocSBbtZJ9dymU8a5z/3fAyd1Offp4TtANK77wv0OkOvPfCdxILeRs+DTn/50xsvyUbb2N93tul3faX0n9Tj36eHc5z+ue3fHJFHZVPu8V5z74j33cGeic1wo741C+Uxws06q5zadsnxUKOfeTX3OfWrHOBvnIhPr8/0v+8d4srbLuc88uhvnMW1yqpnezs7OvLt7jOzi3Bcvzn3x4twXL849eG+AzwXwNwHEA8WrK49yP7QkzGPl5eXyH//xH+ZfFBfOffHi3Bcvzn3x4tyD9wb4XAB/E0A8ULzK8yj3Q0tCAAAAAAAAoMjRkhAAAAAAAAAociQJAQAAAAAAgCJHkhAAAAAAAAAociQJAQAAAAAAgCJHkhAAAAAAAAAociQJC8S2bdvklFNOkcMOO0yOOOIIeeihh3K9S5hES5culRkzZsgFF1zAcS9wv/71r+Xggw+WBQsWyL333pvr3cEk4jovTvx9B+8TTIS/D8WDOLB4cZ0Xp205yPN4gsFgMOuvgqzbuXOn7N69W4488kjx+/3yzne+U1599VWprq7m6BeBJ554Qnp6euT++++Xn//857neHWTJyMiI+QOh57uurs5c53/5y1+kvr6eY14EuM6LE3/fwfsEE+HvQ3EgDixuXOfFaWcO8jy0JCwQs2bNMm8c1dzcbJIGHR0dud4tTJLFixdLbW0tx7vAPfvss3L44YfLPvvsY873mWeeKY899liudwuThOu8OPH3HbxPMBH+PhQH4sDixnVenGblIM9DknCSbNiwQc4++2yZPXu2eDweeeSRR8bVueuuu2S//faTiooKOfroo+Wpp55K6bU2btwogUBA5s6dm4E9x1Q69yjs98KOHTtMgtAyZ84cefvttydt/5E6PgeKVybPPX/fpy7iwOLF5z8y9V4gDpy6+BwoXhumYBxIknCS9Pb2yqJFi+SOO+6IW7527Vq56qqr5Itf/KK88MILctJJJ8mSJUtk69atkTr6hlm4cOG4h/7BsLS3t8vFF18s99xzz6T8Xsifc4/Cfy/EGx1C/9igOD4HUNznnr/vUxtxYPEiDkSm3gvEgVMXcWDx6p2KcaCOSYjJpYf94Ycfjlr2rne9K7hy5cqoZYccckjw+uuvd7zdgYGB4EknnRT80Y9+lLF9xdQ49+qJJ54Inn/++RnZT+Tne+Hpp58OnnfeeZGyK6+8MvjTn/6U01VEnwNc58V57vn7XliIA4sXcSDSeS8QBxYG4sDiJVMkDqQlYR4YGhqS5557Tk4//fSo5fr8mWeecbQNfc9dcsklcuqpp8pFF12UpT1FPp57FM974V3vepe89NJLpotxd3e3rFu3Ts4444wc7TEyhc+B4uXk3PP3vfARBxYvPv/h5r1AHFiY+BwoXkN5GgeSJMwDbW1tMjo6Ki0tLVHL9fmuXbscbePpp582TVW1j7sObKmPF198MUt7jHw690oTRRdeeKFJGuk4dX/96185SQX4XigpKZFvfetbZuDio446Sq699lppaGjI0R5jsj8HuM6L89zz973wEQcWL+JAuHkvEAcWJuLA4tWWp3FgSVa3DldixxbTrLHT8cZOPPFEM4gliu/cK2a4LZ73wjnnnGMeKL5zz3VenOeev+/FgziweBEHwul7gTiwcBEHFi9PnsWBtCTMA42NjeLz+ca1HPP7/eOyyigsnHvwXgCfA8WLcw/eB8WNzwDwXgCfA8WrMU/zQCQJ80BZWZmZvXb9+vVRy/X58ccfn7P9QvZx7sF7AXwOFC/OPXgfFDc+A8B7AXwOFK+yPM0D0d14kvT09MjmzZsjz7ds2SKbNm2S+vp6mTdvnlx99dVmIMpjjjlGjjvuODO1tU57vXLlysnaRWQJ5x68F8DnQPHi3IP3QXHjMwC8F8DnQPHqmYp5oEmZQxnBJ554wkx5HftYvnx55Ojceeedwfnz5wfLysqC73znO4NPPvkkR64AcO7BewF8DhQvzj14HxQ3PgPAewF8DhSvJ6ZgHsij/8tdihIAAAAAAABArjEmIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICAAAAAAAARY4kIQAAAAAAAFDkSBICQB7ad9995bbbbsv1bgAAAGCSEQcCyBWShACQhksuuUQ8Ho95lJaWyv777y/XXHON9Pb2TrjuKaecIt/73vc4/gAAAFMQcSCAQlOS6x0AgKnuAx/4gPzwhz+U4eFheeqpp2TFihUmSbhmzZqE63R0dMgzzzwjP/3pTydtP0dHR00y0+vl/hAAAEAmEAcCKCR8UwSANJWXl8vMmTNl7ty58rGPfUz+5V/+RR555JGk6/zmN7+RRYsWyT777JOwTnd3t9leTU2NzJ49W26//fao8tWrV8s73vEOqa6uNq+9atUq6enpiZTfd999Mn36dPn1r38thx12mNnPt956i/MNAACQIcSBAAoJSUIAyLDKykrTqjCZX/3qV3LuuecmrXPrrbfKEUccIc8//7zccMMN8rnPfU7Wr18fKdcWgd/97nflpZdekvvvv19+//vfy3XXXRe1jb6+Prnlllvk3nvvlb///e/S3Nyc5m8HAACARIgDAUxlnmAwGMz1TgDAVB6LZu/evZGWg88++6yceeaZctppp8natWvjrjM4OChNTU3y9NNPm5aAiQasPvTQQ+W3v/1tZNlHPvIR6erqknXr1sVd56GHHpJPfepT0tbWFmlJeOmll8qmTZtMq0UAAABkDnEggEJDS0IASJN259UuwRUVFXLcccfJySefPK5rsJ22+GtoaEiYILTotmKfv/LKK5HnTzzxhLz//e83XZZra2vl4osvlvb29qhJU8rKykxrRAAAAGQecSCAQkKSEADStHjxYtNa79VXX5WBgQH55S9/mbRbr5OuxonoxCNKxxbUFosLFy6UX/ziF/Lcc8/JnXfeacrsXZ21y4u1DgAAADKLOBBAIWF2YwBIk04ccuCBBzqqqyM8/M///I/86Ec/mrDun//853HPDznkEPPzxo0bZWRkRL71rW9FZit+8MEHU9p/AAAApIY4EEAhIUkIAJNIW/xpd2DtkjwRHbPwG9/4hpx33nlmwhIdc1BnRVYHHHCASRJqt+azzz7b1P3e9743Cb8BAAAAUkEcCCDf0d0YACbRo48+KmeddZaUlEx8j+bzn/+8CSaPOuoo+c///E/TavCMM84wZUceeaSsXr1avv71r5suxz/96U/NLMYAAADIT8SBAPIdsxsDwCTSSUS+9KUvyYc//GGOOwAAQBEhDgSQ72hJCACTZGhoSM4//3xZsmQJxxwAAKCIEAcCmApoSQgAAAAAAAAUOVoSAgAAAAAAAEWOJCEAAAAAAABQ5EgSAgAAAAAAAEWOJCEAAAAAAABQ5EgSAgAAAAAAAEWOJCEAAAAAAABQ5EgSAgAAAAAAAEWOJCEAAAAAAABQ5EgSAgAAAAAAAFLc/n8dy8f3+dzuewAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1300x420 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "meta = chebyshev[0][\"network_kinetics\"]\n",
+    "pressures = [10 ** (math.log10(meta[\"pmin_bar\"]) + i * (math.log10(meta[\"pmax_bar\"]) - math.log10(meta[\"pmin_bar\"])) / 60)\n",
+    "             for i in range(61)]\n",
+    "\n",
+    "# One association (well-forming) channel and one exchange channel, for contrast.\n",
+    "def first_of(kind):\n",
+    "    return next((r for r in chebyshev if r[\"network_channel\"][\"channel_kind\"] == kind), None)\n",
+    "\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(13, 4.2))\n",
+    "for axis, kind in zip(axes, (\"association\", \"exchange\")):\n",
+    "    rec = first_of(kind)\n",
+    "    if rec is None:\n",
+    "        axis.set_title(f\"no {kind} channel\")\n",
+    "        continue\n",
+    "    for T in (500.0, 1000.0, 1500.0, 2000.0):\n",
+    "        axis.loglog(pressures, [chebyshev_k(rec, T, p) for p in pressures],\n",
+    "                    lw=2, label=f\"{T:.0f} K\")\n",
+    "    axis.set_xlabel(\"P / bar\")\n",
+    "    axis.set_ylabel(f\"k / {rec['network_kinetics']['rate_units']}\")\n",
+    "    axis.set_title(f\"{kind}:  {channel_label(rec)[:40]}\", fontsize=10)\n",
+    "    axis.grid(alpha=0.3, which=\"both\")\n",
+    "    axis.legend(fontsize=8)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2312ce51",
+   "metadata": {},
+   "source": [
+    "### A self-consistency check\n",
+    "\n",
+    "This network was fitted **twice** — Chebyshev from one master-equation run, PLOG from\n",
+    "a sister run of the same network with a different interpolation model. Two independent\n",
+    "fits of the same physics is a redundancy, and redundancy is where a database can be\n",
+    "checked against itself: evaluating both at the same (T, P) tests the stored numbers\n",
+    "rather than just reading them back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b0f3cfd8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T07:03:06.416605Z",
+     "iopub.status.busy": "2026-08-10T07:03:06.416399Z",
+     "iopub.status.idle": "2026-08-10T07:03:06.422047Z",
+     "shell.execute_reply": "2026-08-10T07:03:06.421599Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21 of 21 channels stored in both forms\n",
+      "\n",
+      "channel                               kind           k Chebyshev  k PLOG     ratio\n",
+      "----------------------------------------------------------------------------------\n",
+      "N=N + [H][H] -> 2 [NH2]               exchange       1.693        1.671      1.013\n",
+      "N=N + [H][H] -> [H][H] + [N-]=[NH2+]  exchange       8.869e-05    8.715e-05  1.018\n",
+      "N=N + [H][H] -> [H] + [NH]N           exchange       0.001471     0.00157    0.937\n",
+      "[H] + [NH]N -> [H][H] + [N-]=[NH2+]   exchange       8.294e+10    8.934e+10  0.928\n",
+      "2 [NH2] -> [H] + [NH]N                exchange       1.737e+08    1.894e+08  0.917\n",
+      "[H] + [NH]N -> N=N + [H][H]           exchange       1.194e+08    1.339e+08  0.892\n",
+      "2 [NH2] -> [H][H] + [N-]=[NH2+]       exchange       2.579e+07    2.245e+07  1.148\n",
+      "2 [NH2] -> N=N + [H][H]               exchange       3195         3730       0.857\n",
+      "N=N + [H][H] -> N=N + [H][H]          exchange       8.86e-08     1.053e-07  0.842\n",
+      "[H][H] + [N-]=[NH2+] -> N=N + [H][H]  exchange       0.1969       0.2373     0.830\n",
+      "[H][H] + [N-]=[NH2+] -> [NH-][NH3+]   association    5.001        6.932      0.721\n",
+      "[NH-][NH3+] -> NN                     isomerization  1.319e+07    1.968e+07  0.670\n",
+      "2 [NH2] -> [NH-][NH3+]                association    3.202e+08    4.788e+08  0.669\n",
+      "N=N + [H][H] -> [NH-][NH3+]           association    0.001006     0.001818   0.553\n",
+      "[H][H] + [N-]=[NH2+] -> NN            association    554.6        1030       0.539\n",
+      "[H] + [NH]N -> [NH-][NH3+]            association    5.636e+08    1.131e+09  0.498\n",
+      "N=N + [H][H] -> [NH-][NH3+]           association    1.24e-08     2.732e-08  0.454\n",
+      "2 [NH2] -> NN                         association    4.022e+11    9.829e+11  0.409\n",
+      "N=N + [H][H] -> NN                    association    0.0001261    0.0004091  0.308\n",
+      "[H] + [NH]N -> NN                     association    3.688e+10    1.302e+11  0.283\n",
+      "N=N + [H][H] -> NN                    association    4.591e-07    1.79e-06   0.256\n",
+      "\n",
+      "at 1000 K, 1 bar, units cm3_mol_s\n"
+     ]
+    }
+   ],
+   "source": [
+    "plog_by_key = {channel_key(r): r for r in plog}\n",
+    "pairs = [(c, plog_by_key[channel_key(c)]) for c in chebyshev if channel_key(c) in plog_by_key]\n",
+    "print(f\"{len(pairs)} of {len(chebyshev)} channels stored in both forms\\n\")\n",
+    "\n",
+    "rows = []\n",
+    "for cheb, pl in pairs:\n",
+    "    k_c, k_p = chebyshev_k(cheb, 1000.0, 1.0), plog_k(pl, 1000.0, 1.0)\n",
+    "    rows.append((abs(math.log10(k_c/k_p)), channel_label(cheb),\n",
+    "                 cheb[\"network_channel\"][\"channel_kind\"], k_c, k_p))\n",
+    "rows.sort()\n",
+    "\n",
+    "table(\n",
+    "    [[lab[:40], kind, f\"{k_c:.4g}\", f\"{k_p:.4g}\", f\"{k_c/k_p:.3f}\"]\n",
+    "     for _, lab, kind, k_c, k_p in rows],\n",
+    "    [\"channel\", \"kind\", \"k Chebyshev\", \"k PLOG\", \"ratio\"],\n",
+    ")\n",
+    "print(f\"\\nat 1000 K, 1 bar, units {chebyshev[0]['network_kinetics']['rate_units']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "592d06e7",
+   "metadata": {},
+   "source": [
+    "Sorting by disagreement sorts by `kind`, which is not a coincidence.\n",
+    "\n",
+    "Every `exchange` channel — bimolecular in, bimolecular out — agrees to within about\n",
+    "20%. Every channel that ends in a collisionally stabilised well (`association`, and the\n",
+    "one `isomerization`) disagrees by more, up to a factor of about 4. And the drift is\n",
+    "**one-directional**: for all of them the Chebyshev value is the lower one. A systematic\n",
+    "offset along a physically meaningful axis is not scatter, and it is not a bug in either\n",
+    "evaluator — a coding error in the reduced coordinates or the basis would spoil the\n",
+    "`exchange` channels too.\n",
+    "\n",
+    "What it is, exactly, this notebook cannot say: two fitting forms, fitted from two\n",
+    "separate master-equation runs, need not agree where the surface is hardest to fit. What\n",
+    "it *is* good for is calibration — it bounds how much precision to claim from a fitted\n",
+    "k(T,P), and it says the bound is much tighter for exchange channels than for\n",
+    "stabilisation.\n",
+    "\n",
+    "Note what this check does not do. It does not certify that the network is right; both\n",
+    "fits could descend from the same wrong solve. It bounds the disagreement between two\n",
+    "representations of one calculation — a more modest claim, and the one the data\n",
+    "supports. A stored number you can only read back is a number you have to take on\n",
+    "faith; a stored number you can *rebuild two ways* tells you something when the two\n",
+    "ways disagree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47d7483c",
+   "metadata": {},
+   "source": [
+    "<a id=\"7\"></a>\n",
+    "## 7. How much should you trust this?\n",
     "\n",
     "Every scientific record carries a review state. TCKDB deliberately keeps three\n",
     "*separate* judgements rather than collapsing them into one score:\n",
@@ -586,14 +1629,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "e2f198e7",
+   "execution_count": 21,
+   "id": "eb054e4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:09.898882Z",
-     "iopub.status.busy": "2026-08-08T08:00:09.898782Z",
-     "iopub.status.idle": "2026-08-08T08:00:10.210058Z",
-     "shell.execute_reply": "2026-08-08T08:00:10.209678Z"
+     "iopub.execute_input": "2026-08-10T07:03:06.423568Z",
+     "iopub.status.busy": "2026-08-10T07:03:06.423432Z",
+     "iopub.status.idle": "2026-08-10T07:03:06.720147Z",
+     "shell.execute_reply": "2026-08-10T07:03:06.719498Z"
     }
    },
    "outputs": [
@@ -609,45 +1652,46 @@
      "output_type": "stream",
      "text": [
       "\n",
-      " 422 unknown_include_token: unknown_include_token: token(s) ['not_a_real_token'] not legal for /scientific/thermo/search. Legal tokens: ['artifacts', 'assessments', 'calculations', 'internal_ids', 'provenance', 'review', 'all']\n"
+      "code   unknown_include_token\n",
+      "detail unknown_include_token: token(s) ['not_a_real_token'] not legal for /scientific/thermo/search. Legal tokens: ['artifacts', 'assessments', 'calculations', 'internal_ids', 'provenance', 'review', 'all']\n"
      ]
     }
    ],
    "source": [
     "# Every search response carries a review roll-up for free.\n",
-    "print(\"review summary:\", get(\"scientific/thermo/search\", species_ref=SPECIES_REF)[\"review_summary\"])\n",
+    "summary = get(\"scientific/thermo/search\", species_ref=SPECIES_REF)[\"review_summary\"]\n",
+    "print(\"review summary:\", summary)\n",
     "\n",
     "# Heavier blocks are opt-in. Ask for an illegal token and the server tells you\n",
     "# exactly which are legal for that endpoint -- a fast way to explore the API.\n",
     "try:\n",
     "    get(\"scientific/thermo/search\", species_ref=SPECIES_REF, include=\"not_a_real_token\")\n",
-    "except RuntimeError as exc:\n",
-    "    print(\"\\n\", exc)"
+    "except TCKDBError as exc:\n",
+    "    print(f\"\\ncode   {exc.code}\")\n",
+    "    print(f\"detail {exc.detail}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3ea6aad2",
+   "id": "610ad5f6",
    "metadata": {},
    "source": [
     "### A worked trust block\n",
     "\n",
-    "`include=trust` on a calculation returns the deterministic evidence evaluation —\n",
-    "the rubric that ran, the checks it passed, and the label it concluded. This is the\n",
-    "part that lets a reader decide for themselves rather than taking a status word on\n",
-    "faith."
+    "`include=trust` on a calculation returns the deterministic evidence evaluation — the\n",
+    "rubric that ran, the checks it passed, and the label it concluded."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "33440c96",
+   "execution_count": 22,
+   "id": "bc008ea2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T08:00:10.211063Z",
-     "iopub.status.busy": "2026-08-08T08:00:10.210972Z",
-     "iopub.status.idle": "2026-08-08T08:00:10.368710Z",
-     "shell.execute_reply": "2026-08-08T08:00:10.368299Z"
+     "iopub.execute_input": "2026-08-10T07:03:06.722003Z",
+     "iopub.status.busy": "2026-08-10T07:03:06.721810Z",
+     "iopub.status.idle": "2026-08-10T07:03:07.024630Z",
+     "shell.execute_reply": "2026-08-10T07:03:07.023884Z"
     }
    },
    "outputs": [
@@ -655,12 +1699,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "review status: under_review\n",
-      "trust status : well_supported\n",
+      "calculation  calc_heds3dt3dsqxmqkcchibvbtwi4\n",
+      "review       under_review\n",
+      "trust        mostly_supported\n",
+      "rubric       computed_calculation_v1 v1  ->  mostly_supported\n",
       "\n",
-      "rubric: computed_calculation_v1 v1  ->  well_supported\n",
-      "\n",
-      "passed checks:\n",
       "   + calculation_has_owner\n",
       "   + calculation_type_present\n",
       "   + level_of_theory_present\n",
@@ -669,68 +1712,88 @@
       "   + input_geometry_present\n",
       "   + output_geometry_present\n",
       "   + result_block_present\n",
-      "   + geometry_validation_present\n",
-      "   + artifacts_present\n",
-      "   + parameters_parsed\n",
-      "   - quality_recorded (missing)\n"
+      "   + calculation_dependencies_present_when_expected\n",
+      "   - quality_recorded (missing)\n",
+      "   - artifacts_present (missing)\n",
+      "   - parameters_parsed (missing)\n"
      ]
     }
    ],
    "source": [
-    "# A calculation from the real-data validation set.\n",
-    "CALC_REF = \"calc_hh7v4go23xr6drhbb4f4ewuvbq\"\n",
+    "# Any calculation from this deployment; take the first the analytics surface reports.\n",
+    "calc_rows = records(\"scientific/analytics/calculations\", limit=1)\n",
+    "CALC_REF = calc_rows[0][\"calculation_ref\"] if calc_rows else None\n",
     "\n",
-    "trust = get(f\"scientific/calculations/{CALC_REF}\", include=\"trust\")[\"record\"][\"trust\"]\n",
-    "print(\"review status:\", trust[\"review_status\"])\n",
-    "print(\"trust status :\", trust[\"trust_status\"])\n",
+    "detail = try_get(f\"scientific/calculations/{CALC_REF}\", include=\"trust\") if CALC_REF else None\n",
+    "trust = (detail or {}).get(\"record\", {}).get(\"trust\")\n",
     "\n",
-    "ev = trust[\"evidence\"]\n",
-    "print(f\"\\nrubric: {ev['rubric']} v{ev['rubric_version']}  ->  {ev['label']}\")\n",
-    "print(\"\\npassed checks:\")\n",
-    "for check in ev.get(\"passed_checks\", []):\n",
-    "    print(\"   +\", check)\n",
-    "for check in ev.get(\"missing_checks\", []) or []:\n",
-    "    print(\"   -\", check, \"(missing)\")"
+    "if trust:\n",
+    "    print(f\"calculation  {CALC_REF}\")\n",
+    "    print(f\"review       {trust['review_status']}\")\n",
+    "    print(f\"trust        {trust['trust_status']}\")\n",
+    "    ev = trust[\"evidence\"]\n",
+    "    print(f\"rubric       {ev['rubric']} v{ev['rubric_version']}  ->  {ev['label']}\\n\")\n",
+    "    for check in ev.get(\"passed_checks\", []) or []:\n",
+    "        print(\"   +\", check)\n",
+    "    for check in ev.get(\"missing_checks\", []) or []:\n",
+    "        print(\"   -\", check, \"(missing)\")\n",
+    "else:\n",
+    "    print(\"no trust block available for this record\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2bc3f519",
+   "id": "30a6ecdd",
    "metadata": {},
    "source": [
-    "## 6. Where to go next\n",
+    "## Where to go next\n",
     "\n",
-    "- `scientific/transport/search` — Lennard-Jones parameters\n",
-    "- `scientific/kinetics/search` and `scientific/reactions/search` — rate coefficients\n",
-    "- `scientific/calculations/{ref}?include=all` — the full record for one calculation,\n",
-    "  including artifacts and geometries\n",
+    "Endpoints this tour did not use:\n",
     "\n",
-    "Every search response carries a `pagination` block; pass `include=` to opt into heavier\n",
-    "sections. Anything omitted by default is omitted on purpose — the default response is\n",
-    "meant to stay small and predictable.\n",
+    "| endpoint | what it gives you |\n",
+    "|---|---|\n",
+    "| `scientific/calculations/{ref}?include=all` | one calculation in full — geometries, artifacts, parameters |\n",
+    "| `scientific/calculations/{ref}/irc` | the intrinsic reaction coordinate path |\n",
+    "| `scientific/conformers/search` | conformer groups and observations |\n",
+    "| `scientific/transport/search` | Lennard-Jones parameters |\n",
+    "| `scientific/artifacts/search` | the deposited output files themselves |\n",
+    "| `scientific/export/ndjson`, `export/ml/*.ndjson` | bulk export, and ML-ready feature rows |\n",
+    "| `scientific/releases` | citable, frozen dataset releases |\n",
+    "| `lookup/*` | a lighter lookup family returning `{query, match, results}` |\n",
+    "\n",
+    "Two conventions worth remembering:\n",
+    "\n",
+    "- **`include=`** opts into heavier blocks. Anything omitted by default is omitted on\n",
+    "  purpose — the default response stays small and predictable. Pass a nonsense token to\n",
+    "  be told the legal ones, as in section 7.\n",
+    "- **every search response carries `pagination`** with a true `total`, so you always know\n",
+    "  whether you are looking at everything.\n",
     "\n",
     "### Using the typed client instead\n",
     "\n",
-    "```python\n",
+    "```\n",
     "pip install tckdb-client\n",
     "```\n",
     "```python\n",
     "from tckdb_client import TCKDBClient\n",
-    "with TCKDBClient(base_url=\"https://tckdb.homecalvin.com\") as c:\n",
-    "    print(c.health())\n",
+    "\n",
+    "with TCKDBClient(base_url=\"https://tckdb.homecalvin.com\") as client:\n",
+    "    print(client.health())\n",
     "```\n",
-    "Match the client version to the deployment: a client built against a newer contract will\n",
-    "404 on endpoints an older server doesn't serve yet.\n",
+    "\n",
+    "Match the client version to the deployment: a client built against a newer contract\n",
+    "will 404 on endpoints an older server does not serve yet.\n",
     "\n",
     "---\n",
-    "*Read-only tour. The script form of this notebook is `explore_tckdb.py` in the same\n",
-    "directory, runnable as `python examples/clients/explore_tckdb.py`.*"
+    "*Read-only tour. The script form is `explore_tckdb.py` in this directory —\n",
+    "`python examples/clients/explore_tckdb.py` prints the same tour without plots, and\n",
+    "every function in it is importable.*"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tckdb_env",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/clients/explore_tckdb.py
+++ b/examples/clients/explore_tckdb.py
@@ -1,4 +1,4 @@
-"""Explore a live TCKDB deployment — the script form of ``explore_tckdb.ipynb``.
+"""Explore a live TCKDB deployment - the script form of ``explore_tckdb.ipynb``.
 
 Read-only. Every request here is an anonymous GET against the public
 scientific read API; nothing in this file can modify the database.
@@ -6,27 +6,47 @@ scientific read API; nothing in this file can modify the database.
 Run it directly to print a tour of what a deployment holds::
 
     python examples/clients/explore_tckdb.py
-    TCKDB_BASE_URL=http://localhost:8000 python examples/clients/explore_tckdb.py
+    TCKDB_BASE_URL=http://localhost:8000/api/v1 python examples/clients/explore_tckdb.py
 
 The notebook alongside this file is the version to hand to a colleague: it
-carries the same calls with explanation and plots. This module keeps the
-functions importable so the notebook stays thin and both stay in sync.
+carries the same calls with explanation and plots. This module keeps every
+function importable, so a script, a notebook or a REPL can all reuse it::
 
-Only ``requests`` is required. ``tckdb-client`` is the better choice for
-programmatic work, but it pins a contract version, and a client newer than
-the deployment it talks to will 404 on endpoints the server does not have
-yet. Plain HTTP keeps this tour working against any deployment.
+    from examples.clients.explore_tckdb import inventory, chebyshev_k
+
+Only ``requests`` is required (``matplotlib`` only for the notebook's plots).
+``tckdb-client`` is the better choice for programmatic work, but it pins a
+contract version, and a client newer than the deployment it talks to will 404
+on endpoints the server does not have yet. Plain HTTP keeps this tour working
+against any deployment, which matters when handing it to someone else.
+
+Nothing here assumes a particular deployment holds particular data. Every
+section degrades to "not present in this deployment" rather than raising, so
+the tour runs against an empty local instance as well as against a populated
+one.
 """
 
 from __future__ import annotations
 
+import math
 import os
-from typing import Any
+import time
+from typing import Any, Iterable
 
 import requests
 
 DEFAULT_BASE_URL = "https://tckdb.homecalvin.com/api/v1"
 TIMEOUT_S = 30
+
+#: How many times to wait out a 429 before giving up.
+#:
+#: A full tour is a few hundred requests, which is enough to trip a public
+#: deployment's rate limiter. The server does not leave a client guessing: it
+#: answers 429 with a ``Retry-After`` header and a ``retry_after_seconds``
+#: context field saying exactly how long the window has left. Reading that is
+#: the whole of correct behaviour here -- a fixed sleep would be either too
+#: short (and hammer a limiter that is already refusing) or needlessly long.
+RATE_LIMIT_RETRIES = 3
 
 #: One connection, reused for every call.
 #:
@@ -38,10 +58,32 @@ TIMEOUT_S = 30
 #: call with a fresh connection each time, 144 ms with this session. ``curl``
 #: does not show the problem because it races both stacks (Happy Eyeballs)
 #: and gives up on IPv6 in milliseconds.
-#:
-#: Reusing the connection pays that cost once instead of per request. It is
-#: also simply correct for repeated calls to one host.
 SESSION = requests.Session()
+
+R_J_MOL_K = 8.31446261815324
+R_KJ_MOL_K = R_J_MOL_K / 1000.0
+
+
+class TCKDBError(RuntimeError):
+    """An error the server described in its own typed envelope.
+
+    TCKDB answers a failed request with ``{"code", "detail", "context"}``
+    rather than a bare status line. ``code`` is the machine-readable half and
+    is the thing to branch on; ``detail`` is written for a human. Keeping both
+    on the exception means a caller never has to re-parse the response.
+    """
+
+    def __init__(self, status: int, code: str, detail: Any, context: Any = None):
+        self.status = status
+        self.code = code
+        self.detail = detail
+        self.context = context or {}
+        super().__init__(f"{status} {code}: {detail}")
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
 
 
 def base_url() -> str:
@@ -49,23 +91,72 @@ def base_url() -> str:
     return os.environ.get("TCKDB_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
 
 
-def get(path: str, **params: Any) -> dict:
-    """One anonymous GET against the scientific read API.
+def _retry_after_seconds(response: requests.Response, envelope: dict) -> float:
+    """How long the server says to wait, from the header or the envelope."""
+    header = response.headers.get("Retry-After")
+    if header:
+        try:
+            return float(header)
+        except ValueError:
+            pass
+    context = envelope.get("context") or {}
+    return float(context.get("retry_after_seconds") or 1.0)
 
-    Raises with the server's own error envelope when there is one — TCKDB
-    returns a typed ``{"code", "detail", "context"}`` body, which says far
-    more than a bare status line.
+
+def get(path: str, **params: Any) -> dict:
+    """One anonymous GET against the read API, waiting out any rate limit.
+
+    :raises TCKDBError: when the server returns its typed error envelope.
     """
-    response = SESSION.get(f"{base_url()}/{path.lstrip('/')}", params=params, timeout=TIMEOUT_S)
-    if not response.ok:
+    url = f"{base_url()}/{path.lstrip('/')}"
+    for attempt in range(RATE_LIMIT_RETRIES + 1):
+        response = SESSION.get(url, params=params, timeout=TIMEOUT_S)
+        if response.ok:
+            return response.json()
         try:
             envelope = response.json()
-            raise RuntimeError(
-                f"{response.status_code} {envelope.get('code', '?')}: {envelope.get('detail', response.text[:200])}"
-            )
         except ValueError:
             response.raise_for_status()
-    return response.json()
+            raise  # unreachable; keeps type checkers happy
+
+        if response.status_code == 429 and attempt < RATE_LIMIT_RETRIES:
+            delay = _retry_after_seconds(response, envelope)
+            # Say so. A silent sleep is indistinguishable from a hang, and this
+            # one can be tens of seconds.
+            print(f"  rate limited; waiting {delay:.0f}s before retrying {path}")
+            time.sleep(delay)
+            continue
+
+        raise TCKDBError(
+            response.status_code,
+            envelope.get("code", "unknown"),
+            envelope.get("detail", response.text[:200]),
+            envelope.get("context"),
+        )
+    raise AssertionError("unreachable")
+
+
+def try_get(path: str, **params: Any) -> dict | None:
+    """Like :func:`get`, but ``None`` when this deployment cannot answer.
+
+    Only swallows "this deployment does not have that": a 404 (endpoint or
+    record absent) or a 405. A 422 still raises, because that means *the
+    request itself* was wrong -- a missing filter, an unknown include token --
+    and silently returning ``None`` for a mistake in the query is how a tour
+    ends up quietly showing nothing and looking like an empty database.
+    """
+    try:
+        return get(path, **params)
+    except TCKDBError as exc:
+        if exc.status in (404, 405):
+            return None
+        raise
+
+
+def records(path: str, **params: Any) -> list[dict]:
+    """The ``records`` list of a search response, or ``[]`` if unavailable."""
+    payload = try_get(path, **params)
+    return list(payload.get("records", [])) if payload else []
 
 
 def health() -> dict:
@@ -73,101 +164,459 @@ def health() -> dict:
     return get("health")
 
 
+# ---------------------------------------------------------------------------
+# What is in this deployment?
+#
+# Every /search endpoint is lookup-by-identity: it requires a filter, and
+# answers 422 without one. That is deliberate -- you ask a scientific database
+# for a molecule, not for a page of rows. The analytics surfaces are the
+# exception, and the only way to ask "what is in here?" before you know what
+# to ask for.
+# ---------------------------------------------------------------------------
+
+ANALYTICS = ("thermo", "kinetics", "statmech", "calculations")
+
+
+def inventory() -> dict[str, dict]:
+    """Row counts and review roll-ups per analytics surface.
+
+    :returns: ``{surface: {"total": int, "review": {...}}}``, omitting any
+        surface this deployment does not serve.
+    """
+    found: dict[str, dict] = {}
+    for surface in ANALYTICS:
+        payload = try_get(f"scientific/analytics/{surface}", limit=1)
+        if payload is None:
+            continue
+        found[surface] = {
+            "total": payload.get("pagination", {}).get("total", 0),
+            "review": payload.get("review_summary", {}),
+        }
+    return found
+
+
+VOCABULARIES = ("methods", "basis-sets", "software", "reaction-families")
+
+
+def vocabularies() -> dict[str, list[dict]]:
+    """The controlled vocabularies actually represented, with usage counts.
+
+    This is the fastest way to see what a deployment is *about*: which levels
+    of theory it was built from, which codes produced it, which reaction
+    families it covers.
+    """
+    found: dict[str, list[dict]] = {}
+    for name in VOCABULARIES:
+        payload = try_get(f"scientific/meta/{name}")
+        if payload is None:
+            continue
+        found[name] = list(payload.get("results") or [])
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Species
+# ---------------------------------------------------------------------------
+
+
 def find_species(**identifier: Any) -> list[dict]:
     """Look up species by identity.
 
-    The search endpoints are lookup-by-identity, not list-everything: at
-    least one of ``smiles``, ``inchi``, ``inchi_key``, ``formula``,
-    ``species_ref`` or ``species_entry_ref`` is required. That is deliberate
-    for a scientific database — you ask for a molecule, not a page of rows.
+    At least one of ``smiles``, ``inchi``, ``inchi_key``, ``formula``,
+    ``species_ref`` or ``species_entry_ref`` is required.
     """
-    return get("scientific/species/search", **identifier)["records"]
+    return records("scientific/species/search", **identifier)
+
+
+def substructure_search(smarts: str, **params: Any) -> list[dict]:
+    """Every species containing a SMARTS pattern.
+
+    The complement of :func:`find_species`: identity search answers "do you
+    have *this* molecule", substructure search answers "what do you have that
+    *contains* this". Served by the RDKit cartridge in PostgreSQL, so the
+    matching happens in the database rather than by pulling every structure
+    across the wire.
+    """
+    return records("scientific/species/structure-search", query_smarts=smarts, **params)
 
 
 def thermo_for(species_ref: str) -> list[dict]:
     """Every thermodynamic record attached to one species."""
-    return get("scientific/thermo/search", species_ref=species_ref)["records"]
+    return records("scientific/thermo/search", species_ref=species_ref)
 
 
 def calculations_for(species_ref: str) -> list[dict]:
     """Every quantum-chemistry calculation behind one species."""
-    return get("scientific/calculations/search", species_ref=species_ref)["records"]
+    return records("scientific/calculations/search", species_ref=species_ref)
 
 
 def statmech_for(species_ref: str) -> list[dict]:
     """Statistical-mechanics records (frequencies, rotors) for one species."""
-    return get("scientific/statmech/search", species_ref=species_ref)["records"]
+    return records("scientific/statmech/search", species_ref=species_ref)
+
+
+def transport_for(species_ref: str) -> list[dict]:
+    """Transport records (Lennard-Jones parameters) for one species."""
+    return records("scientific/transport/search", species_ref=species_ref)
 
 
 # ---------------------------------------------------------------------------
 # NASA polynomials
 #
 # A NASA-7 fit stores two coefficient sets meeting at ``t_mid``. Evaluating
-# them is what turns a stored record back into Cp(T), H(T) and S(T), so the
-# functions below are the point of querying thermo at all.
+# them is what turns a stored record back into Cp(T), H(T) and S(T), and is
+# the reason to query thermo at all rather than read a summary table.
 # ---------------------------------------------------------------------------
 
-R_J_MOL_K = 8.31446261815324
 
-
-def _coefficients(nasa: dict, temperature_k: float) -> list[float]:
+def _nasa_coefficients(nasa: dict, temperature_k: float) -> list[float]:
     if temperature_k <= nasa["t_mid"]:
         return nasa["low_temperature_coefficients"]
     return nasa["high_temperature_coefficients"]
 
 
 def cp_j_mol_k(nasa: dict, temperature_k: float) -> float:
-    """Cp/R = a1 + a2·T + a3·T² + a4·T³ + a5·T⁴."""
-    a = _coefficients(nasa, temperature_k)
+    """Cp/R = a1 + a2*T + a3*T^2 + a4*T^3 + a5*T^4."""
+    a = _nasa_coefficients(nasa, temperature_k)
     t = temperature_k
     return R_J_MOL_K * (a[0] + a[1] * t + a[2] * t**2 + a[3] * t**3 + a[4] * t**4)
 
 
 def h_kj_mol(nasa: dict, temperature_k: float) -> float:
-    """H/(R·T) = a1 + a2·T/2 + a3·T²/3 + a4·T³/4 + a5·T⁴/5 + a6/T."""
-    a = _coefficients(nasa, temperature_k)
+    """H/(R*T) = a1 + a2*T/2 + a3*T^2/3 + a4*T^3/4 + a5*T^4/5 + a6/T."""
+    a = _nasa_coefficients(nasa, temperature_k)
     t = temperature_k
-    dimensionless = (
-        a[0] + a[1] * t / 2 + a[2] * t**2 / 3 + a[3] * t**3 / 4 + a[4] * t**4 / 5 + a[5] / t
-    )
+    dimensionless = a[0] + a[1] * t / 2 + a[2] * t**2 / 3 + a[3] * t**3 / 4 + a[4] * t**4 / 5 + a[5] / t
     return R_J_MOL_K * t * dimensionless / 1000.0
 
 
 def s_j_mol_k(nasa: dict, temperature_k: float) -> float:
-    """S/R = a1·lnT + a2·T + a3·T²/2 + a4·T³/3 + a5·T⁴/4 + a7."""
-    import math
-
-    a = _coefficients(nasa, temperature_k)
+    """S/R = a1*lnT + a2*T + a3*T^2/2 + a4*T^3/3 + a5*T^4/4 + a7."""
+    a = _nasa_coefficients(nasa, temperature_k)
     t = temperature_k
-    return R_J_MOL_K * (
-        a[0] * math.log(t) + a[1] * t + a[2] * t**2 / 2 + a[3] * t**3 / 3 + a[4] * t**4 / 4 + a[6]
+    return R_J_MOL_K * (a[0] * math.log(t) + a[1] * t + a[2] * t**2 / 2 + a[3] * t**3 / 3 + a[4] * t**4 / 4 + a[6])
+
+
+def first_nasa(thermo_records: Iterable[dict]) -> dict | None:
+    """The first NASA-7 polynomial among some thermo records, if any."""
+    for record in thermo_records:
+        nasa = record.get("thermo", {}).get("nasa")
+        if nasa:
+            return nasa
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Reactions and kinetics
+# ---------------------------------------------------------------------------
+
+
+def reaction_entry_refs(limit: int = 50) -> list[str]:
+    """Reaction entries that have kinetics, discovered via analytics.
+
+    ``/scientific/reactions/search`` needs reactants, products or a ref to
+    scope it, so it cannot be used to find out *which* reactions exist. The
+    kinetics analytics surface can, and every row carries the entry ref that
+    the reaction endpoints take.
+    """
+    rows = records("scientific/analytics/kinetics", limit=limit)
+    seen: list[str] = []
+    for row in rows:
+        ref = row.get("reaction_entry_ref")
+        if ref and ref not in seen:
+            seen.append(ref)
+    return seen
+
+
+def reaction(reaction_entry_ref: str) -> dict | None:
+    """One reaction entry: equation, family, participants, availability."""
+    found = records("scientific/reactions/search", reaction_entry_ref=reaction_entry_ref)
+    return found[0] if found else None
+
+
+def reaction_full(reaction_entry_ref: str) -> dict | None:
+    """Reaction entry with species, kinetics and transition states attached."""
+    return try_get(f"scientific/reaction-entries/{reaction_entry_ref}/full", include="all")
+
+
+def kinetics_for(reaction_entry_ref: str) -> list[dict]:
+    """Every rate coefficient stored for one reaction entry."""
+    return records(f"scientific/reaction-entries/{reaction_entry_ref}/kinetics")
+
+
+def arrhenius_k(parameters: dict, temperature_k: float) -> float:
+    """Evaluate k(T) = A * T^n * exp(-Ea / R T) from a kinetics record.
+
+    ``n`` is absent for a plain (two-parameter) Arrhenius form and defaults to
+    zero. The returned value carries the record's own ``A_units``: TCKDB does
+    not normalise rate units, because the correct unit depends on molecularity
+    and silently converting would be a guess. Read ``A_units`` and say what
+    you plotted.
+    """
+    a = parameters["A"]
+    n = parameters.get("n") or 0.0
+    ea = parameters.get("Ea_kj_mol") or 0.0
+    return a * temperature_k**n * math.exp(-ea / (R_KJ_MOL_K * temperature_k))
+
+
+# ---------------------------------------------------------------------------
+# Transition states
+# ---------------------------------------------------------------------------
+
+
+def transition_states(**filters: Any) -> list[dict]:
+    """Transition states matching a filter (e.g. ``has_freq="true"``).
+
+    Like every search endpoint this needs at least one filter. The ``has_*``
+    family is the useful one here: it asks for saddle points by *what evidence
+    exists for them*, not by identity.
+    """
+    return records("scientific/transition-states/search", **filters)
+
+
+# ---------------------------------------------------------------------------
+# Pressure-dependent networks
+#
+# A master-equation solve produces k(T, P) for every channel in a network. The
+# fitted forms below are how that surface is stored: Chebyshev is a smooth
+# two-dimensional fit, PLOG is a set of Arrhenius expressions at fixed
+# pressures with logarithmic interpolation between them.
+# ---------------------------------------------------------------------------
+
+
+def networks(**filters: Any) -> list[dict]:
+    """Pressure-dependent networks matching a filter."""
+    return records("scientific/networks/search", **filters)
+
+
+def network_kinetics(model: str, limit: int = 50) -> list[dict]:
+    """Channel rate coefficients of one fitted form.
+
+    :param model: ``"chebyshev"`` or ``"plog"``.
+    """
+    flag = {"chebyshev": "has_chebyshev", "plog": "has_plog"}[model]
+    include = {"chebyshev": "coefficients", "plog": "plog"}[model]
+    return records(
+        "scientific/network-kinetics/search",
+        include=include,
+        limit=limit,
+        **{flag: "true"},
     )
+
+
+def channel_key(record: dict) -> tuple[str, str]:
+    """Identify a channel by the composition of the states it connects.
+
+    Two fits of the same channel come back as two different records with two
+    different refs, so ref equality cannot pair them. The composition hashes
+    can: they are computed from the participating species and stoichiometry,
+    which is what makes "the same channel" the same.
+    """
+    channel = record["network_channel"]
+    return (
+        channel["source_state_composition_hash"],
+        channel["sink_state_composition_hash"],
+    )
+
+
+def channel_label(record: dict) -> str:
+    """A readable ``A + B -> C`` label for a channel."""
+
+    def side(state: dict) -> str:
+        parts = []
+        for participant in state["participants"]:
+            stoich = participant["stoichiometry"]
+            prefix = f"{stoich} " if stoich != 1 else ""
+            parts.append(prefix + participant["canonical_smiles"])
+        return " + ".join(parts)
+
+    channel = record["network_channel"]
+    return f"{side(channel['source_state'])} -> {side(channel['sink_state'])}"
+
+
+def _chebyshev_basis(order: int, x: float) -> float:
+    """Chebyshev polynomial of the first kind, T_n(x) = cos(n * arccos x)."""
+    return math.cos(order * math.acos(x))
+
+
+def chebyshev_k(record: dict, temperature_k: float, pressure_bar: float) -> float:
+    """Evaluate a stored Chebyshev fit at one (T, P).
+
+    The Chemkin convention, which is what the stored coefficients assume:
+
+    * temperature is reduced in **inverse** T, ``Tr = (2/T - 1/Tmin - 1/Tmax)
+      / (1/Tmax - 1/Tmin)``, because Arrhenius behaviour is linear in 1/T;
+    * pressure is reduced in **log** P, ``Pr = (2 lgP - lgPmin - lgPmax) /
+      (lgPmax - lgPmin)``, because falloff is a decade-scale phenomenon;
+    * both map the fitted domain onto ``[-1, 1]``, where the Chebyshev basis
+      is defined, and the sum is of ``lg k`` (hence ``stores_log10_k``).
+
+    Reduced coordinates are clamped to the fitted domain. Outside it the basis
+    functions diverge, so an unclamped evaluation does not extrapolate, it
+    produces nonsense -- silently, and by many orders of magnitude.
+    """
+    meta = record["network_kinetics"]
+    block = record["coefficients"]
+    t_min, t_max = meta["tmin_k"], meta["tmax_k"]
+    p_min, p_max = meta["pmin_bar"], meta["pmax_bar"]
+
+    t_reduced = (2.0 / temperature_k - 1.0 / t_min - 1.0 / t_max) / (1.0 / t_max - 1.0 / t_min)
+    p_reduced = (2.0 * math.log10(pressure_bar) - math.log10(p_min) - math.log10(p_max)) / (
+        math.log10(p_max) - math.log10(p_min)
+    )
+    t_reduced = max(-1.0, min(1.0, t_reduced))
+    p_reduced = max(-1.0, min(1.0, p_reduced))
+
+    log10_k = sum(
+        term["coefficient"]
+        * _chebyshev_basis(term["temperature_order"], t_reduced)
+        * _chebyshev_basis(term["pressure_order"], p_reduced)
+        for term in block["coefficients"]
+    )
+    return 10.0**log10_k
+
+
+def plog_k(record: dict, temperature_k: float, pressure_bar: float) -> float:
+    """Evaluate a stored PLOG fit at one (T, P).
+
+    Arrhenius is evaluated at each bracketing pressure and the two results are
+    interpolated linearly in ``lg k`` against ``lg P`` -- the definition of the
+    PLOG form. Below the lowest and above the highest tabulated pressure the
+    nearest expression is used unchanged, which is what Chemkin does.
+    """
+    entries = record["plog"]
+    pressures = sorted({entry["pressure_bar"] for entry in entries})
+
+    def arrhenius_sum(pressure: float) -> float:
+        return sum(
+            entry["a"] * temperature_k ** entry["n"] * math.exp(-entry["ea_kj_mol"] / (R_KJ_MOL_K * temperature_k))
+            for entry in entries
+            if entry["pressure_bar"] == pressure
+        )
+
+    if pressure_bar <= pressures[0]:
+        return arrhenius_sum(pressures[0])
+    if pressure_bar >= pressures[-1]:
+        return arrhenius_sum(pressures[-1])
+
+    low = max(p for p in pressures if p <= pressure_bar)
+    high = min(p for p in pressures if p >= pressure_bar)
+    if low == high:
+        return arrhenius_sum(low)
+
+    k_low, k_high = arrhenius_sum(low), arrhenius_sum(high)
+    weight = (math.log10(pressure_bar) - math.log10(low)) / (math.log10(high) - math.log10(low))
+    return 10 ** (math.log10(k_low) + weight * (math.log10(k_high) - math.log10(k_low)))
+
+
+def paired_channel_fits(limit: int = 50) -> list[tuple[dict, dict]]:
+    """Channels stored in **both** a Chebyshev and a PLOG form.
+
+    A network fitted twice is a redundancy, and redundancy is where a database
+    can be checked against itself: the two forms come from independent fits, so
+    evaluating both at the same (T, P) tests the stored numbers rather than
+    just reading them back.
+    """
+    chebyshev = network_kinetics("chebyshev", limit=limit)
+    plog = {channel_key(record): record for record in network_kinetics("plog", limit=limit)}
+    return [(record, plog[channel_key(record)]) for record in chebyshev if channel_key(record) in plog]
+
+
+# ---------------------------------------------------------------------------
+# Command-line tour
+# ---------------------------------------------------------------------------
+
+
+def _rule(title: str) -> None:
+    print(f"\n{title}\n{'-' * len(title)}")
 
 
 def _tour() -> None:
     print(f"deployment : {base_url()}")
-    print(f"health     : {health()}\n")
+    print(f"health     : {health()}")
 
+    _rule("What this deployment holds")
+    stock = inventory()
+    if not stock:
+        print("  no analytics surfaces served here")
+    for surface, block in stock.items():
+        approved = block["review"].get("approved", 0)
+        print(f"  {surface:14s} {block['total']:6d} records  ({approved} approved)")
+    for name, entries in vocabularies().items():
+        top = ", ".join(f"{e['value']} ({e['count']})" for e in entries[:4])
+        print(f"  {name:14s} {top}" if top else f"  {name:14s} -")
+
+    _rule("Species and thermodynamics")
     for smiles in ("C=C", "[CH3]", "[OH]", "O"):
-        species = find_species(smiles=smiles)
-        if not species:
-            print(f"{smiles:8s} not present in this deployment")
+        found = find_species(smiles=smiles)
+        if not found:
+            print(f"  {smiles:8s} not present in this deployment")
             continue
-        record = species[0]
+        record = found[0]
         ref = record["species_ref"]
         thermo = thermo_for(ref)
-        calcs = calculations_for(ref)
         print(
-            f"{smiles:8s} {record['inchi_key']:29s} "
-            f"thermo={len(thermo):2d} calcs={len(calcs):3d} statmech={len(statmech_for(ref)):2d}"
+            f"  {smiles:8s} {record['inchi_key']:29s} "
+            f"thermo={len(thermo):2d} calcs={len(calculations_for(ref)):3d} "
+            f"statmech={len(statmech_for(ref)):2d}"
         )
-        nasa = next((t["thermo"].get("nasa") for t in thermo if t["thermo"].get("nasa")), None)
+        nasa = first_nasa(thermo)
         if nasa:
             print(
-                f"         Cp(300K)={cp_j_mol_k(nasa, 300):7.2f} J/mol/K   "
+                f"           Cp(300K)={cp_j_mol_k(nasa, 300):7.2f} J/mol/K   "
                 f"H(300K)={h_kj_mol(nasa, 300):8.2f} kJ/mol   "
                 f"S(300K)={s_j_mol_k(nasa, 300):7.2f} J/mol/K"
             )
+
+    _rule("Reactions")
+    refs = reaction_entry_refs(limit=5)
+    if not refs:
+        print("  no reactions with kinetics in this deployment")
+    for ref in refs:
+        entry = reaction(ref)
+        if entry is None:
+            continue
+        available = entry["availability"]
+        print(f"  {entry['equation']}")
+        print(
+            f"     family={entry.get('family') or '-'}  "
+            f"kinetics={available['kinetics_count']}  "
+            f"TS={available['has_transition_state']}  "
+            f"atom_map={available['has_atom_map']}"
+        )
+        for record in kinetics_for(ref)[:1]:
+            params = record["parameters"]
+            evidence = record.get("evidence_completeness") or {}
+            print(
+                f"     k(1000 K) = {arrhenius_k(params, 1000.0):.4g} {params['A_units']}"
+                f"   evidence {evidence.get('score', '?')}/{evidence.get('max', '?')}"
+            )
+
+    _rule("Pressure-dependent networks")
+    found = networks(has_channels="true")
+    if not found:
+        print("  none in this deployment")
+    for record in found:
+        summary = record["evidence_summary"]
+        print(
+            f"  {record['network']['name']}: {summary['species_count']} species, "
+            f"{summary['channel_count']} channels, {summary['kinetics_count']} k(T,P) records"
+        )
+
+    pairs = paired_channel_fits()
+    if pairs:
+        print(f"\n  {len(pairs)} channel(s) stored in both Chebyshev and PLOG form.")
+        print(f"  {'channel':46s} {'k_cheb':>11s} {'k_plog':>11s} {'ratio':>7s}   (1000 K, 1 bar)")
+        worst, worst_channel = 0.0, ""
+        for index, (cheb, plog) in enumerate(pairs):
+            k_c = chebyshev_k(cheb, 1000.0, 1.0)
+            k_p = plog_k(plog, 1000.0, 1.0)
+            if abs(math.log10(k_c / k_p)) > worst:
+                worst = abs(math.log10(k_c / k_p))
+                worst_channel = channel_label(cheb)
+            if index < 5:
+                print(f"  {channel_label(cheb)[:46]:46s} {k_c:11.4g} {k_p:11.4g} {k_c / k_p:7.3f}")
+        print(f"\n  worst disagreement: {10**worst:.2f}x on {worst_channel}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `explore_tckdb` notebook stopped at thermodynamics. It never showed a reaction, a rate coefficient, or the pressure-dependent network that is the most interesting object in the deployment. It also opened with `species/search` — the one call a newcomer cannot make, since every search endpoint requires an identifier and answers `422` without one.

Sections 1 and 4–6 are new. Outputs are committed from a real run against the hosted deployment.

## What's new

**1. What's in this deployment?** The analytics surfaces are the only endpoints that list without a filter, so they are how you find out what is here before you know what to ask for. Inventory plus the controlled vocabularies (methods, basis sets, software, reaction families).

**2.** Substructure search by SMARTS alongside identity search — served by the RDKit cartridge in Postgres.

**4. Reactions.** Browse via kinetics analytics to get entry refs, then one reaction in full: equation, family, participants, and a rate coefficient with its temperature coverage, multiplicative A uncertainty, and evidence checklist.

**5. Transition states.** Filtered by what evidence exists for them rather than by identity, with a note on why `IRC validation: absent` does not mean the IRC is missing.

**6. Pressure-dependent networks.** The showpiece.

## The self-consistency check

The hydrazine network is stored twice — Chebyshev from one Arkane run, PLOG from a sister run of the same network with a different interpolation model. Evaluating both at the same (T, P) is a check the database can run against itself. All 21 channels pair cleanly on their state composition hashes.

Sorting the result by disagreement sorts it by channel kind:

| kind | agreement at 1000 K, 1 bar |
|---|---|
| `exchange` (bimolecular → bimolecular) | within ~20% |
| `association` / `isomerization` (ends in a stabilised well) | up to 3.9x, **always Chebyshev low** |

A systematic offset along a physically meaningful axis is not scatter, and not an evaluator bug — a coding error in the reduced coordinates or the basis would spoil the exchange channels too. It bounds how much precision to claim from a stored k(T,P).

The notebook is explicit that this does **not** certify the network: both fits descend from one solve. It bounds the disagreement between two representations of one calculation, which is a more modest claim and the one the data supports.

## Two defects found while writing it, fixed here

**A full run trips the rate limiter.** The server answers `429` with `Retry-After` and a `retry_after_seconds` context field, so `get()` now reads it and waits exactly that long, announcing the pause — a silent sleep is indistinguishable from a hung cell. It fired twice while executing the committed outputs.

**The Arrhenius uncertainty band was invisible.** A x1.25 factor is under a tenth of a decade against an axis spanning nine, so the legend claimed something the reader could not see. Now plotted twice: full fitted range, and a 900–1200 K window where the band is legible.

## Robustness

`try_get()` swallows only 404/405. A `422` still raises, because that means the *request* was wrong, and quietly returning `None` for a bad query is how a tour ends up showing nothing and looking like an empty database. Every section degrades to "not present in this deployment" rather than raising, so this runs against an empty local instance too.

## Reported, not fixed here

Section 6 documents a read-surface defect it has to work around: two `species_entry` rows share one `species` row for diazene, so three distinct channels render as two identical strings and one that appears to go from a state to itself. The data is fine — the composition hashes separate them correctly — but the labels do not. Tracked as a separate task, with `file:line` anchors.

## Notes

- `examples/` is not in CI's ruff scope; the script is formatted at the repo's `line-length = 120` from `backend/pyproject.toml`, not ruff's default 88.
- `explore_tckdb.py` is kept in step with the notebook and every function in it is importable.