### PR TITLE
Gate the half of the suite that gated nothing

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,7 +35,7 @@ jobs:
             name: Backend API gate
           - gate: scientific
             name: Scientific read and service gate
-          # The three gates are a partition of backend/tests/, not three
+          # The three gates cover backend/tests/ between them, not three
           # samples of it. `rest` is defined as the complement of the other
           # two (see scripts/test-rest.sh), so a directory added to tests/
           # gates the pull request that adds it. Before this entry existed,

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,6 +35,17 @@ jobs:
             name: Backend API gate
           - gate: scientific
             name: Scientific read and service gate
+          # The three gates are a partition of backend/tests/, not three
+          # samples of it. `rest` is defined as the complement of the other
+          # two (see scripts/test-rest.sh), so a directory added to tests/
+          # gates the pull request that adds it. Before this entry existed,
+          # 3,806 tests -- over half the suite -- ran on no PR at all, and
+          # `test-api.sh` read as "the API gate" while being "some of the
+          # API". The gate runs in parallel with the other two and finishes
+          # inside the scientific gate's wall clock, so it costs a runner,
+          # not PR latency.
+          - gate: rest
+            name: Backend complement gate
 
     services:
       postgres:
@@ -78,6 +89,18 @@ jobs:
       DB_PORT: "5432"
       DB_USER: tckdb
       DB_PASSWORD: tckdb
+      # The *ambient* database: it exists and is deliberately never migrated,
+      # which is exactly the condition backend-nightly.yml presents. Until
+      # #124, five /status tests reached this database through an engine bound
+      # at import to `settings.database_url` rather than through any fixture,
+      # and CI ran `alembic upgrade head` against this name in a step before
+      # the gates while the nightly did not. So the same five tests passed here
+      # and failed every night, and the divergence -- not the coupling -- is
+      # what made that invisible for eleven nights. The migration now runs
+      # against its own scratch database (see "Alembic upgrade head" below),
+      # leaving this one empty in both workflows: a test that acquires a
+      # dependency on a migrated ambient database now fails the pull request
+      # that introduces it.
       DB_NAME: tckdb_${{ matrix.gate }}_ci
       DB_CLIENT_ENCODING: utf8
       # Must match the isolated-test-database pattern enforced in
@@ -154,6 +177,7 @@ jobs:
           bash -n backend/scripts/test-fast.sh
           bash -n backend/scripts/test-api.sh
           bash -n backend/scripts/test-scientific.sh
+          bash -n backend/scripts/test-rest.sh
           bash -n backend/scripts/test-full.sh
           bash -n backend/scripts/test-profile.sh
           bash -n backend/scripts/update-openapi-golden.sh
@@ -163,8 +187,39 @@ jobs:
           make help
 
       - name: Alembic upgrade head
+        if: matrix.gate == 'api'
         working-directory: backend
+        # Runs against its own scratch database, not the ambient DB_NAME.
+        #
+        # These two steps are migration checks -- does the revision graph have
+        # one head, does it apply, do the models and the migrations describe
+        # the same schema. None of that is a property of the ambient database;
+        # it needs *a* migrated database, and it should not be the one the test
+        # process can see. Pointing them at DB_NAME made "CI happens to migrate
+        # the database the tests inherit" a load-bearing and undeclared part of
+        # the environment, which is the difference that let five /status tests
+        # pass here and fail nightly (#64 cause 2, #92).
+        #
+        # Scoped to one gate for the same reason the lint and mypy steps are:
+        # the answer cannot differ between matrix legs, so paying for it three
+        # times only buys three chances to flake.
+        env:
+          DB_NAME: tckdb_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
         run: |
+          conda run -n tckdb_env python - <<'PY'
+          import os
+
+          import psycopg
+
+          name = os.environ["DB_NAME"]
+          dsn = (
+              f"host={os.environ['DB_HOST']} port={os.environ['DB_PORT']} "
+              f"user={os.environ['DB_USER']} password={os.environ['DB_PASSWORD']} "
+              "dbname=postgres"
+          )
+          with psycopg.connect(dsn, autocommit=True) as conn:
+              conn.execute(f'CREATE DATABASE "{name}"')
+          PY
           conda run -n tckdb_env alembic upgrade head
           heads_output="$(conda run -n tckdb_env alembic heads)"
           printf '%s\n' "$heads_output"
@@ -172,7 +227,10 @@ jobs:
           conda run -n tckdb_env alembic current
 
       - name: Alembic drift check
+        if: matrix.gate == 'api'
         working-directory: backend
+        env:
+          DB_NAME: tckdb_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
         # The models and the migrations must describe the same schema. Until
         # now this could not be a gate: two migration-only RDKit indexes
         # (ix_species_entry_mol_gist, ix_species_formula_lookup) are absent
@@ -213,20 +271,14 @@ jobs:
         working-directory: backend
         run: conda run -n tckdb_env pytest tests/api/test_openapi_snapshot.py -q
 
-      - name: Ops and repo-check gate
-        if: matrix.gate == 'api'
-        working-directory: backend
-        # Neither of these lives under tests/api/, so neither test-api.sh nor
-        # test-scientific.sh reaches them and they would otherwise only run
-        # nightly. tests/ops/ covers the alerting path -- the one part of the
-        # deployment whose failure produces silence rather than an error --
-        # and the ASCII test pins the lint's boundary, which is the part that
-        # decides whether anyone leaves it switched on. Both need to gate the
-        # PR that breaks them, not the night after.
-        run: >-
-          conda run -n tckdb_env pytest -q
-          tests/ops/
-          tests/scripts/test_check_runtime_ascii.py
+      # The "Ops and repo-check gate" step that used to sit here ran
+      # tests/ops/ and tests/scripts/test_check_runtime_ascii.py as their own
+      # invocation, because neither lives under tests/api/ and nothing else on
+      # a PR reached them. The complement gate below reaches both, so the step
+      # was deleted rather than left to duplicate it -- and running tests/ops/
+      # inside the large invocation is the stronger version: as its own
+      # process it was the only bare `conftest` on sys.path, which is precisely
+      # what hid the module collision #124 had to diagnose from a nightly.
 
       - name: API test gate
         if: matrix.gate == 'api'
@@ -238,6 +290,13 @@ jobs:
       - name: Scientific read and service gate
         if: matrix.gate == 'scientific'
         run: conda run -n tckdb_env bash backend/scripts/test-scientific.sh --maxfail=5
+
+      # Everything the two gates above do not run, defined as their complement
+      # rather than as a list, so it cannot fall behind tests/. See
+      # backend/scripts/test-rest.sh for what that buys and what it replaces.
+      - name: Backend complement gate
+        if: matrix.gate == 'rest'
+        run: conda run -n tckdb_env bash backend/scripts/test-rest.sh --maxfail=5
 
       # The MCP integration is a consumer of the backend's error contract
       # and had no CI job at all, so nothing stopped a change here from

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -206,7 +206,14 @@ jobs:
         env:
           DB_NAME: tckdb_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
         run: |
-          conda run -n tckdb_env python - <<'PY'
+          # Written to a file and run by path, NOT piped as `conda run python -
+          # <<'PY'`. `conda run` does not forward this shell's stdin to the
+          # process it spawns, so `python -` reads EOF, does nothing, and exits
+          # 0 -- a provisioning step that silently provisions nothing. The
+          # "Initialize artifact bucket" step below did exactly that on every
+          # green run until this commit. `cat` is a shell builtin path with no
+          # conda in it, so the heredoc lands intact.
+          cat > "${RUNNER_TEMP}/create_scratch_db.py" <<'PY'
           import os
 
           import psycopg
