### PR TITLE
Make the watchdog watch something, and let the alert path fail loudly

### DIFF
--- a/backend/docs/deployment/monitoring.md
+++ b/backend/docs/deployment/monitoring.md
@@ -248,6 +248,14 @@ which expects a ping on a schedule and alerts when one does not arrive.
 4. Point healthchecks.io's notification at the **same ntfy topic**, so both
    classes of alarm land in one place.
 
+**Treat the ping URL exactly like the ntfy topic: it is a password.** Its path
+is the whole credential, and anyone holding it can forge this heartbeat and keep
+the alerts quiet for as long as they like — silencing the one channel that
+covers the host dying. It lives only in the env file (and, for the CI watchdog,
+in a repository secret), never in this repository, and neither script logs it:
+a failed ping names the host it could not reach and curl's exit code, and
+nothing that can be replayed.
+
 **The ping means "the checker ran", not "TCKDB is well",** and it is sent on
 every completed run including a degraded one. That distinction is the whole
 design. If the ping were conditional on a healthy verdict, an object-store

--- a/backend/docs/deployment/monitoring.md
+++ b/backend/docs/deployment/monitoring.md
@@ -284,6 +284,27 @@ breaks, systemd tells you when the checker breaks, and healthchecks.io tells
 you when the Pi stops talking at all. No one of them depends on another
 surviving.
 
+**What it can and cannot report.** Three things had to be fixed before the
+sentence above was true of the shipped units, and each had failed silently:
+
+- The alert unit's `EnvironmentFile=` had no leading `-`. Without it systemd
+  refuses to *start* the unit when the file is missing — and a missing
+  `EnvironmentFile` is one of the reasons `tckdb-alert.service` fails, so both
+  units died of the same cause and nothing was pushed. It now carries the `-`.
+  The main unit deliberately does not: it cannot check anything without the
+  topic, so a missing file *should* fail it and fire `OnFailure=`.
+- With the file present but `TCKDB_NTFY_TOPIC` unset, the push went to
+  `https://ntfy.sh/` — a valid URL, answered, `curl` happy, unit green, nobody
+  told. It now refuses with exit 78 and says so in the journal. **There is no
+  push in this case and there cannot be**, because the topic is the address;
+  what covers it is the dead man's switch and a unit visible in
+  `systemctl --failed`.
+- `SuccessExitStatus=0 1` told systemd that exit 1 was fine, so that an
+  accidental death — bash exits 1 on an unbound variable — was recorded as a
+  successful check and `OnFailure=` never fired. `tckdb_alert_check.sh` now
+  exits **2** for any exit taken before it reaches a verdict, and 2 is not in
+  `SuccessExitStatus`. Do not add it.
+
 Prove it, rather than assuming — the same ten minutes that is the only way to
 know anything about monitoring:
 
@@ -291,12 +312,22 @@ know anything about monitoring:
 sudo systemctl stop tckdb-alert.timer     # then wait past the deadman period
 # expect: a healthchecks.io alert, and no ntfy traffic at all
 sudo systemctl start tckdb-alert.timer
+
+sudo systemctl start tckdb-alert-failed.service   # expect one push, unit green
+sudo mv ~/.config/tckdb-alert.env{,.bak}
+sudo systemctl start tckdb-alert-failed.service   # expect 78/CONFIG and a
+sudo mv ~/.config/tckdb-alert.env{.bak,}          # journal line, not silence
 ```
 
 The behaviour above is covered by `backend/tests/ops/test_alert_check_liveness.py`,
 which runs the real script as a subprocess against a fake host and asserts what
 reaches the outside world on each broken path — including that a checker which
-refuses to start sends nothing.
+refuses to start sends nothing, that the alert unit's `ExecStart` really does
+deliver a push when run, and that it refuses rather than posting to an empty
+topic. Systemd itself is not available to the test suite, so the `-` on
+`EnvironmentFile=` and the `SuccessExitStatus=` list are asserted by reading the
+units; both were verified by hand with `systemd-run --user` against the shipped
+files.
 
 ## The same problem, one level out: monitoring CI
 
@@ -339,6 +370,31 @@ missed one.
 
 **It advances that marker only after ntfy accepts the push,** for the same
 reason the Pi-side checker does.
+
+**It counts what it checked, and a run that checked nothing is not a pass.**
+Every entry of `TCKDB_WATCHED_WORKFLOWS` that is not `file.yml:hours` used to be
+warned about and skipped, so a whole list of typos left the loop with nothing to
+do — and the script then exited 0 *and pinged the dead man's switch*, so the
+external monitor vouched for a checker that had checked nothing. The verdict
+count is now printed before the result (`watched=2 verdicts=2 unchecked=0`), and
+zero verdicts suppresses the heartbeat and exits 2. Note that an *empty* or
+unset `TCKDB_WATCHED_WORKFLOWS` is not this case: it falls back to the built-in
+list, which is correct and stays that way.
+
+Its exit codes are the ones
+[`verify_artifact_integrity.py`](../../scripts/ops/verify_artifact_integrity.py)
+uses, deliberately, so two scripts in one directory need one scheme:
+
+| Code | Means | Runbook |
+|---|---|---|
+| 0 | every watched workflow is green and running | nothing to do |
+| 1 | something is red or silent, or a push could not be delivered | read the push; fix the workflow |
+| 2 | something in scope was **not checked** — a malformed watch-list entry, an unreadable API, an unparseable run list, or no verdict at all | fix the invocation or the token, then re-run; this run is not evidence of anything |
+
+1 wins when both are true, because a red nightly is the more actionable of the
+two. There is no `--allow-empty` equivalent, unlike the integrity sweep: an
+empty corpus is a legitimate state for a fresh deployment, while watching
+nothing is never a legitimate state for a watchdog.
 
 The push names the workflow, the branch, the consecutive-failure count, the
 commit, the failing job and step, and links the run — because "nightly failed"

--- a/backend/scripts/ops/tckdb-alert-failed.service
+++ b/backend/scripts/ops/tckdb-alert-failed.service
@@ -13,10 +13,44 @@ Description=Push an alert when the TCKDB health checker itself fails
 
 [Service]
 Type=oneshot
-EnvironmentFile=/home/calvin/.config/tckdb-alert.env
+
+# The leading `-` is mandatory, and its absence was a hole in exactly the shape
+# this unit exists to close. Without it systemd REFUSES TO START the unit when
+# the file is missing -- and "the EnvironmentFile is missing" is one of the
+# listed reasons tckdb-alert.service fails in the first place. So the one
+# failure this unit named first was the one it could not report: both units
+# died of the same cause, systemd logged `resources` for this one, and no push
+# was sent. Verified, not assumed: `systemd-run --wait -p EnvironmentFile=/no
+# /bin/sh -c 'echo ran'` never runs the command, and the same with `-/no` does.
+EnvironmentFile=-/home/calvin/.config/tckdb-alert.env
+
 # %i is not available on a non-templated OnFailure unit, so the failing unit is
 # named literally. If you rename tckdb-alert.service, rename it here too.
