### PR TITLE
Make a refusal identifiable on every consumer surface

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -203,6 +203,17 @@ jobs:
         if: matrix.gate == 'scientific'
         run: conda run -n tckdb_env bash backend/scripts/test-scientific.sh --maxfail=5
 
+      # The MCP integration is a consumer of the backend's error contract
+      # and had no CI job at all, so nothing stopped a change here from
+      # silently flattening every scientific refusal back into one code.
+      # It needs no database and no extra install -- httpx and pytest are
+      # already in the environment, and `pythonpath = ["src"]` in the
+      # package's own pyproject puts the sources on the path.
+      - name: MCP integration gate
+        if: matrix.gate == 'api'
+        working-directory: integrations/mcp
+        run: conda run -n tckdb_env pytest -q
+
   backend-ci:
     name: Backend CI
     needs: backend-gate

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any
 
 from fastapi import FastAPI, Request
@@ -161,6 +162,14 @@ def _no_result_found_handler(
 # Public responses must not leak raw psycopg/PostgreSQL text. We classify
 # the failure by SQLSTATE (stable across PG versions) and return a small,
 # stable envelope. Full driver detail goes to the server log.
+#
+# SQLSTATE is the *floor*, not the answer. It says a check constraint
+# fired; it cannot say which scientific rule that constraint encodes, so
+# on its own it renders "an atom changed element across this reaction"
+# and "a required column was null" as the same ``state_conflict``. A
+# constraint that the scientific check register names carries its own
+# code and sentence, looked up by name in ``_constraint_rejections``
+# below; everything else still falls back to the SQLSTATE bucket.
 
 _SQLSTATE_TO_CATEGORY: dict[str, tuple[str, str]] = {
     # (category code, sanitized public message)
@@ -175,6 +184,28 @@ _SQLSTATE_TO_CATEGORY: dict[str, tuple[str, str]] = {
 }
 
 _FALLBACK = ("integrity_conflict", "Integrity constraint violation.")
+
+
+@lru_cache(maxsize=1)
+def _constraint_rejections() -> dict[str, tuple[str, str]]:
+    """Scientific 409 codes, keyed on the constraint PostgreSQL names.
+
+    Imported lazily and cached because the register pulls in the service
+    and chemistry modules that declare its entries, several of which
+    import this module for :class:`DomainError` -- so a module-level
+    import would be a cycle. Nothing here runs until the first integrity
+    error, by which point the application is fully imported.
+
+    The mapping is *derived*, never written here. A hand-kept table in
+    this module would be a second place to remember a constraint rename;
+    building it from the register means the rename fails
+    ``test_database_object_exists_in_live_schema`` -- which queries
+    ``pg_constraint`` -- before it can silently downgrade a scientific
+    refusal back to a generic ``state_conflict``.
+    """
+    from app.scientific_checks.declarations import constraint_rejections
+
+    return constraint_rejections()
 
 
 def _classify_integrity_error(exc: IntegrityError) -> tuple[str, str]:
@@ -205,7 +236,22 @@ def _integrity_error_handler(
     constraint = getattr(getattr(orig, "diag", None), "constraint_name", None)
     if constraint:
         diag["constraint"] = constraint
-    if constraint == IDEMPOTENCY_UNIQUE_CONSTRAINT:
+    context: dict[str, Any] = {}
+    # Named before classified. A constraint that encodes chemistry is a
+    # stronger guarantee than any Python check -- no write path can get
+    # around it -- and until now it was the one a client was told least
+    # about, because every violation collapsed into its SQLSTATE bucket.
+    # Keyed on the constraint name rather than on the driver's message
+    # text: parsing prose is what the typed envelope exists to replace.
+    rejection = _constraint_rejections().get(constraint) if constraint else None
+    if rejection is not None:
+        code, message = rejection
+        # The schema object name, not a row id. It is the key into
+        # ``docs/guides/scientific_check_register.md``, so a client (or a
+        # human reading a traceback) can look up which scientific position
+        # refused the write and what the escape hatch is.
+        context["constraint"] = constraint
+    elif constraint == IDEMPOTENCY_UNIQUE_CONSTRAINT:
         code = "idempotency_conflict"
         message = (
             "Idempotency key was used concurrently for a different request."
@@ -226,7 +272,7 @@ def _integrity_error_handler(
             "detail": message,
             "code": code,
             "category": "integrity_error",
-            "context": {},
+            "context": context,
         },
     )
 

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -49,6 +49,44 @@ class NotFoundError(Exception):
         self.code = code
 
 
+def not_found(
+    kind: str,
+    *,
+    row_id: object = None,
+    ref: str | None = None,
+    code: str | None = None,
+) -> NotFoundError:
+    """Build a 404 that names the resource without disclosing its row id.
+
+    The obvious way to write a 404 is ``f"{kind} not found ({kind}_id=
+    {row_id})"``, which is why roughly thirty of them were written that
+    way. It reads helpfully and it is wrong twice over. A row id is an
+    implementation detail of one database instance -- it does not survive
+    a restore, it does not agree across the hosted deployment and a lab
+    self-host, and no public surface is keyed on it -- so a client that
+    learns to read it builds against something TCKDB never promised to
+    keep stable. And the id is useless to the caller anyway: the whole
+    point of a 404 is that the row is not there.
+
+    Whoever actually needs the id is the operator reading the log, so it
+    goes there. A public ref *is* echoed, because the caller supplied it
+    and quoting it back is what makes a 404 diagnosable at all.
+
+    :param kind: The resource, in the vocabulary the API uses for it
+        (``"calculation"``, ``"species_entry"``).
+    :param row_id: The internal id that was looked up. Logged, never
+        returned.
+    :param ref: A public ref the caller supplied, echoed into the body.
+    :param code: Stable application code for the envelope.
+    """
+    if row_id is not None:
+        logger.info("404 %s not found: row_id=%s ref=%s", kind, row_id, ref)
+    detail = f"{kind} not found"
+    if ref is not None:
+        detail += f" ({kind}_ref={ref!r})"
+    return NotFoundError(detail, code=code)
+
+
 class DataIntegrityError(Exception):
     """Persisted data violates a scientific invariant assumed by the API.
 

--- a/backend/app/api/routes/lookup.py
+++ b/backend/app/api/routes/lookup.py
@@ -348,7 +348,7 @@ def _apply_selection(
 
         calcs = sorted(calcs, key=_energy_sort_key)
         winner = calcs[0]
-        mb.add(SELECTION_APPLIED, f"selection=lowest_energy chose calculation {winner.id}")
+        mb.add(SELECTION_APPLIED, f"selection=lowest_energy chose calculation {winner.public_ref}")
         return [winner]
 
     if selection == "latest":
@@ -357,7 +357,7 @@ def _apply_selection(
             key=lambda c: (-(c.created_at.timestamp() if c.created_at else 0), c.id),
         )
         winner = calcs[0]
-        mb.add(SELECTION_APPLIED, f"selection=latest chose calculation {winner.id}")
+        mb.add(SELECTION_APPLIED, f"selection=latest chose calculation {winner.public_ref}")
         return [winner]
 
     if selection == "earliest":
@@ -366,7 +366,7 @@ def _apply_selection(
             key=lambda c: (c.created_at.timestamp() if c.created_at else float("inf"), c.id),
         )
         winner = calcs[0]
-        mb.add(SELECTION_APPLIED, f"selection=earliest chose calculation {winner.id}")
+        mb.add(SELECTION_APPLIED, f"selection=earliest chose calculation {winner.public_ref}")
         return [winner]
 
     return calcs
@@ -505,7 +505,7 @@ def _resolve_species_list(
             mb.add(code, f"{role}[{i}] '{smi}' not found in database")
             return None
         code = REACTANT_RESOLVED if role == "reactant" else PRODUCT_RESOLVED
-        mb.add(code, f"{role}[{i}] '{smi}' resolved to species {sp.id}")
+        mb.add(code, f"{role}[{i}] '{smi}' resolved to species {sp.public_ref}")
         species_rows.append(sp)
     return species_rows
 

--- a/backend/app/scientific_checks/__init__.py
+++ b/backend/app/scientific_checks/__init__.py
@@ -204,9 +204,17 @@ class CodeChannel(str, Enum):
     trust_label = "trust_label"
 
     #: Enforced only by PostgreSQL, so the refusal arrives through the
-    #: integrity handler as a 409 whose code names the SQLSTATE class
-    #: (``state_conflict`` and friends) rather than the scientific claim.
-    #: An honest "the client is told *something*, but not which check".
+    #: integrity handler as a 409 rather than a 422. It used to mean "the
+    #: client is told *something*, but not which check", because the
+    #: handler classified every violation by SQLSTATE and reported
+    #: ``state_conflict`` for all of them -- a guarantee that is
+    #: *stronger* than a Python check, since no write path can bypass it,
+    #: paired with the weakest thing a client could be told about it.
+    #: A constraint that declares
+    #: :attr:`DatabaseConstraint.rejection_code` is now named: the handler
+    #: keys on ``diag.constraint_name`` and reports the scientific code.
+    #: The channel still exists to say *which status* carries it, because
+    #: 409-with-a-code and 422-with-a-code are different retry advice.
     database_constraint = "database_constraint"
 
     #: No machine-readable code reaches anybody. Recorded rather than
@@ -274,6 +282,14 @@ class PythonCheck:
         return f"``{self.func.__qualname__}``"
 
 
+#: Constraint kinds for which PostgreSQL populates ``diag.constraint_name``
+#: on the error it raises, which is the only thing the integrity handler
+#: can key on. Measured rather than assumed: a NOT NULL violation
+#: (SQLSTATE 23502) arrives with ``constraint_name = None``, so a claim
+#: held only by a NOT NULL column cannot be named to a client this way.
+_NAMED_BY_POSTGRES = frozenset({"check", "unique", "foreign_key", "exclusion"})
+
+
 @dataclass(frozen=True)
 class DatabaseConstraint:
     """A check enforced by PostgreSQL, identified by its schema object name.
@@ -289,12 +305,48 @@ class DatabaseConstraint:
     :param name: Expanded object name as PostgreSQL holds it.
     :param kind: ``check``, ``unique``, ``foreign_key`` or ``trigger``.
     :param definition: The SQL predicate, for the register document.
+    :param rejection_code: The code the 409 body carries when *this*
+        object is the one that fired. Declaring it here rather than on
+        the entry is what lets one claim own several constraints that a
+        client must be able to tell apart, and lets a claim enforced both
+        in Python and in PostgreSQL report the *same* code from both
+        sites. ``None`` means the refusal still arrives as the
+        SQLSTATE-derived category, which is honest but tells a client
+        only that *some* consistency rule fired.
+    :param rejection_detail: The sanitized public sentence that goes out
+        with ``rejection_code``. Written here, in the register, beside the
+        scientific claim it explains — not in the exception handler,
+        which has no idea what the constraint means. ASCII only: it is a
+        runtime string.
     """
 
     table: str
     name: str
     kind: str
     definition: str | None = None
+    rejection_code: str | None = None
+    rejection_detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if bool(self.rejection_code) != bool(self.rejection_detail):
+            raise ValueError(
+                f"DatabaseConstraint({self.name!r}) declares "
+                f"rejection_code={self.rejection_code!r} and "
+                f"rejection_detail={self.rejection_detail!r}. A code with no "
+                "sentence would reach a client as a bare token, and a sentence "
+                "with no code is the generic 409 this field exists to replace; "
+                "declare both or neither."
+            )
+        if self.rejection_code and self.kind not in _NAMED_BY_POSTGRES:
+            raise ValueError(
+                f"DatabaseConstraint({self.name!r}) is a {self.kind!r} and "
+                f"declares rejection_code={self.rejection_code!r}, but the "
+                "handler keys on ``diag.constraint_name`` and PostgreSQL "
+                f"populates it only for {sorted(_NAMED_BY_POSTGRES)}. A "
+                "NOT NULL violation reports no name at all, and a trigger that "
+                "RAISEs reports whatever the function chose. Mapping one of "
+                "those would declare a code that can never arrive."
+            )
 
     @property
     def location(self) -> str:
@@ -559,6 +611,45 @@ def collect_registered_checks(modules: tuple[ModuleType, ...]) -> list[Scientifi
     )
 
 
+def collect_constraint_rejections(
+    checks: list[ScientificCheck],
+) -> dict[str, tuple[str, str]]:
+    """Map PostgreSQL constraint name to the ``(code, detail)`` a 409 carries.
+
+    The integrity handler builds its lookup from this rather than holding
+    a table of its own. A second table would be a second thing to keep in
+    step with the schema, and the register is already the one place that
+    is drift-guarded against live ``pg_constraint`` metadata -- so a
+    constraint that is renamed in a migration fails the *existing* guard
+    instead of quietly reverting its refusal to a generic
+    ``state_conflict`` that nobody would notice.
+
+    :param checks: The register, as :func:`collect_registered_checks`
+        returns it.
+    :returns: Constraint name to ``(code, public detail)``.
+    :raises ValueError: If two entries claim the same constraint name
+        with different codes, which would make the refusal depend on
+        dictionary order.
+    """
+
+    rejections: dict[str, tuple[str, str]] = {}
+    for check in checks:
+        for site in check.enforced_by:
+            if not isinstance(site, DatabaseConstraint) or not site.rejection_code:
+                continue
+            assert site.rejection_detail is not None  # enforced in __post_init__
+            entry = (site.rejection_code, site.rejection_detail)
+            existing = rejections.setdefault(site.name, entry)
+            if existing != entry:
+                raise ValueError(
+                    f"Constraint {site.name!r} is declared with two different "
+                    f"rejections, {existing!r} and {entry!r}. One violation "
+                    "cannot report two codes; the same object named by two "
+                    "entries must agree on what a client is told."
+                )
+    return rejections
+
+
 __all__ = [
     "CheckTier",
     "CodeChannel",
@@ -570,5 +661,6 @@ __all__ = [
     "PythonCheck",
     "ScientificCheck",
     "Threshold",
+    "collect_constraint_rejections",
     "collect_registered_checks",
 ]

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -67,6 +67,7 @@ from app.scientific_checks import (
     ProvenanceThreshold,
     PythonCheck,
     ScientificCheck,
+    collect_constraint_rejections,
     collect_registered_checks,
 )
 from app.services import (
@@ -478,6 +479,17 @@ CHECK_ATOM_MAP_ELEMENT_CONSERVED = ScientificCheck(
             name="ck_reaction_atom_map_pair_element_matches",
             kind="check",
             definition="upper(element) = upper(ts_element)",
+            # Deliberately the *same* code the wire check raises. The two
+            # sites enforce one claim, so a client that learned to handle
+            # ``atom_map_element_not_conserved`` from a 422 handles it
+            # identically when a second write path reaches the database
+            # first; only the status differs, and the status is what says
+            # whether the payload was rejected before or after resolution.
+            rejection_code=wire_atom_map.W_ATOM_MAP_ELEMENT_NOT_CONSERVED,
+            rejection_detail=(
+                "An atom map pairs two atoms of different elements. An atom "
+                "does not change element on the way across a reaction."
+            ),
         ),
     ),
     escape_hatch=(
@@ -519,12 +531,22 @@ CHECK_ATOM_MAP_IS_A_BIJECTION = ScientificCheck(
             name="uq_reaction_atom_map_pair_ts_atom_index",
             kind="unique",
             definition="(atom_map_id, side, ts_atom_index)",
+            rejection_code=wire_atom_map.W_ATOM_MAP_NOT_A_BIJECTION,
+            rejection_detail=(
+                "Two atoms of one leg claim the same saddle-point atom. A map "
+                "is a bijection or it is not a map."
+            ),
         ),
         DatabaseConstraint(
             table="reaction_atom_map_pair",
             name="uq_reaction_atom_map_pair_atom_map_id",
             kind="unique",
             definition="(atom_map_id, structure_participant_id, atom_index)",
+            rejection_code=wire_atom_map.W_ATOM_MAP_NOT_A_BIJECTION,
+            rejection_detail=(
+                "One participant atom is mapped more than once. A map is a "
+                "bijection or it is not a map."
+            ),
         ),
     ),
     escape_hatch=(
@@ -705,6 +727,19 @@ CHECK_ATOM_MAP_PROVENANCE_IS_DECLARED = ScientificCheck(
 # Pressure-dependent networks
 # ---------------------------------------------------------------------------
 
+#: 409 codes for the PDep constraints. These are refusal codes, not
+#: :mod:`app.services.provenance_warnings` tokens, and the distinction is
+#: load-bearing: ``network_wide_energy_transfer_scope`` is the *warning*
+#: that says a network-wide <dE>down was declared, which is accepted
+#: science. The code below is the opposite -- a row whose ``scope`` and
+#: whose columns contradict each other, which is not a deposit anyone
+#: meant to make. Reusing the warning token for it would tell a client
+#: that an accepted upload and a refused one were the same event.
+R_ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE = "energy_transfer_scope_columns_disagree"
+R_NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE = (
+    "network_solve_reported_requires_literature"
+)
+
 CHECK_NETWORK_SOLVE_KIND_EVIDENCE = ScientificCheck(
     group="Pressure-dependent networks",
     sort_key=1,
@@ -734,6 +769,12 @@ CHECK_NETWORK_SOLVE_KIND_EVIDENCE = ScientificCheck(
             name="ck_network_solve_reported_requires_literature",
             kind="check",
             definition="kind <> 'reported' OR literature_id IS NOT NULL",
+            rejection_code=R_NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE,
+            rejection_detail=(
+                "A network solve declared as 'reported' cites no literature. "
+                "Transcribed rates must name the publication they came from, "
+                "because nothing else in the deposit accounts for them."
+            ),
         ),
         DatabaseConstraint(
             table="network_solve",
@@ -807,6 +848,13 @@ CHECK_ENERGY_TRANSFER_SCOPE = ScientificCheck(
                 "(scope='network_wide' AND state_id IS NULL AND "
                 "collider_species_entry_id IS NULL)"
             ),
+            rejection_code=R_ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE,
+            rejection_detail=(
+                "A collisional energy-transfer model declares a scope its own "
+                "columns contradict: a 'per_well' model must name the well and "
+                "the collider it was determined for, and a 'network_wide' one "
+                "must name neither."
+            ),
         ),
     ),
     escape_hatch=(
@@ -829,16 +877,22 @@ CHECK_ENERGY_TRANSFER_SCOPE = ScientificCheck(
 # Statistical mechanics
 # ---------------------------------------------------------------------------
 
+#: The 409 code for the statmech subject constraint. This entry was the
+#: register's own worked example of the gap #66 closes: it was the one
+#: check declared with no code and no channel *solely* because its claim
+#: was held by PostgreSQL, where nothing could carry a code to a client.
+R_STATMECH_SUBJECT_NOT_EXACTLY_ONE = "statmech_subject_not_exactly_one"
+
 CHECK_STATMECH_HAS_EXACTLY_ONE_SUBJECT = ScientificCheck(
     group="Statistical mechanics",
     sort_key=1,
-    code=None,
+    code=R_STATMECH_SUBJECT_NOT_EXACTLY_ONE,
     asserts=(
         "A partition function belongs to exactly one subject — a species entry "
         "or a transition-state entry, never both and never neither."
     ),
     tier=CheckTier.structural,
-    channel=CodeChannel.none,
+    channel=CodeChannel.database_constraint,
     tier_rationale=(
         "A modelling position rather than an arithmetic bound. Canonical "
         "transition state theory needs the saddle point's own partition "
@@ -850,13 +904,19 @@ CHECK_STATMECH_HAS_EXACTLY_ONE_SUBJECT = ScientificCheck(
         "deliberately exempt."
     ),
     adr="0008",
-    emitted=False,
+    emitted=True,
     enforced_by=(
         DatabaseConstraint(
             table="statmech",
             name="ck_statmech_statmech_exactly_one_subject",
             kind="check",
             definition="(species_entry_id IS NULL) <> (transition_state_entry_id IS NULL)",
+            rejection_code=R_STATMECH_SUBJECT_NOT_EXACTLY_ONE,
+            rejection_detail=(
+                "A partition function names both a species entry and a "
+                "transition-state entry, or neither. It belongs to exactly one "
+                "subject."
+            ),
         ),
     ),
     escape_hatch=None,
@@ -1036,4 +1096,16 @@ def register() -> list[ScientificCheck]:
     return collect_registered_checks(DECLARING_MODULES)
 
 
-__all__ = ["DECLARING_MODULES", "register"]
+def constraint_rejections() -> dict[str, tuple[str, str]]:
+    """Constraint name to the ``(code, detail)`` a 409 body should carry.
+
+    Consumed by ``app.api.errors._integrity_error_handler``. Kept here
+    rather than in the handler because the register is what the schema
+    drift guard already checks against live ``pg_constraint`` metadata,
+    so the name in this mapping is the name PostgreSQL will report or CI
+    is already red.
+    """
+    return collect_constraint_rejections(register())
+
+
+__all__ = ["DECLARING_MODULES", "constraint_rejections", "register"]

--- a/backend/app/services/accepted_science.py
+++ b/backend/app/services/accepted_science.py
@@ -66,7 +66,7 @@ def lock_scientific_records(
             continue
         row = session.scalar(select(model).where(model.id == record_id).with_for_update())
         if row is None:
-            raise DomainError(f"{record_type.value} record {record_id} does not exist")
+            raise DomainError(f"the requested {record_type.value} record does not exist")
         rows[(record_type, record_id)] = row
     return rows
 

--- a/backend/app/services/calculation_scan_resolution.py
+++ b/backend/app/services/calculation_scan_resolution.py
@@ -30,9 +30,9 @@ def persist_calculation_scan(
 
     calculation = session.get(Calculation, calculation_id)
     if calculation is None:
-        raise ValueError(f"Unknown calculation_id={calculation_id}")
+        raise ValueError("Unknown calculation")
     if calculation.scan_result is not None:
-        raise ValueError(f"Calculation {calculation_id} already has a scan result.")
+        raise ValueError("Calculation already has a scan result.")
 
     scan_result = CalculationScanResult(
         calculation_id=calculation_id,

--- a/backend/app/services/llm_precheck/context_builder.py
+++ b/backend/app/services/llm_precheck/context_builder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.submission import Submission, SubmissionRecordLink
 from app.services.llm_precheck.schemas import LLMPrecheckContext, LLMRecordRef
 
@@ -17,7 +17,7 @@ def build_llm_precheck_context(
     """Build a compact structured context for optional AI Review Assistant precheck."""
     submission = session.get(Submission, submission_id)
     if submission is None:
-        raise NotFoundError(f"Submission {submission_id} not found")
+        raise not_found("Submission", row_id=submission_id)
 
     links = session.scalars(
         select(SubmissionRecordLink)

--- a/backend/app/services/machine_review/curator_task_lifecycle.py
+++ b/backend/app/services/machine_review/curator_task_lifecycle.py
@@ -39,7 +39,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
-from app.api.errors import DomainError, NotFoundError
+from app.api.errors import DomainError, not_found
 from app.db.models.common import MachineReviewCuratorTaskState
 from app.db.models.machine_review_curator_task import MachineReviewCuratorTask
 
@@ -65,8 +65,8 @@ def _now_naive_utc() -> datetime:
 def _get_task_or_404(session: Session, task_id: int) -> MachineReviewCuratorTask:
     task = session.get(MachineReviewCuratorTask, task_id)
     if task is None:
-        raise NotFoundError(
-            f"Curator task {task_id} not found", code="curator_task_not_found"
+        raise not_found(
+            "Curator task", row_id=task_id, code="curator_task_not_found"
         )
     return task
 
@@ -176,7 +176,7 @@ def resolve_curator_task(
             # original resolver/note/timestamp intact.
             return task
         raise DomainError(
-            f"Curator task {task_id} is already resolved as "
+            "Curator task is already resolved as "
             f"{task.workflow_state.value!r}; cannot re-resolve as "
             f"{resolution.value!r}. Reopen it first to change the resolution."
         )

--- a/backend/app/services/reproducibility_assessment.py
+++ b/backend/app/services/reproducibility_assessment.py
@@ -126,7 +126,7 @@ def _require_record_exists(
     """Reject an assessment whose polymorphic target row does not exist."""
     _, model = resolve_reproducibility_record_model(record_type)
     if session.get(model, record_id) is None:
-        raise ValueError(f"{record_type.value} record {record_id} does not exist")
+        raise ValueError(f"the requested {record_type.value} record does not exist")
 
 
 def append_reproducibility_assessment(

--- a/backend/app/services/reproducibility_rubric.py
+++ b/backend/app/services/reproducibility_rubric.py
@@ -640,7 +640,7 @@ def evaluate_reproducibility(
         raise ValueError("record_id must be positive")
     target = session.get(model, record_id)
     if target is None:
-        raise ValueError(f"{resolved_type.value} record {record_id} does not exist")
+        raise ValueError(f"the requested {resolved_type.value} record does not exist")
 
     target_evidence = _target_snapshot(target, resolved_type)
     source_refs = _source_refs(target)

--- a/backend/app/services/scientific_read/calculation_paths.py
+++ b/backend/app/services/scientific_read/calculation_paths.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import NotFoundError, not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationIRCPoint,
@@ -124,10 +124,7 @@ def get_calculation_scan(
     calculation_id = resolve_calculation_handle(session, calculation_handle)
     calc = session.get(Calculation, calculation_id)
     if calc is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"calculation not found (calculation_id={calculation_id})",
-            code="handle_not_found",
-        )
+        raise not_found("calculation", row_id=calculation_id, code="handle_not_found")
 
     scan_summary = _build_scan_include_summary(session, calculation_id)
     if scan_summary is None:
@@ -352,10 +349,7 @@ def get_calculation_irc(
     calculation_id = resolve_calculation_handle(session, calculation_handle)
     calc = session.get(Calculation, calculation_id)
     if calc is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"calculation not found (calculation_id={calculation_id})",
-            code="handle_not_found",
-        )
+        raise not_found("calculation", row_id=calculation_id, code="handle_not_found")
 
     irc_summary = _build_irc_include_summary(session, calculation_id)
     if irc_summary is None:
@@ -513,10 +507,7 @@ def get_calculation_path_search(
     calculation_id = resolve_calculation_handle(session, calculation_handle)
     calc = session.get(Calculation, calculation_id)
     if calc is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"calculation not found (calculation_id={calculation_id})",
-            code="handle_not_found",
-        )
+        raise not_found("calculation", row_id=calculation_id, code="handle_not_found")
 
     path_search_summary = _build_path_search_include_summary(
         session, calculation_id

--- a/backend/app/services/scientific_read/calculations.py
+++ b/backend/app/services/scientific_read/calculations.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from sqlalchemy import exists, false, func, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.api.errors import NotFoundError
+from app.api.errors import NotFoundError, not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationArtifact,
@@ -237,10 +237,7 @@ def get_calculation(
     calculation_id = resolve_calculation_handle(session, calculation_handle)
     calc = _load_calculation_for_read(session, calculation_id, includes)
     if calc is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"calculation not found (calculation_id={calculation_id})",
-            code="handle_not_found",
-        )
+        raise not_found("calculation", row_id=calculation_id, code="handle_not_found")
 
     badge = _load_review_badge(session, calculation_id)
     record = build_record(session, calc, includes, badge=badge)

--- a/backend/app/services/scientific_read/conformers.py
+++ b/backend/app/services/scientific_read/conformers.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from sqlalchemy import and_, exists, func, select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationGeometryValidation,
@@ -144,10 +144,7 @@ def get_conformer_group(
     cg_id = resolve_conformer_group_handle(session, conformer_group_handle)
     cg = session.get(ConformerGroup, cg_id)
     if cg is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"conformer_group not found (conformer_group_id={cg_id})",
-            code="handle_not_found",
-        )
+        raise not_found("conformer_group", row_id=cg_id, code="handle_not_found")
 
     cg_badge = _load_review_badge(
         session, SubmissionRecordType.conformer_group, cg.id
@@ -297,17 +294,13 @@ def get_conformer_observation(
     )
     obs = session.get(ConformerObservation, obs_id)
     if obs is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            "conformer_observation not found "
-            f"(conformer_observation_id={obs_id})",
-            code="handle_not_found",
-        )
+        raise not_found("conformer_observation", row_id=obs_id, code="handle_not_found")
 
     cg = session.get(ConformerGroup, obs.conformer_group_id)
     if cg is None:  # pragma: no cover — FK guarantees existence
-        raise NotFoundError(
-            "conformer_group not found for observation "
-            f"(conformer_observation_id={obs.id})",
+        raise not_found(
+            "conformer_group for the requested conformer_observation",
+            row_id=obs.conformer_group_id,
             code="handle_not_found",
         )
 

--- a/backend/app/services/scientific_read/energy_correction_schemes.py
+++ b/backend/app/services/scientific_read/energy_correction_schemes.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.energy_correction import (
     AppliedEnergyCorrection,
     EnergyCorrectionScheme,
@@ -89,10 +89,7 @@ def get_energy_correction_scheme(
     )
     ecs = session.get(EnergyCorrectionScheme, ecs_id)
     if ecs is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"energy_correction_scheme not found (energy_correction_scheme_id={ecs_id})",
-            code="handle_not_found",
-        )
+        raise not_found("energy_correction_scheme", row_id=ecs_id, code="handle_not_found")
 
     record = build_energy_correction_scheme_record(
         session, ecs=ecs, includes=includes

--- a/backend/app/services/scientific_read/frequency_scale_factors.py
+++ b/backend/app/services/scientific_read/frequency_scale_factors.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.energy_correction import (
     AppliedEnergyCorrection,
     FrequencyScaleFactor,
@@ -89,10 +89,7 @@ def get_frequency_scale_factor(
     )
     fsf = session.get(FrequencyScaleFactor, fsf_id)
     if fsf is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"frequency_scale_factor not found (frequency_scale_factor_id={fsf_id})",
-            code="handle_not_found",
-        )
+        raise not_found("frequency_scale_factor", row_id=fsf_id, code="handle_not_found")
 
     record = build_frequency_scale_factor_record(
         session, fsf=fsf, includes=includes

--- a/backend/app/services/scientific_read/handles.py
+++ b/backend/app/services/scientific_read/handles.py
@@ -423,15 +423,22 @@ def reconcile_id_ref(
         # The ref points at no row; that contradicts the supplied id by
         # definition, which is a 422 conflict (not silent empty results).
         raise ValueError(
-            f"{conflict_code}: {kind_label}_id={id_value} and "
+            f"{conflict_code}: the supplied {kind_label}_id and "
             f"{kind_label}_ref={ref_value!r} do not refer to the same row "
-            f"(ref does not exist)"
+            f"(the ref does not exist)"
         )
     if resolved != int(id_value):
+        # The row id the ref resolves to is deliberately absent. Echoing
+        # it made this endpoint an oracle for the whole ref-to-id
+        # mapping: supply a public ref and any wrong id, and the 422 hands
+        # back the real one. That mapping is exactly what
+        # ``internal_ids`` exists to withhold, so the one place in the
+        # read layer that gave it away was a 422 nobody thought of as a
+        # disclosure. The caller supplied both inputs and is told which
+        # two disagreed, which is all it needs to fix the request.
         raise ValueError(
-            f"{conflict_code}: {kind_label}_id={id_value} and "
-            f"{kind_label}_ref={ref_value!r} resolve to different rows "
-            f"(ref → id={resolved})"
+            f"{conflict_code}: the supplied {kind_label}_id and "
+            f"{kind_label}_ref={ref_value!r} resolve to different rows"
         )
     return resolved
 

--- a/backend/app/services/scientific_read/handles.py
+++ b/backend/app/services/scientific_read/handles.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import RecordReviewStatus, SubmissionRecordType
 from app.db.models.energy_correction import (
@@ -248,9 +248,7 @@ def _enforce_curated_floor(
         row_id,
         status.value,
     )
-    raise NotFoundError(
-        f"{kind_label} not found", code="handle_not_found"
-    )
+    raise not_found(kind_label, code="handle_not_found")
 
 
 def resolve_path_handle(
@@ -298,9 +296,7 @@ def resolve_path_handle(
                 kind_label,
                 row_id,
             )
-            raise NotFoundError(
-                f"{kind_label} not found", code="handle_not_found"
-            )
+            raise not_found(kind_label, code="handle_not_found")
         _enforce_curated_floor(session, model_cls, row_id, kind_label)
         return row_id
 
@@ -323,10 +319,10 @@ def resolve_path_handle(
             kind_label,
             ref,
         )
-        raise NotFoundError(
-            f"{kind_label} not found ({kind_label}_ref={ref!r})",
-            code="handle_not_found",
-        )
+        # ``row_id`` is deliberately not passed: the specific log line
+        # above already carries more than the helper would, and the ref
+        # is the half a 404 may echo.
+        raise not_found(kind_label, ref=ref, code="handle_not_found")
     _enforce_curated_floor(session, model_cls, row_id, kind_label)
     return row_id
 

--- a/backend/app/services/scientific_read/kinetics.py
+++ b/backend/app/services/scientific_read/kinetics.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from sqlalchemy import select
 from sqlalchemy.orm import Session, aliased, selectinload
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationArtifact,
@@ -328,9 +328,7 @@ def get_reaction_kinetics(
 
     entry = session.get(ReactionEntry, reaction_entry_id)
     if entry is None:
-        raise NotFoundError(
-            f"reaction_entry not found (reaction_entry_id={reaction_entry_id})"
-        )
+        raise not_found("reaction_entry", row_id=reaction_entry_id)
     reaction_entry_ref = entry.public_ref
 
     # Phase C: reconcile level_of_theory_id + level_of_theory_ref.

--- a/backend/app/services/scientific_read/kinetics_search.py
+++ b/backend/app/services/scientific_read/kinetics_search.py
@@ -193,7 +193,7 @@ def search_kinetics(
 
         kinetics_records = collect_bounded_pages(
             fetch_kinetics_page,
-            resource_name=f"kinetics candidates for reaction_entry {entry_id}",
+            resource_name="kinetics candidates for one reaction entry",
         )
         for kinetics_record in kinetics_records:
             flat.append(

--- a/backend/app/services/scientific_read/literature.py
+++ b/backend/app/services/scientific_read/literature.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.author import Author
 from app.db.models.calculation import Calculation
 from app.db.models.kinetics import Kinetics
@@ -98,10 +98,7 @@ def get_literature(
     lit_id = resolve_literature_handle(session, literature_handle)
     lit = session.get(Literature, lit_id)
     if lit is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"literature not found (literature_id={lit_id})",
-            code="handle_not_found",
-        )
+        raise not_found("literature", row_id=lit_id, code="handle_not_found")
 
     authors = _load_authors(session, lit.id)
     counts = _load_record_counts(session, lit.id)

--- a/backend/app/services/scientific_read/literature_records.py
+++ b/backend/app/services/scientific_read/literature_records.py
@@ -22,7 +22,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
     NetworkSolveKind,
@@ -143,10 +143,7 @@ def get_literature_records(
     lit_id = resolve_literature_handle(session, literature_handle)
     lit = session.get(Literature, lit_id)
     if lit is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"literature not found (literature_id={lit_id})",
-            code="handle_not_found",
-        )
+        raise not_found("literature", row_id=lit_id, code="handle_not_found")
 
     selected_types: tuple[str, ...]
     if request.record_type is None:

--- a/backend/app/services/scientific_read/network_kinetics.py
+++ b/backend/app/services/scientific_read/network_kinetics.py
@@ -25,7 +25,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api.config import settings
-from app.api.errors import DataIntegrityError, NotFoundError
+from app.api.errors import DataIntegrityError, not_found
 from app.db.models.common import (
     RecordReviewStatus,
     SubmissionRecordType,
@@ -140,10 +140,7 @@ def get_network_kinetics(
     nk_id = resolve_network_kinetics_handle(session, network_kinetics_handle)
     nk = session.get(NetworkKinetics, nk_id)
     if nk is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"network_kinetics not found (network_kinetics_id={nk_id})",
-            code="handle_not_found",
-        )
+        raise not_found("network_kinetics", row_id=nk_id, code="handle_not_found")
 
     # ``NetworkKinetics`` itself is not a reviewable record type; the
     # parent solve carries the badge. Falls back to ``not_reviewed`` when

--- a/backend/app/services/scientific_read/networks.py
+++ b/backend/app/services/scientific_read/networks.py
@@ -28,7 +28,7 @@ from sqlalchemy import and_, exists, func, select
 from sqlalchemy.orm import Session
 
 from app.api.config import settings
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
     NetworkKineticsModelKind,
@@ -148,10 +148,7 @@ def get_network(
     network_id = resolve_network_handle(session, network_handle)
     n = session.get(Network, network_id)
     if n is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"network not found (network_id={network_id})",
-            code="handle_not_found",
-        )
+        raise not_found("network", row_id=network_id, code="handle_not_found")
 
     badge = _load_review_badge(session, n.id)
     record = build_network_record(
@@ -1113,10 +1110,7 @@ def get_network_solve(
     solve_id = resolve_network_solve_handle(session, network_solve_handle)
     s = session.get(NetworkSolve, solve_id)
     if s is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"network_solve not found (network_solve_id={solve_id})",
-            code="handle_not_found",
-        )
+        raise not_found("network_solve", row_id=solve_id, code="handle_not_found")
 
     badge = _load_solve_review_badge(session, s.id)
     record = build_network_solve_record(

--- a/backend/app/services/scientific_read/provenance.py
+++ b/backend/app/services/scientific_read/provenance.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.config import settings
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationDependency,
@@ -159,9 +159,7 @@ def get_reaction_full(
 
     entry = session.get(ReactionEntry, reaction_entry_id)
     if entry is None:
-        raise NotFoundError(
-            f"reaction_entry not found (reaction_entry_id={reaction_entry_id})"
-        )
+        raise not_found("reaction_entry", row_id=reaction_entry_id)
 
     chem = session.get(ChemReaction, entry.reaction_id)
     family_name: str | None = None

--- a/backend/app/services/scientific_read/species_calculations_search.py
+++ b/backend/app/services/scientific_read/species_calculations_search.py
@@ -36,7 +36,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.error_contract import CodedValueError, reject_unsupported_filters
-from app.api.errors import NotFoundError
+from app.api.errors import NotFoundError, not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationArtifact,
@@ -424,9 +424,7 @@ def _resolve_species_entry_context(
     if species_entry_id is not None:
         entry = session.get(SpeciesEntry, species_entry_id)
         if entry is None:
-            raise NotFoundError(
-                f"species_entry not found (species_entry_id={species_entry_id})"
-            )
+            raise not_found("species_entry", row_id=species_entry_id)
         species = session.get(Species, entry.species_id)
         if species is None:  # pragma: no cover — referential integrity
             raise NotFoundError("species_entry references a missing species row")
@@ -438,9 +436,7 @@ def _resolve_species_entry_context(
     if species_id is not None:
         species = session.get(Species, species_id)
         if species is None:
-            raise NotFoundError(
-                f"species not found (species_id={species_id})"
-            )
+            raise not_found("species", row_id=species_id)
         entries = list(species.entries)
         return {
             e.id: _species_context_from_orm(species, e) for e in entries

--- a/backend/app/services/scientific_read/species_statmech.py
+++ b/backend/app/services/scientific_read/species_statmech.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.common import (
     RecordReviewStatus,
     SubmissionRecordType,
@@ -107,9 +107,7 @@ def get_species_statmech(
 
     entry = session.get(SpeciesEntry, species_entry_id)
     if entry is None:
-        raise NotFoundError(
-            f"species_entry not found (species_entry_id={species_entry_id})"
-        )
+        raise not_found("species_entry", row_id=species_entry_id)
     species_entry_ref = entry.public_ref
 
     rows = session.execute(

--- a/backend/app/services/scientific_read/species_transport.py
+++ b/backend/app/services/scientific_read/species_transport.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.common import (
     RecordReviewStatus,
     SubmissionRecordType,
@@ -104,9 +104,7 @@ def get_species_transport(
 
     entry = session.get(SpeciesEntry, species_entry_id)
     if entry is None:
-        raise NotFoundError(
-            f"species_entry not found (species_entry_id={species_entry_id})"
-        )
+        raise not_found("species_entry", row_id=species_entry_id)
     species_entry_ref = entry.public_ref
 
     rows = session.execute(

--- a/backend/app/services/scientific_read/statmech.py
+++ b/backend/app/services/scientific_read/statmech.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from sqlalchemy import and_, exists, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
     RecordReviewStatus,
@@ -216,10 +216,7 @@ def get_statmech(
     else:
         sm = session.get(Statmech, sm_id)
     if sm is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"statmech not found (statmech_id={sm_id})",
-            code="handle_not_found",
-        )
+        raise not_found("statmech", row_id=sm_id, code="handle_not_found")
 
     badge = _load_review_badge(session, sm.id)
     record = build_statmech_record(

--- a/backend/app/services/scientific_read/thermo.py
+++ b/backend/app/services/scientific_read/thermo.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationGeometryValidation,
@@ -199,9 +199,7 @@ def get_species_thermo(
 
     species_entry = session.get(SpeciesEntry, species_entry_id)
     if species_entry is None:
-        raise NotFoundError(
-            f"species_entry not found (species_entry_id={species_entry_id})"
-        )
+        raise not_found("species_entry", row_id=species_entry_id)
     species_entry_ref = species_entry.public_ref
 
     # Phase C: reconcile level_of_theory_id + level_of_theory_ref into a

--- a/backend/app/services/scientific_read/thermo_search.py
+++ b/backend/app/services/scientific_read/thermo_search.py
@@ -211,7 +211,7 @@ def search_thermo(
 
         thermo_records = collect_bounded_pages(
             fetch_thermo_page,
-            resource_name=f"thermo candidates for species_entry {entry_id}",
+            resource_name="thermo candidates for one species entry",
         )
         for thermo_record in thermo_records:
             flat.append(ThermoSearchRecord(species=ctx, thermo=thermo_record))

--- a/backend/app/services/scientific_read/transition_states.py
+++ b/backend/app/services/scientific_read/transition_states.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from sqlalchemy import and_, exists, func, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import (
     Calculation,
     CalculationDependency,
@@ -268,10 +268,7 @@ def get_transition_state(
     ts_id = resolve_transition_state_handle(session, transition_state_handle)
     ts = session.get(TransitionState, ts_id)
     if ts is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"transition_state not found (transition_state_id={ts_id})",
-            code="handle_not_found",
-        )
+        raise not_found("transition_state", row_id=ts_id, code="handle_not_found")
 
     ts_badge = _load_review_badge(
         session, SubmissionRecordType.transition_state, ts.id
@@ -396,17 +393,13 @@ def get_transition_state_entry(
     else:
         tse = session.get(TransitionStateEntry, tse_id)
     if tse is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            "transition_state_entry not found "
-            f"(transition_state_entry_id={tse_id})",
-            code="handle_not_found",
-        )
+        raise not_found("transition_state_entry", row_id=tse_id, code="handle_not_found")
 
     ts = session.get(TransitionState, tse.transition_state_id)
     if ts is None:  # pragma: no cover — FK guarantees existence
-        raise NotFoundError(
-            "transition_state not found for entry "
-            f"(transition_state_entry_id={tse.id})",
+        raise not_found(
+            "transition_state for the requested transition_state_entry",
+            row_id=tse.transition_state_id,
             code="handle_not_found",
         )
 

--- a/backend/app/services/scientific_read/transport.py
+++ b/backend/app/services/scientific_read/transport.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from sqlalchemy import and_, exists, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.api.errors import NotFoundError
+from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
     RecordReviewStatus,
@@ -140,10 +140,7 @@ def get_transport(
     else:
         tr = session.get(Transport, tr_id)
     if tr is None:  # pragma: no cover — defended by resolver 404
-        raise NotFoundError(
-            f"transport not found (transport_id={tr_id})",
-            code="handle_not_found",
-        )
+        raise not_found("transport", row_id=tr_id, code="handle_not_found")
 
     badge = _load_review_badge(session, tr.id)
     record = build_transport_record(

--- a/backend/app/services/selection.py
+++ b/backend/app/services/selection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import DomainError, NotFoundError
+from app.api.errors import DomainError, not_found
 from app.db.models.common import (
     ConformerSelectionKind,
     TransitionStateSelectionKind,
@@ -55,15 +55,13 @@ def create_conformer_selection(
     """
     group = session.get(ConformerGroup, conformer_group_id)
     if group is None:
-        raise NotFoundError(
-            f"ConformerGroup {conformer_group_id} not found"
-        )
+        raise not_found("ConformerGroup", row_id=conformer_group_id)
 
     if assignment_scheme_id is not None:
         scheme = session.get(ConformerAssignmentScheme, assignment_scheme_id)
         if scheme is None:
-            raise NotFoundError(
-                f"ConformerAssignmentScheme {assignment_scheme_id} not found"
+            raise not_found(
+                "ConformerAssignmentScheme", row_id=assignment_scheme_id
             )
 
     scheme_clause = (
@@ -80,9 +78,8 @@ def create_conformer_selection(
     )
     if existing is not None:
         raise DomainError(
-            f"A '{selection_kind.value}' selection already exists for "
-            f"conformer group {conformer_group_id} under the specified "
-            "assignment scheme"
+            f"A '{selection_kind.value}' selection already exists for this "
+            "conformer group under the specified assignment scheme"
         )
 
     selection = ConformerSelection(
@@ -124,9 +121,7 @@ def create_transition_state_selection(
     """
     transition_state = session.get(TransitionState, transition_state_id)
     if transition_state is None:
-        raise NotFoundError(
-            f"TransitionState {transition_state_id} not found"
-        )
+        raise not_found("TransitionState", row_id=transition_state_id)
 
     existing = session.scalar(
         select(TransitionStateSelection).where(
@@ -136,8 +131,8 @@ def create_transition_state_selection(
     )
     if existing is not None:
         raise DomainError(
-            f"A '{selection_kind.value}' selection already exists for "
-            f"transition state {transition_state_id}"
+            f"A '{selection_kind.value}' selection already exists for this "
+            "transition state"
         )
 
     selection = TransitionStateSelection(

--- a/backend/app/services/species_entry_review.py
+++ b/backend/app/services/species_entry_review.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import DomainError, NotFoundError
+from app.api.errors import DomainError, not_found
 from app.db.models.common import SpeciesEntryReviewRole
 from app.db.models.species import SpeciesEntry, SpeciesEntryReview
 
@@ -39,7 +39,7 @@ def create_species_entry_review(
         for the target species entry.
     """
     if session.get(SpeciesEntry, species_entry_id) is None:
-        raise NotFoundError(f"SpeciesEntry {species_entry_id} not found")
+        raise not_found("SpeciesEntry", row_id=species_entry_id)
 
     existing = session.scalar(
         select(SpeciesEntryReview).where(
@@ -51,7 +51,7 @@ def create_species_entry_review(
     if existing is not None:
         raise DomainError(
             f"A '{role.value}' review by the current user already exists for "
-            f"species entry {species_entry_id}"
+            "this species entry"
         )
 
     review = SpeciesEntryReview(
@@ -76,7 +76,7 @@ def list_species_entry_reviews(
         can distinguish "no reviews yet" from "unknown entry".
     """
     if session.get(SpeciesEntry, species_entry_id) is None:
-        raise NotFoundError(f"SpeciesEntry {species_entry_id} not found")
+        raise not_found("SpeciesEntry", row_id=species_entry_id)
 
     rows = session.scalars(
         select(SpeciesEntryReview)

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -583,7 +583,7 @@ def resolve_species_entry_reference(
     if species_entry_id is not None:
         species_entry = session.get(SpeciesEntry, species_entry_id)
         if species_entry is None:
-            raise ValueError(f"Unknown species_entry_id={species_entry_id}")
+            raise ValueError("Unknown species_entry")
         return species_entry
 
     assert payload is not None

--- a/backend/app/services/submission.py
+++ b/backend/app/services/submission.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.errors import DomainError, NotFoundError
+from app.api.errors import DomainError, not_found
 from app.db.models.app_user import AppUser
 from app.db.models.common import (
     AppUserRole,
@@ -86,7 +86,7 @@ def _resolve_actor_kind(user: AppUser) -> SubmissionActorKind:
 def _require_submission(session: Session, submission_id: int) -> Submission:
     submission = session.get(Submission, submission_id)
     if submission is None:
-        raise NotFoundError(f"Submission {submission_id} not found")
+        raise not_found("Submission", row_id=submission_id)
     return submission
 
 
@@ -133,7 +133,7 @@ def create_submission(
         not resolve to an existing submission.
     """
     if session.get(AppUser, created_by) is None:
-        raise NotFoundError(f"AppUser {created_by} not found")
+        raise not_found("AppUser", row_id=created_by)
 
     if supersedes_submission_id is not None:
         _require_submission(session, supersedes_submission_id)

--- a/backend/app/workflows/kinetics.py
+++ b/backend/app/workflows/kinetics.py
@@ -83,7 +83,7 @@ def _find_sp_for_species(
         raise ValueError(
             "Multiple SP calculations found for the requested species entry "
             "at the declared energy level of theory. "
-            "Cannot auto-resolve — multi-conformer disambiguation not yet supported."
+            "Cannot auto-resolve: multi-conformer disambiguation not yet supported."
         )
     return results[0]
 

--- a/backend/app/workflows/kinetics.py
+++ b/backend/app/workflows/kinetics.py
@@ -75,15 +75,15 @@ def _find_sp_for_species(
 
     if len(results) == 0:
         raise ValueError(
-            f"No SP calculation found for species_entry {species_entry_id} "
-            f"at the declared energy level of theory. "
-            f"Upload the conformer with the SP as an additional calculation first."
+            "No SP calculation found for the requested species entry "
+            "at the declared energy level of theory. "
+            "Upload the conformer with the SP as an additional calculation first."
         )
     if len(results) > 1:
         raise ValueError(
-            f"Multiple SP calculations found for species_entry {species_entry_id} "
-            f"at the declared energy level of theory. "
-            f"Cannot auto-resolve — multi-conformer disambiguation not yet supported."
+            "Multiple SP calculations found for the requested species entry "
+            "at the declared energy level of theory. "
+            "Cannot auto-resolve — multi-conformer disambiguation not yet supported."
         )
     return results[0]
 

--- a/backend/docs/specs/read_query_api_audit.md
+++ b/backend/docs/specs/read_query_api_audit.md
@@ -1249,14 +1249,30 @@ scientific surface — only metadata is exposed.
 
 ### 11.1 IntegrityError / 422 hygiene
 
-`backend/app/api/errors.py:117-152`:
+`backend/app/api/errors.py::_integrity_error_handler`:
 
-- Constraint name extracted from `orig.diag` is **logged server-side
-  only**, never echoed in the HTTP body.
-- Responses use stable codes: `unique_conflict`, `reference_conflict`,
-  `state_conflict`, `integrity_conflict`.
-- `NotFoundError` (404) logs the integer id server-side; the
-  client-facing detail is generic.
+- Raw psycopg/PostgreSQL text is **logged server-side only**, never
+  echoed in the HTTP body.
+- Unrecognised violations use stable SQLSTATE-derived codes:
+  `unique_conflict`, `reference_conflict`, `state_conflict`,
+  `integrity_conflict`.
+- A constraint that the scientific check register names carries its own
+  code and sentence instead — `atom_map_element_not_conserved` rather
+  than `state_conflict` — and echoes the **constraint name** in
+  `context.constraint`. That is a deliberate reversal of the earlier
+  position that the name is never echoed. A schema object name is not a
+  row id: it is stable across instances, it is the key into
+  `docs/guides/scientific_check_register.md`, and withholding it left
+  the client unable to tell which scientific rule refused the write when
+  the guarantee behind it is the strongest one TCKDB makes. See
+  `backend/tests/api/test_api_database_constraint_codes.py`.
+- `app.api.errors.not_found` is the single constructor for a 404: it
+  logs the integer id server-side and returns a detail that names the
+  resource kind, plus the public ref if the caller supplied one. A
+  structural guard,
+  `backend/tests/api/test_no_row_ids_in_user_facing_text.py`, fails CI
+  if a row id is interpolated into user-facing text anywhere under
+  `backend/app/`.
 - 422 codes are stable application codes (`invalid_handle`,
   `handle_type_mismatch`, `*_handle_conflict`, `unknown_include_token`,
   `client_sort_not_supported`, `missing_identifier`, etc.) — no raw

--- a/backend/scripts/generate_client_rejection_codes.py
+++ b/backend/scripts/generate_client_rejection_codes.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+"""Generate ``clients/python/src/tckdb_client/rejection_codes.py``.
+
+Why generate it
+---------------
+The codes exist on the server and nowhere else, so a client hard-codes
+strings -- and a typo in a hard-coded string does not fail, it silently
+never matches. ``if err.code == "reaction_mass_balace_failed":`` is a
+branch that will never be taken, on the day the deposit it was written
+for finally arrives. Generating the enum from the register moves that
+from a runtime non-event to an import error, and keeps the two in step
+by construction rather than by discipline.
+
+What goes in, and what deliberately does not
+--------------------------------------------
+Only the codes a *refusal* carries: the ``error_envelope`` channel (HTTP
+422, refused before anything was written) and the rejection codes
+declared on database constraints (HTTP 409, refused by a position
+PostgreSQL holds). ``upload_warning`` codes arrive alongside an
+*accepted* upload, in a different part of the response, and putting them
+in an enum named for rejections would invite a client to treat an
+accepted deposit as a failed one. ``trust_label`` codes are not refusals
+at all.
+
+Nothing else is emitted. No file paths, no line numbers, no docstrings,
+no counts, no prose lifted from ``asserts``. That is a deliberate
+constraint on the *output*, not laziness about it: this file is compared
+against its committed copy in CI, so whatever appears in it becomes a
+thing that can turn the gate red. The register generator learned this
+the expensive way -- it keyed on line numbers, a comment added elsewhere
+shifted a check from 120 to 121, and the gate fired on a digit. A gate
+that fires on cosmetic movement gets regenerated reflexively without
+anyone reading the diff, which is exactly how a real drift eventually
+lands unnoticed. So this file changes when, and only when, the set of
+codes or the status carrying them changes -- which is precisely when a
+client author needs to look.
+
+Usage::
+
+    conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py
+    conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+from app.scientific_checks import CodeChannel  # noqa: E402
+from app.scientific_checks.declarations import (  # noqa: E402
+    constraint_rejections,
+    register,
+)
+
+OUTPUT = (
+    REPO_ROOT
+    / "clients"
+    / "python"
+    / "src"
+    / "tckdb_client"
+    / "rejection_codes.py"
+)
+
+GENERATOR = "backend/scripts/generate_client_rejection_codes.py"
+
+_HEADER = f'''"""Machine-readable codes TCKDB reports when it refuses a deposit.
+
+**Generated. Do not edit by hand.** Regenerate with
+``conda run -n tckdb_env python {GENERATOR}``;
+``backend/tests/api/test_client_rejection_codes_generated.py`` fails if
+this file and the server's scientific check register disagree.
+
+Every member here is a position TCKDB takes about chemistry -- a claim a
+referee could argue with -- and each one is proved to arrive in a real
+HTTP response body by a test on the server side. The register that
+generates this file is rendered for humans at
+``docs/guides/scientific_check_register.md``, which is where to look for
+what a code asserts, why it refuses rather than warns, and what the
+escape hatch is for legitimate chemistry it would otherwise reject.
+
+Deliberately absent: warning codes, which arrive alongside an *accepted*
+upload, and trust labels, which are applied at read time and refuse
+nothing. Both would be misread as failures under this name.
+
+Using it::
+
+    from tckdb_client import RejectionCode, rejection_code
+
+    try:
+        client.upload_reaction(payload)
+    except TCKDBHTTPError as exc:
+        match rejection_code(exc.code):
+            case RejectionCode.REACTION_MASS_BALANCE_FAILED:
+                raise                      # the deposit is wrong; do not retry
+            case RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH:
+                payload = repair(payload)  # recoverable
+            case None:
+                raise                      # a code this client does not know
+
+Use :func:`rejection_code` rather than ``RejectionCode(exc.code)``. A
+server is routinely newer than the client pinned against it, and a code
+added since this file was generated must not turn a handled refusal into
+an unhandled ``ValueError``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = [
+    "CONFLICT_REJECTION_CODES",
+    "RejectionCode",
+    "VALIDATION_REJECTION_CODES",
+    "rejection_code",
+]
+
+
+class RejectionCode(str, Enum):
+    """A code TCKDB reports in the ``code`` field of a refusal body.
+
+    ``str`` subclass so a member compares equal to the wire string and
+    can be used wherever the raw code was.
+    """
+
+'''
+
+_FOOTER = '''
+
+def rejection_code(value: object) -> RejectionCode | None:
+    """Return the member for *value*, or ``None`` if this client cannot name it.
+
+    ``None`` covers three genuinely different situations, and a caller
+    should treat all three the same way -- as a refusal it does not have
+    a specific branch for: the server is newer than this client and sent
+    a code added since; the refusal was not a scientific one (a rate
+    limit, an authentication failure, a generic conflict); or there was
+    no code at all.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        return RejectionCode(value)
+    except ValueError:
+        return None
+'''
+
+
+def _member(code: str) -> str:
+    return code.upper()
+
+
+def render() -> str:
+    checks = register()
+
+    validation = sorted(
+        {
+            code
+            for check in checks
+            if check.channel is CodeChannel.error_envelope
+            for code in check.codes
+        }
+    )
+    conflict = sorted({code for code, _detail in constraint_rejections().values()})
+
+    if not validation:
+        raise SystemExit(
+            "The register declares no error_envelope codes. Generating an "
+            "empty enum would quietly remove a published client API; refusing."
+        )
+
+    lines = [_HEADER]
+    for code in sorted(set(validation) | set(conflict)):
+        lines.append(f'    {_member(code)} = "{code}"\n')
+
+    lines.append(
+        "\n\n#: Codes carried by an HTTP 422: the payload was refused before\n"
+        "#: anything was written, so nothing was stored and a corrected\n"
+        "#: payload may be sent again under the same idempotency key.\n"
+        "VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(\n"
+        "    {\n"
+    )
+    for code in validation:
+        lines.append(f"        RejectionCode.{_member(code)},\n")
+    lines.append("    }\n)\n")
+
+    lines.append(
+        "\n#: Codes carried by an HTTP 409: a position PostgreSQL holds\n"
+        "#: refused the write. A code may appear in both sets -- the same\n"
+        "#: claim can be enforced at the wire boundary and again in the\n"
+        "#: schema, and which one fires depends on the write path, not on\n"
+        "#: what the depositor did wrong.\n"
+        "CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(\n"
+        "    {\n"
+    )
+    for code in conflict:
+        lines.append(f"        RejectionCode.{_member(code)},\n")
+    lines.append("    }\n)\n")
+
+    lines.append(_FOOTER)
+    return "".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if the committed file is out of date",
+    )
+    args = parser.parse_args()
+
+    rendered = render()
+    if args.check:
+        if not OUTPUT.exists():
+            print(f"{OUTPUT} does not exist; run without --check.", file=sys.stderr)
+            return 1
+        if OUTPUT.read_text() != rendered:
+            print(
+                f"{OUTPUT} is out of date with the scientific check register. "
+                f"Regenerate it with `python {GENERATOR}` "
+                "and bump the client version in clients/python/pyproject.toml.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{OUTPUT} is up to date.")
+        return 0
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(rendered)
+    print(f"Wrote {OUTPUT}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/generate_scientific_check_register.py
+++ b/backend/scripts/generate_scientific_check_register.py
@@ -83,8 +83,8 @@ _CHANNEL_BLURB = {
         "a read-time trust label (`HardFailReason`), not any refusal"
     ),
     CodeChannel.database_constraint: (
-        "PostgreSQL only, so the client sees a generic 409 integrity code "
-        "rather than this check's name"
+        "PostgreSQL only, so the refusal is a 409 rather than a 422 — named, "
+        "where the constraint declares a rejection code"
     ),
     CodeChannel.none: "*nothing carries a code*",
 }
@@ -142,6 +142,14 @@ disagree, this one is right by construction.
 - **Enforced at** — `file::qualified_name` for Python, or the
   constraint/trigger name for PostgreSQL. Database names are verified against live schema metadata by
   `backend/tests/db/test_scientific_check_register.py`, not trusted as strings.
+  Where a constraint names the 409 code it returns, that code is printed with
+  it. A database-held position is the *strongest* guarantee here — no write
+  path can bypass a check constraint — and it used to be the one a client was
+  told least about, because every violation collapsed into its SQLSTATE bucket
+  and arrived as `state_conflict`. The mapping is keyed on the constraint name
+  PostgreSQL reports, never on the driver's message text, and each one is
+  proved by `backend/tests/api/test_api_database_constraint_codes.py`, which
+  provokes the real violation and reads the code out of the response body.
 - **Thresholds** — the numeric lines the check fires on, and *where each number
   comes from*. A constant is fixed in code and printed. A provenance-derived
   threshold is not a number at all: it is resolved per record from the
@@ -230,6 +238,11 @@ def _render_enforcement(check: ScientificCheck) -> str:
             body = site.label
             if site.definition:
                 body += f"\n  `{site.definition}`"
+            if site.rejection_code:
+                body += (
+                    f"\n  Violating this returns **409 `{site.rejection_code}`** — "
+                    f"{_md(site.rejection_detail or '')}"
+                )
         elif isinstance(site, DesignPosition):
             body = site.label
         else:  # pragma: no cover - exhaustive over Enforcement
@@ -322,9 +335,10 @@ def _render_check(check: ScientificCheck, index: int) -> str:
             "*(No machine-readable code reaches anybody for this one. Recorded "
             "as a gap rather than invented, because a code nothing carries is a "
             "code no client can match on. See the enforcement sites above for "
-            "why: a position held by a database constraint alone surfaces as a "
-            "generic integrity conflict, and one held by schema shape or by a "
-            "stored evidence row never surfaces as a refusal at all.)*",
+            "why: a position held by schema shape, or by a stored evidence row, "
+            "never surfaces as a refusal at all. A position held by a database "
+            "constraint no longer belongs here — such a constraint can declare "
+            "a rejection code and be named in its 409.)*",
             "",
         ]
     return "\n".join(lines)

--- a/backend/tests/api/test_api_database_constraint_codes.py
+++ b/backend/tests/api/test_api_database_constraint_codes.py
@@ -1,0 +1,263 @@
+"""The proof that a database-enforced scientific refusal names itself.
+
+The sibling file ``test_api_scientific_rejection_codes.py`` does this for
+refusals raised in Python. This one does it for the population that is
+harder to reach and, until now, told a client the least: the positions
+PostgreSQL holds. Those are the *strongest* guarantees TCKDB makes --
+no write path, no bulk loader and no future service can get around a
+check constraint -- and every one of them used to arrive as the same
+generic ``409 state_conflict``, so a client could not tell "an atom
+changed element on the way across this reaction" from "some consistency
+rule fired somewhere".
+
+Two independent facts have to hold, and they fail in different ways, so
+they are proved separately:
+
+1. **PostgreSQL reports the constraint by the name the register uses.**
+   Proved by violating the real constraint on the real schema and
+   reading ``diag.constraint_name`` off the driver's own error. This is
+   the half that a migration renaming a constraint would break, and it
+   is why the provocation is a genuine failing INSERT rather than a
+   hand-built exception. It also pins down a measured fact the mapping
+   depends on: a NOT NULL violation (SQLSTATE 23502) reports *no*
+   constraint name at all, which is why ``DatabaseConstraint`` refuses to
+   accept a rejection code for a kind PostgreSQL does not name.
+
+2. **The handler turns that name into the declared code, in the body.**
+   Proved by putting the real ``IntegrityError`` from (1) through the
+   real exception handlers -- ``register_exception_handlers`` is the
+   production wiring -- and asserting ``response.json()["code"]``, not
+   that the code appears somewhere in the prose. The assertion has to be
+   on the field, because matching the message is exactly what passes on
+   the broken system.
+
+Provoking a violation without a valid parent row
+------------------------------------------------
+``network_solve_energy_transfer`` needs a solve, which needs a network,
+which needs a reaction. Building all of that would test the upload path
+rather than the constraint. Instead each provocation fills every NOT NULL
+column that has no default with a type-appropriate dummy, overrides the
+columns under test, and runs inside ``SET LOCAL session_replication_role
+= replica``, which suspends foreign-key triggers while leaving CHECK and
+UNIQUE constraints fully armed. It is transaction-local and rolls back
+with the test.
+
+A new ``rejection_code`` in the register is not accepted until it is
+named here -- see ``test_every_constraint_rejection_code_is_provoked``
+in ``backend/tests/db/test_scientific_check_register.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app.api.errors import register_exception_handlers
+from app.scientific_checks.declarations import constraint_rejections
+
+#: One provocation per registered constraint: the table, and the column
+#: values that violate it. Everything else the row needs is filled in by
+#: :func:`_violating_row`. Keyed by constraint name so the drift guard can
+#: compare this against the register directly.
+PROVOCATIONS: dict[str, tuple[str, dict[str, object], dict[str, object] | None]] = {
+    # (table, violating values, values of a first row to insert for uniques)
+    "ck_statmech_statmech_exactly_one_subject": (
+        "statmech",
+        {"species_entry_id": None, "transition_state_entry_id": None},
+        None,
+    ),
+    "ck_network_solve_energy_transfer_scope_columns_agree": (
+        "network_solve_energy_transfer",
+        {"scope": "network_wide", "state_id": 1, "collider_species_entry_id": None},
+        None,
+    ),
+    "ck_network_solve_reported_requires_literature": (
+        "network_solve",
+        {"kind": "reported", "literature_id": None},
+        None,
+    ),
+    "ck_reaction_atom_map_pair_element_matches": (
+        "reaction_atom_map_pair",
+        {"element": "C", "ts_element": "N"},
+        None,
+    ),
+    # The two uniques share a table, so each first row differs from its
+    # violating row in exactly the column the *other* unique covers --
+    # otherwise which of the two fires would depend on index order.
+    "uq_reaction_atom_map_pair_ts_atom_index": (
+        "reaction_atom_map_pair",
+        {"atom_map_id": 1, "ts_atom_index": 7, "structure_participant_id": 2},
+        {"atom_map_id": 1, "ts_atom_index": 7, "structure_participant_id": 1},
+    ),
+    "uq_reaction_atom_map_pair_atom_map_id": (
+        "reaction_atom_map_pair",
+        {"atom_map_id": 1, "atom_index": 5, "structure_participant_id": 1,
+         "ts_atom_index": 9},
+        {"atom_map_id": 1, "atom_index": 5, "structure_participant_id": 1,
+         "ts_atom_index": 8},
+    ),
+}
+
+_NOT_NULL_COLUMNS = """
+SELECT a.attname,
+       format_type(a.atttypid, a.atttypmod) AS coltype,
+       t.typtype,
+       (SELECT e.enumlabel FROM pg_enum e
+         WHERE e.enumtypid = a.atttypid ORDER BY e.enumsortorder LIMIT 1) AS enum_first
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_type t ON t.oid = a.atttypid
+ WHERE c.relname = :table
+   AND a.attnum > 0
+   AND NOT a.attisdropped
+   AND a.attnotnull
+   AND NOT EXISTS (
+       SELECT 1 FROM pg_attrdef d
+        WHERE d.adrelid = c.oid AND d.adnum = a.attnum)
+"""
+
+
+def _dummy(coltype: str, typtype: str, enum_first: str | None) -> object:
+    """A value of the right type, chosen only to satisfy NOT NULL."""
+    if typtype == "e":
+        return enum_first
+    if coltype.startswith(("integer", "bigint", "smallint")):
+        return 1
+    if coltype.startswith(("numeric", "double", "real")):
+        return 1
+    if coltype.startswith("boolean"):
+        return False
+    if coltype.startswith(("timestamp", "date")):
+        return "2020-01-01T00:00:00"
+    if coltype.startswith("json"):
+        return "{}"
+    if coltype.startswith("uuid"):
+        return "00000000-0000-0000-0000-000000000000"
+    return "x"
+
+
+def _row(session, table: str, overrides: dict[str, object]) -> dict[str, object]:
+    rows = session.execute(text(_NOT_NULL_COLUMNS), {"table": table}).mappings().all()
+    values: dict[str, object] = {
+        row["attname"]: _dummy(row["coltype"], row["typtype"], row["enum_first"])
+        for row in rows
+    }
+    values.update(overrides)
+    return values
+
+
+def _insert(session, table: str, values: dict[str, object]) -> None:
+    columns = ", ".join(f'"{name}"' for name in values)
+    binds = ", ".join(f":{name}" for name in values)
+    session.execute(text(f"INSERT INTO {table} ({columns}) VALUES ({binds})"), values)
+    session.flush()
+
+
+def _provoke(session, name: str) -> IntegrityError:
+    """Violate *name* for real and hand back the driver's own error."""
+    table, violating, seed = PROVOCATIONS[name]
+    savepoint = session.begin_nested()
+    try:
+        session.execute(text("SET LOCAL session_replication_role = replica"))
+        if seed is not None:
+            _insert(session, table, _row(session, table, seed))
+        with pytest.raises(IntegrityError) as caught:
+            _insert(session, table, _row(session, table, violating))
+        return caught.value
+    finally:
+        savepoint.rollback()
+
+
+@pytest.fixture
+def envelope_client() -> TestClient:
+    """A client whose single route re-raises whatever it is given.
+
+    Built with the production ``register_exception_handlers`` so the path
+    under test is the real one: handler, envelope, JSON encoder. The
+    route exists only to get an exception into that path -- there is no
+    real endpoint that inserts a malformed ``statmech`` row, and inventing
+    one would prove something about the fake route instead.
+    """
+    app = FastAPI()
+    holder: dict[str, BaseException] = {}
+
+    @app.get("/boom")
+    def boom() -> None:  # pragma: no cover - raises by design
+        raise holder["exc"]
+
+    register_exception_handlers(app)
+    client = TestClient(app, raise_server_exceptions=False)
+    client.holder = holder  # type: ignore[attr-defined]
+    return client
+
+
+@pytest.mark.parametrize("name", sorted(PROVOCATIONS))
+def test_postgres_reports_the_constraint_the_register_names(name, db_session):
+    """Fact 1: the violation arrives labelled with the registered name."""
+    error = _provoke(db_session, name)
+    reported = getattr(getattr(error.orig, "diag", None), "constraint_name", None)
+    assert reported == name, (
+        f"Provoking {name!r} produced a violation PostgreSQL labelled "
+        f"{reported!r}. The handler keys on that label, so a mapping under the "
+        "registered name would never be consulted. Either the provocation trips "
+        "a different constraint first, or the constraint was renamed in a "
+        "migration without the register following."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(PROVOCATIONS))
+def test_the_response_body_names_the_scientific_rule(name, db_session, envelope_client):
+    """Fact 2: the declared code reaches ``response.json()["code"]``."""
+    expected_code, expected_detail = constraint_rejections()[name]
+    envelope_client.holder["exc"] = _provoke(db_session, name)
+
+    response = envelope_client.get("/boom")
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["code"] == expected_code, (
+        f"expected code={expected_code!r} for {name!r}, got {body['code']!r}. "
+        "A generic integrity code here means the client is back to being told "
+        "only that something conflicted."
+    )
+    assert body["detail"] == expected_detail
+    assert body["context"]["constraint"] == name
+    # The sanitization the handler has always promised: no driver text.
+    assert "psycopg" not in response.text
+    assert "INSERT INTO" not in response.text
+
+
+def test_an_unregistered_constraint_still_falls_back_to_its_sqlstate(
+    db_session, envelope_client
+):
+    """Naming some constraints must not stop the others being handled.
+
+    The fallback is the whole reason the mapping is a lookup rather than a
+    rewrite of the handler: the register covers the positions that encode
+    chemistry, and the several hundred constraints that encode plumbing
+    must keep arriving as the sanitized SQLSTATE bucket rather than as a
+    ``KeyError`` or as raw driver text.
+    """
+    savepoint = db_session.begin_nested()
+    try:
+        db_session.execute(text("SET LOCAL session_replication_role = replica"))
+        with pytest.raises(IntegrityError) as caught:
+            _insert(
+                db_session,
+                "species",
+                _row(db_session, "species", {"charge": None}),
+            )
+    finally:
+        savepoint.rollback()
+
+    envelope_client.holder["exc"] = caught.value
+    response = envelope_client.get("/boom")
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["code"] == "state_conflict"
+    assert body["context"] == {}
+    assert "null value in column" not in response.text

--- a/backend/tests/api/test_client_rejection_codes_generated.py
+++ b/backend/tests/api/test_client_rejection_codes_generated.py
@@ -1,0 +1,115 @@
+"""The generated client enum must not drift from the register.
+
+The staleness gate, in the same shape as the one guarding
+``docs/guides/scientific_check_register.md``: regenerate in memory,
+compare against the committed file, fail if they differ. This lives on
+the server side because only the backend can import the register --
+``clients/python`` has no dependency on ``app`` and must not gain one.
+
+What this buys a client author is narrow and specific. Without it the
+codes exist on the server and are transcribed by hand into ARC and every
+other consumer, where a typo is not an error: ``exc.code ==
+"reaction_mass_balace_failed"`` compiles, runs, and simply never matches,
+so the branch written for an unbalanced deposit silently never fires. A
+generated enum turns that into an ``AttributeError`` at import.
+
+The gate is deliberately narrow too. The generated file carries codes and
+statuses and nothing else -- no prose, no anchors, no counts -- so it
+cannot fire on a reworded sentence or a moved line. See the generator's
+docstring for why that restraint is the point rather than an omission.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from app.scientific_checks import CodeChannel
+from app.scientific_checks.declarations import constraint_rejections, register
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GENERATOR = REPO_ROOT / "backend" / "scripts" / "generate_client_rejection_codes.py"
+GENERATED = (
+    REPO_ROOT
+    / "clients"
+    / "python"
+    / "src"
+    / "tckdb_client"
+    / "rejection_codes.py"
+)
+
+
+def test_generated_enum_is_in_sync_with_the_register() -> None:
+    assert GENERATED.exists(), f"{GENERATED} has not been generated"
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR), "--check"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"{GENERATED} is out of date with the scientific check register.\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_every_refusal_code_the_register_declares_is_exported() -> None:
+    """Read as a client would, not by re-running the generator.
+
+    The sync test above compares two renderings of the same function, so
+    it cannot notice the generator dropping a whole channel -- both sides
+    would drop it together. This one derives the expected set
+    independently from the register and looks for each code as a literal
+    in the file a client actually imports.
+    """
+    expected = {
+        code
+        for check in register()
+        if check.channel is CodeChannel.error_envelope
+        for code in check.codes
+    }
+    expected |= {code for code, _detail in constraint_rejections().values()}
+    assert expected, "no refusal codes at all -- the guard would pass vacuously"
+
+    published = GENERATED.read_text()
+    missing = sorted(code for code in expected if f'"{code}"' not in published)
+    assert not missing, (
+        f"These codes are declared to reach a client but are absent from "
+        f"{GENERATED.name}: {missing}. A consumer would have to hard-code them, "
+        "and a hard-coded code that is wrong never matches rather than failing."
+    )
+
+
+def test_the_generated_file_carries_no_anchor_that_moves_for_free() -> None:
+    """Nothing derived from where a check lives, for the reason #119 established.
+
+    A gate keyed on something that moves cosmetically gets regenerated
+    reflexively without anyone reading the diff, which is how a real
+    drift eventually lands unnoticed. #119's case was a line number: a
+    comment added to a service module shifted a check from 120 to 121 and
+    turned the tier red on main.
+
+    Two things are forbidden, and the difference matters. A line-number
+    anchor moves whenever anything above it does. A path under
+    ``backend/app`` or ``schemas`` would be *rendered from the live check
+    object*, so it moves whenever a check is relocated -- which is not a
+    contract change and must not read as one. Fixed prose naming the
+    generator and this guard is neither: it is part of the header, it is
+    not derived from anything, and it changes only if somebody edits it.
+    """
+    published = GENERATED.read_text()
+
+    line_anchors = re.findall(r"\.py:\d+", published)
+    assert not line_anchors, (
+        f"The generated enum carries line-number anchors: {line_anchors}. "
+        "Editing the code above a check would then turn the staleness gate red."
+    )
+
+    derived_paths = re.findall(r"\b(?:backend/app|schemas)/\S+\.py", published)
+    assert not derived_paths, (
+        "The generated enum names the modules checks live in, so moving a "
+        f"declaration would fire the gate without any contract changing: "
+        f"{derived_paths}"
+    )

--- a/backend/tests/api/test_no_row_ids_in_user_facing_text.py
+++ b/backend/tests/api/test_no_row_ids_in_user_facing_text.py
@@ -1,0 +1,245 @@
+"""No internal row id may be interpolated into text a user receives.
+
+The rule -- never put a database primary or foreign key in user-facing
+detail; log it server-side instead -- has been written down for a long
+time. It was violated in roughly fifty places. That is the whole
+argument for this file: writing a rule down does not enforce it, and a
+one-time sweep regresses on the next pull request, because the next
+author will reach for ``f"{kind} not found (id={row.id})"`` exactly as
+every previous author did. It is the obvious thing to write.
+
+Why the ids matter
+------------------
+A row id is not secret, but it is not *ours to give*. It is an
+implementation detail of a specific database instance: it does not
+survive a restore into a fresh database, it does not mean the same thing
+on the hosted deployment and on a lab self-host, and it is not what any
+public surface is keyed on -- ``public_ref`` is. A client that learns to
+key on ids builds against something TCKDB has never promised to keep
+stable, and a 404 that echoes the id it was asked about also confirms,
+by omission or presence, what exists.
+
+The one genuinely bad shape is a *disclosure*: a message that hands back
+an id the caller did not already have. ``handles.reconcile_id_ref`` had
+one -- supply a public ref and any wrong id, and the 422 told you the
+real row id the ref resolves to, which is precisely the mapping
+``internal_ids`` exists to hide.
+
+What this catches
+-----------------
+An f-string interpolating an id-shaped expression into a call that
+constructs a user-facing refusal, or into a field of a successful
+response. Detection is on the AST, not on the text, so it does not care
+about wording, and it cannot be satisfied by rephrasing.
+
+What this cannot catch, honestly
+--------------------------------
+* A message built into a local variable first, then raised. The check
+  looks at the argument expression, not at what flowed into it.
+* ``%``-formatting and ``str.format``.
+* An id-valued expression whose *name* does not look like an id
+  (``row.pk``, ``winner.identifier``, a bare integer returned from a
+  helper).
+* An id stored in a row that is served later -- ``__init__``'s
+  ``record_ref = str(record_id)`` family. Those are inventoried in the
+  candidate list rather than caught here, because catching them needs
+  taint analysis rather than a shape check.
+
+So this is a floor, not a proof. It makes the *obvious* way to write the
+mistake fail in CI, which is the shape the mistake has actually taken
+every time so far.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+APP_ROOT = Path(__file__).resolve().parents[2] / "app"
+
+#: Callables whose string argument becomes a response body. The exception
+#: types are registered in ``app/api/errors.py``, which puts ``str(exc)``
+#: verbatim into the envelope; ``MatchDetail`` strings go out in a
+#: successful 200.
+USER_FACING_CALLS = frozenset(
+    {
+        "CodedValidationError",
+        "CodedValueError",
+        "DomainError",
+        "HTTPException",
+        "NotFoundError",
+        "ValueError",
+    }
+)
+
+#: Keyword arguments of the above (and of response-model constructors)
+#: whose value is rendered to a user.
+USER_FACING_KEYWORDS = frozenset({"detail", "message", "resource_name"})
+
+#: Method calls that are user-facing sinks only in a particular module.
+#: ``add`` is far too common a name to treat as a sink everywhere, but
+#: ``_MatchBuilder.add`` in the lookup routes writes free text straight
+#: into the ``details`` list of a **200** body, which is a worse place for
+#: an id than any refusal: nothing went wrong, and the id is handed over
+#: on the success path.
+USER_FACING_METHODS: dict[str, frozenset[str]] = {
+    "app/api/routes/lookup.py": frozenset({"add"}),
+}
+
+#: An expression named like a database key. Deliberately about the
+#: *name*: an id-valued expression called something else is out of reach
+#: of a shape check, and pretending otherwise would oversell the guard.
+ID_NAME = re.compile(r"^id$|^ids$|^id_|_id$|_ids$")
+
+#: Literal text immediately before an interpolation, which labels
+#: whatever follows as an id whatever that expression is called. This is
+#: the only text-shaped rule here and it earns its place: the single
+#: worst leak found -- ``f"(ref -> id={resolved})"`` in
+#: ``handles.reconcile_id_ref`` -- interpolated a name the ID_NAME rule
+#: cannot see, while announcing in the surrounding prose exactly what it
+#: was about to disclose.
+ID_LABEL = re.compile(r"(^|[^a-z0-9_])(id|ids|row_id|pk)\s*[=:]?\s*$", re.IGNORECASE)
+
+#: Sites that interpolate an id-shaped name into user-facing text and are
+#: nonetheless correct, each with the reason. Deliberately not a wildcard
+#: and deliberately not silent: adding one means writing down why, in a
+#: diff a reviewer sees. An empty allowance is the goal, not a failure.
+ALLOWED: dict[tuple[str, str], str] = {}
+
+
+def _is_id_expression(node: ast.expr) -> str | None:
+    """The id-shaped name in *node*, or ``None``.
+
+    Only the expression's own head is inspected -- a ``Name``, or the
+    attribute at the end of a dotted chain, or a constant subscript key.
+    It deliberately does not descend into a ``Call``, because ``len(ids)``
+    is a count and ``str(record_id)`` is a conversion whose *result* is
+    the id; the second is caught by the ``Name`` inside it only if it is
+    the head, which is the conservative reading.
+    """
+    if isinstance(node, ast.Name):
+        return node.id if ID_NAME.search(node.id) else None
+    if isinstance(node, ast.Attribute):
+        return node.attr if ID_NAME.search(node.attr) else None
+    if isinstance(node, ast.Subscript):
+        key = node.slice
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            return key.value if ID_NAME.search(key.value) else None
+    return None
+
+
+def _labelled_as_id(joined: ast.JoinedStr, index: int) -> bool:
+    """Whether the literal text just before part *index* announces an id."""
+    if index == 0:
+        return False
+    previous = joined.values[index - 1]
+    if not isinstance(previous, ast.Constant) or not isinstance(previous.value, str):
+        return False
+    return bool(ID_LABEL.search(previous.value))
+
+
+def _interpolated_ids(node: ast.expr) -> list[str]:
+    """Every id-shaped expression interpolated into *node*, if it is text."""
+    found: list[str] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.JoinedStr):
+            continue
+        for index, part in enumerate(child.values):
+            if not isinstance(part, ast.FormattedValue):
+                continue
+            name = _is_id_expression(part.value)
+            if name is not None:
+                found.append(name)
+            elif _labelled_as_id(child, index):
+                found.append(ast.unparse(part.value))
+    return found
+
+
+def _offenders_in(path: Path, relative: str) -> list[tuple[int, str, str]]:
+    tree = ast.parse(path.read_text())
+    methods = USER_FACING_METHODS.get(relative, frozenset())
+    offenders: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        name = callee.id if isinstance(callee, ast.Name) else getattr(callee, "attr", "")
+
+        candidates: list[ast.expr] = []
+        if name in USER_FACING_CALLS or name in methods:
+            candidates.extend(node.args)
+        candidates.extend(
+            keyword.value
+            for keyword in node.keywords
+            if keyword.arg in USER_FACING_KEYWORDS
+        )
+        for argument in candidates:
+            for leaked in _interpolated_ids(argument):
+                offenders.append((argument.lineno, name or "<call>", leaked))
+    return offenders
+
+
+def _sweep() -> list[tuple[str, int, str, str]]:
+    results: list[tuple[str, int, str, str]] = []
+    for path in sorted(APP_ROOT.rglob("*.py")):
+        relative = str(path.relative_to(APP_ROOT.parent))
+        for lineno, callee, leaked in _offenders_in(path, relative):
+            if (relative, leaked) in ALLOWED:
+                continue
+            results.append((relative, lineno, callee, leaked))
+    return results
+
+
+def test_no_row_id_is_interpolated_into_user_facing_text() -> None:
+    offenders = _sweep()
+    assert not offenders, (
+        "These sites put a database row id into text a user receives. Log the "
+        "id server-side and name the resource instead -- a public ref if the "
+        "caller supplied one, otherwise just the kind:\n"
+        + "\n".join(
+            f"  {path}:{lineno}  {callee}(...)  interpolates {leaked!r}"
+            for path, lineno, callee, leaked in offenders
+        )
+    )
+
+
+def test_the_scan_actually_reaches_the_code_it_claims_to() -> None:
+    """Guard the guard: a broken path or parse would pass vacuously."""
+    files = list(APP_ROOT.rglob("*.py"))
+    assert len(files) > 200, f"only {len(files)} modules scanned"
+    assert (APP_ROOT / "services" / "scientific_read" / "handles.py") in files
+
+
+def test_the_detector_recognises_the_shape_it_exists_to_catch() -> None:
+    """The detector must fail on the mistake and pass on the fix.
+
+    Without this, a refactor that quietly stopped matching anything would
+    leave every assertion above passing on an empty sweep -- the failure
+    mode of every lint written as a search.
+    """
+    def leaks(source: str) -> list[str]:
+        return [
+            leaked
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            for argument in node.args
+            for leaked in _interpolated_ids(argument)
+        ]
+
+    assert leaks(
+        'raise NotFoundError(f"calculation not found (calculation_id={calc_id})")'
+    ) == ["calc_id"]
+    # The label rule, which is the only thing that can see this one: the
+    # expression is called ``resolved``, and the prose around it is what
+    # announces that a row id is about to be disclosed.
+    assert leaks('raise ValueError(f"ref resolves elsewhere (ref -> id={resolved})")')
+
+    for clean in (
+        'raise NotFoundError("calculation not found")',
+        'raise NotFoundError(f"calculation not found (calculation_ref={ref!r})")',
+        'raise ValueError(f"matched {count} records, narrow the query")',
+        'raise ValueError(f"{len(ids)} records is too many")',
+        'raise ValueError(f"invalid handle {handle!r}")',
+    ):
+        assert not leaks(clean), clean

--- a/backend/tests/db/test_scientific_check_register.py
+++ b/backend/tests/db/test_scientific_check_register.py
@@ -38,7 +38,11 @@ from app.scientific_checks import (
     PythonCheck,
     ScientificCheck,
 )
-from app.scientific_checks.declarations import DECLARING_MODULES, register
+from app.scientific_checks.declarations import (
+    DECLARING_MODULES,
+    constraint_rejections,
+    register,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BACKEND_ROOT = REPO_ROOT / "backend"
@@ -52,10 +56,18 @@ ENVELOPE_PROOF = (
     BACKEND_ROOT / "tests" / "api" / "test_api_scientific_rejection_codes.py"
 )
 
+#: The equivalent proof for the positions PostgreSQL holds: it violates
+#: each named constraint for real and asserts the declared code reaches
+#: the 409 body.
+CONSTRAINT_PROOF = (
+    BACKEND_ROOT / "tests" / "api" / "test_api_database_constraint_codes.py"
+)
+
 #: The exception types that carry a code out of a check as an attribute.
 CODED_ERROR_TYPES = frozenset({"CodedValueError", "CodedValidationError"})
 
 REGISTER = register()
+REJECTIONS = constraint_rejections()
 
 
 def test_register_is_non_empty_and_proportionate() -> None:
@@ -300,6 +312,105 @@ def test_every_error_envelope_code_is_proved_end_to_end() -> None:
         "response.json()['code'] == the code — not that the message contains "
         "it, which is the assertion that let the gap survive."
     )
+
+
+def test_constraint_rejections_exist_to_verify() -> None:
+    """Guard the guard: an empty mapping makes the three below vacuous."""
+    assert REJECTIONS, (
+        "No DatabaseConstraint declares a rejection_code, so every "
+        "database-enforced scientific position is back to arriving as a "
+        "generic 409 and the guards below pass by describing nothing."
+    )
+
+
+def test_constraint_rejections_are_usable_runtime_strings() -> None:
+    """A 409's code and sentence must be ASCII, and the sentence a sentence.
+
+    ASCII because these are runtime strings on the wire, and the register
+    prose around them is not -- the ``asserts`` field is written with em
+    dashes for the document. Copying one of those into a response body is
+    the easy mistake, so it is checked rather than remembered.
+    """
+    for name, (code, detail) in sorted(REJECTIONS.items()):
+        assert code.isascii() and detail.isascii(), (
+            f"{name}: non-ASCII in the 409 payload ({code!r} / {detail!r}). "
+            "The register's prose fields may use typographic punctuation; a "
+            "runtime string may not."
+        )
+        assert re.fullmatch(r"[a-z][a-z0-9_]*", code), (
+            f"{name}: {code!r} is not a matchable token. Clients branch on "
+            "this string, and the generated client enum derives its member "
+            "name from it."
+        )
+        assert len(detail) > 40 and detail.endswith("."), (
+            f"{name}: {detail!r} is not a sentence a depositor can act on. "
+            "The point of naming the constraint is to say which scientific "
+            "rule refused the write, not to emit a second token."
+        )
+
+
+def test_a_constraint_that_names_a_code_is_not_declared_as_carrying_none() -> None:
+    """``channel=none`` and a named constraint cannot both be true.
+
+    ``CodeChannel.none`` is the register's way of saying *no
+    machine-readable code reaches anybody*. The moment a constraint
+    declares a rejection code that claim is false, and the entry that
+    still says ``none`` is the one a reader would trust.
+    """
+    for check in REGISTER:
+        named = [
+            site
+            for site in check.enforced_by
+            if isinstance(site, DatabaseConstraint) and site.rejection_code
+        ]
+        if not named:
+            continue
+        assert check.channel is not CodeChannel.none, (
+            f"{check.asserts!r} declares channel=none while "
+            f"{[site.name for site in named]} name codes a client now receives."
+        )
+
+
+def test_every_constraint_rejection_code_is_provoked_against_postgres() -> None:
+    """Each named constraint must be violated for real by the proof file.
+
+    The weak version of this guard would assert the mapping is non-empty
+    and stop. That would not catch the failure that actually matters:
+    a constraint whose *name* in the register no longer matches what
+    PostgreSQL reports, because a migration renamed it or because the
+    violation trips a different constraint first. Neither is visible from
+    Python -- only from provoking the violation and reading
+    ``diag.constraint_name`` -- so the register's claim is anchored to a
+    test that does exactly that, and a new rejection code cannot be
+    declared without one.
+    """
+    assert CONSTRAINT_PROOF.exists(), f"{CONSTRAINT_PROOF} is missing"
+    from tests.api.test_api_database_constraint_codes import PROVOCATIONS
+
+    missing = sorted(set(REJECTIONS) - set(PROVOCATIONS))
+    assert not missing, (
+        f"These constraints declare a rejection code but {CONSTRAINT_PROOF.name} "
+        f"never provokes them: {missing}. Add an entry to PROVOCATIONS -- the "
+        "code is otherwise a claim that the mapping key matches what PostgreSQL "
+        "reports, which nothing has checked."
+    )
+    stale = sorted(set(PROVOCATIONS) - set(REJECTIONS))
+    assert not stale, (
+        f"{CONSTRAINT_PROOF.name} provokes constraints the register no longer "
+        f"names: {stale}. Drop the provocation or restore the declaration."
+    )
+
+
+def test_the_handler_reads_the_register_rather_than_its_own_table() -> None:
+    """The API's mapping must *be* the register's, not a copy of it.
+
+    A hand-kept table in ``app/api/errors.py`` would pass every other
+    guard here while drifting from the schema at its own pace. Comparing
+    the objects is what makes "derived, never written twice" enforced.
+    """
+    from app.api.errors import _constraint_rejections
+
+    assert _constraint_rejections() == REJECTIONS
 
 
 def test_declaring_modules_covers_every_file_that_declares_a_check() -> None:

--- a/backend/tests/services/test_reproducibility_assessment.py
+++ b/backend/tests/services/test_reproducibility_assessment.py
@@ -253,8 +253,12 @@ def test_expected_context_hash_must_match_computed_digest(db_session):
 
 
 def test_append_rejects_missing_polymorphic_target(db_session):
-    with pytest.raises(ValueError, match="reaction record 999999 does not exist"):
+    with pytest.raises(ValueError, match="reaction record does not exist") as caught:
         _append(db_session, record_id=999999)
+    # Names the record type, not the row id it was asked about. The id is
+    # an implementation detail of one database instance and is logged
+    # rather than returned; this message used to carry it.
+    assert "999999" not in str(caught.value)
 
 
 def test_timezone_aware_assessed_at_is_stored_as_naive_utc(db_session):

--- a/backend/tests/services/test_reproducibility_rubric.py
+++ b/backend/tests/services/test_reproducibility_rubric.py
@@ -802,12 +802,17 @@ def test_registry_covers_all_addressable_assessment_types() -> None:
 
 
 def test_missing_record_fails_closed(db_session) -> None:
-    with pytest.raises(ValueError, match="calculation record 999999999 does not exist"):
+    with pytest.raises(ValueError, match="calculation record does not exist") as caught:
         evaluate_reproducibility(
             db_session,
             record_type="calculation",
             record_id=999_999_999,
         )
+    # The refusal names the record *type*, which is what the caller needs,
+    # and not the row id it asked about, which is an implementation detail
+    # of one database. Asserted rather than assumed: this message used to
+    # echo the id, and the id in it is what a regression would restore.
+    assert "999999999" not in str(caught.value)
 
 
 def test_insufficient_grade_migration_layers_on_current_head() -> None:

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -179,6 +179,50 @@ except TCKDBValidationError as exc:
     print(exc.status_code, exc.detail)
 ```
 
+### Telling one refusal from another
+
+The status tells you who is at fault; it does not tell you what to do.
+A `422` covers every refusal the server can make, and those want opposite
+responses — a geometry that disagrees with its declared SMILES is worth
+repairing and resending, while a reaction that does not balance means the
+deposit is wrong and should not be retried at all.
+
+`exc.code` names which one it was. `RejectionCode` is generated from the
+server's scientific check register, so a code that is renamed breaks the
+import rather than turning a branch into one that silently never matches:
+
+```python
+from tckdb_client import RejectionCode, TCKDBHTTPError, rejection_code
+
+try:
+    client.upload("reactions", payload)
+except TCKDBHTTPError as exc:
+    match rejection_code(exc.code):
+        case RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH:
+            payload = repair_geometry(payload)  # recoverable
+        case RejectionCode.REACTION_MASS_BALANCE_FAILED:
+            raise                               # the deposit is wrong
+        case None:
+            raise                               # not a code this client knows
+    print(exc.detail)                           # prose, for a human
+    print(exc.response_json["context"])         # the same facts, structured
+```
+
+Use `rejection_code(exc.code)` rather than `RejectionCode(exc.code)`: a
+server is routinely newer than the client pinned against it, and a code
+added since must return `None` rather than raise inside your own error
+handler.
+
+`VALIDATION_REJECTION_CODES` and `CONFLICT_REJECTION_CODES` say which
+status carries each code — `409` means a database-held rule refused the
+write, `422` means nothing was written at all. A code can be in both: the
+same scientific claim is sometimes enforced at the wire boundary and
+again in the schema.
+
+What each code asserts, why it refuses rather than warns, and how
+legitimate chemistry it would otherwise reject can still be deposited, is
+in [the scientific check register](https://github.com/TCKDB/TCKDB/blob/main/docs/guides/scientific_check_register.md).
+
 ## Scientific read/query methods
 
 The client exposes thin wrappers over the backend's `/api/v1/scientific/*`

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.33.0"
+version = "0.34.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/__init__.py
+++ b/clients/python/src/tckdb_client/__init__.py
@@ -20,6 +20,12 @@ from tckdb_client.errors import (
     TCKDBValidationError,
 )
 from tckdb_client.idempotency import make_idempotency_key, validate_idempotency_key
+from tckdb_client.rejection_codes import (
+    CONFLICT_REJECTION_CODES,
+    RejectionCode,
+    VALIDATION_REJECTION_CODES,
+    rejection_code,
+)
 from tckdb_client.replay import (
     ClientFactory,
     ReplayFailure,
@@ -101,6 +107,10 @@ __all__ = [
     "TCKDBConflictError",
     "TCKDBIdempotencyConflictError",
     "TCKDBPaginationError",
+    "CONFLICT_REJECTION_CODES",
+    "RejectionCode",
+    "VALIDATION_REJECTION_CODES",
+    "rejection_code",
     "validate_idempotency_key",
     "make_idempotency_key",
     "ClientFactory",

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -1,0 +1,142 @@
+"""Machine-readable codes TCKDB reports when it refuses a deposit.
+
+**Generated. Do not edit by hand.** Regenerate with
+``conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py``;
+``backend/tests/api/test_client_rejection_codes_generated.py`` fails if
+this file and the server's scientific check register disagree.
+
+Every member here is a position TCKDB takes about chemistry -- a claim a
+referee could argue with -- and each one is proved to arrive in a real
+HTTP response body by a test on the server side. The register that
+generates this file is rendered for humans at
+``docs/guides/scientific_check_register.md``, which is where to look for
+what a code asserts, why it refuses rather than warns, and what the
+escape hatch is for legitimate chemistry it would otherwise reject.
+
+Deliberately absent: warning codes, which arrive alongside an *accepted*
+upload, and trust labels, which are applied at read time and refuse
+nothing. Both would be misread as failures under this name.
+
+Using it::
+
+    from tckdb_client import RejectionCode, rejection_code
+
+    try:
+        client.upload_reaction(payload)
+    except TCKDBHTTPError as exc:
+        match rejection_code(exc.code):
+            case RejectionCode.REACTION_MASS_BALANCE_FAILED:
+                raise                      # the deposit is wrong; do not retry
+            case RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH:
+                payload = repair(payload)  # recoverable
+            case None:
+                raise                      # a code this client does not know
+
+Use :func:`rejection_code` rather than ``RejectionCode(exc.code)``. A
+server is routinely newer than the client pinned against it, and a code
+added since this file was generated must not turn a handled refusal into
+an unhandled ``ValueError``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = [
+    "CONFLICT_REJECTION_CODES",
+    "RejectionCode",
+    "VALIDATION_REJECTION_CODES",
+    "rejection_code",
+]
+
+
+class RejectionCode(str, Enum):
+    """A code TCKDB reports in the ``code`` field of a refusal body.
+
+    ``str`` subclass so a member compares equal to the wire string and
+    can be used wherever the raw code was.
+    """
+
+    ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH = "arrhenius_a_units_molecularity_mismatch"
+    ATOM_MAP_ATOMS_UNACCOUNTED_FOR = "atom_map_atoms_unaccounted_for"
+    ATOM_MAP_CONTRADICTS_IRC_MAPPING = "atom_map_contradicts_irc_mapping"
+    ATOM_MAP_ELEMENT_NOT_CONSERVED = "atom_map_element_not_conserved"
+    ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE = "atom_map_indices_not_geometry_relative"
+    ATOM_MAP_INFERRED_REQUIRES_NOTE = "atom_map_inferred_requires_note"
+    ATOM_MAP_NOT_A_BIJECTION = "atom_map_not_a_bijection"
+    ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE = "energy_transfer_scope_columns_disagree"
+    N_IMAG_CONTRADICTS_MINIMUM = "n_imag_contradicts_minimum"
+    NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE = "network_solve_reported_requires_literature"
+    REACTION_CHARGE_NOT_CONSERVED = "reaction_charge_not_conserved"
+    REACTION_MASS_BALANCE_FAILED = "reaction_mass_balance_failed"
+    SPECIES_GEOMETRY_COMPOSITION_MISMATCH = "species_geometry_composition_mismatch"
+    SPECIES_GEOMETRY_ISOTOPE_MISMATCH = "species_geometry_isotope_mismatch"
+    SPECIES_SMILES_CHARGE_MISMATCH = "species_smiles_charge_mismatch"
+    STATMECH_SUBJECT_NOT_EXACTLY_ONE = "statmech_subject_not_exactly_one"
+    TRANSITION_STATE_CHARGE_MISMATCH = "transition_state_charge_mismatch"
+    TRANSITION_STATE_COMPOSITION_MISMATCH = "transition_state_composition_mismatch"
+    TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH = "transition_state_irc_mapping_element_mismatch"
+    TRANSITION_STATE_NO_IMAGINARY_MODE = "transition_state_no_imaginary_mode"
+    TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS = "transition_state_reaction_coordinate_ambiguous"
+    TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED = "transition_state_reaction_coordinate_not_designated"
+
+
+#: Codes carried by an HTTP 422: the payload was refused before
+#: anything was written, so nothing was stored and a corrected
+#: payload may be sent again under the same idempotency key.
+VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
+    {
+        RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH,
+        RejectionCode.ATOM_MAP_ATOMS_UNACCOUNTED_FOR,
+        RejectionCode.ATOM_MAP_CONTRADICTS_IRC_MAPPING,
+        RejectionCode.ATOM_MAP_ELEMENT_NOT_CONSERVED,
+        RejectionCode.ATOM_MAP_INDICES_NOT_GEOMETRY_RELATIVE,
+        RejectionCode.ATOM_MAP_INFERRED_REQUIRES_NOTE,
+        RejectionCode.ATOM_MAP_NOT_A_BIJECTION,
+        RejectionCode.N_IMAG_CONTRADICTS_MINIMUM,
+        RejectionCode.REACTION_CHARGE_NOT_CONSERVED,
+        RejectionCode.REACTION_MASS_BALANCE_FAILED,
+        RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH,
+        RejectionCode.SPECIES_GEOMETRY_ISOTOPE_MISMATCH,
+        RejectionCode.SPECIES_SMILES_CHARGE_MISMATCH,
+        RejectionCode.TRANSITION_STATE_CHARGE_MISMATCH,
+        RejectionCode.TRANSITION_STATE_COMPOSITION_MISMATCH,
+        RejectionCode.TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH,
+        RejectionCode.TRANSITION_STATE_NO_IMAGINARY_MODE,
+        RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS,
+        RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED,
+    }
+)
+
+#: Codes carried by an HTTP 409: a position PostgreSQL holds
+#: refused the write. A code may appear in both sets -- the same
+#: claim can be enforced at the wire boundary and again in the
+#: schema, and which one fires depends on the write path, not on
+#: what the depositor did wrong.
+CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
+    {
+        RejectionCode.ATOM_MAP_ELEMENT_NOT_CONSERVED,
+        RejectionCode.ATOM_MAP_NOT_A_BIJECTION,
+        RejectionCode.ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE,
+        RejectionCode.NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE,
+        RejectionCode.STATMECH_SUBJECT_NOT_EXACTLY_ONE,
+    }
+)
+
+
+def rejection_code(value: object) -> RejectionCode | None:
+    """Return the member for *value*, or ``None`` if this client cannot name it.
+
+    ``None`` covers three genuinely different situations, and a caller
+    should treat all three the same way -- as a refusal it does not have
+    a specific branch for: the server is newer than this client and sent
+    a code added since; the refusal was not a scientific one (a rate
+    limit, an authentication failure, a generic conflict); or there was
+    no code at all.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        return RejectionCode(value)
+    except ValueError:
+        return None

--- a/clients/python/tests/test_rejection_codes.py
+++ b/clients/python/tests/test_rejection_codes.py
@@ -1,0 +1,91 @@
+"""Client-side properties of the generated rejection-code enum.
+
+The staleness gate lives on the server, where the register can be
+imported. These are the properties a *consumer* depends on and that the
+server-side gate cannot see, because the client package is what has to
+keep working when it is pinned against a newer server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tckdb_client import (
+    CONFLICT_REJECTION_CODES,
+    RejectionCode,
+    VALIDATION_REJECTION_CODES,
+    rejection_code,
+)
+
+
+def test_a_member_is_the_wire_string() -> None:
+    """A caller may compare against the raw ``code`` field without converting."""
+    assert RejectionCode.REACTION_MASS_BALANCE_FAILED == "reaction_mass_balance_failed"
+    assert str(RejectionCode.REACTION_MASS_BALANCE_FAILED.value) == (
+        "reaction_mass_balance_failed"
+    )
+
+
+def test_member_names_are_the_upper_cased_codes() -> None:
+    """The naming rule is the whole ergonomic claim, so it is checked.
+
+    ``RejectionCode.REACTION_MASS_BALANCE_FAILED`` has to be guessable
+    from the string a server sent, or a consumer goes back to pasting
+    literals -- which is the failure this file exists to remove.
+    """
+    for member in RejectionCode:
+        assert member.name == member.value.upper()
+
+
+def test_an_unknown_code_is_none_rather_than_an_exception() -> None:
+    """A newer server must not break an older client.
+
+    This is the property that makes the enum safe to use in a ``match``
+    at all. Servers are routinely ahead of the clients pinned against
+    them, so a code added after this file was generated has to degrade to
+    "a refusal I have no branch for" -- not to a ``ValueError`` raised
+    inside the caller's own error handler.
+    """
+    assert rejection_code("some_code_added_next_year") is None
+    with pytest.raises(ValueError):
+        RejectionCode("some_code_added_next_year")
+
+
+@pytest.mark.parametrize("value", [None, 42, b"reaction_mass_balance_failed", {}])
+def test_a_non_string_code_is_none(value: object) -> None:
+    """``exc.code`` is ``str | None``; a missing code is not a crash."""
+    assert rejection_code(value) is None
+
+
+def test_a_known_code_round_trips() -> None:
+    assert rejection_code("reaction_mass_balance_failed") is (
+        RejectionCode.REACTION_MASS_BALANCE_FAILED
+    )
+
+
+def test_the_status_sets_partition_nothing_and_cover_everything() -> None:
+    """Every member is reachable through at least one status.
+
+    Not a partition: a claim enforced both at the wire boundary and by a
+    check constraint reports the same code from both, so the two sets
+    legitimately overlap. What must not happen is a member in neither --
+    a code a client is told about with no indication of what it means for
+    retrying.
+    """
+    covered = VALIDATION_REJECTION_CODES | CONFLICT_REJECTION_CODES
+    orphans = sorted(member.value for member in RejectionCode if member not in covered)
+    assert not orphans, orphans
+    assert VALIDATION_REJECTION_CODES & CONFLICT_REJECTION_CODES, (
+        "No code is enforced at both the wire boundary and in the schema. That "
+        "may be legitimate, but it used to be true of the atom-map checks and "
+        "losing it silently would mean a dual-enforcement claim stopped "
+        "reporting one code from both sites."
+    )
+
+
+def test_the_enum_is_not_empty_and_covers_the_conservation_laws() -> None:
+    """Guard the guard, and pin the entries a client is most likely to branch on."""
+    assert len(RejectionCode) >= 10
+    assert RejectionCode.REACTION_MASS_BALANCE_FAILED in VALIDATION_REJECTION_CODES
+    assert RejectionCode.REACTION_CHARGE_NOT_CONSERVED in VALIDATION_REJECTION_CODES
+    assert RejectionCode.ATOM_MAP_ELEMENT_NOT_CONSERVED in CONFLICT_REJECTION_CODES

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -51,6 +51,14 @@ disagree, this one is right by construction.
 - **Enforced at** — `file::qualified_name` for Python, or the
   constraint/trigger name for PostgreSQL. Database names are verified against live schema metadata by
   `backend/tests/db/test_scientific_check_register.py`, not trusted as strings.
+  Where a constraint names the 409 code it returns, that code is printed with
+  it. A database-held position is the *strongest* guarantee here — no write
+  path can bypass a check constraint — and it used to be the one a client was
+  told least about, because every violation collapsed into its SQLSTATE bucket
+  and arrived as `state_conflict`. The mapping is keyed on the constraint name
+  PostgreSQL reports, never on the driver's message text, and each one is
+  proved by `backend/tests/api/test_api_database_constraint_codes.py`, which
+  provokes the real violation and reads the code out of the response body.
 - **Thresholds** — the numeric lines the check fires on, and *where each number
   comes from*. A constant is fixed in code and printed. A provenance-derived
   threshold is not a number at all: it is resolved per record from the
@@ -90,8 +98,8 @@ disagree, this one is right by construction.
 | `error_envelope` | 17 | the `code` field of the 422 error body — a client can branch on it |
 | `upload_warning` | 9 | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | `trust_label` | 1 | a read-time trust label (`HardFailReason`), not any refusal |
-| `database_constraint` | 0 | PostgreSQL only, so the client sees a generic 409 integrity code rather than this check's name |
-| `none` | 3 | *nothing carries a code* |
+| `database_constraint` | 1 | PostgreSQL only, so the refusal is a 409 rather than a 422 — named, where the constraint declares a rejection code |
+| `none` | 2 | *nothing carries a code* |
 | **total** | **30** | |
 
 ## Recorded divergences
@@ -297,7 +305,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** The stored column is named `is_isomorphic` and the surrounding policy is worded as graph isomorphism, but the code tests the **molecular formula** only. Atom mapping falls back to a SMILES-graph matcher whenever bond perception from XYZ fails, which is the common case for the radicals, ions and stretched geometries this service mostly sees, and that fallback rejects a candidate on one condition: the per-element atom counts disagree. Verified by direct call in the module docstring — ethanol declared with dimethyl ether deposited passes, and methane with one hydrogen pulled to 5 A passes. So the rearrangement, bond-breaking, dissociation and proton-transfer cases the module was written to catch are not caught. Already self-documented in the module docstring rather than discovered here; recorded because the field name is what a consumer sees and it still overstates the guarantee.
 
-*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by a database constraint alone surfaces as a generic integrity conflict, and one held by schema shape or by a stored evidence row never surfaces as a refusal at all.)*
+*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by schema shape, or by a stored evidence row, never surfaces as a refusal at all. A position held by a database constraint no longer belongs here — such a constraint can declare a rejection code and be named in its 409.)*
 
 ## Stationary points
 
@@ -463,6 +471,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
   *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
 - `ck_reaction_atom_map_pair_element_matches` (check on `reaction_atom_map_pair`)
   `upper(element) = upper(ts_element)`
+  Violating this returns **409 `atom_map_element_not_conserved`** — An atom map pairs two atoms of different elements. An atom does not change element on the way across a reaction.
 
 **Escape hatch.** Case is not load-bearing. The comparison is deliberately case-insensitive because the two ends quote two different geometries and nothing guarantees they spell an element the same way — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not. `b4e7c1d20f83` canonicalises the symbol on the way into `geometry_atom.element`, which makes disagreement rare on rows written through the API; it is a convention rather than a constraint, so both the database check and the Python check still normalise instead of assuming it. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
@@ -483,8 +492,10 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
   *Stated twice on purpose: once at the wire boundary, where the payload already holds every XYZ block the rule needs so the refusal arrives as a clean 422 before anything is written, and once as a database constraint, where a second write path cannot get around it.*
 - `uq_reaction_atom_map_pair_ts_atom_index` (unique on `reaction_atom_map_pair`)
   `(atom_map_id, side, ts_atom_index)`
+  Violating this returns **409 `atom_map_not_a_bijection`** — Two atoms of one leg claim the same saddle-point atom. A map is a bijection or it is not a map.
 - `uq_reaction_atom_map_pair_atom_map_id` (unique on `reaction_atom_map_pair`)
   `(atom_map_id, structure_participant_id, atom_index)`
+  Violating this returns **409 `atom_map_not_a_bijection`** — One participant atom is mapped more than once. A map is a bijection or it is not a map.
 
 **Escape hatch.** Per leg, not globally: the reactant and product legs each claim the whole saddle point, which is the point of storing two maps both pointing at it. A `side` column exists on the pair row purely so this can be a unique constraint, because SQL cannot dereference the participant to find its role.
 
@@ -635,8 +646,8 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | Field | Value |
 | --- | --- |
 | **Tier** | `structural` |
-| **Code** | *(none — prose only)* |
-| **Code reaches a client via** | *nothing carries a code* |
+| **Code** | `statmech_subject_not_exactly_one` |
+| **Code reaches a client via** | PostgreSQL only, so the refusal is a 409 rather than a 422 — named, where the constraint declares a rejection code |
 | **Governing ADR** | 0008 |
 
 **Why this tier.** A modelling position rather than an arithmetic bound. Canonical transition state theory needs the saddle point's own partition function, so a transition state has to be a first-class subject of a statmech row. The alternative — encoding a transition state as a pseudo-species — would make every partition function's subject ambiguous and would put saddle points into a kind reserved for lumped and phenomenological constructs that the conservation laws deliberately exempt.
@@ -645,10 +656,9 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 - `ck_statmech_statmech_exactly_one_subject` (check on `statmech`)
   `(species_entry_id IS NULL) <> (transition_state_entry_id IS NULL)`
+  Violating this returns **409 `statmech_subject_not_exactly_one`** — A partition function names both a species entry and a transition-state entry, or neither. It belongs to exactly one subject.
 
 **Escape hatch.** None.
-
-*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by a database constraint alone surfaces as a generic integrity conflict, and one held by schema shape or by a stored evidence row never surfaces as a refusal at all.)*
 
 ## Pressure-dependent networks
 
@@ -667,6 +677,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 - `ck_network_solve_reported_requires_literature` (check on `network_solve`)
   `kind <> 'reported' OR literature_id IS NOT NULL`
+  Violating this returns **409 `network_solve_reported_requires_literature`** — A network solve declared as 'reported' cites no literature. Transcribed rates must name the publication they came from, because nothing else in the deposit accounts for them.
 - `ct_network_solve_computed_evidence` (trigger on `network_solve`)
   `deferred constraint trigger, at COMMIT: a computed solve must hold at least one state energy; at least one energy-transfer model if its network declares a well; at least one channel barrier if its network declares a saddle-point path`
 
@@ -689,6 +700,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 - `ck_network_solve_energy_transfer_scope_columns_agree` (check on `network_solve_energy_transfer`)
   `(scope='per_well' AND state_id IS NOT NULL AND collider_species_entry_id IS NOT NULL) OR (scope='network_wide' AND state_id IS NULL AND collider_species_entry_id IS NULL)`
+  Violating this returns **409 `energy_transfer_scope_columns_disagree`** — A collisional energy-transfer model declares a scope its own columns contradict: a 'per_well' model must name the well and the collider it was determined for, and a 'network_wide' one must name neither.
 
 **Escape hatch.** Declare `scope='network_wide'`. The physics behind the old per-well rule was never in dispute — ⟨ΔE⟩down depends on the density of states of the excited well and on the collider's ability to accept internal energy, so argon and helium do not relax the same well identically. The rule was wrong in practice because it confused what the quantity *is* with what a calculation *determined*: the only way to satisfy it was to paste one number once per well, and the repository's own Arkane ingester did exactly that. Those rows are indistinguishable from independently determined values — a provenance loss manufactured by the validation itself, worse than the gap it closed, because an absent value is honest while a duplicated one is a false positive every consumer will faithfully propagate.
 
@@ -739,7 +751,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by a database constraint alone surfaces as a generic integrity conflict, and one held by schema shape or by a stored evidence row never surfaces as a refusal at all.)*
+*(No machine-readable code reaches anybody for this one. Recorded as a gap rather than invented, because a code nothing carries is a code no client can match on. See the enforcement sites above for why: a position held by schema shape, or by a stored evidence row, never surfaces as a refusal at all. A position held by a database constraint no longer belongs here — such a constraint can declare a rejection code and be named in its 409.)*
 
 ---
 

--- a/integrations/mcp/src/tckdb_mcp/errors.py
+++ b/integrations/mcp/src/tckdb_mcp/errors.py
@@ -2,11 +2,31 @@
 
 Goals:
 
-- Stable, narrow vocabulary of agent-facing error codes.
+- Report the code the *server* chose, and fall back to a stable, narrow
+  status-derived vocabulary only when the server did not choose one.
 - Never leak raw ``httpx`` exception classes.
 - Never embed integer DB IDs in user-facing detail (defensive — the
   backend already enforces this, see
   ``docs/integrity-error-response-hardening-spec.md``).
+
+Why the server's code wins
+--------------------------
+This layer used to derive ``code`` from the HTTP status alone and throw
+away the ``code`` the response body carried. The status is a coarse
+bucket: ``422`` covers every refusal the wire schemas and the scientific
+checks can make, so an agent was told ``invalid_input`` whether its
+geometry disagreed with its SMILES (fix the payload and retry) or its
+reaction did not balance (the deposit is wrong; abort). Both are
+recoverable in different directions, and the whole point of the typed
+envelope is that the difference is a field rather than a sentence to
+grep. Discarding it left an agent string-matching English — over a
+transport whose consumer is a language model, which will do exactly
+that, plausibly, and wrongly.
+
+The status-derived value is not lost; it moves to ``status_class``, so a
+consumer that only wants "was this my fault or theirs" still has one
+field to read, and one that wants to branch on a specific scientific
+refusal now can.
 """
 
 from __future__ import annotations
@@ -43,6 +63,20 @@ class MCPToolError(Exception):
 
     Raised by tools and the HTTP wrapper; the MCP dispatcher renders
     these as ``{"error": {...}}`` text content for the agent.
+
+    :param code: What refused, as specifically as it can be said. The
+        server's own code when the response body carried one, otherwise
+        the status-derived bucket.
+    :param detail: The human sentence, scrubbed.
+    :param http_status: The status, or ``None`` for transport failures.
+    :param status_class: The status-derived bucket, always populated so a
+        consumer that wants the coarse answer never has to re-derive it
+        from ``http_status``. Defaults to ``code``, which is right for
+        errors raised locally: no server chose anything, so the two are
+        the same fact.
+    :param context: Structured facts the server attached to the refusal.
+        Passed through verbatim — see :func:`_scrub` for why this one is
+        deliberately not masked.
     """
 
     def __init__(
@@ -50,17 +84,24 @@ class MCPToolError(Exception):
         code: str,
         detail: str,
         http_status: int | None = None,
+        *,
+        status_class: str | None = None,
+        context: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(f"{code}: {detail}")
         self.code = code
         self.detail = detail
         self.http_status = http_status
+        self.status_class = status_class or code
+        self.context = dict(context or {})
 
     def to_payload(self) -> dict[str, Any]:
         return {
             "code": self.code,
             "detail": self.detail,
             "http_status": self.http_status,
+            "status_class": self.status_class,
+            "context": self.context,
         }
 
 
@@ -69,10 +110,29 @@ def invalid_input(detail: str) -> MCPToolError:
     return MCPToolError("invalid_input", _scrub(detail), http_status=422)
 
 
-def map_http_status(status: int, detail: str) -> MCPToolError:
-    """Map a server HTTP status into an MCPToolError."""
-    code = _HTTP_STATUS_CODES.get(status, "internal_error")
-    return MCPToolError(code, _scrub(detail) or f"HTTP {status}", http_status=status)
+def map_http_status(
+    status: int,
+    detail: str,
+    *,
+    code: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> MCPToolError:
+    """Map a server HTTP response into an MCPToolError.
+
+    :param code: The ``code`` field of the server's error envelope. When
+        present it *is* the reported code — the server knows which of the
+        many refusals a 422 can carry actually fired, and this layer does
+        not. Absent (a legacy body, a proxy's own error page, a
+        non-JSON response), the status-derived bucket stands in.
+    """
+    status_class = _HTTP_STATUS_CODES.get(status, "internal_error")
+    return MCPToolError(
+        code or status_class,
+        _scrub(detail) or f"HTTP {status}",
+        http_status=status,
+        status_class=status_class,
+        context=context,
+    )
 
 
 def map_httpx_exception(exc: BaseException) -> MCPToolError:
@@ -99,7 +159,16 @@ def map_httpx_exception(exc: BaseException) -> MCPToolError:
 
 
 def _scrub(detail: Any) -> str:
-    """Stringify and mask anything that looks like a raw DB id."""
+    """Stringify and mask anything that looks like a raw DB id.
+
+    Applied to ``detail`` only, never to ``context``. ``detail`` is prose,
+    where an id can hide inside a sentence and nothing downstream depends
+    on the exact characters. ``context`` is a typed field the server built
+    deliberately, whose values are the facts an agent is supposed to act
+    on — masking a six-digit number there would corrupt the very thing the
+    field exists to carry (a temperature, a count, a molar mass) to defend
+    against a leak the server is separately guarded against.
+    """
     if detail is None:
         return ""
     if not isinstance(detail, str):

--- a/integrations/mcp/src/tckdb_mcp/http_client.py
+++ b/integrations/mcp/src/tckdb_mcp/http_client.py
@@ -143,8 +143,10 @@ class TCKDBHttpClient:
         if response.is_success:
             return parsed if parsed is not None else {}
 
-        detail = _extract_detail(parsed, response.status_code)
-        raise map_http_status(response.status_code, detail)
+        detail, code, context = _extract_error(parsed, response.status_code)
+        raise map_http_status(
+            response.status_code, detail, code=code, context=context
+        )
 
     def _headers(self) -> dict[str, str]:
         headers = {"Accept": "application/json"}
@@ -202,23 +204,53 @@ def _strip_api_prefix(url: str) -> str:
     return url.rstrip("/")
 
 
-def _extract_detail(parsed: Any, status: int) -> str:
-    """Pull a human-readable detail out of a server error envelope."""
+def _extract_error(
+    parsed: Any, status: int
+) -> tuple[str, str | None, dict[str, Any] | None]:
+    """Pull detail, code and context out of a server error envelope.
+
+    The backend's envelope is ``{code, detail, context}`` on every error
+    path. Reading only ``detail`` — which is what this did — was the
+    single line that undid the typed contract for every MCP consumer: the
+    code was present in the body, parsed, and dropped on the floor one
+    frame before it would have been reported.
+
+    Everything is optional, because not every non-2xx body is ours. A
+    reverse proxy's 502 page and a 404 from a route that does not exist
+    both arrive here, and neither carries a code; those fall back to the
+    status-derived bucket in :func:`map_http_status`.
+    """
+    detail = f"HTTP {status}"
+    code: str | None = None
+    context: dict[str, Any] | None = None
     if isinstance(parsed, dict):
-        d = parsed.get("detail")
-        if isinstance(d, str) and d:
-            return d
-        if isinstance(d, list):
-            return str(d)
-        code = parsed.get("code")
-        if isinstance(code, str) and code:
-            return code
-    return f"HTTP {status}"
+        raw_detail = parsed.get("detail")
+        if isinstance(raw_detail, str) and raw_detail:
+            detail = raw_detail
+        elif isinstance(raw_detail, list):
+            detail = str(raw_detail)
+        raw_code = parsed.get("code")
+        if isinstance(raw_code, str) and raw_code:
+            code = raw_code
+            if detail == f"HTTP {status}":
+                # A body with a code and no usable prose. Saying the code
+                # twice beats saying "HTTP 422" and nothing.
+                detail = raw_code
+        raw_context = parsed.get("context")
+        if isinstance(raw_context, dict) and raw_context:
+            context = raw_context
+    return detail, code, context
 
 
-def raise_for_status(status: int, detail: str) -> MCPToolError:
+def raise_for_status(
+    status: int,
+    detail: str,
+    *,
+    code: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> MCPToolError:
     """Re-export of ``map_http_status`` for callers that build errors directly."""
-    return map_http_status(status, detail)
+    return map_http_status(status, detail, code=code, context=context)
 
 
 __all__ = [

--- a/integrations/mcp/tests/test_error_mapping.py
+++ b/integrations/mcp/tests/test_error_mapping.py
@@ -95,7 +95,80 @@ def test_to_payload_shape() -> None:
         "code": "not_found",
         "detail": "no such ref",
         "http_status": 404,
+        # Nothing chose a code above this error, so the specific and the
+        # coarse answer are the same fact rather than a missing one.
+        "status_class": "not_found",
+        "context": {},
     }
+
+
+def test_to_payload_carries_the_server_code_and_its_context() -> None:
+    err = map_http_status(
+        422,
+        "Reaction is not element-balanced (reaction_mass_balance_failed).",
+        code="reaction_mass_balance_failed",
+        context={"reactant_atoms": {"C": 1, "H": 5}, "product_atoms": {"C": 1, "H": 3}},
+    )
+    payload = err.to_payload()
+    assert payload["code"] == "reaction_mass_balance_failed"
+    assert payload["status_class"] == "invalid_input"
+    assert payload["http_status"] == 422
+    assert payload["context"]["reactant_atoms"] == {"C": 1, "H": 5}
+
+
+@pytest.mark.parametrize(
+    ("status", "status_class"),
+    [(400, "invalid_input"), (404, "not_found"), (409, "conflict"), (422, "invalid_input")],
+)
+def test_a_server_code_always_wins_over_the_status_bucket(
+    status: int, status_class: str
+) -> None:
+    """The status is a bucket; the code is the answer.
+
+    Deriving ``code`` from the status was the defect: every refusal a
+    ``422`` can carry — a bad include token, a geometry that disagrees
+    with its SMILES, a reaction that does not balance — collapsed into
+    one value, and the agent was left grepping English for the
+    difference. The bucket is still reported, under its own name.
+    """
+    err = map_http_status(status, "some detail", code="something_specific")
+    assert err.code == "something_specific"
+    assert err.status_class == status_class
+
+
+def test_two_different_refusals_at_one_status_stay_distinguishable() -> None:
+    """The regression, stated as the property it broke."""
+    first = map_http_status(422, "a", code="species_geometry_composition_mismatch")
+    second = map_http_status(422, "b", code="reaction_mass_balance_failed")
+    assert first.code != second.code
+    assert first.status_class == second.status_class == "invalid_input"
+
+
+def test_a_body_with_no_code_still_falls_back_to_the_status_bucket() -> None:
+    """Not every non-2xx body is ours -- a proxy's 502 page carries nothing."""
+    err = map_http_status(502, "Bad Gateway")
+    assert err.code == "service_unavailable"
+    assert err.status_class == "service_unavailable"
+    assert err.context == {}
+
+
+def test_context_is_not_scrubbed_the_way_detail_is() -> None:
+    """Masking a fact would defeat the field that exists to carry facts.
+
+    ``detail`` is prose and a bare six-digit integer in it might be a row
+    id, so it is masked. ``context`` is typed, deliberate, and its values
+    are what the agent is supposed to act on; a pressure of 1013250 Pa
+    must survive.
+    """
+    err = map_http_status(
+        422,
+        "value 1013250 is out of range",
+        code="value_out_of_range",
+        context={"pressure_pa": 1013250, "note": "1013250"},
+    )
+    assert "1013250" not in err.detail
+    assert err.context["pressure_pa"] == 1013250
+    assert err.context["note"] == "1013250"
 
 
 def test_detail_scrubs_large_integers() -> None:
@@ -110,7 +183,7 @@ def test_detail_scrubs_large_integers() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_http_422_from_server_maps_to_invalid_input() -> None:
+def test_http_422_from_server_reports_the_server_code() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -123,9 +196,108 @@ def test_http_422_from_server_maps_to_invalid_input() -> None:
     client = _client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         species_tool.run(client, Config.from_env(env={}), {"smiles": "CCO"})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "unknown_include_token"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     assert "unknown_include_token" in excinfo.value.detail
+    client.close()
+
+
+def test_a_scientific_refusal_survives_the_whole_wrapper() -> None:
+    """The end-to-end shape of what #115 made possible and this restores.
+
+    Through the real request path, not the mapping function: an agent
+    that deposits an unbalanced reaction is told which scientific rule
+    refused it, and gets the element counts as data rather than as a
+    sentence to parse.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={
+                "code": "reaction_mass_balance_failed",
+                "detail": (
+                    "Reaction is not element-balanced "
+                    "(reaction_mass_balance_failed)."
+                ),
+                "context": {
+                    "reactant_atoms": {"C": 1, "H": 5},
+                    "product_atoms": {"C": 1, "H": 3},
+                },
+            },
+        )
+
+    client = _client(handler)
+    with pytest.raises(MCPToolError) as excinfo:
+        species_tool.run(client, Config.from_env(env={}), {"smiles": "CCO"})
+    err = excinfo.value
+    assert err.code == "reaction_mass_balance_failed"
+    assert err.status_class == "invalid_input"
+    assert err.context["reactant_atoms"] == {"C": 1, "H": 5}
+    client.close()
+
+
+def test_a_named_database_constraint_survives_as_a_conflict() -> None:
+    """A 409 that names its chemistry must not flatten back to ``conflict``.
+
+    The 409 path is the one the backend only just started naming, so it
+    is the one most likely to be dropped again by a wrapper that assumes
+    a conflict is a conflict.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            409,
+            json={
+                "code": "atom_map_element_not_conserved",
+                "detail": (
+                    "An atom map pairs two atoms of different elements. An "
+                    "atom does not change element on the way across a "
+                    "reaction."
+                ),
+                "category": "integrity_error",
+                "context": {"constraint": "ck_reaction_atom_map_pair_element_matches"},
+            },
+        )
+
+    client = _client(handler)
+    with pytest.raises(MCPToolError) as excinfo:
+        species_tool.run(client, Config.from_env(env={}), {"smiles": "CCO"})
+    err = excinfo.value
+    assert err.code == "atom_map_element_not_conserved"
+    assert err.status_class == "conflict"
+    assert err.http_status == 409
+    assert err.context["constraint"] == "ck_reaction_atom_map_pair_element_matches"
+    client.close()
+
+
+def test_a_body_that_carries_only_a_code_still_says_something() -> None:
+    """No prose is not the same as no information."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json={"code": "unsupported_filter"})
+
+    client = _client(handler)
+    with pytest.raises(MCPToolError) as excinfo:
+        species_tool.run(client, Config.from_env(env={}), {"smiles": "CCO"})
+    assert excinfo.value.code == "unsupported_filter"
+    assert excinfo.value.detail == "unsupported_filter"
+    client.close()
+
+
+def test_a_non_json_error_page_degrades_to_the_status_bucket() -> None:
+    """An nginx 502 has no envelope; the wrapper must not require one."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="<html>502 Bad Gateway</html>")
+
+    client = _client(handler)
+    with pytest.raises(MCPToolError) as excinfo:
+        species_tool.run(client, Config.from_env(env={}), {"smiles": "CCO"})
+    assert excinfo.value.code == "service_unavailable"
+    assert excinfo.value.status_class == "service_unavailable"
+    assert excinfo.value.context == {}
     client.close()
 
 

--- a/integrations/mcp/tests/test_geometry_tool.py
+++ b/integrations/mcp/tests/test_geometry_tool.py
@@ -316,7 +316,8 @@ def test_rejects_non_list_include() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -329,7 +330,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         geom_tool.run(client, {"geometry_ref": VALID_REF})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "handle_type_mismatch"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 

--- a/integrations/mcp/tests/test_kinetics_search_tool.py
+++ b/integrations/mcp/tests/test_kinetics_search_tool.py
@@ -765,7 +765,8 @@ def test_software_forwarded() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -778,7 +779,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         ks_tool.run(client, _cfg(), {"family": "H_Abstraction"})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "missing_identifier"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 

--- a/integrations/mcp/tests/test_reaction_full_tool.py
+++ b/integrations/mcp/tests/test_reaction_full_tool.py
@@ -396,7 +396,8 @@ def test_review_filters_serialize_as_lowercase_strings() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -409,7 +410,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         rf_tool.run(client, {"reaction_entry_ref": VALID_REF})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "handle_type_mismatch"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 

--- a/integrations/mcp/tests/test_reaction_kinetics_tool.py
+++ b/integrations/mcp/tests/test_reaction_kinetics_tool.py
@@ -514,7 +514,8 @@ def test_review_filters_forwarded_as_lowercase_strings() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -527,7 +528,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         rk_tool.run(client, _cfg(), {"reaction_entry_ref": VALID_REF})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "handle_type_mismatch"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 

--- a/integrations/mcp/tests/test_reactions_tool.py
+++ b/integrations/mcp/tests/test_reactions_tool.py
@@ -419,7 +419,8 @@ def test_envelope_returned_unchanged() -> None:
     client.close()
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -432,7 +433,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         reactions_tool.run(client, _cfg(), {"family": "H_Abstraction"})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "post_search_fields_must_be_in_body"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 

--- a/integrations/mcp/tests/test_species_thermo_tool.py
+++ b/integrations/mcp/tests/test_species_thermo_tool.py
@@ -539,7 +539,8 @@ def test_review_filters_serialize_as_lowercase_strings() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -552,7 +553,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         st_tool.run(client, _cfg(), {"species_entry_ref": VALID_REF})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "handle_type_mismatch"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 

--- a/integrations/mcp/tests/test_thermo_search_tool.py
+++ b/integrations/mcp/tests/test_thermo_search_tool.py
@@ -584,7 +584,8 @@ def test_software_forwarded() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_server_422_maps_to_invalid_input() -> None:
+def test_server_422_reports_the_server_code() -> None:
+    """The server said which refusal it was; the agent is told that."""
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             422,
@@ -597,7 +598,8 @@ def test_server_422_maps_to_invalid_input() -> None:
     client = _make_client(handler)
     with pytest.raises(MCPToolError) as excinfo:
         ts_tool.run(client, _cfg(), {"smiles": "CCO"})
-    assert excinfo.value.code == "invalid_input"
+    assert excinfo.value.code == "missing_identifier"
+    assert excinfo.value.status_class == "invalid_input"
     assert excinfo.value.http_status == 422
     client.close()
 


### PR DESCRIPTION
Four changes, four commits, one theme: **a client can tell one refusal from another.** #115 built the typed `{code, detail, context}` envelope; the codes then stopped at the server. Each consumer surface either discarded them, never had them, or never got them in the first place. #67 is the adjacent question of what the read layer is *allowed* to say, and shares the files.

## What a client can now distinguish

### A database-held scientific rule (#66)

A check constraint is the strongest guarantee TCKDB makes — no write path, no bulk loader and no future service can bypass it — and it was the one a client learned least from. `_integrity_error_handler` classified every violation by SQLSTATE, so "an atom changed element on the way across this reaction" and "a required column was null" were the same response.

**Before**

```json
{ "detail": "Request violates a consistency rule.",
  "code": "state_conflict", "category": "integrity_error", "context": {} }
```

**After**

```json
{ "detail": "An atom map pairs two atoms of different elements. An atom does not change element on the way across a reaction.",
  "code": "atom_map_element_not_conserved",
  "category": "integrity_error",
  "context": { "constraint": "ck_reaction_atom_map_pair_element_matches" } }
```

Six constraints are named. The three atom-map ones reuse the code the wire check already raises — one claim, two enforcement sites, so a client that handles `atom_map_element_not_conserved` from a 422 handles it unchanged when a different write path reaches the database first. The `context.constraint` is the key into `docs/guides/scientific_check_register.md`, not a row id.

The mapping is **derived from the register**, not written in the handler. A second table would be a second thing to keep in step with the schema; a derived one means a constraint renamed in a migration fails the existing `pg_constraint` guard rather than silently downgrading its refusal.

`DatabaseConstraint` refuses a rejection code for a kind PostgreSQL does not name — measured, not assumed: a NOT NULL violation reports `constraint_name = None`.

### The same refusal over MCP (#65)

`map_http_status` derived `code` from the HTTP status and dropped the body's own `code` one frame after parsing it. Every refusal reached an agent as `invalid_input`.

**Before** — `{"code": "invalid_input", "detail": "Reaction is not element-balanced (reaction_mass_balance_failed).", "http_status": 422}`

**After** — `{"code": "reaction_mass_balance_failed", "status_class": "invalid_input", "http_status": 422, "context": {"reactant_atoms": {"C": 1, "H": 5}, "product_atoms": {"C": 1, "H": 3}}}`

The status-derived bucket is not lost, it moves to `status_class`. `context` now survives too — #115 lifted structured facts there precisely so a consumer would not parse prose. `context` is deliberately **not** run through `_scrub`: `detail` is prose where a six-digit integer might be a row id, while `context` values are the facts an agent acts on, and masking a pressure or a count to defend against a leak the server separately guards is a bad trade.

Nine tests asserted the old behaviour — each built a body carrying a specific code and asserted it was discarded. All nine now assert the specific code *and* the bucket.

**The MCP package had no CI job at all.** Added one to the API gate; it needs no database and no extra install.

### Codes a client can name (#68)

`tckdb_client.RejectionCode`, generated from the register. Without it, ARC transcribes strings by hand, and a wrong hard-coded code does not fail — it simply never matches.

```python
match rejection_code(exc.code):
    case RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH: payload = repair(payload)
    case RejectionCode.REACTION_MASS_BALANCE_FAILED: raise
    case None: raise
```

22 members, split into `VALIDATION_REJECTION_CODES` (422) and `CONFLICT_REJECTION_CODES` (409). `rejection_code()` returns `None` for an unknown code, because a server is routinely newer than the client pinned against it and a new code must not raise inside the caller's own error handler.

Per #119's lesson, the generated file carries **codes and statuses and nothing else** — no prose, no anchors, no counts. A test asserts it names no line numbers and no module paths, so the gate cannot regress into firing on a moved line. Client 0.33.0 -> 0.34.0.

## Row ids out of user-facing text (#67)

55 sites. The guard matters more than the sweep, so it is an AST shape check, not a text search: an id-shaped expression interpolated into a call that builds a refusal or a response field.

The one that was a genuine **disclosure**: `handles.reconcile_id_ref` answered a mismatched `*_id`/`*_ref` pair with `(ref -> id={resolved})`. Supply a public ref and any wrong id and the 422 handed back the real row id — the mapping `internal_ids` exists to withhold, given away by a refusal nobody thought of as an oracle. Four more were on the **success** path: `lookup`'s `MatchDetail` wrote `calculation {id}` into 200 bodies.

The rest is the 404 cluster. `app.api.errors.not_found` is now the single place that decides what a 404 may say: names the resource, echoes a public ref the caller supplied, logs the row id for the operator — the only party it was ever useful to.

What the guard cannot catch is stated in its docstring: a message built into a variable first, `%`/`.format`, and an id-valued expression whose name does not look like one. It makes the *obvious* way to write the mistake fail, which is the shape it has taken every time.

## Gates

| gate | result |
|---|---|
| `test-api.sh` | **2516 passed** (2497 at `8293d4e`, +19 new) |
| `test-scientific.sh` | **1983 passed** (unchanged) |
| `test-full.sh` | **6671 passed, 14 skipped** |
| Python client | **1347 passed** |
| MCP | **578 passed** (566 before) |
| `ruff` / `mypy` | clean / 146 files clean |
| `alembic check` | no new upgrade operations (no migration in this PR) |

No test was weakened, skipped, xfailed or deleted. Eleven had their assertions **strengthened** to the new contract.

Measuring these needed `DB_TEST_NAME` set — see the first candidate follow-up.

## Candidate follow-ups

- **`backend/tests/conftest.py:118`** — `_resolve_test_db_name` derives per-worker names as `tckdb_test_gw0..gw7`, which are not unique to a *run*. Two concurrent pytest runs on one host silently share and race to drop/create the same eight databases. Observed here: a gate run reported `2305 errors` purely because another checkout was running its suite, and the same commit gave `2516 passed` once `DB_TEST_NAME` was set. No gate script sets it. A pid or run-id component would make this impossible.
- **`backend/scripts/test-api.sh:27` / `test-scientific.sh:12`** — between them the two gates run `tests/api/`, `tests/api/scientific/` and `tests/services/scientific_read/`. `tests/services/`, `tests/db/`, `tests/workflows/` and `tests/integration/` are in **neither**. Two real failures in this branch were invisible to both and only surfaced under `test-full.sh`. CI's definition of green excludes roughly a third of the suite.
- **`backend/app/services/reproducibility_rubric.py:216`** — `record_ref` falls back to `f"{record_type.value}:{target.id}"` when the row has no public ref, and that string is **stored** in an append-only assessment served through the public API. A durable leak rather than a transient one, and out of scope here because the honest fix has to decide what an audit snapshot may identify a row by, and whether existing rows are backfilled.
- **`backend/app/services/machine_review/curator_task_lifecycle.py`** — row ids participate in the stored `context_hash`. Changing them invalidates existing rows, so it needs a migration decision, not an edit.
- **`backend/app/scientific_checks/declarations.py`** — three atom-map foreign keys (`fk_reaction_atom_map_pair_geometry_id_geometry_atom` and siblings) enforce ADR 0011's geometry-relative indexing and are still unnamed. Left out because `SET LOCAL session_replication_role = replica` — how the proof provokes the other constraints without building valid parent rows — suspends exactly the FK triggers that would need to fire, so they cannot be proved by the same mechanism.
- **`backend/app/scientific_checks/declarations.py`** — `ct_network_solve_computed_evidence` is a deferred constraint trigger. Whether its `RAISE` populates `diag.constraint_name` is a property of the trigger function, not of the SQLSTATE class, so naming it needs the migration's PL/pgSQL read first.
- **`backend/app/services/contribution_bundle_export.py:191`** and **`backend/app/services/cccbdb_molecular_property_import.py`** — interpolate row ids into `RuntimeError`/`ValueError`. Not caught by the guard because they raise types that are not registered exception handlers. Believed CLI-only; worth confirming no route path reaches them before either sweeping or allowlisting.
- **`integrations/mcp/src/tckdb_mcp/server.py`** — no test imports it, which is why the whole MCP suite passes without the `mcp` package installed. The new CI job inherits that blind spot.
- **`clients/python/src/tckdb_client/rejection_codes.py`** — `upload_warning` codes are deliberately excluded. A consumer that wants to branch on warnings attached to an *accepted* upload still hard-codes those strings; a second generated enum would close it.