### PR TITLE
Make a rotting nightly reach a phone

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -158,6 +158,7 @@ jobs:
           bash -n backend/scripts/test-profile.sh
           bash -n backend/scripts/update-openapi-golden.sh
           bash -n backend/scripts/ops/tckdb_alert_check.sh
+          bash -n backend/scripts/ops/tckdb_ci_watchdog.sh
           bash -n backend/scripts/ops/tckdb_deploy.sh
           make help
 

--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -5,6 +5,12 @@ name: Backend Nightly (full suite)
 # (backend/scripts/test-full.sh, ~4,700 tests) so regressions in the
 # untier-gated areas (workflows, invariants, parsers, CLI, importers)
 # surface within a day instead of at the next manual pre-push run.
+#
+# A red run here notifies nobody by itself: GitHub does not email about a
+# failed scheduled workflow and it leaves no mark on any PR, which is how this
+# job came to fail eleven nights in a row unnoticed. ci-watchdog.yml reads this
+# workflow's run history once a day and pushes to ntfy on a change of verdict,
+# and on this job going silent as well as on it going red.
 
 on:
   schedule:

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -1,0 +1,117 @@
+name: ci-watchdog
+
+# Makes a scheduled workflow's failure -- and its SILENCE -- reach a phone.
+#
+# THE HOLE THIS FILLS
+#   backend-nightly.yml is the only job that runs the third of the test suite
+#   the two PR gates never touch. On 2026-08-10 it was found to have failed on
+#   every run back to 2026-07-31: eleven consecutive nights, conclusion
+#   `failure` each time, and nothing anywhere said so. GitHub does not email
+#   about a red scheduled run, the Actions tab is not a place anyone passes
+#   daily, and a red nightly leaves no mark on any PR. The suite was still
+#   being paid for; it had simply stopped being read.
+#
+#   The second, worse case is a workflow that stops running at all. GitHub
+#   disables scheduled workflows in a repository with 60 days of no commit
+#   activity, and uptime-check.yml -- the dead man's switch for the deployed
+#   instance -- carries exactly the same exposure. A workflow that has stopped
+#   firing produces no failures, so anything that only watches for failures
+#   reports it as healthy. Both watched workflows are therefore checked for
+#   FRESHNESS as well as for verdict.
+#
+# WHAT WATCHES THE WATCHDOG
+#   Nothing in GitHub. This job is itself scheduled, so the 60-day disable
+#   takes it down alongside the workflows it watches -- the same failure
+#   domain, which is the one thing monitoring must not share. That is closed
+#   the same way the Pi-side checker closes it: an external dead man's switch
+#   (TCKDB_DEADMAN_URL, a healthchecks.io ping URL) which alerts when the
+#   pings STOP. Until that secret exists this job says so in its own log every
+#   run, and the gap is real. See backend/docs/deployment/monitoring.md.
+#
+# SETUP
+#   gh secret set TCKDB_NTFY_TOPIC --repo TCKDB/TCKDB       # already present
+#   gh secret set TCKDB_DEADMAN_URL --repo TCKDB/TCKDB      # optional, recommended
+#   The topic is password-equivalent and this repository is public: it lives
+#   only in the secret, is read into the environment rather than interpolated
+#   into a command line, and must never be written into a file here.
+
+on:
+  schedule:
+    # Late enough that a nightly which started at 02:17 UTC, drifted by three
+    # hours and then ran for its full two-hour timeout has still finished and
+    # been given a conclusion before this job looks at it.
+    - cron: "23 9 * * *"
+  workflow_dispatch:
+
+# Never two at once: overlapping runs would both see the same edge and both
+# push, and the second would then write the state the first had already
+# advanced.
+concurrency:
+  group: ci-watchdog
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  watch:
+    if: github.repository == 'TCKDB/TCKDB'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # The edge-trigger state. A hosted runner has no disk that survives, so
+      # the "what have I already said" marker rides in the Actions cache.
+      # Losing it is benign by construction: an empty state makes the next bad
+      # verdict look like a fresh edge, so the worst case is one duplicate
+      # push -- never a missed one.
+      - name: Restore watchdog state
+        id: state
+        uses: actions/cache/restore@v4
+        with:
+          path: .watchdog-state
+          key: ci-watchdog-state-${{ github.run_id }}
+          restore-keys: |
+            ci-watchdog-state-
+
+      - name: Check the watched workflows and alert on failure or silence
+        id: watch
+        env:
+          # Read into the environment rather than interpolated into a command,
+          # so the topic never appears in a rendered command line. This
+          # repository is public; GitHub masks secret values in logs, but the
+          # safe habit is not to put them anywhere that gets echoed.
+          TCKDB_NTFY_TOPIC: ${{ secrets.TCKDB_NTFY_TOPIC }}
+          TCKDB_DEADMAN_URL: ${{ secrets.TCKDB_DEADMAN_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TCKDB_WATCH_REPO: ${{ github.repository }}
+          TCKDB_WATCH_BRANCH: main
+          TCKDB_WATCHDOG_STATE_DIR: .watchdog-state
+          # backend-nightly.yml is daily; GitHub's cron has been observed to
+          # drift by three hours, so 30h is silence rather than lateness.
+          # uptime-check.yml is every 15 minutes; high-frequency schedules are
+          # dropped under load often enough that a short threshold would page
+          # on GitHub's queue rather than on a real fault, so it gets 6h of
+          # total silence before it counts.
+          TCKDB_WATCHED_WORKFLOWS: "backend-nightly.yml:30 uptime-check.yml:6"
+        run: |
+          if [ -z "${TCKDB_NTFY_TOPIC}" ]; then
+            echo "::error::TCKDB_NTFY_TOPIC is not set, so this watchdog cannot alert anyone."
+            exit 1
+          fi
+          bash backend/scripts/ops/tckdb_ci_watchdog.sh
+
+      # always(): the state must be kept even when the run ends red, which is
+      # the normal outcome while a watched workflow is broken. Skipping the
+      # save on failure would re-announce the same breakage every single day,
+      # which is the noise this design exists to avoid.
+      - name: Save watchdog state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .watchdog-state
+          key: ci-watchdog-state-${{ github.run_id }}

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -99,7 +99,12 @@ jobs:
 
           if [ -n "${NTFY_TOPIC}" ]; then
             message="$(printf '%s\n\nChecked from GitHub Actions, which runs independently of the deployment host. Repeats every ~15 minutes until resolved.' "$detail")"
-            curl -sS --max-time 25 \
+            # --fail because here an HTTP error IS the answer: a 401 from a
+            # protected topic or a 5xx from ntfy means the push reached
+            # nobody, and without it curl exits 0 and this job logs a
+            # delivered alert that was never delivered. The same bug was
+            # fixed in the Pi-side checker; it lived on here.
+            curl -sS --fail --max-time 25 \
               -H "Title: ${summary}" \
               -H "Priority: urgent" \
               -H "Tags: rotating_light" \

--- a/backend/docs/deployment/monitoring.md
+++ b/backend/docs/deployment/monitoring.md
@@ -298,6 +298,91 @@ which runs the real script as a subprocess against a fake host and asserts what
 reaches the outside world on each broken path — including that a checker which
 refuses to start sends nothing.
 
+## The same problem, one level out: monitoring CI
+
+Everything above watches the deployment. The *tests* have the identical hole,
+and it went unnoticed for longer.
+
+`.github/workflows/backend-nightly.yml` runs the full suite at 02:17 UTC. It is
+the only job covering the third of the suite the two PR gates never touch, so
+it is the only thing standing between that third and silent rot. On 2026-08-10
+it was found to have failed on **every run back to 2026-07-31** — eleven
+consecutive nights, conclusion `failure` each time — and nobody knew. GitHub
+does not email about a red scheduled run, a red nightly leaves no mark on any
+PR, and the Actions tab is not somewhere anyone passes daily. The suite was
+still being paid for; it had simply stopped being read.
+
+`.github/workflows/ci-watchdog.yml` closes that, and it is shaped by the same
+three rules as the deployment alerting:
+
+**It watches for silence as well as for failure.** A workflow that stops
+running produces no failures, so anything that only watches for failures
+reports it as healthy — the same shape as a dead checker looking like a healthy
+Pi. GitHub disables scheduled workflows in a repository with 60 days of no
+commit activity, and `uptime-check.yml` — the dead man's switch for the
+deployment itself — carries exactly that exposure. So each watched workflow
+gets an expected cadence, and a run older than it is a fault in its own right:
+
+| Watched | Expected | Silent after |
+|---|---|---|
+| `backend-nightly.yml` | daily | 30h (GitHub's cron has drifted 3h here) |
+| `uptime-check.yml` | every 15 min | 6h (high-frequency crons are dropped under load) |
+
+**It is edge triggered.** Eleven identical failures must not become eleven
+identical pushes. A notification goes out when the verdict *changes* —
+green→red, red→green, running→silent — plus one reminder per seven further
+consecutive failures so a long breakage does not fade back into silence. The
+marker rides in the Actions cache, since a hosted runner keeps no disk; losing
+it is benign by construction, because an empty state makes the next bad verdict
+look like a fresh edge, so the worst case is one duplicate push and never a
+missed one.
+
+**It advances that marker only after ntfy accepts the push,** for the same
+reason the Pi-side checker does.
+
+The push names the workflow, the branch, the consecutive-failure count, the
+commit, the failing job and step, and links the run — because "nightly failed"
+with nothing to act on is how people learn to ignore an alert, which is the
+thing being fixed.
+
+### What watches the watchdog
+
+Nothing in GitHub. `ci-watchdog.yml` is itself a scheduled workflow, so the
+60-day disable takes it down alongside the workflows it watches: the same
+failure domain, which is the one thing monitoring must not share. Close it the
+way the Pi-side checker closes it — an external dead man's switch:
+
+```bash
+# healthchecks.io check, period 1 day, grace 6 hours
+gh secret set TCKDB_DEADMAN_URL --repo TCKDB/TCKDB
+```
+
+Until that secret exists the job says so in its own log on every run, and the
+gap is real rather than covered. (GitHub does email the repository owner before
+disabling scheduled workflows for inactivity, which is a backstop, not a
+monitor.)
+
+### Proving it, rather than assuming
+
+The same ten minutes as everything else on this page. The script takes its
+GitHub API base, its ntfy server and its state directory from the environment,
+so it can be pointed anywhere:
+
+```bash
+export TCKDB_NTFY_TOPIC="tckdb-scratch-$(head -c 6 /dev/urandom | base32 | tr '[:upper:]' '[:lower:]')"
+export GH_TOKEN="$(gh auth token)"
+export TCKDB_WATCHDOG_STATE_DIR=/tmp/watchdog-state
+bash backend/scripts/ops/tckdb_ci_watchdog.sh          # expect a push
+curl -s "https://ntfy.sh/${TCKDB_NTFY_TOPIC}/json?poll=1" | jq -r .message
+bash backend/scripts/ops/tckdb_ci_watchdog.sh          # expect silence
+```
+
+`backend/tests/ops/test_ci_watchdog.py` runs the real script as a subprocess
+against a fake GitHub API and a fake ntfy, and asserts what leaves the machine
+on each path — including that an unreadable or wrong-shaped run history is
+reported loudly rather than read as green, which is the one way this watchdog
+could quietly vouch against the outage it exists to find.
+
 ## Redeploying elsewhere
 
 Everything above is three files in the repo — the script and the two units —

--- a/backend/scripts/ops/tckdb_ci_watchdog.sh
+++ b/backend/scripts/ops/tckdb_ci_watchdog.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# Watch scheduled GitHub Actions workflows and push to ntfy when they rot.
+#
+# WHY THIS EXISTS
+#   backend-nightly.yml is the only job that runs the third of the test suite
+#   the two PR gates never touch. On 2026-08-10 it was found to have failed on
+#   every run back to 2026-07-31 -- eleven consecutive nights -- and nobody
+#   knew, because a red scheduled workflow produces no email, no push and no
+#   red mark anywhere a human passes. A gate whose failure nobody sees is not
+#   a gate; it is a job that costs 40 minutes of CI a night and buys nothing.
+#
+# WHAT IT WATCHES FOR, AND WHY BOTH
+#   1. RED. The workflow ran and failed.
+#   2. SILENCE. The workflow did not run at all. This is the failure mode that
+#      matters more, because it is indistinguishable from success from the
+#      outside: no run, no failure, no alert, and the last thing you remember
+#      is a green tick. GitHub disables scheduled workflows in a repository
+#      with 60 days of no commit activity, and it will happily leave them
+#      disabled; a fork, a renamed default branch or a deleted secret get you
+#      to the same place. So the absence of a run is treated as a fault in its
+#      own right, with a per-workflow expected cadence.
+#
+# WHAT IT DOES NOT COVER
+#   Its own silence. This script runs from a scheduled workflow, so it shares
+#   a failure domain with the things it watches: the 60-day disable takes the
+#   watchdog down with the nightly, and nothing is left to say so. That is the
+#   same shape of hole tckdb_alert_check.sh has on the Pi, and it has the same
+#   fix -- an external dead man's switch, TCKDB_DEADMAN_URL, pinged once per
+#   completed run so that an outside service alerts on the ping STOPPING.
+#   The ping means "this watchdog ran", never "CI is well", and it is
+#   deliberately not sent when the script aborts before reaching a verdict.
+#   See backend/docs/deployment/monitoring.md.
+#
+# NOISE BEHAVIOUR, DELIBERATE
+#   Eleven identical failures must not become eleven identical pushes. Like
+#   the Pi-side checker this is EDGE TRIGGERED: a notification goes out when
+#   the verdict CHANGES (green -> red, red -> green, running -> silent), plus
+#   one reminder per TCKDB_WATCHDOG_REMINDER_RUNS consecutive failures so a
+#   long-running breakage does not fade into silence either.
+#
+#   The state file is advanced ONLY after ntfy has accepted the push. A failed
+#   publish that recorded "you have been told" would mean the next run sees no
+#   edge and stays quiet -- an alert lost for a week. That exact bug was fixed
+#   in the Pi-side checker and is not being reintroduced here.
+#
+# ENVIRONMENT
+#   TCKDB_NTFY_TOPIC             required. ntfy topics are public to anyone who
+#                                knows the name, so it is a password: it must
+#                                come from a secret and must never be written
+#                                into this repository, a workflow file or a log
+#   TCKDB_NTFY_SERVER            default https://ntfy.sh
+#   TCKDB_WATCHED_WORKFLOWS      space-separated "<workflow-file>:<max-age-hours>"
+#                                default "backend-nightly.yml:30 uptime-check.yml:6"
+#   TCKDB_WATCH_REPO             default $GITHUB_REPOSITORY, else TCKDB/TCKDB
+#   TCKDB_WATCH_BRANCH           default main
+#   TCKDB_GH_API_BASE            default https://api.github.com
+#   GH_TOKEN / GITHUB_TOKEN      needs actions:read; without it the API is
+#                                rate-limited to 60 requests/hour per IP
+#   TCKDB_WATCHDOG_STATE_DIR     default ~/.cache/tckdb-ci-watchdog
+#   TCKDB_WATCHDOG_REMINDER_RUNS default 7 (remind every 7th consecutive failure)
+#   TCKDB_WATCHDOG_REMINDER_HOURS default 168 (remind weekly while silent)
+#   TCKDB_DEADMAN_URL            optional, strongly recommended -- external URL
+#                                pinged after every completed run
+#
+# EXIT CODES
+#   0  every watched workflow is green and running
+#   1  something is red, silent, or a push could not be delivered
+#   2  the watchdog could not run at all (no topic, no jq, API unreachable).
+#      Nothing is pinged in this case: a dead watchdog's only honest signal is
+#      its silence.
+set -uo pipefail
+
+GH_API_BASE="${TCKDB_GH_API_BASE:-https://api.github.com}"
+REPO="${TCKDB_WATCH_REPO:-${GITHUB_REPOSITORY:-TCKDB/TCKDB}}"
+BRANCH="${TCKDB_WATCH_BRANCH:-main}"
+WATCHED="${TCKDB_WATCHED_WORKFLOWS:-backend-nightly.yml:30 uptime-check.yml:6}"
+NTFY_SERVER="${TCKDB_NTFY_SERVER:-https://ntfy.sh}"
+STATE_DIR="${TCKDB_WATCHDOG_STATE_DIR:-$HOME/.cache/tckdb-ci-watchdog}"
+REMINDER_RUNS="${TCKDB_WATCHDOG_REMINDER_RUNS:-7}"
+REMINDER_HOURS="${TCKDB_WATCHDOG_REMINDER_HOURS:-168}"
+DEADMAN_URL="${TCKDB_DEADMAN_URL:-}"
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+if [[ -z "${TCKDB_NTFY_TOPIC:-}" ]]; then
+    echo "TCKDB_NTFY_TOPIC is not set; refusing to run." >&2
+    exit 2
+fi
+
+# No grep/sed fallback here, unlike the Pi-side checker. That script parses one
+# flat object and a wrong parse is recoverable; this one walks an array of runs
+# and decides an edge from it, where a silently wrong parse means "green" -- the
+# answer that produces no alert. Refusing to start is the safe direction,
+# because a watchdog that exits 2 is a red job, while a watchdog that guesses
+# wrong is a green one.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required by the CI watchdog; refusing to guess at the run list." >&2
+    exit 2
+fi
+
+mkdir -p "$STATE_DIR"
+
+CURL_HEADERS=(-H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
+if [[ -n "$TOKEN" ]]; then
+    CURL_HEADERS+=(-H "Authorization: Bearer ${TOKEN}")
+fi
+
+# --fail because for the API an HTTP error IS the answer: a 404 (workflow file
+# renamed or deleted) and a 401 (token without actions:read) both return a body
+# that jq parses to zero runs, which this script would otherwise report as
+# "the workflow has never run" -- true-sounding, wrong, and pointing at the
+# wrong fix.
+api_get() {
+    curl -sS --fail --max-time 30 "${CURL_HEADERS[@]}" "${GH_API_BASE}$1"
+}
+
+# publish <title> <priority> <tags> <body>; returns curl's exit status so the
+# caller can decide whether the notification actually happened.
+#
+# --fail because a 401 from a protected topic or a 5xx from ntfy means the push
+# reached nobody; without it curl reports success and the caller records an
+# alert that was never delivered. --retry so one transient 5xx does not cost a
+# whole reminder period of silence.
+publish() {
+    curl -sS --fail --retry 2 --retry-delay 2 --max-time 30 \
+        -H "Title: $1" \
+        -H "Priority: $2" \
+        -H "Tags: $3" \
+        -d "$4" \
+        "${NTFY_SERVER}/${TCKDB_NTFY_TOPIC}" >/dev/null
+}
+
+summary_line() {
+    echo "$1"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        echo "$1" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+annotate() {
+    # GitHub log annotations put the verdict on the run's summary page as well
+    # as in the log body. Guarded so local runs and the test suite see plain
+    # text rather than workflow-command noise.
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "::${1}::${2}"
+    fi
+}
+
+epoch_of() {
+    # ISO-8601 UTC timestamp -> epoch seconds; empty string on anything unparseable.
+    [[ -z "$1" ]] && return 0
+    date -u -d "$1" +%s 2>/dev/null || true
+}
+
+now_epoch="$(date -u +%s)"
+overall_rc=0
+watchdog_usable=1
+notified_any=0
+
+for spec in $WATCHED; do
+    workflow="${spec%%:*}"
+    max_age_hours="${spec##*:}"
+    if [[ "$workflow" == "$spec" || -z "$max_age_hours" ]]; then
+        echo "warning: ignoring malformed TCKDB_WATCHED_WORKFLOWS entry '${spec}' (want file.yml:hours)" >&2
+        continue
+    fi
+
+    # Cleared every iteration: `eval` of a jq that produced nothing would
+    # otherwise leave the PREVIOUS workflow's run url and sha in scope and
+    # report them against this one -- a push pointing at the wrong run is
+    # worse than no push.
+    unset wf_display_name verdict_list latest_url latest_sha latest_conclusion latest_id latest_started
+
+    runs_json="$(api_get "/repos/${REPO}/actions/workflows/${workflow}/runs?branch=${BRANCH}&per_page=30&exclude_pull_requests=true")"
+    api_rc=$?
+    if [[ $api_rc -ne 0 || -z "$runs_json" ]]; then
+        # Cannot see the run history, so cannot form a verdict. Loud, and no
+        # dead man's ping: an unreachable API is the watchdog failing, not the
+        # nightly, and forging a heartbeat here would hide it.
+        echo "error: could not read run history for ${workflow} from ${REPO}" >&2
+        annotate error "CI watchdog could not read run history for ${workflow}"
+        watchdog_usable=0
+        overall_rc=1
+        continue
+    fi
+
+    # Freshness is computed over ALL runs including in-progress ones: a nightly
+    # that is still running is emphatically not silent, and treating it as such
+    # would page every time the watchdog overlapped a slow run.
+    latest_any_started="$(jq -r '[.workflow_runs[] | (.run_started_at // .created_at)] | max // ""' <<<"$runs_json")"
+
+    # Verdicts are computed over completed runs with a decisive conclusion.
+    # `cancelled`, `skipped` and `action_required` are evidence of neither
+    # health nor breakage and must not break a streak in either direction.
+    parsed="$(jq -r '
+        def decisive:
+            (.conclusion // "") as $c
+            | (["success", "failure", "timed_out", "startup_failure"] | index($c)) != null;
+        [ .workflow_runs[]
+          | select(.status == "completed")
+          | select(decisive)
+        ]
+        | sort_by(.run_started_at // .created_at)
+        | reverse
+        | . as $runs
+        | ($runs | map(if .conclusion == "success" then "green" else "red" end)) as $verdicts
+        | "wf_display_name=\(($runs[0].name // "") | @sh)",
+          "verdict_list=\(($verdicts | join(" ")) | @sh)",
+          "latest_url=\(($runs[0].html_url // "") | @sh)",
+          "latest_sha=\(($runs[0].head_sha // "") | @sh)",
+          "latest_conclusion=\(($runs[0].conclusion // "") | @sh)",
+          "latest_id=\(($runs[0].id // "" | tostring) | @sh)",
+          "latest_started=\(($runs[0].run_started_at // $runs[0].created_at // "") | @sh)"
+    ' <<<"$runs_json")"
+    jq_rc=$?
+
+    # A jq that errored leaves `parsed` empty, and an empty parse looks exactly
+    # like "no failures" -- the answer that produces no alert. A watchdog is
+    # only worth having if its own broken states are loud, so this is treated
+    # as no verdict at all rather than as good news.
+    if [[ $jq_rc -ne 0 ]]; then
+        echo "error: could not parse the run history for ${workflow}; refusing to read it as green" >&2
+        annotate error "CI watchdog could not parse the run history for ${workflow}"
+        watchdog_usable=0
+        overall_rc=1
+        continue
+    fi
+    eval "$parsed"
+
+    wf_display_name="${wf_display_name:-}"
+    verdict_list="${verdict_list:-}"
+    latest_url="${latest_url:-}"
+    latest_sha="${latest_sha:-}"
+    latest_conclusion="${latest_conclusion:-}"
+    latest_id="${latest_id:-}"
+    display_name="${wf_display_name:-$workflow}"
+    [[ -z "$display_name" ]] && display_name="$workflow"
+
+    # Consecutive leading failures -- the number that turns "it broke" into
+    # "it has been broken for eleven nights", which is a different sentence.
+    streak=0
+    for v in ${verdict_list:-}; do
+        [[ "$v" == "red" ]] || break
+        streak=$((streak + 1))
+    done
+
+    age_hours=""
+    latest_epoch="$(epoch_of "$latest_any_started")"
+    if [[ -n "$latest_epoch" ]]; then
+        age_hours=$(( (now_epoch - latest_epoch) / 3600 ))
+    fi
+
+    # ---------------------------------------------------------------
+    # Verdict
+    # ---------------------------------------------------------------
+    if [[ -z "${verdict_list:-}" && -z "$latest_any_started" ]]; then
+        state_key="never"
+        title="CI watchdog: ${workflow} has never run"
+        priority="high"
+        tags="warning"
+        detail="No runs of ${workflow} exist on ${BRANCH} in ${REPO}. Either the workflow file has just landed and its schedule has not fired yet, or the schedule is wrong and never will."
+    elif [[ -n "$age_hours" && "$age_hours" -gt "$max_age_hours" ]]; then
+        # Silence. Bucketed so a workflow that stays disabled reminds weekly
+        # rather than daily, without needing a second state field.
+        overdue_hours=$((age_hours - max_age_hours))
+        bucket=$((overdue_hours / REMINDER_HOURS))
+        state_key="silent:${bucket}"
+        title="CI watchdog: ${workflow} has not run for ${age_hours}h"
+        priority="high"
+        tags="warning"
+        detail="${display_name} last started ${age_hours}h ago; it is expected at least every ${max_age_hours}h. A scheduled workflow that stops running looks exactly like one that keeps passing. GitHub disables scheduled workflows after 60 days without repository activity -- re-enable it at https://github.com/${REPO}/actions/workflows/${workflow} -- and a deleted secret, a renamed default branch or an edited cron get you here too."
+    elif [[ "$streak" -gt 0 ]]; then
+        bucket=$(( (streak - 1) / REMINDER_RUNS ))
+        state_key="red:${bucket}"
+        nights="run"
+        [[ "$streak" -gt 1 ]] && nights="consecutive runs"
+        title="CI watchdog: ${workflow} failed (${streak} ${nights})"
+        priority="high"
+        tags="warning"
+        detail="$(printf 'Workflow: %s (%s)\nBranch: %s\nVerdict: %s, %s failing %s in a row\nCommit: %s\nRun: %s' \
+            "$workflow" "$display_name" "$BRANCH" "${latest_conclusion:-failure}" "$streak" \
+            "$([[ "$streak" -gt 1 ]] && echo "runs" || echo "run")" \
+            "${latest_sha:0:12}" "${latest_url:-https://github.com/${REPO}/actions/workflows/${workflow}}")"
+
+        # Best-effort enrichment: naming the failed step is the difference
+        # between a push you act on and a push you swipe away. A failure here
+        # must never suppress the alert, so its exit status is ignored.
+        if [[ -n "${latest_id:-}" ]]; then
+            jobs_json="$(api_get "/repos/${REPO}/actions/runs/${latest_id}/jobs?per_page=50" 2>/dev/null)"
+            if [[ -n "$jobs_json" ]]; then
+                failed_steps="$(jq -r '
+                    [ .jobs[]?
+                      | select(.conclusion == "failure" or .conclusion == "timed_out")
+                      | . as $job
+                      | ( [ $job.steps[]? | select(.conclusion == "failure" or .conclusion == "timed_out") | .name ]
+                          | if length == 0 then [$job.name]
+                            else map(if . == $job.name then . else "\($job.name) / \(.)" end)
+                            end )
+                    ]
+                    | flatten | unique | join("; ")
+                ' <<<"$jobs_json" 2>/dev/null)"
+                [[ -n "$failed_steps" ]] && detail="${detail}"$'\n'"Failed: ${failed_steps}"
+            fi
+        fi
+    else
+        state_key="green"
+        title="CI watchdog: ${workflow} is green again"
+        priority="default"
+        tags="white_check_mark"
+        detail="$(printf '%s passed on %s.\nCommit: %s\nRun: %s' \
+            "$display_name" "$BRANCH" "${latest_sha:0:12}" \
+            "${latest_url:-https://github.com/${REPO}/actions/workflows/${workflow}}")"
+    fi
+
+    # ---------------------------------------------------------------
+    # Edge trigger
+    # ---------------------------------------------------------------
+    state_file="${STATE_DIR}/$(printf '%s' "$workflow" | tr -c 'A-Za-z0-9._-' '_')"
+    previous="$(cat "$state_file" 2>/dev/null || echo "unknown")"
+
+    summary_line "${workflow}: ${state_key} (was ${previous})"
+    [[ "$state_key" == "green" ]] || overall_rc=1
+    if [[ "$state_key" != "green" ]]; then
+        annotate error "${title}"
+    fi
+
+    if [[ "$state_key" == "$previous" ]]; then
+        continue
+    fi
+
+    if [[ "$state_key" == "green" && "$previous" == "unknown" ]]; then
+        # First ever look and it is fine: record the state so a later break is
+        # still an edge, but do not announce a non-event.
+        printf '%s' "$state_key" > "$state_file"
+        continue
+    fi
+
+    footer="$(printf 'Reported by the CI watchdog (.github/workflows/ci-watchdog.yml), which notifies on a change of verdict and once per %s further failures. All workflows: https://github.com/%s/actions' "$REMINDER_RUNS" "$REPO")"
+    if publish "$title" "$priority" "$tags" "${detail}"$'\n\n'"${footer}"; then
+        printf '%s' "$state_key" > "$state_file"
+        notified_any=1
+    else
+        # Not advancing the state file is the whole point: the next run sees
+        # the same edge and tries again.
+        echo "warning: failed to publish ${workflow} alert to ntfy; state not advanced, will retry" >&2
+        annotate error "CI watchdog could not deliver the ${workflow} alert to ntfy"
+        overall_rc=1
+    fi
+done
+
+# THE DEAD MAN'S PING. Sent for every completed run whatever the verdict: it
+# asserts that THIS WATCHDOG RAN, which is a different claim from "CI is well".
+# Tying it to a green verdict would mean a red nightly also silences the
+# heartbeat, and the external service would page "the watchdog is gone" while
+# the watchdog was busy saying exactly which workflow had failed.
+#
+# It is skipped when the watchdog could not reach the API at all, because that
+# is a watchdog without a verdict, and its silence is the only honest signal it
+# has left.
+if [[ -n "$DEADMAN_URL" ]]; then
+    if [[ "$watchdog_usable" -eq 1 ]]; then
+        curl -sS --fail --max-time 20 -o /dev/null "$DEADMAN_URL" || \
+            echo "warning: dead man's switch ping to the watchdog deadman URL failed" >&2
+    else
+        echo "warning: no verdict reached, so the dead man's switch was not pinged" >&2
+    fi
+else
+    # Said every run rather than once, because unlike the Pi-side checker this
+    # one has nowhere durable to remember that it has already said it, and a
+    # line in a log is cheap. It is not a push: an unmonitored watchdog is a
+    # real gap but not a 3am one.
+    echo "warning: TCKDB_DEADMAN_URL is unset, so nothing will notice if this watchdog itself stops running" >&2
+    annotate warning "TCKDB_DEADMAN_URL is unset: nothing will notice if this watchdog stops running. See backend/docs/deployment/monitoring.md"
+fi
+
+echo "$(date -Is) watchdog rc=${overall_rc} notified=${notified_any}"
+exit "$overall_rc"

--- a/backend/scripts/ops/tckdb_ci_watchdog.sh
+++ b/backend/scripts/ops/tckdb_ci_watchdog.sh
@@ -247,6 +247,12 @@ for spec in $WATCHED; do
     latest_epoch="$(epoch_of "$latest_any_started")"
     if [[ -n "$latest_epoch" ]]; then
         age_hours=$(( (now_epoch - latest_epoch) / 3600 ))
+    elif [[ -n "$latest_any_started" ]]; then
+        # A timestamp that will not parse means the freshness check silently
+        # does not happen, and a freshness check that does not happen reads as
+        # "not silent". Say so rather than skip quietly.
+        echo "warning: could not parse the last run time for ${workflow}; freshness was not checked" >&2
+        annotate warning "CI watchdog could not check whether ${workflow} is still running"
     fi
 
     # ---------------------------------------------------------------

--- a/backend/tests/ops/conftest.py
+++ b/backend/tests/ops/conftest.py
@@ -22,6 +22,8 @@ import pytest
 
 OPS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "ops"
 ALERT_CHECK = OPS_DIR / "tckdb_alert_check.sh"
+CI_WATCHDOG = OPS_DIR / "tckdb_ci_watchdog.sh"
+WORKFLOWS_DIR = Path(__file__).resolve().parents[3] / ".github" / "workflows"
 
 #: Every external binary tckdb_alert_check.sh requires, minus jq. Used to build
 #: a PATH on which jq genuinely does not exist. ``hostname`` is deliberately
@@ -65,6 +67,9 @@ class FakeHost:
     status_response: tuple[int, str] = (200, "")
     #: Paths that answer 500, used to prove failed publishes are retried.
     failing_paths: set[str] = field(default_factory=set)
+    #: Canned JSON answers keyed by path prefix, for the GitHub API stand-in.
+    #: Longest prefix wins, and the query string is ignored when matching.
+    json_routes: dict[str, tuple[int, str]] = field(default_factory=dict)
 
     @property
     def base(self) -> str:
@@ -72,6 +77,9 @@ class FakeHost:
 
     def set_status(self, payload: dict, code: int = 200) -> None:
         self.status_response = (code, json.dumps(payload))
+
+    def set_json(self, prefix: str, payload: object, code: int = 200) -> None:
+        self.json_routes[prefix] = (code, json.dumps(payload))
 
     def paths(self, prefix: str) -> list[Request]:
         return [r for r in self.requests if r.path.startswith(prefix)]
@@ -98,6 +106,15 @@ def fake_host():
                 self.end_headers()
                 self.wfile.write(b"nope")
                 return
+            bare = self.path.split("?", 1)[0]
+            for prefix in sorted(host.json_routes, key=len, reverse=True):
+                if bare.startswith(prefix):
+                    code, body = host.json_routes[prefix]
+                    self.send_response(code)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(body.encode("utf-8"))
+                    return
             if self.path.startswith("/status"):
                 code, body = host.status_response
                 self.send_response(code)
@@ -182,4 +199,40 @@ def run_alert_check(fake_host, tmp_path):
         return proc
 
     _run.state_file = state_file
+    return _run
+
+
+@pytest.fixture
+def run_ci_watchdog(fake_host, tmp_path):
+    """Run tckdb_ci_watchdog.sh against the fake host and return the result.
+
+    The GitHub API is a stand-in served by the same socket as ntfy and the
+    dead man, so a test can assert on exactly what the watchdog sent and to
+    where -- which is the only claim about a notifier worth making.
+    """
+
+    state_dir = tmp_path / "watchdog-state"
+
+    def _run(*, env_overrides: dict | None = None):
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "TCKDB_GH_API_BASE": f"{fake_host.base}/gh",
+            "TCKDB_NTFY_SERVER": f"{fake_host.base}/ntfy",
+            "TCKDB_NTFY_TOPIC": "test-topic",
+            "TCKDB_WATCH_REPO": "TCKDB/TCKDB",
+            "TCKDB_WATCH_BRANCH": "main",
+            "TCKDB_WATCHDOG_STATE_DIR": str(state_dir),
+            "TCKDB_WATCHED_WORKFLOWS": "backend-nightly.yml:30",
+        }
+        env.update(env_overrides or {})
+        return subprocess.run(
+            ["bash", str(CI_WATCHDOG)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    _run.state_dir = state_dir
     return _run

--- a/backend/tests/ops/test_ci_watchdog.py
+++ b/backend/tests/ops/test_ci_watchdog.py
@@ -282,6 +282,16 @@ def test_a_still_running_workflow_is_not_silence(fake_host, run_ci_watchdog):
     assert pushes(fake_host) == []
 
 
+def test_an_unparseable_run_time_is_not_read_as_fresh(fake_host, run_ci_watchdog):
+    """A freshness check that does not happen reads as "not silent"."""
+    broken = run("success", hours_ago=1, run_id=200)
+    broken["run_started_at"] = "whenever"
+    broken["created_at"] = "whenever"
+    serve_runs(fake_host, [broken])
+    proc = run_ci_watchdog()
+    assert "freshness was not checked" in proc.stderr
+
+
 def test_a_workflow_that_has_never_run_is_reported(fake_host, run_ci_watchdog):
     serve_runs(fake_host, [])
     proc = run_ci_watchdog()

--- a/backend/tests/ops/test_ci_watchdog.py
+++ b/backend/tests/ops/test_ci_watchdog.py
@@ -1,0 +1,531 @@
+"""A notification path nobody has ever seen fire is not a notification path.
+
+The CI watchdog exists because backend-nightly.yml failed eleven nights
+running and nothing said so. Testing it by reading it would repeat the
+original mistake one level up, so it is run as a real process against a
+real socket that stands in for the GitHub API, ntfy and the dead man's
+switch, and every test asserts on *what left the machine*.
+
+Three rules are load-bearing here and each has been got wrong in the wild:
+
+    A workflow that stops running is a fault, not a pass.
+    A verdict that has not changed is not news.
+    A push that was not delivered was not sent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.ops.conftest import CI_WATCHDOG, OPS_DIR, WORKFLOWS_DIR
+
+WORKFLOW = "backend-nightly.yml"
+RUNS_PATH = f"/gh/repos/TCKDB/TCKDB/actions/workflows/{WORKFLOW}/runs"
+JOBS_PREFIX = "/gh/repos/TCKDB/TCKDB/actions/runs/"
+NTFY = "/ntfy"
+
+
+def ago(hours: float) -> str:
+    stamp = datetime.now(timezone.utc) - timedelta(hours=hours)
+    return stamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(
+    conclusion: str | None,
+    *,
+    hours_ago: float,
+    run_id: int = 100,
+    sha: str = "ec53167e7ccc1e34367b66490e00bb6644ccae79",
+    status: str = "completed",
+) -> dict:
+    return {
+        "id": run_id,
+        "name": "Backend Nightly (full suite)",
+        "status": status,
+        "conclusion": conclusion,
+        "head_sha": sha,
+        "run_started_at": ago(hours_ago),
+        "created_at": ago(hours_ago),
+        "html_url": f"https://github.com/TCKDB/TCKDB/actions/runs/{run_id}",
+    }
+
+
+def serve_runs(fake_host, runs: list[dict]) -> None:
+    fake_host.set_json(RUNS_PATH, {"total_count": len(runs), "workflow_runs": runs})
+
+
+def serve_jobs(fake_host, failed_step: str = "Full test suite") -> None:
+    fake_host.set_json(
+        JOBS_PREFIX,
+        {
+            "jobs": [
+                {
+                    "name": "Full test suite",
+                    "conclusion": "failure",
+                    "steps": [
+                        {"name": "Check out repository", "conclusion": "success"},
+                        {"name": failed_step, "conclusion": "failure"},
+                    ],
+                }
+            ]
+        },
+    )
+
+
+def pushes(fake_host) -> list:
+    return fake_host.paths(NTFY)
+
+
+def titles(fake_host) -> list[str]:
+    return [r.headers.get("title", "") for r in pushes(fake_host)]
+
+
+def red_history(nights: int) -> list[dict]:
+    """`nights` consecutive nightly failures, most recent first."""
+    return [
+        run("failure", hours_ago=2 + 24 * i, run_id=100 - i)
+        for i in range(nights)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# A red workflow becomes a push that can be acted on
+# ---------------------------------------------------------------------------
+
+
+def test_a_failing_workflow_is_pushed_with_enough_to_act_on(fake_host, run_ci_watchdog):
+    """"Nightly failed" with no link is how people learn to ignore alerts.
+
+    The push has to name the workflow, the commit, the failing step and the
+    run URL, or the recipient still has to go and find all of it -- and the
+    reason this alert did not already exist is that nobody was going to look.
+    """
+    serve_runs(fake_host, red_history(11))
+    serve_jobs(fake_host)
+
+    proc = run_ci_watchdog()
+    assert proc.returncode == 1, proc.stderr
+
+    sent = pushes(fake_host)
+    assert len(sent) == 1, "a fresh red verdict is news exactly once"
+    body = sent[0].body
+    assert WORKFLOW in sent[0].headers.get("title", "")
+    assert "11" in sent[0].headers.get("title", ""), "the streak belongs in the title"
+    assert "https://github.com/TCKDB/TCKDB/actions/runs/100" in body
+    assert "ec53167e7ccc" in body, "the commit under test"
+    assert "Full test suite" in body, "the step that actually failed"
+    assert "Full test suite / Full test suite" not in body, (
+        "a job whose only step shares its name says it once"
+    )
+
+
+def test_the_failing_step_is_named_within_its_job(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, red_history(1))
+    fake_host.set_json(
+        JOBS_PREFIX,
+        {
+            "jobs": [
+                {"name": "lint", "conclusion": "success", "steps": []},
+                {
+                    "name": "full-suite",
+                    "conclusion": "failure",
+                    "steps": [{"name": "Initialize artifact bucket", "conclusion": "failure"}],
+                },
+            ]
+        },
+    )
+    run_ci_watchdog()
+    body = pushes(fake_host)[0].body
+    assert "full-suite / Initialize artifact bucket" in body
+    assert "lint" not in body, "a job that passed is not part of the diagnosis"
+
+
+def test_the_streak_counts_only_the_leading_failures(fake_host, run_ci_watchdog):
+    serve_runs(
+        fake_host,
+        [
+            run("failure", hours_ago=2, run_id=100),
+            run("failure", hours_ago=26, run_id=99),
+            run("success", hours_ago=50, run_id=98),
+            run("failure", hours_ago=74, run_id=97),
+        ],
+    )
+    serve_jobs(fake_host)
+    run_ci_watchdog()
+    assert "(2 consecutive runs)" in titles(fake_host)[0]
+
+
+def test_cancelled_runs_are_evidence_of_nothing(fake_host, run_ci_watchdog):
+    """A cancelled run must break neither a red streak nor a green one.
+
+    Counting it as green would silently clear a real breakage -- the alert
+    would say "green again" while the suite had not passed since July.
+    """
+    serve_runs(
+        fake_host,
+        [
+            run("cancelled", hours_ago=1, run_id=101),
+            run("failure", hours_ago=2, run_id=100),
+            run("failure", hours_ago=26, run_id=99),
+        ],
+    )
+    serve_jobs(fake_host)
+    proc = run_ci_watchdog()
+    assert proc.returncode == 1
+    assert "(2 consecutive runs)" in titles(fake_host)[0]
+
+
+# ---------------------------------------------------------------------------
+# Edge triggering: eleven identical failures are not eleven pushes
+# ---------------------------------------------------------------------------
+
+
+def test_an_unchanged_verdict_is_not_re_announced(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, red_history(3))
+    serve_jobs(fake_host)
+
+    run_ci_watchdog()
+    assert len(pushes(fake_host)) == 1
+
+    serve_runs(fake_host, red_history(4))
+    second = run_ci_watchdog()
+    assert second.returncode == 1, "still red, still a red job"
+    assert len(pushes(fake_host)) == 1, (
+        "a breakage that has not changed is not news; an alert you learn to "
+        "ignore is worse than no alert"
+    )
+
+
+def test_a_long_breakage_is_reminded_about_periodically(fake_host, run_ci_watchdog):
+    """Edge triggering must not become permanent silence either."""
+    serve_runs(fake_host, red_history(1))
+    serve_jobs(fake_host)
+    run_ci_watchdog(env_overrides={"TCKDB_WATCHDOG_REMINDER_RUNS": "7"})
+    assert len(pushes(fake_host)) == 1
+
+    serve_runs(fake_host, red_history(7))
+    run_ci_watchdog(env_overrides={"TCKDB_WATCHDOG_REMINDER_RUNS": "7"})
+    assert len(pushes(fake_host)) == 1, "still inside the first reminder window"
+
+    serve_runs(fake_host, red_history(8))
+    run_ci_watchdog(env_overrides={"TCKDB_WATCHDOG_REMINDER_RUNS": "7"})
+    assert len(pushes(fake_host)) == 2, "a week of red earns one more mention"
+    assert "(8 consecutive runs)" in titles(fake_host)[1]
+
+
+def test_recovery_is_announced(fake_host, run_ci_watchdog):
+    """Otherwise you are left wondering whether it is still broken."""
+    serve_runs(fake_host, red_history(3))
+    serve_jobs(fake_host)
+    run_ci_watchdog()
+
+    serve_runs(fake_host, [run("success", hours_ago=1, run_id=200), *red_history(3)])
+    proc = run_ci_watchdog()
+    assert proc.returncode == 0
+    assert len(pushes(fake_host)) == 2
+    assert "green again" in titles(fake_host)[1]
+
+
+def test_a_first_look_at_a_healthy_workflow_says_nothing(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, [run("success", hours_ago=2, run_id=200)])
+    proc = run_ci_watchdog()
+    assert proc.returncode == 0
+    assert pushes(fake_host) == [], "a non-event is not an alert"
+    assert (run_ci_watchdog.state_dir / WORKFLOW).read_text() == "green", (
+        "but the state is recorded, so a later break is still an edge"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Silence is the failure mode that looks like success
+# ---------------------------------------------------------------------------
+
+
+def test_a_workflow_that_stopped_running_is_a_fault(fake_host, run_ci_watchdog):
+    """The case a failure-only monitor reports as healthy.
+
+    Every run in the history passed. There simply has not been one for
+    three days, which is what a disabled schedule looks like -- and it is
+    exactly how GitHub leaves a repository after 60 days of inactivity.
+    """
+    serve_runs(fake_host, [run("success", hours_ago=72, run_id=200)])
+    proc = run_ci_watchdog()
+    assert proc.returncode == 1
+    assert len(pushes(fake_host)) == 1
+    title = titles(fake_host)[0]
+    assert "has not run" in title
+    body = pushes(fake_host)[0].body
+    assert "60 days" in body, "the push has to name the most likely cause"
+    assert f"actions/workflows/{WORKFLOW}" in body, "and where to re-enable it"
+
+
+def test_a_still_running_workflow_is_not_silence(fake_host, run_ci_watchdog):
+    """A slow nightly overlapping the watchdog must not page.
+
+    The in-progress run has no conclusion, so a freshness check that only
+    looked at completed runs would call a workflow that is running right
+    now "not run for 72 hours".
+    """
+    serve_runs(
+        fake_host,
+        [
+            run(None, hours_ago=1, run_id=201, status="in_progress"),
+            run("success", hours_ago=72, run_id=200),
+        ],
+    )
+    proc = run_ci_watchdog()
+    assert proc.returncode == 0
+    assert pushes(fake_host) == []
+
+
+def test_a_workflow_that_has_never_run_is_reported(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, [])
+    proc = run_ci_watchdog()
+    assert proc.returncode == 1
+    assert "has never run" in titles(fake_host)[0]
+
+
+# ---------------------------------------------------------------------------
+# A push that never arrived must not be recorded as delivered
+# ---------------------------------------------------------------------------
+
+
+def test_failed_push_is_retried_on_the_next_run(fake_host, run_ci_watchdog):
+    """State advances on delivery, not on intent.
+
+    Edge triggering means a missed transition is missed until the next
+    reminder window -- up to a week of a red suite and a quiet phone. So
+    the state file only moves once ntfy has accepted the push. This bug
+    was found and fixed in the Pi-side checker; it is not being rebuilt.
+    """
+    serve_runs(fake_host, red_history(2))
+    serve_jobs(fake_host)
+    fake_host.failing_paths.add(f"{NTFY}/test-topic")
+
+    first = run_ci_watchdog()
+    assert first.returncode == 1
+    assert "state not advanced" in first.stderr
+    assert not (run_ci_watchdog.state_dir / WORKFLOW).exists(), (
+        "an undelivered alert must not be recorded as delivered"
+    )
+
+    fake_host.failing_paths.clear()
+    second = run_ci_watchdog()
+    assert second.returncode == 1
+    assert (run_ci_watchdog.state_dir / WORKFLOW).read_text().startswith("red:")
+    delivered = [r for r in pushes(fake_host) if r.method == "POST"]
+    assert len(delivered) >= 2, "one failed attempt, one successful retry"
+
+
+# ---------------------------------------------------------------------------
+# ... and the watchdog's own death is silence, deliberately
+# ---------------------------------------------------------------------------
+
+
+def test_a_watchdog_that_cannot_start_sends_no_ping(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, red_history(2))
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_NTFY_TOPIC": "",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 2
+    assert fake_host.paths("/deadman") == [], (
+        "a watchdog that refused to run must stay silent so its silence is the alarm"
+    )
+
+
+def test_an_unreadable_run_history_is_loud_and_unpinged(fake_host, run_ci_watchdog):
+    """A 404 or a token without actions:read parses to zero runs.
+
+    Reported as "has never run" that would be true-sounding, wrong, and
+    point at the wrong fix -- so the API error is handled before the run
+    list is believed, and no heartbeat is forged for a verdict never reached.
+    """
+    fake_host.set_json(RUNS_PATH, {"message": "Not Found"}, code=404)
+    proc = run_ci_watchdog(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert proc.returncode == 1
+    assert pushes(fake_host) == []
+    assert fake_host.paths("/deadman") == []
+    assert "could not read run history" in proc.stderr
+
+
+def test_an_unparseable_run_history_is_not_read_as_green(fake_host, run_ci_watchdog):
+    """The failure this whole file is about, one level in.
+
+    An empty parse is indistinguishable from "no failures", so a jq that
+    errors would make the watchdog report a broken nightly as healthy --
+    monitoring vouching against the outage it exists to find. A 200 with
+    the wrong shape has to be as loud as a 404.
+    """
+    fake_host.set_json(RUNS_PATH, {"workflow_runs": {"not": "an array"}})
+    proc = run_ci_watchdog(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert proc.returncode == 1
+    assert pushes(fake_host) == []
+    assert fake_host.paths("/deadman") == []
+    assert "refusing to read it as green" in proc.stderr
+
+
+def test_deadman_is_pinged_even_when_a_watched_workflow_is_red(fake_host, run_ci_watchdog):
+    """The ping means "this watchdog ran", never "CI is well".
+
+    Tying it to a green verdict would let a red nightly silence the
+    heartbeat, and the external service would page "the watchdog is gone"
+    while the watchdog was busy naming the workflow that failed.
+    """
+    serve_runs(fake_host, red_history(2))
+    serve_jobs(fake_host)
+    proc = run_ci_watchdog(
+        env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
+    )
+    assert proc.returncode == 1
+    assert len(fake_host.paths("/deadman")) == 1
+    assert len(pushes(fake_host)) == 1
+
+
+def test_a_missing_deadman_is_named_as_a_gap(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, [run("success", hours_ago=2, run_id=200)])
+    proc = run_ci_watchdog()
+    assert "TCKDB_DEADMAN_URL is unset" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# The topic is password-equivalent and this repository is public
+# ---------------------------------------------------------------------------
+
+
+def test_the_topic_never_reaches_the_log(fake_host, run_ci_watchdog):
+    serve_runs(fake_host, red_history(2))
+    serve_jobs(fake_host)
+    proc = run_ci_watchdog(env_overrides={"TCKDB_NTFY_TOPIC": "tckdb-secret-topic"})
+    assert "tckdb-secret-topic" not in proc.stdout
+    assert "tckdb-secret-topic" not in proc.stderr
+
+
+def test_the_script_holds_no_topic_of_its_own():
+    body = CI_WATCHDOG.read_text()
+    assert "ntfy.sh/tckdb-" not in body
+    assert body.isascii(), "runtime strings stay ASCII"
+
+
+# ---------------------------------------------------------------------------
+# Several watched workflows, independently
+# ---------------------------------------------------------------------------
+
+
+def test_each_watched_workflow_gets_its_own_verdict(fake_host, run_ci_watchdog):
+    """A green uptime-check must not mask a red nightly, or vice versa."""
+    serve_runs(fake_host, red_history(2))
+    serve_jobs(fake_host)
+    fake_host.set_json(
+        "/gh/repos/TCKDB/TCKDB/actions/workflows/uptime-check.yml/runs",
+        {"workflow_runs": [run("success", hours_ago=0.2, run_id=300)]},
+    )
+
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_WATCHED_WORKFLOWS": f"{WORKFLOW}:30 uptime-check.yml:6",
+        }
+    )
+    assert proc.returncode == 1
+    assert len(pushes(fake_host)) == 1
+    assert WORKFLOW in titles(fake_host)[0]
+    assert (run_ci_watchdog.state_dir / "uptime-check.yml").read_text() == "green"
+
+
+def test_a_stale_uptime_check_is_caught_too(fake_host, run_ci_watchdog):
+    """uptime-check.yml carries the same 60-day disable exposure.
+
+    It is the dead man's switch for the deployment, so its going quiet is
+    the same class of invisible fault as the nightly's, one level out.
+    """
+    serve_runs(fake_host, [run("success", hours_ago=1, run_id=100)])
+    fake_host.set_json(
+        "/gh/repos/TCKDB/TCKDB/actions/workflows/uptime-check.yml/runs",
+        {"workflow_runs": [run("success", hours_ago=48, run_id=300)]},
+    )
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_WATCHED_WORKFLOWS": f"{WORKFLOW}:30 uptime-check.yml:6",
+        }
+    )
+    assert proc.returncode == 1
+    assert any("uptime-check.yml" in t and "has not run" in t for t in titles(fake_host))
+
+
+# ---------------------------------------------------------------------------
+# The workflow wiring is part of the mechanism, so it is asserted too
+# ---------------------------------------------------------------------------
+
+
+def test_the_watchdog_workflow_is_wired_to_the_script_and_the_secret():
+    body = (WORKFLOWS_DIR / "ci-watchdog.yml").read_text()
+    assert "backend/scripts/ops/tckdb_ci_watchdog.sh" in body
+    assert "secrets.TCKDB_NTFY_TOPIC" in body
+    assert "schedule:" in body and "workflow_dispatch:" in body
+    assert "actions: read" in body, "the run-history API needs it"
+    # Without this the state is dropped on exactly the runs that set it --
+    # the red ones -- and every red day becomes another identical push.
+    save = body.split("Save watchdog state", 1)[1]
+    assert "if: always()" in save
+
+
+def _curl_invocations(text: str) -> list[str]:
+    """Every curl command in a file, with line continuations folded in."""
+    joined = re.sub(r"\\\n\s*", " ", text)
+    return re.findall(r"curl\b[^\n]*", joined)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        WORKFLOWS_DIR / "uptime-check.yml",
+        OPS_DIR / "tckdb_alert_check.sh",
+        OPS_DIR / "tckdb_ci_watchdog.sh",
+    ],
+    ids=lambda p: p.name,
+)
+def test_every_ntfy_publish_fails_loudly_on_an_http_error(path):
+    """Without --fail a 401 or a 5xx is counted as a delivered alert.
+
+    curl exits 0 on an HTTP error unless told otherwise, so the caller
+    records "they have been told" when nobody has. That bug was fixed in
+    the Pi-side checker and had survived in uptime-check.yml; every place
+    that pushes to ntfy is pinned against it here so it cannot come back
+    in the next one.
+    """
+    commands = [c for c in _curl_invocations(path.read_text()) if "ntfy" in c.lower()]
+    assert commands, f"{path.name} was expected to publish to ntfy"
+    for command in commands:
+        assert "--fail" in command, f"{path.name}: {command}"
+
+
+def test_the_nightly_is_actually_watched():
+    """The whole point. A watchdog watching nothing is worse than none."""
+    body = (WORKFLOWS_DIR / "ci-watchdog.yml").read_text()
+    assert "backend-nightly.yml:" in body
+    assert "uptime-check.yml:" in body
+
+
+def test_the_watched_list_is_a_parseable_spec():
+    body = (WORKFLOWS_DIR / "ci-watchdog.yml").read_text()
+    line = next(
+        stripped
+        for raw in body.splitlines()
+        if (stripped := raw.strip()).startswith("TCKDB_WATCHED_WORKFLOWS:")
+    )
+    spec = json.loads(line.split(":", 1)[1].strip())
+    for entry in spec.split():
+        name, _, hours = entry.rpartition(":")
+        assert name.endswith(".yml"), entry
+        assert hours.isdigit() and int(hours) > 0, entry
+        assert (WORKFLOWS_DIR / name).exists(), f"{name} is watched but does not exist"


### PR DESCRIPTION
## The problem

`.github/workflows/backend-nightly.yml` is the only job that runs the third of the test suite the two PR gates never touch. It has failed on **every run back to 2026-07-31** — eleven consecutive nights, conclusion `failure` each time (the last green run was 2026-07-30, `30516197866`).

Nothing said so. GitHub sends no mail for a red scheduled workflow, a red nightly leaves no mark on any PR, and the Actions tab is not somewhere anyone passes daily. The suite was still being paid for — roughly 40 minutes of CI a night — and had simply stopped being read.

**This PR does not make the nightly green.** That is #64, in flight separately. This is the part that means the next rot is noticed on the second night rather than the eleventh.

## What lands

`.github/workflows/ci-watchdog.yml` + `backend/scripts/ops/tckdb_ci_watchdog.sh`: once a day, read the run history of the watched workflows and push to ntfy.

**It watches for silence as well as for failure.** A workflow that stops running produces no failures, so a failure-only monitor reports it as healthy — the same shape as a dead checker looking like a healthy Pi. GitHub disables scheduled workflows in a repository with 60 days of no commit activity, and `uptime-check.yml` — the dead man's switch for the deployment itself — carries exactly that exposure, so it is watched too:

| Watched | Expected | Reported silent after |
|---|---|---|
| `backend-nightly.yml` | daily | 30h (GitHub's cron has drifted 3h on this repo) |
| `uptime-check.yml` | every 15 min | 6h (high-frequency crons get dropped under load) |

**It is edge triggered,** the way `tckdb_alert_check.sh` is: notify on a change of verdict (green→red, red→green, running→silent) plus one reminder per seven further consecutive failures. Eleven identical failures must not become eleven identical pushes. The marker rides in the Actions cache since a hosted runner keeps no disk; losing it is benign by construction, because an empty state makes the next bad verdict look like a fresh edge — worst case one duplicate push, never a missed one.

**The state advances only after ntfy accepts the push,** and `curl --fail` throughout — both lessons from #122, which is also where `uptime-check.yml`'s own publish is fixed here: it was missing `--fail`, so a 401 or a 5xx counted as a delivered alert.

**An unreadable or wrong-shaped run history is loud, not green.** An empty parse looks exactly like "no failures", which is the answer that alerts nobody; a 404, a token without `actions:read` and a 200 with the wrong shape are all handled before the run list is believed.

The push carries what you need to act: workflow, branch, consecutive-failure count, commit, the failing job **and step**, and the run URL. "Nightly failed" with nothing to act on is how people learn to ignore an alert, which is the thing being fixed.

## How I know it fires

A notification path nobody has seen fire is not a notification path, so all three were exercised for real.

**1. Against the live GitHub API and real ntfy delivery, locally** (scratch topic, message read back from `ntfy.sh/<topic>/json?poll=1`):

```
backend-nightly.yml: red:1 (was unknown)      -> notified=1
backend-nightly.yml: red:1 (was red:1)        -> notified=0     # edge trigger holds
```
```
TITLE: CI watchdog: backend-nightly.yml failed (11 consecutive runs)
Workflow: backend-nightly.yml (Backend Nightly (full suite))
Branch: main
Verdict: failure, 11 failing runs in a row
Commit: ec53167e7ccc
Run: https://github.com/TCKDB/TCKDB/actions/runs/31354440415
Failed: Full test suite
```

**2. The silence path, also against the live API** — pointed at `docs.yml:1`, a real workflow that genuinely had not run in the last hour:

```
TITLE: CI watchdog: docs.yml has not run for 5h
Docs last started 5h ago; it is expected at least every 1h. ... GitHub disables
scheduled workflows after 60 days without repository activity -- re-enable it at
https://github.com/TCKDB/TCKDB/actions/workflows/docs.yml -- ...
```
Second run: `notified=0`. ntfy reported exactly 1 message delivered.

**3. On a real GitHub runner with the real repository secret**, via a temporary `push:` trigger on this branch, since `workflow_dispatch` only works once the file is on `main`. The trigger and its two commits have been removed from the branch:

- run [31422534831](https://github.com/TCKDB/TCKDB/actions/runs/31422534831) — `Cache not found` → `backend-nightly.yml: red:1 (was unknown)` → `watchdog rc=1 notified=1`, with `##[error]CI watchdog: backend-nightly.yml failed (11 consecutive runs)` on the run page. **A real push went to the real topic.**
- run [31422603505](https://github.com/TCKDB/TCKDB/actions/runs/31422603505) — `Cache restored from key: ci-watchdog-state-31422534831` → `(was red:1)` → `notified=0`. The cache-backed edge trigger works on a hosted runner.

The topic appeared as `***` in both logs.

**4. `backend/tests/ops/test_ci_watchdog.py`** — 26 tests running the real script as a subprocess against a fake GitHub API, a fake ntfy and a fake dead man, asserting on what leaves the machine: the streak count, cancelled runs being evidence of neither verdict, an in-progress run not counting as silence, an undelivered push not advancing state, a watchdog that cannot start sending no heartbeat, and an unparseable history not being read as green. `tests/ops/` is already in the API gate, so these gate the PR that breaks them.

## Secrets

`TCKDB_NTFY_TOPIC` **already exists** as a repository secret — nothing to create.

`TCKDB_DEADMAN_URL` does not, and is the one gap left open: this watchdog is itself a scheduled workflow, so the 60-day disable takes it down alongside the workflows it watches. Same failure domain, which is the one thing monitoring must not share. Closing it is a healthchecks.io check (period 1 day, grace 6h) and:

```bash
gh secret set TCKDB_DEADMAN_URL --repo TCKDB/TCKDB
```

Until then the job says so in its own log and as a `::warning::` on every run. The gap is real, not covered.

## Verification

- `pytest tests/ops/` — 47 passed (26 new)
- `ruff check tests/ops/ scripts/` — clean
- `bash -n backend/scripts/ops/tckdb_ci_watchdog.sh` — clean, and added to the Hygiene checks alongside the other ops scripts
- Two live GitHub Actions runs and three live-API local runs, above

Runbook: `backend/docs/deployment/monitoring.md` gains a "The same problem, one level out: monitoring CI" section, including how to point the script at a scratch topic and watch it fire.