-ExecStart=/bin/sh -c 'curl -sS --max-time 20 \
+#
+# Two guards on the push itself, because an alerting unit that exits 0 without
+# alerting anyone is worse than one that is obviously broken:
+#
+#   1. An unset TCKDB_NTFY_TOPIC used to POST to `https://ntfy.sh/` -- ntfy
+#      answers that URL, curl was happy, the unit went green and nobody was
+#      told. There is no fallback topic to use instead (the topic IS the
+#      address, and it is a secret), so this refuses and says so in the
+#      journal. The unit then stays failed, which is visible in
+#      `systemctl --failed`, and the external dead man's switch is what
+#      actually converts this case into a page.
+#   2. --fail, so a 401 from a protected topic or a 5xx from ntfy is a failed
+#      unit rather than a delivered alert. curl exits 0 on an HTTP error
+#      unless told otherwise; that same bug has been fixed twice already, in
+#      tckdb_alert_check.sh and in uptime-check.yml.
+#
+# -o /dev/null because ntfy's publish response is a JSON message object that
+# repeats the topic back, and curl's stdout here goes to the journal. The topic
+# is password-equivalent; it does not belong in a log any more than it belongs
+# in this file.
+ExecStart=/bin/sh -c 'if [ -z "${TCKDB_NTFY_TOPIC:-}" ]; then \
+  echo "TCKDB_NTFY_TOPIC is unset (missing or incomplete /home/calvin/.config/tckdb-alert.env), so the health checker failed AND this alert cannot be delivered to anyone. Nothing was pushed." >&2; \
+  exit 78; \
+fi; \
+curl -sS --fail --max-time 20 -o /dev/null \
   -H "Title: TCKDB health checker FAILED" \
   -H "Priority: urgent" \
   -H "Tags: rotating_light" \

--- a/backend/scripts/ops/tckdb-alert.service
+++ b/backend/scripts/ops/tckdb-alert.service
@@ -18,12 +18,25 @@ Type=oneshot
 
 # Set these for your deployment. EnvironmentFile keeps the secret topic out of
 # the unit file, which is world-readable.
+#
+# No leading `-` here, and that asymmetry with tckdb-alert-failed.service is
+# deliberate. This unit cannot do its job without the topic, so a missing file
+# SHOULD stop it and fire OnFailure=; the OnFailure unit needs the `-` because
+# it is the thing that has to survive that exact failure in order to report it.
 EnvironmentFile=/home/calvin/.config/tckdb-alert.env
 ExecStart=/home/calvin/repos/tckdbv2/backend/scripts/ops/tckdb_alert_check.sh
 
 # The script exits 1 when the deployment is unhealthy. That is information,
 # not a unit failure -- without this, systemd marks the unit failed and the
 # journal fills with noise about the checker rather than about TCKDB.
+#
+# This is only safe because the script no longer lets 1 mean two things. bash
+# exits 1 when it dies on an unbound variable, so this line used to tell
+# systemd that an accidental death partway through the script was a success,
+# and OnFailure= never fired for it -- the one class of failure that produces
+# no push of its own. tckdb_alert_check.sh now reports 2 for any exit taken
+# before a verdict exists, and 2 is deliberately absent from this list.
+# Do not add it.
 SuccessExitStatus=0 1
 
 User=calvin

--- a/backend/scripts/ops/tckdb_alert_check.sh
+++ b/backend/scripts/ops/tckdb_alert_check.sh
@@ -61,7 +61,41 @@
 #   TCKDB_DEADMAN_URL  optional but strongly recommended -- external URL pinged
 #                      after every completed run; its silence is what tells you
 #                      this checker died
+#
+# EXIT CODES
+#   0  the deployment is healthy
+#   1  a VERDICT of unhealthy: unreachable, bad endpoint, or degraded. The unit
+#      lists this in SuccessExitStatus, because a degraded deployment is
+#      information the script delivered successfully, not a failure of the
+#      script -- the push has already gone out and OnFailure= must not fire.
+#   2  no verdict was reached: no topic, or the script died before deciding.
+#      Never in SuccessExitStatus, so systemd marks the unit failed and
+#      tckdb-alert-failed.service pushes.
+#
+# WHY 1 IS NOT ALLOWED TO MEAN BOTH THINGS
+#   bash exits 1 when it dies on an unbound variable under `set -u`, and 1 is
+#   also this script's "the deployment is unhealthy". SuccessExitStatus=0 1
+#   therefore told systemd to call an accidental death a success, so OnFailure=
+#   never fired for the entire class of bug that kills the script partway
+#   through -- and a dead checker looks exactly like a healthy deployment.
+#   The trap below closes that: 1 keeps its meaning only once a verdict exists,
+#   and any other early exit is reported as 2.
 set -uo pipefail
+
+verdict_reached=0
+on_exit() {
+    local rc=$?
+    if [[ "$rc" -ne 0 && "$verdict_reached" -eq 0 ]]; then
+        # Quiet when the code is already 2 -- that is a deliberate refusal
+        # further down, which has said its own piece.
+        if [[ "$rc" -ne 2 ]]; then
+            echo "error: the checker exited ${rc} before reaching a verdict; reporting 2 so systemd does not read it as a completed check." >&2
+        fi
+        exit 2
+    fi
+    exit "$rc"
+}
+trap on_exit EXIT
 
 STATUS_URL="${TCKDB_STATUS_URL:-https://tckdb.homecalvin.com/api/v1/status}"
 NTFY_SERVER="${TCKDB_NTFY_SERVER:-https://ntfy.sh}"