@@ -219,7 +226,9 @@ jobs:
           )
           with psycopg.connect(dsn, autocommit=True) as conn:
               conn.execute(f'CREATE DATABASE "{name}"')
+          print(f"created scratch migration database {name}")
           PY
+          conda run -n tckdb_env python "${RUNNER_TEMP}/create_scratch_db.py"
           conda run -n tckdb_env alembic upgrade head
           heads_output="$(conda run -n tckdb_env alembic heads)"
           printf '%s\n' "$heads_output"
@@ -242,8 +251,15 @@ jobs:
         run: conda run -n tckdb_env alembic check
 
       - name: Initialize artifact bucket
+        # This step had never run. As `conda run -n tckdb_env python - <<'PY'`
+        # it provisioned nothing on every green run since it was added --
+        # `conda run` does not forward stdin, so `python -` read EOF and exited
+        # 0, and a step that prints nothing looks identical to one that
+        # succeeded quietly. Found while debugging the same mistake in the
+        # alembic step above. It now writes the script to a file, runs it by
+        # path, and prints what it did, so silence is no longer a valid state.
         run: |
-          conda run -n tckdb_env python - <<'PY'
+          cat > "${RUNNER_TEMP}/init_artifact_bucket.py" <<'PY'
           import os
 
           import boto3
@@ -262,9 +278,12 @@ jobs:
 
           try:
               s3.head_bucket(Bucket=bucket)
+              print(f"artifact bucket already present: {bucket}")
           except ClientError:
               s3.create_bucket(Bucket=bucket)
+              print(f"created artifact bucket: {bucket}")
           PY
+          conda run -n tckdb_env python "${RUNNER_TEMP}/init_artifact_bucket.py"
 
       - name: OpenAPI golden snapshot
         if: matrix.gate == 'api'

--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -4,7 +4,7 @@ name: Backend Nightly (full suite)
 # tests) in an order nobody chose.
 #
 # It is no longer the only job that runs the whole suite. backend-ci.yml's
-# three gates are a partition of backend/tests/, so a PR now runs every test
+# three gates cover backend/tests/ between them, so a PR now runs every test
 # this job does; what this job adds is the *order*. The PR gates pin a seed so
 # a red gate means a regression rather than an unlucky draw, which is only
 # honestly reproducibility if something still draws -- hence TCKDB_TEST_SEED

--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -124,8 +124,12 @@ jobs:
           conda run -n tckdb_env python -m pip install -e "backend[dev]"
 
       - name: Initialize artifact bucket
+        # See the twin step in backend-ci.yml: as `conda run python - <<'PY'`
+        # this provisioned nothing, because `conda run` does not forward stdin
+        # and a silent step is indistinguishable from a successful one. Written
+        # to a file, run by path, and made to print what it did.
         run: |
-          conda run -n tckdb_env python - <<'PY'
+          cat > "${RUNNER_TEMP}/init_artifact_bucket.py" <<'PY'
           import os
 
           import boto3
@@ -144,9 +148,12 @@ jobs:
 
           try:
               s3.head_bucket(Bucket=bucket)
+              print(f"artifact bucket already present: {bucket}")
           except ClientError:
               s3.create_bucket(Bucket=bucket)
+              print(f"created artifact bucket: {bucket}")
           PY
+          conda run -n tckdb_env python "${RUNNER_TEMP}/init_artifact_bucket.py"
 
       - name: Full test suite
         run: conda run -n tckdb_env bash backend/scripts/test-full.sh

--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -1,10 +1,16 @@
 name: Backend Nightly (full suite)
 
-# The PR-gating workflow (backend-ci.yml) runs only the API and scientific
-# tiers for speed. This nightly run executes the complete test suite
-# (backend/scripts/test-full.sh, ~4,700 tests) so regressions in the
-# untier-gated areas (workflows, invariants, parsers, CLI, importers)
-# surface within a day instead of at the next manual pre-push run.
+# This runs the complete test suite (backend/scripts/test-full.sh, ~6,800
+# tests) in an order nobody chose.
+#
+# It is no longer the only job that runs the whole suite. backend-ci.yml's
+# three gates are a partition of backend/tests/, so a PR now runs every test
+# this job does; what this job adds is the *order*. The PR gates pin a seed so
+# a red gate means a regression rather than an unlucky draw, which is only
+# honestly reproducibility if something still draws -- hence TCKDB_TEST_SEED
+# below. A defect that depends on test order therefore still surfaces here
+# first, and a defect that does not now surfaces on the PR that causes it,
+# which is where it is attributable.
 #
 # A red run here notifies nobody by itself: GitHub does not email about a
 # failed scheduled workflow and it leaves no mark on any PR, which is how this
@@ -60,6 +66,15 @@ jobs:
       DB_PORT: "5432"
       DB_USER: tckdb
       DB_PASSWORD: tckdb
+      # Exists and is never migrated -- and since backend-ci.yml moved its
+      # `alembic upgrade head` onto a scratch database, that is now the same
+      # condition the PR gates present rather than a difference between the
+      # two workflows. It was the difference that mattered: five /status tests
+      # reached this database outside any fixture, found a migrated schema on
+      # CI and an empty one here, and so failed only at night, attached to no
+      # PR (#64 cause 2, #92). Nothing should migrate this name. If a test
+      # starts needing it migrated, that test is coupled to something no
+      # fixture owns, and the fix belongs in the test.
       DB_NAME: tckdb_test_ci
       DB_CLIENT_ENCODING: utf8
       DB_TEST_NAME: tckdb_test_${{ github.run_id }}_${{ github.run_attempt }}

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test-api:
 	conda run -n tckdb_env bash backend/scripts/test-api.sh $(ARGS)
 
 # The complement of test-api and test-scientific. Together the three are a
-# partition of backend/tests/, which is what makes `make test-api` green mean
+# covering of backend/tests/, which is what makes `make test-api` green mean
 # something bounded rather than something vague.
 test-rest:
 	conda run -n tckdb_env bash backend/scripts/test-rest.sh $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 #                      rather than in `reset` so the rotation is an
 #                      explicit, visible step.
 
-.PHONY: up down migrate reset reset-login test test-fast test-scientific test-api test-full test-profile update-openapi-golden api admin doctor check help
+.PHONY: up down migrate reset reset-login test test-fast test-scientific test-api test-rest test-full test-profile update-openapi-golden api admin doctor check help
 
 # Print available targets.
 help:
@@ -48,6 +48,7 @@ help:
 	@echo "  make test-fast        Tier 0/1: ARGS='<path> [-k expr]' for fast inner-loop"
 	@echo "  make test-scientific  Tier 2/3: scientific API + scientific_read services"
 	@echo "  make test-api         Tier 3:   full tests/api/ regression gate"
+	@echo "  make test-rest        Tier 3:   everything the other two gates exclude"
 	@echo "  make test-full        Tier 4:   full backend suite (pre-push)"
 	@echo "  make test-profile     Surface the slowest tests in a target subset"
 	@echo ""
@@ -112,6 +113,12 @@ test-scientific:
 
 test-api:
 	conda run -n tckdb_env bash backend/scripts/test-api.sh $(ARGS)
