### PR TITLE
Give each pytest run its own databases, and make the ambient session tell the truth

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -6,6 +6,7 @@ from typing import Iterator
 
 from fastapi import Cookie, Depends, Header, HTTPException, Query
 from sqlalchemy import create_engine, event, select
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.api.config import settings
@@ -60,6 +61,51 @@ def _install_statement_timeout_listener(target_engine) -> None:
 
 
 _install_statement_timeout_listener(engine)
+
+
+def bind_ambient_session_factory(new_engine) -> Engine:
+    """Re-point the module-level ``engine``/``SessionLocal`` at *new_engine*.
+
+    ``engine`` and :data:`SessionLocal` are created at import time from
+    ``settings.database_url``, i.e. from the ambient ``DB_NAME``. That is
+    right in a deployment, where the ambient database *is* the database,
+    and wrong under pytest, where the fixtures create and migrate a
+    per-worker database that ``DB_NAME`` does not name.
+
+    Several call sites cannot be handed a request-scoped session and so
+    cannot avoid this factory:
+
+    * ``app.services.upload_submission.record_failed_upload`` and
+      ``app.services.artifact_integrity.record_artifact_integrity_event``
+      must write in a transaction *independent* of the request's, which
+      has already rolled back by the time they run;
+    * ``app.workers.upload_worker`` and ``app.api.idempotency`` run
+      outside any request;
+    * ``app.api.startup_checks.check_server_encoding`` runs at boot;
+    * ``/health``, ``/readyz`` and ``/status`` deliberately probe the
+      process's *own* engine — routing them through an overridable
+      request dependency would let a test declare a deployment healthy
+      while the deployment's engine is broken.
+
+    For all of them the fix is to make this binding tell the truth rather
+    than to remove the binding. :func:`sessionmaker.configure` mutates
+    :data:`SessionLocal` in place, so modules that did
+    ``from app.api.deps import SessionLocal`` at import time follow the
+    rebind — rebinding only the module attribute would not reach them.
+
+    Returns the previous engine so a caller can restore it. The caller
+    owns *new_engine* entirely, including its pooling and any statement
+    timeout: no listener is installed here, because a rebinder that
+    silently imposed ``settings.db_statement_timeout_ms`` on someone
+    else's engine would be changing behaviour behind their back.
+
+    Called by ``backend/tests/conftest.py``; not used in deployment.
+    """
+    global engine
+    previous = engine
+    engine = new_engine
+    SessionLocal.configure(bind=new_engine)
+    return previous
 
 
 def get_db() -> Iterator[Session]:

--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -208,54 +208,110 @@ There is **no slow-test budget today**. When that lands, add a
 above the threshold and have CI deselect or quarantine it. Until
 then, treat `make test-profile` output as informational.
 
-## Concurrent runs and shared `DB_TEST_NAME`
+## Concurrent runs and `DB_TEST_NAME`
 
-Do not run multiple pytest processes against the same explicit
-`DB_TEST_NAME` on the same Postgres host. The session fixture in
-[`tests/conftest.py`](../tests/conftest.py) recreates the named test
-database during setup and terminates active connections on it — a
-second process pointed at the same name will see its DB dropped out
-from under it mid-run, with confusing `OperationalError`s as the
-visible symptom.
+**Two pytest runs on one host no longer interfere, whatever you pass
+as `DB_TEST_NAME`.** That was not true until 2026-08-11, and the way
+it failed is worth knowing, because the symptom named nothing:
 
-The session fixture derives a test-DB name with the following
-precedence (see `_resolve_test_db_name` in
-[`tests/conftest.py`](../tests/conftest.py)):
+> Three agents worked in parallel on one box. One reported **2305
+> errors** on a tree that, re-run alone, gave a clean pass at the same
+> commit. Every error read `terminating connection due to
+> administrator command` or `relation does not exist`. Nothing in the
+> output said "another run is using your database".
 
-1. **Explicit `DB_TEST_NAME` *and* `PYTEST_XDIST_WORKER`** — the
-   explicit name with the worker id appended, e.g.
-   `tckdb_test_api_991_gw3`. This case comes **first**, and that
-   ordering is load-bearing: every gate script and every CI job sets
-   `DB_TEST_NAME`, so while the explicit name won unconditionally,
-   turning on `-n` pointed all workers at one database. They raced to
-   drop and recreate it during session setup, and whichever survived
-   was then written concurrently by every worker — reintroducing
-   exactly the cross-test visibility the per-test rollback exists to
-   prevent. Asking for a specific database name *and* N workers is
-   asking for N databases. Over-long names have the base trimmed, not
-   the suffix, because Postgres truncates identifiers silently and
-   `…_gw10` / `…_gw11` must not collapse onto one name.
-2. **Explicit `DB_TEST_NAME`** alone — used verbatim. Backward-compatible
-   with existing CI configs that pin a job-specific name. Explicit
-   names are **single-tenant**: only one pytest process at a time may
-   use them. For CI runners that share one Postgres host, set
-   `DB_TEST_NAME` per job (e.g. include the runner / job id) so
-   parallel jobs do not collide.
-3. **`PYTEST_XDIST_WORKER`** alone — each worker exports its id
-   (`gw0`, `gw1`, …) and the fixture maps it to `tckdb_test_<worker>`
-   (e.g. `tckdb_test_gw0`, `tckdb_test_gw1`). Worker ids are sanitized
-   to safe identifier characters, so each worker owns its own database
-   and the drop-and-recreate sequence cannot race.
-4. **Fallback** — `tckdb_test_<pid>` so two ad-hoc pytest processes
-   on one host (e.g. two terminals running `make test-fast`) never
-   share a database, even without xdist.
+Names were derived from `PYTEST_XDIST_WORKER` alone, so they were
+unique *within* a run and identical *across* runs. Eight databases,
+shared by everybody, each run dropping and recreating the others'
+schemas mid-flight. CI escaped only because it sets `DB_TEST_NAME` per
+`github.run_id`; no gate script did.
+
+### The name
+
+The session fixture (`_resolve_test_db_name` in
+[`tests/conftest.py`](../tests/conftest.py)) builds:
+
+```
+<base>_<run token>[_<worker>]
+```
+
+- **base** — `DB_TEST_NAME` when set, otherwise `tckdb_test`. An
+  explicit `DB_TEST_NAME` is a **label**, not the final name.
+- **run token** — eight hex characters minted once per pytest run and
+  exported as `TCKDB_TEST_RUN_TOKEN`. The xdist controller imports the
+  root conftest before execnet spawns the workers, so all eight
+  databases of one run share one token; if a future pytest stops
+  importing it there, each worker mints its own, which is still
+  correct (the token only ever has to differ *between* runs).
+- **worker** — the sanitized `PYTEST_XDIST_WORKER` id. Asking for a
+  specific database name *and* N workers is asking for N databases:
+  when the explicit name won unconditionally, `-n` pointed every
+  worker at one database and they raced to drop, recreate and then
+  concurrently write it, reintroducing exactly the cross-test
+  visibility the per-test rollback exists to prevent.
+
+Over-long names have the **base** trimmed, never the suffix. Postgres
+truncates identifiers silently, so trimming the tail would eat the run
+token first — turning the cross-run guarantee off for precisely the
+operators who pin long, descriptive job names — and would collapse
+`…_gw10` and `…_gw11` onto one database.
+
+The run token is why the explicit name can no longer be used verbatim.
+Making only the *default* unique would have missed the collision shape
+that actually happens: two runs copy-pasting the same
+`DB_TEST_NAME=...` out of the same document. Set it for readability
+(`DB_TEST_NAME=tckdb_test_analytics` makes your databases obvious in
+`\l`); it is no longer load-bearing for isolation.
 
 The resolved name is exported back into `os.environ["DB_TEST_NAME"]`
 so subprocess-based tests (e.g. the contribution-bundle CLI smoke
-test) inherit the same database.
+test) inherit the same database. Re-resolving an already-resolved name
+is idempotent — a second token is never stacked on.
 
 The xdist controller process never creates a database: it collects but
 does not execute tests, and `PYTEST_XDIST_WORKER` is unset there.
+
+### The refusal
+
+Random tokens make a collision vanishingly unlikely, and "unlikely" is
+not the same as "reported". Before it drops anything,
+`_recreate_test_database` refuses when either holds:
+
+- a **live backend** is attached to the exact name. Within one run each
+  worker owns a distinct name and creates it once, so a connection
+  already there belongs to somebody else;
+- the database carries an **ownership marker from a different run** on
+  this host whose creator pid is still alive — a run that has created
+  its database but not yet connected, which the backend check misses.
+
+The refusal raises `ForeignTestDatabaseError` naming both run tokens
+and saying what to do. An orphan from a *dead* run is reclaimed, not
+refused: leaks are expected, and a permanent blocker would be worse
+than the leak.
+
+An unmarked database is not refused — it was not created by this
+harness, its name has already been validated against the
+isolated-test-database pattern, and dropping it is the documented
+behaviour of an explicit `DB_TEST_NAME`.
+
+### Scratch databases created by individual tests
+
+Migration tests create their own throwaway databases to drive Alembic
+against. **Every one of them must get its name from
+`conftest.scratch_database_name(label)`**, which returns
+`tckdb_test_<label>_<uuid>` — inside the `tckdb_test%` pattern both
+reclaimers below use, and trimmed so the unique part survives the
+63-byte identifier limit.
+
+Names built by hand (`tckdb_et_scope_migration_*`,
+`tckdb_stage2_legacy_*`, `tckdb_exec_env_migration_*`) matched neither
+reclaimer, so a run killed partway leaked them permanently; one was
+found and dropped by hand on 2026-08-10.
+[`tests/test_scratch_database_names.py`](../tests/test_scratch_database_names.py)
+fails any test file that issues `CREATE DATABASE` without going
+through the helper, so the next one cannot drift out silently, and
+asserts the sweep and the standalone reclaim script still agree on
+what "reclaimable" means.
 
 ### Pinned order and parallel workers
 
@@ -322,7 +378,7 @@ after the script's.
 
 ### Test-database cleanup and the startup sweep
 
-Because the fallback name embeds the pid, **no name is ever reused** —
+Because every name embeds a per-run token, **no name is ever reused** —
 so any run that fails to drop its database leaks it permanently. Two
 mechanisms keep that from accumulating:
 
@@ -336,8 +392,8 @@ mechanisms keep that from accumulating:
    OOM kill, or a power loss, so `_sweep_stale_test_databases` runs
    once at session start to reclaim that residue. Every database the
    fixture creates is stamped with a `COMMENT ON DATABASE` recording
-   the creating host and pid; the sweep drops a database **only** when
-   all of the following hold:
+   the creating host, pid and run token; the sweep drops a database
+   **only** when all of the following hold:
 
    - it carries this harness's marker (databases created by anything
      else — including orphans that predate the marker — are never
@@ -346,6 +402,10 @@ mechanisms keep that from accumulating:
      (this is what stops a concurrently-starting pytest run from
      having its freshly created database swept away before it
      connects);
+   - the marker's run token is **not this run's**. Under `-n` the
+     eight workers of one run share a token, so a worker whose creator
+     pid has been recycled must not have a sibling's live database
+     dropped underneath it;
    - `pg_stat_activity` reports no backend attached;
    - the name matches the isolated-test-database pattern and is not
      this session's own database.
@@ -415,6 +475,62 @@ psql -h 127.0.0.1 -U tckdb -d postgres -c "
   external storage (MinIO) skip themselves when MinIO is not
   reachable — that's expected on a workstation without the dev
   container running.