@@ -171,6 +205,11 @@ else
         fi
     fi
 fi
+
+# A verdict exists from here on, so exit 1 now means "unhealthy deployment"
+# rather than "died on the way", and the unit may go on treating it as a
+# completed run. Everything above this line exits 2.
+verdict_reached=1
 
 # Only notify on a state change. Recovery is worth a push too -- otherwise you
 # are left wondering whether it is still broken.

--- a/backend/scripts/ops/tckdb_alert_check.sh
+++ b/backend/scripts/ops/tckdb_alert_check.sh
@@ -256,8 +256,29 @@ fi
 if [[ -n "$DEADMAN_URL" ]]; then
     # --fail so a typo'd ping URL (404) is reported rather than counted as a
     # heartbeat that went nowhere.
-    curl -sS --fail --max-time 20 -o /dev/null "$DEADMAN_URL" || \
-        echo "warning: dead man's switch ping to ${DEADMAN_URL} failed" >&2
+    #
+    # THE URL ITSELF IS NEVER LOGGED. A healthchecks.io ping URL is
+    # password-equivalent in the same way the ntfy topic is: the secret is the
+    # whole path, and anyone holding it can forge this heartbeat and keep the
+    # alerts quiet indefinitely -- silencing the one channel that covers the
+    # host dying. A failed ping is precisely the moment somebody reads this
+    # journal and pastes it into an issue, so the line says only what helps:
+    # the host that could not be reached, and curl's exit code, which
+    # separates DNS (6) from refused (7) from an HTTP error (22) from a
+    # timeout (28). curl's own stderr is dropped for the same reason rather
+    # than trusted to be discreet. The CI watchdog has always withheld this;
+    # the two scripts used to disagree about a rule one of them already kept.
+    curl -sS --fail --max-time 20 -o /dev/null "$DEADMAN_URL" 2>/dev/null
+    ping_rc=$?
+    if [[ $ping_rc -ne 0 ]]; then
+        # scheme, then any user:password@, then the path: what is left is the
+        # host (with its port), which is not a secret and is the only part
+        # worth naming.
+        deadman_host="${DEADMAN_URL#*://}"
+        deadman_host="${deadman_host##*@}"
+        deadman_host="${deadman_host%%/*}"
+        echo "warning: dead man's switch ping to ${deadman_host:-the configured host} failed (curl exit ${ping_rc}); the ping URL is password-equivalent and is not logged" >&2
+    fi
 fi
 
 echo "$(date -Is) status=${current} (was ${previous})"

--- a/backend/scripts/ops/tckdb_ci_watchdog.sh
+++ b/backend/scripts/ops/tckdb_ci_watchdog.sh
@@ -62,13 +62,42 @@
 #   TCKDB_DEADMAN_URL            optional, strongly recommended -- external URL
 #                                pinged after every completed run
 #
+# A RUN THAT CHECKED NOTHING IS NOT A PASS
+#   The count of verdicts reached is reported unconditionally and before the
+#   result, because it is the number that says whether the run is evidence of
+#   anything at all. It exists because it was once possible for every entry in
+#   TCKDB_WATCHED_WORKFLOWS to be rejected as malformed -- each one warned
+#   about on stderr, none of them watched -- and for the script to then exit 0
+#   and send the dead man's ping, so the external monitor vouched for a checker
+#   that had checked nothing. Zero verdicts is now the loudest state this
+#   script has: no ping, and exit 2.
+#
+#   There is deliberately no --allow-empty equivalent, unlike
+#   verify_artifact_integrity.py, which has one because a fresh deployment can
+#   legitimately hold nothing to verify. Watching nothing is never legitimate
+#   here: an unset or empty TCKDB_WATCHED_WORKFLOWS falls back to the built-in
+#   list, so the only way to reach zero is to have written something the script
+#   could not read, and an opt-out for that is an opt-out from the whole point.
+#
 # EXIT CODES
 #   0  every watched workflow is green and running
 #   1  something is red, silent, or a push could not be delivered
-#   2  the watchdog could not run at all (no topic, no jq, API unreachable).
-#      Nothing is pinged in this case: a dead watchdog's only honest signal is
-#      its silence.
+#   2  something in scope was NOT CHECKED: no topic, no jq, a malformed entry
+#      in TCKDB_WATCHED_WORKFLOWS, an unreadable API, an unparseable run list
+#      -- or no verdict at all.
+#
+#   The split is the one backend/scripts/ops/verify_artifact_integrity.py uses,
+#   on purpose, so that two scripts in one directory do not need two schemes:
+#   1 means something is wrong, 2 means we did not find out, and a runbook that
+#   gates on "not zero" catches both. 1 wins when both are true, because a red
+#   nightly is the more actionable of the two. Nothing is pinged when no
+#   verdict was reached at all: a dead watchdog's only honest signal is its
+#   silence.
 set -uo pipefail
+
+EXIT_OK=0
+EXIT_ALERT=1
+EXIT_NOT_CHECKED=2
 
 GH_API_BASE="${TCKDB_GH_API_BASE:-https://api.github.com}"
 REPO="${TCKDB_WATCH_REPO:-${GITHUB_REPOSITORY:-TCKDB/TCKDB}}"
@@ -83,7 +112,7 @@ TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
 if [[ -z "${TCKDB_NTFY_TOPIC:-}" ]]; then
     echo "TCKDB_NTFY_TOPIC is not set; refusing to run." >&2
-    exit 2
+    exit "$EXIT_NOT_CHECKED"
 fi
 
 # No grep/sed fallback here, unlike the Pi-side checker. That script parses one
@@ -94,7 +123,7 @@ fi
 # wrong is a green one.
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required by the CI watchdog; refusing to guess at the run list." >&2
-    exit 2
+    exit "$EXIT_NOT_CHECKED"
 fi
 
 mkdir -p "$STATE_DIR"
@@ -152,15 +181,34 @@ epoch_of() {
 }
 
 now_epoch="$(date -u +%s)"
-overall_rc=0
+alert_rc=0
 watchdog_usable=1
 notified_any=0
 