+
+# The complement of test-api and test-scientific. Together the three are a
+# partition of backend/tests/, which is what makes `make test-api` green mean
+# something bounded rather than something vague.
+test-rest:
+	conda run -n tckdb_env bash backend/scripts/test-rest.sh $(ARGS)
 
 test-full:
 	conda run -n tckdb_env bash backend/scripts/test-full.sh $(ARGS)

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -16,11 +16,31 @@ narrowest tier that proves the change you're making.
 | 1    | One affected module / feature                 | < 1 min if poss.  | `test-fast.sh <dir>` (`-k`)   |
 | 2    | Scientific read + service confidence          | 1–3 min           | `test-scientific.sh`          |
 | 3    | Full API surface regression gate              | several minutes   | `test-api.sh`                 |
+| 3    | Everything the other two gates exclude        | several minutes   | `test-rest.sh`                |
 | 4    | Full backend suite — pre-push / release       | ~6 min (`-n 8`)   | `test-full.sh`                |
 
 Tier 0 and Tier 1 use the same script with different arguments — the
 distinction is intent (single failure debug vs. validating a focused
 change), not a different command.
+
+The two Tier 3 gates and `test-scientific.sh` are a **partition** of
+`backend/tests/`: every test file is selected by exactly one of them, and
+`test-rest.sh` is defined as the complement of the other two rather than
+as a list of directories, so a directory added to `tests/` joins a gate
+the day it is created. That is enforced, not asserted — see
+[`tests/scripts/test_gate_coverage.py`](../tests/scripts/test_gate_coverage.py),
+which reads the scripts and `backend-ci.yml` and fails if any test file
+is run by no required CI job.
+
+It is enforced because it silently stopped being true. Until August 2026
+the two required PR jobs ran `tests/api/` and `tests/api/scientific/` +
+`tests/services/scientific_read/` and nothing else, so 3,806 tests — more
+than half the suite by count — gated no pull request. They ran nightly,
+which meant a defect merged green and surfaced the next morning attached
+to no PR; `tests/db/test_identifier_lengths.py` sat red on `main` for
+days that way. Nothing in the scripts said so, which is the part worth
+remembering: `test-api.sh` read as "the API gate" while being "some of
+the API".
 
 ## Scripts
 
@@ -34,6 +54,7 @@ work as you'd expect:
 | [`test-fast.sh`](../scripts/test-fast.sh)             | `pytest -v -x --tb=short "$@"`                                         | 0 |
 | [`test-scientific.sh`](../scripts/test-scientific.sh) | `pytest -q --tb=short tests/api/scientific/ tests/services/scientific_read/ "$@"` | 8 |
 | [`test-api.sh`](../scripts/test-api.sh)               | `pytest -q --tb=short tests/api/ "$@"`                                 | 8 |
+| [`test-rest.sh`](../scripts/test-rest.sh)             | `pytest -q --tb=short tests/ --ignore=tests/api --ignore=tests/services/scientific_read "$@"` | 8 |
 | [`test-full.sh`](../scripts/test-full.sh)             | `pytest -q --tb=short tests/ "$@"`                                     | 8 |
 | [`test-profile.sh`](../scripts/test-profile.sh)       | `pytest -v --durations=50 [<path>|tests/]`                             | 0 |
 
@@ -53,6 +74,7 @@ environment:
 make test-fast       ARGS="tests/api/test_api_health.py"
 make test-scientific
 make test-api        ARGS="-x"