+
+### The ambient session factory
+
+`app.api.deps` builds `engine` / `SessionLocal` at **import time** from
+`settings.database_url` — the ambient `DB_NAME`, locally `tckdb_dev`.
+That is right in a deployment, where the ambient database *is* the
+database, and wrong under pytest, where nothing creates, migrates,
+inspects or rolls back it.
+
+It is not a theoretical hazard. It was root cause 2 of the
+seed-independence work: five `/status` tests probed through
+`health.SessionLocal`, passed in a dev shell and passed on the PR gate
+(which runs `alembic upgrade head` against `DB_NAME` in an earlier
+step), and failed only on the nightly, which does not. They were green
+for a reason unrelated to what they asserted. Worse than a false
+green: several of these call sites **commit**, and a commit into
+`tckdb_dev` is invisible to the committed-row tripwire and to every
+assertion in the suite.
+
+Several sites cannot be handed a request-scoped session, so "thread a
+session through" is not available to them:
+
+| Site | Why it needs an out-of-request session |
+|---|---|
+| `services/upload_submission.record_failed_upload` | writes the failed-upload audit in a transaction *independent* of the request's, which has already rolled back |
+| `services/artifact_integrity.record_artifact_integrity_event` | same shape — an append-only observation that must survive the caller's failure |
+| `workers/upload_worker` | runs outside any request |
+| `api/idempotency` | decorator; needs its own transaction for the idempotency record |
+| `api/startup_checks.check_server_encoding` | runs at boot; there is no request |
+| `routes/health` — `/health`, `/readyz`, `/status` | deliberately probe the process's **own** engine. Routing them through an overridable request dependency would let a test declare a deployment healthy while the deployment's engine is broken — the opposite of what the endpoint is for |
+
+So the binding is made truthful rather than removed. `tests/conftest.py`
+does two things, via `deps.bind_ambient_session_factory`:
+
+1. **At import**, before any fixture, it points the factory at an
+   engine that *refuses to connect*. A path that needs an
+   out-of-request session and never requested `db_engine` now says so,
+   instead of quietly writing to `tckdb_dev`.
+2. **`db_engine`** rebinds it to the real per-worker engine for the
+   session, and restores the refusing engine at teardown.
+
+`sessionmaker.configure` mutates the factory in place, so the modules
+that hold a `from app.api.deps import SessionLocal` reference — health,
+idempotency, the upload worker, the archive CLI — all follow. Rebinding
+only the module attribute would not have reached them, which is exactly
+how the `/status` probes stayed broken.
+
+Consequence for CI: **the suite no longer needs `DB_NAME` to exist, let
+alone be migrated.** `tests/api/` passes with `DB_NAME` pointing at a
+database that has never been created. Coverage lives in
+[`tests/test_ambient_session_binding.py`](../tests/test_ambient_session_binding.py).
+
+If you are writing a service that needs its own transaction, prefer an
+injectable `session_factory=` parameter (as both services above have)
+over reaching for `SessionLocal` directly — it lets a test pass the
+per-test connection without touching global state.
 
 ### Isolation contract: what a test may leave behind
 
@@ -577,12 +693,20 @@ the matrix result is `success`, while leaving both detailed gate checks visible.
 Each CI job owns an isolated Postgres service and MinIO service. Its
 `DB_TEST_NAME` and `S3_BUCKET` include both the GitHub run id/attempt and the
 job role, so concurrent jobs and workflow runs do not share test resources.
+The run token now makes the `DB_TEST_NAME` half of that redundant for
+isolation — it stays because it makes a job's databases identifiable.
 
 The gates run under xdist, at `TCKDB_TEST_WORKERS=4` rather than the local
 default of 8, because a GitHub standard runner has 4 vCPUs and one Postgres
 container. `DB_TEST_NAME` is still set per job; `_resolve_test_db_name` appends
-the worker id to it, so each worker gets its own database instead of four
-workers racing on one recreated one.
+the run token and the worker id to it, so each worker gets its own database
+instead of four workers racing on one recreated one.
+
+Nothing in the suite depends on `DB_NAME` any more — see *The ambient
+session factory* above. A workflow step that runs `alembic upgrade head`
+against `DB_NAME` before the gate is no longer load-bearing for the
+tests, and the PR gate / nightly divergence it created (one migrated it,
+the other did not) can no longer hide a failure in one environment.
 
 The full Tier 4 suite is intentionally not part of this v0 PR workflow.
 Keep running `make test-full` locally before push/merge until a
@@ -672,10 +796,11 @@ Order-independence was the prerequisite, not a separate nicety: xdist
 distributes tests across workers in arbitrary groupings, so a suite that only
 passed in particular orders could not survive it. What made it safe:
 
-- **A database per worker.** `_resolve_test_db_name` appends the worker id even
-  when `DB_TEST_NAME` is set explicitly, which every gate script and CI job
-  does. Without that, all workers dropped, recreated and then wrote one
-  database concurrently.
+- **A database per worker, and per run.** `_resolve_test_db_name` appends the
+  run token and the worker id even when `DB_TEST_NAME` is set explicitly,
+  which every gate script and CI job does. Without the worker id, all workers
+  dropped, recreated and then wrote one database concurrently; without the run
+  token, two runs on one host did the same to each other.
 - **No test commits to the shared database.** ~50 tests across 16 files did;
   they now persist through `db_conn`, and the tripwire above keeps it that way.
 - **Advisory locks are per-database.** The only one in the app

--- a/backend/scripts/dev/reclaim_leaked_test_databases.py
+++ b/backend/scripts/dev/reclaim_leaked_test_databases.py
@@ -16,6 +16,24 @@ carrying the harness's ownership marker, so the *pre-existing* orphans — which
 predate the marker — are invisible to it and must be removed deliberately, by
 a human, with this script.
 
+Coverage, and how it is kept
+----------------------------
+``TEST_DB_NAME`` below is the *only* thing this script will drop, and
+``_sweep_stale_test_databases`` in ``backend/tests/conftest.py`` uses the
+identical pattern.  Migration tests used to build scratch names outside it
+(``tckdb_et_scope_migration_*``, ``tckdb_stage2_legacy_*``,
+``tckdb_exec_env_migration_*``); a run killed partway leaked those permanently
+because neither reclaimer could see them.
+
+The fix was to bring the *names* inside the pattern rather than to widen the
+pattern: tests now build scratch names with ``conftest.scratch_database_name``,
+so a new migration test that follows the convention is covered automatically,
+whereas a widened pattern would have to be remembered.
+``backend/tests/test_scratch_database_names.py`` enforces both halves — that
+every test issuing ``CREATE DATABASE`` uses the helper, and that this script
+and the sweep still agree on the pattern.  If you change ``TEST_DB_NAME`` here,
+that test will tell you the sweep no longer matches.
+
 Safety model
 ------------
 This script never decides for itself what to delete.  It runs in two phases:

--- a/backend/scripts/dev/reclaim_leaked_test_databases.py
+++ b/backend/scripts/dev/reclaim_leaked_test_databases.py
@@ -94,6 +94,13 @@ PROTECTED = frozenset(
         "tckdb",
         "tckdb_dev",
         "tckdb_prod",
+        # Not created by the harness and never carries its marker, so the
+        # in-process sweep leaves it alone -- but this script does not read
+        # markers, and the name is inside ``tckdb_test%``. It is the
+        # ``DB_NAME`` of the nightly CI job
+        # (``.github/workflows/backend-nightly.yml``), so on a self-hosted
+        # runner ``plan`` would otherwise offer up the job's own database.
+        "tckdb_test_ci",
     }
 )
 

--- a/backend/tests/api/test_api_db_statement_timeout.py
+++ b/backend/tests/api/test_api_db_statement_timeout.py
@@ -31,13 +31,22 @@ from app.api.errors import register_exception_handlers
 # ---------------------------------------------------------------------------
 
 
-def _build_engine_with_listener(timeout_ms: int | None):
+def _build_engine_with_listener(db_engine, timeout_ms: int | None):
     """Create a one-shot engine and install the timeout listener.
 
-    Uses the test DB connection so the listener actually runs
-    against PostgreSQL.
+    Built from ``db_engine.url`` — the per-worker pytest database — rather
+    than from ``settings.database_url``, which names the ambient ``DB_NAME``
+    that no fixture creates. Reaching for the ambient database is how five
+    ``/status`` tests came to pass on the PR gate (which migrates ``DB_NAME``
+    in an earlier step) and fail every night on the nightly (which does not);
+    these two were the last place in ``tests/api/`` still doing it, and they
+    failed the same way against a ``DB_NAME`` that has never existed.
+
+    A *fresh* engine is still required: the listener is registered on
+    ``connect``, so it has to be installed before the engine hands out its
+    first connection. That is what makes this test real rather than a mock.
     """
-    eng = create_engine(settings.database_url, pool_pre_ping=True)
+    eng = create_engine(db_engine.url, pool_pre_ping=True)
     # Patch the module-level setting for the duration of the listener
     # registration; SQLAlchemy reads the closure value when ``connect``
     # fires.
@@ -50,8 +59,8 @@ def _build_engine_with_listener(timeout_ms: int | None):
         settings.db_statement_timeout_ms = previous
 
 
-def test_listener_applies_configured_timeout():
-    eng = _build_engine_with_listener(15_000)
+def test_listener_applies_configured_timeout(db_engine):
+    eng = _build_engine_with_listener(db_engine, 15_000)
     try:
         with Session(eng) as s:
             value = s.execute(text("SHOW statement_timeout")).scalar()
@@ -61,9 +70,9 @@ def test_listener_applies_configured_timeout():
         eng.dispose()
 
 
-def test_listener_zero_disables_app_level_setting():
+def test_listener_zero_disables_app_level_setting(db_engine):
     """``db_statement_timeout_ms = 0`` skips the SET; role default wins."""
-    eng = _build_engine_with_listener(0)
+    eng = _build_engine_with_listener(db_engine, 0)
     try:
         with Session(eng) as s:
             value = s.execute(text("SHOW statement_timeout")).scalar()

--- a/backend/tests/api/test_api_health.py
+++ b/backend/tests/api/test_api_health.py
@@ -11,7 +11,16 @@ from app.api.routes import health as health_route
 
 @pytest.fixture(autouse=True)
 def _bind_health_probe_to_test_database(db_engine, monkeypatch):
-    """Run direct health-probe sessions against the migrated pytest database."""
+    """Run direct health-probe sessions against the migrated pytest database.
+
+    Since ``tests/conftest.py`` rebinds ``app.api.deps.SessionLocal`` to the
+    per-worker database, this is no longer what *makes* these tests correct —
+    they pass without it, including with ``DB_NAME`` naming a database that
+    has never been created. It stays because the tests below monkeypatch
+    ``health_route.SessionLocal`` in their own bodies to force a specific
+    probe outcome, and a fixture that establishes the baseline they override
+    is what makes "undone first" true for all of them.
+    """
     test_session_factory = sessionmaker(bind=db_engine, expire_on_commit=False)
     monkeypatch.setattr(health_route, "SessionLocal", test_session_factory)
 

--- a/backend/tests/api/test_api_status.py
+++ b/backend/tests/api/test_api_status.py
@@ -43,18 +43,20 @@ def _bind_status_probes_to_test_database(db_engine, monkeypatch):
     to the ambient ``DB_NAME``, which is *not* the per-worker database this
     suite creates and migrates.
 
-    So without this binding these tests assert on a database no fixture
-    owns. Whether they pass depends on whether something outside the test
-    run happened to migrate it: a developer shell inherits ``tckdb_dev``
-    and passes; the PR gate runs ``alembic upgrade head`` against its
-    ``DB_NAME`` in an earlier workflow step and passes; the nightly has no
-    such step and fails five tests every night for a reason that is
-    nowhere in this file.
+    That binding is what made these five tests assert on a database no
+    fixture owned: a developer shell inherited ``tckdb_dev`` and passed, the
+    PR gate ran ``alembic upgrade head`` against its ``DB_NAME`` in an
+    earlier workflow step and passed, and the nightly -- which has no such
+    step -- failed five tests every night for a reason that was nowhere in
+    this file.
 