-for spec in $WATCHED; do
+# The three numbers the result is computed from, rather than a single rc that
+# cannot tell "nothing was wrong" from "nothing was looked at".
+#   watched_count   entries in TCKDB_WATCHED_WORKFLOWS
+#   verdicts_count  entries that produced an actual verdict this run
+#   unchecked_count entries that did not, for any reason
+# shellcheck disable=SC2086
+set -- $WATCHED
+watched_count=$#
+verdicts_count=0
+unchecked_count=0
+
+for spec in "$@"; do
     workflow="${spec%%:*}"
     max_age_hours="${spec##*:}"
     if [[ "$workflow" == "$spec" || -z "$max_age_hours" ]]; then
+        # An entry that cannot be parsed is a workflow the operator asked for
+        # and did not get. Warning about it and carrying on was how every
+        # entry could be dropped and the run still called clean, so it now
+        # counts as unchecked and takes the heartbeat with it -- the config is
+        # wrong until someone fixes it, and nothing here can fix it.
         echo "warning: ignoring malformed TCKDB_WATCHED_WORKFLOWS entry '${spec}' (want file.yml:hours)" >&2
+        annotate error "CI watchdog cannot parse the watch-list entry '${spec}'; that workflow is NOT being watched"
+        unchecked_count=$((unchecked_count + 1))
+        watchdog_usable=0
         continue
     fi
 
@@ -179,7 +227,7 @@ for spec in $WATCHED; do
         echo "error: could not read run history for ${workflow} from ${REPO}" >&2
         annotate error "CI watchdog could not read run history for ${workflow}"
         watchdog_usable=0
-        overall_rc=1
+        unchecked_count=$((unchecked_count + 1))
         continue
     fi
 
@@ -221,7 +269,7 @@ for spec in $WATCHED; do
         echo "error: could not parse the run history for ${workflow}; refusing to read it as green" >&2
         annotate error "CI watchdog could not parse the run history for ${workflow}"
         watchdog_usable=0
-        overall_rc=1
+        unchecked_count=$((unchecked_count + 1))
         continue
     fi
     eval "$parsed"
@@ -317,6 +365,12 @@ for spec in $WATCHED; do
             "${latest_url:-https://github.com/${REPO}/actions/workflows/${workflow}}")"
     fi
 
+    # A verdict, whatever it says. Counted here rather than at the top of the
+    # loop because reaching this line is the only thing that makes the run
+    # evidence of anything: every `continue` above got here without looking at
+    # a workflow, and a run of nothing but those must not be a pass.
+    verdicts_count=$((verdicts_count + 1))
+
     # ---------------------------------------------------------------
     # Edge trigger
     # ---------------------------------------------------------------
@@ -324,7 +378,7 @@ for spec in $WATCHED; do
     previous="$(cat "$state_file" 2>/dev/null || echo "unknown")"
 
     summary_line "${workflow}: ${state_key} (was ${previous})"
-    [[ "$state_key" == "green" ]] || overall_rc=1
+    [[ "$state_key" == "green" ]] || alert_rc=1
     if [[ "$state_key" != "green" ]]; then
         annotate error "${title}"
     fi
@@ -349,9 +403,36 @@ for spec in $WATCHED; do
         # the same edge and tries again.
         echo "warning: failed to publish ${workflow} alert to ntfy; state not advanced, will retry" >&2
         annotate error "CI watchdog could not deliver the ${workflow} alert to ntfy"
-        overall_rc=1
+        alert_rc=1
     fi
 done
+
+# THE COUNT, FIRST AND UNCONDITIONALLY, before any result line and before the
+# heartbeat. Same convention as verify_artifact_integrity.py's `verified=...`:
+# the reader should not have to infer from an absence of complaints that
+# anything was looked at.
+summary_line "watched=${watched_count} verdicts=${verdicts_count} unchecked=${unchecked_count}"
+
+if [[ "$verdicts_count" -eq 0 ]]; then
+    # Not a pass, and not a red workflow either: no workflow was looked at.
+    # Setting watchdog_usable here is what suppresses the dead man's ping --
+    # the existing, documented signal for "this run reached no verdict" --
+    # so an external monitor sees the silence instead of a forged heartbeat.
+    watchdog_usable=0
+    echo "error: NOT CHECKED. No watched workflow produced a verdict, so this run says nothing about CI. The watch list was '${WATCHED}' (entries must read file.yml:hours); the errors above say what happened to each one." >&2
+    annotate error "CI watchdog reached no verdict at all: it watched nothing this run"
+fi
+
+# 1 before 2, as in verify_artifact_integrity.py: a red workflow is the more
+# actionable finding, and "we did not manage to look at the others" is still
+# true of the same run.
+if [[ "$alert_rc" -ne 0 ]]; then
+    overall_rc=$EXIT_ALERT
+elif [[ "$verdicts_count" -eq 0 || "$unchecked_count" -gt 0 ]]; then
+    overall_rc=$EXIT_NOT_CHECKED
+else
+    overall_rc=$EXIT_OK
+fi
 
 # THE DEAD MAN'S PING. Sent for every completed run whatever the verdict: it
 # asserts that THIS WATCHDOG RAN, which is a different claim from "CI is well".
@@ -359,9 +440,12 @@ done
 # heartbeat, and the external service would page "the watchdog is gone" while
 # the watchdog was busy saying exactly which workflow had failed.
 #
-# It is skipped when the watchdog could not reach the API at all, because that
-# is a watchdog without a verdict, and its silence is the only honest signal it
-# has left.
+# It is skipped whenever any watched entry failed to reach a verdict -- an
+# unreachable API, an unparseable run list, an entry this script could not
+# read -- and in particular when NONE of them did, because that is a watchdog
+# without a verdict, and its silence is the only honest signal it has left.
+# The ping asserts that a check happened; a run that checked nothing may not
+# make that claim.
 if [[ -n "$DEADMAN_URL" ]]; then
     if [[ "$watchdog_usable" -eq 1 ]]; then
         curl -sS --fail --max-time 20 -o /dev/null "$DEADMAN_URL" || \
@@ -378,5 +462,5 @@ else
     annotate warning "TCKDB_DEADMAN_URL is unset: nothing will notice if this watchdog stops running. See backend/docs/deployment/monitoring.md"
 fi
 
-echo "$(date -Is) watchdog rc=${overall_rc} notified=${notified_any}"
+echo "$(date -Is) watchdog verdicts=${verdicts_count}/${watched_count} rc=${overall_rc} notified=${notified_any}"
 exit "$overall_rc"

