### PR TITLE
Canonicalise element symbols where they are compared, not where they are cited

### DIFF
--- a/backend/alembic/versions/b4e7c1d20f83_canonical_element_symbols.py
+++ b/backend/alembic/versions/b4e7c1d20f83_canonical_element_symbols.py
@@ -4,18 +4,35 @@
 exactly as the depositor's file wrote it. Electronic-structure codes do
 not agree about capitalisation, so a ``character(2)`` column that every
 element comparison in the codebase reads could hold ``Cl``, ``CL``,
-``cl`` and ``bR`` for one element. Three separate sites existed only to
-paper over that at comparison time, and the class of bug they papered
-over had already shipped twice: a saddle point written ``CL`` contradicted
-its own reaction, and a mixed-case deposit was accepted at the blocking
-tier while ``calc_geometry_validation`` recorded ``fail`` on the same
-bytes.
+``cl`` and ``bR`` for one element. Several sites normalise at comparison
+time to cope with that, and the class of bug they cope with had already
+shipped twice: a saddle point written ``CL`` contradicted its own
+reaction, and a mixed-case deposit was accepted at the blocking tier while
+``calc_geometry_validation`` recorded ``fail`` on the same bytes.
 
 ``parse_xyz`` now canonicalises the symbol before it becomes a row
 (``normalize_element_symbol`` -- first character upper, rest lower, and
 nothing else). This revision brings the rows written before it into the
-same form, so that "a symbol read out of ``geometry_atom`` is canonical"
-is true of the whole table rather than only of its future.
+same form.
+
+What that does and does not buy
+-------------------------------
+It makes the common case clean: one spelling per element in the column
+joins and comparisons run against. It does **not** establish an invariant.
+No CHECK constraint requires ``geometry_atom.element`` to be canonical, so
+canonicality is a convention held by application code, and a restore from
+an older backup or a bulk import can break it at any time. The
+comparison-time normalisation therefore **stays** everywhere it was --
+notably the blocking element-conservation check in
+``app.services.reaction_atom_map``, which has to be correct on rows the
+running process never wrote. Removing it would trade a tidy column for a
+false refusal on correct chemistry, which ADR 0008 puts out of bounds for
+a blocking check. On canonical input it is a no-op and costs nothing.
+
+Making canonicality structural is a separate question with a separate
+cost: a CHECK constraint cannot be added until the accepted rows are
+already canonical, which is exactly the thing this revision refuses to
+force (below). It can be its own task.
 
 Case only, deliberately
 -----------------------
@@ -86,39 +103,37 @@ Two constraints that could have been a problem and are not:
   ``(geometry_id, atom_index)`` is already the primary key, so the
   triple's uniqueness never depended on ``element``.
 
-Why the accepted-science guard is stood down for this UPDATE
-------------------------------------------------------------
+Why the accepted-science guard is left standing
+-----------------------------------------------
 ``trg_as_geometry_atom`` (from ``c6f2a9d4e7b1``) refuses any UPDATE to a
 ``geometry_atom`` row whose geometry is attached to an **accepted**
-calculation. On the deployed database that is most of the interesting
-rows, and skipping them is not an option: a backfill that leaves accepted
-geometries non-canonical leaves the invariant this revision exists to
-establish false, and the code change that goes with it -- deleting the
-comparison-time normalisation in ``app.services.reaction_atom_map`` --
-would then produce a *false refusal* on exactly the oldest, most-cited
-data. Partial is worse than either whole or none.
+calculation. This revision does **not** disable it, and deliberately does
+not: it is a scientific-integrity control, and a migration that stands one
+down mutates approved science without anybody being asked.
 
-The guard is therefore disabled for the duration of this transaction and
-re-enabled inside it. That is defensible here and would not be for an
-ordinary data edit, for a specific reason: **the accepted record does not
-change.** ``geom_hash`` is untouched, so the geometry's identity and its
-citable public ref are the same before and after; ``geometry.xyz_text``
-is untouched, so the evidence the record was approved on still reads back
-byte-for-byte as deposited; the coordinates, the isotope labels and the
-atom ordering are untouched. What changes is the case of a symbol in a
-derived index column that every consumer in the tree already read
-case-insensitively -- this revision makes the storage agree with the
-meaning the code always gave it. Reviewers approved the chlorine, not the
-shift key.
+Measured on the deployed database before writing this, read-only:
+``geometry_atom`` holds 46,566 rows over 3,653 geometries -- C 14368,
+H 28844, O 2415, S 331, N 222, Cl 202, F 184 -- and **every one is already
+canonical**. ``reaction_atom_map_pair`` holds 0 rows.
+``geometry.xyz_text`` is non-NULL everywhere. So on the database this was
+written for, the backfill below matches nothing, updates nothing, and the
+guard never fires. Standing a control down to repair rows that do not
+exist is not a trade-off; it is a straight loss.
 
-``ALTER TABLE ... DISABLE TRIGGER`` needs table ownership, which the
-migration role has and the application role does not; see
-``backend/docs/deployment/database_roles.md`` and the ownership boundary
-recorded in ``backend/docs/specs/dataset_release_and_profiles.md``.
+What happens on a database that *does* hold a non-canonical accepted row:
+the UPDATE trips the guard and the migration fails, loudly, with the
+guard's own ``accepted calculation record N is immutable`` message. That
+is the correct outcome rather than a shortcoming. The decision to rewrite
+a value inside an approved record belongs to the operator who has one, not
+to this file -- and nothing downstream depends on the rewrite happening,
+because the code that ships with this revision still normalises at
+comparison time (see ``app.services.reaction_atom_map``). Canonical
+storage is the common case made clean, not an invariant anything blocking
+relies on.
 
 The upgrade re-checks its own work before returning and raises if any
-non-canonical row survives, so a guard that could not be stood down
-fails the migration instead of silently half-applying it.
+non-canonical row survives, so a partial backfill -- for any reason, guard
+or otherwise -- fails the migration instead of silently half-applying it.
 
 Revision ID: b4e7c1d20f83
 Revises: d7f1a3c5e948
@@ -152,8 +167,6 @@ _GEOMETRY_ATOM_FKS = (
     "fk_reaction_atom_map_pair_ts_geometry_id_geometry_atom",
 )
 
-_ACCEPTED_SCIENCE_TRIGGER = "trg_as_geometry_atom"
-
 
 def upgrade() -> None:
     element = _canonical("element")
@@ -165,13 +178,9 @@ def upgrade() -> None:
     # docstring for why no ordering of undeferred updates works.
     op.execute(f"SET CONSTRAINTS {', '.join(_GEOMETRY_ATOM_FKS)} DEFERRED")
 
-    # Stood down, not removed: re-enabled below, in the same transaction, so a
-    # failure anywhere in this revision rolls the guard back on with the data.
-    op.execute(
-        f"ALTER TABLE public.geometry_atom "
-        f"DISABLE TRIGGER {_ACCEPTED_SCIENCE_TRIGGER}"
-    )
-
+    # `trg_as_geometry_atom` is left enabled on purpose. If a row here belongs
+    # to an accepted calculation, this statement fails with the guard's own
+    # message and the whole revision rolls back -- see the module docstring.
     op.execute(
         f"""
         UPDATE geometry_atom
@@ -189,20 +198,21 @@ def upgrade() -> None:
         """
     )
 
-    # Back to IMMEDIATE before the guard goes back on, and not only for
-    # tidiness: deferring the two foreign keys leaves pending trigger events on
-    # `geometry_atom`, and PostgreSQL refuses `ALTER TABLE ... ENABLE TRIGGER`
-    # on a table that has any ("cannot ALTER TABLE because it has pending
-    # trigger events"). Setting them IMMEDIATE runs the referential check here,
-    # against the finished state, which drains the queue -- and has the better
-    # failure mode besides: a violation is reported at this statement rather
-    # than at COMMIT, with the revision's own frame on the traceback.
+    # Back to IMMEDIATE, which runs the referential check here, against the
+    # finished state. Two reasons it is worth an explicit statement rather than
+    # letting COMMIT do it:
+    #
+    # * Failure mode. A violation is reported at this statement, with this
+    #   revision's own frame on the traceback, instead of surfacing from an
+    #   Alembic COMMIT with no indication of which migration produced it.
+    # * Pending trigger events are not free. A deferred constraint leaves them
+    #   queued on `geometry_atom`, and PostgreSQL refuses `ALTER TABLE` on a
+    #   table that has any ("cannot ALTER TABLE because it has pending trigger
+    #   events"). Nothing here alters the table any more, but a follow-up
+    #   revision that stacks onto this one would hit it, and draining the queue
+    #   at a known point is what makes the deferral local to these two
+    #   statements rather than to the whole transaction.
     op.execute(f"SET CONSTRAINTS {', '.join(_GEOMETRY_ATOM_FKS)} IMMEDIATE")