-    ``tests/api/test_api_health.py`` binds the same way for the same
-    reason. Tests below that want a *specific* probe outcome monkeypatch
-    ``health.SessionLocal`` again in their own body, which wins here and is
-    undone first.
+    **``tests/conftest.py`` now rebinds the ambient factory to the pytest
+    database for the whole session**, so this fixture is no longer load
+    bearing: these tests pass without it, including with ``DB_NAME`` naming a
+    database that has never been created. It stays because the tests below
+    that want a *specific* probe outcome monkeypatch ``health.SessionLocal``
+    again in their own body, and an explicit baseline is what makes "wins
+    here and is undone first" true rather than incidental.
     """
     monkeypatch.setattr(
         health, "SessionLocal", sessionmaker(bind=db_engine, expire_on_commit=False)

--- a/backend/tests/cli/test_configure_database_roles.py
+++ b/backend/tests/cli/test_configure_database_roles.py
@@ -9,6 +9,7 @@ import uuid
 
 import psycopg
 import pytest
+from conftest import scratch_database_name
 from psycopg import sql
 
 from scripts.configure_database_roles import (
@@ -63,7 +64,7 @@ def _admin_connection(database: str, *, autocommit: bool = False) -> psycopg.Con
 
 def test_configure_roles_enforces_runtime_boundary() -> None:
     suffix = uuid.uuid4().hex[:10]
-    database = f"tckdb_role_test_{suffix}"
+    database = scratch_database_name("role_test")
     owner = f"tckdb_owner_{suffix}"
     runtime = f"tckdb_app_{suffix}"
     owner_password = f"owner-{suffix}"
@@ -200,7 +201,7 @@ def test_configure_roles_enforces_runtime_boundary() -> None:
 
 def test_migration_owner_can_build_schema_and_runtime_receives_dml_privileges() -> None:
     suffix = uuid.uuid4().hex[:10]
-    database = f"tckdb_role_migration_{suffix}"
+    database = scratch_database_name("role_migration")
     owner = f"tckdb_owner_{suffix}"
     runtime = f"tckdb_app_{suffix}"
     owner_password = f"owner-{suffix}"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import secrets
 import socket
 import subprocess
 import warnings
 from pathlib import Path
 from typing import Iterator
+from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import Connection, create_engine, text
 from sqlalchemy.orm import Session
+from sqlalchemy.pool import NullPool
 
+from app.api import deps as api_deps
 from app.api.app import create_app
 from app.api.config import settings
 from app.api.deps import get_current_user, get_db, get_write_db
@@ -99,62 +103,102 @@ def _sanitize_identifier(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", value)
 
 
-def _with_worker_suffix(base: str, safe_worker: str) -> str:
-    """Append the xdist worker id to ``base``, keeping the result distinct.
+#: Environment variable carrying this pytest *run*'s identity.
+#:
+#: Set once, at conftest import, by whichever process gets there first.  With
+#: ``-n``, that is the xdist controller: it imports the rootdir conftest before
+#: execnet spawns the workers, and the workers inherit ``os.environ``, so all
+#: eight databases of one run share one token.  If a future pytest or xdist
+#: stops importing this file in the controller, each worker mints its own token
+#: instead — which is still correct, because the token only ever has to differ
+#: *between runs*; sharing it within a run buys diagnosis ("these eight
+#: databases are one run"), not safety.
+_RUN_TOKEN_ENV = "TCKDB_TEST_RUN_TOKEN"
+
+
+def _mint_run_token() -> str:
+    """A short token unique to this pytest run on this host.
+
+    Not a pid: two runs a week apart can share a pid, and — more to the
+    point — the pid of the *controller* is not available to a worker that
+    mints its own.  Eight random hex characters is 2**32 values; combined
+    with the refusal check in :func:`_recreate_test_database`, a collision
+    is reported rather than acted on.
+    """
+    return secrets.token_hex(4)
+
+
+RUN_TOKEN = os.environ.setdefault(_RUN_TOKEN_ENV, _mint_run_token())
+
+
+def _with_run_suffix(base: str, suffix: str) -> str:
+    """Append ``suffix`` to ``base``, keeping the result distinct.
 
     Postgres truncates over-long identifiers rather than rejecting them, so
     naively concatenating could hand ``gw10`` and ``gw11`` the same database.
     The base is trimmed instead — the suffix, which is what makes the name
     unique, is always preserved intact.
     """
-    suffix = f"_{safe_worker}"
     budget = _MAX_IDENTIFIER_BYTES - len(suffix)
     if budget < 1:
-        # Pathologically long worker id: the suffix alone is the identity.
+        # Pathologically long suffix: the suffix alone is the identity.
         return f"tckdb_test{suffix}"[:_MAX_IDENTIFIER_BYTES]
     return f"{base[:budget]}{suffix}"
 
 
 def _resolve_test_db_name() -> str:
-    """Derive a test-DB name that won't collide across concurrent runners.
+    """Derive a test-DB name unique to this *run*, this worker and this host.
 
-    Precedence:
+    The name is ``<base>_<run token>[_<worker>]``:
 
-    1. ``DB_TEST_NAME`` **plus** ``PYTEST_XDIST_WORKER`` — the explicit name
-       with the worker id appended, e.g. ``tckdb_test_api_991_gw3``. This case
-       comes first deliberately. Every gate script and CI job sets
-       ``DB_TEST_NAME`` (see ``.github/workflows/backend-ci.yml``), and while
-       the explicit name won unconditionally, turning on ``-n`` pointed all
-       workers at one database: they raced to ``DROP``/``CREATE`` it during
-       session setup, and whichever survived was then written concurrently by
-       every worker — reintroducing exactly the cross-test visibility the
-       per-test rollback exists to prevent. An operator asking for a specific
-       database name and asking for N workers is asking for N databases.
-    2. Explicit ``DB_TEST_NAME`` alone — used verbatim. Single-tenant: do not
-       point two concurrent pytest runs at the same value on one Postgres host
-       (see ``docs/testing.md``).
-    3. ``PYTEST_XDIST_WORKER`` alone — pytest-xdist worker id (e.g. ``gw0``),
-       producing ``tckdb_test_<worker>``. Sanitized so any value Postgres
-       would reject becomes safe identifier characters.
-    4. Fallback — ``tckdb_test_<pid>`` so two ad-hoc pytest processes on
-       one host never share a database, even without xdist.
+    * **base** is ``DB_TEST_NAME`` when set, otherwise ``tckdb_test``.  An
+      explicit ``DB_TEST_NAME`` is a *label*, not the final name — see below.
+    * **run token** is :data:`RUN_TOKEN`, minted once per pytest run.
+    * **worker** is the sanitized ``PYTEST_XDIST_WORKER`` id when running
+      under ``-n``.  Every gate script and CI job sets ``DB_TEST_NAME``, and
+      while the explicit name won unconditionally, turning on ``-n`` pointed
+      all workers at one database: they raced to ``DROP``/``CREATE`` it during
+      session setup, and whichever survived was then written concurrently by
+      every worker — reintroducing exactly the cross-test visibility the
+      per-test rollback exists to prevent.  Asking for a specific database
+      name and for N workers is asking for N databases.
 
-    The xdist controller process has ``PYTEST_XDIST_WORKER`` unset and never
-    creates a database (it collects but does not run tests), so only the
-    workers reach cases 1 and 3.
+    The run token is why ``DB_TEST_NAME`` can no longer be the whole name.
+    Before it, names were unique *within* a run and identical *across* runs:
+    two pytest processes on one host — two agents in two worktrees, a
+    developer alongside a self-hosted runner — shared eight databases and
+    dropped each other's schemas mid-run.  On 2026-08-10 that produced 2305
+    errors on a tree that passed alone, and none of them said "another run is
+    using your database"; they said ``terminating connection due to
+    administrator command``.  Making the *default* unique would not have
+    helped, because the collision shape that actually happens is two runs
+    copy-pasting the same ``DB_TEST_NAME=...`` out of the same document.
+
+    Over-long names have the base trimmed, never the suffix: Postgres
+    truncates identifiers silently, and ``…_gw10``/``…_gw11`` must not
+    collapse onto one name.
+
+    The resolved name is exported back to ``DB_TEST_NAME`` by the
+    ``db_engine`` fixture, so subprocess-based tests still inherit the exact
+    database this session created.
+
+    The xdist controller has ``PYTEST_XDIST_WORKER`` unset and never creates a
+    database (it collects but does not run tests).
     """
-    explicit = os.environ.get("DB_TEST_NAME")
+    base = os.environ.get("DB_TEST_NAME") or "tckdb_test"
     worker = os.environ.get("PYTEST_XDIST_WORKER")
     safe_worker = _sanitize_identifier(worker) if worker else None
 
-    if explicit and safe_worker:
-        return _with_worker_suffix(explicit, safe_worker)
-    if explicit:
-        return explicit
+    suffix = f"_{RUN_TOKEN}"
     if safe_worker:
-        return f"tckdb_test_{safe_worker}"
-
-    return f"tckdb_test_{os.getpid()}"
+        suffix = f"{suffix}_{safe_worker}"
+    if base.endswith(suffix):
+        # Idempotent: ``db_engine`` exports the resolved name back into
+        # ``DB_TEST_NAME``, so a second resolution in the same process (a
+        # subprocess test, a fixture driven directly) must not stack a
+        # second token onto a name that already carries one.
+        return base
+    return _with_run_suffix(base, suffix)
 
 
 # Keep the boot-time dependency probes out of the suite.
@@ -193,6 +237,63 @@ def _validate_test_db_name(db_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# The ambient session factory
+#
+# ``app.api.deps`` builds ``engine``/``SessionLocal`` at import time from
+# ``settings.database_url``, i.e. from the ambient ``DB_NAME`` -- locally
+# ``tckdb_dev``, and never the per-worker database this file creates.  Code
+# that reaches for that factory during a test is therefore talking to a
+# different database than every fixture and every assertion.
+#
+# That is not hypothetical.  It was root cause 2 of the seed-independence work
+# (#64): five ``/status`` tests probed through ``health.SessionLocal``, passed
+# in a dev shell and on the PR gate -- which runs ``alembic upgrade head``
+# against ``DB_NAME`` in an earlier step -- and failed only on the nightly,
+# which does not.  They were green for a reason unrelated to what they
+# asserted.  The live hazard is worse than a false green: several of these call
+# sites *commit*, and a commit into ``tckdb_dev`` is invisible to the
+# committed-row tripwire below and to every assertion in the suite.
+#
+# Two bindings, in order:
+#
+# 1. At import, before any fixture runs, the factory is pointed at an engine
+#    that refuses to connect.  A code path that needs an out-of-request session
+#    and does not go through ``db_engine`` then *says so*, instead of quietly
+#    writing somewhere nobody is looking.
+# 2. ``db_engine`` rebinds it to the real per-worker engine for the duration of
+#    the session, and puts the refusing engine back at teardown.
+#
+# ``sessionmaker.configure`` mutates the factory in place, so the modules that
+# hold a ``from app.api.deps import SessionLocal`` reference -- health,
+# idempotency, the upload worker, the archive CLI -- all follow.
+# ---------------------------------------------------------------------------
+
+_AMBIENT_REFUSAL_MESSAGE = (
+    "app.api.deps.SessionLocal was used during a test while it is not bound "
+    "to the pytest database. It binds at import to the ambient DB_NAME "
+    "(locally tckdb_dev), which no fixture creates, migrates or inspects -- a "
+    "write through it would be invisible to every assertion in the suite. "
+    "Take the db_engine fixture (directly or via client/db_conn/db_session), "
+    "or pass an explicit session_factory= to the service being tested."
+)
+
+
+def _refusing_ambient_engine():
+    """An Engine that raises instead of connecting to the ambient database."""
+
+    def _refuse():
+        raise RuntimeError(_AMBIENT_REFUSAL_MESSAGE)
+
+    return create_engine(
+        "postgresql+psycopg://", creator=_refuse, poolclass=NullPool, future=True
+    )
+
+
+_AMBIENT_REFUSING_ENGINE = _refusing_ambient_engine()
+api_deps.bind_ambient_session_factory(_AMBIENT_REFUSING_ENGINE)
+
+
+# ---------------------------------------------------------------------------
 # Ownership marker
 #
 # Every database this fixture creates is stamped with a comment recording the
@@ -204,7 +305,11 @@ def _validate_test_db_name(db_name: str) -> str:
 # ---------------------------------------------------------------------------
 
 _MARKER_PREFIX = "tckdb-test-harness"
-_MARKER_PATTERN = re.compile(rf"^{re.escape(_MARKER_PREFIX)} host=(\S+) pid=(\d+)$")
+#: ``run=`` is optional so markers written before run tokens existed still
+#: parse, and so the sweep keeps recognising them as its own.
+_MARKER_PATTERN = re.compile(
+    rf"^{re.escape(_MARKER_PREFIX)} host=(\S+) pid=(\d+)(?: run=([A-Za-z0-9]+))?$"
+)
 
 
 def _safe_host() -> str:
@@ -213,7 +318,7 @@ def _safe_host() -> str:
 
 
 def _ownership_marker() -> str:
-    return f"{_MARKER_PREFIX} host={_safe_host()} pid={os.getpid()}"
+    return f"{_MARKER_PREFIX} host={_safe_host()} pid={os.getpid()} run={RUN_TOKEN}"
 
 
 def _pid_is_running(pid: int) -> bool:
@@ -237,16 +342,126 @@ def _marker_is_reclaimable(marker: str | None) -> bool:
     A missing or foreign marker means the database was not created by this
     harness (or was created on a different host, where we cannot reason about
     pids at all) — in both cases the conservative answer is "leave it alone".
+
+    A marker carrying *this run's* token is never reclaimable, whatever its
+    pid says.  Under ``-n`` the eight workers of one run share a token, and a
+    worker whose creator pid has somehow been recycled must not have a sibling
+    worker's live database dropped underneath it.
     """
     if not marker:
         return False
     match = _MARKER_PATTERN.match(marker.strip())
     if match is None:
         return False