--- a/backend/tests/ops/test_alert_check_liveness.py
+++ b/backend/tests/ops/test_alert_check_liveness.py
@@ -354,9 +354,10 @@ def test_the_onfailure_push_actually_leaves_the_host(fake_host):
     assert sent[0].path == "/ntfy/test-topic"
     assert "FAILED" in sent[0].headers.get("title", "")
     assert "tckdb-alert.service" in sent[0].body, "name the unit that died"
-    assert "test-topic" not in proc.stdout, (
-        "ntfy echoes the topic back in its response body, and stdout here is "
-        "the journal; the topic is password-equivalent"
+    assert proc.stdout == "", (
+        "ntfy's publish response echoes the topic back, and this command's "
+        "stdout is the journal; the topic is password-equivalent, so the "
+        "response body is discarded rather than logged"
     )
 
 

--- a/backend/tests/ops/test_alert_check_liveness.py
+++ b/backend/tests/ops/test_alert_check_liveness.py
@@ -173,6 +173,37 @@ def test_ping_failure_is_reported_rather_than_swallowed(fake_host, run_alert_che
     assert "dead man's switch ping" in proc.stderr
 
 
+def test_a_failed_ping_does_not_put_the_ping_url_in_the_log(
+    fake_host, run_alert_check
+):
+    """The ping URL is password-equivalent, like the ntfy topic.
+
+    A healthchecks.io ping URL's whole path is the secret: anyone holding
+    it can forge this heartbeat and keep the alerts quiet for as long as
+    they like, which silences the one channel that covers the host dying.
+    And a failed ping is exactly the moment someone reads this journal and
+    pastes it into an issue -- so the failure path is the one that must not
+    quote it. The CI watchdog has always withheld it; this script used to
+    print it in full.
+    """
+    secret = "0e9f4a21-not-a-real-check-uuid"
+    url = f"{fake_host.base}/deadman/{secret}"
+    fake_host.set_status(HEALTHY)
+    fake_host.failing_paths.add(f"/deadman/{secret}")
+
+    proc = run_alert_check(env_overrides={"TCKDB_DEADMAN_URL": url})
+
+    assert proc.returncode == 0, "a failed heartbeat is not a failed check"
+    assert deadman_pings(fake_host), "it was attempted"
+    for stream_name, stream in (("stdout", proc.stdout), ("stderr", proc.stderr)):
+        assert secret not in stream, f"the ping secret reached {stream_name}"
+        assert url not in stream, f"the ping URL reached {stream_name}"
+    # Still diagnosable: the host it could not reach, and why.
+    assert "dead man's switch ping" in proc.stderr
+    assert f"127.0.0.1:{fake_host.port}" in proc.stderr
+    assert "curl exit 22" in proc.stderr, "an HTTP error, not DNS or a timeout"
+
+
 # ---------------------------------------------------------------------------
 # An unmonitored monitor announces itself, once
 # ---------------------------------------------------------------------------

--- a/backend/tests/ops/test_alert_check_liveness.py
+++ b/backend/tests/ops/test_alert_check_liveness.py
@@ -20,6 +20,11 @@ looks alive, which is the defect these tests exist to prevent.
 
 from __future__ import annotations
 
+import os
+import re
+import shlex
+import subprocess
+
 import pytest
 
 from tests.ops.conftest import OPS_DIR
@@ -244,6 +249,11 @@ def test_the_unit_alerts_when_the_checker_itself_fails():
     A moved repo, a missing EnvironmentFile, a syntax error: the script
     never runs, so no ping is even attempted, and only systemd knows.
     OnFailure= turns that red unit into a push.
+
+    Reading the unit is all this test does, which is exactly how three
+    separate silent failures survived in it. The tests below run its
+    ExecStart as a process instead; this one only pins the wiring that no
+    process can show.
     """
     unit = (OPS_DIR / "tckdb-alert.service").read_text()
     assert "OnFailure=tckdb-alert-failed.service" in unit
@@ -252,6 +262,189 @@ def test_the_unit_alerts_when_the_checker_itself_fails():
     body = failure_unit.read_text()
     assert "TCKDB_NTFY_TOPIC" in body
     assert "ExecStart=" in body
+
+
+def test_the_onfailure_unit_survives_a_missing_environment_file():
+    """The leading `-` is not decoration; systemd requires it.
+
+    Without it systemd refuses to START the unit when the file is absent,
+    and "the EnvironmentFile is missing" is one of the failures of
+    tckdb-alert.service this unit is supposed to report. Both units then
+    die of the same cause and nothing is pushed -- the alerting path
+    failing for precisely the reason it was needed.
+
+    This is asserted by reading, because systemd is not available to the
+    test suite. It was verified by running the shipped unit under
+    `systemd-run --user`: with `EnvironmentFile=/absent` the command never
+    executes (Result=resources), with `EnvironmentFile=-/absent` it runs
+    and exits 78/CONFIG with the reason in the journal.
+    """
+    body = (OPS_DIR / "tckdb-alert-failed.service").read_text()
+    line = next(
+        stripped
+        for raw in body.splitlines()
+        if (stripped := raw.strip()).startswith("EnvironmentFile=")
+    )
+    assert line.startswith("EnvironmentFile=-"), (
+        "an OnFailure unit that cannot start without its env file cannot "
+        "report a missing env file"
+    )
+
+
+def test_the_checker_unit_requires_its_environment_file():
+    """And the main unit deliberately does not carry the `-`.
+
+    It cannot check anything without the topic, so a missing file should
+    stop it and fire OnFailure=. The asymmetry between the two units is
+    the mechanism, not an oversight, so it is pinned in both directions.
+    """
+    body = (OPS_DIR / "tckdb-alert.service").read_text()
+    line = next(
+        stripped
+        for raw in body.splitlines()
+        if (stripped := raw.strip()).startswith("EnvironmentFile=")
+    )
+    assert not line.startswith("EnvironmentFile=-")
+
+
+def _exec_start(unit_name: str) -> list[str]:
+    """The unit's ExecStart as an argv, with systemd's line folding applied.
+
+    systemd joins `\\`-continued lines with whitespace and then splits the
+    result the way a shell would; shlex is close enough for a command line
+    that is one program and one single-quoted argument.
+    """
+    text = (OPS_DIR / unit_name).read_text()
+    text = re.sub(r"\\\n\s*", " ", text)
+    line = next(
+        stripped
+        for raw in text.splitlines()
+        if (stripped := raw.strip()).startswith("ExecStart=")
+    )
+    return shlex.split(line.split("=", 1)[1])
+
+
+def _run_exec_start(unit_name: str, env: dict[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        _exec_start(unit_name),
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), **env},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_the_onfailure_push_actually_leaves_the_host(fake_host):
+    """The happy path of the alerting path, executed rather than read.
+
+    Nobody had ever seen this command run. It is the only thing that
+    speaks when the checker cannot, so it is run here against a socket
+    that records what arrived.
+    """
+    proc = _run_exec_start(
+        "tckdb-alert-failed.service",
+        {
+            "TCKDB_NTFY_SERVER": f"{fake_host.base}/ntfy",
+            "TCKDB_NTFY_TOPIC": "test-topic",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    sent = fake_host.paths("/ntfy")
+    assert len(sent) == 1
+    assert sent[0].path == "/ntfy/test-topic"
+    assert "FAILED" in sent[0].headers.get("title", "")
+    assert "tckdb-alert.service" in sent[0].body, "name the unit that died"
+    assert "test-topic" not in proc.stdout, (
+        "ntfy echoes the topic back in its response body, and stdout here is "
+        "the journal; the topic is password-equivalent"
+    )
+
+
+def test_an_unset_topic_alerts_nobody_and_says_so(fake_host):
+    """The second silent failure: a push to ntfy.sh/ with no topic.
+
+    An empty TCKDB_NTFY_TOPIC left the URL ending in a slash. ntfy answers
+    it, curl was satisfied, the unit went green, and the alert reached
+    nobody -- the alerting path reporting success for a delivery it had
+    not made. There is no fallback topic to use instead, so the only
+    honest outcome is to refuse loudly.
+    """
+    proc = _run_exec_start(
+        "tckdb-alert-failed.service",
+        {"TCKDB_NTFY_SERVER": f"{fake_host.base}/ntfy", "TCKDB_NTFY_TOPIC": ""},
+    )
+    assert proc.returncode != 0, "a push that reached nobody is not a success"
+    assert fake_host.paths("/ntfy") == [], "and nothing was posted to no topic"
+    assert "TCKDB_NTFY_TOPIC" in proc.stderr, "the journal has to say why"
+
+
+def test_the_onfailure_push_fails_loudly_on_an_http_error(fake_host):
+    """A 5xx from ntfy is not a delivered alert.
+
+    curl exits 0 on an HTTP error unless told otherwise; the same bug has
+    been fixed in tckdb_alert_check.sh and in uptime-check.yml, and this
+    is the third place it lived.
+    """
+    fake_host.failing_paths.add("/ntfy/test-topic")
+    proc = _run_exec_start(
+        "tckdb-alert-failed.service",
+        {
+            "TCKDB_NTFY_SERVER": f"{fake_host.base}/ntfy",
+            "TCKDB_NTFY_TOPIC": "test-topic",
+        },
+    )
+    assert proc.returncode != 0
+    assert fake_host.paths("/ntfy"), "it was attempted"
+
+
+def test_a_checker_that_dies_before_a_verdict_does_not_exit_one(tmp_path, fake_host):
+    """The third silent failure: SuccessExitStatus=0 1 masking a crash.
+
+    bash exits 1 on an unbound variable under `set -u`, which is the same
+    code this script uses for "the deployment is unhealthy" -- and the
+    unit tells systemd that 1 is a success, so OnFailure= never fired for
+    a checker that died partway through. A dead checker and a healthy
+    deployment are the same observation from a phone.
+
+    The bug is injected into a copy rather than waited for: a real one
+    would be a line somebody adds later, and the guard has to hold for a
+    line nobody has written yet.
+    """
+    mutated = tmp_path / "crashing_alert_check.sh"
+    original = (OPS_DIR / "tckdb_alert_check.sh").read_text()
+    marker = 'raw="$(curl'
+    assert marker in original, "the script no longer has the line this test cuts at"
+    mutated.write_text(original.replace(marker, 'echo "${a_typo_nobody_caught}"\n' + marker, 1))
+
+    proc = subprocess.run(
+        ["bash", str(mutated)],
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "TCKDB_STATUS_URL": f"{fake_host.base}/status",
+            "TCKDB_NTFY_SERVER": f"{fake_host.base}/ntfy",
+            "TCKDB_NTFY_TOPIC": "test-topic",
+            "TCKDB_STATE_FILE": str(tmp_path / "state"),
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        },
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 2, (
+        "an exit the unit lists as a success is how a dead checker stays "
+        "invisible; a death before a verdict must not be reported as one"
+    )
+    assert deadman_pings(fake_host) == [], "and it did not reach a verdict to ping for"
+    unit = (OPS_DIR / "tckdb-alert.service").read_text()
+    success_line = next(
+        stripped
+        for raw in unit.splitlines()
+        if (stripped := raw.strip()).startswith("SuccessExitStatus=")
+    )
+    assert str(proc.returncode) not in success_line.split("=", 1)[1].split(), (
+        "the code the checker dies with must not be one systemd calls success"
+    )
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/ops/test_ci_watchdog.py
+++ b/backend/tests/ops/test_ci_watchdog.py
@@ -638,6 +638,9 @@ def _curl_invocations(text: str) -> list[str]:
         WORKFLOWS_DIR / "uptime-check.yml",
         OPS_DIR / "tckdb_alert_check.sh",
         OPS_DIR / "tckdb_ci_watchdog.sh",
+        # The systemd unit publishes too, and was the one place still
+        # missing --fail: a 5xx from ntfy left it green having told nobody.
+        OPS_DIR / "tckdb-alert-failed.service",
     ],
     ids=lambda p: p.name,
 )

--- a/backend/tests/ops/test_ci_watchdog.py
+++ b/backend/tests/ops/test_ci_watchdog.py
@@ -356,12 +356,17 @@ def test_an_unreadable_run_history_is_loud_and_unpinged(fake_host, run_ci_watchd
     Reported as "has never run" that would be true-sounding, wrong, and
     point at the wrong fix -- so the API error is handled before the run
     list is believed, and no heartbeat is forged for a verdict never reached.
+
+    Exit 2, not 1: the only watched workflow was never looked at, which is
+    what this script's own header has always said 2 means and what
+    verify_artifact_integrity.py means by it. Nothing here is evidence that
+    a workflow is red.
     """
     fake_host.set_json(RUNS_PATH, {"message": "Not Found"}, code=404)
     proc = run_ci_watchdog(
         env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
     )
-    assert proc.returncode == 1
+    assert proc.returncode == 2
     assert pushes(fake_host) == []
     assert fake_host.paths("/deadman") == []
     assert "could not read run history" in proc.stderr
@@ -379,7 +384,7 @@ def test_an_unparseable_run_history_is_not_read_as_green(fake_host, run_ci_watch
     proc = run_ci_watchdog(
         env_overrides={"TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman"}
     )
-    assert proc.returncode == 1
+    assert proc.returncode == 2, "not checked, rather than checked and found red"
     assert pushes(fake_host) == []
     assert fake_host.paths("/deadman") == []
     assert "refusing to read it as green" in proc.stderr
@@ -406,6 +411,138 @@ def test_a_missing_deadman_is_named_as_a_gap(fake_host, run_ci_watchdog):
     serve_runs(fake_host, [run("success", hours_ago=2, run_id=200)])
     proc = run_ci_watchdog()
     assert "TCKDB_DEADMAN_URL is unset" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# A watchdog that watched nothing is not a watchdog that found nothing
+# ---------------------------------------------------------------------------
+
+
+UPTIME_RUNS = "/gh/repos/TCKDB/TCKDB/actions/workflows/uptime-check.yml/runs"
+
+
+def test_a_watch_list_that_parses_to_nothing_is_not_a_pass(fake_host, run_ci_watchdog):
+    """The defect: every entry skipped, and the run still called clean.
+
+    ``backend-nightly.yml`` without ``:hours`` is malformed, so the loop
+    body never ran; nothing set the "no verdict" flag, so the dead man's
+    ping went out anyway and the external monitor vouched for a checker
+    that had checked nothing. A watchdog forging its own heartbeat is
+    worse than no watchdog, because it is believed.
+    """
+    serve_runs(fake_host, red_history(2))
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_WATCHED_WORKFLOWS": "backend-nightly.yml uptime-check.yml",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 2, "nothing was checked; that is not a pass"
+    assert fake_host.paths("/deadman") == [], (
+        "the heartbeat asserts that a check happened, and none did"
+    )
+    assert pushes(fake_host) == []
+    assert "verdicts=0" in proc.stdout, "the count is reported, not implied"
+    assert "NOT CHECKED" in proc.stderr
+
+
+def test_a_watch_list_of_pure_whitespace_watches_nothing_and_says_so(
+    fake_host, run_ci_watchdog
+):
+    """The zero-iteration case in its purest form.
+
+    A list of one space is non-empty, so it does not reach the built-in
+    default, and it splits into no entries at all: the loop body never
+    runs, nothing is malformed, nothing errors, and every counter the
+    script keeps stays at its starting value. This is the case where only
+    the verdict count itself can tell the difference between a clean run
+    and a run that never began.
+    """
+    serve_runs(fake_host, red_history(2))
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_WATCHED_WORKFLOWS": "   ",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 2
+    assert fake_host.paths("/deadman") == []
+    assert "watched=0 verdicts=0 unchecked=0" in proc.stdout
+    assert "NOT CHECKED" in proc.stderr
+
+
+def test_an_empty_watch_list_falls_back_to_the_built_in_default(
+    fake_host, run_ci_watchdog
+):
+    """An unset or empty list is not an empty list; it is the default one.
+
+    Worth pinning, because the obvious reading of the zero-verdict bug is
+    "empty input means watch nothing" -- and fixing that reading instead
+    of the real one would leave the malformed path exactly as it was.
+    """
+    serve_runs(fake_host, [run("success", hours_ago=2, run_id=200)])
+    fake_host.set_json(UPTIME_RUNS, {"workflow_runs": [run("success", hours_ago=0.2, run_id=300)]})
+
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_WATCHED_WORKFLOWS": "",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 0
+    assert "verdicts=2" in proc.stdout, "both default workflows were watched"
+    assert len(fake_host.paths("/deadman")) == 1
+    assert (run_ci_watchdog.state_dir / "uptime-check.yml").read_text() == "green"
+
+
+def test_one_unwatchable_entry_does_not_pass_on_the_others(fake_host, run_ci_watchdog):
+    """A workflow the operator asked for and did not get is a fault.
+
+    A green nightly says nothing about the uptime check, so a run that
+    silently dropped the second entry must not exit 0 on the strength of
+    the first. It exits 2 -- part of the scope was not checked -- which is
+    the same sentence verify_artifact_integrity.py's exit 2 says.
+    """
+    serve_runs(fake_host, [run("success", hours_ago=2, run_id=200)])
+    proc = run_ci_watchdog(
+        env_overrides={
+            "TCKDB_WATCHED_WORKFLOWS": f"{WORKFLOW}:30 uptime-check.yml",
+            "TCKDB_DEADMAN_URL": f"{fake_host.base}/deadman",
+        }
+    )
+    assert proc.returncode == 2
+    assert "watched=2 verdicts=1 unchecked=1" in proc.stdout
+    assert fake_host.paths("/deadman") == [], (
+        "half a check is not the completed run the heartbeat claims"
+    )
+
+
+def test_a_red_workflow_outranks_an_unchecked_one(fake_host, run_ci_watchdog):
+    """1 before 2 when both are true, as in verify_artifact_integrity.py.
+
+    "Something is red" is the more actionable of the two findings, and the
+    unchecked entry is still named on stderr for whoever triages it.
+    """
+    serve_runs(fake_host, red_history(2))
+    serve_jobs(fake_host)
+    fake_host.set_json(UPTIME_RUNS, {"message": "Not Found"}, code=404)
+
+    proc = run_ci_watchdog(
+        env_overrides={"TCKDB_WATCHED_WORKFLOWS": f"{WORKFLOW}:30 uptime-check.yml:6"}
+    )
+    assert proc.returncode == 1
+    assert "watched=2 verdicts=1 unchecked=1" in proc.stdout
+    assert "could not read run history for uptime-check.yml" in proc.stderr
+    assert len(pushes(fake_host)) == 1, "the workflow it could see is still reported"
+
+
+def test_the_verdict_count_is_reported_on_a_clean_run(fake_host, run_ci_watchdog):
+    """Reported unconditionally, so a pass carries its own evidence."""
+    serve_runs(fake_host, [run("success", hours_ago=2, run_id=200)])
+    proc = run_ci_watchdog()
+    assert proc.returncode == 0
+    assert "watched=1 verdicts=1 unchecked=0" in proc.stdout
+    assert "verdicts=1/1" in proc.stdout, "and again on the closing line"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

```
$ TCKDB_WATCHED_WORKFLOWS="backend-nightly.yml uptime-check.yml" ... tckdb_ci_watchdog.sh
warning: ignoring malformed TCKDB_WATCHED_WORKFLOWS entry 'backend-nightly.yml' (want file.yml:hours)
warning: ignoring malformed TCKDB_WATCHED_WORKFLOWS entry 'uptime-check.yml' (want file.yml:hours)
watchdog rc=0 notified=0
exit=0
```

Every entry was `continue`d, the loop body never ran, `watchdog_usable` stayed
`1`, and the dead man's ping went out on the strength of that flag alone. **A
watchdog that watched nothing exited 0 and forged its own heartbeat**, so the
external monitor vouched for a checker that had checked nothing.

An *empty* `TCKDB_WATCHED_WORKFLOWS` was never part of this: it falls back to
the built-in default list, which is correct. Only the all-malformed path (and
a whitespace-only list) reached zero iterations. Both verified before and after.

## The fix

Verdicts are counted; the count is printed unconditionally and before the
result. Zero verdicts sets `watchdog_usable=0` — the existing, documented signal
that already suppresses the heartbeat — and exits 2.

```
watched=2 verdicts=0 unchecked=2
error: NOT CHECKED. No watched workflow produced a verdict, ...
warning: no verdict reached, so the dead man's switch was not pinged
2026-08-11T13:48:55+03:00 watchdog verdicts=0/2 rc=2 notified=0
```

Exit codes now match `verify_artifact_integrity.py` (PR #127) rather than
inventing a second scheme for the same directory:

| Code | `verify_artifact_integrity.py` | `tckdb_ci_watchdog.sh` |
|---|---|---|
| 0 | verified, no breaks | every watched workflow green and running |
| 1 | a break was recorded | something red, silent, or a push undelivered |
| 2 | something in scope was not checked | no verdict for some/any watched workflow |

1 wins when both are true, as there. Two consequences worth flagging:

- an unreadable or unparseable run history is now **2, not 1** — which is what
  this script's own header always said 2 meant (`API unreachable`); the code
  disagreed with its documentation. Two existing tests assert the new code.
- a malformed entry now *counts*. A workflow the operator asked for and did not
  get is a fault, not a footnote, so it makes the run "not checked" and takes
  the heartbeat with it.

No `--allow-empty` equivalent, deliberately: the integrity sweep has one because
a fresh deployment can legitimately hold nothing to verify, while an unset or
empty watch list here falls back to the default. Reaching zero means something
was written that the script could not read, and an opt-out for that is an
opt-out from the whole point.

## Also in scope: #86, the alert path's three silent failures

All three fixed, all three mutation-checked.

1. **`EnvironmentFile=` without a leading `-`** on `tckdb-alert-failed.service`.
   systemd refuses to *start* a unit whose non-optional env file is missing —
   and a missing env file is one of the failures of `tckdb-alert.service` this
   unit exists to report. Both units died of the same cause; nothing was pushed.
2. **An unset `TCKDB_NTFY_TOPIC` posted to `https://ntfy.sh/`** — answered,
   `curl` happy without `--fail`, unit green, nobody told. Now refuses with 78
   and says so in the journal. There is no push in this case and there cannot
   be, because the topic *is* the address; the dead man's switch is what covers
   it, and the runbook now says so instead of claiming a push.
3. **`SuccessExitStatus=0 1` masked accidental exit-1 crashes.** bash exits 1 on
   an unbound variable under `set -u`, and 1 is also the checker's "deployment
   unhealthy". `tckdb_alert_check.sh` now reports **2** for any exit taken
   before a verdict exists, via an EXIT trap; 2 is not in `SuccessExitStatus`
   and the unit says not to add it. Exit 1 keeps its meaning for a real verdict,
   so no existing behaviour or test changes.

Plus `-o /dev/null` on the unit's curl: ntfy echoes the topic back in its
response body and that stdout goes to the journal.

## What the tests do and do not establish

The unit was covered only by a string-grep of the unit file, which is exactly
how three separate failures survived in it. Its `ExecStart` is now folded,
split and **executed as a process** against the fake-ntfy socket the rest of
`tests/ops/` uses: the push is asserted to arrive, an empty topic is asserted to
produce no request at all, and a 5xx is asserted to be a non-zero exit.

Systemd itself is not available to the suite, so `EnvironmentFile=-` and the
`SuccessExitStatus=` list are still asserted by reading the units. **Those two
assertions do not prove runtime behaviour.** They were verified by hand against
the shipped files with `systemd-run --user` / a transient user unit:

| Case | Result |
|---|---|
| env file absent | `78/CONFIG`, reason in the journal (before the fix: never ran, `Result=resources`) |
| env file present, topic set | one POST to the topic, unit green |
| env file present, no topic | `78/CONFIG`, **no POST at all** |
| ntfy answers 500 | curl 22, unit failed |

## Mutation checks

| Reverted | Failing tests |
|---|---|
| zero-verdict guard (`verdicts_count -eq 0` branch + its arm of the rc ladder) | 2 (`..._parses_to_nothing_is_not_a_pass`, `..._pure_whitespace_watches_nothing_and_says_so`), 32 still passing |
| deadman suppression (`watchdog_usable` ignored) | 5, 29 still passing |
| the crash trap (`verdict_reached` pre-set to 1) | 1, 59 still passing |
| `EnvironmentFile=-`, the empty-topic guard and `--fail`, together | 4, 56 still passing |
| `-o /dev/null` on the unit's curl | 1, 18 still passing (that file alone) |

Gates: `test-rest.sh` 3877 passed / 14 skipped, `test-api.sh` 2543 passed
(baseline at `43f25cff`), ruff and mypy clean.