-
-    op.execute(
-        f"ALTER TABLE public.geometry_atom "
-        f"ENABLE TRIGGER {_ACCEPTED_SCIENCE_TRIGGER}"
-    )
 
     connection = op.get_bind()
     for table, columns in (
@@ -218,10 +228,12 @@ def upgrade() -> None:
         if remaining:
             raise RuntimeError(
                 f"b4e7c1d20f83: {remaining} row(s) of {table} still hold a "
-                "non-canonical element symbol after the backfill. The "
-                "migration refuses to leave the table half-canonical, "
-                "because the code that ships with it stops normalising at "
-                "comparison time."
+                "non-canonical element symbol after the backfill. An UPDATE "
+                "that matched fewer rows than it selected means something "
+                "silently refused part of the rewrite, and a half-canonical "
+                "table is a worse state to leave behind than an untouched "
+                "one. Nothing is broken by rolling back: comparisons still "
+                "normalise, so non-canonical rows read correctly either way."
             )
 
 

--- a/backend/alembic/versions/b4e7c1d20f83_canonical_element_symbols.py
+++ b/backend/alembic/versions/b4e7c1d20f83_canonical_element_symbols.py
@@ -1,0 +1,248 @@
+"""store one spelling of an element symbol, not three
+
+``parse_xyz`` used to put ``parts[0]`` into ``geometry_atom.element``
+exactly as the depositor's file wrote it. Electronic-structure codes do
+not agree about capitalisation, so a ``character(2)`` column that every
+element comparison in the codebase reads could hold ``Cl``, ``CL``,
+``cl`` and ``bR`` for one element. Three separate sites existed only to
+paper over that at comparison time, and the class of bug they papered
+over had already shipped twice: a saddle point written ``CL`` contradicted
+its own reaction, and a mixed-case deposit was accepted at the blocking
+tier while ``calc_geometry_validation`` recorded ``fail`` on the same
+bytes.
+
+``parse_xyz`` now canonicalises the symbol before it becomes a row
+(``normalize_element_symbol`` -- first character upper, rest lower, and
+nothing else). This revision brings the rows written before it into the
+same form, so that "a symbol read out of ``geometry_atom`` is canonical"
+is true of the whole table rather than only of its future.
+
+Case only, deliberately
+-----------------------
+``D`` and ``T`` are left as ``D`` and ``T``. They are legal XYZ tokens
+that every major ESS emits or accepts, and they are the depositor's own
+isotope labelling; collapsing them to ``H`` here would destroy a fact
+about the deposit rather than settle a spelling of one. Code that counts
+elements resolves them at the point of counting
+(``app.chemistry.geometry.resolve_element_symbol``).
+
+What is deliberately NOT rewritten
+----------------------------------
+``geometry.xyz_text``. ``geom_hash`` is a sha256 over that text, it is
+the dedupe key in ``app.services.geometry_resolution``, and
+``app.services.public_refs`` mints ``geometry:geom_hash=<hash>`` as a
+citable public ref. Rewriting a symbol inside the hashed text would
+re-key every already-stored geometry whose XYZ shouted an element:
+published refs would dangle, and a re-upload of the very same file would
+compute the old hash and fail to dedupe onto its own row. So
+``geometry.xyz_text`` may read ``CL`` for an atom whose
+``geometry_atom.element`` reads ``Cl``, and that divergence is the point:
+``xyz_text`` is the deposited evidence and has to read back as deposited,
+``geometry_atom`` is the parsed index that joins and comparisons run
+against, and only the second one has to be canonical for the first one to
+stay citable.
+
+``energy_correction_scheme_atom_param.element`` is also NOT rewritten,
+and that is a decision rather than an oversight. It is ``text``, it is
+half of that table's primary key, and it is a *reference library* key --
+the element label a published correction scheme (AEC, SOC, BAC) uses for
+its own parameters. Nothing in the tree joins it to ``geometry_atom`` or
+compares it against a deposited geometry today, so there is no comparison
+being papered over. Normalising a primary-key column is also not the same
+operation: two rows of one scheme spelled ``C`` and ``c`` would collide on
+update, which needs a merge policy rather than an ``UPDATE``. When a
+correction is actually applied to a geometry's atom counts, that join is
+where the canonical form has to be settled, and it can carry its own
+revision.
+
+Ordering, and why it is safe
+----------------------------
+``reaction_atom_map_pair`` carries ``element`` and ``ts_element`` into
+two composite foreign keys onto
+``geometry_atom (geometry_id, atom_index, element)``. The element column
+is part of the referenced key, so *no* ordering of two plain UPDATEs is
+valid: rewriting the parent first orphans every child row that quotes the
+old spelling, and rewriting a child first points it at a parent key that
+does not exist yet. Both directions fail at statement end.
+
+Both foreign keys were created ``DEFERRABLE INITIALLY IMMEDIATE`` (see
+``d3a7f1c9b284``), so this revision defers them by name, updates both
+tables, and then sets them back to IMMEDIATE. The referential check runs
+once, at that point, against the finished state -- in which every child
+triple ``(geometry_id, atom_index, element)`` again names a real
+``geometry_atom`` row, because both sides received the *same*
+transformation. Deferral is what makes the two updates atomic with
+respect to the constraint; the order of the statements between them is
+therefore irrelevant, and ``geometry_atom`` is updated first only because
+it is the side that defines the truth.
+
+Two constraints that could have been a problem and are not:
+
+* ``ck_reaction_atom_map_pair_element_matches`` (``upper(element) =
+  upper(ts_element)``) is a CHECK and cannot be deferred. It does not need
+  to be: ``upper()`` is invariant under this transformation, so every
+  intermediate row satisfies it exactly as it did before.
+* ``uq_geometry_atom_geometry_id_element`` cannot be violated --
+  ``(geometry_id, atom_index)`` is already the primary key, so the
+  triple's uniqueness never depended on ``element``.
+
+Why the accepted-science guard is stood down for this UPDATE
+------------------------------------------------------------
+``trg_as_geometry_atom`` (from ``c6f2a9d4e7b1``) refuses any UPDATE to a
+``geometry_atom`` row whose geometry is attached to an **accepted**
+calculation. On the deployed database that is most of the interesting
+rows, and skipping them is not an option: a backfill that leaves accepted
+geometries non-canonical leaves the invariant this revision exists to
+establish false, and the code change that goes with it -- deleting the
+comparison-time normalisation in ``app.services.reaction_atom_map`` --
+would then produce a *false refusal* on exactly the oldest, most-cited
+data. Partial is worse than either whole or none.
+
+The guard is therefore disabled for the duration of this transaction and
+re-enabled inside it. That is defensible here and would not be for an
+ordinary data edit, for a specific reason: **the accepted record does not
+change.** ``geom_hash`` is untouched, so the geometry's identity and its
+citable public ref are the same before and after; ``geometry.xyz_text``
+is untouched, so the evidence the record was approved on still reads back
+byte-for-byte as deposited; the coordinates, the isotope labels and the
+atom ordering are untouched. What changes is the case of a symbol in a
+derived index column that every consumer in the tree already read
+case-insensitively -- this revision makes the storage agree with the
+meaning the code always gave it. Reviewers approved the chlorine, not the
+shift key.
+
+``ALTER TABLE ... DISABLE TRIGGER`` needs table ownership, which the
+migration role has and the application role does not; see
+``backend/docs/deployment/database_roles.md`` and the ownership boundary
+recorded in ``backend/docs/specs/dataset_release_and_profiles.md``.
+
+The upgrade re-checks its own work before returning and raises if any
+non-canonical row survives, so a guard that could not be stood down
+fails the migration instead of silently half-applying it.
+
+Revision ID: b4e7c1d20f83
+Revises: d7f1a3c5e948
+Create Date: 2026-08-10
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4e7c1d20f83"
+down_revision: Union[str, Sequence[str], None] = "d7f1a3c5e948"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: SQL spelling of ``str.strip().capitalize()`` for a one- or two-character
+#: element symbol: upper-case the first character, lower-case the rest.
+#: ``btrim`` first, because ``geometry_atom.element`` is ``character(2)`` and a
+#: one-letter symbol is stored blank-padded as ``'C '``.
+def _canonical(column: str) -> str:
+    return (
+        f"upper(substr(btrim({column}), 1, 1)) || lower(substr(btrim({column}), 2))"
+    )
+
+
+_GEOMETRY_ATOM_FKS = (
+    "fk_reaction_atom_map_pair_geometry_id_geometry_atom",
+    "fk_reaction_atom_map_pair_ts_geometry_id_geometry_atom",
+)
+
+_ACCEPTED_SCIENCE_TRIGGER = "trg_as_geometry_atom"
+
+
+def upgrade() -> None:
+    element = _canonical("element")
+    ts_element = _canonical("ts_element")
+
+    # Both foreign keys are DEFERRABLE INITIALLY IMMEDIATE. Deferring them here
+    # holds the referential check until COMMIT, which is the only way the
+    # parent and the child can be rewritten in one step -- see the module
+    # docstring for why no ordering of undeferred updates works.
+    op.execute(f"SET CONSTRAINTS {', '.join(_GEOMETRY_ATOM_FKS)} DEFERRED")
+
+    # Stood down, not removed: re-enabled below, in the same transaction, so a
+    # failure anywhere in this revision rolls the guard back on with the data.
+    op.execute(
+        f"ALTER TABLE public.geometry_atom "
+        f"DISABLE TRIGGER {_ACCEPTED_SCIENCE_TRIGGER}"
+    )
+
+    op.execute(
+        f"""
+        UPDATE geometry_atom
+        SET element = {element}
+        WHERE btrim(element) <> {element}
+        """
+    )
+    op.execute(
+        f"""
+        UPDATE reaction_atom_map_pair
+        SET element = {element},
+            ts_element = {ts_element}
+        WHERE btrim(element) <> {element}
+           OR btrim(ts_element) <> {ts_element}
+        """
+    )
+
+    # Back to IMMEDIATE before the guard goes back on, and not only for
+    # tidiness: deferring the two foreign keys leaves pending trigger events on
+    # `geometry_atom`, and PostgreSQL refuses `ALTER TABLE ... ENABLE TRIGGER`
+    # on a table that has any ("cannot ALTER TABLE because it has pending
+    # trigger events"). Setting them IMMEDIATE runs the referential check here,
+    # against the finished state, which drains the queue -- and has the better
+    # failure mode besides: a violation is reported at this statement rather
+    # than at COMMIT, with the revision's own frame on the traceback.
+    op.execute(f"SET CONSTRAINTS {', '.join(_GEOMETRY_ATOM_FKS)} IMMEDIATE")
+
+    op.execute(
+        f"ALTER TABLE public.geometry_atom "
+        f"ENABLE TRIGGER {_ACCEPTED_SCIENCE_TRIGGER}"
+    )
+
+    connection = op.get_bind()
+    for table, columns in (
+        ("geometry_atom", ("element",)),
+        ("reaction_atom_map_pair", ("element", "ts_element")),
+    ):
+        predicate = " OR ".join(
+            f"btrim({column}) <> {_canonical(column)}" for column in columns
+        )
+        remaining = connection.exec_driver_sql(
+            f"SELECT count(*) FROM {table} WHERE {predicate}"
+        ).scalar()
+        if remaining:
+            raise RuntimeError(
+                f"b4e7c1d20f83: {remaining} row(s) of {table} still hold a "
+                "non-canonical element symbol after the backfill. The "
+                "migration refuses to leave the table half-canonical, "
+                "because the code that ships with it stops normalising at "
+                "comparison time."
+            )
+
+
+def downgrade() -> None:
+    """Deliberately a no-op, and the reason is not squeamishness.
+
+    The upgrade is lossy in the only direction that matters: ``Cl`` does
+    not record whether the file it came from wrote ``Cl``, ``CL`` or
+    ``cl``, and nothing else in the database remembers per row either.
+    ``geometry.xyz_text`` keeps the deposited spelling, but it is
+    deliberately not the column being rewritten, and recovering the old
+    casing through it means re-parsing every geometry and would silently
+    do nothing wherever ``xyz_text`` is NULL.
+
+    Re-deriving the old casing was therefore considered and rejected on
+    its merits as well as its cost: it would restore the exact defect this
+    revision exists to remove, during a downgrade that is normally run to
+    get *back* to a working state. Leaving the canonical form in place is
+    forward-compatible -- every pre-upgrade code path normalised at
+    comparison time, so canonical rows are precisely what it already
+    handled correctly.
+
+    Nothing structural was added, so there is nothing structural to drop.
+    """

--- a/backend/app/chemistry/geometry.py
+++ b/backend/app/chemistry/geometry.py
@@ -24,20 +24,29 @@ def normalize_element_symbol(symbol: str) -> str:
     the same rule :mod:`app.chemistry.isotopes` already applies before handing
     a symbol to RDKit's periodic table.
 
-    Where this is applied
-    ---------------------
-    At **ingestion**, since Alembic revision ``b4e7c1d20f83``. :func:`parse_xyz`
-    runs every parsed symbol through this function before it becomes a
-    ``geometry_atom.element`` row, and that revision backfilled the rows written
-    before it. A symbol read out of ``geometry_atom`` is therefore canonical by
-    construction, and two of them may be compared directly — see
-    :mod:`app.services.reaction_atom_map`, which used to normalise at
-    comparison time and no longer needs to.
+    Where this is applied — in two places, on purpose
+    -------------------------------------------------
+    **At ingestion**, since Alembic revision ``b4e7c1d20f83``.
+    :func:`parse_xyz` runs every parsed symbol through this function before it
+    becomes a ``geometry_atom.element`` row, and that revision brought the rows
+    written before it into the same form. That is what makes the column one
+    spelling per element in the ordinary case.
 
-    It is still required wherever a symbol arrives from *outside* that column
-    and has to be lined up against it: RDKit's title-case ``GetSymbol()``, a
-    raw XYZ string that has not been through :func:`parse_xyz`, the wire
-    schema's
+    **And still at comparison time**, everywhere it already was. Ingestion
+    canonicalisation is a convention held by this module, not an invariant the
+    schema enforces: no CHECK constraint requires
+    ``geometry_atom.element`` to be canonical, so a restore from an older
+    backup, a bulk import, or any future write path that does not call
+    :func:`parse_xyz` can put ``CL`` back. Anything **blocking** has to be
+    correct on rows the running process never wrote, so it normalises both
+    sides rather than trusting the convention — see the element-conservation
+    check in :mod:`app.services.reaction_atom_map`. On canonical input that is
+    a no-op, so the correctness costs nothing.
+
+    It is required outright wherever a symbol arrives from *outside* that
+    column and has to be lined up against it: RDKit's title-case
+    ``GetSymbol()``, a raw XYZ string that has not been through
+    :func:`parse_xyz`, the wire schema's
     :func:`tckdb_schemas.fragments.reaction_atom_map.parse_xyz_elements`. Those
     sides are canonicalised by their own rules, or not at all, and this
     function is what makes the two rules one rule.
@@ -127,10 +136,12 @@ class ParsedXYZ:
     def isotope_substitutions(self) -> dict[tuple[str, int], int]:
         """Count non-standard isotope substitutions by ``(element, mass_number)``.
 
-        The element is read straight out of :attr:`atoms`, which
-        :func:`parse_xyz` has already canonicalised, so the key lines up with
-        the title-case symbols RDKit produces for the SMILES side without a
-        second normalisation step here.
+        The element is read straight out of :attr:`atoms` of *this* object,
+        which only :func:`parse_xyz` constructs and which it canonicalises on
+        the way in — so unlike a symbol read back out of ``geometry_atom``,
+        this one is canonical by construction and the key lines up with the
+        title-case symbols RDKit produces for the SMILES side without a second
+        normalisation step.
 
         :returns: Mapping used to cross-check the geometry against the
             isotope labels declared in the species-entry SMILES.
@@ -156,10 +167,14 @@ def parse_xyz(payload: GeometryPayload) -> ParsedXYZ:
     canonicalised through :func:`normalize_element_symbol`, so a file that
     writes ``CL`` and a file that writes ``Cl`` both store ``Cl``. That column
     is the *parsed index* the database computes on: it is the target of
-    ``reaction_atom_map_pair``'s two composite foreign keys, the ``character(2)``
-    value every element comparison in the service layer reads, and the thing
-    ADR 0008 forbids from refusing a correct deposit over a capital letter.
-    A column that is compared has to have one spelling.
+    ``reaction_atom_map_pair``'s two composite foreign keys and the
+    ``character(2)`` value every element comparison in the service layer reads,
+    and one spelling per element is what makes those reads say what they mean.
+
+    This is a *convention*, not an invariant: nothing in the schema requires the
+    column to be canonical, so the comparisons still normalise both sides and
+    stay correct on rows that arrived some other way. Canonicalising here makes
+    the common case clean; it does not license anything downstream to assume it.
 
     ``canonical_xyz_text`` becomes ``geometry.xyz_text`` and, hashed, becomes
     ``geom_hash``. Element symbols there are left **exactly as deposited**. Two

--- a/backend/app/chemistry/geometry.py
+++ b/backend/app/chemistry/geometry.py
@@ -13,15 +13,10 @@ from app.schemas.fragments.geometry import GeometryPayload
 def normalize_element_symbol(symbol: str) -> str:
     """Return an element symbol in the one case every comparison agrees on.
 
-    ``geometry_atom.element`` is stored **verbatim** as the depositor's XYZ
-    wrote it (see :func:`parse_xyz`), and electronic-structure codes are not
-    consistent about capitalisation: ``Cl``, ``CL`` and ``cl`` are the same
-    element and different strings. Anything that compares a stored element
-    against a symbol from another source — RDKit's title-case ``GetSymbol()``,
-    a second geometry deposited from a different program, the wire schema's
-    :func:`tckdb_schemas.fragments.reaction_atom_map.parse_xyz_elements` — must
-    normalise both sides first, or it refuses correct chemistry over
-    capitalisation, which ADR 0008 disqualifies a blocking check from doing.
+    Electronic-structure codes are not consistent about capitalisation: ``Cl``,
+    ``CL`` and ``cl`` are one element written three ways. Comparing those
+    strings raw refuses correct chemistry over a capital letter, which ADR 0008
+    disqualifies a blocking check from doing.
 
     ``str.capitalize`` is the rule: it upper-cases the first character and
     lower-cases the rest, which is exactly the wire schema's
@@ -29,10 +24,27 @@ def normalize_element_symbol(symbol: str) -> str:
     the same rule :mod:`app.chemistry.isotopes` already applies before handing
     a symbol to RDKit's periodic table.
 
-    Normalising here, at comparison time, rather than at ingestion is
-    deliberate: it is correct for the rows already stored as well as for new
-    ones, where canonicalising ``parse_xyz`` would fix only the future and
-    leave a backfill question behind.
+    Where this is applied
+    ---------------------
+    At **ingestion**, since Alembic revision ``b4e7c1d20f83``. :func:`parse_xyz`
+    runs every parsed symbol through this function before it becomes a
+    ``geometry_atom.element`` row, and that revision backfilled the rows written
+    before it. A symbol read out of ``geometry_atom`` is therefore canonical by
+    construction, and two of them may be compared directly — see
+    :mod:`app.services.reaction_atom_map`, which used to normalise at
+    comparison time and no longer needs to.
+
+    It is still required wherever a symbol arrives from *outside* that column
+    and has to be lined up against it: RDKit's title-case ``GetSymbol()``, a
+    raw XYZ string that has not been through :func:`parse_xyz`, the wire
+    schema's
+    :func:`tckdb_schemas.fragments.reaction_atom_map.parse_xyz_elements`. Those
+    sides are canonicalised by their own rules, or not at all, and this
+    function is what makes the two rules one rule.
+
+    Note what it does **not** do: it does not touch ``geometry.xyz_text``. That
+    column keeps the symbol the depositor's file wrote, and :func:`parse_xyz`
+    explains why.
     """
 
     return symbol.strip().capitalize()
@@ -44,8 +56,9 @@ def resolve_element_symbol(symbol: str) -> str:
     :func:`normalize_element_symbol` settles capitalisation. This settles the
     other way an XYZ can spell an element that a comparison must not trip over:
     ``D`` and ``T`` are hydrogen. Both are legal, common tokens — Gaussian,
-    ORCA, Molpro and CFOUR all emit or accept them — and
-    ``geometry_atom.element`` stores them verbatim by design, so a check that
+    ORCA, Molpro and CFOUR all emit or accept them — and ingestion
+    canonicalisation deliberately leaves them alone, so
+    ``geometry_atom.element`` stores them as ``D`` and ``T``, and a check that
     compares raw symbols reads a perfectly ordinary deuterated geometry as
     containing an element its SMILES never mentions. That refuses correct
     chemistry, which ADR 0008 disqualifies a blocking check from doing.
@@ -114,13 +127,18 @@ class ParsedXYZ:
     def isotope_substitutions(self) -> dict[tuple[str, int], int]:
         """Count non-standard isotope substitutions by ``(element, mass_number)``.
 
+        The element is read straight out of :attr:`atoms`, which
+        :func:`parse_xyz` has already canonicalised, so the key lines up with
+        the title-case symbols RDKit produces for the SMILES side without a
+        second normalisation step here.
+
         :returns: Mapping used to cross-check the geometry against the
             isotope labels declared in the species-entry SMILES.
         """
 
         counts: dict[tuple[str, int], int] = {}
         for atom_index, mass_number in self.isotopes:
-            element = self.atoms[atom_index - 1][0].capitalize()
+            element = self.atoms[atom_index - 1][0]
             key = (element, mass_number)
             counts[key] = counts.get(key, 0) + 1
         return counts
@@ -128,6 +146,44 @@ class ParsedXYZ:
 
 def parse_xyz(payload: GeometryPayload) -> ParsedXYZ:
     """Parse and canonicalize an uploaded XYZ payload.
+
+    Two products, two different rules
+    ---------------------------------
+    This function produces two things from one set of parsed atom lines, and
+    they deliberately do **not** spell the element the same way.
+
+    ``atoms`` becomes the ``geometry_atom`` rows. Element symbols there are
+    canonicalised through :func:`normalize_element_symbol`, so a file that
+    writes ``CL`` and a file that writes ``Cl`` both store ``Cl``. That column
+    is the *parsed index* the database computes on: it is the target of
+    ``reaction_atom_map_pair``'s two composite foreign keys, the ``character(2)``
+    value every element comparison in the service layer reads, and the thing
+    ADR 0008 forbids from refusing a correct deposit over a capital letter.
+    A column that is compared has to have one spelling.
+
+    ``canonical_xyz_text`` becomes ``geometry.xyz_text`` and, hashed, becomes
+    ``geom_hash``. Element symbols there are left **exactly as deposited**. Two
+    reasons, in order of weight:
+
+    * ``geom_hash`` is a public ref. :func:`app.services.public_refs` mints
+      ``geometry:geom_hash=<hash>`` as a citable identifier, and it is also the
+      dedupe key in :mod:`app.services.geometry_resolution`. Canonicalising the
+      symbol inside the hashed text would re-key every geometry already stored
+      whose XYZ shouted an element: published refs would dangle, and
+      re-uploading the very same file would fail to dedupe onto its own row.
+      This is the same constraint that keeps the isotope suffix off
+      :attr:`ParsedXYZ.hash_text` for unlabelled geometries.
+    * ``xyz_text`` is the deposited evidence. It is the block a depositor reads
+      back, and the symbol is the one part of an atom line this function does
+      not already reformat. ``D`` is what they wrote and what they should read
+      back, for the reason :func:`resolve_element_symbol` gives; the same is
+      true of ``CL``.
+
+    So ``geometry.xyz_text`` may read ``CL`` while ``geometry_atom.element``
+    reads ``Cl`` for the same atom. That is not drift: one is the record of what
+    was deposited, the other is the index the database joins and compares on,
+    and only the second one has to be canonical for the first one to stay
+    citable.
 
     :param payload: Upload-facing geometry payload.
     :returns: Parsed XYZ representation with canonicalized coordinate text.
@@ -152,22 +208,33 @@ def parse_xyz(payload: GeometryPayload) -> ParsedXYZ:
         )
 
     atoms: list[tuple[str, float, float, float]] = []
+    #: The element token exactly as the file wrote it, kept alongside the
+    #: canonicalised one so ``canonical_xyz_text`` — and therefore
+    #: ``geom_hash`` — is byte-for-byte what it was before this function
+    #: canonicalised anything. See the docstring.
+    deposited_symbols: list[str] = []
     for line in atom_lines:
         parts = line.split()
         if len(parts) != 4:
             raise ValueError("Each XYZ atom line must contain element x y z")
-        element = parts[0]
+        deposited = parts[0]
+        # `normalize_element_symbol`, not `resolve_element_symbol`: `D` and `T`
+        # must stay `D` and `T` in the stored column. Collapsing them to `H`
+        # here would destroy deposited isotope labelling, which is a fact about
+        # the deposit and not a spelling of one.
+        element = normalize_element_symbol(deposited)
         try:
             x = float(parts[1])
             y = float(parts[2])
             z = float(parts[3])
         except ValueError as exc:
             raise ValueError("XYZ coordinates must be numeric") from exc
+        deposited_symbols.append(deposited)
         atoms.append((element, x, y, z))
 
     canonical_lines = [str(natoms), ""]
-    for element, x, y, z in atoms:
-        canonical_lines.append(f"{element} {x:.12f} {y:.12f} {z:.12f}")
+    for deposited, (_element, x, y, z) in zip(deposited_symbols, atoms):
+        canonical_lines.append(f"{deposited} {x:.12f} {y:.12f} {z:.12f}")
 
     isotopes: list[tuple[int, int]] = []
     for atom_index, mass_number in sorted((payload.isotopes or {}).items()):

--- a/backend/app/chemistry/geometry.py
+++ b/backend/app/chemistry/geometry.py
@@ -233,7 +233,7 @@ def parse_xyz(payload: GeometryPayload) -> ParsedXYZ:
         atoms.append((element, x, y, z))
 
     canonical_lines = [str(natoms), ""]
-    for deposited, (_element, x, y, z) in zip(deposited_symbols, atoms):
+    for deposited, (_element, x, y, z) in zip(deposited_symbols, atoms, strict=True):
         canonical_lines.append(f"{deposited} {x:.12f} {y:.12f} {z:.12f}")
 
     isotopes: list[tuple[int, int]] = []

--- a/backend/app/chemistry/isotopes.py
+++ b/backend/app/chemistry/isotopes.py
@@ -34,9 +34,13 @@ __all__ = [
 #: ``D`` is deuterium and ``T`` is tritium.
 #:
 #: They are legal, common XYZ tokens — Gaussian, ORCA, Molpro and CFOUR all
-#: emit or accept them — and ``geometry_atom.element`` stores whatever the
-#: depositor's XYZ said, verbatim (see :func:`app.chemistry.geometry.parse_xyz`).
-#: Anything that *counts elements* must therefore resolve them to ``H`` first
+#: emit or accept them — and ``geometry_atom.element`` keeps them. Ingestion
+#: canonicalises the *case* of every symbol it stores
+#: (:func:`app.chemistry.geometry.normalize_element_symbol`, applied in
+#: :func:`app.chemistry.geometry.parse_xyz`) and deliberately stops there: a
+#: ``D`` collapsed to ``H`` at deposit time would destroy the depositor's own
+#: isotope labelling, which is a fact about the deposit rather than a spelling
+#: of one. Anything that *counts elements* must therefore resolve them to ``H``
 #: (:func:`app.chemistry.geometry.resolve_element_symbol`), or it refuses a
 #: correctly deposited isotopologue for spelling its hydrogens the way its ESS
 #: did — which ADR 0008 puts out of bounds for a blocking check.
@@ -51,6 +55,15 @@ HYDROGEN_ISOTOPE_SYMBOLS: dict[str, int] = {"D": 2, "T": 3}
 
 def _periodic_table() -> Chem.PeriodicTable:
     return Chem.GetPeriodicTable()
+
+
+# The `.capitalize()` calls below survive the move of case canonicalisation into
+# `parse_xyz`. They are not comparison-time patches over a verbatim column: they
+# adapt an arbitrary caller-supplied symbol to RDKit's periodic table, which is
+# case-sensitive and raises on `CL`. These are exported helpers that take
+# `element: str` from SMILES, from geometry payloads and from callers that have
+# not been through `parse_xyz`, so RDKit is the "other side" that
+# `normalize_element_symbol` exists to line up with.
 
 
 def most_common_isotope(element: str) -> int | None:

--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -201,11 +201,12 @@ def element_counts_from_smiles(smiles: str) -> Counter[str]:
       (:func:`app.services.species_resolution.assert_geometry_isotopes_match_identity`).
     * **Symbols are resolved to elements** through
       :func:`~app.chemistry.geometry.resolve_element_symbol`, because the other
-      side of every comparison is an XYZ element column that keeps the
-      depositor's nuclide labelling: ESS codes write hydrogen's isotopes as
-      elements (``D``, ``T``), and ingestion deliberately preserves that.
-      (Capitalisation was the other half of this until ``b4e7c1d20f83``
-      canonicalised it at ingestion; ``D`` and ``T`` remain.) RDKit's
+      side of every comparison is an XYZ element column that ESS codes fill in
+      their own spelling: they disagree about capitalisation (``CL``, ``cl``)
+      and write hydrogen's isotopes as elements (``D``, ``T``).
+      ``b4e7c1d20f83`` canonicalises the case on the way in, which makes the
+      first of those rare rather than impossible — it is a convention, not a
+      constraint — and deliberately preserves the second. RDKit's
       ``GetSymbol()`` produces neither spelling, so this call is a no-op on
       this side — it is here so that both sides of every comparison are counted
       by one rule rather than two that must be remembered to agree.

--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -201,12 +201,14 @@ def element_counts_from_smiles(smiles: str) -> Counter[str]:
       (:func:`app.services.species_resolution.assert_geometry_isotopes_match_identity`).
     * **Symbols are resolved to elements** through
       :func:`~app.chemistry.geometry.resolve_element_symbol`, because the other
-      side of every comparison is an XYZ element stored verbatim: ESS codes
-      disagree about capitalisation (``CL``, ``cl``) and write hydrogen's
-      isotopes as elements (``D``, ``T``). RDKit's ``GetSymbol()`` produces
-      neither spelling, so this call is a no-op on this side — it is here so
-      that both sides of every comparison are counted by one rule rather than
-      two that must be remembered to agree.
+      side of every comparison is an XYZ element column that keeps the
+      depositor's nuclide labelling: ESS codes write hydrogen's isotopes as
+      elements (``D``, ``T``), and ingestion deliberately preserves that.
+      (Capitalisation was the other half of this until ``b4e7c1d20f83``
+      canonicalised it at ingestion; ``D`` and ``T`` remain.) RDKit's
+      ``GetSymbol()`` produces neither spelling, so this call is a no-op on
+      this side — it is here so that both sides of every comparison are counted
+      by one rule rather than two that must be remembered to agree.
 
     :param smiles: SMILES string to count.
     :returns: Mapping of element symbol to atom count.

--- a/backend/app/chemistry/torsion_fingerprint.py
+++ b/backend/app/chemistry/torsion_fingerprint.py
@@ -466,9 +466,10 @@ def _find_matches_using_smiles_graph(
     Both sides go through
     :func:`~app.chemistry.geometry.resolve_element_symbol` before they are
     grouped, because they come from sources that spell elements differently by
-    construction: the XYZ side keeps the depositor's nuclide labelling (``D``,
-    ``T``) and may not have been through ``parse_xyz`` at all, the reference
-    side holds RDKit's title-case ``GetSymbol()``. Grouping the raw strings
+    construction: the XYZ side holds whatever the depositor's file said
+    (``CL``, ``c``, ``D``) — ingestion canonicalises the case by convention,
+    but the reference side holds RDKit's title-case ``GetSymbol()`` and the
+    nuclide labelling is preserved on purpose. Grouping the raw strings
     makes a correct geometry look
     like it has no atoms in common with its own SMILES, and the caller records
     that as ``is_isomorphic=False`` / ``validation_status='fail'`` — a false

--- a/backend/app/chemistry/torsion_fingerprint.py
+++ b/backend/app/chemistry/torsion_fingerprint.py
@@ -466,9 +466,10 @@ def _find_matches_using_smiles_graph(
     Both sides go through
     :func:`~app.chemistry.geometry.resolve_element_symbol` before they are
     grouped, because they come from sources that spell elements differently by
-    construction: the XYZ side holds whatever the depositor's file said
-    (``CL``, ``c``, ``D``), the reference side holds RDKit's title-case
-    ``GetSymbol()``. Grouping the raw strings makes a correct geometry look
+    construction: the XYZ side keeps the depositor's nuclide labelling (``D``,
+    ``T``) and may not have been through ``parse_xyz`` at all, the reference
+    side holds RDKit's title-case ``GetSymbol()``. Grouping the raw strings
+    makes a correct geometry look
     like it has no atoms in common with its own SMILES, and the caller records
     that as ``is_isomorphic=False`` / ``validation_status='fail'`` — a false
     ``fail`` on correct chemistry, and one that disagreed with

--- a/backend/app/db/models/geometry.py
+++ b/backend/app/db/models/geometry.py
@@ -31,6 +31,14 @@ class Geometry(Base, TimestampMixin, PublicRefMixin):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     natoms: Mapped[int] = mapped_column(Integer, nullable=False)
     geom_hash: Mapped[str] = mapped_column(CHAR(64), nullable=False, unique=True)
+
+    #: The deposited XYZ block, coordinates reformatted to a fixed precision
+    #: and **element symbols left exactly as the file wrote them**. This is the
+    #: text ``geom_hash`` is taken over, and ``geom_hash`` is both the dedupe
+    #: key and a citable public ref (``geometry:geom_hash=...``), so
+    #: canonicalising a symbol here would re-key every geometry already stored.
+    #: ``geometry_atom.element`` is canonical instead; see
+    #: :func:`app.chemistry.geometry.parse_xyz` for the full argument.
     xyz_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     atoms: Mapped[list["GeometryAtom"]] = relationship(
@@ -59,6 +67,20 @@ class GeometryAtom(Base):
     )
 
     atom_index: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    #: Element symbol, **case-canonical**: first character upper, rest lower
+    #: (:func:`app.chemistry.geometry.normalize_element_symbol`, applied by
+    #: :func:`app.chemistry.geometry.parse_xyz` and backfilled onto older rows
+    #: by Alembic revision ``b4e7c1d20f83``). A file that writes ``CL`` stores
+    #: ``Cl`` here while ``geometry.xyz_text`` keeps the ``CL`` it deposited;
+    #: this column is the index the database joins and compares on, and a
+    #: column that is compared has to have one spelling.
+    #:
+    #: Case is the *only* thing canonicalised. ``D`` and ``T`` are stored as
+    #: ``D`` and ``T``: they are the depositor's isotope labelling, and code
+    #: that counts elements resolves them with
+    #: :func:`app.chemistry.geometry.resolve_element_symbol` at the point of
+    #: counting.
     element: Mapped[str] = mapped_column(CHAR(2), nullable=False)
     x: Mapped[float] = mapped_column(nullable=False)
     y: Mapped[float] = mapped_column(nullable=False)

--- a/backend/app/db/models/geometry.py
+++ b/backend/app/db/models/geometry.py
@@ -68,13 +68,18 @@ class GeometryAtom(Base):
 
     atom_index: Mapped[int] = mapped_column(Integer, primary_key=True)
 
-    #: Element symbol, **case-canonical**: first character upper, rest lower
-    #: (:func:`app.chemistry.geometry.normalize_element_symbol`, applied by
-    #: :func:`app.chemistry.geometry.parse_xyz` and backfilled onto older rows
-    #: by Alembic revision ``b4e7c1d20f83``). A file that writes ``CL`` stores
-    #: ``Cl`` here while ``geometry.xyz_text`` keeps the ``CL`` it deposited;
-    #: this column is the index the database joins and compares on, and a
-    #: column that is compared has to have one spelling.
+    #: Element symbol, **case-canonical by convention**: first character upper,
+    #: rest lower (:func:`app.chemistry.geometry.normalize_element_symbol`,
+    #: applied by :func:`app.chemistry.geometry.parse_xyz` and backfilled onto
+    #: older rows by Alembic revision ``b4e7c1d20f83``). A file that writes
+    #: ``CL`` stores ``Cl`` here while ``geometry.xyz_text`` keeps the ``CL`` it
+    #: deposited; this column is the index the database joins and compares on.
+    #:
+    #: "By convention" is load-bearing: there is deliberately **no** CHECK
+    #: constraint enforcing it, so a restore from a backup older than
+    #: ``b4e7c1d20f83`` or a write path that bypasses ``parse_xyz`` can hold a
+    #: non-canonical symbol. Readers that compare this column must normalise;
+    #: none of them may assume it.
     #:
     #: Case is the *only* thing canonicalised. ``D`` and ``T`` are stored as
     #: ``D`` and ``T``: they are the depositor's isotope labelling, and code

--- a/backend/app/db/models/reaction_atom_map.py
+++ b/backend/app/db/models/reaction_atom_map.py
@@ -60,16 +60,25 @@ first one refuses.
   trigger.
 
   There are **two** of them, ``element`` and ``ts_element``, rather than one
-  column shared by both foreign keys, and the reason is that
-  ``geometry_atom.element`` is stored verbatim as the depositor's XYZ wrote it.
-  ``CL`` and ``Cl`` are the same element and different ``character(2)`` values,
-  so when a reactant geometry comes out of one program and the saddle point out
-  of another, *no single stored value satisfies both foreign keys* and a
-  perfectly correct map cannot be written at all. One column would therefore
-  have made capitalisation load-bearing — the same defect, one table over, that
-  made a ``CL`` saddle point contradict its own reaction. Each end now stores
+  column shared by both foreign keys. The reason was that
+  ``geometry_atom.element`` used to be stored verbatim as the depositor's XYZ
+  wrote it: ``CL`` and ``Cl`` are the same element and different
+  ``character(2)`` values, so when a reactant geometry came out of one program
+  and the saddle point out of another, *no single stored value satisfied both
+  foreign keys* and a perfectly correct map could not be written at all. One
+  column made capitalisation load-bearing — the same defect, one table over,
+  that made a ``CL`` saddle point contradict its own reaction. Each end stores
   what its own geometry stores, and the ``upper(...)`` check carries the
   scientific rule the shared column used to carry.
+
+  Alembic revision ``b4e7c1d20f83`` removed that reason at the source:
+  ``geometry_atom.element`` is now canonicalised at ingestion and was
+  backfilled, so both geometries spell an element the same way and the two
+  columns hold the same string on every valid row. The split is kept anyway —
+  collapsing it is a schema change with its own migration, its own backfill and
+  its own reconsideration of whether the case-insensitive ``upper(...)`` check
+  should become a plain equality, and none of that belongs in the revision that
+  merely made the two agree.
 
   ``isotope_mass_number`` is *not* carried the same way, because it is nullable
   and a NULL column silently disables a MATCH SIMPLE foreign key — isotope
@@ -284,9 +293,11 @@ class ReactionAtomMapPair(Base):
     #: The saddle-point atom's element, spelled as the *transition-state*
     #: geometry spells it. Held equal to ``element`` case-insensitively by
     #: ``ck_reaction_atom_map_pair_element_matches``, which is the rule "an
-    #: element does not change across a reaction"; kept as its own column
-    #: because the two geometries may capitalise the same element differently
-    #: and a shared column would refuse that correct map outright.
+    #: element does not change across a reaction". It has its own column
+    #: because the two geometries could capitalise the same element
+    #: differently and a shared column would have refused that correct map
+    #: outright; since ``b4e7c1d20f83`` they cannot, and the module docstring
+    #: says why the split is kept regardless.
     ts_element: Mapped[str] = mapped_column(CHAR(2), nullable=False)
 
     atom_map: Mapped["ReactionAtomMap"] = relationship(back_populates="pairs")
@@ -352,10 +363,15 @@ class ReactionAtomMapPair(Base):
         CheckConstraint("atom_index >= 1", name="atom_index_ge_1"),
         CheckConstraint("ts_atom_index >= 1", name="ts_atom_index_ge_1"),
         # "An element does not change across a reaction." Case-insensitive
-        # because the two ends quote two geometries, and a geometry stores the
-        # symbol its depositor's XYZ wrote: carbon becoming nitrogen is a
-        # record that cannot be what it says it is, while ``Cl`` becoming
-        # ``CL`` is one program shouting where another did not.
+        # because the two ends quote two geometries, and a geometry used to
+        # store the symbol its depositor's XYZ wrote: carbon becoming nitrogen
+        # is a record that cannot be what it says it is, while ``Cl`` becoming
+        # ``CL`` is one program shouting where another did not. Ingestion
+        # canonicalisation (``b4e7c1d20f83``) means both ends now arrive
+        # identical, so ``upper(...)`` no longer changes which rows pass; it is
+        # left in place because tightening it to plain equality is a separate
+        # constraint change, and a check that is merely wider than it needs to
+        # be refuses nothing correct.
         CheckConstraint(
             "upper(element) = upper(ts_element)",
             name="element_matches",

--- a/backend/app/db/models/reaction_atom_map.py
+++ b/backend/app/db/models/reaction_atom_map.py
@@ -71,14 +71,14 @@ first one refuses.
   what its own geometry stores, and the ``upper(...)`` check carries the
   scientific rule the shared column used to carry.
 
-  Alembic revision ``b4e7c1d20f83`` removed that reason at the source:
-  ``geometry_atom.element`` is now canonicalised at ingestion and was
-  backfilled, so both geometries spell an element the same way and the two
-  columns hold the same string on every valid row. The split is kept anyway —
-  collapsing it is a schema change with its own migration, its own backfill and
-  its own reconsideration of whether the case-insensitive ``upper(...)`` check
-  should become a plain equality, and none of that belongs in the revision that
-  merely made the two agree.
+  Alembic revision ``b4e7c1d20f83`` made that rare rather than impossible:
+  ``geometry_atom.element`` is canonicalised at ingestion and older rows were
+  backfilled, so two geometries deposited through the API now spell an element
+  the same way. It is a convention and not a constraint — no CHECK enforces it,
+  and a restore or a bulk import can reintroduce ``CL`` — so the two columns and
+  the case-insensitive ``upper(...)`` check both remain load-bearing rather than
+  vestigial. Collapsing them would require canonicality to be structural first,
+  which is its own task.
 
   ``isotope_mass_number`` is *not* carried the same way, because it is nullable
   and a NULL column silently disables a MATCH SIMPLE foreign key — isotope
@@ -294,10 +294,10 @@ class ReactionAtomMapPair(Base):
     #: geometry spells it. Held equal to ``element`` case-insensitively by
     #: ``ck_reaction_atom_map_pair_element_matches``, which is the rule "an
     #: element does not change across a reaction". It has its own column
-    #: because the two geometries could capitalise the same element
-    #: differently and a shared column would have refused that correct map
-    #: outright; since ``b4e7c1d20f83`` they cannot, and the module docstring
-    #: says why the split is kept regardless.
+    #: because the two geometries may capitalise the same element differently
+    #: and a shared column would refuse that correct map outright. Ingestion
+    #: canonicalisation (``b4e7c1d20f83``) makes that rare, not impossible —
+    #: nothing enforces it — so the split stays; see the module docstring.
     ts_element: Mapped[str] = mapped_column(CHAR(2), nullable=False)
 
     atom_map: Mapped["ReactionAtomMap"] = relationship(back_populates="pairs")
@@ -363,15 +363,13 @@ class ReactionAtomMapPair(Base):
         CheckConstraint("atom_index >= 1", name="atom_index_ge_1"),
         CheckConstraint("ts_atom_index >= 1", name="ts_atom_index_ge_1"),
         # "An element does not change across a reaction." Case-insensitive
-        # because the two ends quote two geometries, and a geometry used to
-        # store the symbol its depositor's XYZ wrote: carbon becoming nitrogen
-        # is a record that cannot be what it says it is, while ``Cl`` becoming
+        # because the two ends quote two geometries, and nothing guarantees the
+        # two spell an element the same way: carbon becoming nitrogen is a
+        # record that cannot be what it says it is, while ``Cl`` becoming
         # ``CL`` is one program shouting where another did not. Ingestion
-        # canonicalisation (``b4e7c1d20f83``) means both ends now arrive
-        # identical, so ``upper(...)`` no longer changes which rows pass; it is
-        # left in place because tightening it to plain equality is a separate
-        # constraint change, and a check that is merely wider than it needs to
-        # be refuses nothing correct.
+        # canonicalisation (``b4e7c1d20f83``) makes disagreement rare on rows
+        # written through the API, and does not make it impossible -- no
+        # constraint holds the column canonical -- so this stays case-blind.
         CheckConstraint(
             "upper(element) = upper(ts_element)",
             name="element_matches",

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -481,15 +481,19 @@ CHECK_ATOM_MAP_ELEMENT_CONSERVED = ScientificCheck(
         ),
     ),
     escape_hatch=(
-        "Case is not load-bearing, and since ``b4e7c1d20f83`` it cannot be: "
-        "``geometry_atom.element`` is canonicalised on the way in, so both "
-        "ends of a pair spell an element the same way. The constraint stays "
-        "case-insensitive anyway — carbon becoming nitrogen is a "
-        "contradiction, while ``Cl`` becoming ``CL`` is one program shouting "
-        "where another did not, and a check wider than it needs to be refuses "
-        "nothing correct. Isotope mass number is deliberately *not* carried "
-        "across the same way, because a NULL disables a MATCH SIMPLE foreign "
-        "key; isotope consistency is checked in the service layer instead."
+        "Case is not load-bearing. The comparison is deliberately "
+        "case-insensitive because the two ends quote two different "
+        "geometries and nothing guarantees they spell an element the same "
+        "way — carbon becoming nitrogen is a contradiction, while ``Cl`` "
+        "becoming ``CL`` is one program shouting where another did not. "
+        "``b4e7c1d20f83`` canonicalises the symbol on the way into "
+        "``geometry_atom.element``, which makes disagreement rare on rows "
+        "written through the API; it is a convention rather than a "
+        "constraint, so both the database check and the Python check still "
+        "normalise instead of assuming it. Isotope mass number is "
+        "deliberately *not* carried across the same way, because a NULL "
+        "disables a MATCH SIMPLE foreign key; isotope consistency is checked "
+        "in the service layer instead."
     ),
 )
 

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -481,14 +481,15 @@ CHECK_ATOM_MAP_ELEMENT_CONSERVED = ScientificCheck(
         ),
     ),
     escape_hatch=(
-        "Case is not load-bearing. The comparison is deliberately "
-        "case-insensitive because the two ends quote two different "
-        "geometries, and a geometry stores the symbol its depositor's XYZ "
-        "wrote — carbon becoming nitrogen is a contradiction, while ``Cl`` "
-        "becoming ``CL`` is one program shouting where another did not. "
-        "Isotope mass number is deliberately *not* carried across the same "
-        "way, because a NULL disables a MATCH SIMPLE foreign key; isotope "
-        "consistency is checked in the service layer instead."
+        "Case is not load-bearing, and since ``b4e7c1d20f83`` it cannot be: "
+        "``geometry_atom.element`` is canonicalised on the way in, so both "
+        "ends of a pair spell an element the same way. The constraint stays "
+        "case-insensitive anyway — carbon becoming nitrogen is a "
+        "contradiction, while ``Cl`` becoming ``CL`` is one program shouting "
+        "where another did not, and a check wider than it needs to be refuses "
+        "nothing correct. Isotope mass number is deliberately *not* carried "
+        "across the same way, because a NULL disables a MATCH SIMPLE foreign "
+        "key; isotope consistency is checked in the service layer instead."
     ),
 )
 

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -70,6 +70,7 @@ from tckdb_schemas.fragments.reaction_atom_map import (
 from tckdb_schemas.upload_warning import UploadWarning
 
 from app.api.error_contract import CodedValueError
+from app.chemistry.geometry import normalize_element_symbol
 from app.db.models.common import AtomMapSource, ReactionRole
 from app.db.models.geometry import GeometryAtom
 from app.db.models.reaction import ReactionEntryStructureParticipant
@@ -264,17 +265,27 @@ def persist_reaction_atom_map(
                     context={"ts_atom_index": ts_atom_index},
                     message_prefix=False,
                 )
-            # Compared raw, and that is now safe. Both sides come out of
-            # ``geometry_atom.element``, which `parse_xyz` canonicalises at
-            # ingestion and Alembic revision ``b4e7c1d20f83`` backfilled, so
-            # ``Cl`` and ``CL`` deposited by two programs are one stored string
-            # by the time they reach here. This comparison used to run both
-            # ends through `normalize_element_symbol`, because refusing that
-            # map would reject correct chemistry over a capital letter, which
-            # ADR 0008 puts out of bounds for a blocking check; the rule is now
-            # kept by the column instead of by the comparison. Carbon becoming
-            # nitrogen still cannot be what it says it is, and still blocks.
-            if element != ts_element:
+            # Compared normalised, and it stays that way even though
+            # `parse_xyz` now canonicalises the case at ingestion.
+            #
+            # Ingestion canonicalisation is a *convention held by application
+            # code*, not an invariant the database enforces: no CHECK
+            # constraint requires `geometry_atom.element` to be canonical, so
+            # anything that writes the table without going through `parse_xyz`
+            # -- a restore from a backup older than ``b4e7c1d20f83``, a bulk
+            # import, a future write path -- can put `CL` back. This is a
+            # blocking check, so it has to be correct on rows this process
+            # never wrote. Dropping the normalisation would make it refuse a
+            # perfectly correct map over a capital letter on exactly those
+            # rows, which is what ADR 0008 disqualifies a blocking check from
+            # doing.
+            #
+            # On canonical input it is a no-op, so correctness here costs
+            # nothing. Carbon becoming nitrogen still cannot be what it says it
+            # is, and still blocks.
+            if normalize_element_symbol(element) != normalize_element_symbol(
+                ts_element
+            ):
                 raise CodedValueError(
                     W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
                     f"{field_path} maps atom {atom_index} of {side.value} "
@@ -300,11 +311,11 @@ def persist_reaction_atom_map(
                     transition_state_geometry_id=transition_state_geometry_id,
                     ts_atom_index=ts_atom_index,
                     # Each end stores what its own geometry stores, so both
-                    # composite foreign keys into ``geometry_atom`` resolve.
-                    # Since ingestion canonicalisation the two are the same
-                    # string whenever the map is valid; the columns stay
-                    # separate because collapsing them is a schema change with
-                    # its own migration, not a side effect of this one.
+                    # composite foreign keys into ``geometry_atom`` resolve
+                    # even where the two geometries disagree about case. On a
+                    # deposit that came through `parse_xyz` they now agree, but
+                    # the write path must not assume it any more than the
+                    # comparison above does.
                     element=element,
                     ts_element=ts_element,
                 )
@@ -581,12 +592,15 @@ def _element_index(
     values into two foreign keys that make the claim structural.
 
     Returned **as stored**, only unpadded — ``geometry_atom.element`` is
-    ``character(2)``, so a one-letter symbol reads back as ``"C "``. Nothing
-    else is done to it, for two reasons that now point the same way: each value
-    has to go back into its own geometry's foreign key exactly as that geometry
-    spells it, and since :func:`~app.chemistry.geometry.parse_xyz`
-    canonicalises the case at ingestion there is nothing left to normalise.
-    Callers may therefore compare two of these directly.
+    ``character(2)``, so a one-letter symbol reads back as ``"C "``. It is not
+    case-normalised here, because each value has to go back into its own
+    geometry's foreign key exactly as that geometry spells it; callers
+    normalise through
+    :func:`~app.chemistry.geometry.normalize_element_symbol` when they
+    *compare*. :func:`~app.chemistry.geometry.parse_xyz` canonicalises the case
+    on the way in, so in practice the stored value is already canonical — but
+    nothing in the schema requires it to be, so a caller that compares must
+    still normalise.
     """
 
     rows = session.execute(

--- a/backend/app/services/reaction_atom_map.py
+++ b/backend/app/services/reaction_atom_map.py
@@ -70,7 +70,6 @@ from tckdb_schemas.fragments.reaction_atom_map import (
 from tckdb_schemas.upload_warning import UploadWarning
 
 from app.api.error_contract import CodedValueError
-from app.chemistry.geometry import normalize_element_symbol
 from app.db.models.common import AtomMapSource, ReactionRole
 from app.db.models.geometry import GeometryAtom
 from app.db.models.reaction import ReactionEntryStructureParticipant
@@ -265,16 +264,17 @@ def persist_reaction_atom_map(
                     context={"ts_atom_index": ts_atom_index},
                     message_prefix=False,
                 )
-            # Compared normalised, stored raw. The two ends quote two
-            # geometries, each of which stores the element symbol its own XYZ
-            # wrote: ``Cl`` and ``CL`` are one element written by two
-            # programs, and refusing that map would reject correct chemistry
-            # over a capital letter, which ADR 0008 puts out of bounds for a
-            # blocking check. Carbon becoming nitrogen still cannot be what it
-            # says it is, and still blocks.
-            if normalize_element_symbol(element) != normalize_element_symbol(
-                ts_element
-            ):
+            # Compared raw, and that is now safe. Both sides come out of
+            # ``geometry_atom.element``, which `parse_xyz` canonicalises at
+            # ingestion and Alembic revision ``b4e7c1d20f83`` backfilled, so
+            # ``Cl`` and ``CL`` deposited by two programs are one stored string
+            # by the time they reach here. This comparison used to run both
+            # ends through `normalize_element_symbol`, because refusing that
+            # map would reject correct chemistry over a capital letter, which
+            # ADR 0008 puts out of bounds for a blocking check; the rule is now
+            # kept by the column instead of by the comparison. Carbon becoming
+            # nitrogen still cannot be what it says it is, and still blocks.
+            if element != ts_element:
                 raise CodedValueError(
                     W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
                     f"{field_path} maps atom {atom_index} of {side.value} "
@@ -300,8 +300,11 @@ def persist_reaction_atom_map(
                     transition_state_geometry_id=transition_state_geometry_id,
                     ts_atom_index=ts_atom_index,
                     # Each end stores what its own geometry stores, so both
-                    # composite foreign keys into ``geometry_atom`` resolve
-                    # even when the two geometries disagree about case.
+                    # composite foreign keys into ``geometry_atom`` resolve.
+                    # Since ingestion canonicalisation the two are the same
+                    # string whenever the map is valid; the columns stay
+                    # separate because collapsing them is a schema change with
+                    # its own migration, not a side effect of this one.
                     element=element,
                     ts_element=ts_element,
                 )
@@ -578,12 +581,12 @@ def _element_index(
     values into two foreign keys that make the claim structural.
 
     Returned **as stored**, only unpadded — ``geometry_atom.element`` is
-    ``character(2)``, so a one-letter symbol reads back as ``"C "``. It is not
-    case-normalised here, because each value has to go back into its own
-    geometry's foreign key exactly as that geometry spells it; callers
-    normalise through
-    :func:`~app.chemistry.geometry.normalize_element_symbol` when they
-    *compare*.
+    ``character(2)``, so a one-letter symbol reads back as ``"C "``. Nothing
+    else is done to it, for two reasons that now point the same way: each value
+    has to go back into its own geometry's foreign key exactly as that geometry
+    spells it, and since :func:`~app.chemistry.geometry.parse_xyz`
+    canonicalises the case at ingestion there is nothing left to normalise.
+    Callers may therefore compare two of these directly.
     """
 
     rows = session.execute(

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -903,12 +903,15 @@ def _transition_state_element_counts(
     Both branches are resolved through
     :func:`~app.chemistry.geometry.resolve_element_symbol` before they are
     counted, and so is the reactant side, because the two sources spell
-    elements differently by construction: ``geometry_atom.element`` holds
-    whatever the depositor's XYZ said, while ``_element_counts_for_species``
-    reads RDKit's title-case ``GetSymbol()``. Comparing them raw makes a saddle
-    point written ``CL``, ``c`` or ``D`` contradict a reaction it is in fact
-    made of, which refuses correct chemistry over a string — the failure ADR
-    0008 puts out of bounds for a blocking check.
+    elements differently by construction: ``geometry_atom.element`` holds the
+    depositor's isotope labelling, while ``_element_counts_for_species`` reads
+    RDKit's title-case ``GetSymbol()``. Comparing them raw makes a saddle point
+    written ``D`` contradict a reaction it is in fact made of, which refuses
+    correct chemistry over a string — the failure ADR 0008 puts out of bounds
+    for a blocking check. Capitalisation used to be the other half of this and
+    is no longer: ``b4e7c1d20f83`` canonicalises the case at ingestion, so
+    ``CL`` and ``c`` never reach a comparison. The resolution stays because
+    ``D`` and ``T`` still do.
     """
 
     if transition_state_geometry_id is not None:

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -906,12 +906,12 @@ def _transition_state_element_counts(
     elements differently by construction: ``geometry_atom.element`` holds the
     depositor's isotope labelling, while ``_element_counts_for_species`` reads
     RDKit's title-case ``GetSymbol()``. Comparing them raw makes a saddle point
-    written ``D`` contradict a reaction it is in fact made of, which refuses
-    correct chemistry over a string — the failure ADR 0008 puts out of bounds
-    for a blocking check. Capitalisation used to be the other half of this and
-    is no longer: ``b4e7c1d20f83`` canonicalises the case at ingestion, so
-    ``CL`` and ``c`` never reach a comparison. The resolution stays because
-    ``D`` and ``T`` still do.
+    written ``CL``, ``c`` or ``D`` contradict a reaction it is in fact made of,
+    which refuses correct chemistry over a string — the failure ADR 0008 puts
+    out of bounds for a blocking check. ``b4e7c1d20f83`` canonicalises the case
+    at ingestion, which makes ``CL`` and ``c`` rare here rather than absent;
+    ``D`` and ``T`` are preserved on purpose and are never absent. Both halves
+    of the resolution therefore stay.
     """
 
     if transition_state_geometry_id is not None:

--- a/backend/tests/db/test_canonical_element_symbols_migration.py
+++ b/backend/tests/db/test_canonical_element_symbols_migration.py
@@ -1,0 +1,421 @@
+"""Disposable-database contract for the element-symbol canonicalisation.
+
+``b4e7c1d20f83`` rewrites ``geometry_atom.element`` (and the two element
+columns of ``reaction_atom_map_pair`` that mirror it into composite foreign
+keys) into one spelling per element. Four things about that have to be
+checkable without going anywhere near the service layer, because each one is
+a way the backfill could go wrong on a real database and look fine on an empty
+one:
+
+1. **The rows actually change**, on both sides, in one transaction. The
+   element column is part of the key ``reaction_atom_map_pair`` references, so
+   neither table can be updated first without breaking referential integrity
+   mid-migration. If the deferral is wrong, this fails.
+2. **``geom_hash`` does not change, and neither does ``xyz_text``.**
+   ``geom_hash`` is the dedupe key *and* a citable public ref
+   (``geometry:geom_hash=...``); re-keying it would dangle published
+   references and stop a re-upload of the same file deduping onto its own row.
+   The deposited spelling survives in ``xyz_text``, which is what makes the
+   divergence between the two columns a design decision rather than drift.
+3. **An accepted calculation's geometry is backfilled too.**
+   ``trg_as_geometry_atom`` refuses updates to a geometry attached to an
+   accepted calculation, so the revision stands the guard down for its own
+   transaction. A backfill that silently skipped accepted rows would leave the
+   invariant false on precisely the oldest and most-cited data -- and the code
+   shipping with the revision stops normalising at comparison time.
+4. **The guard is back on afterwards.** Standing it down is scoped to the
+   migration; if it stayed down, the revision would have quietly removed
+   accepted-science immutability for every geometry in the database.
+
+``D`` is seeded alongside the shouted symbols to pin the other half of the
+policy: case is canonicalised, isotope labelling is not.
+"""
+
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import DBAPIError
+
+BASE_REVISION = "d7f1a3c5e948"
+CANONICAL_REVISION = "b4e7c1d20f83"
+
+#: What an ESS that shouts its elements actually deposits. The reactant is
+#: written ``CL``/``c``, the saddle point ``Cl``/``C``: one element, two
+#: programs, and before this revision two different ``character(2)`` values.
+_REACTANT_XYZ = "3\n\nCL 0 0 0\nc 0 0 1.8\nD 0 0 2.9"
+_TS_XYZ = "3\n\nCl 0 0 0\nC 0 0 2.1\nD 0 0 3.2"
+_REACTANT_HASH = "e1" * 32
+_TS_HASH = "e2" * 32
+
+
+class _MigrationHarness:
+    """Create a throwaway database and drive alembic against it."""
+
+    def __init__(self, name_prefix: str):
+        from conftest import _database_url, _db_env
+
+        self.db_name = f"{name_prefix}_{uuid4().hex}"
+        self.env = _db_env(self.db_name)
+        self._database_url = _database_url
+        self._admin = create_engine(
+            _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
+        )
+        self._admin_conn = self._admin.connect()
+        self._admin_conn.execute(text(f'CREATE DATABASE "{self.db_name}"'))
+        self.engine = None
+        self.root = Path(__file__).resolve().parents[2]
+
+    def run(self, direction: str, revision: str, *, check: bool = True):
+        if self.engine is not None:
+            self.engine.dispose()
+            self.engine = None
+        completed = subprocess.run(
+            ["conda", "run", "-n", "tckdb_env", "alembic", direction, revision],
+            cwd=self.root,
+            env=self.env,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+        self.engine = create_engine(self._database_url(self.db_name), pool_pre_ping=True)
+        return completed
+
+    def close(self) -> None:
+        if self.engine is not None:
+            self.engine.dispose()
+        try:
+            self._admin_conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :name"
+                ),
+                {"name": self.db_name},
+            )
+            self._admin_conn.execute(text(f'DROP DATABASE IF EXISTS "{self.db_name}"'))
+        finally:
+            self._admin_conn.close()
+            self._admin.dispose()
+
+
+@pytest.fixture
+def harness():
+    created = _MigrationHarness("tckdb_test_element_migration")
+    yield created
+    created.close()
+
+
+def _seed_geometry(conn, *, geom_hash: str, xyz_text: str, elements) -> int:
+    geometry_id = conn.scalar(
+        text(
+            "INSERT INTO geometry (natoms, geom_hash, xyz_text) "
+            "VALUES (:natoms, :geom_hash, :xyz_text) RETURNING id"
+        ),
+        {"natoms": len(elements), "geom_hash": geom_hash, "xyz_text": xyz_text},
+    )
+    for index, element in enumerate(elements, start=1):
+        conn.execute(
+            text(
+                "INSERT INTO geometry_atom "
+                "(geometry_id, atom_index, element, x, y, z) "
+                "VALUES (:geometry_id, :atom_index, :element, 0, 0, :z)"
+            ),
+            {
+                "geometry_id": geometry_id,
+                "atom_index": index,
+                "element": element,
+                "z": float(index),
+            },
+        )
+    return geometry_id
+
+
+def _seed(conn) -> dict[str, int]:
+    """Write a mapped reaction whose geometries shout their elements.
+
+    Deliberately built with raw SQL at ``BASE_REVISION``: the point is to
+    reproduce rows that the *old* ingestion path could write, which the new one
+    can no longer produce.
+    """
+    suffix = uuid4().hex[:8]
+
+    species_id = conn.scalar(
+        text(
+            "INSERT INTO species "
+            "(kind, smiles, inchi_key, charge, multiplicity, stereo_kind) "
+            "VALUES ('molecule', 'CCl', :inchi_key, 0, 1, 'achiral') RETURNING id"
+        ),
+        {"inchi_key": f"ELEMENTMIG{suffix}AAAAAAAAAAA"[:27]},
+    )
+    species_entry_id = conn.scalar(
+        text(
+            "INSERT INTO species_entry (species_id, unmapped_smiles) "
+            "VALUES (:species_id, 'CCl') RETURNING id"
+        ),
+        {"species_id": species_id},
+    )
+    reaction_id = conn.scalar(
+        text("INSERT INTO chem_reaction (reversible) VALUES (true) RETURNING id")
+    )
+    reaction_entry_id = conn.scalar(
+        text(
+            "INSERT INTO reaction_entry (reaction_id) VALUES (:reaction_id) "
+            "RETURNING id"
+        ),
+        {"reaction_id": reaction_id},
+    )
+    participant_id = conn.scalar(
+        text(
+            "INSERT INTO reaction_entry_structure_participant "
+            "(reaction_entry_id, species_entry_id, role, participant_index) "
+            "VALUES (:reaction_entry_id, :species_entry_id, 'reactant', 1) "
+            "RETURNING id"
+        ),
+        {
+            "reaction_entry_id": reaction_entry_id,
+            "species_entry_id": species_entry_id,
+        },
+    )
+    transition_state_id = conn.scalar(
+        text(
+            "INSERT INTO transition_state (reaction_entry_id) "
+            "VALUES (:reaction_entry_id) RETURNING id"
+        ),
+        {"reaction_entry_id": reaction_entry_id},
+    )
+    ts_entry_id = conn.scalar(
+        text(
+            "INSERT INTO transition_state_entry "
+            "(transition_state_id, charge, multiplicity) "
+            "VALUES (:transition_state_id, 0, 1) RETURNING id"
+        ),
+        {"transition_state_id": transition_state_id},
+    )
+
+    reactant_geometry_id = _seed_geometry(
+        conn,
+        geom_hash=_REACTANT_HASH,
+        xyz_text=_REACTANT_XYZ,
+        elements=["CL", "c", "D"],
+    )
+    ts_geometry_id = _seed_geometry(
+        conn,
+        geom_hash=_TS_HASH,
+        xyz_text=_TS_XYZ,
+        elements=["Cl", "C", "D"],
+    )
+
+    atom_map_id = conn.scalar(
+        text(
+            "INSERT INTO reaction_atom_map "
+            "(reaction_entry_id, transition_state_entry_id, "
+            " transition_state_geometry_id, source) "
+            "VALUES (:reaction_entry_id, :ts_entry_id, :ts_geometry_id, "
+            " 'declared') RETURNING id"
+        ),
+        {
+            "reaction_entry_id": reaction_entry_id,
+            "ts_entry_id": ts_entry_id,
+            "ts_geometry_id": ts_geometry_id,
+        },
+    )
+    for atom_index, (element, ts_element) in enumerate(
+        (("CL", "Cl"), ("c", "C"), ("D", "D")), start=1
+    ):
+        conn.execute(
+            text(
+                "INSERT INTO reaction_atom_map_pair "
+                "(atom_map_id, side, structure_participant_id, geometry_id, "
+                " atom_index, transition_state_geometry_id, ts_atom_index, "
+                " element, ts_element) "
+                "VALUES (:atom_map_id, 'reactant', :participant_id, "
+                " :geometry_id, :atom_index, :ts_geometry_id, :atom_index, "
+                " :element, :ts_element)"
+            ),
+            {
+                "atom_map_id": atom_map_id,
+                "participant_id": participant_id,
+                "geometry_id": reactant_geometry_id,
+                "atom_index": atom_index,
+                "ts_geometry_id": ts_geometry_id,
+                "element": element,
+                "ts_element": ts_element,
+            },
+        )
+
+    # The reactant geometry is the output of a calculation somebody approved.
+    # Everything above had to exist before this row, because the guard refuses
+    # writes to `geometry_atom` once it does.
+    calculation_id = conn.scalar(
+        text(
+            "INSERT INTO calculation (type, species_entry_id) "
+            "VALUES ('opt', :species_entry_id) RETURNING id"
+        ),
+        {"species_entry_id": species_entry_id},
+    )
+    conn.execute(
+        text(
+            "INSERT INTO calculation_output_geometry "
+            "(calculation_id, geometry_id, output_order) "
+            "VALUES (:calculation_id, :geometry_id, 1)"
+        ),
+        {"calculation_id": calculation_id, "geometry_id": reactant_geometry_id},
+    )
+    reviewer_id = conn.scalar(
+        text(
+            "INSERT INTO app_user (username, role) "
+            "VALUES (:username, 'curator') RETURNING id"
+        ),
+        {"username": f"element-migration-reviewer-{suffix}"},
+    )
+    conn.execute(
+        text(
+            "INSERT INTO record_review "
+            "(record_type, record_id, status, reviewed_by, reviewed_at, "
+            " first_approved_at) "
+            "VALUES ('calculation', :calculation_id, 'approved', :reviewer_id, "
+            " now(), now())"
+        ),
+        {"calculation_id": calculation_id, "reviewer_id": reviewer_id},
+    )
+
+    return {
+        "reactant_geometry_id": reactant_geometry_id,
+        "ts_geometry_id": ts_geometry_id,
+        "atom_map_id": atom_map_id,
+        "calculation_id": calculation_id,
+    }
+
+
+def _elements(conn, geometry_id: int) -> list[str]:
+    return [
+        row[0].strip()
+        for row in conn.execute(
+            text(
+                "SELECT element FROM geometry_atom WHERE geometry_id = :id "
+                "ORDER BY atom_index"
+            ),
+            {"id": geometry_id},
+        )
+    ]
+
+
+def _assert_guard_refuses(harness, geometry_id: int, element: str) -> None:
+    """The accepted-science guard still stops an ordinary UPDATE.
+
+    Rolled back explicitly rather than through ``engine.begin()``: the
+    statement aborts the transaction, and committing an aborted one is not
+    what this is checking.
+    """
+    with harness.engine.connect() as conn:
+        transaction = conn.begin()
+        try:
+            with pytest.raises(DBAPIError) as excinfo:
+                conn.execute(
+                    text(
+                        "UPDATE geometry_atom SET element = :element "
+                        "WHERE geometry_id = :id AND atom_index = 1"
+                    ),
+                    {"id": geometry_id, "element": element},
+                )
+            assert "is immutable" in str(excinfo.value)
+        finally:
+            transaction.rollback()
+
+
+def test_element_symbols_are_canonicalised_without_re_keying_a_geometry(
+    harness,
+) -> None:
+    harness.run("upgrade", BASE_REVISION)
+    with harness.engine.begin() as conn:
+        seeded = _seed(conn)
+
+        # The pre-migration state this revision exists to remove: one element,
+        # two spellings, and the accepted-science guard already standing over
+        # the reactant.
+        assert _elements(conn, seeded["reactant_geometry_id"]) == ["CL", "c", "D"]
+        assert _elements(conn, seeded["ts_geometry_id"]) == ["Cl", "C", "D"]
+
+    # Exactly the refusal the revision has to get past, quoted here so a
+    # reader can see the migration is not merely lucky.
+    _assert_guard_refuses(harness, seeded["reactant_geometry_id"], "Cl")
+
+    harness.run("upgrade", CANONICAL_REVISION)
+
+    with harness.engine.begin() as conn:
+        # 1. Both tables moved, and the composite foreign keys still resolve --
+        #    which they could not if only one side had been rewritten.
+        assert _elements(conn, seeded["reactant_geometry_id"]) == ["Cl", "C", "D"]
+        assert _elements(conn, seeded["ts_geometry_id"]) == ["Cl", "C", "D"]
+
+        pairs = conn.execute(
+            text(
+                "SELECT atom_index, btrim(element), btrim(ts_element) "
+                "FROM reaction_atom_map_pair WHERE atom_map_id = :id "
+                "ORDER BY atom_index"
+            ),
+            {"id": seeded["atom_map_id"]},
+        ).all()
+        assert pairs == [(1, "Cl", "Cl"), (2, "C", "C"), (3, "D", "D")]
+
+        assert conn.scalar(
+            text(
+                "SELECT count(*) FROM reaction_atom_map_pair p "
+                "JOIN geometry_atom a ON a.geometry_id = p.geometry_id "
+                " AND a.atom_index = p.atom_index AND a.element = p.element "
+                "WHERE p.atom_map_id = :id"
+            ),
+            {"id": seeded["atom_map_id"]},
+        ) == 3
+
+        # 2. The geometry is the same geometry: same hash, same public ref,
+        #    same deposited text -- ``CL`` and ``c`` still readable in it.
+        stored = conn.execute(
+            text("SELECT geom_hash, xyz_text FROM geometry WHERE id = :id"),
+            {"id": seeded["reactant_geometry_id"]},
+        ).one()
+        assert stored.geom_hash.strip() == _REACTANT_HASH
+        assert stored.xyz_text == _REACTANT_XYZ
+
+        # 4. The guard is back on, and the calculation is still accepted.
+        assert conn.scalar(
+            text(
+                "SELECT tgenabled = 'O' FROM pg_trigger "
+                "WHERE tgname = 'trg_as_geometry_atom'"
+            )
+        )
+
+    _assert_guard_refuses(harness, seeded["reactant_geometry_id"], "Br")
+
+
+def test_downgrade_is_a_documented_no_op_and_upgrade_is_idempotent(harness) -> None:
+    """The casing cannot be restored, so the revision does not pretend to.
+
+    What must hold is that the round trip is *safe*: downgrading leaves a
+    schema and a dataset the previous revision's code handles correctly (it
+    normalised at comparison time, so canonical rows are what it already
+    coped with), and upgrading again over already-canonical rows is a no-op
+    rather than a second rewrite.
+    """
+    harness.run("upgrade", BASE_REVISION)
+    with harness.engine.begin() as conn:
+        seeded = _seed(conn)
+
+    harness.run("upgrade", CANONICAL_REVISION)
+    with harness.engine.begin() as conn:
+        canonical = _elements(conn, seeded["reactant_geometry_id"])
+    assert canonical == ["Cl", "C", "D"]
+
+    harness.run("downgrade", BASE_REVISION)
+    with harness.engine.begin() as conn:
+        assert _elements(conn, seeded["reactant_geometry_id"]) == canonical
+        assert conn.scalar(
+            text("SELECT geom_hash FROM geometry WHERE id = :id"),
+            {"id": seeded["reactant_geometry_id"]},
+        ).strip() == _REACTANT_HASH
+
+    harness.run("upgrade", CANONICAL_REVISION)
+    with harness.engine.begin() as conn:
+        assert _elements(conn, seeded["reactant_geometry_id"]) == canonical

--- a/backend/tests/db/test_canonical_element_symbols_migration.py
+++ b/backend/tests/db/test_canonical_element_symbols_migration.py
@@ -17,15 +17,17 @@ one:
    references and stop a re-upload of the same file deduping onto its own row.
    The deposited spelling survives in ``xyz_text``, which is what makes the
    divergence between the two columns a design decision rather than drift.
-3. **An accepted calculation's geometry is backfilled too.**
-   ``trg_as_geometry_atom`` refuses updates to a geometry attached to an
-   accepted calculation, so the revision stands the guard down for its own
-   transaction. A backfill that silently skipped accepted rows would leave the
-   invariant false on precisely the oldest and most-cited data -- and the code
-   shipping with the revision stops normalising at comparison time.
-4. **The guard is back on afterwards.** Standing it down is scoped to the
-   migration; if it stayed down, the revision would have quietly removed
-   accepted-science immutability for every geometry in the database.
+3. **A non-canonical row inside an accepted calculation stops the
+   migration, loudly.** ``trg_as_geometry_atom`` refuses updates to a geometry
+   attached to an accepted calculation, and this revision leaves that guard
+   **standing**. Failing is the designed outcome: rewriting a value inside
+   approved science is the operator's decision, not a migration's, and nothing
+   downstream needs the rewrite because comparisons still normalise. The
+   earlier draft of this revision disabled the guard, so the test asserts the
+   failure happens rather than merely that the data is fine afterwards.
+4. **The revision contains no ``DISABLE TRIGGER``.** Read straight off the
+   file, so that standing the guard down cannot come back by accident in a
+   later edit and pass on the strength of an empty test database.
 
 ``D`` is seeded alongside the shouted symbols to pin the other half of the
 policy: case is canonicalised, isotope labelling is not.
@@ -132,12 +134,16 @@ def _seed_geometry(conn, *, geom_hash: str, xyz_text: str, elements) -> int:
     return geometry_id
 
 
-def _seed(conn) -> dict[str, int]:
+def _seed(conn, *, accepted: bool = False) -> dict[str, int]:
     """Write a mapped reaction whose geometries shout their elements.
 
     Deliberately built with raw SQL at ``BASE_REVISION``: the point is to
     reproduce rows that the *old* ingestion path could write, which the new one
     can no longer produce.
+
+    :param accepted: Approve the calculation that owns the reactant geometry,
+        arming ``trg_as_geometry_atom`` over its atoms. The backfill must then
+        fail rather than rewrite them.
     """
     suffix = uuid4().hex[:8]
 
@@ -245,9 +251,10 @@ def _seed(conn) -> dict[str, int]:
             },
         )
 
-    # The reactant geometry is the output of a calculation somebody approved.
-    # Everything above had to exist before this row, because the guard refuses
-    # writes to `geometry_atom` once it does.
+    # The reactant geometry is the output of a calculation. Whether anybody
+    # approved it decides whether the backfill is allowed to touch its atoms.
+    # Everything above had to exist before the approval, because the guard
+    # refuses writes to `geometry_atom` from the moment it lands.
     calculation_id = conn.scalar(
         text(
             "INSERT INTO calculation (type, species_entry_id) "
@@ -263,23 +270,24 @@ def _seed(conn) -> dict[str, int]:
         ),
         {"calculation_id": calculation_id, "geometry_id": reactant_geometry_id},
     )
-    reviewer_id = conn.scalar(
-        text(
-            "INSERT INTO app_user (username, role) "
-            "VALUES (:username, 'curator') RETURNING id"
-        ),
-        {"username": f"element-migration-reviewer-{suffix}"},
-    )
-    conn.execute(
-        text(
-            "INSERT INTO record_review "
-            "(record_type, record_id, status, reviewed_by, reviewed_at, "
-            " first_approved_at) "
-            "VALUES ('calculation', :calculation_id, 'approved', :reviewer_id, "
-            " now(), now())"
-        ),
-        {"calculation_id": calculation_id, "reviewer_id": reviewer_id},
-    )
+    if accepted:
+        reviewer_id = conn.scalar(
+            text(
+                "INSERT INTO app_user (username, role) "
+                "VALUES (:username, 'curator') RETURNING id"
+            ),
+            {"username": f"element-migration-reviewer-{suffix}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO record_review "
+                "(record_type, record_id, status, reviewed_by, reviewed_at, "
+                " first_approved_at) "
+                "VALUES ('calculation', :calculation_id, 'approved', "
+                " :reviewer_id, now(), now())"
+            ),
+            {"calculation_id": calculation_id, "reviewer_id": reviewer_id},
+        )
 
     return {
         "reactant_geometry_id": reactant_geometry_id,
@@ -303,7 +311,7 @@ def _elements(conn, geometry_id: int) -> list[str]:
 
 
 def _assert_guard_refuses(harness, geometry_id: int, element: str) -> None:
-    """The accepted-science guard still stops an ordinary UPDATE.
+    """The accepted-science guard stops an ordinary UPDATE.
 
     Rolled back explicitly rather than through ``engine.begin()``: the
     statement aborts the transaction, and committing an aborted one is not
@@ -325,6 +333,27 @@ def _assert_guard_refuses(harness, geometry_id: int, element: str) -> None:
             transaction.rollback()
 
 
+def test_the_revision_leaves_the_accepted_science_guard_alone() -> None:
+    """No ``DISABLE TRIGGER``, asserted off the file rather than the database.
+
+    An earlier draft of this revision disabled ``trg_as_geometry_atom`` to push
+    the backfill through accepted rows. On a database with no non-canonical
+    accepted rows -- which is every one we can see, including the deployed
+    Pi -- that is indistinguishable from not disabling it, so no behavioural
+    test can tell the two apart. Reading the source can.
+    """
+    revision = (
+        Path(__file__).resolve().parents[2]
+        / "alembic"
+        / "versions"
+        / "b4e7c1d20f83_canonical_element_symbols.py"
+    ).read_text()
+    body = revision.split('"""', 2)[2]
+    assert "DISABLE TRIGGER" not in body.upper()
+    assert "ENABLE TRIGGER" not in body.upper()
+    assert "SESSION_REPLICATION_ROLE" not in body.upper()
+
+
 def test_element_symbols_are_canonicalised_without_re_keying_a_geometry(
     harness,
 ) -> None:
@@ -333,14 +362,9 @@ def test_element_symbols_are_canonicalised_without_re_keying_a_geometry(
         seeded = _seed(conn)
 
         # The pre-migration state this revision exists to remove: one element,
-        # two spellings, and the accepted-science guard already standing over
-        # the reactant.
+        # two spellings.
         assert _elements(conn, seeded["reactant_geometry_id"]) == ["CL", "c", "D"]
         assert _elements(conn, seeded["ts_geometry_id"]) == ["Cl", "C", "D"]
-
-    # Exactly the refusal the revision has to get past, quoted here so a
-    # reader can see the migration is not merely lucky.
-    _assert_guard_refuses(harness, seeded["reactant_geometry_id"], "Cl")
 
     harness.run("upgrade", CANONICAL_REVISION)
 
@@ -379,7 +403,9 @@ def test_element_symbols_are_canonicalised_without_re_keying_a_geometry(
         assert stored.geom_hash.strip() == _REACTANT_HASH
         assert stored.xyz_text == _REACTANT_XYZ
 
-        # 4. The guard is back on, and the calculation is still accepted.
+        # 3/4. The guard is enabled, and was never otherwise: the revision does
+        #      not touch it, so a migration that ran to completion proves the
+        #      rows it rewrote were ones it was permitted to rewrite.
         assert conn.scalar(
             text(
                 "SELECT tgenabled = 'O' FROM pg_trigger "
@@ -387,6 +413,61 @@ def test_element_symbols_are_canonicalised_without_re_keying_a_geometry(
             )
         )
 
+
+def test_a_non_canonical_row_inside_accepted_science_stops_the_migration(
+    harness,
+) -> None:
+    """Failing here is the feature, not the shortcoming.
+
+    Same seed, one difference: the calculation that owns the reactant geometry
+    has been approved, so ``trg_as_geometry_atom`` stands over its atoms. The
+    revision does not stand the guard down, so the backfill trips it and the
+    whole migration rolls back.
+
+    That is the correct outcome. Rewriting a value inside an approved record is
+    a decision for the operator holding that database, not for a migration
+    executing unattended, and nothing downstream depends on the rewrite: the
+    code shipping with this revision still normalises at comparison time, so a
+    row left spelled ``CL`` reads correctly everywhere it is compared.
+
+    Both halves are asserted -- that it fails, *and* that the data is untouched
+    -- because a migration that failed after a partial rewrite would be worse
+    than either outcome.
+    """
+    harness.run("upgrade", BASE_REVISION)
+    with harness.engine.begin() as conn:
+        seeded = _seed(conn, accepted=True)
+
+    _assert_guard_refuses(harness, seeded["reactant_geometry_id"], "Cl")
+
+    refused = harness.run("upgrade", CANONICAL_REVISION, check=False)
+    assert refused.returncode != 0
+    assert "is immutable" in refused.stderr
+
+    with harness.engine.begin() as conn:
+        # Untouched, both tables, and still at the previous revision.
+        assert _elements(conn, seeded["reactant_geometry_id"]) == ["CL", "c", "D"]
+        pairs = conn.execute(
+            text(
+                "SELECT btrim(element), btrim(ts_element) "
+                "FROM reaction_atom_map_pair WHERE atom_map_id = :id "
+                "ORDER BY atom_index"
+            ),
+            {"id": seeded["atom_map_id"]},
+        ).all()
+        assert pairs == [("CL", "Cl"), ("c", "C"), ("D", "D")]
+        assert conn.scalar(text("SELECT version_num FROM alembic_version")) == (
+            BASE_REVISION
+        )
+
+    # And the guard is exactly as it was: never disabled, never left down.
+    with harness.engine.begin() as conn:
+        assert conn.scalar(
+            text(
+                "SELECT tgenabled = 'O' FROM pg_trigger "
+                "WHERE tgname = 'trg_as_geometry_atom'"
+            )
+        )
     _assert_guard_refuses(harness, seeded["reactant_geometry_id"], "Br")
 
 

--- a/backend/tests/invariants/test_hash_invariants.py
+++ b/backend/tests/invariants/test_hash_invariants.py
@@ -13,6 +13,8 @@ be pinned explicitly here.
 
 from __future__ import annotations
 
+import hashlib
+
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.refs import LevelOfTheoryRef
 from app.services.calculation_resolution import _level_of_theory_hash
@@ -85,6 +87,118 @@ def test_geom_hash_changes_when_an_element_changes() -> None:
     coordinates and must be independently sensitive."""
     altered = _WATER_XYZ.replace("O 0.0000", "S 0.0000", 1)
     assert _geom_hash(_WATER_XYZ) != _geom_hash(altered)
+
+
+# ---------------------------------------------------------------------------
+# geom_hash vs. the canonical element column
+# ---------------------------------------------------------------------------
+
+#: Chloromethane the way an ESS that shouts halogens writes it.
+_CH3CL_SHOUTED = (
+    "5\nchloromethane, elements as an ESS wrote them\n"
+    "c  0.000  0.000  0.000\n"
+    "CL 1.781  0.000  0.000\n"
+    "h -0.372  1.028  0.000\n"
+    "h -0.372 -0.514  0.890\n"
+    "h -0.372 -0.514 -0.890\n"
+)
+
+
+def _hash_of_canonical_text(atoms: list[tuple[str, float, float, float]]) -> str:
+    """Rebuild the hashed text from first principles, without ``parse_xyz``.
+
+    Deliberately duplicates the format string rather than importing it: a test
+    that reads the hash input out of the code under test cannot notice the code
+    changing it.
+    """
+    lines = [str(len(atoms)), ""]
+    for element, x, y, z in atoms:
+        lines.append(f"{element} {x:.12f} {y:.12f} {z:.12f}")
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def test_geom_hash_is_untouched_by_element_symbol_canonicalisation() -> None:
+    """``geom_hash`` is what it was before ingestion canonicalised anything.
+
+    ``parse_xyz`` now stores ``Cl`` in ``geometry_atom.element`` for a file
+    that wrote ``CL``, but the hashed text still carries ``CL``. It has to:
+    ``geom_hash`` is the dedupe key *and* ``app.services.public_refs`` mints
+    ``geometry:geom_hash=<hash>`` as a citable identifier, so moving it would
+    dangle every published reference to a geometry whose XYZ shouted an
+    element and stop a re-upload of the same file deduping onto its own row.
+
+    The expected value is rebuilt here from the deposited symbols rather than
+    read back from the parser, so this fails if the canonicalisation ever
+    leaks into the hash input.
+    """
+    expected = _hash_of_canonical_text(
+        [
+            ("c", 0.0, 0.0, 0.0),
+            ("CL", 1.781, 0.0, 0.0),
+            ("h", -0.372, 1.028, 0.0),
+            ("h", -0.372, -0.514, 0.890),
+            ("h", -0.372, -0.514, -0.890),
+        ]
+    )
+    assert _geom_hash(_CH3CL_SHOUTED) == expected
+
+
+def test_the_deposited_spelling_survives_in_the_hashed_text() -> None:
+    """``xyz_text`` is the evidence, and it reads back as deposited.
+
+    This is the other half of the divergence: ``geometry_atom.element`` is
+    canonical because it is compared, ``geometry.xyz_text`` is verbatim
+    because it is cited.
+    """
+    created = geometry_create_from_payload(GeometryPayload(xyz_text=_CH3CL_SHOUTED))
+
+    assert [line.split()[0] for line in created.xyz_text.splitlines()[2:]] == [
+        "c",
+        "CL",
+        "h",
+        "h",
+        "h",
+    ]
+    assert [atom.element for atom in created.atoms] == ["C", "Cl", "H", "H", "H"]
+
+
+def test_two_spellings_of_one_geometry_still_hash_apart() -> None:
+    """Known, deliberate under-normalization, pinned so it cannot drift silently.
+
+    The same molecule at the same coordinates, deposited by a program that
+    shouts and one that does not, produces two ``geometry`` rows. Closing that
+    would mean canonicalising the hashed text, which is exactly what re-keys
+    published geometries -- so the duplicate is the cheaper of the two costs,
+    and it is a duplicate rather than a contradiction: both rows carry the same
+    canonical ``geometry_atom`` elements, so every comparison downstream reads
+    them as the same chemistry.
+    """
+    whispered = _CH3CL_SHOUTED.replace("CL 1.781", "Cl 1.781")
+    assert _geom_hash(_CH3CL_SHOUTED) != _geom_hash(whispered)
+
+    shouted_atoms = geometry_create_from_payload(
+        GeometryPayload(xyz_text=_CH3CL_SHOUTED)
+    ).atoms
+    whispered_atoms = geometry_create_from_payload(
+        GeometryPayload(xyz_text=whispered)
+    ).atoms
+    assert [atom.element for atom in shouted_atoms] == [
+        atom.element for atom in whispered_atoms
+    ]
+
+
+def test_hydrogen_isotope_labels_are_not_canonicalised_away() -> None:
+    """Case is settled at ingestion; nuclide labelling is not.
+
+    ``D`` and ``T`` are what the depositor wrote, and they stay in
+    ``geometry_atom.element``. Collapsing them to ``H`` here would destroy
+    deposited isotope labelling; code that *counts* elements resolves them at
+    the point of counting instead
+    (``app.chemistry.geometry.resolve_element_symbol``).
+    """
+    heavy_water = "3\nheavy water\nO 0.0 0.0 0.117\nd 0.0 0.757 -0.469\nT 0.0 -0.757 -0.469"
+    created = geometry_create_from_payload(GeometryPayload(xyz_text=heavy_water))
+    assert [atom.element for atom in created.atoms] == ["O", "D", "T"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_ts_irc_mapping_elements.py
+++ b/backend/tests/services/test_ts_irc_mapping_elements.py
@@ -351,8 +351,11 @@ def test_an_isotopologue_written_with_D_is_not_a_mismatch(db_session) -> None:
     """``D`` in an XYZ is hydrogen, and a blocking check may not say otherwise.
 
     Gaussian, ORCA, Molpro and CFOUR all emit or accept ``D``/``T`` for
-    hydrogen's isotopes, and ``geometry_atom.element`` stores them verbatim by
-    design. The SMILES side spells the same nucleus ``[2H]``. Both sides are
+    hydrogen's isotopes, and ``geometry_atom.element`` keeps them by design:
+    ingestion canonicalises the *case* of a symbol and stops there, because a
+    ``D`` collapsed to ``H`` at deposit time would destroy the depositor's own
+    isotope labelling. The SMILES side spells the same nucleus ``[2H]``. Both
+    sides are
     counted through ``resolve_element_symbol``, so the two agree; comparing raw
     symbols would read a perfectly ordinary deuterated saddle point as
     containing an element its participants never mention.

--- a/backend/tests/workflows/test_reaction_atom_map.py
+++ b/backend/tests/workflows/test_reaction_atom_map.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 
 from app.db.models.app_user import AppUser
 from app.db.models.common import AtomMapSource, ReactionRole
+from app.db.models.geometry import Geometry, GeometryAtom
 from app.db.models.reaction_atom_map import ReactionAtomMap, ReactionAtomMapPair
 from app.schemas.workflows.computed_reaction_upload import (
     ComputedReactionUploadRequest,
@@ -787,9 +788,9 @@ def test_same_participant_mapped_twice_is_refused(db_conn) -> None:
 # ---------------------------------------------------------------------------
 
 #: Methyl and the saddle point, with the same atoms written in different case.
-#: ``geometry_atom.element`` stores the depositor's symbol verbatim, so this is
-#: what a reactant optimised in one program and a saddle point located in
-#: another actually looks like once both are in the database.
+#: This is what a reactant optimised in one program and a saddle point located
+#: in another look like as *deposited*; ``geometry.xyz_text`` keeps both
+#: spellings, and ``geometry_atom.element`` canonicalises them.
 _XYZ_CH3_LOWER = (
     "4\nmethyl, elements whispered\n"
     "c  0.000  0.000  0.000\n"
@@ -804,12 +805,19 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
 ) -> None:
     """``c`` and ``C`` are one element, and a map across them is one map.
 
-    Both ends of a pair quote a *different* geometry, and each geometry stores
-    the element symbol its own XYZ wrote. If the two ends are compared raw, or
-    forced through one shared column, then a depositor whose reactant came out
-    of a program that writes ``c`` and whose saddle point came out of one that
-    writes ``C`` cannot record a correct map at all — refused for a capital
-    letter, which is the failure ADR 0008 puts out of bounds.
+    Both ends of a pair quote a *different* geometry. A depositor whose
+    reactant came out of a program that writes ``c`` and whose saddle point
+    came out of one that writes ``C`` must be able to record a correct map;
+    refusing it for a capital letter is the failure ADR 0008 puts out of
+    bounds.
+
+    Since ``b4e7c1d20f83`` the two spellings never reach the comparison:
+    ``parse_xyz`` canonicalises the symbol before it becomes a
+    ``geometry_atom`` row, so both ends of the pair store ``C`` and the two
+    composite foreign keys resolve against one string rather than two. The
+    deposited ``c`` is still readable — it survives in ``geometry.xyz_text``,
+    which is asserted here too, because that column is what ``geom_hash`` is
+    taken over and rewriting a symbol in it would re-key a published geometry.
 
     The map here is the same map as everywhere else in this module; only the
     methyl geometry's capitalisation differs.
@@ -832,7 +840,8 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
         assert len(pairs) == 10
 
         # Each end kept the spelling of the geometry it points at, which is
-        # what lets both composite foreign keys into ``geometry_atom`` resolve.
+        # what lets both composite foreign keys into ``geometry_atom`` resolve
+        # -- and both geometries now spell it the same canonical way.
         methyl_carbon = next(
             pair
             for pair in pairs
@@ -841,8 +850,29 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
             and pair.atom_index == 1
             and pair.ts_atom_index == 1
         )
-        assert methyl_carbon.element.strip() == "c"
+        assert methyl_carbon.element.strip() == "C"
         assert methyl_carbon.ts_element.strip() == "C"
+
+        # The stored atom is canonical...
+        methyl_atoms = session.execute(
+            select(GeometryAtom.atom_index, GeometryAtom.element)
+            .where(GeometryAtom.geometry_id == methyl_carbon.geometry_id)
+            .order_by(GeometryAtom.atom_index)
+        ).all()
+        assert [element.strip() for _index, element in methyl_atoms] == [
+            "C",
+            "H",
+            "H",
+            "H",
+        ]
+
+        # ...and the deposit still reads back as it was written.
+        methyl_geometry = session.get(Geometry, methyl_carbon.geometry_id)
+        assert methyl_geometry is not None
+        assert methyl_geometry.xyz_text is not None
+        assert [
+            line.split()[0] for line in methyl_geometry.xyz_text.splitlines()[2:]
+        ] == ["c", "h", "h", "h"]
 
 
 def test_an_element_really_changing_across_the_map_is_still_refused(

--- a/backend/tests/workflows/test_reaction_atom_map.py
+++ b/backend/tests/workflows/test_reaction_atom_map.py
@@ -23,12 +23,18 @@ from typing import Iterator
 
 import pytest
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
+from tckdb_schemas.fragments.reaction_atom_map import (
+    W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
+    ReactionAtomMapIn,
+)
 
+from app.api.error_contract import CodedValueError
 from app.db.models.app_user import AppUser
 from app.db.models.common import AtomMapSource, ReactionRole
 from app.db.models.geometry import Geometry, GeometryAtom
+from app.db.models.reaction import ReactionEntryStructureParticipant
 from app.db.models.reaction_atom_map import ReactionAtomMap, ReactionAtomMapPair
 from app.schemas.workflows.computed_reaction_upload import (
     ComputedReactionUploadRequest,
@@ -37,6 +43,8 @@ from app.services.reaction_atom_map import (
     W_ATOM_MAP_ATOMS_INCOMPLETE,
     W_ATOM_MAP_PARTICIPANTS_INCOMPLETE,
     W_MISSING_REACTION_ATOM_MAP,
+    ResolvedAtomMapParticipant,
+    persist_reaction_atom_map,
 )
 from app.workflows.computed_reaction import persist_computed_reaction_upload
 
@@ -811,13 +819,17 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
     refusing it for a capital letter is the failure ADR 0008 puts out of
     bounds.
 
-    Since ``b4e7c1d20f83`` the two spellings never reach the comparison:
+    On the *deposit* path the two spellings no longer reach the comparison:
     ``parse_xyz`` canonicalises the symbol before it becomes a
-    ``geometry_atom`` row, so both ends of the pair store ``C`` and the two
-    composite foreign keys resolve against one string rather than two. The
-    deposited ``c`` is still readable — it survives in ``geometry.xyz_text``,
-    which is asserted here too, because that column is what ``geom_hash`` is
-    taken over and rewriting a symbol in it would re-key a published geometry.
+    ``geometry_atom`` row, so both ends of the pair store ``C``. The deposited
+    ``c`` is still readable — it survives in ``geometry.xyz_text``, which is
+    asserted here too, because that column is what ``geom_hash`` is taken over
+    and rewriting a symbol in it would re-key a published geometry.
+
+    That is the *common* case, not a guarantee. See
+    :func:`test_a_map_across_a_stored_symbol_that_is_not_canonical_is_accepted`
+    for the same rule holding on a row that did not come through ``parse_xyz``,
+    which is what the comparison-time normalisation is for.
 
     The map here is the same map as everywhere else in this module; only the
     methyl geometry's capitalisation differs.
@@ -873,6 +885,224 @@ def test_map_across_geometries_that_disagree_only_about_case_persists(
         assert [
             line.split()[0] for line in methyl_geometry.xyz_text.splitlines()[2:]
         ] == ["c", "h", "h", "h"]
+
+
+#: Which bundle-local species key sits in which ``(side, participant_index)``
+#: slot of :func:`_complete_map`. Needed to rebuild the resolved participants
+#: that :func:`persist_reaction_atom_map` takes, when calling it directly.
+_SPECIES_KEY_BY_SLOT = {
+    (ReactionRole.reactant, 1): "ch3",
+    (ReactionRole.reactant, 2): "h",
+    (ReactionRole.product, 1): "ch4",
+}
+
+
+def test_a_map_across_a_stored_symbol_that_is_not_canonical_is_accepted(
+    db_conn,
+) -> None:
+    """The blocking rule must hold on rows this process did not write.
+
+    ``parse_xyz`` canonicalises the element on the way into ``geometry_atom``,
+    and ``b4e7c1d20f83`` brought the older rows into line — but that is a
+    convention held by application code, not an invariant. **No CHECK
+    constraint requires the column to be canonical**, so a restore from a
+    backup older than that revision, a bulk import, or any future write path
+    that does not call ``parse_xyz`` can leave ``CL`` in the table. A blocking
+    check has to be correct on those rows too: refusing a correct map because
+    one geometry shouts its carbon is refusing correct chemistry over a capital
+    letter, which ADR 0008 puts out of bounds.
+
+    The non-canonical row is written **directly**, bypassing ``parse_xyz``,
+    because that is the only way such a row can exist now — which is exactly
+    the point. The map is then persisted against it through the real service
+    entry point.
+
+    This test is the one that fails if the comparison-time normalisation is
+    ever removed on the strength of ingestion canonicalising.
+    """
+    payload = _payload()
+    payload["atom_map"] = _complete_map()
+
+    with _isolated_session(db_conn) as session:
+        result = _upload(session, payload)
+
+        atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
+        assert atom_map is not None
+        pairs = session.scalars(
+            select(ReactionAtomMapPair).where(
+                ReactionAtomMapPair.atom_map_id == atom_map.id
+            )
+        ).all()
+        geometry_id_by_participant = {
+            pair.structure_participant_id: pair.geometry_id for pair in pairs
+        }
+        ts_geometry_id = atom_map.transition_state_geometry_id
+
+        participant_rows = session.scalars(
+            select(ReactionEntryStructureParticipant).where(
+                ReactionEntryStructureParticipant.reaction_entry_id
+                == result["reaction_entry_id"]
+            )
+        ).all()
+        participants = [
+            ResolvedAtomMapParticipant(
+                side=row.role,
+                species_key=_SPECIES_KEY_BY_SLOT[(row.role, row.participant_index)],
+                participant_index=row.participant_index,
+                structure_participant_id=row.id,
+            )
+            for row in participant_rows
+        ]
+        geometry_id_by_key = {
+            f"{participant.species_key}-geom": geometry_id_by_participant[
+                participant.structure_participant_id
+            ]
+            for participant in participants
+        }
+        geometry_id_by_key["ts-geom"] = ts_geometry_id
+
+        methyl_geometry_id = geometry_id_by_key["ch3-geom"]
+
+        # Clear the map so the same one can be written again; the composite
+        # foreign keys read `geometry_atom.element`, so the pairs have to go
+        # before the atom rows can be rewritten.
+        for pair in pairs:
+            session.delete(pair)
+        session.delete(atom_map)
+        session.flush()
+
+        # The row `parse_xyz` can no longer produce, written the only way it
+        # can now arrive: directly.
+        session.execute(
+            update(GeometryAtom)
+            .where(
+                GeometryAtom.geometry_id == methyl_geometry_id,
+                GeometryAtom.atom_index == 1,
+            )
+            .values(element="c")
+        )
+        session.flush()
+        assert session.scalar(
+            select(GeometryAtom.element).where(
+                GeometryAtom.geometry_id == methyl_geometry_id,
+                GeometryAtom.atom_index == 1,
+            )
+        ).strip() == "c"
+
+        # The saddle point still spells it `C`. Nothing may refuse this.
+        rewritten = persist_reaction_atom_map(
+            session,
+            ReactionAtomMapIn(**_complete_map()),
+            reaction_entry_id=result["reaction_entry_id"],
+            transition_state_entry_id=result["transition_state_entry_id"],
+            transition_state_geometry_id=ts_geometry_id,
+            participants=participants,
+            geometry_id_by_key=geometry_id_by_key,
+            created_by=_USER_ID,
+        )
+        session.flush()
+
+        assert rewritten is not None
+        rewritten_pairs = session.scalars(
+            select(ReactionAtomMapPair).where(
+                ReactionAtomMapPair.atom_map_id == rewritten.id
+            )
+        ).all()
+        assert len(rewritten_pairs) == 10
+
+        # Each end still stores its own geometry's spelling, which is what
+        # keeps both composite foreign keys resolvable across the disagreement.
+        methyl_carbon = next(
+            pair
+            for pair in rewritten_pairs
+            if pair.side is ReactionRole.reactant
+            and pair.geometry_id == methyl_geometry_id
+            and pair.atom_index == 1
+        )
+        assert methyl_carbon.element.strip() == "c"
+        assert methyl_carbon.ts_element.strip() == "C"
+
+
+def test_a_non_canonical_stored_symbol_does_not_blunt_the_element_rule(
+    db_conn,
+) -> None:
+    """Normalising a stored symbol must not stop carbon-to-nitrogen blocking.
+
+    The companion to the test above: tolerating case must buy tolerance of
+    case and nothing else. Here the saddle point really is a different element
+    from the reactant atom mapped onto it, spelled in the awkward case, and it
+    still blocks.
+    """
+    payload = _payload()
+    payload["atom_map"] = _complete_map()
+
+    with _isolated_session(db_conn) as session:
+        result = _upload(session, payload)
+
+        atom_map = session.get(ReactionAtomMap, result["atom_map_id"])
+        assert atom_map is not None
+        pairs = session.scalars(
+            select(ReactionAtomMapPair).where(
+                ReactionAtomMapPair.atom_map_id == atom_map.id
+            )
+        ).all()
+        geometry_id_by_participant = {
+            pair.structure_participant_id: pair.geometry_id for pair in pairs
+        }
+        ts_geometry_id = atom_map.transition_state_geometry_id
+
+        participant_rows = session.scalars(
+            select(ReactionEntryStructureParticipant).where(
+                ReactionEntryStructureParticipant.reaction_entry_id
+                == result["reaction_entry_id"]
+            )
+        ).all()
+        participants = [
+            ResolvedAtomMapParticipant(
+                side=row.role,
+                species_key=_SPECIES_KEY_BY_SLOT[(row.role, row.participant_index)],
+                participant_index=row.participant_index,
+                structure_participant_id=row.id,
+            )
+            for row in participant_rows
+        ]
+        geometry_id_by_key = {
+            f"{participant.species_key}-geom": geometry_id_by_participant[
+                participant.structure_participant_id
+            ]
+            for participant in participants
+        }
+        geometry_id_by_key["ts-geom"] = ts_geometry_id
+        methyl_geometry_id = geometry_id_by_key["ch3-geom"]
+
+        for pair in pairs:
+            session.delete(pair)
+        session.delete(atom_map)
+        session.flush()
+
+        # ``n`` is nitrogen however it is spelled, and nitrogen is not carbon.
+        session.execute(
+            update(GeometryAtom)
+            .where(
+                GeometryAtom.geometry_id == methyl_geometry_id,
+                GeometryAtom.atom_index == 1,
+            )
+            .values(element="n")
+        )
+        session.flush()
+
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_reaction_atom_map(
+                session,
+                ReactionAtomMapIn(**_complete_map()),
+                reaction_entry_id=result["reaction_entry_id"],
+                transition_state_entry_id=result["transition_state_entry_id"],
+                transition_state_geometry_id=ts_geometry_id,
+                participants=participants,
+                geometry_id_by_key=geometry_id_by_key,
+                created_by=_USER_ID,
+            )
+        assert excinfo.value.code == W_ATOM_MAP_ELEMENT_NOT_CONSERVED
 
 
 def test_an_element_really_changing_across_the_map_is_still_refused(

--- a/backend/tests/workflows/test_species_geometry_composition.py
+++ b/backend/tests/workflows/test_species_geometry_composition.py
@@ -84,8 +84,8 @@ _XYZ_CH3 = (
 )
 #: Chloromethane, CH3Cl. Five atoms: C (index 1), Cl (index 2), three H
 #: (indices 3-5). Written the way plenty of electronic-structure output writes
-#: it — chlorine shouted, carbon and hydrogen whispered — because
-#: ``geometry_atom.element`` stores whatever the XYZ said, verbatim.
+#: it — chlorine shouted, carbon and hydrogen whispered. ``geometry.xyz_text``
+#: keeps that spelling; ``geometry_atom.element`` canonicalises it.
 _XYZ_CH3CL_MIXED_CASE = (
     "5\nchloromethane, elements as an ESS wrote them\n"
     "c  0.000  0.000  0.000\n"
@@ -96,7 +96,8 @@ _XYZ_CH3CL_MIXED_CASE = (
 )
 #: Heavy water, written the way an ESS is entitled to write it: ``D`` in the
 #: element column. Gaussian, ORCA, Molpro and CFOUR all emit or accept the
-#: token, and ``geometry_atom.element`` stores it verbatim by design.
+#: token, and ``geometry_atom.element`` keeps it by design — ingestion
+#: canonicalises case and deliberately leaves nuclide labelling alone.
 _XYZ_D2O = (
     "3\nheavy water, hydrogens written as D\n"
     "O  0.000  0.000  0.117\n"
@@ -331,7 +332,7 @@ def test_deuterium_written_as_the_element_D_is_accepted(db_conn) -> None:
     """``D`` is hydrogen, and this check must know it.
 
     ``D`` is a legal, common XYZ token — Gaussian, ORCA, Molpro and CFOUR all
-    emit or accept it — and ``geometry_atom.element`` stores it verbatim. A raw
+    emit or accept it — and ``geometry_atom.element`` keeps it. A raw
     comparison reads this geometry as containing an element water's SMILES
     never mentions and refuses a deposit that was accepted before any
     composition check existed. That is a regression on correct chemistry, and
@@ -386,10 +387,12 @@ def test_a_D_geometry_with_the_wrong_atom_count_is_still_refused(
 def test_element_symbols_in_any_case_are_accepted(db_conn) -> None:
     """``CL`` is chlorine and ``c`` is carbon.
 
-    ``geometry_atom.element`` holds whatever the depositor's XYZ said, and
-    electronic-structure codes are not consistent about capitalisation.
-    Refusing correct chemistry over a string is what ADR 0008 puts out of
-    bounds for a blocking check; this exact bug shipped once already.
+    Electronic-structure codes are not consistent about capitalisation, and
+    refusing correct chemistry over a string is what ADR 0008 puts out of
+    bounds for a blocking check; this exact bug shipped once already. Since
+    ``b4e7c1d20f83`` the case is settled on the way into
+    ``geometry_atom.element`` rather than at each comparison, but the deposit
+    under test is unchanged and so is what it must be allowed to do.
 
     The upload succeeding is only half of it. ``validate_calculation_geometry``
     compares the very same symbols on the very same deposit, and it compared

--- a/backend/tests/workflows/test_transition_state_composition.py
+++ b/backend/tests/workflows/test_transition_state_composition.py
@@ -290,12 +290,17 @@ def test_a_saddle_point_whose_xyz_shouts_its_elements_is_accepted(
 ) -> None:
     """``CL`` and ``c`` are ``Cl`` and ``C``, and this check must know it.
 
-    ``geometry_atom.element`` holds the depositor's XYZ symbol verbatim, while
+    The deposit is what an ESS that shouts its halogens actually writes, and
     the reactant side of the comparison comes from RDKit's title-case
-    ``GetSymbol()``. Comparing the two raw makes a correct saddle point read as
-    ``CCLHHH`` against a reaction of ``CH3Cl`` and refuses it — rejecting
+    ``GetSymbol()``. Comparing the two raw made a correct saddle point read as
+    ``CCLHHH`` against a reaction of ``CH3Cl`` and refused it — rejecting
     correct chemistry over capitalisation, which ADR 0008 disqualifies a
     blocking check from doing.
+
+    Since ``b4e7c1d20f83`` the shouting is settled before the comparison rather
+    than inside it: ``parse_xyz`` canonicalises the case on the way into
+    ``geometry_atom.element``. The deposit under test is unchanged, and so is
+    what it must be allowed to do.
     """
     with _isolated_session(db_conn) as session:
         result = _upload(session, _chlorine_bundle(ts_xyz=_XYZ_TS_MIXED_CASE))

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -252,7 +252,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `canonical_species_identity` — `backend/app/chemistry/species.py:540`
+- `canonical_species_identity` — `backend/app/chemistry/species.py:541`
   *Charge is compared against `formal_charge` of the sanitized identity molecule — the sum of RDKit per-atom formal charges, which is a notation convention rather than an electron count. A referee may object that formal-charge assignment on hypervalent, zwitterionic or dative-bonded SMILES is notation-dependent.*
 
 **Escape hatch.** A free electron short-circuits before the comparison, returning a pinned identity pair. Multiplicity is deliberately **not** validated against the SMILES at all: standard SMILES does not encode spin state, so RDKit's inferred radical count is only a hint and the uploaded multiplicity is authoritative — which is what lets singlet CH2 (whose SMILES `[CH2]` implies a triplet) and the singlet and triplet states of O2 be represented.
@@ -462,7 +462,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - `ck_reaction_atom_map_pair_element_matches` (check on `reaction_atom_map_pair`)
   `upper(element) = upper(ts_element)`
 
-**Escape hatch.** Case is not load-bearing, and since `b4e7c1d20f83` it cannot be: `geometry_atom.element` is canonicalised on the way in, so both ends of a pair spell an element the same way. The constraint stays case-insensitive anyway — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not, and a check wider than it needs to be refuses nothing correct. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
+**Escape hatch.** Case is not load-bearing. The comparison is deliberately case-insensitive because the two ends quote two different geometries and nothing guarantees they spell an element the same way — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not. `b4e7c1d20f83` canonicalises the symbol on the way into `geometry_atom.element`, which makes disagreement rare on rows written through the API; it is a convention rather than a constraint, so both the database check and the Python check still normalise instead of assuming it. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
 ### 18. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 
@@ -541,7 +541,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:348`
+- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:359`
   *Called from *both* seams — `persist_reaction_atom_map` and `persist_transition_state_validation_evidence` — and reads both surfaces from the database rather than from either caller's payload, so whichever a deposit writes second delivers the same verdict. Today the second is always the atom map: the computed-reaction bundle is the only payload with an `atom_map` field and writes it after the evidence, and no path can attach a map to a saddle point deposited earlier because every transition-state entry is created fresh by the deposit that writes it. Both are incidental orderings, so neither is relied on.*
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction.
@@ -561,7 +561,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_absent` — `backend/app/services/reaction_atom_map.py:611`
+- `_warn_absent` — `backend/app/services/reaction_atom_map.py:625`
   *A reaction with no transition state is not warned about: both legs of a map run toward the saddle point, so a barrierless channel has nothing to map onto and a warning it could never satisfy would train depositors to ignore the one that matters. The PDep bundle has no `atom_map` field yet, so on that path the warning carries a different remedy sentence rather than naming a field that does not exist.*
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
@@ -579,7 +579,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:642`
+- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:656`
   *Two codes from one seam: `reaction_atom_map_participants_incomplete` when a declared molecule is missing from the map entirely, `reaction_atom_map_atoms_incomplete` when a mapped participant leaves its own atoms unmapped or a leg leaves saddle-point atoms claimed by nobody.*
 
 **Escape hatch.** None.

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -541,7 +541,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:345`
+- `validate_atom_map_agrees_with_irc_evidence` — `backend/app/services/reaction_atom_map.py:348`
   *Called from *both* seams — `persist_reaction_atom_map` and `persist_transition_state_validation_evidence` — and reads both surfaces from the database rather than from either caller's payload, so whichever a deposit writes second delivers the same verdict. Today the second is always the atom map: the computed-reaction bundle is the only payload with an `atom_map` field and writes it after the evidence, and no path can attach a map to a saddle point deposited earlier because every transition-state entry is created fresh by the deposit that writes it. Both are incidental orderings, so neither is relied on.*
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction.
@@ -561,7 +561,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_absent` — `backend/app/services/reaction_atom_map.py:608`
+- `_warn_absent` — `backend/app/services/reaction_atom_map.py:611`
   *A reaction with no transition state is not warned about: both legs of a map run toward the saddle point, so a barrierless channel has nothing to map onto and a warning it could never satisfy would train depositors to ignore the one that matters. The PDep bundle has no `atom_map` field yet, so on that path the warning carries a different remedy sentence rather than naming a field that does not exist.*
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
@@ -579,7 +579,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:639`
+- `_warn_incomplete` — `backend/app/services/reaction_atom_map.py:642`
   *Two codes from one seam: `reaction_atom_map_participants_incomplete` when a declared molecule is missing from the map entirely, `reaction_atom_map_atoms_incomplete` when a mapped participant leaves its own atoms unmapped or a leg leaves saddle-point atoms claimed by nobody.*
 
 **Escape hatch.** None.

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -252,7 +252,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Enforced at.**
 
-- `canonical_species_identity` — `backend/app/chemistry/species.py:538`
+- `canonical_species_identity` — `backend/app/chemistry/species.py:540`
   *Charge is compared against `formal_charge` of the sanitized identity molecule — the sum of RDKit per-atom formal charges, which is a notation convention rather than an electron count. A referee may object that formal-charge assignment on hypervalent, zwitterionic or dative-bonded SMILES is notation-dependent.*
 
 **Escape hatch.** A free electron short-circuits before the comparison, returning a pinned identity pair. Multiplicity is deliberately **not** validated against the SMILES at all: standard SMILES does not encode spin state, so RDKit's inferred radical count is only a hint and the uploaded multiplicity is authoritative — which is what lets singlet CH2 (whose SMILES `[CH2]` implies a triplet) and the singlet and triplet states of O2 be represented.
@@ -462,7 +462,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - `ck_reaction_atom_map_pair_element_matches` (check on `reaction_atom_map_pair`)
   `upper(element) = upper(ts_element)`
 
-**Escape hatch.** Case is not load-bearing. The comparison is deliberately case-insensitive because the two ends quote two different geometries, and a geometry stores the symbol its depositor's XYZ wrote — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
+**Escape hatch.** Case is not load-bearing, and since `b4e7c1d20f83` it cannot be: `geometry_atom.element` is canonicalised on the way in, so both ends of a pair spell an element the same way. The constraint stays case-insensitive anyway — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not, and a check wider than it needs to be refuses nothing correct. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
 ### 18. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 


### PR DESCRIPTION
Closes the class of bug that the atom-map branch (#113) worked around at comparison time.

`parse_xyz` stored `parts[0]` verbatim, so `geometry_atom.element` — a `character(2)` column that every element comparison in the tree reads — could hold `Cl`, `CL`, `cl` and `bR` for one element. The defect had already shipped twice: a saddle point written `CL` contradicted its own reaction, and a mixed-case deposit was accepted at the blocking tier while `calc_geometry_validation` recorded `fail` on the same bytes. This canonicalises at the source, so the column reads as chemistry rather than as whatever the file shouted.

## Measured first: on the live database this backfill is a no-op

Queried read-only before writing the migration:

| | |
|---|---|
| `geometry_atom` | **46,566 rows** over 3,653 geometries — C 14368, H 28844, O 2415, S 331, N 222, **Cl 202**, F 184 |
| non-canonical symbols | **zero**, no exceptions |
| `reaction_atom_map_pair` | **0 rows** |
| `geometry.xyz_text` NULL | **0** |

So the backfill below matches nothing on the deployed database and updates nothing. It exists so that a database which *does* hold older rows converges, not because ours needs repair. That fact decides two things further down: the migration does not disable the accepted-science guard, and nothing blocking is allowed to assume the backfill ran.

## The decision a reviewer must not have to infer: `xyz_text` and `element` deliberately disagree

`parse_xyz` produces two things from one set of parsed atom lines, and **they now spell the element differently on purpose.**

| | Element symbol | Why |
|---|---|---|
| `ParsedXYZ.atoms` → `geometry_atom.element` | **canonicalised** (`CL` → `Cl`) | It is the *parsed index the database joins and compares on*: the target of `reaction_atom_map_pair`'s two composite foreign keys, and the value every element comparison in the service layer reads. |
| `ParsedXYZ.canonical_xyz_text` → `geometry.xyz_text`, hashed into `geom_hash` | **left exactly as deposited** (`CL` stays `CL`) | It is the *deposited evidence, and it is citable*. |

The second row is the load-bearing one. `geom_hash` is a sha256 over that text; it is the dedupe key in `app/services/geometry_resolution.py`, and `app/services/public_refs.py` mints `geometry:geom_hash=<hash>` as a citable public ref. Canonicalising a symbol inside the hashed text would **re-key every geometry already stored whose XYZ shouted an element**: published refs would dangle, and a re-upload of the very same file would compute the old hash and fail to dedupe onto its own row. Same constraint that keeps the isotope suffix off `ParsedXYZ.hash_text` for unlabelled geometries.

So `geometry.xyz_text` may read `CL` for an atom whose `geometry_atom.element` reads `Cl`. That is not drift: **one is the record of what was deposited, the other is the index joins and comparisons run against, and only the second has to be canonical for the first to stay citable.** A depositor still reads back the symbol they wrote, for the reason `resolve_element_symbol` already gives about `D`.

Pinned by test, not only by prose — `tests/invariants/test_hash_invariants.py::test_geom_hash_is_untouched_by_element_symbol_canonicalisation` rebuilds the expected hash input from the deposited symbols without going through the parser, so it fails if the canonicalisation ever leaks into the hash.

**Case only.** `D` and `T` stay `D` and `T`. `resolve_element_symbol` is deliberately *not* used here: collapsing them to `H` at deposit time would destroy the depositor's own isotope labelling, which is a fact about the deposit rather than a spelling of one. Code that *counts* elements resolves them at the point of counting, exactly as before.

## Canonical storage is a convention, so nothing blocking may assume it

**Every comparison-time normalisation stays**, including the blocking element-conservation check in `app/services/reaction_atom_map.py`. There is deliberately **no CHECK constraint** holding `geometry_atom.element` canonical, so a restore from a backup older than this revision, a bulk import, or any future write path that skips `parse_xyz` can put `CL` back. A blocking check has to be correct on rows the running process never wrote; comparing raw would refuse a correct map over a capital letter, which ADR 0008 puts out of bounds. On canonical input the normalisation is a no-op, so the correctness costs nothing.

An earlier revision of this branch removed that normalisation on the argument that "the rule is now kept by the column instead of by the comparison". That was false — the column keeps nothing — and it was the root of the trigger problem below. `tests/workflows/test_reaction_atom_map.py::test_a_map_across_a_stored_symbol_that_is_not_canonical_is_accepted` is the regression test for it; verified by mutation (restoring the raw comparison makes exactly that test fail, and only that test).

Making canonicality structural was considered and deferred: a CHECK cannot be added until accepted rows are already canonical, which puts us straight back to needing the guard down. Filed as a follow-up.

## Backfill ordering, and why it is safe

`reaction_atom_map_pair.element` / `.ts_element` are part of the key two composite foreign keys reference on `geometry_atom (geometry_id, atom_index, element)`. **No ordering of two plain `UPDATE`s is valid**: parent-first orphans every child that quotes the old spelling; child-first points it at a parent key that does not exist yet. Both fail at statement end.

Both FKs were created `DEFERRABLE INITIALLY IMMEDIATE` in `d3a7f1c9b284`, so the revision defers them, updates `geometry_atom` then `reaction_atom_map_pair` (order between them now irrelevant; the parent goes first only because it defines the truth), sets the constraints back to `IMMEDIATE` — which runs the referential check inside the revision, with its own frame on the traceback, rather than at an anonymous COMMIT — and finally re-counts non-canonical rows in both tables and **raises** if any survive.

Two constraints that could have been a problem and are not: `ck_reaction_atom_map_pair_element_matches` (`upper(element) = upper(ts_element)`) is a CHECK and cannot be deferred, but `upper()` is invariant under this transformation, so every intermediate row satisfies it; and `uq_geometry_atom_geometry_id_element` cannot be violated because `(geometry_id, atom_index)` is already the primary key.

### The accepted-science guard is left standing

`trg_as_geometry_atom` refuses updates to a geometry attached to an accepted calculation. **This revision does not disable it.** It is a scientific-integrity control, and on the deployed database it would have been stood down to repair rows that do not exist (see the numbers at the top).

Where such a row *does* exist, the migration trips the guard and fails, loudly, and that is the designed outcome: rewriting a value inside approved science is a decision for the operator holding that database, not for a migration running unattended — and nothing downstream needs the rewrite, because comparisons still normalise. Demonstrated rather than asserted: on a scratch database seeded with a non-canonical row under an approved calculation, `alembic upgrade head` exits non-zero with

```
psycopg.errors.ObjectNotInPrerequisiteState: accepted calculation record 1 is immutable
HINT:  Create and approve a replacement, then record a supersession.
```

leaving `geometry_atom` as `['CL', 'c', 'D', 'Cl', 'C', 'D']`, the pairs as `[('CL','Cl'), ('c','C'), ('D','D')]`, and `alembic_version` still at `d7f1a3c5e948`. `tests/db/test_canonical_element_symbols_migration.py` covers both halves, and asserts off the revision source that it contains no `DISABLE TRIGGER` / `ENABLE TRIGGER` / `session_replication_role`, since on a clean database that difference is otherwise invisible.

### `downgrade()` is a documented no-op

`Cl` does not record whether the file wrote `Cl`, `CL` or `cl`, and nothing else remembers per row. Re-deriving the casing from `xyz_text` was considered and rejected: it would restore the exact defect the revision removes, during a downgrade normally run to get *back* to a working state, and it would silently do nothing wherever `xyz_text` is NULL. Leaving the canonical form is forward-compatible — every pre-upgrade code path normalised at comparison time, so canonical rows are what it already handled.

### `energy_correction_scheme_atom_param.element` is deliberately not touched

Recorded in the revision docstring rather than left implicit. It is `text`, half that table's primary key, and a *reference library* key — the element label a published correction scheme uses for its own parameters. Nothing joins it to `geometry_atom` today, and normalising a PK column needs a merge policy (`C` and `c` in one scheme collide on update), not an `UPDATE`. Filed as a follow-up.

## Deliberately not in this PR

`reaction_atom_map_pair`'s two element columns and the case-insensitive `upper(...)` in its CHECK both **stay load-bearing**, for the same reason the comparison-time normalisation does: two geometries are not guaranteed to spell an element the same way. Collapsing them needs canonicality to be structural first.

## Verification

- `pytest tests/ -n 8`: **6645 passed, 14 skipped, 1 failed** (300s). The single failure is `tests/db/test_identifier_lengths.py::test_no_reliance_on_identifier_truncation`, pre-existing on `main` and unrelated — it flags two over-long FK names on `execution_environment_manifest`, a file this branch does not touch.
- `backend/scripts/test-api.sh`: **2497 passed**.
- `backend/scripts/test-scientific.sh`: **1983 passed**.
- Migration round trip on a scratch `tckdb_test_*` database: `upgrade head` → `downgrade -1` → `upgrade head`, green; plus the seeded-guard failure demonstrated above.
- Mutation check on the new regression test: restoring the raw comparison fails `test_a_map_across_a_stored_symbol_that_is_not_canonical_is_accepted` and nothing else.
- `schema.dbml` regenerated — no diff (the model changes are comments). `ruff check backend/app backend/tests` clean.

## Follow-up tasks (filed, not left in this description)

1. Make canonicality structural — a CHECK on `geometry_atom.element` — once there is an agreed path for accepted rows. That is what would let the comparison-time normalisation actually retire. — `backend/app/db/models/geometry.py:89`
2. Collapse `reaction_atom_map_pair.element` / `.ts_element` into one column and tighten the CHECK to plain equality; blocked on (1). — `backend/app/db/models/reaction_atom_map.py:301`, `backend/app/db/models/reaction_atom_map.py:375`
3. Give `energy_correction_scheme_atom_param.element` a canonical form and a merge policy before anything joins it to geometry atom counts. — `backend/app/db/models/energy_correction.py:127`
4. Over-long FK identifiers on `execution_environment_manifest` (pre-existing red test). — `backend/app/db/models/execution_environment.py:35`, `:40`
5. Two spellings of one geometry still produce two `geometry` rows (deliberate under-normalization, now pinned by test); closing it needs a hash-version scheme, not a re-key. — `backend/app/chemistry/geometry.py:251`
6. The accepted-science guard has no auditable repair path, so any legitimate data repair has to be done by an operator with owner rights and leaves no record. — `backend/alembic/versions/c6f2a9d4e7b1_enforce_accepted_science_immutability.py:761`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