-    host, pid = match.group(1), match.group(2)
+    host, pid, run = match.group(1), match.group(2), match.group(3)
     if host != _safe_host():
         return False
+    if run is not None and run == RUN_TOKEN:
+        return False
     return not _pid_is_running(int(pid))
+
+
+class ForeignTestDatabaseError(RuntimeError):
+    """Raised when the database this run wants is owned by another run.
+
+    Loud refusal is the whole point.  The failure this replaces was 2305
+    errors reading ``terminating connection due to administrator command``,
+    with nothing anywhere naming the real cause.
+    """
+
+
+def _refuse_foreign_test_database(connection, db_name: str) -> None:
+    """Refuse to drop a database another pytest run is using.
+
+    Run tokens make a collision vanishingly unlikely; this is the backstop
+    that turns "unlikely" into "reported".  Two signals, either sufficient:
+
+    * a **live backend** on the exact name we are about to recreate.  Within
+      one run each worker owns a distinct name and creates it once, so a
+      connection already attached to it belongs to somebody else;
+    * an **ownership marker from a different run** on this host whose creator
+      pid is still running — a run that has created its database but not yet
+      connected to it, which the live-backend check alone would miss.
+
+    An unmarked database is *not* refused: it was not created by this harness,
+    the name pattern has already been validated, and dropping it is the
+    documented behaviour of an explicit ``DB_TEST_NAME``.
+    """
+    row = connection.execute(
+        text("""
+            SELECT shobj_description(d.oid, 'pg_database') AS marker,
+                   (
+                       SELECT count(*) FROM pg_stat_activity a
+                       WHERE a.datname = d.datname
+                   ) AS backends
+            FROM pg_database d
+            WHERE d.datname = :db_name
+        """),
+        {"db_name": db_name},
+    ).one_or_none()
+    if row is None:
+        return
+
+    marker, backends = row.marker, int(row.backends or 0)
+    reason: str | None = None
+    if backends > 0:
+        reason = f"{backends} live backend(s) are attached to it"
+    else:
+        match = _MARKER_PATTERN.match((marker or "").strip())
+        if (
+            match is not None
+            and match.group(1) == _safe_host()
+            and match.group(3) is not None
+            and match.group(3) != RUN_TOKEN
+            and _pid_is_running(int(match.group(2)))
+        ):
+            reason = (
+                f"it is owned by pytest run {match.group(3)} "
+                f"(pid {match.group(2)}), which is still running"
+            )
+    if reason is None:
+        return
+
+    raise ForeignTestDatabaseError(
+        f"refusing to drop and recreate test database {db_name!r}: {reason}. "
+        f"This run is {RUN_TOKEN}. Another pytest run on this host is using "
+        "this database; dropping it would destroy that run and produce "
+        "thousands of unrelated-looking connection errors in both. Give this "
+        "run its own DB_TEST_NAME, or wait for the other one to finish."
+    )
+
+
+#: Scratch-database names built by individual tests must be reclaimable by
+#: ``_sweep_stale_test_databases`` and by
+#: ``backend/scripts/dev/reclaim_leaked_test_databases.py``, both of which only
+#: ever look at ``tckdb_test%``.  Migration tests that named their scratch
+#: databases ``tckdb_et_scope_*`` / ``tckdb_stage2_*`` leaked them permanently
+#: whenever a run was killed partway.
+_SCRATCH_PREFIX = "tckdb_test_"
+
+
+def scratch_database_name(label: str) -> str:
+    """Return a unique, reclaimable name for a test-owned scratch database.
+
+    Every test that issues ``CREATE DATABASE`` must get its name from here.
+    That is enforced by ``tests/test_scratch_database_names.py``, so a new
+    migration test cannot quietly drift back outside the reclaimers' reach.
+
+    ``label`` is a short human tag (``stage2_legacy``, ``et_scope_downgrade``)
+    that survives into the name for diagnosis.  The uniqueness comes from a
+    uuid4 hex, and the whole thing is trimmed to Postgres's 63-byte identifier
+    limit **from the label end**, so the random part is never the thing
+    truncation eats.
+    """
+    safe_label = _sanitize_identifier(label).strip("_")
+    if not safe_label:
+        raise ValueError("scratch database label must contain identifier characters")
+    unique = uuid4().hex
+    budget = _MAX_IDENTIFIER_BYTES - len(_SCRATCH_PREFIX) - len(unique) - 1
+    if budget < 1:  # pragma: no cover - constant arithmetic, kept honest
+        raise ValueError("scratch database name budget exhausted")
+    name = f"{_SCRATCH_PREFIX}{safe_label[:budget]}_{unique}"
+    return _validate_test_db_name(name)
 
 
 def _sweep_stale_test_databases(current_db_name: str) -> None:
@@ -313,6 +528,9 @@ def _recreate_test_database(db_name: str) -> None:
 
     try:
         with engine.connect() as connection:
