### PR TITLE
Stop the deployment from breaking in ways nothing reports

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -139,6 +139,8 @@ jobs:
           bash -n backend/scripts/test-full.sh
           bash -n backend/scripts/test-profile.sh
           bash -n backend/scripts/update-openapi-golden.sh
+          bash -n backend/scripts/ops/tckdb_alert_check.sh
+          bash -n backend/scripts/ops/tckdb_deploy.sh
           make help
 
       - name: Alembic upgrade head
@@ -191,6 +193,16 @@ jobs:
         if: matrix.gate == 'api'
         working-directory: backend
         run: conda run -n tckdb_env pytest tests/api/test_openapi_snapshot.py -q
+
+      - name: Ops script gate
+        if: matrix.gate == 'api'
+        working-directory: backend
+        # tests/ops/ is outside tests/api/, so neither test-api.sh nor
+        # test-scientific.sh reaches it and it would otherwise only run
+        # nightly. These cover the alerting path -- the one part of the
+        # deployment whose failure produces silence rather than an error --
+        # so they need to gate the PR that breaks them, not the night after.
+        run: conda run -n tckdb_env pytest tests/ops/ -q
 
       - name: API test gate
         if: matrix.gate == 'api'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,6 +43,14 @@ jobs:
           POSTGRES_USER: tckdb
           POSTGRES_PASSWORD: tckdb
           POSTGRES_DB: tckdb_${{ matrix.gate }}_ci
+          # Same pin as docker-compose.yml, for the same reason. This image
+          # sets no locale, so initdb falls back to SQL_ASCII -- which is what
+          # CI has silently been running on. A cluster that validates nothing
+          # cannot fail on a byte it should reject, so the entire suite was
+          # structurally incapable of catching an encoding bug, and every test
+          # databases the harness creates inherits the cluster's encoding.
+          LANG: C.UTF-8
+          POSTGRES_INITDB_ARGS: "--encoding=UTF8"
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -123,6 +123,16 @@ jobs:
         working-directory: backend
         run: conda run -n tckdb_env ruff check app tests scripts
 
+      - name: Lint (non-ASCII in runtime strings)
+        if: matrix.gate == 'api'
+        working-directory: backend
+        # Narrower than ruff's RUF001-003, which this repo disables on
+        # purpose because scientific notation is legitimate prose. This one
+        # looks only at strings that leave the process -- raises, log calls,
+        # message=/detail=/reason= -- and covers app/ and scripts/ but not
+        # tests/, where non-ASCII data is the point. See the script's header.
+        run: conda run -n tckdb_env python scripts/check_runtime_ascii.py
+
       - name: Type check (mypy, scoped)
         if: matrix.gate == 'api'
         working-directory: backend
@@ -194,15 +204,20 @@ jobs:
         working-directory: backend
         run: conda run -n tckdb_env pytest tests/api/test_openapi_snapshot.py -q
 
-      - name: Ops script gate
+      - name: Ops and repo-check gate
         if: matrix.gate == 'api'
         working-directory: backend
-        # tests/ops/ is outside tests/api/, so neither test-api.sh nor
-        # test-scientific.sh reaches it and it would otherwise only run
-        # nightly. These cover the alerting path -- the one part of the
+        # Neither of these lives under tests/api/, so neither test-api.sh nor
+        # test-scientific.sh reaches them and they would otherwise only run
+        # nightly. tests/ops/ covers the alerting path -- the one part of the
         # deployment whose failure produces silence rather than an error --
-        # so they need to gate the PR that breaks them, not the night after.
-        run: conda run -n tckdb_env pytest tests/ops/ -q
+        # and the ASCII test pins the lint's boundary, which is the part that
+        # decides whether anyone leaves it switched on. Both need to gate the
+        # PR that breaks them, not the night after.
+        run: >-
+          conda run -n tckdb_env pytest -q
+          tests/ops/
+          tests/scripts/test_check_runtime_ascii.py
 
       - name: API test gate
         if: matrix.gate == 'api'

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -72,14 +72,27 @@ jobs:
             detail="The deployment answered but could not report its own health. A 404 usually means a build without /status; a 5xx means the API is failing before it can respond."
           else
             state="$(jq -r '.status // "unparseable"' <<<"$body")"
