### PR TITLE
Make the suite pass in an order nobody chose

### DIFF
--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -66,6 +66,13 @@ jobs:
       # See the note in backend-ci.yml: 4 vCPUs on a standard runner, and each
       # worker creates and migrates its own database.
       TCKDB_TEST_WORKERS: "4"
+      # The PR gates pin the order so a red gate is a regression rather than an
+      # unlucky draw. Something still has to run an order nobody chose, or the
+      # suite is only ever proved against the one ordering the pin selects --
+      # and a nightly is exactly the job that can afford to draw a new one.
+      # pytest-randomly prints the seed it drew, so anything this finds is
+      # reproducible with TCKDB_TEST_SEED=<that value>.
+      TCKDB_TEST_SEED: random
       AUTH_ALLOW_OPEN_REGISTRATION: "true"
       DEPLOYMENT_MODE: local
       EXPOSE_API_DOCS: "true"

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -277,12 +277,18 @@ full suite is verified green at seeds **1, 2, 3, 4, 5, 7, 11, 90210 and
 since it puts all ~6,770 tests in one process against one database and so
 exercises every cross-file adjacency the sharded runs hide.
 
-**Set `TCKDB_TEST_SEED=random` for an unpinned order.** It drops
-`--randomly-seed` and lets `pytest-randomly` seed itself from the clock;
-the seed it drew is printed in the pytest header, so anything that falls over
-in that order is reproducible with `TCKDB_TEST_SEED=<that value>`. Use it for
-scheduled full-suite runs: a nightly pinned to one seed re-tests one ordering
-365 times a year, which is not what a nightly is for.
+**Set `TCKDB_TEST_SEED=random` for an unpinned order.** The script draws a
+fresh seed per invocation and echoes it:
+
+```
+tckdb: unpinned order, drew --randomly-seed=636985447 (replay with TCKDB_TEST_SEED=636985447)
+```
+
+It draws the seed itself rather than letting `pytest-randomly` pick one from
+the clock because the plugin announces its choice in `pytest_report_header`,
+which the `-q` every gate script passes suppresses — so a failure in an
+unpinned order would arrive with no way to replay the order that produced it.
+`backend-nightly.yml` runs this way; the PR gates stay pinned.
 
 **Workers default to 8**, not to core count. Each xdist worker creates its own
 database and runs `alembic upgrade head` into it (~6 s), so every extra worker

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -271,6 +271,19 @@ purely because they drew different orders. A pinned seed does not make the
 suite order-independent; the rollback fixtures and the committed-row tripwire
 below do that. It makes a gate *result* reproducible.
 
+That claim is only worth anything if somebody checks it, so it is checked. The
+full suite is verified green at seeds **1, 2, 3, 4, 5, 7, 11, 90210 and
+424242**, under **8, 4, 2 and 0** workers — 0 (serial) being the strict case,
+since it puts all ~6,770 tests in one process against one database and so
+exercises every cross-file adjacency the sharded runs hide.
+
+**Set `TCKDB_TEST_SEED=random` for an unpinned order.** It drops
+`--randomly-seed` and lets `pytest-randomly` seed itself from the clock;
+the seed it drew is printed in the pytest header, so anything that falls over
+in that order is reproducible with `TCKDB_TEST_SEED=<that value>`. Use it for
+scheduled full-suite runs: a nightly pinned to one seed re-tests one ordering
+365 times a year, which is not what a nightly is for.
+
 **Workers default to 8**, not to core count. Each xdist worker creates its own
 database and runs `alembic upgrade head` into it (~6 s), so every extra worker
 costs a database, a migration and a connection pool against one shared
@@ -291,6 +304,7 @@ contention describe the contention rather than the tests.
 
 ```bash
 TCKDB_TEST_SEED=7 bash backend/scripts/test-full.sh        # a different order
+TCKDB_TEST_SEED=random bash backend/scripts/test-full.sh   # unpinned order
 bash backend/scripts/test-full.sh --randomly-seed=last     # caller wins
 TCKDB_TEST_WORKERS=16 bash backend/scripts/test-full.sh    # more workers
 TCKDB_TEST_WORKERS=0  bash backend/scripts/test-full.sh    # serial
@@ -362,9 +376,16 @@ psql -h 127.0.0.1 -U tckdb -d postgres -c "
   *independence* by varying it on purpose:
 
   ```bash