+            # Before the first destructive statement, not after: the whole
+            # point is that another run's schema is never dropped.
+            _refuse_foreign_test_database(connection, db_name)
             connection.execute(
                 text("""
                     SELECT pg_terminate_backend(pid)
@@ -382,6 +600,11 @@ def db_engine():
             text=True,
         )
         engine = create_engine(_database_url(db_name), future=True)
+        # Everything that cannot be handed a request-scoped session -- the
+        # commit-time upload audit, the artifact-integrity event writer, the
+        # upload worker, the idempotency decorator, the health probes -- now
+        # reaches *this* database instead of the ambient one.
+        api_deps.bind_ambient_session_factory(engine)
         yield engine
     except BaseException:
         body_failed = True
@@ -397,6 +620,11 @@ def db_engine():
         # silently: when the body succeeded it propagates as before, and when
         # the body failed it is downgraded to a warning so both survive.
         for cleanup in (
+            # Put the refusing engine back first: the disposal and the drop
+            # below both make this engine unusable, and anything reaching for
+            # the ambient factory afterwards should hear why rather than
+            # discover it through a dead connection.
+            lambda: api_deps.bind_ambient_session_factory(_AMBIENT_REFUSING_ENGINE),
             lambda: engine.dispose() if engine is not None else None,
             lambda: _drop_test_database(db_name),
         ):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -813,6 +813,70 @@ def _record_committed_baseline(counts: dict[str, int], nodeid: str) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_out_of_request_sessions(request) -> Iterator[None]:
+    """Give out-of-request writers a connection that is rolled back at teardown.
+
+    Some app code cannot be handed the request's session and must open its
+    own — the durable failed-upload audit
+    (``app.services.upload_submission.record_failed_upload``) is the one that
+    fires most: every 4xx from a ``/uploads/*`` route records a ``submission``
+    plus two audit events **in a transaction deliberately independent of the
+    request's**, which has already rolled back by the time it runs. That
+    independence is the feature; it is also why the request's per-test
+    rollback cannot undo the write.
+
+    Until the ambient factory was rebound to the pytest database, none of
+    this landed anywhere the suite could see: it went to the ambient
+    ``DB_NAME``, where the ``created_by`` foreign key has no matching
+    ``app_user`` row, so every audit insert failed and was swallowed as
+    best-effort. Twenty-one API tests drove that path and asserted only their
+    status code. Once the binding tells the truth they commit for real, and
+    the tripwire below reports them — correctly, because a committed
+    ``submission`` row *is* visible to every later test.
+
+    So the ambient factory gets a connection of its own, with the same
+    outer-transaction-plus-SAVEPOINT shape ``db_conn`` uses:
+
+    * a **different connection** from the request's, so the request's
+      rollback does not reach it — the property the audit exists to have,
+      and the one ``tests/services/test_upload_audit_isolation.py`` pins;
+    * its own outer transaction, rolled back here, so nothing is ever
+      committed and the tripwire has nothing to report.
+
+    Autouse rather than part of ``client`` on purpose: bespoke client
+    fixtures exist (``committed_api_client`` in
+    ``tests/api/test_api_idempotency_receipt_isolation.py``), and one that
+    forgot this would reintroduce the leak silently. A test that reaches no
+    database fixture pays nothing, and a test that wants the write visible
+    from a third connection still binds its own factory, which wins.
+    """
+    if _DB_FIXTURE_NAMES.isdisjoint(request.fixturenames):
+        yield
+        return
+
+    engine = request.getfixturevalue("db_engine")
+    connection = engine.connect()
+    transaction = connection.begin()
+    # An open SAVEPOINT makes SQLAlchemy resolve each Session's
+    # ``join_transaction_mode`` to ``create_savepoint``, so a writer's commit
+    # stays inside this transaction instead of ending it.
+    connection.begin_nested()
+    # Hold the factory object, not the module attribute: a test that
+    # monkeypatches ``api_deps.SessionLocal`` outright must have its own
+    # object restored by monkeypatch, and this teardown must put the bind
+    # back on the object it took it from.
+    factory = api_deps.SessionLocal
+    previous_bind = factory.kw.get("bind")
+    factory.configure(bind=connection)
+    try:
+        yield
+    finally:
+        factory.configure(bind=previous_bind)
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture(autouse=True)
 def _refuse_committed_rows(request) -> Iterator[None]:
     """Fail the test that commits, not the test that trips over the residue.
 
@@ -972,6 +1036,9 @@ def client(db_engine, _api_test_user) -> Iterator[TestClient]:
 
     The session is bound to a connection with an open transaction that is
     rolled back after the test, so no data persists between tests.
+
+    Out-of-request writers (the failed-upload audit, above all) do not use
+    this session — see ``_isolate_out_of_request_sessions``.
     """
     app = create_app()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -552,12 +552,39 @@ def _recreate_test_database(db_name: str) -> None:
 
 
 def _drop_test_database(db_name: str) -> None:
-    """Remove the per-run database after pytest releases pooled connections."""
+    """Remove the per-run database after pytest releases pooled connections.
+
+    Refuses if the database carries another run's ownership marker. This
+    ``DROP`` terminates backends first — it has to, because pytest's pool may
+    not have released every connection — so it is the one statement in the
+    harness that can destroy a *live* database, and the refusal in
+    ``_recreate_test_database`` does not cover it.
+
+    Found by forcing the collision the run token normally prevents: two runs
+    pinned to one ``TCKDB_TEST_RUN_TOKEN``. The second refused to recreate,
+    exactly as designed — and then its fixture ``finally`` dropped the first
+    run's database anyway, taking the first run down with 38 errors. Refusing
+    to overwrite something and then deleting it is not a refusal.
+    """
     db_name = _validate_test_db_name(db_name)
     admin_url = _database_url("postgres")
     engine = create_engine(admin_url, future=True, isolation_level="AUTOCOMMIT")
     try:
         with engine.connect() as connection:
+            marker = connection.execute(
+                text(
+                    "SELECT shobj_description(oid, 'pg_database') "
+                    "FROM pg_database WHERE datname = :db_name"
+                ),
+                {"db_name": db_name},
+            ).scalar_one_or_none()
+            match = _MARKER_PATTERN.match((marker or "").strip())
+            if match is not None and match.group(3) not in (None, RUN_TOKEN):
+                raise ForeignTestDatabaseError(
+                    f"refusing to drop test database {db_name!r}: it is stamped "
+                    f"by pytest run {match.group(3)} (pid {match.group(2)} on "
+                    f"{match.group(1)}), not by this run ({RUN_TOKEN})."
+                )
             connection.execute(
                 text("""
                     SELECT pg_terminate_backend(pid)
@@ -589,8 +616,14 @@ def db_engine():
     # Previously these ran before the ``try`` and each one leaked a fully
     # migrated database under a name that is never reused.
     body_failed = False
+    # Only this session's own database is ever dropped. Without this flag, a
+    # run that *refused* to recreate a foreign run's database would go on to
+    # drop it in the ``finally`` below -- which is how the first version of
+    # the refusal still took the other run down.
+    created = False
     try:
         _recreate_test_database(db_name)
+        created = True
         subprocess.run(
             ["conda", "run", "-n", "tckdb_env", "alembic", "upgrade", "head"],
             cwd=REPO_ROOT,
@@ -626,7 +659,7 @@ def db_engine():
             # discover it through a dead connection.
             lambda: api_deps.bind_ambient_session_factory(_AMBIENT_REFUSING_ENGINE),
             lambda: engine.dispose() if engine is not None else None,
-            lambda: _drop_test_database(db_name),
+            lambda: _drop_test_database(db_name) if created else None,
         ):
             try:
                 cleanup()

--- a/backend/tests/db/test_canonical_element_symbols_migration.py
+++ b/backend/tests/db/test_canonical_element_symbols_migration.py
@@ -57,9 +57,9 @@ class _MigrationHarness:
     """Create a throwaway database and drive alembic against it."""
 
     def __init__(self, name_prefix: str):
-        from conftest import _database_url, _db_env
+        from conftest import _database_url, _db_env, scratch_database_name
 
-        self.db_name = f"{name_prefix}_{uuid4().hex}"
+        self.db_name = scratch_database_name(name_prefix)
         self.env = _db_env(self.db_name)
         self._database_url = _database_url
         self._admin = create_engine(
@@ -104,7 +104,7 @@ class _MigrationHarness:
 
 @pytest.fixture
 def harness():
-    created = _MigrationHarness("tckdb_test_element_migration")
+    created = _MigrationHarness("element_migration")
     yield created
     created.close()
 

--- a/backend/tests/db/test_energy_transfer_scope_migration.py
+++ b/backend/tests/db/test_energy_transfer_scope_migration.py
@@ -10,7 +10,6 @@ collider, and now a token that says so.
 
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
@@ -81,9 +80,9 @@ def test_existing_energy_transfer_rows_still_read_as_per_well():
     fact about them, not a guess — and nothing about the row's meaning may
     change on the way through.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_et_scope_migration_{uuid4().hex}"
+    db_name = scratch_database_name("et_scope_migration")
     admin = create_engine(
         _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
     )
@@ -263,9 +262,9 @@ def test_downgrade_refuses_to_destroy_a_network_wide_declaration():
     declaration or silently re-present it as per-well data it never was. The
     refusal has to name what is in the way and what the operator should do.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_et_scope_downgrade_{uuid4().hex}"
+    db_name = scratch_database_name("et_scope_downgrade")
     admin = create_engine(
         _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
     )

--- a/backend/tests/db/test_execution_environment_migration.py
+++ b/backend/tests/db/test_execution_environment_migration.py
@@ -2,7 +2,6 @@
 
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 from sqlalchemy import create_engine, text
 
@@ -33,9 +32,9 @@ def test_execution_environment_migration_creates_and_reverses_complete_graph():
 
 def test_execution_environment_real_upgrade_and_downgrade_contract():
     """Exercise the revision on a disposable database, including nullable legacy rows."""
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_exec_env_migration_{uuid4().hex}"
+    db_name = scratch_database_name("exec_env_migration")
     admin = create_engine(_database_url("postgres"), isolation_level="AUTOCOMMIT")
     engine = None
     try:

--- a/backend/tests/db/test_isotope_identity_migration.py
+++ b/backend/tests/db/test_isotope_identity_migration.py
@@ -15,7 +15,6 @@ service layer:
 
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -44,9 +43,9 @@ class _MigrationHarness:
     """Create a throwaway database and drive alembic against it."""
 
     def __init__(self, name_prefix: str):
-        from conftest import _database_url, _db_env
+        from conftest import _database_url, _db_env, scratch_database_name
 
-        self.db_name = f"{name_prefix}_{uuid4().hex}"
+        self.db_name = scratch_database_name(name_prefix)
         self.env = _db_env(self.db_name)
         self._database_url = _database_url
         self._admin = create_engine(
@@ -91,7 +90,7 @@ class _MigrationHarness:
 
 @pytest.fixture
 def harness(request):
-    created = _MigrationHarness("tckdb_iso_migration")
+    created = _MigrationHarness("iso_migration")
     yield created
     created.close()
 

--- a/backend/tests/db/test_network_solve_computed_evidence_trigger.py
+++ b/backend/tests/db/test_network_solve_computed_evidence_trigger.py
@@ -30,7 +30,6 @@ solve with four state energies out of five commits. That rule lives in
 
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -86,9 +85,9 @@ def trigger_engine():
     back, because a deferred constraint trigger fires at COMMIT and a rolled
     back transaction would prove nothing at all.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_test_computed_evidence_{uuid4().hex}"
+    db_name = scratch_database_name("computed_evidence")
     admin, admin_conn = _create_database(db_name)
     engine = None
     try:
@@ -636,9 +635,9 @@ def test_migration_round_trips_and_downgrade_removes_the_trigger():
     could not *say* what a reported solve is. Here the rule simply reverts to
     living in ``validate_mechanistic_channel_evidence``, where it still is.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_test_computed_evidence_roundtrip_{uuid4().hex}"
+    db_name = scratch_database_name("computed_evidence_roundtrip")
     admin, admin_conn = _create_database(db_name)
     engine = None
     try:
@@ -706,9 +705,9 @@ def test_upgrade_refuses_computed_solves_it_could_not_have_enforced():
     violates it would produce a rule true only of the future, so the upgrade
     asks, names the offenders and stops.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_test_computed_evidence_guard_{uuid4().hex}"
+    db_name = scratch_database_name("computed_evidence_guard")
     admin, admin_conn = _create_database(db_name)
     engine = None
     try:

--- a/backend/tests/db/test_network_solve_kind_migration.py
+++ b/backend/tests/db/test_network_solve_kind_migration.py
@@ -11,7 +11,6 @@ them silently reclassified as something a paper merely asserts.
 
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
@@ -143,9 +142,9 @@ def test_existing_solves_still_read_as_computed():
     row's meaning, or about the k(T,P) hanging off it, may change on the way
     through.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_test_solve_kind_migration_{uuid4().hex}"
+    db_name = scratch_database_name("solve_kind_migration")
     admin = create_engine(
         _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
     )
@@ -344,9 +343,9 @@ def test_downgrade_refuses_to_relabel_reported_rates_as_derived():
     confusion the revision exists to prevent. The refusal has to name what is
     in the way and what the operator should do.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_test_solve_kind_downgrade_{uuid4().hex}"
+    db_name = scratch_database_name("solve_kind_downgrade")
     admin = create_engine(
         _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
     )

--- a/backend/tests/db/test_repro_assessment_public_ref_migration.py
+++ b/backend/tests/db/test_repro_assessment_public_ref_migration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -45,9 +44,9 @@ def test_raw_sql_fallback_has_standard_base32_shape(db_session):
 
 def test_legacy_upgrade_backfills_refs_and_restores_append_only():
     """Exercise the real revision against a UUID-named disposable database."""
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_rpa_migration_{uuid4().hex}"
+    db_name = scratch_database_name("rpa_migration")
     admin = create_engine(_database_url("postgres"), isolation_level="AUTOCOMMIT")
     engine = None
     try:

--- a/backend/tests/db/test_stage2_scientific_integrity_migration.py
+++ b/backend/tests/db/test_stage2_scientific_integrity_migration.py
@@ -2,7 +2,6 @@
 
 import subprocess
 from pathlib import Path
-from uuid import uuid4
 
 from sqlalchemy import create_engine, text
 
@@ -12,9 +11,9 @@ STAGE2_REVISION = "c1d2e3f4a5b6"
 
 def test_stage2_scientific_integrity_upgrade_downgrade_contract():
     """Exercise c1's additive science graph and its reversible legacy shape."""
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_stage2_migration_{uuid4().hex}"
+    db_name = scratch_database_name("stage2_migration")
     admin_url = _database_url("postgres")
     admin = create_engine(admin_url, isolation_level="AUTOCOMMIT", pool_pre_ping=True)
     admin_conn = None
@@ -241,9 +240,9 @@ def test_stage2_upgrade_refuses_pre_v2_pdep_rows():
     DDL. The deployed database really does hold such rows — this is the
     reproduction, not a hypothetical.
     """
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_stage2_legacy_{uuid4().hex}"
+    db_name = scratch_database_name("stage2_legacy")
     admin = create_engine(
         _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
     )
@@ -341,9 +340,9 @@ def test_stage2_upgrade_refuses_pre_v2_pdep_rows():
 
 def test_stage2_downgrade_refuses_parallel_channels():
     """Parallel channels cannot be re-expressed under the old unique triple."""
-    from conftest import _database_url, _db_env
+    from conftest import _database_url, _db_env, scratch_database_name
 
-    db_name = f"tckdb_stage2_parallel_{uuid4().hex}"
+    db_name = scratch_database_name("stage2_parallel")
     admin = create_engine(
         _database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True
     )

--- a/backend/tests/test_ambient_session_binding.py
+++ b/backend/tests/test_ambient_session_binding.py
@@ -1,0 +1,148 @@
+"""The ambient session factory must name the database the fixtures own.
+
+``app.api.deps`` builds ``engine``/``SessionLocal`` at import time from
+``settings.database_url`` — the ambient ``DB_NAME``, locally ``tckdb_dev``.
+Nothing in the test harness creates, migrates, inspects or rolls back that
+database, so any code path that reaches the factory during a test is talking
+to somewhere no assertion is looking.
+
+This is not a hypothetical class of bug. It was root cause 2 of the
+seed-independence work: five ``/status`` tests probed through
+``health.SessionLocal``, passed in a dev shell and on the PR gate — which
+runs ``alembic upgrade head`` against ``DB_NAME`` in an earlier step — and
+failed only on the nightly, which does not. They were green for a reason
+unrelated to what they asserted.
+
+The call sites cannot simply be handed a request-scoped session: the
+commit-time upload audit and the artifact-integrity event writer need a
+transaction *independent* of the request's, which has already rolled back by
+the time they run; the upload worker and the idempotency decorator run
+outside any request at all; the startup encoding check runs at boot; and the
+health probes deliberately exercise the process's own engine, which is the
+question they exist to answer. So the fix is to make the binding truthful,
+and these are the assertions that keep it that way.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from sqlalchemy import text
+
+from app.api import deps as api_deps
+from app.api.routes import health
+from app.services import artifact_integrity, upload_submission
+from app.workers import upload_worker
+
+
+def test_ambient_engine_points_at_the_pytest_database(db_engine) -> None:
+    assert api_deps.engine is db_engine
+    assert api_deps.engine.url.database == db_engine.url.database
+    assert db_engine.url.database.startswith("tckdb_test")
+
+
+def test_ambient_session_reads_the_pytest_database(db_engine) -> None:
+    """Not just the same URL — the same, migrated, database.
+
+    ``alembic_version`` is the table whose absence made the nightly's
+    ``/status`` failures look like an application fault.
+    """
+    with api_deps.SessionLocal() as session:
+        revision = session.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one_or_none()
+        current = session.execute(text("SELECT current_database()")).scalar_one()
+
+    assert revision is not None
+    assert current == db_engine.url.database
+
+
+@pytest.mark.parametrize(
+    "module, attribute",
+    [
+        (health, "SessionLocal"),
+        (upload_worker, "SessionLocal"),
+        (api_deps, "SessionLocal"),
+    ],
+    ids=["health", "upload_worker", "deps"],
+)
+def test_modules_holding_an_import_time_reference_follow_the_rebind(
+    db_engine, module, attribute
+) -> None:
+    """``from app.api.deps import SessionLocal`` copies the object.
+
+    Rebinding only ``app.api.deps.SessionLocal`` would leave every one of
+    these modules pointed at the ambient database, which is precisely how the
+    ``/status`` probes stayed broken. ``sessionmaker.configure`` mutates the
+    factory in place instead, so the copies follow.
+    """
+    factory = getattr(module, attribute)
+
+    with factory() as session:
+        current = session.execute(text("SELECT current_database()")).scalar_one()
+
+    assert current == db_engine.url.database
+
+
+@pytest.mark.parametrize(
+    "module", [upload_submission, artifact_integrity], ids=["upload", "integrity"]
+)
+def test_out_of_request_writers_still_fall_back_to_the_ambient_factory(
+    module,
+) -> None:
+    """Pins *which* factory these two committing services default to.
+
+    Both take an injectable ``session_factory`` and fall back to
+    ``app.api.deps.SessionLocal``; both *commit*, in a transaction
+    deliberately independent of the request's. That independence is why they
+    cannot be handed a request session — and it is also why a commit through
+    an ambient binding is the worst case: it lands in a database the
+    committed-row tripwire does not watch and no assertion can see. The
+    write is not merely unasserted, it is invisible.
+
+    If a future change routes them somewhere else, this fails and the
+    guarantee above has to be re-argued rather than quietly lost.
+    """
+    source = inspect.getsource(module)
+
+    assert "from app.api.deps import SessionLocal as session_factory" in source
+
+
+def test_ambient_factory_refuses_when_no_test_database_is_bound() -> None:
+    """Without the rebind, using the factory must fail loudly.
+
+    A pure-unit test that reaches an out-of-request writer never requests
+    ``db_engine``, so nothing would rebind — and before this refusal it would
+    have silently opened a connection to ``tckdb_dev``. The refusal turns
+    that into a message naming the mistake.
+    """
+    import conftest
+
+    previous = api_deps.engine
+    api_deps.bind_ambient_session_factory(conftest._AMBIENT_REFUSING_ENGINE)
+    try:
+        with pytest.raises(Exception) as excinfo:
+            with api_deps.SessionLocal() as session:
+                session.execute(text("SELECT 1"))
+    finally:
+        api_deps.bind_ambient_session_factory(previous)
+
+    assert "not bound to the pytest database" in str(excinfo.value)
+
+
+def test_refusing_engine_is_installed_before_any_fixture_runs() -> None:
+    """The import-time binding, checked without disturbing it.
+
+    ``conftest`` binds the refusing engine at module import, i.e. before the
+    first fixture and before any test module is imported. This asserts the
+    engine object exists and is not the ambient one, which is what makes the
+    default posture "refuse" rather than "write to tckdb_dev".
+    """
+    import conftest
+
+    from app.api.config import settings
+
+    assert conftest._AMBIENT_REFUSING_ENGINE is not None
+    assert conftest._AMBIENT_REFUSING_ENGINE.url.database != settings.db_name
+    assert conftest._AMBIENT_REFUSING_ENGINE.url.database in (None, "")

--- a/backend/tests/test_db_harness_lifecycle.py
+++ b/backend/tests/test_db_harness_lifecycle.py
@@ -334,6 +334,76 @@ def test_recreate_refuses_a_database_with_a_live_backend() -> None:
         _force_drop(db_name)
 
 
+def test_drop_refuses_a_database_stamped_by_another_run() -> None:
+    """Refusing to overwrite something and then deleting it is not a refusal.
+
+    ``_drop_test_database`` terminates backends before it drops — it has to,
+    because pytest's pool may not have released every connection — so it is
+    the one statement in the harness that can destroy a *live* database.
+
+    Found by forcing the collision the run token normally prevents: two runs
+    pinned to one ``TCKDB_TEST_RUN_TOKEN``. The second refused to recreate,
+    exactly as designed, and its fixture ``finally`` then dropped the first
+    run's database anyway — 38 errors in a run that had done nothing wrong.
+    """
+    db_name = scratch_database_name("dropforeign")
+    marker = (
+        f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} "
+        f"pid={os.getpid()} run=deadbeef"
+    )
+    _create_marked(db_name, marker)
+    try:
+        with pytest.raises(conftest.ForeignTestDatabaseError):
+            conftest._drop_test_database(db_name)
+
+        assert _database_exists(db_name), "cleanup dropped another run's database"
+    finally:
+        _force_drop(db_name)
+
+
+def test_drop_accepts_this_runs_own_database() -> None:
+    """The refusal must not stop the harness cleaning up after itself."""
+    db_name = scratch_database_name("dropown")
+    try:
+        conftest._recreate_test_database(db_name)
+        assert _database_exists(db_name)
+
+        conftest._drop_test_database(db_name)
+
+        assert not _database_exists(db_name)
+    finally:
+        _force_drop(db_name)
+
+
+def test_a_refused_session_does_not_drop_the_database_it_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: the fixture body refuses, and cleanup leaves it alone.
+
+    Drives the ``db_engine`` body directly against a database stamped by a
+    live foreign run, which is what the forced-collision experiment produced.
+    """
+    monkeypatch.setenv("DB_TEST_NAME", scratch_database_name("refusedsession"))
+    monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
+    db_name = conftest._resolve_test_db_name()
+    marker = (
+        f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} "
+        f"pid={os.getpid()} run=deadbeef"
+    )
+    _create_marked(db_name, marker)
+
+    try:
+        generator = _db_engine_generator()
+        with pytest.raises(conftest.ForeignTestDatabaseError):
+            next(generator)
+
+        assert _database_exists(db_name), (
+            "a refused session dropped the database it had just refused to touch"
+        )
+    finally:
+        _force_drop(db_name)
+
+
 def test_recreate_accepts_a_database_abandoned_by_a_dead_run() -> None:
     """An orphan from a crashed run is reclaimed, not refused.
 

--- a/backend/tests/test_db_harness_lifecycle.py
+++ b/backend/tests/test_db_harness_lifecycle.py
@@ -26,6 +26,7 @@ import warnings
 
 import conftest
 import pytest
+from conftest import scratch_database_name
 from sqlalchemy import create_engine, text
 
 
@@ -109,6 +110,25 @@ def _name_the_database_exactly(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _restore_ambient_session_binding():
+    """Undo the fixture body's rebinding of ``app.api.deps.SessionLocal``.
+
+    ``db_engine`` binds the ambient session factory to its engine and puts
+    the refusing engine back in its ``finally``. The tests below drive that
+    body directly, outside pytest's fixture runner, so its teardown would
+    leave the ambient factory refusing for every *later* test in this worker
+    — a session-scoped side effect escaping a function-scoped test.
+    """
+    from app.api import deps as api_deps
+
+    previous = api_deps.engine
+    try:
+        yield
+    finally:
+        api_deps.bind_ambient_session_factory(previous)
+
+
 # ---------------------------------------------------------------------------
 # 1. The leak itself
 # ---------------------------------------------------------------------------
@@ -124,8 +144,8 @@ def test_db_engine_drops_database_when_migrations_fail(monkeypatch: pytest.Monke
     Against the pre-fix fixture this test fails on the final assertion (the
     database survives); against the fixed fixture it passes.
     """
-    db_name = f"tckdb_test_regress_{os.getpid()}"
-    monkeypatch.setenv("DB_TEST_NAME", db_name)
+    monkeypatch.setenv("DB_TEST_NAME", scratch_database_name("regress"))
+    db_name = conftest._resolve_test_db_name()
     # Keep this unit test off the sweep path entirely.
     monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
 
@@ -156,8 +176,8 @@ def test_db_engine_drops_database_when_session_body_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An exception thrown into the fixture must also drop the database."""
-    db_name = f"tckdb_test_regress_throw_{os.getpid()}"
-    monkeypatch.setenv("DB_TEST_NAME", db_name)
+    monkeypatch.setenv("DB_TEST_NAME", scratch_database_name("regress_throw"))
+    db_name = conftest._resolve_test_db_name()
     monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
 
     def _noop_migration(*args: object, **kwargs: object) -> None:
@@ -187,7 +207,7 @@ def test_db_engine_drops_database_when_session_body_raises(
 
 def test_sweep_reclaims_abandoned_marked_database() -> None:
     """A marked database whose creator pid is gone is reclaimed."""
-    db_name = f"tckdb_test_sweepdead_{os.getpid()}"
+    db_name = scratch_database_name("sweepdead")
     marker = f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} pid={_dead_pid()}"
     _create_marked(db_name, marker)
     try:
@@ -205,7 +225,7 @@ def test_sweep_ignores_unmarked_database() -> None:
     another tool that happens to match the name pattern) from being deleted
     without a human deciding to.
     """
-    db_name = f"tckdb_test_sweepunmarked_{os.getpid()}"
+    db_name = scratch_database_name("sweepunmarked")
     _create_marked(db_name, marker=None)
     try:
         conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
@@ -217,7 +237,7 @@ def test_sweep_ignores_unmarked_database() -> None:
 def test_sweep_ignores_database_owned_by_a_live_process() -> None:
     """A concurrent pytest run that has created but not yet connected to its
     database must not have it swept out from under it."""
-    db_name = f"tckdb_test_sweeplive_{os.getpid()}"
+    db_name = scratch_database_name("sweeplive")
     _create_marked(db_name, conftest._ownership_marker())  # our own, very much alive
     try:
         conftest._sweep_stale_test_databases("tckdb_test_not_this_one")
@@ -228,7 +248,7 @@ def test_sweep_ignores_database_owned_by_a_live_process() -> None:
 
 def test_sweep_ignores_foreign_host_marker() -> None:
     """Markers written on another host carry pids we cannot reason about."""
-    db_name = f"tckdb_test_sweepforeign_{os.getpid()}"
+    db_name = scratch_database_name("sweepforeign")
     marker = f"{conftest._MARKER_PREFIX} host=some-other-box pid={_dead_pid()}"
     _create_marked(db_name, marker)
     try:
@@ -239,7 +259,7 @@ def test_sweep_ignores_foreign_host_marker() -> None:
 
 
 def test_sweep_never_targets_the_current_session_database() -> None:
-    db_name = f"tckdb_test_sweepcurrent_{os.getpid()}"
+    db_name = scratch_database_name("sweepcurrent")
     marker = f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} pid={_dead_pid()}"
     _create_marked(db_name, marker)
     try:
@@ -250,7 +270,7 @@ def test_sweep_never_targets_the_current_session_database() -> None:
 
 
 def test_sweep_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    db_name = f"tckdb_test_sweepoff_{os.getpid()}"
+    db_name = scratch_database_name("sweepoff")
     marker = f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} pid={_dead_pid()}"
     _create_marked(db_name, marker)
     monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
@@ -261,9 +281,103 @@ def test_sweep_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
         _force_drop(db_name)
 
 
+# ---------------------------------------------------------------------------
+# 3. Refusing another run's database
+#
+# Run tokens make two concurrent runs pick different names, so the refusal
+# below is a backstop rather than the primary defence. It exists because the
+# failure it replaces was unreadable: on 2026-08-10 two runs sharing eight
+# databases produced 2305 errors, every one of them reading `terminating
+# connection due to administrator command`, and nothing anywhere said "another
+# run is using your database".
+# ---------------------------------------------------------------------------
+
+
+def test_recreate_refuses_a_database_owned_by_another_live_run() -> None:
+    """A marker from a different, still-running run stops the drop."""
+    db_name = scratch_database_name("foreignrun")
+    marker = (
+        f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} "
+        f"pid={os.getpid()} run=deadbeef"
+    )
+    _create_marked(db_name, marker)
+    try:
+        with pytest.raises(conftest.ForeignTestDatabaseError) as excinfo:
+            conftest._recreate_test_database(db_name)
+
+        assert "deadbeef" in str(excinfo.value)
+        assert _database_exists(db_name), "refusal still dropped the database"
+    finally:
+        _force_drop(db_name)
+
+
+def test_recreate_refuses_a_database_with_a_live_backend() -> None:
+    """A connection already attached to the name is somebody else's.
+
+    Within one run each worker owns a distinct name and creates it exactly
+    once, so this can only be a foreign run — including one whose marker this
+    harness cannot read (an older harness, or a different host's).
+    """
+    db_name = scratch_database_name("foreignbackend")
+    _create_marked(db_name, marker=None)
+    engine = create_engine(conftest._database_url(db_name), future=True)
+    try:
+        with engine.connect() as held:
+            held.execute(text("SELECT 1"))
+            with pytest.raises(conftest.ForeignTestDatabaseError) as excinfo:
+                conftest._recreate_test_database(db_name)
+
+        assert "live backend" in str(excinfo.value)
+        assert _database_exists(db_name)
+    finally:
+        engine.dispose()
+        _force_drop(db_name)
+
+
+def test_recreate_accepts_a_database_abandoned_by_a_dead_run() -> None:
+    """An orphan from a crashed run is reclaimed, not refused.
+
+    The refusal must not turn every leaked database into a permanent
+    blocker — the whole reason names carry a run token is that leaks are
+    expected and reclaimable.
+    """
+    db_name = scratch_database_name("deadrun")
+    marker = (
+        f"{conftest._MARKER_PREFIX} host={conftest._safe_host()} "
+        f"pid={_dead_pid()} run=deadbeef"
+    )
+    _create_marked(db_name, marker)
+    try:
+        conftest._recreate_test_database(db_name)
+        assert _database_exists(db_name)
+    finally:
+        _force_drop(db_name)
+
+
+def test_two_runs_resolve_different_database_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same DB_TEST_NAME in two runs must not name one database.
+
+    This is the shape that actually bit: two agents copy-pasting the same
+    ``DB_TEST_NAME=...`` out of the same document, on one host.
+    """
+    monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_shared_label")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "aaaa1111")
+    first = conftest._resolve_test_db_name()
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "bbbb2222")
+    second = conftest._resolve_test_db_name()
+
+    assert first != second
+    assert first.endswith("_aaaa1111_gw3")
+    assert second.endswith("_bbbb2222_gw3")
+
+
 def test_recreate_stamps_ownership_marker() -> None:
     """The marker the sweep depends on is actually written at creation."""
-    db_name = f"tckdb_test_marker_{os.getpid()}"
+    db_name = scratch_database_name("marker")
     try:
         conftest._recreate_test_database(db_name)
         engine = _admin_engine()
@@ -299,7 +413,7 @@ def test_cleanup_failure_does_not_mask_the_body_error(
     Against a fixture whose ``finally`` calls cleanup unguarded, this test
     fails with ``RuntimeError`` instead of ``CalledProcessError``.
     """
-    db_name = f"tckdb_test_mask_{os.getpid()}"
+    db_name = scratch_database_name("mask")
     monkeypatch.setenv("DB_TEST_NAME", db_name)
     monkeypatch.setenv("TCKDB_TEST_DB_SWEEP", "0")
 

--- a/backend/tests/test_db_name_resolution.py
+++ b/backend/tests/test_db_name_resolution.py
@@ -1,13 +1,28 @@
 """Unit tests for the test-database name resolution helper in conftest.
 
-Covers the three branches of ``_resolve_test_db_name`` so the parallel-safe
-naming contract documented in ``docs/testing.md`` is enforced.
+The contract ``_resolve_test_db_name`` has to satisfy has three parts, and
+they are easy to satisfy two out of three:
+
+* unique **per worker**, so ``-n 8`` gives eight databases rather than eight
+  workers racing to drop and recreate one;
+* unique **per run**, so two pytest processes on one host do not share
+  databases and destroy each other mid-run;
+* stable **within** a run, so a subprocess-based test inherits the same
+  database the fixtures created.
+
+Until 2026-08-10 only the first held. Names derived from
+``PYTEST_XDIST_WORKER`` alone were identical across runs, and two agents in
+two worktrees shared eight databases: one reported 2305 errors on a tree
+that passed alone.
+
+See ``docs/testing.md`` for the naming contract this pins.
 """
 
 from __future__ import annotations
 
 import os
 
+import conftest
 import pytest
 from conftest import _resolve_test_db_name
 
@@ -21,12 +36,37 @@ def _clean_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
 
 
-def test_explicit_db_test_name_used_verbatim_without_xdist(
+def test_explicit_db_test_name_is_a_label_not_the_whole_name(
     monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
 ) -> None:
-    monkeypatch.setenv("DB_TEST_NAME", "ci_job_42_db")
+    """An explicit name still carries the run token.
 
-    assert _resolve_test_db_name() == "ci_job_42_db"
+    It has to. The collision that actually happened was not two runs falling
+    back to the same default — it was two runs *setting the same explicit
+    name*, because that is what the gate command in the docs tells you to
+    pass. A fix that only made the default unique would have left the real
+    case untouched.
+    """
+    monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_ci_job_42")
+
+    resolved = _resolve_test_db_name()
+
+    assert resolved.startswith("tckdb_test_ci_job_42_")
+    assert resolved.endswith(conftest.RUN_TOKEN)
+    assert resolved != "tckdb_test_ci_job_42"
+
+
+def test_two_runs_never_share_a_database(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
+    monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_shared")
+
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "1111aaaa")
+    first = _resolve_test_db_name()
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "2222bbbb")
+    second = _resolve_test_db_name()
+
+    assert first != second
 
 
 def test_explicit_db_test_name_is_still_per_worker_under_xdist(
@@ -39,26 +79,30 @@ def test_explicit_db_test_name_is_still_per_worker_under_xdist(
     write the same database concurrently.
     """
     monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_api_ci")
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "1111aaaa")
 
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
     first = _resolve_test_db_name()
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
     second = _resolve_test_db_name()
 
-    assert first == "tckdb_test_api_ci_gw0"
-    assert second == "tckdb_test_api_ci_gw1"
+    assert first == "tckdb_test_api_ci_1111aaaa_gw0"
+    assert second == "tckdb_test_api_ci_1111aaaa_gw1"
     assert first != second
 
 
-def test_long_explicit_name_keeps_workers_distinct(
+def test_long_explicit_name_keeps_workers_and_runs_distinct(
     monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
 ) -> None:
     """Postgres truncates over-long identifiers silently rather than failing.
 
     A 63-byte cap applied to the concatenation would give ``gw10`` and ``gw11``
-    the same database. The base is trimmed so the worker suffix survives.
+    the same database, and would eat the run token first — turning the
+    cross-run guarantee off for exactly the operators who pin long,
+    descriptive job names. The base is trimmed so the whole suffix survives.
     """
     monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_" + "x" * 80)
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "1111aaaa")
 
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw10")
     first = _resolve_test_db_name()
@@ -67,15 +111,23 @@ def test_long_explicit_name_keeps_workers_distinct(
 
     assert len(first) <= 63
     assert len(second) <= 63
-    assert first.endswith("_gw10")
-    assert second.endswith("_gw11")
+    assert first.endswith("_1111aaaa_gw10")
+    assert second.endswith("_1111aaaa_gw11")
     assert first != second
 
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "2222bbbb")
+    other_run = _resolve_test_db_name()
+    assert other_run.endswith("_2222bbbb_gw11")
+    assert other_run != second
 
-def test_xdist_worker_derives_suffix(monkeypatch: pytest.MonkeyPatch, _clean_db_env: None) -> None:
+
+def test_xdist_worker_derives_suffix(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "1111aaaa")
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
 
-    assert _resolve_test_db_name() == "tckdb_test_gw0"
+    assert _resolve_test_db_name() == "tckdb_test_1111aaaa_gw0"
 
 
 def test_xdist_worker_name_is_sanitized(
@@ -83,6 +135,7 @@ def test_xdist_worker_name_is_sanitized(
 ) -> None:
     # Hypothetical pathological worker id with characters Postgres would
     # reject in an unquoted identifier — the helper must replace them.
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "1111aaaa")
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw-1.master")
 
     resolved = _resolve_test_db_name()
@@ -90,13 +143,47 @@ def test_xdist_worker_name_is_sanitized(
     assert resolved.startswith("tckdb_test_")
     assert "-" not in resolved
     assert "." not in resolved
-    assert resolved == "tckdb_test_gw_1_master"
+    assert resolved == "tckdb_test_1111aaaa_gw_1_master"
 
 
-def test_fallback_uses_pid(monkeypatch: pytest.MonkeyPatch, _clean_db_env: None) -> None:
-    resolved = _resolve_test_db_name()
+def test_fallback_without_xdist_is_still_run_unique(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
+    monkeypatch.setattr(conftest, "RUN_TOKEN", "1111aaaa")
 
-    assert resolved == f"tckdb_test_{os.getpid()}"
+    assert _resolve_test_db_name() == "tckdb_test_1111aaaa"
+
+
+def test_resolution_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch, _clean_db_env: None
+) -> None:
+    """Resolving the exported name again must not stack a second token.
+
+    ``db_engine`` writes the resolved name back into ``DB_TEST_NAME`` so
+    subprocess tests inherit it; anything that re-resolves in the same
+    process — a fixture driven directly, a nested harness — would otherwise
+    end up naming a database that does not exist.
+    """
+    monkeypatch.setenv("DB_TEST_NAME", "tckdb_test_base")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
+
+    once = _resolve_test_db_name()
+    monkeypatch.setenv("DB_TEST_NAME", once)
+
+    assert _resolve_test_db_name() == once
+
+
+def test_run_token_is_shared_through_the_environment() -> None:
+    """Workers inherit the controller's token rather than minting their own.
+
+    ``os.environ.setdefault`` at conftest import is what does it; the
+    assertion is here so a refactor that drops the export is noticed. A
+    per-worker token would still be *correct* (uniqueness is only ever
+    required between runs), but the databases of one run would no longer be
+    identifiable as one run.
+    """
+    assert os.environ.get("TCKDB_TEST_RUN_TOKEN") == conftest.RUN_TOKEN
+    assert conftest.RUN_TOKEN
 
 
 def test_session_fixture_exports_db_test_name(db_engine) -> None:
@@ -104,4 +191,4 @@ def test_session_fixture_exports_db_test_name(db_engine) -> None:
     name back into ``os.environ`` so subprocess tests (e.g. the bundle
     export CLI smoke test) inherit the same database."""
     assert "DB_TEST_NAME" in os.environ
-    assert os.environ["DB_TEST_NAME"]
+    assert os.environ["DB_TEST_NAME"] == db_engine.url.database

--- a/backend/tests/test_scratch_database_names.py
+++ b/backend/tests/test_scratch_database_names.py
@@ -1,0 +1,181 @@
+"""Every scratch database a test creates must be reclaimable.
+
+Two reclaimers exist, and both only ever look at ``tckdb_test%``:
+
+* ``_sweep_stale_test_databases`` in :mod:`conftest`, which runs at session
+  start and drops databases this harness abandoned;
+* ``backend/scripts/dev/reclaim_leaked_test_databases.py``, the deliberate
+  human-driven cleanup for everything the sweep cannot reason about.
+
+Several migration tests used to build their own scratch names —
+``tckdb_et_scope_migration_*``, ``tckdb_stage2_legacy_*``,
+``tckdb_exec_env_migration_*``, ``tckdb_rpa_migration_*``. They matched
+neither reclaimer, so a run killed partway (a session limit, a Ctrl-C, an
+OOM) leaked them permanently; one was found and dropped by hand on
+2026-08-10.
+
+Renaming them fixed the ones that existed. This file is what stops the next
+one drifting back out silently: a new migration test that follows the
+convention is covered automatically, and one that does not is named here
+rather than discovered as a stray database months later.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import conftest
+import pytest
+
+TESTS_ROOT = Path(__file__).resolve().parent
+BACKEND_ROOT = TESTS_ROOT.parent
+
+#: ``conftest`` owns the session database and validates that name itself; this
+#: file only quotes the statement it is scanning for.
+_EXEMPT = {TESTS_ROOT / "conftest.py", Path(__file__).resolve()}
+
+
+def _test_modules_that_create_databases() -> list[Path]:
+    found = []
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        if path in _EXEMPT:
+            continue
+        if "CREATE DATABASE" in path.read_text(encoding="utf-8"):
+            found.append(path)
+    return found
+
+
+def test_the_scan_finds_the_files_it_is_meant_to_guard() -> None:
+    """A guard whose scan matches nothing would pass forever.
+
+    Pinned to a floor rather than an exact list so adding a migration test
+    does not fail this assertion for the wrong reason — the per-file check
+    below is what actually judges a new one.
+    """
+    creators = _test_modules_that_create_databases()
+
+    assert len(creators) >= 8, (
+        "expected the migration tests that create scratch databases to be "
+        f"found by this scan; got {[str(p) for p in creators]}"
+    )
+    names = {p.name for p in creators}
+    assert "test_stage2_scientific_integrity_migration.py" in names
+    assert "test_energy_transfer_scope_migration.py" in names
+
+
+@pytest.mark.parametrize(
+    "path", _test_modules_that_create_databases(), ids=lambda p: p.name
+)
+def test_scratch_databases_come_from_the_reclaimable_helper(path: Path) -> None:
+    """A test that issues ``CREATE DATABASE`` must name it via the helper.
+
+    Deliberately a structural rule, not a name pattern: matching the name
+    pattern at the call site would still let a future test build a
+    conforming-looking name by hand and get the length arithmetic wrong,
+    which Postgres resolves by silently truncating. Routing every name
+    through one function makes the guarantee one function's job.
+    """
+    source = path.read_text(encoding="utf-8")
+
+    assert "scratch_database_name" in source, (
+        f"{path.relative_to(BACKEND_ROOT)} issues CREATE DATABASE but does not "
+        "use conftest.scratch_database_name. Scratch databases named any other "
+        "way are invisible to _sweep_stale_test_databases and to "
+        "scripts/dev/reclaim_leaked_test_databases.py, so a killed run leaks "
+        "them permanently."
+    )
+
+    tree = ast.parse(source, filename=str(path))
+    imported = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "conftest"
+        and any(alias.name == "scratch_database_name" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert imported, (
+        f"{path.relative_to(BACKEND_ROOT)} references scratch_database_name but "
+        "never imports it from conftest"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The helper's own contract
+# ---------------------------------------------------------------------------
+
+
+def test_helper_output_is_reclaimable_by_both_reclaimers() -> None:
+    name = conftest.scratch_database_name("stage2_legacy")
+
+    assert conftest._TEST_DATABASE_NAME.fullmatch(name)
+    assert _reclaim_script_pattern().fullmatch(name)
+    assert name.startswith("tckdb_test_")
+    assert "stage2_legacy" in name
+
+
+def test_helper_output_fits_postgres_identifier_limit() -> None:
+    """Postgres truncates over-long names silently rather than rejecting them.
+
+    A truncated name is still reclaimable — the prefix survives — but two
+    long labels must not collapse onto one database, so the uniqueness suffix
+    is what has to survive trimming, not the label.
+    """
+    long_label = "a_very_long_migration_label_" + "x" * 80
+
+    first = conftest.scratch_database_name(long_label)
+    second = conftest.scratch_database_name(long_label)
+
+    assert len(first) <= 63
+    assert len(second) <= 63
+    assert first != second
+    assert conftest._TEST_DATABASE_NAME.fullmatch(first)
+
+
+def test_helper_is_unique_per_call() -> None:
+    names = {conftest.scratch_database_name("dupe") for _ in range(50)}
+
+    assert len(names) == 50
+
+
+def test_helper_sanitizes_labels_postgres_would_reject() -> None:
+    name = conftest.scratch_database_name("et-scope.downgrade")
+
+    assert conftest._TEST_DATABASE_NAME.fullmatch(name)
+    assert "-" not in name
+    assert "." not in name
+
+
+def test_helper_rejects_an_empty_label() -> None:
+    with pytest.raises(ValueError):
+        conftest.scratch_database_name("---")
+
+
+# ---------------------------------------------------------------------------
+# The two reclaimers must agree on what "reclaimable" means
+# ---------------------------------------------------------------------------
+
+
+def _reclaim_script_pattern() -> re.Pattern[str]:
+    """The name pattern the standalone reclaim script enforces.
+
+    Read out of the source rather than imported: the script lives under
+    ``scripts/dev`` and importing it drags in ``psycopg`` and argparse
+    plumbing this file has no use for.
+    """
+    source = (
+        BACKEND_ROOT / "scripts" / "dev" / "reclaim_leaked_test_databases.py"
+    ).read_text(encoding="utf-8")
+    match = re.search(r"^TEST_DB_NAME = re\.compile\(r\"(.+)\"\)$", source, re.MULTILINE)
+    assert match is not None, "could not locate TEST_DB_NAME in the reclaim script"
+    return re.compile(match.group(1))
+
+
+def test_both_reclaimers_use_the_same_name_pattern() -> None:
+    """Widening one reclaimer without the other would be a silent half-fix.
+
+    The sweep runs automatically and the script is run by a human; a name
+    covered by one and not the other is reclaimed only sometimes, which is
+    the worst of the three outcomes.
+    """
+    assert _reclaim_script_pattern().pattern == conftest._TEST_DATABASE_NAME.pattern

--- a/backend/tests/test_scratch_database_names.py
+++ b/backend/tests/test_scratch_database_names.py
@@ -171,6 +171,30 @@ def _reclaim_script_pattern() -> re.Pattern[str]:
     return re.compile(match.group(1))
 
 
+def test_the_nightly_job_database_is_protected_from_the_reclaim_script() -> None:
+    """``tckdb_test_ci`` is a CI ``DB_NAME``, not a harness database.
+
+    The in-process sweep is safe from it by construction — no harness marker,
+    no reclaim. This script reads no markers, and the name sits inside
+    ``tckdb_test%``, so on a self-hosted runner ``plan`` would list the
+    nightly job's own database as a candidate.
+    """
+    source = (
+        BACKEND_ROOT / "scripts" / "dev" / "reclaim_leaked_test_databases.py"
+    ).read_text(encoding="utf-8")
+    protected = re.search(r"PROTECTED = frozenset\((.*?)\n\)", source, re.DOTALL)
+
+    assert protected is not None
+    assert '"tckdb_test_ci"' in protected.group(1)
+
+    workflow = (
+        BACKEND_ROOT.parent / ".github" / "workflows" / "backend-nightly.yml"
+    ).read_text(encoding="utf-8")
+    # Non-vacuous: the protection is only worth anything while the nightly
+    # actually uses this name.
+    assert "DB_NAME: tckdb_test_ci" in workflow
+
+
 def test_both_reclaimers_use_the_same_name_pattern() -> None:
     """Widening one reclaimer without the other would be a silent half-fix.
 


### PR DESCRIPTION
Three defects, one theme: **the tests and the application disagreed about which
database they were talking to.** All three bit on 2026-08-10.

## #80 — two concurrent runs destroyed each other's databases

Names came from `PYTEST_XDIST_WORKER` alone: unique *within* a run, identical
*across* runs. Two runs on one host shared eight databases and dropped each
other's schemas mid-flight. One agent reported **2305 errors** on a tree that
passed alone at the same commit, and every error read `terminating connection
due to administrator command` — nothing anywhere said "another run is using
your database".

Names are now `<base>_<run token>[_<worker>]`, where the token is minted once
per run and exported as `TCKDB_TEST_RUN_TOKEN`. The xdist controller imports
the root conftest before execnet spawns workers, so all eight databases of one
run share one token — verified live:

```
tckdb_test_own90_f14d837a_gw0 | tckdb-test-harness host=archlinux pid=4003779 run=f14d837a
...
tckdb_test_own90_f14d837a_gw7 | tckdb-test-harness host=archlinux pid=4003863 run=f14d837a
```

**`DB_TEST_NAME` is now a label, not the name.** Making only the *default*
unique would have missed the shape that actually happens: two runs
copy-pasting the same `DB_TEST_NAME=...` out of the same document. The old
resolver, run twice with `DB_TEST_NAME=tckdb_test_own90` and worker `gw3`,
returns `tckdb_test_own90_gw3` both times.

**Unlikely is not the same as reported.** Before any destructive statement the
harness refuses when a live backend is attached to the name, or when the
database carries another run's marker whose pid is still alive:
`ForeignTestDatabaseError`, naming both run tokens.

## #90 — live code bound to the ambient database

`app/api/deps.py` binds `engine`/`SessionLocal` at import to the ambient
`DB_NAME`. **I did not thread a session through**, and the six call sites are
why — see the table in `docs/testing.md`. Three of them (`record_failed_upload`,
`record_artifact_integrity_event`, the upload worker / idempotency /
startup-check trio) need a transaction *independent* of the request's, which
has already rolled back by the time they run; a request session is not
available to them in principle, not just inconveniently. The other three are
`/health`, `/readyz` and `/status`, which deliberately probe the process's own
engine — routing them through an overridable dependency would let a test
declare a deployment healthy while the deployment's engine is broken.

So the binding is made truthful instead. `sessionmaker.configure` mutates the
factory in place, so modules holding a `from app.api.deps import SessionLocal`
reference follow; rebinding the module attribute would not have reached them,
which is exactly how the `/status` probes stayed broken. Before any fixture
runs the factory is pointed at an engine that **refuses to connect**, so a
path that needs an out-of-request session and never took `db_engine` says so.

### What that uncovered

The task said "nothing commits through it today". It does: **every 4xx from a
`/uploads/*` route writes a durable failed-upload audit**. It was going to
`tckdb_dev`, where the `created_by` foreign key has no matching `app_user`
row, so every insert failed and was swallowed as best-effort. Twenty-one API
tests drove that path and asserted only their status code. Pointed at a real
database it commits, and the committed-row tripwire reported all 21.

They are now isolated on a connection of their own per test — a *different*
connection from the request's (the property the audit exists to have, pinned
by `test_upload_audit_isolation.py`), inside an outer transaction rolled back
at teardown. Autouse rather than part of `client`, because bespoke client
fixtures exist and one that forgot would leak silently.

### This removes the ambient coupling entirely — @#81/#92 agent

`test-api.sh` gives **2541 passed** whether `DB_NAME` names a real database
or `tckdb_never_created_x9` — the same count, not a smaller one. Two tests in
`test_api_db_statement_timeout.py` were the last holdouts (they built an
engine from `settings.database_url`); they now build it from `db_engine.url`. The **suite** no longer depends on `alembic upgrade head` against
`DB_NAME`; the CI step that does it is still a real gate for the *migrations*
(`alembic heads`/`current`/drift), so keep it for that reason, not for the
tests. The PR-gate/nightly divergence can no longer hide a failure in one.

## #91 — scratch databases the reclaimer could not see

`tckdb_et_scope_*`, `tckdb_stage2_*`, `tckdb_exec_env_*`, `tckdb_rpa_*`,
`tckdb_iso_*`, `tckdb_role_*` matched neither reclaimer. Renamed rather than
widening the pattern: every test that issues `CREATE DATABASE` now calls
`conftest.scratch_database_name(label)`, and `tests/test_scratch_database_names.py`
fails any file that does not — so a new migration test is covered
automatically instead of remembered. It also asserts the sweep and the
standalone reclaim script still use the same pattern, so widening one without
the other is caught.

## The defect the verification found

The forced-collision experiment — two runs pinned to one
`TCKDB_TEST_RUN_TOKEN` — showed the refusal was half of one. Run B correctly
declined to *recreate* run A's database, then its fixture `finally` dropped it
anyway: **run A died with 38 errors**. `_drop_test_database` terminates
backends before dropping, so it is the one statement that can destroy a live
database, and the recreate-side refusal never covered it. Fixed on both sides
(marker check in the drop, plus `db_engine` only cleaning up a database it
created); re-run of the same experiment gives run B `exit=1` with
`ForeignTestDatabaseError` and run A `44 passed, exit=0`.

## Verification

| | result |
|---|---|
| `test-full.sh` | **6834 passed, 14 skipped** |
| `test-api.sh` | **2541 passed** |
| `test-scientific.sh` | **1998 passed** |
| `test-api.sh` with `DB_NAME=tckdb_never_created_x9` | **2541 passed** — byte-identical count, which is the ambient-coupling proof |
| Two concurrent runs, identical `DB_TEST_NAME=tckdb_test_race` | **3491 passed each**, 8 distinct databases (`_4a4a590b_gw0..3`, `_b3c5a5ba_gw0..3`) |
| Forced collision (both runs pinned to one run token) | B `exit=1` `ForeignTestDatabaseError`, A `44 passed, exit=0` |
| `ruff check app tests scripts` | clean |

The `#91` guard was checked non-vacuously: reverting one migration test to
its old `tckdb_exec_env_migration_{uuid4().hex}` form fails
`test_scratch_databases_come_from_the_reclaimable_helper[test_execution_environment_migration.py]`
by name.

No test weakened, skipped, xfailed or deleted. No schema, migration or
OpenAPI-golden change. `.github/workflows/*` and `scripts/test-*.sh`
untouched.