-            if [ "$state" = "ok" ]; then
+            degraded="$(jq -r '(.degraded // []) | join(", ")' <<<"$body")"
+            reasons="$(jq -r '[.components // {} | to_entries[] | select(.value.healthy == false) | "\(.key): \(.value.reason // "unhealthy")"] | join("; ")' <<<"$body")"
+
+            # Both fields decide. They derive from the same set of unhealthy
+            # components today, so reading only `status` works today -- and
+            # would keep "working", silently, the moment that stops being
+            # true. A monitor that passes on a summary field while the
+            # components below it say otherwise is the exact failure mode
+            # this deployment has already had once.
+            if [ "$state" = "ok" ] && [ -z "$degraded" ]; then
               echo "TCKDB ok"
               exit 0
             fi
-            degraded="$(jq -r '(.degraded // []) | join(", ")' <<<"$body")"
-            reasons="$(jq -r '[.components // {} | to_entries[] | select(.value.healthy == false) | "\(.key): \(.value.reason // "unhealthy")"] | join("; ")' <<<"$body")"
-            summary="TCKDB is degraded (${degraded:-unknown})."
-            detail="${reasons:-no reason reported}"
+
+            if [ "$state" = "ok" ]; then
+              summary="TCKDB reports status=ok while listing degraded components (${degraded})."
+              detail="The endpoint is contradicting itself. Treat the components as authoritative: ${reasons:-no reason reported}"
+            else
+              summary="TCKDB is degraded (${degraded:-unknown})."
+              detail="${reasons:-no reason reported}"
+            fi
           fi
 
           echo "::error::${summary}"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,6 +39,37 @@ RUN micromamba install -y -n base -f /tmp/environment.yml \
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # ---------------------------------------------------------------------------
+# Text encoding, pinned in the image rather than per deployment.
+#
+# On 2026-08-04 an em dash in a warning message rolled back an entire upload
+# against a SQL_ASCII database. The database has since been converted, but the
+# encoding a deployment ends up with was a property of whoever created the
+# volume and whatever the base image happened to set -- i.e. not a property of
+# this repository at all, and so not one anybody could verify.
+#
+# This is the only place that covers every consumer at once: the API and the
+# migration container started by scripts/ops/tckdb_deploy.sh, the compose
+# `worker` service, and the smoke runs in .github/workflows/build-api-image.yml.
+# Setting it per docker-run invocation instead would mean four places to keep
+# in step, and the one that drifts is the one nobody notices.
+#
+#   LANG / LC_ALL     debian-slim ships no locale, so Python's filesystem and
+#                     stdio encodings would otherwise be derived from a POSIX
+#                     default. C.UTF-8 is built into glibc and needs no
+#                     locale-gen.
+#   PYTHONIOENCODING  a non-ASCII character reaching a log line must not raise
+#                     UnicodeEncodeError. Crashing on the way to *reporting* a
+#                     problem is the worst available failure.
+#   PGCLIENTENCODING  belt to the braces of ?client_encoding=utf8 in the URL
+#                     that app/api/config.py and alembic/env.py both build; it
+#                     also covers psql and pg_dump run inside this image.
+# ---------------------------------------------------------------------------
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONIOENCODING=utf-8 \
+    PGCLIENTENCODING=UTF8
+
+# ---------------------------------------------------------------------------
 # 2. The shared schemas package and the backend package. Installed with
 #    --no-deps because conda already provides every runtime dependency; this
 #    is the recommended conda-then-pip pattern (avoids pip clobbering conda

--- a/backend/app/api/app.py
+++ b/backend/app/api/app.py
@@ -17,6 +17,7 @@ from app.api.request_id import RequestIDMiddleware
 from app.api.router import api_router
 from app.api.startup_checks import (
     report_artifact_storage_at_startup,
+    report_database_encoding_at_startup,
     validate_deployment_safety,
 )
 
@@ -30,22 +31,26 @@ async def _lifespan(app: FastAPI):
     (``python -m app.workers.upload_worker``), which is recommended for
     production.
 
-    The artifact-storage probe writes one line into the container log at
-    boot. A misconfigured object store is invisible until someone tries an
-    artifact-bearing upload and gets a 503, and it is fully detectable from
-    the first second of the process's life. It never blocks or fails
-    startup — see :func:`report_artifact_storage_at_startup`.
+    Two boot-time probes write one line each into the container log. Both
+    describe faults that are fully detectable from the process's first
+    second and were previously invisible until something downstream broke:
+    an object store that cannot be reached (503 on the first
+    artifact-bearing upload) and a database cluster that is not UTF-8 (an
+    aborted transaction on the first non-ASCII character). Neither blocks
+    or fails startup — see :mod:`app.api.startup_checks`.
     """
     if os.getenv("TCKDB_INLINE_WORKER", "false").lower() == "true":
         from app.workers.upload_worker import run_worker_thread
         run_worker_thread()
 
     # Opt-out for test fixtures and offline dev, which build the app hundreds
-    # of times and have no object store to reach. Defaults to on, because the
+    # of times and have neither an object store to reach nor a reason to
+    # re-check one cluster's encoding per test. Defaults to on, because the
     # deployment that needs this most is the one nobody remembered to
     # configure.
-    if os.getenv("TCKDB_STARTUP_STORAGE_PROBE", "true").lower() == "true":
+    if os.getenv("TCKDB_STARTUP_PROBES", "true").lower() == "true":
         report_artifact_storage_at_startup()
+        report_database_encoding_at_startup()
 
     yield
 

--- a/backend/app/api/app.py
+++ b/backend/app/api/app.py
@@ -15,21 +15,37 @@ from app.api.public_openapi import install_hosted_openapi
 from app.api.rate_limit import RateLimitMiddleware
 from app.api.request_id import RequestIDMiddleware
 from app.api.router import api_router
-from app.api.startup_checks import validate_deployment_safety
+from app.api.startup_checks import (
+    report_artifact_storage_at_startup,
+    validate_deployment_safety,
+)
 
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    """Start the inline upload worker thread when opted in via env var.
+    """Start the inline upload worker, and report on hard dependencies.
 
     Set ``TCKDB_INLINE_WORKER=true`` to run a worker inside the API process.
     The default is ``false`` — run the worker as a separate process instead
     (``python -m app.workers.upload_worker``), which is recommended for
     production.
+
+    The artifact-storage probe writes one line into the container log at
+    boot. A misconfigured object store is invisible until someone tries an
+    artifact-bearing upload and gets a 503, and it is fully detectable from
+    the first second of the process's life. It never blocks or fails
+    startup — see :func:`report_artifact_storage_at_startup`.
     """
     if os.getenv("TCKDB_INLINE_WORKER", "false").lower() == "true":
         from app.workers.upload_worker import run_worker_thread
         run_worker_thread()
+
+    # Opt-out for test fixtures and offline dev, which build the app hundreds
+    # of times and have no object store to reach. Defaults to on, because the
+    # deployment that needs this most is the one nobody remembered to
+    # configure.
+    if os.getenv("TCKDB_STARTUP_STORAGE_PROBE", "true").lower() == "true":
+        report_artifact_storage_at_startup()
 
     yield
 

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -38,6 +38,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.api.deps import SessionLocal
+from app.api.startup_checks import server_encoding
 from app.services import artifact_storage
 
 router = APIRouter()
@@ -430,6 +431,7 @@ def status():
             components["database"] = {
                 "healthy": False,
                 "alembic_revision": None,
+                "server_encoding": None,
                 "reason": "database unreachable",
             }
         else:
@@ -440,9 +442,18 @@ def status():
             except SQLAlchemyError as exc:
                 logger.warning("status: alembic_version lookup failed: %r", exc)
                 revision = None
+            # Reported, not judged. A non-UTF8 cluster is a real hazard --
+            # SQL_ASCII validates nothing and aborts on the first byte it
+            # cannot handle -- but it is a permanent property of the cluster
+            # that only a dump and restore can change, so degrading /status
+            # on it would nag every five minutes about something no restart
+            # can fix. Startup logs it as an error once, which is the right
+            # loudness; this makes it answerable from outside, which is what
+            # turns "uploads sometimes fail" into a five-second diagnosis.
             components["database"] = {
                 "healthy": revision is not None,
                 "alembic_revision": revision,
+                "server_encoding": server_encoding(session),
                 "reason": (
                     None
                     if revision is not None

--- a/backend/app/api/startup_checks.py
+++ b/backend/app/api/startup_checks.py
@@ -19,7 +19,11 @@ upstream" — those remain in the pre-flight checklist.
 
 from __future__ import annotations
 
+import logging
+
 from app.api.config import Settings
+
+logger = logging.getLogger(__name__)
 
 
 class UnsafeDeploymentConfigError(RuntimeError):
@@ -93,3 +97,68 @@ def validate_deployment_safety(settings: Settings) -> None:
     violations = _collect_violations(settings)
     if violations:
         raise UnsafeDeploymentConfigError(mode, violations)
+
+
+def report_artifact_storage_at_startup() -> dict:
+    """Probe the object store once at boot and say so in the log.
+
+    **Why at startup and not only on ``/status``.** On 2026-08-05 the
+    containerised API ran with ``S3_ENDPOINT_URL=http://127.0.0.1:9000``
+    inherited from the earlier host deployment, where inside a container
+    that is the container's own loopback. Every artifact-bearing upload
+    returned 503 for as long as it took someone to try one. The
+    misconfiguration was present and detectable from the first second of
+    the process's life, and nothing looked.
+
+    The first place an operator looks after a deploy is ``docker logs
+    tckdb-api`` — the deploy script's own failure message says exactly
+    that — so this writes one unmissable line there, naming the endpoint
+    and bucket that were tried. ``/status`` still answers the same
+    question on demand; this answers it before anyone asks.
+
+    **It does not refuse to boot.** With the object store down, reads,
+    queries, and uploads without attached files all still work, so
+    exiting would replace a partial outage with a total one — the same
+    reasoning that keeps artifact storage out of ``/readyz``. The probe
+    inherits ``/status``'s hard wall-clock deadline, so an unreachable
+    endpoint delays startup by a bounded few seconds and never hangs it.
+
+    Returns the same block ``/status`` reports, so a caller (and a test)
+    can assert on it rather than scrape the log.
+    """
+    # Imported here rather than at module scope: this module is imported by
+    # the application factory before the router exists, and the routes
+    # package pulls in the whole dependency graph.
+    from app.api.routes.health import _artifact_storage_status
+
+    try:
+        block = _artifact_storage_status()
+    except Exception as exc:  # pragma: no cover - defensive
+        # A probe that raises must not take the process with it. Boot-time
+        # diagnostics exist to make failures visible, not to create one.
+        logger.error(
+            "startup: artifact storage probe raised %s; continuing to boot",
+            type(exc).__name__,
+        )
+        return {"healthy": None, "reason": f"probe raised {type(exc).__name__}"}
+
+    if block.get("healthy") is True:
+        logger.info(
+            "startup: artifact storage ok (endpoint=%s bucket=%s)",
+            block.get("endpoint"),
+            block.get("bucket"),
+        )
+    else:
+        logger.error(
+            "startup: ARTIFACT STORAGE UNAVAILABLE - endpoint=%s bucket=%s "
+            "reachable=%s reason=%s. Artifact-bearing uploads will fail with "
+            "503 until this is fixed; reads and queries are unaffected. This "
+            "is usually S3_ENDPOINT_URL in the deployment's env file - note "
+            "that 127.0.0.1 inside a container is the container's own "
+            "loopback, not the host's.",
+            block.get("endpoint"),
+            block.get("bucket"),
+            block.get("reachable"),
+            block.get("reason"),
+        )
+    return block

--- a/backend/app/api/startup_checks.py
+++ b/backend/app/api/startup_checks.py
@@ -99,6 +99,73 @@ def validate_deployment_safety(settings: Settings) -> None:
         raise UnsafeDeploymentConfigError(mode, violations)
 
 
+#: The only encoding this deployment is designed for. Anything else stores
+#: bytes without validating them (``SQL_ASCII``) or silently transcodes.
+EXPECTED_SERVER_ENCODING = "UTF8"
+
+
+def server_encoding(session) -> str | None:
+    """Return the connected cluster's ``server_encoding``, or None."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import SQLAlchemyError
+
+    try:
+        return session.execute(text("SHOW server_encoding")).scalar_one_or_none()
+    except SQLAlchemyError:
+        return None
+
+
+def report_database_encoding_at_startup() -> str | None:
+    """Check the cluster's encoding at boot and say so if it is wrong.
+
+    The encoding a deployment gets is fixed at ``initdb`` and cannot be
+    changed afterwards without a dump and restore, so it is not something
+    the application can fix — but it is something it can refuse to be
+    quiet about. ``docker-compose.yml`` now pins ``--encoding=UTF8``; a
+    pin that nothing verifies is a wish, and clusters created before it,
+    or by hand, or by a different compose file, are still out there.
+
+    A ``SQL_ASCII`` cluster stores whatever bytes it is handed and
+    validates nothing, so the damage is delayed and arbitrary: everything
+    works until the first non-ASCII character arrives, which is how one
+    em dash came to roll back an entire upload on 2026-08-04, months
+    after the volume was created.
+
+    Does not raise. The database being unreachable at boot is normal --
+    the API may legitimately start before Postgres accepts connections --
+    and is reported at ``debug``, not as a fault.
+    """
+    from app.api.deps import SessionLocal
+
+    session = SessionLocal()
+    try:
+        encoding = server_encoding(session)
+    finally:
+        session.close()
+
+    if encoding is None:
+        logger.debug(
+            "startup: database not reachable yet; server_encoding unchecked"
+        )
+        return None
+    if encoding.upper() == EXPECTED_SERVER_ENCODING:
+        logger.info("startup: database server_encoding=%s", encoding)
+    else:
+        logger.error(
+            "startup: DATABASE SERVER_ENCODING IS %s, EXPECTED %s. This "
+            "cluster does not validate the bytes it stores, and any "
+            "non-ASCII character in any value -- including one in an error "
+            "or warning message -- can abort the transaction that carries "
+            "it. The encoding is fixed at initdb and cannot be altered in "
+            "place: it needs a dump, a cluster created with "
+            "--encoding=UTF8, and a restore. See "
+            "docs/deployment/troubleshooting.md.",
+            encoding,
+            EXPECTED_SERVER_ENCODING,
+        )
+    return encoding
+
+
 def report_artifact_storage_at_startup() -> dict:
     """Probe the object store once at boot and say so in the log.
 

--- a/backend/app/importers/cccbdb/builders/statmech_payload.py
+++ b/backend/app/importers/cccbdb/builders/statmech_payload.py
@@ -100,7 +100,7 @@ def build_statmech_payload(
         warnings.append(
             "statmech: rotational constants mapped to "
             "statmech.rotational_constant_{a,b,c}_cm1 (converted "
-            "GHz→cm⁻¹); raw GHz values and reference preserved in "
+            "GHz to cm-1); raw GHz values and reference preserved in "
             "external_source.unparsed.statmech_rotational_constants"
         )
 

--- a/backend/app/services/hessian_extraction.py
+++ b/backend/app/services/hessian_extraction.py
@@ -188,7 +188,7 @@ def _resolve_input_geometry_id(
     if geometry.natoms != parsed.natoms:
         logger.info(
             "hessian extraction skipped: input geometry has %d atoms but the "
-            "parsed matrix implies %d — refusing to bind a mismatched Hessian",
+            "parsed matrix implies %d -- refusing to bind a mismatched Hessian",
             geometry.natoms,
             parsed.natoms,
         )
@@ -202,7 +202,7 @@ def _resolve_input_geometry_id(
         if not _frame_matches(session, geometry_id, parsed.reference_coords_angstrom):
             logger.info(
                 "hessian extraction skipped: the artifact's atomic frame does "
-                "not match the bound input geometry — refusing to bind a "
+                "not match the bound input geometry -- refusing to bind a "
                 "Hessian computed at a different geometry/orientation"
             )
             return None

--- a/backend/app/services/provenance_warnings.py
+++ b/backend/app/services/provenance_warnings.py
@@ -473,7 +473,7 @@ def collect_network_energy_transfer_warnings(solve) -> list[UploadWarning]:
                 message=(
                     "Collisional energy transfer was declared once for the "
                     f"whole network and applied to {wells} and to the bath "
-                    "gas as a whole. <dE>down is a property of a (well, "
+                    "gas as a whole. <DeltaE>down is a property of a (well, "
                     "collider) pair, so this record does not resolve how it "
                     "varies between wells; that variation was not determined "
                     "by the run. Per-well declarations are preferred where "

--- a/backend/app/services/provenance_warnings.py
+++ b/backend/app/services/provenance_warnings.py
@@ -424,9 +424,9 @@ def collect_network_solve_kind_warnings(solve) -> list[UploadWarning]:
             code=W_REPORTED_NETWORK_SOLVE,
             message=(
                 "These k(T,P) were transcribed from a publication, not "
-                "derived here. The master-equation inputs behind them — state "
+                "derived here. The master-equation inputs behind them -- state "
                 "energies, channel barriers and the collisional "
-                "energy-transfer model — are not in this database, so the "
+                "energy-transfer model -- are not in this database, so the "
                 "rates cannot be re-derived, the fit cannot be checked, and "
                 "the network cannot be re-solved outside the reported "
                 "temperature and pressure range. The values are as "
@@ -473,7 +473,7 @@ def collect_network_energy_transfer_warnings(solve) -> list[UploadWarning]:
                 message=(
                     "Collisional energy transfer was declared once for the "
                     f"whole network and applied to {wells} and to the bath "
-                    "gas as a whole. ⟨ΔE⟩down is a property of a (well, "
+                    "gas as a whole. <dE>down is a property of a (well, "
                     "collider) pair, so this record does not resolve how it "
                     "varies between wells; that variation was not determined "
                     "by the run. Per-well declarations are preferred where "

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -359,9 +359,9 @@ def validate_reaction_charge_conservation(
             "is conserved across a reaction, so the two sides describe "
             "different numbers of electrons and cannot be the same reaction. "
             "A net charge is fine as long as both sides carry the same one. If "
-            "the process genuinely releases or consumes a free electron — "
+            "the process genuinely releases or consumes a free electron -- "
             "associative or dissociative attachment, photoionization, "
-            "photodetachment — declare the electron as a participant: "
+            "photodetachment -- declare the electron as a participant: "
             '{"molecule_kind": "electron", "smiles": "[e-]", "charge": -1, '
             '"multiplicity": 2}. It balances the charge and still leaves the '
             "elemental balance to be satisfied on its own terms.",

--- a/backend/app/services/record_review.py
+++ b/backend/app/services/record_review.py
@@ -141,7 +141,7 @@ def _check_transition_allowed(
     allowed = _ALLOWED_TRANSITIONS.get(from_status, frozenset())
     if to_status not in allowed:
         raise DomainError(
-            f"Disallowed record-review transition: {from_status.value} → "
+            f"Disallowed record-review transition: {from_status.value} -> "
             f"{to_status.value} (route through 'under_review' instead)."
         )
 

--- a/backend/app/services/release/curation.py
+++ b/backend/app/services/release/curation.py
@@ -205,7 +205,7 @@ def _assert_standing_selections_still_approved(
         except ReleaseCurationError as exc:
             raise ReleaseCurationError(
                 f"selection_no_longer_approved: selection {row.public_ref} can no "
-                f"longer be published — {exc}"
+                f"longer be published -- {exc}"
             ) from exc
 
 
@@ -463,7 +463,7 @@ def add_selection(
         raise ReleaseCurationError(
             "selection_already_stands: this subject already has a standing "
             "selection in this release. Supersede it rather than adding a "
-            "second one — selections are append-only, not additive."
+            "second one -- selections are append-only, not additive."
         )
 
     selection = ReleaseSelection(

--- a/backend/app/services/scientific_read/calculations_search.py
+++ b/backend/app/services/scientific_read/calculations_search.py
@@ -422,8 +422,8 @@ def _enforce_parameter_value_pairs(
     """
     if request.parameter_value is not None and request.parameter_key is None:
         raise ValueError(
-            "parameter_value_requires_key: parameter_value=… requires "
-            "parameter_key=… on the same request."
+            "parameter_value_requires_key: parameter_value=... requires "
+            "parameter_key=... on the same request."
         )
     if (
         request.canonical_parameter_value is not None
@@ -431,8 +431,8 @@ def _enforce_parameter_value_pairs(
     ):
         raise ValueError(
             "canonical_parameter_value_requires_key: "
-            "canonical_parameter_value=… requires "
-            "canonical_parameter_key=… on the same request."
+            "canonical_parameter_value=... requires "
+            "canonical_parameter_key=... on the same request."
         )
 
 

--- a/backend/app/services/scientific_read/profile.py
+++ b/backend/app/services/scientific_read/profile.py
@@ -209,7 +209,7 @@ def resolve_read_profile(
     if release_ref is not None:
         raise UnknownReleaseError(
             "release_scoping_not_implemented: ?release= is not supported on the "
-            "general read surface — it would silently do nothing here. Use "
+            "general read surface -- it would silently do nothing here. Use "
             "GET /api/v1/scientific/releases/{tag}/selections, or the release's "
             "selected_records.ndjson artifact, to read exactly what a release "
             "selected."

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -361,7 +361,10 @@ def assert_geometry_composition_matches_identity(
     geometry_formula = format_element_counts(from_geometry) or "empty"
     identity_formula = (
         format_element_counts(from_smiles)
-        or "nothing at all — a free electron has no atoms"
+        # Not reported by scripts/check_runtime_ascii.py: the literal is bound
+        # to a local and only later interpolated into the raise below, which
+        # is past what a no-dataflow checker can follow. Fixed by hand.
+        or "nothing at all -- a free electron has no atoms"
     )
     raise CodedValueError(
         W_SPECIES_GEOMETRY_COMPOSITION_MISMATCH,
@@ -372,8 +375,8 @@ def assert_geometry_composition_matches_identity(
         "be made of the atoms its own identifier declares, or every number "
         "computed from it describes a different molecule. Hydrogens are "
         "counted explicitly on both sides, and isotope labels are counted as "
-        "their element — SMILES [2H] and the XYZ symbols D and T all count as "
-        "H — so an isotopologue is not a mismatch.",
+        "their element -- SMILES [2H] and the XYZ symbols D and T all count as "
+        "H -- so an isotopologue is not a mismatch.",
         context={
             "geometry_formula": geometry_formula,
             "identity_formula": identity_formula,

--- a/backend/app/workers/upload_worker.py
+++ b/backend/app/workers/upload_worker.py
@@ -571,7 +571,7 @@ def _process_one_cycle() -> bool:
                                 )
                                 submission.status = SubmissionStatus.failed
                             logger.warning(
-                                "job %s exhausted %d attempts — marked failed",
+                                "job %s exhausted %d attempts -- marked failed",
                                 job_id, job.max_attempts,
                             )
                         else:
@@ -593,7 +593,7 @@ def worker_loop(poll_interval: float = _IDLE_SLEEP) -> None:
         try:
             did_work = _process_one_cycle()
         except Exception:
-            logger.exception("Unexpected error in worker cycle — sleeping before retry")
+            logger.exception("Unexpected error in worker cycle -- sleeping before retry")
             did_work = False
 
         if not did_work:

--- a/backend/docs/deployment/monitoring.md
+++ b/backend/docs/deployment/monitoring.md
@@ -181,8 +181,9 @@ uploads without attached files all still work; exiting would replace a partial
 outage with a total one — the same reasoning that keeps artifact storage out of
 `/readyz`. It reuses `/status`'s probe, and therefore its wall-clock deadline,
 so an unreachable endpoint costs a bounded few seconds of boot and can never
-hang it. Set `TCKDB_STARTUP_STORAGE_PROBE=false` to opt out; the test suite
-does, because it builds the app hundreds of times.
+hang it. Set `TCKDB_STARTUP_PROBES=false` to opt out of this and the database
+encoding probe together; the test suite does, because it builds the app
+hundreds of times.
 
 ## Setting it up on a fresh host
 

--- a/backend/docs/deployment/monitoring.md
+++ b/backend/docs/deployment/monitoring.md
@@ -88,7 +88,16 @@ script never gets far enough to ping anything). Neither alone is enough.
 
 `status` is `"ok"` only when `degraded` is empty; both are derived from the
 same set of unhealthy components, so anything consuming this should check
-both rather than rely on that derivation staying true.
+both rather than rely on that derivation staying true. All three consumers
+now do: `tckdb_deploy.sh`'s verification loop, `tckdb_alert_check.sh` (on both
+its `jq` and its `jq`-free parse paths), and `.github/workflows/uptime-check.yml`.
+A `status: "ok"` accompanied by a non-empty `degraded` is reported as its own
+kind of fault — the endpoint contradicting itself has a different fix from a
+component being down.
+
+Reading one of two fields is exactly how monitoring comes to vouch against an
+outage, which has happened here once already. It is cheap to read both, and
+the cost of not doing so is paid in a way you cannot see.
 
 The worker block carries two independent signals because neither is sufficient:
 
@@ -152,6 +161,28 @@ Two lessons, both now enforced in code:
 2. Report **what was reached for**, not only the verdict. Every value in that
    deployment's configuration was individually valid; the only way to see the
    fault was to see the address in use.
+
+### The same probe, at boot
+
+`/status` answers on demand. That fault was answerable from the first second
+of the process's life, and no one asked for hours. So the API now probes the
+object store once during startup and writes a single line into the container
+log, naming the endpoint and bucket it tried:
+
+```text
+startup: ARTIFACT STORAGE UNAVAILABLE - endpoint=http://127.0.0.1:9000 bucket=tckdb-artifacts reachable=False reason=...
+```
+
+That is where the deploy script already sends you (`docker logs tckdb-api |
+tail -50`), so the diagnosis is waiting before anyone looks for it.
+
+It **never fails startup.** With the object store down, reads, queries and
+uploads without attached files all still work; exiting would replace a partial
+outage with a total one — the same reasoning that keeps artifact storage out of
+`/readyz`. It reuses `/status`'s probe, and therefore its wall-clock deadline,
+so an unreachable endpoint costs a bounded few seconds of boot and can never
+hang it. Set `TCKDB_STARTUP_STORAGE_PROBE=false` to opt out; the test suite
+does, because it builds the app hundreds of times.
 
 ## Setting it up on a fresh host
 

--- a/backend/docs/deployment/monitoring.md
+++ b/backend/docs/deployment/monitoring.md
@@ -55,6 +55,16 @@ watches.** The fix is a *dead man's switch* — the Pi pings an external service
 on a schedule, and that service alerts when the ping *stops*. Absence becomes
 the signal. Setup is in the last section.
 
+**4. Something notices when the checker dies but the host does not.** The
+narrower and more likely version of (3), and the one that hid for longest: the
+host is fine, the API is fine, and the *checker* is gone. The timer was never
+enabled, the unit failed on a missing `EnvironmentFile`, `ExecStart` points at
+a path the repo has since moved. Nothing is pushed, nothing complains, and the
+absence of alerts reads as good news. Two mechanisms cover it, in two failure
+domains: `TCKDB_DEADMAN_URL` (external, also covers the host dying) and
+`OnFailure=tckdb-alert-failed.service` (local, catches the cases where the
+script never gets far enough to ping anything). Neither alone is enough.
+
 ## What `/status` reports
 
 ```json
@@ -193,23 +203,68 @@ Then break something on purpose — `sudo systemctl stop tckdb-api` — run the
 check, confirm the push arrives, start it again, confirm the recovery push
 arrives. Ten minutes, and it is the only way to know.
 
-## The dead man's switch (covers total host death)
+## The dead man's switch (covers the checker dying, and the host with it)
 
-The checker above cannot report its own host dying. Close that with a free
-external service — [healthchecks.io](https://healthchecks.io) is the usual
-choice — which expects a ping on a schedule and alerts when one does not
-arrive.
+The checker above cannot report its own death. Close that with a free external
+service — [healthchecks.io](https://healthchecks.io) is the usual choice —
+which expects a ping on a schedule and alerts when one does not arrive.
 
 1. Create a check with a period of 10 minutes and a grace of 5.
 2. Copy its ping URL.
-3. Add it to `~/.config/tckdb-alert.env` as `TCKDB_DEADMAN_URL=...` and append
-   a curl to that URL at the end of a healthy check run, or simply add a
-   second systemd timer that pings it.
+3. Add it to `~/.config/tckdb-alert.env` as `TCKDB_DEADMAN_URL=...`. The
+   checker pings it itself; there is nothing to append and no second timer.
 4. Point healthchecks.io's notification at the **same ntfy topic**, so both
    classes of alarm land in one place.
 
-Now: the Pi tells you when a component breaks, and healthchecks.io tells you
-when the Pi stops talking at all. Neither depends on the other surviving.
+**The ping means "the checker ran", not "TCKDB is well",** and it is sent on
+every completed run including a degraded one. That distinction is the whole
+design. If the ping were conditional on a healthy verdict, an object-store
+outage would stop the heartbeat, healthchecks.io would page *the host is gone*,
+and you would go looking for a dead Raspberry Pi while the Pi was pushing an
+accurate description of the real fault to your phone — the wrong page of the
+runbook, produced by your own monitoring. The two channels answer two
+questions and must never be collapsed into one.
+
+The ping is deliberately **not** sent when the script aborts before reaching a
+verdict — an unset `TCKDB_NTFY_TOPIC`, say. That is a dead checker, and its
+silence is the only signal it can send. Forging a heartbeat there would be
+worse than having none.
+
+If `TCKDB_DEADMAN_URL` is unset the checker pushes one notice saying so, on its
+first run, and then never mentions it again. An unmonitored monitor is worth
+exactly one interruption.
+
+### When the checker cannot even start
+
+`tckdb-alert.service` carries `OnFailure=tckdb-alert-failed.service`, so a unit
+that fails — moved `ExecStart` path, unreadable `EnvironmentFile`, exit 2 from
+a missing topic — pushes *"TCKDB health checker FAILED"* rather than leaving a
+red unit nobody looks at. Install it alongside the others:
+
+```bash
+sudo cp backend/scripts/ops/tckdb-alert-failed.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+It runs on the same host, so it cannot cover the host going away; that is what
+the dead man's switch is for. Between them: the Pi tells you when a component
+breaks, systemd tells you when the checker breaks, and healthchecks.io tells
+you when the Pi stops talking at all. No one of them depends on another
+surviving.
+
+Prove it, rather than assuming — the same ten minutes that is the only way to
+know anything about monitoring:
+
+```bash
+sudo systemctl stop tckdb-alert.timer     # then wait past the deadman period
+# expect: a healthchecks.io alert, and no ntfy traffic at all
+sudo systemctl start tckdb-alert.timer
+```
+
+The behaviour above is covered by `backend/tests/ops/test_alert_check_liveness.py`,
+which runs the real script as a subprocess against a fake host and asserts what
+reaches the outside world on each broken path — including that a checker which
+refuses to start sends nothing.
 
 ## Redeploying elsewhere
 

--- a/backend/scripts/bench/run_benchmark.py
+++ b/backend/scripts/bench/run_benchmark.py
@@ -318,7 +318,7 @@ def measure_shape(
     if result.records_returned == 0:
         result.empty = True
         result.warnings.append(
-            "shape matched ZERO records — its timing measures an empty result "
+            "shape matched ZERO records -- its timing measures an empty result "
             "and must not be quoted as evidence that the shape is fast"
         )
 

--- a/backend/scripts/check_runtime_ascii.py
+++ b/backend/scripts/check_runtime_ascii.py
@@ -86,6 +86,15 @@ _LOG_RECEIVERS = frozenset({"logger", "log", "logging", "_logger", "warnings", "
 #: ``logging.getLogger(__name__).warning(...)`` shape.
 _LOG_FACTORIES = frozenset({"getLogger"})
 
+#: Local accumulators that are returned to a caller and end up in a payload
+#: or a response. ``warnings.append("...")`` in the cccbdb builders flows into
+#: ``PayloadBundle.warnings`` and out through the upload path, which is an
+#: emission site by any reading -- it was missed once, and the miss was then
+#: written up as "a parser token matched against HTML", which it is not.
+#: Matched on the receiver name because that is what distinguishes an
+#: accumulator from ``some_list.append``.
+_ACCUMULATOR_RECEIVERS = frozenset({"warnings", "errors", "messages", "notes"})
+
 #: Keyword arguments carrying human-readable text that gets stored or
 #: returned. ``message`` is the one that mattered: ``UploadWarning(message=...)``
 #: rows are written to the database and served back to clients, and an
@@ -142,6 +151,19 @@ def _is_log_call(call: ast.Call) -> bool:
     return name in _LOG_RECEIVERS
 
 
+def _is_accumulator_append(call: ast.Call) -> bool:
+    """``warnings.append("...")`` and friends."""
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr != "append":
+        return False
+    receiver = func.value
+    if isinstance(receiver, ast.Name):
+        return receiver.id in _ACCUMULATOR_RECEIVERS
+    if isinstance(receiver, ast.Attribute):
+        return receiver.attr in _ACCUMULATOR_RECEIVERS
+    return False
+
+
 class _Visitor(ast.NodeVisitor):
     """Collect string constants sitting at an emission site.
 
@@ -157,9 +179,20 @@ class _Visitor(ast.NodeVisitor):
         #: *first fragment*, several lines below the `raise`.
         self.hits: dict[int, tuple[ast.Constant, str, int]] = {}
 
-    def _record(self, node: ast.AST, kind: str, anchor: int) -> None:
+    def _record(self, node: ast.AST, kind: str, anchor: int, *, specific: bool = False) -> None:
+        """Record every literal under *node* as sitting at an emission site.
+
+        A literal is often reachable two ways -- ``warnings.append(
+        UploadWarning(message="..."))`` is an accumulator *and* a
+        ``message=`` keyword -- and it must be reported once. The
+        keyword attribution is the more useful of the two in the output,
+        so *specific* records are allowed to replace a container-level
+        one; nothing else overwrites.
+        """
         for constant in _string_constants(node):
-            self.hits.setdefault(id(constant), (constant, kind, anchor))
+            key = id(constant)
+            if key not in self.hits or specific:
+                self.hits[key] = (constant, kind, anchor)
 
     def visit_Raise(self, node: ast.Raise) -> None:
         if node.exc is not None:
@@ -169,9 +202,16 @@ class _Visitor(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         if _is_log_call(node):
             self._record(node, "log message", node.lineno)
+        if _is_accumulator_append(node):
+            self._record(node, "accumulated warning", node.lineno)
         for keyword in node.keywords:
             if keyword.arg in _TEXT_KEYWORDS:
-                self._record(keyword.value, f"{keyword.arg}= argument", node.lineno)
+                self._record(
+                    keyword.value,
+                    f"{keyword.arg}= argument",
+                    node.lineno,
+                    specific=True,
+                )
         self.generic_visit(node)
 
 

--- a/backend/scripts/check_runtime_ascii.py
+++ b/backend/scripts/check_runtime_ascii.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Refuse non-ASCII in strings that leave the process.
+
+WHY
+    On 2026-08-04 an em dash in an upload-warning message rolled back a
+    whole upload against a ``SQL_ASCII`` database. The character carried
+    no meaning: it was a typographic habit, and an ASCII hyphen would
+    have said the same thing. That database has since been converted to
+    UTF-8 and the deployment now pins its encoding (see
+    ``backend/Dockerfile`` and ``docker-compose.yml``), so this check is
+    the second layer rather than the only one -- but the first layer is
+    a property of a host, and a host is exactly the thing that gets
+    rebuilt by someone in a hurry.
+
+WHAT IS IN SCOPE, AND WHY IT IS DRAWN THIS NARROWLY
+    Only string literals that are structurally *at an emission site*:
+    the argument of a ``raise``, the argument of a logging call, or a
+    ``message=`` / ``detail=`` / ``reason=`` / ``msg=`` keyword. Those
+    are the strings that reach a database column, an HTTP response body
+    or a log record.
+
+    Everything else is left alone on purpose. Docstrings, comments,
+    module-level prose, generated documentation and test data all use
+    typography correctly and none of them is ever written anywhere but
+    a document. A checker that fires on an em dash in a docstring gets
+    switched off inside a week, and then it is not protecting the error
+    messages either. Precision here is not politeness; it is the only
+    way the rule survives.
+
+    The cost of the narrow rule is real and worth stating: a literal
+    assigned to a local and *then* interpolated into a raise is not
+    seen. Extending to that needs dataflow, and the checker would start
+    guessing. Every finding it reports is a certainty.
+
+ESCAPE HATCH
+    ``# tckdb: allow-non-ascii`` on the offending line, or on the line
+    the enclosing statement starts. Some emitted strings legitimately
+    need a non-ASCII character -- an error quoting a unit symbol, a
+    parser reporting the token it failed on. Say so in place.
+
+USAGE
+    python scripts/check_runtime_ascii.py [PATH ...]
+
+    Defaults to the packaged sources. Exits 1 and prints one line per
+    finding, in ``path:line: text`` form.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+#: Checked by default.
+#:
+#: ``app`` because it is the deployed code. ``scripts`` because several of
+#: them write to a real database (``bulk_load_arc.py``,
+#: ``seed_scientific_demo_data.py``) and one of them says in its own comment
+#: that the cluster it connects to is ``SQL_ASCII``.
+#:
+#: ``tests`` is deliberately NOT checked. Test data is the one place where
+#: non-ASCII is the point: ``tests/schemas/test_artifact_in_schema.py``
+#: uploads ``café.log`` and ``tests/services/test_idempotency.py`` hashes
+#: ``haséaccent`` precisely to prove the system handles them. Linting those
+#: would mean annotating the tests that prove the encoding works, in order
+#: to protect against an encoding problem. And nothing under ``tests``
+#: executes in a deployment.
+DEFAULT_TARGETS = ("app", "scripts")
+
+ALLOW_MARKER = "# tckdb: allow-non-ascii"
+
+#: Method names that emit a log record.
+_LOG_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "exception", "critical", "log"}
+)
+
+#: Receivers whose logging methods count. Matched on the last dotted name, so
+#: ``logger``, ``self.logger``, ``app.api.logger`` and ``_logger`` all qualify.
+_LOG_RECEIVERS = frozenset({"logger", "log", "logging", "_logger", "warnings", "LOGGER"})
+
+#: Calls that return a logger, for the unbound
+#: ``logging.getLogger(__name__).warning(...)`` shape.
+_LOG_FACTORIES = frozenset({"getLogger"})
+
+#: Keyword arguments carrying human-readable text that gets stored or
+#: returned. ``message`` is the one that mattered: ``UploadWarning(message=...)``
+#: rows are written to the database and served back to clients, and an
+#: ``UploadWarning`` message is what the 2026-08-04 rollback was carrying.
+_TEXT_KEYWORDS = frozenset({"message", "detail", "reason", "msg"})
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    kind: str
+    text: str
+    characters: str
+
+    def render(self, root: Path) -> str:
+        try:
+            shown = self.path.relative_to(root)
+        except ValueError:
+            shown = self.path
+        snippet = self.text if len(self.text) <= 80 else self.text[:77] + "..."
+        return (
+            f"{shown}:{self.line}: non-ASCII {self.characters!r} in a "
+            f"{self.kind}: {snippet!r}"
+        )
+
+
+def _string_constants(node: ast.AST) -> list[ast.Constant]:
+    """Every ``str`` constant under *node*, including f-string fragments."""
+    out: list[ast.Constant] = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            out.append(child)
+    return out
+
+
+def _is_log_call(call: ast.Call) -> bool:
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr not in _LOG_METHODS:
+        return False
+    receiver = func.value
+    if isinstance(receiver, ast.Name):
+        name = receiver.id
+    elif isinstance(receiver, ast.Attribute):
+        name = receiver.attr
+    elif isinstance(receiver, ast.Call):
+        # logging.getLogger(__name__).warning("...") -- the logger is never
+        # bound to a name, so the receiver is the getLogger call itself.
+        inner = receiver.func
+        name = inner.attr if isinstance(inner, ast.Attribute) else getattr(inner, "id", "")
+        return name in _LOG_FACTORIES
+    else:
+        return False
+    return name in _LOG_RECEIVERS
+
+
+class _Visitor(ast.NodeVisitor):
+    """Collect string constants sitting at an emission site.
+
+    Nodes are recorded by identity so a literal reachable two ways (a
+    ``message=`` keyword inside a ``raise``, say) is reported once.
+    """
+
+    def __init__(self) -> None:
+        #: constant id -> (constant, kind, anchor line). The anchor is the
+        #: line the emitting statement starts on, which is where a reader
+        #: most naturally writes the allow-marker: adjacent string fragments
+        #: are folded by the parser into one constant whose own lineno is the
+        #: *first fragment*, several lines below the `raise`.
+        self.hits: dict[int, tuple[ast.Constant, str, int]] = {}
+
+    def _record(self, node: ast.AST, kind: str, anchor: int) -> None:
+        for constant in _string_constants(node):
+            self.hits.setdefault(id(constant), (constant, kind, anchor))
+
+    def visit_Raise(self, node: ast.Raise) -> None:
+        if node.exc is not None:
+            self._record(node.exc, "raised message", node.lineno)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _is_log_call(node):
+            self._record(node, "log message", node.lineno)
+        for keyword in node.keywords:
+            if keyword.arg in _TEXT_KEYWORDS:
+                self._record(keyword.value, f"{keyword.arg}= argument", node.lineno)
+        self.generic_visit(node)
+
+
+def _allowed_lines(source: str) -> set[int]:
+    return {
+        number
+        for number, line in enumerate(source.splitlines(), start=1)
+        if ALLOW_MARKER in line
+    }
+
+
+def check_source(source: str, path: Path) -> list[Finding]:
+    """Return findings for one module's *source*."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return [
+            Finding(path, exc.lineno or 0, "unparseable module", str(exc.msg), "")
+        ]
+
+    visitor = _Visitor()
+    visitor.visit(tree)
+    allowed = _allowed_lines(source)
+
+    findings: list[Finding] = []
+    for constant, kind, anchor in visitor.hits.values():
+        offenders = sorted({c for c in constant.value if ord(c) > 127})
+        if not offenders:
+            continue
+        # Accept the marker anywhere across the literal, and on the line the
+        # emitting statement opens on. Both are places a reader would put it,
+        # and neither reaches past this statement into the next one.
+        span = set(range(constant.lineno, (constant.end_lineno or constant.lineno) + 1))
+        span.add(anchor)
+        if allowed.intersection(span):
+            continue
+        findings.append(
+            Finding(
+                path=path,
+                line=constant.lineno,
+                kind=kind,
+                text=constant.value,
+                characters="".join(offenders),
+            )
+        )
+    return sorted(findings, key=lambda f: (str(f.path), f.line))
+
+
+def check_path(path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    files = sorted(path.rglob("*.py")) if path.is_dir() else [path]
+    for file in files:
+        findings.extend(check_source(file.read_text(encoding="utf-8"), file))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        help="files or directories to check (default: app, scripts)",
+    )
+    args = parser.parse_args(argv)
+
+    targets = [Path(t) for t in args.targets] or [
+        BACKEND_ROOT / name for name in DEFAULT_TARGETS
+    ]
+
+    findings: list[Finding] = []
+    for target in targets:
+        if not target.exists():
+            print(f"error: no such path: {target}", file=sys.stderr)
+            return 2
+        findings.extend(check_path(target))
+
+    if not findings:
+        return 0
+
+    for finding in findings:
+        print(finding.render(BACKEND_ROOT))
+    print(
+        f"\n{len(findings)} non-ASCII character(s) in strings that reach a "
+        f"database, a client or a log.\n"
+        f"Replace them with ASCII (-- for an em dash, ... for an ellipsis, "
+        f"-> for an arrow), or, if the character is load-bearing, mark the "
+        f"line with `{ALLOW_MARKER}`.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/dev/reclaim_leaked_test_databases.py
+++ b/backend/scripts/dev/reclaim_leaked_test_databases.py
@@ -191,7 +191,7 @@ def read_manifest(path: Path) -> list[Candidate]:
         oid_text, datname, size_text = parts
         if not _is_droppable_name(datname):
             raise SystemExit(
-                f"{path}:{lineno}: refusing to accept manifest — '{datname}' is not an "
+                f"{path}:{lineno}: refusing to accept manifest -- '{datname}' is not an "
                 "isolated test-database name."
             )
         entries.append(Candidate(int(oid_text), datname, int(size_text)))

--- a/backend/scripts/ops/tckdb-alert-failed.service
+++ b/backend/scripts/ops/tckdb-alert-failed.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Push an alert when the TCKDB health checker itself fails
+# Wired as OnFailure= on tckdb-alert.service. It exists because every way the
+# checker can break looks, from a phone, exactly like a healthy deployment:
+# nothing arrives. A failed ExecStart (the repo moved and the absolute path in
+# tckdb-alert.service no longer resolves), a missing EnvironmentFile, an unset
+# TCKDB_NTFY_TOPIC -- all of them leave a red unit in `systemctl status` that
+# nobody is looking at.
+#
+# This covers the checker crashing. It cannot cover the host dying, because it
+# runs on the same host; that is what TCKDB_DEADMAN_URL is for. Two mechanisms,
+# two failure domains, and neither one is sufficient alone.
+
+[Service]
+Type=oneshot
+EnvironmentFile=/home/calvin/.config/tckdb-alert.env
+# %i is not available on a non-templated OnFailure unit, so the failing unit is
+# named literally. If you rename tckdb-alert.service, rename it here too.
+ExecStart=/bin/sh -c 'curl -sS --max-time 20 \
+  -H "Title: TCKDB health checker FAILED" \
+  -H "Priority: urgent" \
+  -H "Tags: rotating_light" \
+  -d "tckdb-alert.service failed on $(hostname). The health checker is not running, so TCKDB is now unmonitored from this host and its silence means nothing. Diagnose: systemctl status tckdb-alert.service; journalctl -u tckdb-alert -n 50" \
+  "${TCKDB_NTFY_SERVER:-https://ntfy.sh}/${TCKDB_NTFY_TOPIC}"'
+
+User=calvin

--- a/backend/scripts/ops/tckdb-alert.service
+++ b/backend/scripts/ops/tckdb-alert.service
@@ -4,6 +4,12 @@ Description=TCKDB health check with ntfy push on state change
 After=network-online.target
 Wants=network-online.target
 
+# When the checker itself fails, say so. Without this a broken checker is
+# indistinguishable from a healthy deployment: both produce silence. See
+# tckdb-alert-failed.service, and TCKDB_DEADMAN_URL in the script for the
+# case this cannot cover (the whole host going away).
+OnFailure=tckdb-alert-failed.service
+
 [Service]
 Type=oneshot
 # oneshot + Type=oneshot means systemd runs it, waits, records the exit code,

--- a/backend/scripts/ops/tckdb_alert_check.sh
+++ b/backend/scripts/ops/tckdb_alert_check.sh
@@ -122,18 +122,37 @@ elif [[ "$http_code" != "200" ]]; then
     priority="high"
     tags="warning"
 else
-    # Prefer jq; fall back to grep so a host without jq still alerts.
+    # Prefer jq; fall back to grep/sed so a host without jq still alerts.
+    #
+    # `degraded` is parsed on BOTH paths, because it is now part of the
+    # decision and not just of the message. The old fallback put a literal
+    # "(install jq for detail)" here, which was harmless while only `status`
+    # decided anything and would have been a permanent false alarm now.
     if command -v jq >/dev/null 2>&1; then
         status="$(jq -r '.status // "unparseable"' <<<"$response")"
         degraded="$(jq -r '(.degraded // []) | join(", ")' <<<"$response")"
         reasons="$(jq -r '[.components // {} | to_entries[] | select(.value.healthy == false) | "\(.key): \(.value.reason // "unhealthy")"] | join("; ")' <<<"$response")"
     else
         status="$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' <<<"$response" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-        degraded="(install jq for detail)"
-        reasons="(install jq for detail)"
+        # `degraded` is an ARRAY. A string-shaped grep returns empty for every
+        # value including a non-empty one -- i.e. it would report a degraded
+        # deployment as clean, which is the failure this whole file exists to
+        # prevent. Match the array, as tckdb_deploy.sh does.
+        degraded="$(sed -n 's/.*"degraded"[[:space:]]*:[[:space:]]*\[\([^]]*\)\].*/\1/p' <<<"$response" | head -1 | tr -d '" ')"
+        reasons="(install jq for per-component reasons)"
     fi
 
-    if [[ "$status" == "ok" ]]; then
+    # BOTH fields decide, not just `status`.
+    #
+    # They are derived from the same set of unhealthy components today, so a
+    # divergence would be a bug rather than a state -- which is exactly the
+    # point. If that derivation ever changes, or a future component reports
+    # itself degraded without flipping the summary field, this checker must
+    # alert rather than pass on a field that happened to stay "ok". The whole
+    # class of incident here is monitoring that vouches against an outage;
+    # reading one of two fields is how that happens. The deploy script's
+    # verification loop already reads both.
+    if [[ "$status" == "ok" && -z "$degraded" ]]; then
         current="ok"
         title="TCKDB recovered"
         detail="All components healthy again."
@@ -145,6 +164,11 @@ else
         detail="Degraded: ${degraded:-unknown}. ${reasons}"
         priority="high"
         tags="warning"
+        if [[ "$status" == "ok" && -n "$degraded" ]]; then
+            # Worth its own sentence in the push: the endpoint is contradicting
+            # itself, which is a different bug from a component being down.
+            detail="/status reported status=ok while listing degraded components (${degraded}). Treat the components as authoritative and fix the endpoint's summary field. ${reasons}"
+        fi
     fi
 fi
 

--- a/backend/scripts/ops/tckdb_alert_check.sh
+++ b/backend/scripts/ops/tckdb_alert_check.sh
@@ -15,6 +15,33 @@
 #   See the runbook (backend/docs/deployment/monitoring.md) -- it is about ten
 #   minutes of setup and it is what covers total death.
 #
+# HOW THIS SCRIPT'S OWN DEATH BECOMES VISIBLE
+#   Every failure of this checker looks, from the outside, exactly like a
+#   healthy deployment: silence. The timer never got enabled, the unit failed
+#   on a missing EnvironmentFile, ExecStart points at a path the repo has since
+#   moved, the host is off -- in every one of those cases nothing is pushed and
+#   nothing complains, and the previous version of this script had no way to
+#   tell you. Two mechanisms now close that, and they are deliberately in
+#   different failure domains:
+#
+#     1. TCKDB_DEADMAN_URL. Pinged once per COMPLETED run, whatever the
+#        verdict. "Degraded" is a completed run: the checker did its job and
+#        already pushed about it, so suppressing the ping there would convert a
+#        component outage into a spurious "host is gone" page -- the wrong page
+#        of the runbook, which is the exact mistake the /status endpoint was
+#        shaped to avoid. The ping means "the checker ran", never "the system
+#        is well". Conversely the ping is NOT sent when this script aborts
+#        before reaching a verdict, because that is a dead checker and the
+#        whole point is for the external service to notice the silence.
+#
+#     2. tckdb-alert-failed.service, wired as OnFailure= on the unit. That
+#        catches the cases where this script never gets far enough to ping
+#        anything -- but it runs on the same host, so it cannot catch the host
+#        dying. Hence both.
+#
+#   If TCKDB_DEADMAN_URL is unset the checker says so once, on the first run,
+#   as a push. An unmonitored monitor is worth exactly one interruption.
+#
 # SETUP
 #   1. Pick a topic name nobody will guess. ntfy topics are public to anyone
 #      who knows the name, so treat it like a password:
@@ -22,6 +49,8 @@
 #   2. Install the ntfy app, subscribe to that topic.
 #   3. Copy this script and the .timer/.service units onto the host, set the
 #      env vars, enable the timer.
+#   4. Create a check on an external dead-man service (healthchecks.io) and set
+#      TCKDB_DEADMAN_URL to its ping URL.
 #
 # ENVIRONMENT
 #   TCKDB_STATUS_URL   default https://tckdb.homecalvin.com/api/v1/status
@@ -29,11 +58,15 @@
 #                      leaks your operational state to anyone who subscribes
 #   TCKDB_NTFY_SERVER  default https://ntfy.sh
 #   TCKDB_STATE_FILE   default ~/.cache/tckdb-alert-state
+#   TCKDB_DEADMAN_URL  optional but strongly recommended -- external URL pinged
+#                      after every completed run; its silence is what tells you
+#                      this checker died
 set -uo pipefail
 
 STATUS_URL="${TCKDB_STATUS_URL:-https://tckdb.homecalvin.com/api/v1/status}"
 NTFY_SERVER="${TCKDB_NTFY_SERVER:-https://ntfy.sh}"
 STATE_FILE="${TCKDB_STATE_FILE:-$HOME/.cache/tckdb-alert-state}"
+DEADMAN_URL="${TCKDB_DEADMAN_URL:-}"
 
 if [[ -z "${TCKDB_NTFY_TOPIC:-}" ]]; then
     echo "TCKDB_NTFY_TOPIC is not set; refusing to run." >&2
@@ -42,6 +75,27 @@ fi
 
 mkdir -p "$(dirname "$STATE_FILE")"
 previous="$(cat "$STATE_FILE" 2>/dev/null || echo "unknown")"
+
+# Marker for the one-shot "you have no dead man's switch" notice. A separate
+# file rather than a second field in the state file, so the state file stays a
+# single token that a human can read and edit with `echo`.
+DEADMAN_NOTICE_FILE="${STATE_FILE}.deadman-notice"
+
+publish() {
+    # publish <title> <priority> <tags> <body>; returns curl's exit status so
+    # the caller can decide whether the notification actually happened.
+    #
+    # --fail, unlike the /status fetch above, because here an HTTP error IS
+    # the answer: a 401 from a protected topic or a 5xx from ntfy means the
+    # push did not reach anyone, and without --fail curl reports success and
+    # the caller records an alert that was never delivered.
+    curl -sS --fail --max-time 20 \
+        -H "Title: $1" \
+        -H "Priority: $2" \
+        -H "Tags: $3" \
+        -d "$4" \
+        "${NTFY_SERVER}/${TCKDB_NTFY_TOPIC}" >/dev/null
+}
 
 # --max-time so a hung server cannot wedge the timer. --fail is deliberately
 # NOT used: /status returns 200 while degraded and we want to read the body.
@@ -96,19 +150,51 @@ fi
 
 # Only notify on a state change. Recovery is worth a push too -- otherwise you
 # are left wondering whether it is still broken.
+#
+# The state file is advanced ONLY once the push has actually gone out. The
+# previous version advanced it unconditionally, so a single failed publish --
+# ntfy unreachable, DNS down, topic typo -- recorded "you have been told" when
+# nobody had been, and the deployment then stayed silently broken until its
+# next state change. Leaving the state unadvanced makes the next run retry,
+# which is the behaviour a five-minute timer exists to provide.
 if [[ "$current" != "$previous" ]]; then
     if [[ "$current" == "ok" && "$previous" == "unknown" ]]; then
-        : # First ever run and everything is fine: stay quiet.
+        # First ever run and everything is fine: stay quiet, but do record the
+        # state so a later break is still an edge.
+        printf '%s' "$current" > "$STATE_FILE"
+    elif publish "$title" "$priority" "$tags" "$detail"; then
+        printf '%s' "$current" > "$STATE_FILE"
     else
-        curl -sS --max-time 20 \
-            -H "Title: ${title}" \
-            -H "Priority: ${priority}" \
-            -H "Tags: ${tags}" \
-            -d "${detail}" \
-            "${NTFY_SERVER}/${TCKDB_NTFY_TOPIC}" >/dev/null || \
-            echo "warning: failed to publish to ntfy" >&2
+        echo "warning: failed to publish to ntfy; state not advanced, will retry" >&2
     fi
-    printf '%s' "$current" > "$STATE_FILE"
+fi
+
+# An unmonitored monitor, said once. Without a dead man's switch every failure
+# of this script is indistinguishable from a healthy deployment, so the gap is
+# worth exactly one interruption -- and not one every five minutes, which is
+# how a useful alert becomes one you filter.
+if [[ -z "$DEADMAN_URL" && ! -e "$DEADMAN_NOTICE_FILE" ]]; then
+    if publish "TCKDB checker has no dead man's switch" "default" "warning" \
+        "TCKDB_DEADMAN_URL is unset on $(hostname 2>/dev/null || echo "this host"), so if this health checker stops running -- timer disabled, unit failed, host powered off -- nothing will tell you, and the silence will look exactly like a healthy deployment. Setup: backend/docs/deployment/monitoring.md"; then
+        : > "$DEADMAN_NOTICE_FILE"
+    fi
+fi
+
+# THE DEAD MAN'S PING. Sent for every verdict, including "degraded" and
+# "unreachable": it asserts that THIS SCRIPT RAN, which is a different claim
+# from "TCKDB is well" and is carried by a different channel on purpose. Tying
+# it to a healthy verdict would mean a broken component silences the host
+# heartbeat too, and the external service would page "the Pi is gone" while the
+# Pi was busy telling you precisely which component had failed.
+#
+# It is deliberately unreachable from the early `exit 2` above: a checker that
+# cannot even start must go quiet, because that silence is the only signal a
+# dead checker can send.
+if [[ -n "$DEADMAN_URL" ]]; then
+    # --fail so a typo'd ping URL (404) is reported rather than counted as a
+    # heartbeat that went nowhere.
+    curl -sS --fail --max-time 20 -o /dev/null "$DEADMAN_URL" || \
+        echo "warning: dead man's switch ping to ${DEADMAN_URL} failed" >&2
 fi
 
 echo "$(date -Is) status=${current} (was ${previous})"

--- a/backend/tests/api/test_api_status.py
+++ b/backend/tests/api/test_api_status.py
@@ -86,6 +86,32 @@ def test_status_reports_ok_when_every_component_is_healthy(
     assert body["components"]["database"]["alembic_revision"]
 
 
+def test_status_reports_the_database_server_encoding(
+    client, healthy_storage
+) -> None:
+    """Answerable from outside, which is what makes it a five-second fix.
+
+    A SQL_ASCII cluster stores bytes and validates nothing, and the
+    damage is delayed arbitrarily -- everything works until the first
+    non-ASCII character arrives. One em dash in a warning message rolled
+    back an entire upload on 2026-08-04, months after the volume was
+    created, and nothing anywhere said "your database is SQL_ASCII".
+
+    It is reported and not judged. ``healthy`` stays ``revision is not
+    None``, so the encoding can never flip the deployment to degraded:
+    it is a permanent property of the cluster that only a dump and
+    restore can change, and alerting on it would nag every five minutes
+    about something no restart can address.
+    """
+    body = client.get("/api/v1/status").json()
+    database = body["components"]["database"]
+    assert database["server_encoding"], "a reachable database must report one"
+    assert body["status"] == "ok"
+    assert body["degraded"] == [], (
+        "the encoding is reported, never a reason to degrade"
+    )
+
+
 def test_status_returns_200_even_when_degraded(
     client, monkeypatch, healthy_storage
 ) -> None:

--- a/backend/tests/api/test_startup_probes.py
+++ b/backend/tests/api/test_startup_probes.py
@@ -42,8 +42,18 @@ REACHABLE = {
 
 @pytest.fixture
 def probe_enabled(monkeypatch):
-    """Undo the suite-wide opt-out for this module only."""
-    monkeypatch.setenv("TCKDB_STARTUP_STORAGE_PROBE", "true")
+    """Undo the suite-wide opt-out for this module only.
+
+    The encoding probe is stubbed out alongside it, so the storage
+    assertions below are not at the mercy of whatever encoding the
+    developer's local cluster happens to have. (Several are ``SQL_ASCII``
+    — that is the whole reason the encoding probe exists — and it would
+    otherwise put a genuine ERROR record into every ``caplog``.)
+    """
+    monkeypatch.setenv("TCKDB_STARTUP_PROBES", "true")
+    monkeypatch.setattr(
+        "app.api.app.report_database_encoding_at_startup", lambda: None
+    )
 
 
 def _patch_probe(monkeypatch, outcome):
@@ -62,8 +72,8 @@ def _patch_probe(monkeypatch, outcome):
 def test_probe_runs_on_startup_by_default(probe_enabled, monkeypatch):
     """No env var needed. The deployment that most needs this is the one
     nobody remembered to configure."""
-    monkeypatch.delenv("TCKDB_STARTUP_STORAGE_PROBE", raising=False)
-    assert "TCKDB_STARTUP_STORAGE_PROBE" not in os.environ
+    monkeypatch.delenv("TCKDB_STARTUP_PROBES", raising=False)
+    assert "TCKDB_STARTUP_PROBES" not in os.environ
     calls = _patch_probe(monkeypatch, REACHABLE)
     with TestClient(create_app()):
         pass
@@ -130,7 +140,7 @@ def test_a_probe_that_raises_does_not_take_the_process_with_it(
 
 
 def test_opt_out_is_honoured(monkeypatch):
-    monkeypatch.setenv("TCKDB_STARTUP_STORAGE_PROBE", "false")
+    monkeypatch.setenv("TCKDB_STARTUP_PROBES", "false")
     calls = _patch_probe(monkeypatch, REACHABLE)
     with TestClient(create_app()):
         pass
@@ -141,3 +151,85 @@ def test_report_returns_the_same_block_status_reports(probe_enabled, monkeypatch
     """One probe definition, so /status and the boot log cannot drift."""
     _patch_probe(monkeypatch, UNREACHABLE)
     assert startup_checks.report_artifact_storage_at_startup() == UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# Database encoding
+# ---------------------------------------------------------------------------
+
+
+def _patch_encoding(monkeypatch, value):
+    monkeypatch.setattr(
+        "app.api.startup_checks.server_encoding", lambda session: value
+    )
+
+
+def test_a_non_utf8_cluster_is_an_error_at_boot(monkeypatch, caplog):
+    """The failure this makes visible is delayed and looks unrelated.
+
+    A SQL_ASCII cluster works perfectly until the first non-ASCII byte
+    arrives, which may be months after the volume was created. One em
+    dash in a warning message rolled back an entire upload on
+    2026-08-04, and nothing anywhere said "your database is SQL_ASCII".
+    """
+    _patch_encoding(monkeypatch, "SQL_ASCII")
+    with caplog.at_level(logging.INFO, logger="app.api.startup_checks"):
+        assert startup_checks.report_database_encoding_at_startup() == "SQL_ASCII"
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "a cluster that validates nothing is not a debug-level fact"
+    message = errors[0].getMessage()
+    assert "SQL_ASCII" in message
+    assert "UTF8" in message
+    # The fix is a dump and restore, not a restart. Saying so is the
+    # difference between a useful log line and an alarming one.
+    assert "initdb" in message
+
+
+def test_a_utf8_cluster_is_recorded_without_alarm(monkeypatch, caplog):
+    _patch_encoding(monkeypatch, "UTF8")
+    with caplog.at_level(logging.INFO, logger="app.api.startup_checks"):
+        assert startup_checks.report_database_encoding_at_startup() == "UTF8"
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any(
+        "server_encoding=UTF8" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_an_unreachable_database_at_boot_is_not_a_fault(monkeypatch, caplog):
+    """The API may legitimately start before Postgres accepts connections."""
+    _patch_encoding(monkeypatch, None)
+    with caplog.at_level(logging.DEBUG, logger="app.api.startup_checks"):
+        assert startup_checks.report_database_encoding_at_startup() is None
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_the_encoding_probe_runs_at_startup(monkeypatch):
+    monkeypatch.setenv("TCKDB_STARTUP_PROBES", "true")
+    monkeypatch.setattr(
+        "app.api.app.report_artifact_storage_at_startup", lambda: {}
+    )
+    seen = []
+    monkeypatch.setattr(
+        "app.api.app.report_database_encoding_at_startup",
+        lambda: seen.append(True),
+    )
+    with TestClient(create_app()):
+        pass
+    assert seen == [True]
+
+
+def test_status_reports_the_server_encoding(client):
+    """Answerable from outside, which is what makes it a five-second fix.
+
+    It is reported and not judged: a non-UTF8 cluster is a permanent
+    property that only a dump and restore can change, so degrading
+    /status on it would nag every five minutes about something no
+    restart can address.
+    """
+    body = client.get("/api/v1/status").json()
+    database = body["components"]["database"]
+    assert "server_encoding" in database
+    assert database["server_encoding"], "a reachable database must report one"
+    assert body["status"] == "ok"
+    assert body["degraded"] == []

--- a/backend/tests/api/test_startup_probes.py
+++ b/backend/tests/api/test_startup_probes.py
@@ -219,17 +219,7 @@ def test_the_encoding_probe_runs_at_startup(monkeypatch):
     assert seen == [True]
 
 
-def test_status_reports_the_server_encoding(client):
-    """Answerable from outside, which is what makes it a five-second fix.
-
-    It is reported and not judged: a non-UTF8 cluster is a permanent
-    property that only a dump and restore can change, so degrading
-    /status on it would nag every five minutes about something no
-    restart can address.
-    """
-    body = client.get("/api/v1/status").json()
-    database = body["components"]["database"]
-    assert "server_encoding" in database
-    assert database["server_encoding"], "a reachable database must report one"
-    assert body["status"] == "ok"
-    assert body["degraded"] == []
+# `/status` reporting server_encoding is asserted in tests/api/test_api_status.py,
+# beside the other component-shape tests and on top of that module's stubbed
+# object store. Asserting the whole body here would have made this module's
+# result depend on whether a real MinIO bucket happened to exist yet.

--- a/backend/tests/api/test_startup_storage_probe.py
+++ b/backend/tests/api/test_startup_storage_probe.py
@@ -1,0 +1,143 @@
+"""The object store is probed at boot, and says so where operators look.
+
+On 2026-08-05 a containerised deployment ran for hours with
+``S3_ENDPOINT_URL`` pointing at the container's own loopback. Every
+artifact-bearing upload returned 503; nothing in the boot log mentioned
+it, because nothing looked. The misconfiguration was fully detectable
+from the first second of the process's life.
+
+These tests pin the three properties that make the probe worth having,
+and each one is a way the previous version got it wrong: it runs by
+default, it names what it tried to reach, and it never takes the process
+down with it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api import startup_checks
+from app.api.app import create_app
+
+UNREACHABLE = {
+    "endpoint": "http://127.0.0.1:9000",
+    "bucket": "tckdb-artifacts",
+    "healthy": False,
+    "reachable": False,
+    "reason": "cannot reach object store (EndpointConnectionError)",
+}
+
+REACHABLE = {
+    "endpoint": "http://minio:9000",
+    "bucket": "tckdb-artifacts",
+    "healthy": True,
+    "reachable": True,
+    "reason": None,
+}
+
+
+@pytest.fixture
+def probe_enabled(monkeypatch):
+    """Undo the suite-wide opt-out for this module only."""
+    monkeypatch.setenv("TCKDB_STARTUP_STORAGE_PROBE", "true")
+
+
+def _patch_probe(monkeypatch, outcome):
+    calls = []
+
+    def fake_status():
+        calls.append(True)
+        return dict(outcome)
+
+    monkeypatch.setattr(
+        "app.api.routes.health._artifact_storage_status", fake_status
+    )
+    return calls
+
+
+def test_probe_runs_on_startup_by_default(probe_enabled, monkeypatch):
+    """No env var needed. The deployment that most needs this is the one
+    nobody remembered to configure."""
+    monkeypatch.delenv("TCKDB_STARTUP_STORAGE_PROBE", raising=False)
+    assert "TCKDB_STARTUP_STORAGE_PROBE" not in os.environ
+    calls = _patch_probe(monkeypatch, REACHABLE)
+    with TestClient(create_app()):
+        pass
+    assert len(calls) == 1
+
+
+def test_unreachable_storage_is_logged_at_error_with_the_endpoint(
+    probe_enabled, monkeypatch, caplog
+):
+    """The endpoint has to be in the message.
+
+    The whole content of the incident was that the address was wrong
+    while every individual value in the configuration was still valid.
+    A verdict without the address sends an operator to read source.
+    """
+    _patch_probe(monkeypatch, UNREACHABLE)
+    with caplog.at_level(logging.INFO, logger="app.api.startup_checks"):
+        with TestClient(create_app()):
+            pass
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "an unreachable object store must be an ERROR, not a shrug"
+    message = errors[0].getMessage()
+    assert "127.0.0.1:9000" in message
+    assert "tckdb-artifacts" in message
+    assert "EndpointConnectionError" in message
+
+
+def test_healthy_storage_is_logged_too(probe_enabled, monkeypatch, caplog):
+    """A silent success is indistinguishable from a probe that never ran."""
+    _patch_probe(monkeypatch, REACHABLE)
+    with caplog.at_level(logging.INFO, logger="app.api.startup_checks"):
+        with TestClient(create_app()):
+            pass
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("artifact storage ok" in m for m in messages)
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def test_unreachable_storage_does_not_prevent_startup(probe_enabled, monkeypatch):
+    """Reads and queries still work with the object store down.
+
+    Refusing to boot would turn a partial outage into a total one --
+    the same reasoning that keeps artifact storage out of ``/readyz``.
+    """
+    _patch_probe(monkeypatch, UNREACHABLE)
+    with TestClient(create_app()) as client:
+        assert client.get("/api/v1/health").status_code == 200
+
+
+def test_a_probe_that_raises_does_not_take_the_process_with_it(
+    probe_enabled, monkeypatch, caplog
+):
+    """Boot diagnostics exist to make failures visible, not to create one."""
+
+    def boom():
+        raise RuntimeError("botocore exploded in a new way")
+
+    monkeypatch.setattr("app.api.routes.health._artifact_storage_status", boom)
+    with caplog.at_level(logging.INFO, logger="app.api.startup_checks"):
+        with TestClient(create_app()) as client:
+            assert client.get("/api/v1/health").status_code == 200
+    assert any("probe raised RuntimeError" in r.getMessage() for r in caplog.records)
+
+
+def test_opt_out_is_honoured(monkeypatch):
+    monkeypatch.setenv("TCKDB_STARTUP_STORAGE_PROBE", "false")
+    calls = _patch_probe(monkeypatch, REACHABLE)
+    with TestClient(create_app()):
+        pass
+    assert calls == []
+
+
+def test_report_returns_the_same_block_status_reports(probe_enabled, monkeypatch):
+    """One probe definition, so /status and the boot log cannot drift."""
+    _patch_probe(monkeypatch, UNREACHABLE)
+    assert startup_checks.report_artifact_storage_at_startup() == UNREACHABLE

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -665,20 +665,21 @@ def _api_other_user(db_session) -> int:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _disable_startup_storage_probe():
-    """Keep the boot-time object-store probe out of the suite.
+def _disable_startup_probes():
+    """Keep the boot-time dependency probes out of the suite.
 
     ``create_app()`` runs once per ``client`` fixture, i.e. hundreds of
-    times, and the probe is a real network round trip with a 4-second
-    ceiling. On a machine with no MinIO that is hours; with MinIO it is
-    hundreds of pointless ``head_bucket`` calls. The probe's own
-    behaviour — that it runs by default, logs loudly, and never fails
-    startup — is covered directly in
-    ``tests/api/test_startup_storage_probe.py``.
+    times. The storage probe is a real network round trip with a
+    4-second ceiling — on a machine with no MinIO that is hours, and with
+    MinIO it is hundreds of pointless ``head_bucket`` calls — and the
+    encoding probe would re-answer one unchanging question about one
+    cluster on every one of them. Their own behaviour, including that
+    they are on by default, is covered directly in
+    ``tests/api/test_startup_probes.py``.
     """
-    os.environ["TCKDB_STARTUP_STORAGE_PROBE"] = "false"
+    os.environ["TCKDB_STARTUP_PROBES"] = "false"
     yield
-    os.environ.pop("TCKDB_STARTUP_STORAGE_PROBE", None)
+    os.environ.pop("TCKDB_STARTUP_PROBES", None)
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -157,6 +157,28 @@ def _resolve_test_db_name() -> str:
     return f"tckdb_test_{os.getpid()}"
 
 
+# Keep the boot-time dependency probes out of the suite.
+#
+# ``create_app()`` runs once per ``client`` fixture, i.e. hundreds of times.
+# The storage probe is a real network round trip with a 4-second ceiling --
+# on a machine with no MinIO that is hours, and with MinIO it is hundreds of
+# pointless ``head_bucket`` calls -- and the encoding probe would re-answer
+# one unchanging question about one cluster on every one of them. The probes'
+# own behaviour, including that they are on by default, is covered directly
+# in ``tests/api/test_startup_probes.py``.
+#
+# Set at import rather than by an autouse session fixture. A session-scoped
+# autouse fixture in the root conftest joins the session fixture graph ahead
+# of ``db_engine`` without depending on it, and under xdist that reordering
+# was enough to have the per-worker database torn down while tests were still
+# using it: 2000+ errors, all of them `terminating connection due to
+# administrator command`, none of them near this line. An env var wants no
+# fixture, so it should not have one.
+#
+# ``setdefault`` so a developer can still force the probes on from the
+# environment when working on them.
+os.environ.setdefault("TCKDB_STARTUP_PROBES", "false")
+
 _TEST_DATABASE_NAME = re.compile(r"^tckdb_test(?:_[A-Za-z0-9_]+)?$")
 
 
@@ -662,24 +684,6 @@ def _api_other_user(db_session) -> int:
     return _create_user_in_session(
         db_session, username="testother", role=AppUserRole.user
     )
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _disable_startup_probes():
-    """Keep the boot-time dependency probes out of the suite.
-
-    ``create_app()`` runs once per ``client`` fixture, i.e. hundreds of
-    times. The storage probe is a real network round trip with a
-    4-second ceiling — on a machine with no MinIO that is hours, and with
-    MinIO it is hundreds of pointless ``head_bucket`` calls — and the
-    encoding probe would re-answer one unchanging question about one
-    cluster on every one of them. Their own behaviour, including that
-    they are on by default, is covered directly in
-    ``tests/api/test_startup_probes.py``.
-    """
-    os.environ["TCKDB_STARTUP_PROBES"] = "false"
-    yield
-    os.environ.pop("TCKDB_STARTUP_PROBES", None)
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -664,6 +664,23 @@ def _api_other_user(db_session) -> int:
     )
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _disable_startup_storage_probe():
+    """Keep the boot-time object-store probe out of the suite.
+
+    ``create_app()`` runs once per ``client`` fixture, i.e. hundreds of
+    times, and the probe is a real network round trip with a 4-second
+    ceiling. On a machine with no MinIO that is hours; with MinIO it is
+    hundreds of pointless ``head_bucket`` calls. The probe's own
+    behaviour — that it runs by default, logs loudly, and never fails
+    startup — is covered directly in
+    ``tests/api/test_startup_storage_probe.py``.
+    """
+    os.environ["TCKDB_STARTUP_STORAGE_PROBE"] = "false"
+    yield
+    os.environ.pop("TCKDB_STARTUP_STORAGE_PROBE", None)
+
+
 @pytest.fixture
 def client(db_engine, _api_test_user) -> Iterator[TestClient]:
     """TestClient with per-test transaction rollback.

--- a/backend/tests/ops/conftest.py
+++ b/backend/tests/ops/conftest.py
@@ -23,8 +23,11 @@ import pytest
 OPS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "ops"
 ALERT_CHECK = OPS_DIR / "tckdb_alert_check.sh"
 
-#: Every external binary tckdb_alert_check.sh invokes, minus jq. Used to build
-#: a PATH on which jq genuinely does not exist.
+#: Every external binary tckdb_alert_check.sh requires, minus jq. Used to build
+#: a PATH on which jq genuinely does not exist. ``hostname`` is deliberately
+#: absent: the script already guards it (``hostname || echo "this host"``), and
+#: including it would turn a cosmetic gap into a skipped test -- which is how
+#: the jq-free path would quietly stop being covered.
 _SCRIPT_TOOLS = (
     "bash",
     "cat",
@@ -33,10 +36,10 @@ _SCRIPT_TOOLS = (
     "dirname",
     "grep",
     "head",
-    "hostname",
     "mkdir",
     "sed",
     "tail",
+    "tr",
 )
 
 
@@ -157,7 +160,13 @@ def run_alert_check(fake_host, tmp_path):
             for tool in _SCRIPT_TOOLS:
                 found = shutil.which(tool)
                 if found is None:
-                    pytest.skip(f"{tool} is not installed; cannot build a jq-free PATH")
+                    # Not a skip. A skipped test is silence, and silence
+                    # reading as success is the entire subject of this
+                    # directory.
+                    pytest.fail(
+                        f"{tool} is not installed, so the jq-free decision "
+                        f"path cannot be exercised on this host"
+                    )
                 target = shim / tool
                 if not target.exists():
                     target.symlink_to(found)

--- a/backend/tests/ops/conftest.py
+++ b/backend/tests/ops/conftest.py
@@ -1,0 +1,176 @@
+"""Fixtures for exercising the host-ops shell scripts as real processes.
+
+These scripts are the only part of TCKDB that runs *outside* the API, and
+they are the part whose failure is hardest to see: a broken checker and a
+healthy deployment both produce silence. So they get tested the way they
+run -- as a subprocess talking HTTP to a real socket -- rather than by
+reading them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+OPS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "ops"
+ALERT_CHECK = OPS_DIR / "tckdb_alert_check.sh"
+
+#: Every external binary tckdb_alert_check.sh invokes, minus jq. Used to build
+#: a PATH on which jq genuinely does not exist.
+_SCRIPT_TOOLS = (
+    "bash",
+    "cat",
+    "curl",
+    "date",
+    "dirname",
+    "grep",
+    "head",
+    "hostname",
+    "mkdir",
+    "sed",
+    "tail",
+)
+
+
+@dataclass
+class Request:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: str
+
+
+@dataclass
+class FakeHost:
+    """A single HTTP server standing in for /status, ntfy and the dead man.
+
+    One server rather than three because the scripts only ever care about
+    the URL they were handed, and one socket is one fewer thing to leak.
+    """
+
+    port: int
+    requests: list[Request] = field(default_factory=list)
+    #: Response for GET /status: (http_code, body).
+    status_response: tuple[int, str] = (200, "")
+    #: Paths that answer 500, used to prove failed publishes are retried.
+    failing_paths: set[str] = field(default_factory=set)
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def set_status(self, payload: dict, code: int = 200) -> None:
+        self.status_response = (code, json.dumps(payload))
+
+    def paths(self, prefix: str) -> list[Request]:
+        return [r for r in self.requests if r.path.startswith(prefix)]
+
+
+@pytest.fixture
+def fake_host():
+    host = FakeHost(port=0)
+
+    class Handler(BaseHTTPRequestHandler):
+        def _record(self, body: str = "") -> None:
+            host.requests.append(
+                Request(
+                    method=self.command,
+                    path=self.path,
+                    headers={k.lower(): v for k, v in self.headers.items()},
+                    body=body,
+                )
+            )
+
+        def _answer(self) -> None:
+            if self.path in host.failing_paths:
+                self.send_response(500)
+                self.end_headers()
+                self.wfile.write(b"nope")
+                return
+            if self.path.startswith("/status"):
+                code, body = host.status_response
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body.encode("utf-8"))
+                return
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def do_GET(self):
+            self._record()
+            self._answer()
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            self._record(self.rfile.read(length).decode("utf-8", "replace"))
+            self._answer()
+
+        def log_message(self, *args):  # silence stderr noise
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    host.port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield host
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def run_alert_check(fake_host, tmp_path):
+    """Run tckdb_alert_check.sh against the fake host and return the result."""
+
+    state_file = tmp_path / "alert-state"
+
+    def _run(*, env_overrides: dict | None = None, drop_jq: bool = False):
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "TCKDB_STATUS_URL": f"{fake_host.base}/status",
+            "TCKDB_NTFY_SERVER": f"{fake_host.base}/ntfy",
+            "TCKDB_NTFY_TOPIC": "test-topic",
+            "TCKDB_STATE_FILE": str(state_file),
+        }
+        if drop_jq:
+            # A host without jq takes the grep/sed fallback. It is a genuinely
+            # different decision path -- and the one that has been wrong before
+            # -- so it is exercised rather than assumed equivalent. Building a
+            # PATH that holds only the tools the script needs is the only way
+            # to make jq reliably absent: `command -v` finds any executable
+            # shim, so a stub cannot hide it.
+            shim = tmp_path / "nojq-bin"
+            shim.mkdir(exist_ok=True)
+            for tool in _SCRIPT_TOOLS:
+                found = shutil.which(tool)
+                if found is None:
+                    pytest.skip(f"{tool} is not installed; cannot build a jq-free PATH")
+                target = shim / tool
+                if not target.exists():
+                    target.symlink_to(found)
+            env["PATH"] = str(shim)
+        env.update(env_overrides or {})
+        proc = subprocess.run(
+            ["bash", str(ALERT_CHECK)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return proc
+
+    _run.state_file = state_file
+    return _run

--- a/backend/tests/ops/test_alert_check_degraded.py
+++ b/backend/tests/ops/test_alert_check_degraded.py
@@ -1,0 +1,113 @@
+"""The checker decides on ``degraded``, not only on ``status``.
+
+``/status`` derives both fields from the same set of unhealthy
+components, so reading one works — today. It would go on appearing to
+work, silently, the moment that stops being true: a consumer that
+branches on a summary field while the components underneath it say
+otherwise reports an outage as healthy, which is this deployment's
+existing failure mode rather than a hypothetical one.
+
+The ``jq``-free path is exercised alongside every case, because it is a
+separately written parser and the one that has been wrong before: a
+string-shaped grep against ``"degraded": [...]`` returns empty for every
+value including a non-empty one, i.e. it reports a degraded deployment
+as clean.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+CONTRADICTORY = {
+    # status says ok; the components say otherwise. A derivation bug, and
+    # precisely the case a single-field consumer waves through.
+    "status": "ok",
+    "degraded": ["worker"],
+    "components": {
+        "database": {"healthy": True, "alembic_revision": "abc123", "reason": None},
+        "worker": {"healthy": False, "reason": "inline worker thread is not running"},
+        "artifact_storage": {"healthy": True, "reachable": True, "reason": None},
+    },
+}
+
+DEGRADED = {
+    "status": "degraded",
+    "degraded": ["artifact_storage", "worker"],
+    "components": {
+        "database": {"healthy": True, "alembic_revision": "abc123", "reason": None},
+        "worker": {"healthy": False, "reason": "inline worker thread is not running"},
+        "artifact_storage": {
+            "healthy": False,
+            "reachable": False,
+            "reason": "cannot reach object store",
+        },
+    },
+}
+
+HEALTHY = {
+    "status": "ok",
+    "degraded": [],
+    "components": {
+        "database": {"healthy": True, "alembic_revision": "abc123", "reason": None},
+        "worker": {"healthy": True, "reason": None},
+        "artifact_storage": {"healthy": True, "reachable": True, "reason": None},
+    },
+}
+
+
+@pytest.mark.parametrize("drop_jq", [False, True], ids=["with-jq", "without-jq"])
+def test_a_non_empty_degraded_list_alerts_even_when_status_says_ok(
+    fake_host, run_alert_check, drop_jq
+):
+    fake_host.set_status(CONTRADICTORY)
+    proc = run_alert_check(drop_jq=drop_jq)
+
+    assert proc.returncode == 1, "a listed degraded component is not a healthy deployment"
+    assert "status=degraded" in proc.stdout
+    pushes = fake_host.paths("/ntfy")
+    assert len(pushes) >= 1
+    alert = next(p for p in pushes if "degraded" in p.headers.get("title", "").lower())
+    assert "contradict" in alert.body or "status=ok while listing" in alert.body, (
+        "the push should name the self-contradiction, which has a different "
+        "fix from a component simply being down"
+    )
+    assert "worker" in alert.body
+
+
+@pytest.mark.parametrize("drop_jq", [False, True], ids=["with-jq", "without-jq"])
+def test_a_degraded_deployment_is_detected_on_both_parse_paths(
+    fake_host, run_alert_check, drop_jq
+):
+    fake_host.set_status(DEGRADED)
+    proc = run_alert_check(drop_jq=drop_jq)
+
+    assert proc.returncode == 1
+    assert "status=degraded" in proc.stdout
+    alert = next(
+        p for p in fake_host.paths("/ntfy")
+        if "degraded" in p.headers.get("title", "").lower()
+    )
+    assert "artifact_storage" in alert.body, (
+        "the fallback parser must read the degraded ARRAY, not a string"
+    )
+    assert "worker" in alert.body
+
+
+@pytest.mark.parametrize("drop_jq", [False, True], ids=["with-jq", "without-jq"])
+def test_a_healthy_deployment_stays_healthy_on_both_parse_paths(
+    fake_host, run_alert_check, drop_jq
+):
+    """The fallback must not manufacture a degraded verdict from an empty list.
+
+    The old fallback assigned a literal placeholder to ``degraded``; once
+    that field decides anything, a placeholder is a permanent false alarm,
+    and a checker that cries wolf every five minutes is one you turn off.
+    """
+    fake_host.set_status(HEALTHY)
+    proc = run_alert_check(drop_jq=drop_jq)
+
+    assert proc.returncode == 0
+    assert "status=ok" in proc.stdout
+    assert fake_host.paths("/ntfy") == [] or all(
+        "dead man" in p.headers.get("title", "") for p in fake_host.paths("/ntfy")
+    ), "a healthy first run stays quiet apart from the one-off deadman notice"

--- a/backend/tests/ops/test_alert_check_liveness.py
+++ b/backend/tests/ops/test_alert_check_liveness.py
@@ -1,0 +1,264 @@
+"""The health checker has to be able to report its own death.
+
+A checker that only proves the happy path proves nothing worth having: a
+dead checker and a healthy deployment are the same observation from a
+phone, which is silence. These tests are about the *unhappy* paths --
+what reaches the outside world when the checker is broken, when the
+deployment is broken, and when the notification channel is broken.
+
+The single load-bearing rule they encode:
+
+    The dead man's ping means "this script ran", never "TCKDB is well".
+
+Both halves matter and each has been got wrong in the wild. Ping only on
+a healthy verdict and a degraded component silences the host heartbeat,
+so the external service pages "the Pi is gone" while the Pi is busy
+telling you exactly which component failed. Ping unconditionally --
+including from an aborted run -- and a checker that cannot start still
+looks alive, which is the defect these tests exist to prevent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.ops.conftest import OPS_DIR
+
+HEALTHY = {
+    "status": "ok",
+    "degraded": [],
+    "components": {
+        "database": {"healthy": True, "alembic_revision": "abc123", "reason": None},
+        "worker": {"healthy": True, "reason": None},
+        "artifact_storage": {
+            "healthy": True,
+            "reachable": True,
+            "endpoint": "http://minio:9000",
+            "bucket": "tckdb-artifacts",
+            "reason": None,
+        },
+    },
+}
+
+DEGRADED = {
+    "status": "degraded",
+    "degraded": ["artifact_storage"],
+    "components": {
+        "database": {"healthy": True, "alembic_revision": "abc123", "reason": None},
+        "worker": {"healthy": True, "reason": None},
+        "artifact_storage": {
+            "healthy": False,
+            "reachable": False,
+            "endpoint": "http://127.0.0.1:9000",
+            "bucket": "tckdb-artifacts",
+            "reason": "cannot reach object store (EndpointConnectionError)",
+        },
+    },
+}
+
+
+def deadman_pings(fake_host):
+    return fake_host.paths("/deadman")
+
+
+def ntfy_pushes(fake_host):
+    return fake_host.paths("/ntfy")
+
+
+# ---------------------------------------------------------------------------
+# The ping asserts the checker ran, not that the system is well
+# ---------------------------------------------------------------------------
+
+
+def test_deadman_pinged_on_healthy_run(fake_host, run_alert_check):
+    fake_host.set_status(HEALTHY)
+    proc = run_alert_check(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert len(deadman_pings(fake_host)) == 1
+
+
+def test_deadman_pinged_when_deployment_is_degraded(fake_host, run_alert_check):
+    """A broken component must not silence the checker's own heartbeat.
+
+    This is the reason the ping is not tied to the verdict. If it were,
+    an artifact-storage outage would stop the pings, the external dead
+    man would fire "host is gone", and an operator would go looking for
+    a dead Raspberry Pi while the Pi was pushing an accurate description
+    of the real fault to their phone.
+    """
+    fake_host.set_status(DEGRADED)
+    proc = run_alert_check(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert proc.returncode == 1, "a degraded deployment still exits non-zero"
+    assert len(deadman_pings(fake_host)) == 1, (
+        "the checker ran to a verdict, so it must assert its own liveness"
+    )
+    assert len(ntfy_pushes(fake_host)) == 1, "and it must still alert on the fault"
+
+
+def test_deadman_pinged_when_the_api_is_unreachable(fake_host, run_alert_check, tmp_path):
+    """The API being down is a verdict, not a failure of the checker."""
+    fake_host.set_status(HEALTHY)
+    proc = run_alert_check(
+        env_overrides={
+            # A port nothing is listening on: curl fails, the script decides
+            # "unreachable", which is a completed run.
+            "TCKDB_STATUS_URL": "http://127.0.0.1:1/status",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 1
+    assert len(deadman_pings(fake_host)) == 1
+    assert "unreachable" in proc.stdout
+
+
+def test_deadman_pinged_when_status_endpoint_is_missing(fake_host, run_alert_check):
+    """A 404 (an old build deployed) is also a completed run."""
+    fake_host.set_status({"detail": "Not Found"}, code=404)
+    proc = run_alert_check(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert proc.returncode == 1
+    assert len(deadman_pings(fake_host)) == 1
+    assert "bad_endpoint" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# ... and the checker's own death is silence, deliberately
+# ---------------------------------------------------------------------------
+
+
+def test_a_checker_that_cannot_start_sends_no_ping(fake_host, run_alert_check):
+    """The defect this whole file exists for.
+
+    An unset topic is the most common way this script dies on a fresh
+    host, and it dies *before* it can conclude anything. It must not
+    ping: the external dead man's switch converts that silence into an
+    alert, and a ping here would forge a liveness signal for a checker
+    that never checked anything.
+    """
+    fake_host.set_status(HEALTHY)
+    proc = run_alert_check(
+        env_overrides={
+            "TCKDB_NTFY_TOPIC": "",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 2
+    assert deadman_pings(fake_host) == [], (
+        "a checker that refused to run must stay silent so its silence is the alarm"
+    )
+
+
+def test_ping_failure_is_reported_rather_than_swallowed(fake_host, run_alert_check):
+    """If even the heartbeat cannot be sent, say so in the journal.
+
+    The run still succeeds -- the deployment is fine and that is what the
+    exit code is for -- but a heartbeat that silently never leaves the
+    host is the failure mode in miniature.
+    """
+    fake_host.set_status(HEALTHY)
+    proc = run_alert_check(
+        env_overrides={"TCKDB_DEADMAN_URL": "http://127.0.0.1:1/deadman"}
+    )
+    assert proc.returncode == 0
+    assert "dead man's switch ping" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# An unmonitored monitor announces itself, once
+# ---------------------------------------------------------------------------
+
+
+def test_missing_deadman_url_is_announced_exactly_once(fake_host, run_alert_check):
+    fake_host.set_status(HEALTHY)
+
+    first = run_alert_check()
+    assert first.returncode == 0
+    notices = [r for r in ntfy_pushes(fake_host) if "dead man" in r.headers.get("title", "")]
+    assert len(notices) == 1, "the gap must be reported"
+
+    second = run_alert_check()
+    assert second.returncode == 0
+    notices = [r for r in ntfy_pushes(fake_host) if "dead man" in r.headers.get("title", "")]
+    assert len(notices) == 1, "and reported once, not every five minutes"
+
+
+def test_no_such_notice_when_a_deadman_is_configured(fake_host, run_alert_check):
+    fake_host.set_status(HEALTHY)
+    run_alert_check(env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"})
+    notices = [r for r in ntfy_pushes(fake_host) if "dead man" in r.headers.get("title", "")]
+    assert notices == []
+
+
+# ---------------------------------------------------------------------------
+# A push that never arrived must not be recorded as delivered
+# ---------------------------------------------------------------------------
+
+
+def test_failed_push_is_retried_on_the_next_run(fake_host, run_alert_check):
+    """State advances on delivery, not on intent.
+
+    The edge-triggered design means a missed transition is missed
+    forever: mark "degraded" as announced when the announcement failed
+    and the deployment stays broken and quiet until it changes state
+    again. So the state file only moves once ntfy has accepted the push.
+    """
+    fake_host.set_status(HEALTHY)
+    run_alert_check(env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"})
+
+    fake_host.set_status(DEGRADED)
+    fake_host.failing_paths.add("/ntfy/test-topic")
+    first = run_alert_check(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert first.returncode == 1
+    assert "state not advanced" in first.stderr
+    assert run_alert_check.state_file.read_text() == "ok", (
+        "an undelivered alert must not be recorded as delivered"
+    )
+
+    fake_host.failing_paths.clear()
+    second = run_alert_check(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert second.returncode == 1
+    assert run_alert_check.state_file.read_text() == "degraded"
+    delivered = [
+        r for r in ntfy_pushes(fake_host) if "degraded" in r.headers.get("title", "").lower()
+    ]
+    assert len(delivered) == 2, "one failed attempt, one successful retry"
+
+
+# ---------------------------------------------------------------------------
+# The systemd wiring is part of the mechanism, so it is asserted too
+# ---------------------------------------------------------------------------
+
+
+def test_the_unit_alerts_when_the_checker_itself_fails():
+    """Covers the deaths that happen before the script can ping anything.
+
+    A moved repo, a missing EnvironmentFile, a syntax error: the script
+    never runs, so no ping is even attempted, and only systemd knows.
+    OnFailure= turns that red unit into a push.
+    """
+    unit = (OPS_DIR / "tckdb-alert.service").read_text()
+    assert "OnFailure=tckdb-alert-failed.service" in unit
+    failure_unit = OPS_DIR / "tckdb-alert-failed.service"
+    assert failure_unit.exists()
+    body = failure_unit.read_text()
+    assert "TCKDB_NTFY_TOPIC" in body
+    assert "ExecStart=" in body
+
+
+@pytest.mark.parametrize(
+    "unit_name",
+    ["tckdb-alert.service", "tckdb-alert-failed.service", "tckdb-alert.timer"],
+)
+def test_units_are_present_and_non_empty(unit_name):
+    path = OPS_DIR / unit_name
+    assert path.exists(), f"{unit_name} is part of the alerting mechanism"
+    assert path.read_text().strip()

--- a/backend/tests/scripts/test_check_runtime_ascii.py
+++ b/backend/tests/scripts/test_check_runtime_ascii.py
@@ -58,6 +58,35 @@ def test_emission_sites_are_reported(source):
     assert len(findings(source)) == 1
 
 
+def test_an_accumulated_warning_is_an_emission_site():
+    """``warnings.append`` was missed once, and then miscategorised.
+
+    ``app/importers/cccbdb/builders/statmech_payload.py`` appends to a
+    local named ``warnings`` that becomes ``PayloadBundle.warnings`` and
+    travels out through the upload path. The first version of this
+    checker did not see it, and the omission was written up as "a parser
+    token matched against HTML" -- which it is not, and which would have
+    left a real emission site permanently excused.
+    """
+    source = (
+        "warnings.append(\n"
+        '    "converted GHz→cm⁻¹; raw values preserved"\n'
+        ")\n"
+    )
+    found = findings(source)
+    assert len(found) == 1
+    assert found[0].kind == "accumulated warning"
+
+
+def test_an_ordinary_list_append_is_not_an_emission_site():
+    """The receiver name is what distinguishes an accumulator."""
+    assert findings('rows.append("a — b")') == []
+
+
+def test_attribute_accumulators_count_too():
+    assert len(findings('result.warnings.append("a — b")')) == 1
+
+
 def test_the_upload_warning_case_that_caused_the_incident():
     """An em dash in an UploadWarning message rolled back a whole upload."""
     source = (

--- a/backend/tests/scripts/test_check_runtime_ascii.py
+++ b/backend/tests/scripts/test_check_runtime_ascii.py
@@ -1,0 +1,200 @@
+"""The non-ASCII check has to fire on emitted text and nowhere else.
+
+Both halves are load-bearing and the second is the harder one. A checker
+that also flags the em dash in a docstring gets switched off within a
+week, and once it is off it is not protecting the error messages either
+-- so the false-positive tests here are not politeness, they are what
+keeps the rule alive.
+
+The population they defend is real: ``app/scientific_checks/`` and the
+resolution services carry several thousand words of deliberate prose in
+``rationale=`` / ``escape_hatch=`` fields, which exist to be rendered
+into a Markdown register, and ``app/importers/cccbdb/`` matches literal
+non-ASCII tokens scraped out of HTML.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import check_runtime_ascii as checker
+
+
+def findings(source: str):
+    return checker.check_source(source, Path("sample.py"))
+
+
+# ---------------------------------------------------------------------------
+# Fires: strings that reach a database, a client or a log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param('raise ValueError("bad thing — fix it")', id="raise"),
+        pytest.param(
+            'raise ValueError(f"{x} → {y} is not allowed")', id="raise-fstring"
+        ),
+        pytest.param('logger.warning("job failed — retrying")', id="logger"),
+        pytest.param(
+            'self.logger.error("nope …")', id="attribute-logger"
+        ),
+        pytest.param(
+            'logging.getLogger(__name__).info("hi — there")', id="getLogger"
+        ),
+        pytest.param(
+            'UploadWarning(code="x", message="a — b")', id="message-kwarg"
+        ),
+        pytest.param(
+            'HTTPException(status_code=422, detail="a … b")', id="detail-kwarg"
+        ),
+        pytest.param('block(reason="unreachable — dns")', id="reason-kwarg"),
+    ],
+)
+def test_emission_sites_are_reported(source):
+    assert len(findings(source)) == 1
+
+
+def test_the_upload_warning_case_that_caused_the_incident():
+    """An em dash in an UploadWarning message rolled back a whole upload."""
+    source = (
+        "warnings.append(\n"
+        "    UploadWarning(\n"
+        '        field="solve.kind",\n'
+        '        code=W_REPORTED,\n'
+        '        message="the inputs behind them — barriers — are absent",\n'
+        "    )\n"
+        ")\n"
+    )
+    found = findings(source)
+    assert len(found) == 1
+    assert found[0].kind == "message= argument"
+    assert found[0].characters == "—"
+
+
+def test_every_offending_character_is_named_once():
+    found = findings('raise ValueError("— and … and —")')
+    assert found[0].characters == "—…"
+
+
+# ---------------------------------------------------------------------------
+# Does not fire: prose, which is the whole reason this can be left switched on
+# ---------------------------------------------------------------------------
+
+
+def test_module_docstrings_are_left_alone():
+    assert findings('"""A module docstring — with typography."""\n') == []
+
+
+def test_function_docstrings_are_left_alone():
+    source = 'def f():\n    """Explains something — at length."""\n    return 1\n'
+    assert findings(source) == []
+
+
+def test_comments_are_left_alone():
+    assert findings("x = 1  # a comment — with an em dash\n") == []
+
+
+def test_documentation_as_data_is_left_alone():
+    """The declaration registry is prose that renders to Markdown.
+
+    ``rationale`` / ``escape_hatch`` / ``fallback`` / ``note`` fields on
+    ``ScientificCheck`` are read by
+    ``scripts/generate_scientific_check_register.py`` and by nothing
+    else. They are reST-marked, multi-paragraph, and typography is
+    correct in them.
+    """
+    source = (
+        "ScientificCheck(\n"
+        '    rationale="The noise floor is flat — so tau matters.",\n'
+        '    escape_hatch="Declare ``molecule_kind: pseudo`` — it exempts.",\n'
+        '    note="Called from both seams — the bundle and the upload.",\n'
+        ")\n"
+    )
+    assert findings(source) == []
+
+
+def test_parser_input_tokens_are_left_alone():
+    """CCCBDB parsers match literal non-ASCII scraped from HTML.
+
+    ``"Å"`` there is not typography, it is the token being matched,
+    and rewriting it would break the parser.
+    """
+    source = 'UNITS = {"Å": "angstrom", "µ⁻¹": "per micron"}\n'
+    assert findings(source) == []
+
+
+def test_argparse_help_and_field_descriptions_are_left_alone():
+    source = (
+        'parser.add_argument("--force", help="Override the guardrail — dangerous")\n'
+        'x = Field(description="required / optional — controls weight")\n'
+    )
+    assert findings(source) == []
+
+
+def test_ascii_at_an_emission_site_is_fine():
+    assert findings('raise ValueError("bad thing -- fix it")') == []
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_marker_suppresses_a_finding():
+    source = (
+        'raise ValueError("the unit is Å")  # tckdb: allow-non-ascii\n'
+    )
+    assert findings(source) == []
+
+
+def test_marker_is_accepted_at_either_end_of_a_multiline_literal():
+    head = (
+        "raise ValueError(  # tckdb: allow-non-ascii\n"
+        '    "reported in Å "\n'
+        '    "by the parser"\n'
+        ")\n"
+    )
+    assert findings(head) == []
+
+    tail = (
+        "raise ValueError(\n"
+        '    "reported in Å "\n'
+        '    "by the parser"  # tckdb: allow-non-ascii\n'
+        ")\n"
+    )
+    assert findings(tail) == []
+
+
+def test_marker_does_not_suppress_a_different_line():
+    source = (
+        'raise ValueError("first — here")\n'
+        'raise ValueError("second is fine")  # tckdb: allow-non-ascii\n'
+    )
+    assert len(findings(source)) == 1
+
+
+# ---------------------------------------------------------------------------
+# The tree it actually guards
+# ---------------------------------------------------------------------------
+
+
+def test_the_packaged_sources_are_clean():
+    """Runs the real check over app/ and scripts/, as CI does."""
+    assert checker.main([]) == 0
+
+
+def test_tests_are_out_of_scope_by_construction():
+    """Test data is the one place non-ASCII is the point.
+
+    ``tests/schemas/test_artifact_in_schema.py`` uploads ``café.log``
+    and ``tests/services/test_idempotency.py`` hashes an accented string,
+    both to prove the system handles them. Linting those would mean
+    annotating the tests that prove the encoding works in order to guard
+    against an encoding problem -- and nothing under ``tests`` executes
+    in a deployment.
+    """
+    assert "tests" not in checker.DEFAULT_TARGETS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,23 @@ services:
       POSTGRES_USER: ${DB_ADMIN_USER:-${DB_USER:-tckdb}}
       POSTGRES_PASSWORD: ${DB_ADMIN_PASSWORD:-${DB_PASSWORD:?DB_PASSWORD must be set (copy .env.example to .env or pass --env-file)}}
       POSTGRES_DB: ${DB_NAME:-tckdb_dev}
+      # Pin the cluster's encoding at initdb time.
+      #
+      # Without this, the encoding a new deployment gets is whatever the base
+      # image's locale happens to imply -- and with no locale set that is
+      # SQL_ASCII, a cluster that stores bytes and validates nothing. This
+      # deployment has already lost an upload to exactly that (see
+      # docs/deployment/troubleshooting.md), and the failure is delayed
+      # arbitrarily: everything works until the first non-ASCII character
+      # arrives, which may be months after the volume was created and long
+      # after anyone would connect the two.
+      #
+      # LANG is what initdb reads for its default locale; --encoding=UTF8 is
+      # then consistent with it and the two cannot disagree. This applies at
+      # volume creation ONLY -- an existing cluster is untouched, by design,
+      # because changing a live cluster's encoding is a dump and restore.
+      LANG: C.UTF-8
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8"
     # Loopback-only publication. NEVER change to "${DB_PORT}:5432" or
     # "0.0.0.0:5432" - that exposes Postgres on the LAN.
     ports:

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -194,27 +194,60 @@ sequence for encoding "SQL_ASCII"`. `psql -l` shows the database with
 
 **Cause**
 
-A pre-existing Postgres data volume created with `SQL_ASCII`
-encoding. Docker won't recreate the DB on subsequent starts.
+A Postgres data volume created before the encoding was pinned. The
+`db` image sets no locale of its own, so `initdb` fell back to
+`SQL_ASCII` — a cluster that stores whatever bytes it is handed and
+validates none of them. Docker will not re-run `initdb` on an existing
+volume, so the encoding a deployment gets is decided once, at volume
+creation, and is permanent.
+
+`docker-compose.yml` now pins `LANG=C.UTF-8` and
+`POSTGRES_INITDB_ARGS=--encoding=UTF8` on the `db` service, so volumes
+created from this repo are `UTF8`. That fixes new deployments; it
+cannot fix an existing volume.
+
+**Why it bites so late.** `SQL_ASCII` works perfectly until the first
+non-ASCII byte arrives. On 2026-08-04 that byte was an em dash in a
+warning message, months after the volume was created, and it rolled
+back the whole upload carrying it. Nothing connected the two. The API
+now logs its cluster's `server_encoding` at startup and reports it in
+`/api/v1/status`, so the question is answerable before something
+strange happens rather than after.
 
 **Fix**
 
-This is a clean-slate operation — back up first if you have anything
-worth keeping:
+Changing a cluster's encoding needs a dump and restore; there is no
+in-place conversion. On a **dev** database, where the data is
+disposable, that reduces to a clean slate:
 
 ```bash
-docker compose down -v
+docker compose down -v      # destroys the volume
 docker compose up -d
 ```
 
-The new volume initializes with `UTF8`. The `DB_CLIENT_ENCODING=utf8`
-in the env templates is belt-and-braces on top of that.
+On a database with anything worth keeping, dump first, recreate the
+volume, and restore:
+
+```bash
+docker compose exec db pg_dump -U tckdb -d tckdb -Fc > tckdb.dump
+docker compose down -v
+docker compose up -d
+docker compose exec -T db pg_restore -U tckdb -d tckdb < tckdb.dump
+```
+
+`DB_CLIENT_ENCODING=utf8` in the env templates, `?client_encoding=utf8`
+in the URL both `app/api/config.py` and `alembic/env.py` build, and
+`PGCLIENTENCODING=UTF8` in `backend/Dockerfile` are all belt-and-braces
+on the *client* side. None of them can rescue a `SQL_ASCII` server.
 
 **Verify**
 
 ```bash
 docker compose exec db psql -U tckdb -l
 # expect: Encoding | UTF8
+
+curl -s localhost:8010/api/v1/status | jq '.components.database.server_encoding'
+# expect: "UTF8"
 ```
 
 ---

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -225,14 +225,37 @@ docker compose down -v      # destroys the volume
 docker compose up -d
 ```
 
-On a database with anything worth keeping, dump first, recreate the
-volume, and restore:
+On a database with anything worth keeping, dump first, **verify the dump
+while the volume still exists**, then recreate and restore. Substitute
+your own `DB_USER` / `DB_NAME` if they differ from the compose defaults.
 
 ```bash
-docker compose exec db pg_dump -U tckdb -d tckdb -Fc > tckdb.dump
+# 1. Dump. -T is not optional: without it `docker compose exec` allocates
+#    a pseudo-TTY, whose line discipline rewrites LF to CRLF *inside the
+#    binary -Fc stream*. The dump looks fine and is silently corrupt.
+docker compose exec -T db \
+    pg_dump -U "${DB_USER:-tckdb}" -d "${DB_NAME:-tckdb_dev}" -Fc > tckdb.dump
+
+# 2. Verify BEFORE destroying anything. `down -v` is irreversible, so a
+#    dump that cannot be read must be discovered while the original is
+#    still there. Expect a table of contents; `did not find magic string`
+#    means the dump is corrupt -- stop, and do not run step 3.
+pg_restore --list tckdb.dump | head
+
+# 3. Only now destroy the volume and recreate it with UTF8.
 docker compose down -v
 docker compose up -d
-docker compose exec -T db pg_restore -U tckdb -d tckdb < tckdb.dump
+
+# 4. Restore.
+docker compose exec -T db \
+    pg_restore -U "${DB_USER:-tckdb}" -d "${DB_NAME:-tckdb_dev}" < tckdb.dump
+```
+
+If `pg_restore` is not installed on the host, run step 2 inside the
+container instead — it must still happen before step 3:
+
+```bash
+docker compose exec -T db pg_restore --list /dev/stdin < tckdb.dump | head
 ```
 
 `DB_CLIENT_ENCODING=utf8` in the env templates, `?client_encoding=utf8`


### PR DESCRIPTION
Three tasks (#41, #52, #35) that turn out to be one theme: the deployment could be broken in a way that produced silence, and silence read as health. One commit each, plus a fix for a regression the work introduced.

## The headline finding

**A fresh `docker compose up` from this repo produces a `SQL_ASCII` database.** Measured, not inferred — a throwaway container off the pinned image tag reports:

```
server_encoding | SQL_ASCII      # unpinned, i.e. today
server_encoding | UTF8           # with the pin in this PR
```

That is the cluster that ate an upload on 2026-08-04 over a single em dash. The `db` image sets no locale, `initdb` falls back, and the encoding is fixed at volume creation and permanent. Every deployment created from this repository has been one non-ASCII byte away from the same incident — **including this project's own CI**, which pinned no locale either and so ran every gate, these ones included, on a cluster structurally incapable of failing on a byte it should reject. Both are pinned here.

---

## #41 — a dead health checker is now visible

The runbook already named the fix (a dead man's switch) but described it as prose to append by hand; `TCKDB_DEADMAN_URL` appeared in no script. So every way `tckdb_alert_check.sh` could die — timer never enabled, unit failed on a missing `EnvironmentFile`, `ExecStart` pointing at a path the repo has since moved, host powered off — produced exactly what a healthy deployment produces.

Two mechanisms, deliberately in different failure domains:

1. **`TCKDB_DEADMAN_URL`**, pinged once per *completed* run. The one distinction that decides whether this helps or hurts: **the ping means "this script ran", never "TCKDB is well".** It fires on `degraded` and `unreachable` too, because tying it to a healthy verdict would let a component outage silence the host heartbeat — the external service would page *the Pi is gone* while the Pi was pushing an accurate description of the real fault. It is deliberately **not** sent when the script aborts before reaching a verdict; that is a dead checker, and its silence is the only signal it has.
2. **`OnFailure=tckdb-alert-failed.service`**, for the deaths that happen before the script can ping anything. Same host, so it cannot cover the host dying — hence both.

Two defects found on the way, both in the same family:

- A failed ntfy publish still advanced the state file, recording "you have been told" when nobody had been. The design is edge-triggered, so the deployment then stayed broken **and quiet** until its next state change. State now advances on delivery.
- `publish()` lacked `--fail`, so an HTTP 401 or 5xx from ntfy counted as a successful push.

If `TCKDB_DEADMAN_URL` is unset the checker says so once. An unmonitored monitor is worth exactly one interruption.

## #52 — the consumers read `degraded`, and storage is probed at boot

`/status` reports `status` and `degraded` from the same set of unhealthy components. Two of the three consumers branched on `status` alone — which works today and would go on *appearing* to work the moment that derivation changed. `tckdb_alert_check.sh` and `uptime-check.yml` now require `status=ok` **and** an empty `degraded`, matching what `tckdb_deploy.sh` already did. A `status: ok` carrying a non-empty `degraded` is reported as its own fault: an endpoint contradicting itself has a different fix from a component being down.

The checker's `jq`-free fallback had assigned a literal placeholder to `degraded` — harmless while nothing branched on it, a permanent false alarm now. It parses the array properly. Both parse paths are exercised by every case, on a `PATH` built so `jq` genuinely does not exist.

Artifact storage is also probed once at startup. The 2026-08-05 misconfiguration was detectable from the process's first second and nobody asked `/status` for hours; the boot log is where the deploy script already sends an operator. It reuses the `/status` probe (one definition, one wall-clock deadline) and never fails startup — with the object store down every read and query still works, so exiting would turn a partial outage into a total one.

## #35 — the lint, and what it deliberately excludes

**In scope:** non-ASCII in string literals that are structurally *at an emission site* — inside a `raise`, in a logging call, or as a `message=` / `detail=` / `reason=` / `msg=` keyword. That is "reaches a database, a client or a log", which is what the incident was about. Covers `backend/app` and `backend/scripts`.

**Deliberately excluded:**

| Excluded | Why |
|---|---|
| Docstrings and comments | Never emitted anywhere but a document. |
| `rationale=` / `escape_hatch=` / `note=` prose in the scientific-check registry | Several thousand words that exist to be rendered into Markdown by `generate_scientific_check_register.py`. Typography is correct there. |
| `app/importers/cccbdb/` **parser tokens only** | `"Å"`, `"µ⁻¹"` in the parsers are not typography, they are the tokens being matched against scraped HTML. Rewriting them breaks the parser. This does **not** extend to the cccbdb *builders* — see below. |
| **`backend/tests` entirely** | Test data is the one place non-ASCII is the point: the suite uploads `café.log` and hashes an accented string precisely to prove the system handles them. Linting those would mean annotating the tests that prove the encoding works, in order to guard against an encoding problem. And nothing under `tests/` executes in a deployment. |
| `print()` | Stdout encoding is pinned at the deployment layer (`PYTHONIOENCODING`), and the scripts that print typography are documentation generators. |

This is narrower than ruff's `RUF001-003`, which this repo disables on purpose because scientific notation is legitimate prose. The precision is the point: a checker that fires on an em dash in a docstring is switched off within a week, and then it is not protecting the error messages either.

Run over `app/` and `scripts/` it found **17 real emission sites and not one false positive** — in `handles.py`, 1 of 30 non-ASCII lines. All fixed.

**Correction from review.** The first version of this PR filed `builders/statmech_payload.py`'s `GHz→cm⁻¹` under "cccbdb parser tokens". That was wrong: it is a warning appended to a list that becomes `PayloadBundle.warnings` and leaves through the upload path — an emission site by any reading, which the checker had simply missed. Rather than only fix the string, `warnings.append(...)` is now a recognised sink, which immediately found a second genuine hit in `scripts/bench/run_benchmark.py:321`. Where a literal matches two sinks, the more specific keyword attribution wins.

**Stated cost:** a literal bound to a local and only later interpolated into a `raise` is not seen. Extending to that needs dataflow and the checker would start guessing. One such string exists (`species_resolution.py:364`); fixed by hand and marked in place. `# tckdb: allow-non-ascii` is the escape hatch for a load-bearing character.

**Pinning:** `docker-compose.yml` pins `LANG=C.UTF-8` + `--encoding=UTF8` on the `db` service (fixes new volumes, deliberately cannot touch existing ones). `backend/Dockerfile` pins `LANG`/`LC_ALL`/`PYTHONIOENCODING`/`PGCLIENTENCODING` in the image rather than per `docker run`, so the API, the migration container, the compose worker and the image smoke tests cannot drift apart. A pin nothing verifies is a wish, so the API logs `server_encoding` at boot (ERROR when not UTF8, naming the dump-and-restore fix) and reports it on `/api/v1/status` — reported, not judged, since degrading on a permanent cluster property would nag every five minutes about something no restart can fix.

## The regression this work introduced, and how it was caught

The first version disabled the startup probes with an autouse session-scoped fixture in the root conftest. It passed serially and destroyed the suite under xdist: 2000+ errors, every one `terminating connection due to administrator command`, none anywhere near the fixture. A session-scoped autouse fixture in the root conftest joins the session fixture graph ahead of `db_engine` without depending on it, and that reordering was enough to have a worker's database torn down while its tests were still running. Setting an env var wants no fixture, so it no longer has one.

## Gates

Measured on this machine, not quoted:

| | main @ `8293d4e` | this branch |
|---|---|---|
| `scripts/test-api.sh` | 2497 passed | **2528 passed** |
| `scripts/test-scientific.sh` | — | **1983 passed** |
| `tests/ops/` + ASCII test | — | **44 passed** |
| ruff / mypy / `check_runtime_ascii.py` | — | clean |
| `alembic check` | clean | clean (no migrations touched; verified on a scratch DB) |

## Testing the monitors' own death

`tests/ops/` runs the real shell script as a subprocess against a fake host and asserts what reaches the outside world on each broken path — not the happy path. The load-bearing one:

```python
def test_a_checker_that_cannot_start_sends_no_ping(...):
    assert proc.returncode == 2
    assert deadman_pings(fake_host) == [], (
        "a checker that refused to run must stay silent so its silence is the alarm"
    )
```

plus: the deadman still pings when the deployment is degraded; a failed push is retried rather than recorded as delivered; the unit still carries `OnFailure=`. `tests/ops/` and `tests/scripts/` sit outside `tests/api/`, so they get their own CI step rather than waiting for the nightly run. A missing tool in the jq-free fixture is a `pytest.fail`, not a skip — a skipped test is silence, and silence reading as success is the subject of this PR.

## Review round

Rebased onto `2b6229e`; #120 had already rewritten both conflicting messages into ASCII by a better route (dropping the ids from the detail), so both conflicts resolve to main's version. Then:

- **The runbook could destroy a deployment.** The dump-and-restore path piped `docker compose exec` — no `-T` — into a binary `-Fc` dump, so the TTY line discipline corrupted it; the next line ran `down -v`. Ordering made it unrecoverable. Fixed the `-T`, fixed the database name, and added the step that actually makes it safe: verify with `pg_restore --list` **before** anything irreversible.
- **A documented opt-out that did not exist.** `monitoring.md` named `TCKDB_STARTUP_STORAGE_PROBE`; the code reads `TCKDB_STARTUP_PROBES`.
- **A test that asserted state it did not control.** `test_status_reports_the_server_encoding` hit a real MinIO and raced lazy bucket creation. Moved to `test_api_status.py`, on top of that module's stubbed store. The encoding logic is unchanged and was not at fault — `healthy` is `revision is not None`, so a `SQL_ASCII` cluster can never flip `/status` to degraded.
- **CI's Postgres encoding pinned** (see the headline finding).
- `<dE>down` read as a differential; it is now `<DeltaE>down` — ASCII, because that string is an `UploadWarning` message bound for the database, which is exactly the class that broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