-  TCKDB_TEST_SEED=1 bash backend/scripts/test-full.sh   # a different order
-  bash backend/scripts/test-full.sh -p no:randomly      # declaration order
+  TCKDB_TEST_SEED=1 bash backend/scripts/test-full.sh      # a different order
+  TCKDB_TEST_SEED=random bash backend/scripts/test-full.sh # any order at all
+  bash backend/scripts/test-full.sh -p no:randomly         # declaration order
   ```
+
+  Vary the *worker count* too, and finish with `TCKDB_TEST_WORKERS=0`.
+  Workers shard the suite, so an eight-way run only ever puts a leaking
+  test and its victim in the same process one time in eight; serial puts
+  every test in one process against one database and is the case that
+  actually decides order independence.
 
   For declaration order *reversed*, write a throwaway plugin outside the repo
   and load it by name — deliberately not a supported flag, because the suite
@@ -429,6 +450,17 @@ It started in `tests/workflows/conftest.py` and now covers every tree, because
 by cleaning up: the counts match again by teardown. There is no exemption
 marker, deliberately. `TCKDB_TEST_COMMIT_TRIPWIRE=0` disables it for bisecting
 an unrelated failure, never as a way to land a committing test.
+
+It makes **two** comparisons, not one. The first is the pair above: baseline
+against final count, which catches a test body that commits. The second is
+this test's baseline against the *previous* test's final count, which catches
+rows that appeared when no test body was running at all — the setup of a
+session- or module-scoped fixture (pytest instantiates those before any
+function-scoped autouse fixture, so the first check is blind to them), a
+subprocess, a background thread. That leak used to be undetectable by
+construction and surfaced only as an unqualified query in some later file
+returning a row nothing there created; now it names the two tests it appeared
+between.
 
 It watches a curated ~35-table union rather than all ~110 public tables
 because counting everything costs ~90 ms per probe (~12 minutes over the

--- a/backend/scripts/lib/pytest_run_args.sh
+++ b/backend/scripts/lib/pytest_run_args.sh
@@ -21,8 +21,23 @@
 # 424242 is the seed the order-dependence audit was conducted against; it is
 # deliberately a known-hostile order rather than a lucky one.
 #
+# Pinning is reproducibility, not a workaround — and the difference is only
+# credible if something still runs an unpinned order. The suite is verified
+# order-independent at seeds 1, 2, 3, 4, 5, 7, 11, 90210 and 424242, across 8,
+# 4, 2 and 0 workers (see backend/docs/testing.md), so the pin now costs
+# nothing but the coverage it would remove if it were the only mode. Hence:
+#
+#   TCKDB_TEST_SEED=random bash backend/scripts/test-full.sh
+#
+# drops --randomly-seed entirely and lets pytest-randomly seed itself from the
+# clock. It prints the seed it drew in its header, so a failure found that way
+# is still reproducible with TCKDB_TEST_SEED=<that value>. That is the mode a
+# scheduled full-suite run should use: a nightly that draws the same order
+# every night re-tests one ordering 365 times a year.
+#
 # Run a different order on purpose:
 #   TCKDB_TEST_SEED=1 bash backend/scripts/test-full.sh
+#   TCKDB_TEST_SEED=random bash backend/scripts/test-full.sh
 #   bash backend/scripts/test-full.sh --randomly-seed=last   # (caller wins)
 #
 # ---------------------------------------------------------------------------
@@ -66,7 +81,12 @@ tckdb_pytest_run_args() {
     # is the *operator's* override and outranks it.
     local workers="${TCKDB_TEST_WORKERS:-${TCKDB_DEFAULT_WORKERS:-8}}"
 
-    if [[ "$caller_args" != *" -p no:randomly "* && "$caller_args" != *"--randomly-seed"* ]]; then
+    # ``random`` is not a value pytest-randomly accepts; the way to ask for an
+    # unpinned order is to pass no seed at all, which is what it already does
+    # by default. Handled here rather than by asking every caller to know that.
+    if [[ "$seed" != "random" \
+          && "$caller_args" != *" -p no:randomly "* \
+          && "$caller_args" != *"--randomly-seed"* ]]; then
         TCKDB_PYTEST_ARGS+=("--randomly-seed=${seed}")
     fi
 

--- a/backend/scripts/lib/pytest_run_args.sh
+++ b/backend/scripts/lib/pytest_run_args.sh
@@ -29,8 +29,7 @@
 #
 #   TCKDB_TEST_SEED=random bash backend/scripts/test-full.sh
 #
-# drops --randomly-seed entirely and lets pytest-randomly seed itself from the
-# clock. It prints the seed it drew in its header, so a failure found that way
+# draws a fresh seed per invocation and echoes it, so a failure found that way
 # is still reproducible with TCKDB_TEST_SEED=<that value>. That is the mode a
 # scheduled full-suite run should use: a nightly that draws the same order
 # every night re-tests one ordering 365 times a year.
@@ -81,12 +80,20 @@ tckdb_pytest_run_args() {
     # is the *operator's* override and outranks it.
     local workers="${TCKDB_TEST_WORKERS:-${TCKDB_DEFAULT_WORKERS:-8}}"
 
-    # ``random`` is not a value pytest-randomly accepts; the way to ask for an
-    # unpinned order is to pass no seed at all, which is what it already does
-    # by default. Handled here rather than by asking every caller to know that.
-    if [[ "$seed" != "random" \
-          && "$caller_args" != *" -p no:randomly "* \
+    # ``random`` draws a seed here rather than letting pytest-randomly draw its
+    # own from the clock. Both give an unpinned order; only this one is
+    # reproducible afterwards. pytest-randomly announces the seed it picked in
+    # ``pytest_report_header``, which ``-q`` -- what every gate script passes --
+    # suppresses, so an unpinned failure would arrive with no way to replay the
+    # order that produced it. Drawing it here and echoing it puts the seed in
+    # the job log unconditionally, whatever the verbosity.
+    if [[ "$caller_args" != *" -p no:randomly "* \
           && "$caller_args" != *"--randomly-seed"* ]]; then
+        if [[ "$seed" == "random" ]]; then
+            seed=$(( (RANDOM << 15 | RANDOM) + 1 ))
+            echo "tckdb: unpinned order, drew --randomly-seed=${seed}" \
+                 "(replay with TCKDB_TEST_SEED=${seed})" >&2
+        fi
         TCKDB_PYTEST_ARGS+=("--randomly-seed=${seed}")
     fi
 

--- a/backend/tests/api/test_api_status.py
+++ b/backend/tests/api/test_api_status.py
@@ -24,12 +24,41 @@ import time
 
 import pytest
 from botocore.exceptions import ClientError, EndpointConnectionError
+from sqlalchemy.orm import sessionmaker
 
 from app.api.routes import health
 from app.services import artifact_storage
 
 PROBE_ENDPOINT = "http://minio.test:9000"
 PROBE_BUCKET = "tckdb-artifacts-test"
+
+
+@pytest.fixture(autouse=True)
+def _bind_status_probes_to_test_database(db_engine, monkeypatch):
+    """Probe the migrated pytest database, not whatever ``DB_NAME`` names.
+
+    ``/status`` reports the database as unhealthy when ``alembic_version``
+    is missing, and it reaches that table through ``SessionLocal`` -- the
+    module-level factory bound at import to ``settings.database_url``, i.e.
+    to the ambient ``DB_NAME``, which is *not* the per-worker database this
+    suite creates and migrates.
+
+    So without this binding these tests assert on a database no fixture
+    owns. Whether they pass depends on whether something outside the test
+    run happened to migrate it: a developer shell inherits ``tckdb_dev``
+    and passes; the PR gate runs ``alembic upgrade head`` against its
+    ``DB_NAME`` in an earlier workflow step and passes; the nightly has no
+    such step and fails five tests every night for a reason that is
+    nowhere in this file.
+
+    ``tests/api/test_api_health.py`` binds the same way for the same
+    reason. Tests below that want a *specific* probe outcome monkeypatch
+    ``health.SessionLocal`` again in their own body, which wins here and is
+    undone first.
+    """
+    monkeypatch.setattr(
+        health, "SessionLocal", sessionmaker(bind=db_engine, expire_on_commit=False)
+    )
 
 
 class _FakeS3:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -634,13 +634,13 @@ def _refuse_committed_rows(request) -> Iterator[None]:
         previous = _committed_baseline_owner
         _record_committed_baseline(before, request.node.nodeid)
         raise AssertionError(
-            "rows were committed into the shared test database between "
+            "the shared test database changed between "
             f"{previous} and {request.node.nodeid}, outside either test body: "
             + ", ".join(f"{t} {was}->{now}" for t, (was, now) in sorted(drifted.items()))
             + ". Nothing between those two tests runs inside the per-test "
             "rollback, so the writer is a session- or module-scoped fixture, a "
-            "subprocess, or a background thread. Give it a teardown that "
-            "removes exactly what it wrote."
+            "subprocess, or a background thread. Give it a teardown that undoes "
+            "exactly what it did."
         )
 
     yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -563,6 +563,27 @@ def _committed_counts(connection) -> dict[str, int]:
     return dict(connection.execute(_COUNT_SQL).all())
 
 
+#: The watched counts as of the end of the last test that took them, and the
+#: nodeid of that test.  Together they close the tripwire's one blind spot:
+#: the fixture below can only see what happens *between its own two reads*, so
+#: a write that lands anywhere else — the setup of a session- or module-scoped
+#: fixture, which pytest instantiates before any function-scoped autouse
+#: fixture; a subprocess; an ``atexit`` handler; a background thread — is
+#: invisible to it, and surfaces hundreds of tests later as an unqualified
+#: query returning a row nothing in the file created.  Comparing this test's
+#: baseline against the previous test's final count names the gap the rows
+#: appeared in, which is the difference between a five-minute fix and a day of
+#: bisecting.
+_committed_baseline: dict[str, int] | None = None
+_committed_baseline_owner: str | None = None
+
+
+def _record_committed_baseline(counts: dict[str, int], nodeid: str) -> None:
+    global _committed_baseline, _committed_baseline_owner
+    _committed_baseline = counts
+    _committed_baseline_owner = nodeid
+
+
 @pytest.fixture(autouse=True)
 def _refuse_committed_rows(request) -> Iterator[None]:
     """Fail the test that commits, not the test that trips over the residue.
@@ -576,6 +597,11 @@ def _refuse_committed_rows(request) -> Iterator[None]:
     between, and the next test would be blamed for a leak it did not cause. A
     tripwire that reports order-dependent false positives would be a strange
     thing to install here.
+
+    Two checks, not one. The second compares this test's baseline against the
+    previous test's final count: rows that appeared in between were written by
+    something that is not a test body at all, which is the one leak the
+    original check cannot see (see ``_committed_baseline``).
 
     Set ``TCKDB_TEST_COMMIT_TRIPWIRE=0`` to disable — for bisecting an
     unrelated failure, never as a way to land a committing test.
@@ -592,9 +618,35 @@ def _refuse_committed_rows(request) -> Iterator[None]:
     probe = request.getfixturevalue("_committed_row_probe")
     before = _committed_counts(probe)
 
+    # Rows that appeared since the previous test finished belong to neither
+    # test's body.  Report the gap and re-baseline, so the next test is not
+    # blamed for the same rows a second time.
+    drifted = (
+        {}
+        if _committed_baseline is None
+        else {
+            table: (_committed_baseline[table], before[table])
+            for table in before
+            if table in _committed_baseline and before[table] != _committed_baseline[table]
+        }
+    )
+    if drifted:
+        previous = _committed_baseline_owner
+        _record_committed_baseline(before, request.node.nodeid)
+        raise AssertionError(
+            "rows were committed into the shared test database between "
+            f"{previous} and {request.node.nodeid}, outside either test body: "
+            + ", ".join(f"{t} {was}->{now}" for t, (was, now) in sorted(drifted.items()))
+            + ". Nothing between those two tests runs inside the per-test "
+            "rollback, so the writer is a session- or module-scoped fixture, a "
+            "subprocess, or a background thread. Give it a teardown that "
+            "removes exactly what it wrote."
+        )
+
     yield
 
     after = _committed_counts(probe)
+    _record_committed_baseline(after, request.node.nodeid)
     if after == before:
         return
 

--- a/backend/tests/ops/__init__.py
+++ b/backend/tests/ops/__init__.py
@@ -1,0 +1,17 @@
+"""Host-ops script tests.
+
+This package marker is load-bearing, for the same reason as the one in
+``tests/services/archive/``. Without it pytest imports the sibling
+``conftest.py`` under the bare top-level module name ``conftest`` and
+prepends this directory to ``sys.path``. Whichever of the two bare
+``conftest`` modules a worker imports first wins ``sys.modules`` for the
+rest of that process, so a worker that reached ``tests/ops/`` before
+``tests/db/`` then failed every test that does ``from conftest import
+_database_url`` with an ``ImportError`` naming this file -- a pure
+ordering artefact that no amount of re-running would reproduce at a
+different seed.
+
+Keeping the directory a package makes the fixture module
+``tests.ops.conftest``, which cannot collide. ``tests/test_test_package_layout.py``
+enforces the rule for every future conftest.
+"""

--- a/backend/tests/test_test_package_layout.py
+++ b/backend/tests/test_test_package_layout.py
@@ -1,0 +1,96 @@
+"""The test tree's own import hygiene.
+
+Two properties of the layout are load-bearing for a suite that has to pass
+in an arbitrary order, and both are invisible until they break:
+
+1. **Exactly one bare ``conftest`` module.** With pytest's default
+   ``prepend`` import mode, a ``conftest.py`` in a directory that is not a
+   package is imported as the top-level module ``conftest``, and its
+   directory is prepended to ``sys.path``. Two such directories therefore
+   race for ``sys.modules["conftest"]``: the loser's helpers are simply not
+   there. ``tests/db/*_migration.py``, ``tests/test_db_name_resolution.py``,
+   ``tests/test_db_harness_lifecycle.py`` and
+   ``tests/test_test_database_isolation.py`` all do ``from conftest import
+   ...`` meaning ``tests/conftest.py``, so any sibling bare ``conftest``
+   breaks roughly forty tests -- but only in the orders where a worker
+   happens to import the sibling first.
+
+2. **No duplicate module basenames outside packages.** Same mechanism, same
+   silence: the second file to be imported either shadows the first or dies
+   with pytest's "import file mismatch".
+
+Both are one-line mistakes to make (add a ``conftest.py``, forget the
+``__init__.py``) and cost an evening to diagnose from the symptom, which is
+why they are asserted rather than documented.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent
+
+#: Data trees, not import trees. ``tests/fixtures/pdep/`` holds Arkane input
+#: decks that are ``exec()``-ed with an injected namespace, never imported as
+#: modules (``backend/pyproject.toml`` excludes them from ruff for the same
+#: reason).
+_NOT_IMPORTED = ("fixtures",)
+
+
+def _module_dirs() -> list[Path]:
+    """Every directory under ``tests/`` that pytest will import modules from."""
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(TESTS_ROOT):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        directory = Path(dirpath)
+        relative = directory.relative_to(TESTS_ROOT).parts
+        if any(part in _NOT_IMPORTED for part in relative):
+            continue
+        if any(name.endswith(".py") for name in filenames):
+            found.append(directory)
+    return found
+
+
+def _is_package(directory: Path) -> bool:
+    return (directory / "__init__.py").exists()
+
+
+def test_only_the_root_conftest_is_a_bare_module() -> None:
+    """Any ``conftest.py`` below ``tests/`` must live in a package."""
+    offenders = [
+        directory.relative_to(TESTS_ROOT).as_posix()
+        for directory in _module_dirs()
+        if directory != TESTS_ROOT
+        and (directory / "conftest.py").exists()
+        and not _is_package(directory)
+    ]
+    assert not offenders, (
+        "these directories hold a conftest.py but are not packages, so their "
+        f"fixtures are imported as the bare module 'conftest': {sorted(offenders)}. "
+        "Add an __init__.py -- see tests/ops/__init__.py for why."
+    )
+
+
+def test_no_duplicate_module_basenames_outside_packages() -> None:
+    """A module basename may repeat only when every copy is inside a package."""
+    by_name: dict[str, list[str]] = defaultdict(list)
+    for directory in _module_dirs():
+        for entry in sorted(directory.glob("*.py")):
+            # ``conftest.py`` repeats by design and is pytest's own to place;
+            # the previous test states the rule that keeps it unambiguous.
+            if entry.name in ("__init__.py", "conftest.py"):
+                continue
+            by_name[entry.name].append(directory.relative_to(TESTS_ROOT).as_posix() or ".")
+
+    clashes = {
+        name: locations
+        for name, locations in by_name.items()
+        if len(locations) > 1
+        and any(not _is_package(TESTS_ROOT / location) for location in locations)
+    }
+    assert not clashes, (
+        "duplicate test module basenames in non-package directories -- pytest "
+        f"imports these under one top-level name: {clashes}"
+    )

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -2099,30 +2099,36 @@ def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_conn) -> Non
         assert network.id is not None
 
         # Resolve the O2 scan calc and a species entry that is NOT its owner.
+        #
+        # Both queries are ordered, and the foreign entry is chosen *from the
+        # freq calculations* rather than from all of them. Picking any foreign
+        # calc first and then demanding its entry own exactly one freq is two
+        # unordered assumptions: the payload's other species entries do not all
+        # carry a freq, so an unordered ``first()`` could land on one with none
+        # and the following ``one()`` would raise ``NoResultFound`` -- which it
+        # did, at seed 5 under two workers, having passed at every other seed
+        # tried. Row order is not a property this test is entitled to.
         o2_scan = session.scalars(
-            select(Calculation).where(
+            select(Calculation)
+            .where(
                 Calculation.id > baseline_calc_id,
                 Calculation.type == CalculationType.scan,
             )
+            .order_by(Calculation.id)
         ).one()
-        foreign_calc = session.scalars(
-            select(Calculation).where(
+        foreign_freq = session.scalars(
+            select(Calculation)
+            .where(
                 Calculation.id > baseline_calc_id,
+                Calculation.type == CalculationType.freq,
                 Calculation.species_entry_id.isnot(None),
                 Calculation.species_entry_id != o2_scan.species_entry_id,
             )
+            .order_by(Calculation.id)
         ).first()
-        assert foreign_calc is not None
-        foreign_entry_id = foreign_calc.species_entry_id
+        assert foreign_freq is not None
+        foreign_entry_id = foreign_freq.species_entry_id
         assert foreign_entry_id != o2_scan.species_entry_id
-
-        foreign_freq = session.scalars(
-            select(Calculation).where(
-                Calculation.id > baseline_calc_id,
-                Calculation.type == CalculationType.freq,
-                Calculation.species_entry_id == foreign_entry_id,
-            )
-        ).one()
         statmech = StatmechInBundle(
             statmech_treatment="rrho_1d",
             source_calculations=[{"calculation_key": "foreign_freq", "role": "freq"}],


### PR DESCRIPTION
## Summary

The backend suite was order-dependent, and `backend-nightly.yml` — the only
job that runs the third of the tests the two PR gates never touch — had failed
on every run back to at least 2026-08-03 because of it. This makes the suite
pass in an arbitrary order and points the nightly at one.

Measured on `main` before anything changed: the full suite at seeds **1** and
**2** failed **42 tests each**, in an identical set. At seed **424242** — the
seed the gate scripts pin — it passed. That is the shape of the problem: a
green run at a pinned seed proved nothing, and no amount of re-running it
would have.

## What was wrong

**1. Two `conftest` modules racing for one name.** `tests/ops/` acquired a
`conftest.py` without the package marker its siblings carry. Under pytest's
`prepend` import mode a `conftest.py` in a non-package directory is imported
as the bare top-level module `conftest` and its directory is prepended to
`sys.path`, so `tests/ops/conftest.py` and `tests/conftest.py` compete for
`sys.modules["conftest"]` and the winner is whichever a worker imports first.
Every test that does `from conftest import _database_url` — the `tests/db`
migration contract tests, the harness lifecycle tests, the db-name resolution
tests — then died with an `ImportError` naming a file it never meant to
import. All 42 failures at both seeds were this.

No PR gate could see it: the ops gate runs `pytest -q tests/ops/ …` as its own
invocation, where `tests/ops/conftest.py` is the only bare `conftest` in the
process. Only the full-suite nightly puts both in one interpreter.

Fixed with the package marker, plus `tests/test_test_package_layout.py`, which
asserts the rule for every future `conftest.py` and the neighbouring one about
duplicate module basenames outside packages. Both are one-line mistakes to
make and cost a day to diagnose from the symptom.

**2. Five `/status` tests asserting against a database no fixture owns.** They
reached the database through `health.SessionLocal`, bound at import to
`settings.database_url` — the ambient `DB_NAME`, not the per-worker database
the fixtures create and migrate. So they passed three ways and failed one: a
developer shell inherits a migrated `tckdb_dev`; `backend-ci.yml` runs
`alembic upgrade head` against its `DB_NAME` in a step before the gates;
`backend-nightly.yml` has no such step, so `tckdb_test_ci` has no
`alembic_version`, `/status` reports the database degraded, and five tests
failed every night for a reason that appears nowhere in the file. They now
bind to `db_engine`, the way `tests/api/test_api_health.py` already does.
Reproduce the old failure with `DB_NAME` pointed at any empty database.

**3. A test picking a row Postgres chose for it.**
`test_seam_torsion_ownership_check_rejects_cross_species_scan` took the first
calculation with a foreign species entry, unordered, then required that entry
to own exactly one freq calculation. Not every species entry in the payload
carries a freq, so which entry the unordered `first()` returned decided
whether the following `one()` found a row. `NoResultFound` at seed 5 under two
workers; green at every other seed tried. It now selects the foreign entry
from the freq calculations directly, with an explicit order. Same refusal
asserted.

## Hardening, so the next one is attributable

The committed-row tripwire counts watched tables around each test body, so it
can only see writes landing between its own two reads. Anything else is
invisible to it *by construction*: the setup of a session- or module-scoped
fixture (pytest instantiates those before any function-scoped autouse
fixture), a subprocess, a background thread. It now also compares each test's
baseline against the previous test's final count, so rows appearing when no
test body was running name the two tests they appeared between, instead of
surfacing hundreds of tests later as an unqualified query returning a row
nothing in that file created.

## The pinned seed

Kept, and its justification changed. A PR gate needs a reproducible result —
red must mean regression, not an unlucky draw. But that is only honestly
*reproducibility* rather than a workaround if something still runs an order
nobody chose, and pinning everywhere means the suite is proved against exactly
one ordering forever. So `TCKDB_TEST_SEED=random` draws a fresh seed per
invocation and **echoes it**, and the nightly uses it.

It draws the seed rather than letting `pytest-randomly` pick one from the
clock because the plugin announces its choice in `pytest_report_header`, which
the `-q` every gate script passes suppresses — an unpinned nightly would
otherwise fail in an order nothing recorded. Since #123 the nightly is also
the job somebody hears about.

## Verification

Full suite green at **nine distinct seeds** across **four worker counts**,
including a held-out seed (90210) not used while developing the fix. 6,797
tests each.

| seed | workers | environment | result |
|------|---------|-------------|--------|
| 1 | 8 | developer | 6797 passed |
| 2 | 8 | developer | 6797 passed |
| 3 | 4 | nightly-equivalent | 6797 passed |
| 4 | 8 | developer | 6797 passed |
| 5 | 2 | developer | 6797 passed (found cause 3) |
| 7 | 0 (serial) | developer | 6797 passed |
| 11 | 4 | nightly-equivalent | 6797 passed |
| **90210 (held out)** | 4 | nightly-equivalent | 6797 passed |
| 424242 | 0 (serial) | developer | 6797 passed (53:57) |

"nightly-equivalent" means `DB_NAME` pointed at an unmigrated database and the
nightly's `S3_*`/auth/deployment env, which is what made cause 2 reproducible
locally. Serial (`-n 0`) is the strict case: one process, one database, all
6,797 tests, so it exercises every cross-file adjacency the sharded runs hide.

No test was skipped, xfailed, weakened, deleted, or reordered with a marker.
Test count is unchanged apart from the two new layout assertions.