+make test-rest
 make test-full
 make test-profile    ARGS="tests/api/scientific/"
 ```
@@ -113,6 +135,27 @@ This is the cross-surface regression gate.
 ```bash
 make test-api
 ```
+
+Green here means the HTTP surface is intact. It says nothing about the
+services, workflows, db constraints, schemas, parsers or importers
+underneath it — that is the next section, and the distinction is why
+this one is not called "the backend gate".
+
+### Tier 3 — everything else
+
+Run before committing changes to `app/services/` (outside
+`scientific_read`), `app/workflows/`, `app/db/`, `app/schemas/`,
+`app/importers/`, `app/parsers/`, `app/workers/` or `app/cli/` — which
+is to say most of the backend.
+
+```bash
+make test-rest
+```
+
+It is the complement of the two gates above, not a list, so it needs no
+maintenance when `tests/` grows. In practice these are the *cheap*
+tests: 3,813 of them in 3m50s at four workers, against 1,998 scientific
+tests in 4m21s on the same host.
 
 ### Tier 4 — full backend suite
 
@@ -521,12 +564,13 @@ fixture moved up.
   every save.
 - Land Tier 1 green at minimum before pushing. Land Tier 3 green
   before opening a PR. Tier 4 is required before merging.
-- The initial backend CI gate runs two independent jobs in parallel: the API
-  job runs Tier 3 with `tests/api/scientific/` ignored, while the scientific
-  job runs the scientific API directory plus `tests/services/scientific_read/`
-  through Tier 2. Together they cover every API test once and every
-  scientific-read service test once. Local Tier 4 remains the pre-push and
-  pre-merge insurance until full-suite CI runtime is known.
+- The backend CI gate runs three independent jobs in parallel: the API job
+  runs Tier 3 with `tests/api/scientific/` ignored; the scientific job runs
+  the scientific API directory plus `tests/services/scientific_read/`; and
+  the complement job runs everything neither of those selects. Together they
+  cover every test file in `backend/tests/` exactly once, which is checked
+  rather than claimed
+  ([`tests/scripts/test_gate_coverage.py`](../tests/scripts/test_gate_coverage.py)).
 
 ## CI gate
 
@@ -560,19 +604,38 @@ The gate runs:
 
 - shell/doc hygiene checks (`git diff --check`, `bash -n` for the test
   ladder scripts, and `make help`)
-- `alembic upgrade head`, `alembic heads`, and `alembic current`
-  against the RDKit Postgres service
+- `alembic upgrade head`, `alembic heads`, `alembic current` and
+  `alembic check`, against a scratch database created by the step
 - the OpenAPI golden snapshot test at
   [`tests/api/test_openapi_snapshot.py`](../tests/api/test_openapi_snapshot.py)
 - the API gate via [`../scripts/test-api.sh`](../scripts/test-api.sh)
 - the scientific read/service gate via
   [`../scripts/test-scientific.sh`](../scripts/test-scientific.sh)
+- the complement gate via [`../scripts/test-rest.sh`](../scripts/test-rest.sh)
 
 The API gate ignores both `tests/api/scientific/` (covered by the scientific
 job) and `tests/api/test_openapi_snapshot.py` (run once by its dedicated
 golden-snapshot step). The final `Backend CI` job is a stable aggregate status
 check: it runs even after an upstream failure or cancellation and fails unless
-the matrix result is `success`, while leaving both detailed gate checks visible.
+the matrix result is `success`, while leaving every detailed gate check visible.
+
+### The ambient database is never migrated
+
+`DB_NAME` — the database `settings.database_url` points at, as opposed to the
+per-worker `DB_TEST_NAME` databases the fixtures create and migrate — exists
+and is deliberately left empty in **both** `backend-ci.yml` and
+`backend-nightly.yml`. Nothing should migrate it, and no test should need it
+migrated: a test that reaches it is reaching past every fixture.
+
+The alembic steps run against their own scratch database for exactly this
+reason. They are migration checks (one head, applies cleanly, no model/schema
+drift) and none of that is a property of the ambient database. Pointing them
+at `DB_NAME` made "CI happens to migrate the database the tests inherit" an
+undeclared part of the environment — and since the nightly had no such step,
+five `/status` tests passed on every PR and failed every night for eleven
+nights, attached to no PR and explained by nothing in the file. Both workflows
+now present the same empty database, so that class of coupling fails the pull
+request that introduces it.
 
 Each CI job owns an isolated Postgres service and MinIO service. Its
 `DB_TEST_NAME` and `S3_BUCKET` include both the GitHub run id/attempt and the
@@ -584,9 +647,13 @@ container. `DB_TEST_NAME` is still set per job; `_resolve_test_db_name` appends
 the worker id to it, so each worker gets its own database instead of four
 workers racing on one recreated one.
 
-The full Tier 4 suite is intentionally not part of this v0 PR workflow.
-Keep running `make test-full` locally before push/merge until a
-separate full-suite or nightly CI gate is added.
+Since the three gates partition `backend/tests/`, a PR now runs every test
+[`backend-nightly.yml`](../../.github/workflows/backend-nightly.yml) runs.
+What the nightly still adds is the **order**: the gates pin a seed so a red
+gate means a regression rather than an unlucky draw, and the nightly draws
+`TCKDB_TEST_SEED=random` and echoes it, so an order-dependent defect surfaces
+somewhere. `make test-full` locally remains the cheapest way to get both at
+once before pushing.
 
 ## OpenAPI golden snapshot
 

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -23,14 +23,24 @@ Tier 0 and Tier 1 use the same script with different arguments — the
 distinction is intent (single failure debug vs. validating a focused
 change), not a different command.
 
-The two Tier 3 gates and `test-scientific.sh` are a **partition** of
-`backend/tests/`: every test file is selected by exactly one of them, and
-`test-rest.sh` is defined as the complement of the other two rather than
-as a list of directories, so a directory added to `tests/` joins a gate
-the day it is created. That is enforced, not asserted — see
+Together the two Tier 3 gates and `test-scientific.sh` **cover
+`backend/tests/` completely**, and `test-rest.sh` is defined as the
+complement of the other two rather than as a list of directories, so a
+directory added to `tests/` joins a gate the day it is created.
+
+Covering is the guarantee; being disjoint is not. Run bare,
+`test-api.sh` selects all of `tests/api/` including
+`tests/api/scientific/`, which `test-scientific.sh` also selects — CI
+passes `--ignore=tests/api/scientific/` so each test runs once per PR,
+but locally the two overlap. Nothing depends on the overlap being
+absent; a test running twice costs seconds, a test running zero times
+cost this repo several days.
+
+The covering half is enforced, not asserted — see
 [`tests/scripts/test_gate_coverage.py`](../tests/scripts/test_gate_coverage.py),
-which reads the scripts and `backend-ci.yml` and fails if any test file
-is run by no required CI job.
+which reads the scripts and `backend-ci.yml`, resolves what each job
+selects and ignores, and fails if any test file is run by no required
+CI job.
 
 It is enforced because it silently stopped being true. Until August 2026
 the two required PR jobs ran `tests/api/` and `tests/api/scientific/` +
@@ -568,8 +578,8 @@ fixture moved up.
   runs Tier 3 with `tests/api/scientific/` ignored; the scientific job runs
   the scientific API directory plus `tests/services/scientific_read/`; and
   the complement job runs everything neither of those selects. Together they
-  cover every test file in `backend/tests/` exactly once, which is checked
-  rather than claimed
+  cover every test file in `backend/tests/`, which is checked rather than
+  claimed
   ([`tests/scripts/test_gate_coverage.py`](../tests/scripts/test_gate_coverage.py)).
 
 ## CI gate

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -657,7 +657,7 @@ container. `DB_TEST_NAME` is still set per job; `_resolve_test_db_name` appends
 the worker id to it, so each worker gets its own database instead of four
 workers racing on one recreated one.
 
-Since the three gates partition `backend/tests/`, a PR now runs every test
+Since the three gates cover `backend/tests/` between them, a PR now runs every test
 [`backend-nightly.yml`](../../.github/workflows/backend-nightly.yml) runs.
 What the nightly still adds is the **order**: the gates pin a seed so a red
 gate means a regression rather than an unlucky draw, and the nightly draws

--- a/backend/scripts/test-api.sh
+++ b/backend/scripts/test-api.sh
@@ -16,7 +16,7 @@
 # CI narrows the selection further, and both narrowings are covered
 # elsewhere rather than dropped:
 #
-#   --ignore=tests/api/scientific/            -> scripts/test-scientific.sh
+#   --ignore=tests/api/scientific/              -> scripts/test-scientific.sh
 #   --ignore=tests/api/test_openapi_snapshot.py -> its own workflow step
 #
 # tests/scripts/test_gate_coverage.py checks that claim against the

--- a/backend/scripts/test-api.sh
+++ b/backend/scripts/test-api.sh
@@ -6,6 +6,22 @@
 # request/response shape. Pair with ``-x`` if you want fail-fast on a
 # suspected regression.
 #
+# Excludes: everything outside ``tests/api/``. This is the API gate, not
+# the backend gate. The service, workflow, db, schema, parser, importer
+# and invariant tests are the complement gate's -- scripts/test-rest.sh --
+# and a green run here says nothing about any of them. Saying so is not
+# pedantry: for most of this repo's life the name was read as coverage it
+# did not have, and half the suite gated no pull request as a result.
+#
+# CI narrows the selection further, and both narrowings are covered
+# elsewhere rather than dropped:
+#
+#   --ignore=tests/api/scientific/            -> scripts/test-scientific.sh
+#   --ignore=tests/api/test_openapi_snapshot.py -> its own workflow step
+#
+# tests/scripts/test_gate_coverage.py checks that claim against the
+# workflow rather than trusting this comment.
+#
 # Runs with a pinned random-order seed and parallel workers; see
 # scripts/lib/pytest_run_args.sh for why, and how to override either.
 #

--- a/backend/scripts/test-full.sh
+++ b/backend/scripts/test-full.sh
@@ -5,6 +5,12 @@
 # pre-push and pre-release confidence gate, NOT the edit loop —
 # expect a multi-minute runtime. Forwards extra pytest args.
 #
+# Excludes: nothing. This selection is the union of the three required PR
+# gates -- test-api.sh, test-scientific.sh and test-rest.sh -- which since
+# those three became a partition of tests/ means the nightly and the pull
+# request now run the same set of tests, differing only in the order they
+# run it in (the nightly draws a seed, the gates pin one).
+#
 # Runs with a pinned random-order seed and parallel workers; see
 # scripts/lib/pytest_run_args.sh for why, and how to override either.
 #

--- a/backend/scripts/test-full.sh
+++ b/backend/scripts/test-full.sh
@@ -7,7 +7,7 @@
 #
 # Excludes: nothing. This selection is the union of the three required PR
 # gates -- test-api.sh, test-scientific.sh and test-rest.sh -- which since
-# those three became a partition of tests/ means the nightly and the pull
+# those three cover tests/ between them means the nightly and the pull
 # request now run the same set of tests, differing only in the order they
 # run it in (the nightly draws a seed, the gates pin one).
 #

--- a/backend/scripts/test-rest.sh
+++ b/backend/scripts/test-rest.sh
@@ -37,11 +37,17 @@
 # ---------------------------------------------------------------------------
 # Wall clock
 # ---------------------------------------------------------------------------
-# These are the cheap tests, not the slow ones: 3,806 of them in 2m48s at four
-# workers, against 1,998 scientific tests in 4m21s on the same host. On CI the
-# job lands around 8m30s including container and conda setup, under the
-# scientific gate's 12m09s, so this gate runs beside the existing two without
-# moving the critical path of a pull request.
+# These are the cheap tests, not the slow ones: 3,813 of them in 3m50s at four
+# workers, against 1,998 scientific tests in 4m21s on the same host. More than
+# half the suite by count, and it costs less than the gate that was already
+# there -- which is why gating it was never the trade-off it looked like.
+#
+# On CI the job lands around 8m30s including container and conda setup, under
+# the scientific gate's 12m09s (measured, run 31431866497). The scientific gate
+# is and remains the critical path, so this one runs beside the other two
+# without moving how long a pull request waits. It costs a runner, not latency.
+# Folding the same tests into an existing gate instead would have put them in
+# series and moved that path out by about three minutes on every PR.
 #
 # Runs with a pinned random-order seed and parallel workers; see
 # scripts/lib/pytest_run_args.sh for why, and how to override either.

--- a/backend/scripts/test-rest.sh
+++ b/backend/scripts/test-rest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tier 3: the complement gate -- every test the other two PR gates do not run.
+#
+# Selects ``tests/`` and subtracts exactly the two subtrees the other required
+# gates already own:
+#
+#   tests/api/                      -> scripts/test-api.sh
+#   tests/services/scientific_read/ -> scripts/test-scientific.sh
+#
+# Excludes: nothing else, ever. That is the whole point of the script, and it
+# is why the selection is written as a subtraction rather than as a list of
+# directories to include.
+#
+# ---------------------------------------------------------------------------
+# What this gate exists to stop happening again
+# ---------------------------------------------------------------------------
+# Until it existed, the two required PR jobs ran ``tests/api/`` and
+# ``tests/api/scientific/`` + ``tests/services/scientific_read/`` and nothing
+# else. Everything under tests/db/, tests/workflows/, tests/invariants/,
+# tests/integration/, tests/workers/, tests/schemas/, tests/importers/,
+# tests/parsers/, tests/cli/, tests/smoke/, tests/examples/,
+# tests/client_builder_contract/ and tests/services/ outside scientific_read --
+# 3,806 tests, more than half the suite by count -- ran on no pull request at
+# all. It ran nightly, which meant a defect merged green and surfaced the next
+# morning attached to no PR. ``tests/db/test_identifier_lengths.py`` sat red on
+# main for days that way, and two branches merged whose failures both gates
+# reported green.
+#
+# An enumerated include-list would have reproduced that defect the first time
+# somebody added a directory under tests/ and did not think to add it here. A
+# subtraction cannot: a new directory joins a required gate the day it is
+# created. ``tests/scripts/test_gate_coverage.py`` pins the subtraction against
+# the scripts it subtracts and against the workflow that runs them, so the
+# three selections stay a partition of tests/ rather than drifting back into a
+# gap nobody can see.
+#
+# ---------------------------------------------------------------------------
+# Wall clock
+# ---------------------------------------------------------------------------
+# These are the cheap tests, not the slow ones: 3,806 of them in 2m48s at four
+# workers, against 1,998 scientific tests in 4m21s on the same host. On CI the
+# job lands around 8m30s including container and conda setup, under the
+# scientific gate's 12m09s, so this gate runs beside the existing two without
+# moving the critical path of a pull request.
+#
+# Runs with a pinned random-order seed and parallel workers; see
+# scripts/lib/pytest_run_args.sh for why, and how to override either.
+#
+# Examples:
+#   bash backend/scripts/test-rest.sh
+#   bash backend/scripts/test-rest.sh -x
+#   bash backend/scripts/test-rest.sh -k torsion
+#   conda run -n tckdb_env bash backend/scripts/test-rest.sh
+set -euo pipefail
+
+# Resolve the script directory *before* changing directory. "$0" is relative
+# to the invoking cwd, so re-deriving it after the cd resolves against the
+# new one -- which works from backend/ and fails from the repo root, the way
+# CI invokes these.
+TCKDB_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$TCKDB_SCRIPT_DIR/.."
+# shellcheck source=lib/pytest_run_args.sh
+source "$TCKDB_SCRIPT_DIR/lib/pytest_run_args.sh"
+tckdb_pytest_run_args "$@"
+exec pytest -q --tb=short "${TCKDB_PYTEST_ARGS[@]}" \
+    tests/ --ignore=tests/api --ignore=tests/services/scientific_read "$@"

--- a/backend/scripts/test-rest.sh
+++ b/backend/scripts/test-rest.sh
@@ -31,7 +31,7 @@
 # subtraction cannot: a new directory joins a required gate the day it is
 # created. ``tests/scripts/test_gate_coverage.py`` pins the subtraction against
 # the scripts it subtracts and against the workflow that runs them, so the
-# three selections stay a partition of tests/ rather than drifting back into a
+# three selections keep covering tests/ rather than drifting back into a
 # gap nobody can see.
 #
 # ---------------------------------------------------------------------------

--- a/backend/scripts/test-rest.sh
+++ b/backend/scripts/test-rest.sh
@@ -42,12 +42,13 @@
 # half the suite by count, and it costs less than the gate that was already
 # there -- which is why gating it was never the trade-off it looked like.
 #
-# On CI the job lands around 8m30s including container and conda setup, under
-# the scientific gate's 12m09s (measured, run 31431866497). The scientific gate
-# is and remains the critical path, so this one runs beside the other two
-# without moving how long a pull request waits. It costs a runner, not latency.
-# Folding the same tests into an existing gate instead would have put them in
-# series and moved that path out by about three minutes on every PR.
+# On CI the whole job takes 6m36s including container and conda setup, of which
+# 5m03s is this run (measured, run 31474580773) -- against the scientific gate's
+# 12m09s (run 31431866497). The scientific gate is and remains the critical
+# path, so this one runs beside the other two without moving how long a pull
+# request waits. It costs a runner, not latency. Folding the same tests into an
+# existing gate instead would have put them in series and moved that path out by
+# about five minutes on every PR.
 #
 # Runs with a pinned random-order seed and parallel workers; see
 # scripts/lib/pytest_run_args.sh for why, and how to override either.

--- a/backend/scripts/test-scientific.sh
+++ b/backend/scripts/test-scientific.sh
@@ -6,6 +6,15 @@
 # ``app/api/routes/scientific/`` or ``app/services/scientific_read/``.
 # Extra pytest args (``-k``, ``-x``, ``--maxfail=...``) are forwarded.
 #
+# Excludes: everything except ``tests/api/scientific/`` and
+# ``tests/services/scientific_read/`` — including the rest of tests/api/
+# (scripts/test-api.sh) and every service package outside scientific_read
+# (scripts/test-rest.sh). Read the name precisely: this gate does not run
+# the scientific *domain* logic. The thermo, kinetics, statmech, conformer
+# and provenance tests under tests/services/, tests/workflows/ and
+# tests/invariants/ belong to the complement gate, and a green run here is
+# no evidence about any of them.
+#
 # Runs with a pinned random-order seed and parallel workers; see
 # scripts/lib/pytest_run_args.sh for why, and how to override either.
 #

--- a/backend/tests/scripts/test_gate_coverage.py
+++ b/backend/tests/scripts/test_gate_coverage.py
@@ -1,0 +1,280 @@
+"""Every test file must be run by at least one required CI job.
+
+This is a repo-check, not a backend test: it reads the gate scripts and
+``.github/workflows/backend-ci.yml`` and asserts that the union of what
+they select covers ``backend/tests/`` exactly.
+
+It exists because that property silently stopped holding and nothing
+noticed. The two required jobs ran ``tests/api/`` and
+``tests/api/scientific/`` + ``tests/services/scientific_read/``. Everything
+else -- tests/db/, tests/workflows/, tests/invariants/, tests/services/
+outside scientific_read, tests/schemas/, tests/importers/, tests/parsers/,
+tests/cli/, tests/workers/, tests/integration/ -- 3,806 tests, more than
+half the suite by count, gated no pull request at all. It ran nightly, so a
+defect merged green and surfaced the next morning attached to no PR:
+``tests/db/test_identifier_lengths.py`` sat red on main for days that way.
+
+Nothing about that was visible. ``test-api.sh`` read as "the API gate"
+while being "some of the API", and a directory added to ``tests/`` joined
+no gate unless somebody remembered to add it. The gate scripts now state
+what they exclude, and this test is what makes the statement checkable --
+a comment claiming coverage is the failure mode, not the fix.
+
+The check is deliberately mechanical about the *files*, not the
+directories: it enumerates the real ``test_*.py`` on disk and asks which
+job would run each one, so a new directory is caught the moment it exists
+rather than the next time somebody audits a list.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+import yaml
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_ROOT.parent
+TESTS_ROOT = BACKEND_ROOT / "tests"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+
+#: The gate scripts the workflow is required to invoke. Their union is
+#: supposed to be a partition of ``tests/``; deleting one of these entries
+#: is exactly the regression this file is here to refuse.
+REQUIRED_GATE_SCRIPTS = (
+    "backend/scripts/test-api.sh",
+    "backend/scripts/test-scientific.sh",
+    "backend/scripts/test-rest.sh",
+)
+
+
+class Selection:
+    """A pytest invocation reduced to "which files would this run".
+
+    ``paths`` are the positional test paths; ``ignored`` are the
+    ``--ignore`` arguments. Both are stored relative to ``backend/`` with
+    any trailing slash removed, because the scripts and the workflow are
+    inconsistent about it (``tests/api/`` in one, ``tests/api`` in the
+    other) and that difference must not change the answer.
+    """
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.paths: set[str] = set()
+        self.ignored: set[str] = set()
+
+    def covers(self, rel_path: str) -> bool:
+        if any(_is_under(rel_path, ignored) for ignored in self.ignored):
+            return False
+        return any(_is_under(rel_path, path) for path in self.paths)
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        return f"Selection({self.label!r}, paths={sorted(self.paths)}, ignored={sorted(self.ignored)})"
+
+
+def _normalize(token: str) -> str:
+    return token.rstrip("/")
+
+
+def _is_under(rel_path: str, prefix: str) -> bool:
+    """True when ``rel_path`` is ``prefix`` or lives inside it.
+
+    Compared segment-wise rather than with ``str.startswith`` so that
+    ``tests/api`` does not appear to contain ``tests/api_extra/x.py``.
+    """
+    path_parts = Path(rel_path).parts
+    prefix_parts = Path(prefix).parts
+    return path_parts[: len(prefix_parts)] == prefix_parts
+
+
+def _absorb_args(selection: Selection, tokens: list[str]) -> None:
+    """Fold a pytest argument list into ``selection``."""
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.startswith("--ignore="):
+            selection.ignored.add(_normalize(token.split("=", 1)[1]))
+        elif token == "--ignore" and index + 1 < len(tokens):
+            selection.ignored.add(_normalize(tokens[index + 1]))
+            index += 1
+        elif token.startswith("tests/") or token == "tests":
+            selection.paths.add(_normalize(token))
+        index += 1
+
+
+def _is_syntax_check(tokens: list[str]) -> bool:
+    """``bash -n <script>`` parses a script; it does not run its tests.
+
+    Adjacency matters. The real gate steps read
+    ``conda run -n tckdb_env bash backend/scripts/test-api.sh ...``, which
+    contains both ``bash`` and ``-n`` while being an invocation -- a
+    membership test would classify every gate step as a syntax check and
+    report the whole suite uncovered.
+    """
+    return any(
+        token == "bash" and index + 1 < len(tokens) and tokens[index + 1] == "-n"
+        for index, token in enumerate(tokens)
+    )
+
+
+def _join_continuations(text: str) -> list[str]:
+    """Collapse backslash-continued shell lines into single logical lines."""
+    lines: list[str] = []
+    pending = ""
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped.endswith("\\"):
+            pending += stripped[:-1] + " "
+            continue
+        lines.append(pending + stripped)
+        pending = ""
+    if pending:
+        lines.append(pending)
+    return lines
+
+
+def _script_selection(script_rel: str) -> Selection:
+    """The selection a gate script performs when run with no extra args."""
+    script = REPO_ROOT / script_rel
+    selection = Selection(script_rel)
+    for line in _join_continuations(script.read_text(encoding="utf-8")):
+        if line.startswith("#") or "pytest" not in line:
+            continue
+        _absorb_args(selection, shlex.split(line))
+    return selection
+
+
+def _workflow_selections() -> list[Selection]:
+    """Every pytest selection reachable from a required backend-ci job.
+
+    All matrix legs are unioned because all of them are required: the
+    ``backend-ci`` job needs ``backend-gate`` and asserts its result is
+    ``success``, so a test run by any leg is a test that gates the PR.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    selections: list[Selection] = []
+    for job_name, job in workflow["jobs"].items():
+        for step in job.get("steps", []):
+            run = step.get("run")
+            if not run:
+                continue
+            label = f"{job_name}:{step.get('name', '<unnamed>')}"
+            for line in _join_continuations(run):
+                if line.startswith("#"):
+                    continue
+                try:
+                    tokens = shlex.split(line)
+                except ValueError:
+                    # Heredoc bodies and Python fragments are not shell
+                    # commands; nothing in them invokes pytest.
+                    continue
+                if _is_syntax_check(tokens):
+                    # ``bash -n backend/scripts/test-rest.sh`` parses the
+                    # script and runs nothing. Counting it would let the
+                    # complement gate be deleted from the matrix while the
+                    # hygiene step kept this file green -- the exact shape
+                    # of the defect being guarded against.
+                    continue
+                gate = next(
+                    (token for token in tokens if token in REQUIRED_GATE_SCRIPTS),
+                    None,
+                )
+                if gate is not None:
+                    selection = _script_selection(gate)
+                    selection.label = f"{label} -> {gate}"
+                    _absorb_args(selection, tokens)
+                    selections.append(selection)
+                elif "pytest" in tokens:
+                    selection = Selection(label)
+                    _absorb_args(selection, tokens)
+                    if selection.paths:
+                        selections.append(selection)
+    return selections
+
+
+def _test_files() -> list[str]:
+    return sorted(
+        str(path.relative_to(BACKEND_ROOT).as_posix())
+        for path in TESTS_ROOT.rglob("test_*.py")
+        if "__pycache__" not in path.parts
+    )
+
+
+# ---------------------------------------------------------------------------
+# The property
+# ---------------------------------------------------------------------------
+
+
+def test_every_test_file_is_run_by_a_required_ci_job() -> None:
+    selections = _workflow_selections()
+    files = _test_files()
+    assert files, "no test files discovered; the walk is wrong, not the repo"
+
+    uncovered = [path for path in files if not any(sel.covers(path) for sel in selections)]
+    assert not uncovered, (
+        "these test files are run by no required CI job, so a defect in them "
+        "merges green and surfaces in the nightly attached to no pull "
+        "request:\n  " + "\n  ".join(uncovered)
+    )
+
+
+def test_complement_gate_excludes_only_what_another_gate_runs() -> None:
+    """test-rest.sh may subtract only subtrees another gate owns.
+
+    Adding an ``--ignore`` here is the cheapest possible way to reopen the
+    gap, because it looks like a narrowing rather than a deletion.
+    """
+    rest = _script_selection("backend/scripts/test-rest.sh")
+    others = [
+        _script_selection("backend/scripts/test-api.sh"),
+        _script_selection("backend/scripts/test-scientific.sh"),
+    ]
+    assert rest.paths == {"tests"}, (
+        "test-rest.sh must select the whole tree and subtract from it. An "
+        "include-list stops covering a directory the day somebody adds one."
+    )
+    for ignored in sorted(rest.ignored):
+        owned_by = [other.label for other in others if any(_is_under(path, ignored) or _is_under(ignored, path) for path in other.paths)]
+        assert owned_by, (
+            f"test-rest.sh ignores {ignored!r}, which no other gate script "
+            "selects, so nothing on a pull request runs it."
+        )
+
+
+@pytest.mark.parametrize("script_rel", REQUIRED_GATE_SCRIPTS)
+def test_workflow_invokes_every_gate_script(script_rel: str) -> None:
+    """Named, so a deleted matrix leg fails here and not only in aggregate.
+
+    Asserted against the parsed invocations rather than against the file
+    text: the hygiene step mentions all three scripts under ``bash -n``,
+    and a substring search would call that an invocation.
+    """
+    invoked = {
+        label.split(" -> ", 1)[1]
+        for label in (selection.label for selection in _workflow_selections())
+        if " -> " in label
+    }
+    assert script_rel in invoked, (
+        f"{script_rel} is not invoked by backend-ci.yml. A gate script that "
+        "no workflow runs is documentation, not a gate."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the checks above pass trivially if the parser reports
+# everything as covered, so pin that ignores are actually honoured.
+# ---------------------------------------------------------------------------
+
+
+def test_ignores_are_honoured_by_the_parser() -> None:
+    rest = _script_selection("backend/scripts/test-rest.sh")
+    assert rest.covers("tests/db/test_identifier_lengths.py")
+    assert not rest.covers("tests/api/test_api_health.py")
+    assert not rest.covers("tests/services/scientific_read/test_species.py")
+
+
+def test_prefix_matching_is_segment_wise() -> None:
+    assert _is_under("tests/api/test_x.py", "tests/api")
+    assert not _is_under("tests/api_extra/test_x.py", "tests/api")
+    assert _is_under("tests/api", "tests/api")

--- a/backend/tests/scripts/test_gate_coverage.py
+++ b/backend/tests/scripts/test_gate_coverage.py
@@ -235,7 +235,15 @@ def test_complement_gate_excludes_only_what_another_gate_runs() -> None:
         "include-list stops covering a directory the day somebody adds one."
     )
     for ignored in sorted(rest.ignored):
-        owned_by = [other.label for other in others if any(_is_under(path, ignored) or _is_under(ignored, path) for path in other.paths)]
+        owned_by = [
+            other.label
+            for other in others
+            # Either direction: the complement may subtract a subtree another
+            # gate selects wholesale (tests/services/scientific_read), or one
+            # that contains what another gate selects (tests/api, of which the
+            # scientific gate takes tests/api/scientific).
+            if any(_is_under(path, ignored) or _is_under(ignored, path) for path in other.paths)
+        ]
         assert owned_by, (
             f"test-rest.sh ignores {ignored!r}, which no other gate script "
             "selects, so nothing on a pull request runs it."

--- a/backend/tests/scripts/test_gate_coverage.py
+++ b/backend/tests/scripts/test_gate_coverage.py
@@ -40,7 +40,7 @@ TESTS_ROOT = BACKEND_ROOT / "tests"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
 
 #: The gate scripts the workflow is required to invoke. Their union is
-#: supposed to be a partition of ``tests/``; deleting one of these entries
+#: supposed to cover ``tests/`` between them; deleting one of these entries
 #: is exactly the regression this file is here to refuse.
 REQUIRED_GATE_SCRIPTS = (
     "backend/scripts/test-api.sh",


### PR DESCRIPTION
## Summary

Two required PR jobs ran `tests/api/` and `tests/api/scientific/` +
`tests/services/scientific_read/`. **216 of the 352 test files — 3,806 tests,
more than half the suite by count — ran on no pull request at all.** They ran
nightly, so a defect merged green and surfaced the next morning attached to no
PR: `tests/db/test_identifier_lengths.py` sat red on `main` for days, and two
branches merged whose failures both gates reported green.

This adds a third required gate defined as the *complement* of the other two,
and moves CI's `alembic upgrade head` off the ambient `DB_NAME` so the PR gates
and the nightly hand the test process the same database.

Closes #81. Closes #92.

## The gate structure, and why not the obvious one

Adding everything to one gate makes every PR wait on the full suite. Widening
the two that exist has the same problem in a different place. So: measure
first.

Measured on a 20-core host at four workers (CI's worker count), all three
selections green:

| selection | tests | wall clock |
|---|---:|---:|
| API gate, as CI invokes it | 990 | 2m20s |
| Scientific gate | 1,998 | 4m21s |
| **The uncovered remainder** | **3,813** | **3m50s** |

The remainder is *more than half the suite by count and cheaper than the
scientific gate*. These are the fast tests — schemas, parsers, invariants,
importers — not the slow ones, which is why gating them was never the
trade-off it looked like.

On CI the arithmetic is what decides it, and it is now measured rather than
projected. From run `31431866497`: API job **8m34s** wall, scientific job
**12m09s**, ~1m50s each of that container + conda + install overhead. The new
leg, measured on this branch: **6m33s** — identical to the API gate it runs
beside, and well under the scientific gate's **12m38s** on the same run
(`31475200939`), which is and remains the critical path. **The PR waits exactly as long as it does today.** The cost is
one runner, not latency. Widening the API gate instead would have put the
remainder in series behind it, making that job ~14m and moving the critical
path out by ~5 minutes on every PR.

So: a third matrix leg, `rest`, reusing the existing services, env and setup
steps.

## The exclusion is now stated, and checked

The actual defect was never the missing tests — it was that the omission was
invisible. `test-api.sh` read as "the API gate" and was in fact "some of the
API". Every gate script now says what it does not run:

- **`test-api.sh`** — *"Excludes: everything outside `tests/api/`. This is the
  API gate, not the backend gate."* Plus both of CI's extra `--ignore`s and
  where each is covered instead.
- **`test-scientific.sh`** — *"Read the name precisely: this gate does not run
  the scientific domain logic."* The thermo, kinetics, statmech and conformer
  tests under `tests/services/`, `tests/workflows/` and `tests/invariants/`
  were never in it.
- **`test-rest.sh`** — *"Excludes: nothing else, ever."*
- **`test-full.sh`** — *"Excludes: nothing"*, and is now the union of the three.

Comments rot, so they are not the mechanism.
**`tests/scripts/test_gate_coverage.py`** parses the gate scripts and
`backend-ci.yml`, resolves what each job selects and ignores, and fails if any
`test_*.py` on disk is run by no required CI job.

Bite demos, all three run:

| mutation | result |
|---|---|
| `origin/main`'s workflow | **216 of 352 files uncovered** — fails |
| this branch | 0 uncovered — passes |
| delete only the `Backend complement gate` step | **220 uncovered** — fails, and the named per-script check fires too |

Writing the demos found a real hole in the check itself. The parser first
counted the hygiene step's `bash -n backend/scripts/test-rest.sh` as an
invocation, which would have let someone delete the matrix leg while this file
stayed green — the exact defect, reproduced inside its own guard. Syntax checks
are now excluded, by adjacency rather than membership: the genuine gate steps
read `conda run -n tckdb_env bash backend/scripts/test-api.sh`, which contains
both `bash` and `-n`.

### Why the complement is a subtraction and not a list

`test-rest.sh` selects `tests/` and subtracts `tests/api` and
`tests/services/scientific_read`. An enumerated include-list would reproduce
the original defect the first time somebody added a directory under `tests/`
and did not think to add it — which is precisely how this happened. A
subtraction cannot: a new directory joins a required gate the day it is
created. `test_gate_coverage.py` additionally refuses any `--ignore` in
`test-rest.sh` that no other gate script selects, because narrowing it is the
cheapest way to reopen the gap and looks like tidying.

## Deleted: the "Ops and repo-check gate" step

It ran `tests/ops/` and `tests/scripts/test_check_runtime_ascii.py` as their own
invocation because nothing else on a PR reached them. The complement gate
reaches both, so the step is gone rather than left to duplicate it — and
running `tests/ops/` inside the large invocation is the *stronger* version: as
its own process it was the only bare `conftest` on `sys.path`, which is exactly
what hid the module collision #124 had to diagnose from a nightly.

## A latent defect the debugging turned up: no `conda run` step with a heredoc has ever run

The first CI attempt failed in the new alembic step, and the reason generalises
past this PR.

```
conda run -n tckdb_env python - <<'PY'
```

`conda run` does not forward the calling shell's stdin, so `python -` reads
EOF, executes nothing, and **exits 0**. Reproduced locally in one line:

```console
$ conda run -n tckdb_env python - <<'PY'
print('HEREDOC REACHED PYTHON')
PY
$ echo $?
0
```

No output. No error. Exit 0.

**`Initialize artifact bucket` uses that exact form, in both workflows, and has
therefore never provisioned anything.** Checked against a *green* run
(`31431866497`, job `93596940175`): the step's log contains no boto3 output, no
bucket name, nothing at all between its header and the next step. A step that
prints nothing is indistinguishable from one that succeeded quietly, which is
why it survived — the same failure mode as the coverage gap itself, in a
different costume.

Both steps now write the script to a file, run it by path, and **print what
they did**, so silence is no longer a valid state. Fixed rather than filed: it
is the identical bug three lines from the one I had to fix, in a file this
change already owns.

Confirmed on the green run: the step now logs
`created artifact bucket: tckdb-api-31475200939-1` where it previously logged
nothing at all, and `created scratch migration database ...` likewise. "created"
rather than "already present" also confirms the bucket genuinely had not
existed. Nothing was depending on its absence — all three gates pass with it
present.

## #92 — resolved, with no dependency on #90

`backend-ci.yml` migrated `DB_NAME` in a step before the gates; the nightly did
not. That divergence is what let cause 2 of #64 hide: five `/status` tests
probed the ambient database, found a migrated schema on CI and an empty one at
night, and so failed only where nobody was looking.

Both workflows now leave the ambient database **empty**. The alembic steps run
against a scratch database they create.

That is the right resolution rather than the symmetric one, because these steps
were never about the ambient database. They are migration checks — one head,
applies cleanly, no model/schema drift — and they need *a* migrated database,
just not the one the test process can see. Migrating `DB_NAME` made "CI happens
to migrate the database the tests inherit" a load-bearing, undeclared part of
the environment. Adding the same step to the nightly would have made both
workflows green and hidden the coupling symmetrically; removing it makes the
nightly's condition the *only* condition, so a test that acquires a dependency
on a migrated ambient database now fails the PR that introduces it.

**This needed nothing from #90.** #124 already rebound those five tests to
`db_engine`. Verified empirically rather than assumed — full suite against an
ambient `DB_NAME` pointed at an empty database:

```
6797 passed, 14 skipped in 492.37s
```

The module-level `engine = create_engine(settings.database_url)` at
`backend/app/api/deps.py:27` still exists; nothing now depends on what it
points at. No application code was touched.

The steps are also scoped to `matrix.gate == 'api'`. They ran on every matrix
leg, and the answer cannot differ between legs — paying for it three times buys
three chances to flake.

## What the newly-gated directories revealed

Nothing red. All 3,813 pass, which is the finding: this could be turned on
today without a single test needing a fix, and could have been at any point
after #124. The half-suite was not gating anything *and* was not broken — the
cost was entirely in what could have merged, not in what had.

`tests/db/test_identifier_lengths.py`, red on `main` for days, is green and now
gated.

## Verification

| check | result |
|---|---|
| full suite, unmigrated ambient `DB_NAME`, 6 workers | **6797 passed, 14 skipped** (8m12s) |
| `test-rest.sh --maxfail=5`, unmigrated ambient DB, 4 workers | **3813 passed, 14 skipped** (3m50s) |
| `test-rest.sh` at a second seed (`TCKDB_TEST_SEED=1`) | **3813 passed, 14 skipped** (6m06s) — new gate, new process composition |
| **all three gates on CI, final run `31475200939`** | **all pass** — API 6m33s, complement 6m33s, scientific 12m38s |
| `test-scientific.sh --maxfail=5`, 4 workers | **1998 passed** (4m21s) |
| API gate as CI invokes it, unmigrated ambient DB, 4 workers | **990 passed** (2m25s) — the gate that owns the five `/status` tests |
| `test_gate_coverage.py` | 7 passed; bites on `main` and on a deleted leg |
| `alembic upgrade head` + `heads` + `check` on a fresh scratch DB | clean, `No new upgrade operations detected` |
| `ruff check app tests scripts` | clean |
| `bash -n` on all five ladder scripts, YAML parse of both workflows, `make help` | clean |

No test was skipped, xfailed, weakened or deleted. Test count rises by the 7
assertions in `test_gate_coverage.py` and by nothing else.

## Follow-ups, not fixed here

- `backend/app/api/deps.py:27` — the module-level engine bound to
  `settings.database_url` is still the mechanism by which a test can reach past
  every fixture. Owned by #90.
- `backend/scripts/test-api.sh:27` — the script selects all of `tests/api/`
  while CI invokes it with `--ignore=tests/api/scientific/`, so `make test-api`
  locally runs 2,529 tests and the CI job runs 990. Documented in both scripts;
  moving the ignore into the script would make the two agree.

