### PR TITLE
Freeze declared atom maps once their saddle point is accepted

### DIFF
--- a/backend/alembic/versions/b6c1f4a8e703_freeze_declared_atom_maps.py
+++ b/backend/alembic/versions/b6c1f4a8e703_freeze_declared_atom_maps.py
@@ -1,0 +1,270 @@
+"""Bring declared atom maps under the accepted-science immutability regime.
+
+``c6f2a9d4e7b1`` made every accepted scientific record immutable in the
+database: once a ``record_review`` row for a supported root has ever reached
+``approved``, the root and the rows that carry its scientific meaning can no
+longer be updated, deleted, or added to. Corrections go through
+``scientific_record_supersession`` — a new record, approved on its own terms,
+with an explicit edge from the old one — rather than through mutation.
+
+``d3a7f1c9b284`` added ``reaction_atom_map`` and ``reaction_atom_map_pair``
+after that regime was in place and did not join it. Neither table carries a
+``trg_as_*`` trigger, so a declared atom map attached to an accepted saddle
+point could be edited in place, silently, with no supersession edge and no
+review event — while ``calc_freq_mode`` beside it, an ordinary number rather
+than a mechanistic claim, could not. That reads as an oversight rather than a
+considered exemption: ADR 0011 frames a declared map as a claim the depositor
+is answerable for, which is exactly the property this regime enforces.
+
+Which acceptance freezes a map
+------------------------------
+``reaction_atom_map`` names three things: a ``reaction_entry``, a
+``transition_state_entry``, and the ``geometry`` both legs index into. Only one
+of the three is the right owner.
+
+**``transition_state_entry``** — chosen. It is an accepted-science root
+already (``c6f2a9d4e7b1``'s ``_ROOT_TYPES``), it is a ``NOT NULL`` foreign key
+on every map, and one TS entry determines exactly one reaction entry
+(``transition_state_entry → transition_state → reaction_entry``), so nothing
+unrelated can freeze a map by being approved. Scientifically it is the same
+claim: approving a TS entry asserts that this saddle point connects the
+declared reactants and products, and ADR 0011 says the atom map is what
+"converts that assertion into something a reader can check". The map is not
+adjacent to that assertion, it is its content.
+
+**``reaction_entry``** — rejected. It is not an accepted-science root at all:
+``tckdb_is_accepted_science_type`` does not admit it and
+``tckdb_lock_scientific_record`` has no branch for it, so a guard hung there
+would never fire. Making it one is a change to the whole regime, not to atom
+maps, and a reaction entry is closer to identity than to result.
+
+**The transition-state ``geometry``, via its calculation** — rejected. A
+geometry is reached from a calculation through ``calculation_output_geometry``
+and is not private to one calculation, so this would freeze a map when a
+calculation that merely shares the geometry is approved: acceptance of
+something unrelated. The geometry's own immutability is already handled by
+``tckdb_guard_calculation_geometry``, which is a different question — whether
+the coordinates may move — from whether the map over them may be rewritten.
+
+Insertion is guarded too, deliberately
+--------------------------------------
+``tckdb_guard_accepted_child`` fires on INSERT as well as UPDATE and DELETE, so
+a map cannot be *added* to an already-accepted TS entry. That is the same rule
+``calc_freq_result`` and ``network_state`` live under, and it is the right one
+here: attaching a mechanistic claim to a record reviewers already accepted
+without one changes what was accepted. ADR 0011 puts retroactive mapping
+explicitly out of scope and accepts the resulting split between mapped and
+unmapped records rather than solving it; the correction path is to deposit a
+new transition-state entry carrying the map, approve it, and record a
+``transition_state_entry`` supersession — which
+``ck_scientific_record_supersession_supported_type`` and
+``app.services.accepted_science.supersession_subject`` both already admit.
+
+What this does to ``e7d1c4b8a3f5``'s advice
+-------------------------------------------
+``e7d1c4b8a3f5`` froze ``reaction_atom_map.source`` against in-place
+relabelling and told the operator, in the exception's ``HINT``, that "to
+correct a genuinely mis-declared map, delete it and deposit the real one". That
+was true when nothing stopped a delete. It stops being true for a map whose
+transition-state entry has been accepted, and an operator who follows a stale
+hint into a second refusal learns only that two rules disagree. So this
+revision replaces that function's body — same logic, same error, corrected
+hint — and ``downgrade()`` puts the original text back, because once the
+accepted-science guard is gone the original advice is right again.
+
+No rows are touched
+-------------------
+This revision is pure DDL. Creating a trigger does not evaluate it against
+existing rows, so the migration is safe whatever a deployment holds, and there
+is no backfill to design — consistent with ``d3a7f1c9b284``, whose whole
+argument is that an atom map cannot be manufactured.
+
+``downgrade()`` drops the four triggers and restores the prior state exactly.
+Unlike ``d3a7f1c9b284``'s downgrade it destroys nothing: no map is written,
+read, or removed here, only the rule about who may rewrite one.
+
+Revision ID: b6c1f4a8e703
+Revises: c8b4e1a7d302
+Create Date: 2026-08-11
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b6c1f4a8e703"
+down_revision: Union[str, Sequence[str], None] = "c8b4e1a7d302"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: ``(table, record_type, column)`` — guarded by ``tckdb_guard_accepted_child``
+#: against the accepted root named directly on the row.
+_DIRECT_CHILDREN: tuple[tuple[str, str, str], ...] = (
+    ("reaction_atom_map", "transition_state_entry", "transition_state_entry_id"),
+)
+
+#: ``(table, record_type, child_column, parent_table, parent_pk, root_column)``
+#: — guarded by ``tckdb_guard_accepted_via_child``, which dereferences the
+#: parent row to find the root. A pair names no transition-state entry of its
+#: own; it reaches one through the map it belongs to.
+_VIA_CHILDREN: tuple[tuple[str, str, str, str, str, str], ...] = (
+    (
+        "reaction_atom_map_pair",
+        "transition_state_entry",
+        "atom_map_id",
+        "reaction_atom_map",
+        "id",
+        "transition_state_entry_id",
+    ),
+)
+
+#: TRUNCATE bypasses row triggers entirely, so both tables need the statement
+#: level refusal the rest of the regime carries.
+_TRUNCATE_TABLES: tuple[str, ...] = (
+    "reaction_atom_map",
+    "reaction_atom_map_pair",
+)
+
+
+#: ``e7d1c4b8a3f5``'s source-immutability function, with the delete-and-
+#: redeposit hint qualified by the freeze this revision installs. Only the
+#: ``HINT`` text differs from the original; the condition and the raised error
+#: are byte-for-byte the same, so this replaces no rule and relaxes none.
+_SOURCE_IMMUTABLE_FUNCTION = """
+CREATE OR REPLACE FUNCTION public.tckdb_reaction_atom_map_source_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF NEW.source IS DISTINCT FROM OLD.source THEN
+        RAISE EXCEPTION
+            'atom_map_source_is_immutable: reaction_atom_map % was written '
+            'with source=''%'' and cannot be changed to ''%''. An atom map '
+            'records who stands behind a mechanism claim: relabelling an '
+            'inferred map as declared manufactures human attribution, and '
+            'relabelling a declared map as inferred withdraws one the '
+            'depositor made (ADR 0011).',
+            OLD.id, OLD.source, NEW.source
+            USING ERRCODE = '23514',
+                  HINT = 'To correct a mis-declared map whose transition-state '
+                         'entry has never been approved, delete it and deposit '
+                         'the real one. Once that entry has been approved the '
+                         'map is immutable too: deposit a new transition-state '
+                         'entry carrying the corrected map, approve it, and '
+                         'record a transition_state_entry supersession. Its '
+                         'note and equivalent_map_count remain editable in '
+                         'place while the entry is unapproved.';
+    END IF;
+    RETURN NEW;
+END;
+$$
+"""
+
+#: The original text, restored on downgrade. Copied verbatim from
+#: ``e7d1c4b8a3f5``: with the accepted-science guard dropped, delete and
+#: redeposit is once again the whole of the correction path.
+_SOURCE_IMMUTABLE_FUNCTION_BEFORE = """
+CREATE OR REPLACE FUNCTION public.tckdb_reaction_atom_map_source_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF NEW.source IS DISTINCT FROM OLD.source THEN
+        RAISE EXCEPTION
+            'atom_map_source_is_immutable: reaction_atom_map % was written '
+            'with source=''%'' and cannot be changed to ''%''. An atom map '
+            'records who stands behind a mechanism claim: relabelling an '
+            'inferred map as declared manufactures human attribution, and '
+            'relabelling a declared map as inferred withdraws one the '
+            'depositor made (ADR 0011).',
+            OLD.id, OLD.source, NEW.source
+            USING ERRCODE = '23514',
+                  HINT = 'To correct a genuinely mis-declared map, delete it '
+                         'and deposit the real one. Its note and '
+                         'equivalent_map_count remain editable in place.';
+    END IF;
+    RETURN NEW;
+END;
+$$
+"""
+
+
+def _trigger_name(prefix: str, table: str) -> str:
+    """Mirror ``c6f2a9d4e7b1``'s naming, truncated to PostgreSQL's 63 bytes.
+
+    The names are suffixed with the table rather than with a positional index,
+    because ``c6f2a9d4e7b1`` already owns ``trg_as_child_NN`` /
+    ``trg_as_via_NN`` / ``trg_as_truncate_NN`` and appending to a positional
+    sequence from a second revision would make both revisions' numbering depend
+    on the other's registry.
+    """
+
+    return f"trg_{prefix}_{table}"[:63]
+
+
+def _child_groups() -> list[tuple[str, str, tuple[str, ...]]]:
+    """Collapse the registry to one trigger per ``(table, record_type)``."""
+
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for table, record_type, column in _DIRECT_CHILDREN:
+        grouped.setdefault((table, record_type), []).append(column)
+    return [(table, record_type, tuple(columns)) for (table, record_type), columns in grouped.items()]
+
+
+def upgrade() -> None:
+    """Guard atom maps and their pairs with the accepted-science triggers."""
+
+    for table, record_type, columns in _child_groups():
+        arguments = ", ".join(f"'{column}'" for column in columns)
+        op.execute(
+            f"""
+            CREATE TRIGGER {_trigger_name("as_child", table)}
+            BEFORE INSERT OR UPDATE OR DELETE ON public.{table}
+            FOR EACH ROW
+            EXECUTE FUNCTION public.tckdb_guard_accepted_child(
+                '{record_type}', {arguments}
+            )
+            """
+        )
+    for (
+        table,
+        record_type,
+        child_column,
+        parent_table,
+        parent_pk,
+        root_column,
+    ) in _VIA_CHILDREN:
+        op.execute(
+            f"""
+            CREATE TRIGGER {_trigger_name("as_via", table)}
+            BEFORE INSERT OR UPDATE OR DELETE ON public.{table}
+            FOR EACH ROW EXECUTE FUNCTION public.tckdb_guard_accepted_via_child(
+                '{record_type}', '{child_column}', '{parent_table}',
+                '{parent_pk}', '{root_column}'
+            )
+            """
+        )
+    for table in _TRUNCATE_TABLES:
+        op.execute(
+            f"""
+            CREATE TRIGGER {_trigger_name("as_truncate", table)}
+            BEFORE TRUNCATE ON public.{table}
+            FOR EACH STATEMENT EXECUTE FUNCTION public.tckdb_reject_truncate()
+            """
+        )
+    op.execute(_SOURCE_IMMUTABLE_FUNCTION)
+
+
+def downgrade() -> None:
+    """Drop the atom-map guards, restoring the prior state exactly."""
+
+    for table, _, _ in _child_groups():
+        op.execute(f"DROP TRIGGER IF EXISTS {_trigger_name('as_child', table)} ON public.{table}")
+    for item in _VIA_CHILDREN:
+        op.execute(f"DROP TRIGGER IF EXISTS {_trigger_name('as_via', item[0])} ON public.{item[0]}")
+    for table in _TRUNCATE_TABLES:
+        op.execute(f"DROP TRIGGER IF EXISTS {_trigger_name('as_truncate', table)} ON public.{table}")
+    op.execute(_SOURCE_IMMUTABLE_FUNCTION_BEFORE)

--- a/backend/docs/specs/accepted_science_immutability.md
+++ b/backend/docs/specs/accepted_science_immutability.md
@@ -19,6 +19,14 @@ reproducibility assessments. Calculation input/output geometries and their atom
 coordinates are protected when referenced by an ever-approved calculation.
 Multi-root child changes lock affected roots in sorted order.
 
+`reaction_atom_map` and `reaction_atom_map_pair` (ADR 0011) are owned children
+of `transition_state_entry`. A declared atom map is the content of the claim
+that a saddle point connects the reaction's declared reactants and products, so
+approving the entry freezes the map; correcting one means depositing a new
+transition-state entry that carries the corrected map, approving it, and
+recording a `transition_state_entry` supersession. They joined the regime in
+`b6c1f4a8e703`, after `d3a7f1c9b284` introduced them outside it.
+
 The migration conservatively backfills `first_approved_at` from the earliest
 event that touches `approved`. Current approved or deprecated rows without such
 an event use `reviewed_at`, then `created_at`.

--- a/backend/tests/db/test_accepted_science_trigger_registry.py
+++ b/backend/tests/db/test_accepted_science_trigger_registry.py
@@ -10,34 +10,56 @@ from sqlalchemy import text
 from app.db import models as _models  # noqa: F401
 from app.db.base import Base
 
-_REVISION = (
-    Path(__file__).resolve().parents[2]
-    / "alembic"
-    / "versions"
-    / "c6f2a9d4e7b1_enforce_accepted_science_immutability.py"
-)
+_VERSIONS = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+
+_REVISION = _VERSIONS / "c6f2a9d4e7b1_enforce_accepted_science_immutability.py"
+
+#: ``b6c1f4a8e703`` extends the same regime to the atom-map tables, which
+#: ``d3a7f1c9b284`` added after ``c6f2a9d4e7b1`` shipped and did not join. Its
+#: registry is checked here too, and its triggers are part of the expected set
+#: below: this test asserts set *equality* against ``pg_trigger``, so a guard
+#: added anywhere without being declared here fails, and one declared here
+#: without being created fails as well.
+_ATOM_MAP_REVISION = _VERSIONS / "b6c1f4a8e703_freeze_declared_atom_maps.py"
 
 
 def _revision_namespace() -> dict:
     return runpy.run_path(str(_REVISION))
 
 
+def _atom_map_revision_namespace() -> dict:
+    return runpy.run_path(str(_ATOM_MAP_REVISION))
+
+
 def test_registry_references_real_metadata_and_short_identifiers() -> None:
     revision = _revision_namespace()
+    atom_map_revision = _atom_map_revision_namespace()
     tables = Base.metadata.tables
+    root_types = revision["_ROOT_TYPES"]
 
-    for table in revision["_ROOT_TYPES"].values():
+    for table in root_types.values():
         assert table in tables
         assert "id" in tables[table].c
-    for table, _, column in revision["_DIRECT_CHILDREN"]:
+    for table, _, column in revision["_DIRECT_CHILDREN"] + atom_map_revision["_DIRECT_CHILDREN"]:
         assert table in tables
         assert column in tables[table].c
-    for table, _, child_column, parent, parent_pk, root_column in revision["_VIA_CHILDREN"]:
+    for table, _, child_column, parent, parent_pk, root_column in (
+        revision["_VIA_CHILDREN"] + atom_map_revision["_VIA_CHILDREN"]
+    ):
         assert table in tables
         assert child_column in tables[table].c
         assert parent in tables
         assert parent_pk in tables[parent].c
         assert root_column in tables[parent].c
+
+    # A guard may only name a record type ``tckdb_lock_scientific_record``
+    # knows how to lock. One that does not raises 22023 at runtime rather than
+    # protecting anything, and the failure would only surface the first time a
+    # guarded row was written.
+    for _, record_type, *_rest in atom_map_revision["_DIRECT_CHILDREN"] + atom_map_revision["_VIA_CHILDREN"]:
+        assert record_type in root_types
+    for table in atom_map_revision["_TRUNCATE_TABLES"]:
+        assert table in tables
 
     constraints = tables["scientific_record_supersession"].constraints
     assert all(constraint.name is None or len(constraint.name) <= 63 for constraint in constraints)
@@ -86,6 +108,16 @@ def test_database_trigger_set_matches_registry(db_session) -> None:
         }
     )
     expected.update((table, f"trg_as_truncate_{index:02d}") for index, table in enumerate(truncate_tables))
+
+    atom_map_revision = _atom_map_revision_namespace()
+    atom_map_trigger_name = atom_map_revision["_trigger_name"]
+    expected.update(
+        (table, atom_map_trigger_name("as_child", table)) for table, _, _ in atom_map_revision["_child_groups"]()
+    )
+    expected.update((item[0], atom_map_trigger_name("as_via", item[0])) for item in atom_map_revision["_VIA_CHILDREN"])
+    expected.update(
+        (table, atom_map_trigger_name("as_truncate", table)) for table in atom_map_revision["_TRUNCATE_TABLES"]
+    )
 
     actual = {
         (row.table_name, row.trigger_name)

--- a/backend/tests/db/test_atom_map_immutability.py
+++ b/backend/tests/db/test_atom_map_immutability.py
@@ -193,6 +193,12 @@ def _second_pair(bundle: _Bundle) -> ReactionAtomMapPair:
 def test_map_of_approved_transition_state_entry_cannot_be_rewritten(db_session) -> None:
     actor = _curator(db_session)
     bundle = _make_bundle(db_session, "AMFRZ")
+    # The pair goes before approval so every statement below reaches the map's
+    # own guard and nothing else. Deleting a map that still had pairs would
+    # cascade into them first and be refused by the *pair* guard, which would
+    # leave this test green with the map's trigger missing entirely.
+    db_session.delete(bundle.pair)
+    db_session.flush()
     _approve(db_session, bundle.transition_state_entry.id, actor)
 
     with pytest.raises(DBAPIError), db_session.begin_nested():

--- a/backend/tests/db/test_atom_map_immutability.py
+++ b/backend/tests/db/test_atom_map_immutability.py
@@ -1,0 +1,383 @@
+"""A declared atom map is frozen by its transition-state entry's acceptance.
+
+``c6f2a9d4e7b1`` made accepted scientific records immutable in the database.
+``d3a7f1c9b284`` added ``reaction_atom_map`` / ``reaction_atom_map_pair``
+afterwards and did not join that regime, so a depositor's mechanism claim was
+the one recently added scientific record that could still be rewritten in place
+under an accepted saddle point. ``b6c1f4a8e703`` closes that.
+
+These tests pin both halves of the rule, because a guard that is present but
+never fires is the failure mode:
+
+* an atom map under an **approved** ``transition_state_entry`` cannot be
+  updated, deleted, extended with a new pair, or created at all;
+* an atom map under an **unapproved** one is fully editable, so the freeze is
+  acceptance-triggered rather than a blanket write ban on the table.
+
+The last test proves the correction path exists: a wrong map is replaced by
+depositing a new transition-state entry that carries the right one and
+recording a ``transition_state_entry`` supersession, end to end through the
+curator route. A freeze with no correction path would be worse than no freeze.
+
+Why the transition-state entry and not something else owns this is argued in
+``b6c1f4a8e703``'s module docstring; the short version is that it is the only
+accepted-science root the map names, it is ``NOT NULL`` on every map, and one
+TS entry determines exactly one reaction entry, so nothing unrelated can freeze
+a map by being approved.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.models.app_user import AppUser
+from app.db.models.common import (
+    AppUserRole,
+    AtomMapSource,
+    ReactionRole,
+    RecordReviewStatus,
+    SubmissionRecordType,
+)
+from app.db.models.reaction import ReactionEntryStructureParticipant
+from app.db.models.reaction_atom_map import ReactionAtomMap, ReactionAtomMapPair
+from app.db.models.scientific_record_supersession import ScientificRecordSupersession
+from app.db.models.transition_state import TransitionState, TransitionStateEntry
+from app.services.record_review import ensure_record_review, set_record_review_status
+from tests.services.scientific_read._factories import (
+    attach_geometry_atoms,
+    make_chem_reaction,
+    make_geometry,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    make_transition_state,
+    make_transition_state_entry,
+    next_inchi_key,
+)
+
+#: Two atoms on each side, so a pair can be re-pointed from atom 1 to atom 2
+#: without violating the ``geometry_atom`` foreign keys. The mutation the guard
+#: has to refuse is a *valid* remap -- a guard that only stops nonsense the
+#: foreign keys already stop would prove nothing.
+_SYMBOLS = ["H", "H"]
+_COORDS = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.9]]
+
+
+class _Bundle:
+    """One reaction entry, its saddle point, and one declared atom map."""
+
+    def __init__(self, *, transition_state, transition_state_entry, atom_map, pair, participant, geometries):
+        self.transition_state = transition_state
+        self.transition_state_entry = transition_state_entry
+        self.atom_map = atom_map
+        self.pair = pair
+        self.participant = participant
+        self.reactant_geometry, self.ts_geometry = geometries
+
+
+def _curator(session, username: str = "atom-map-curator") -> AppUser:
+    actor = AppUser(username=username, role=AppUserRole.curator)
+    session.add(actor)
+    session.flush()
+    return actor
+
+
+def _approve(session, record_id: int, actor: AppUser) -> None:
+    ensure_record_review(
+        session,
+        record_type=SubmissionRecordType.transition_state_entry,
+        record_id=record_id,
+    )
+    review = set_record_review_status(
+        session,
+        record_type=SubmissionRecordType.transition_state_entry,
+        record_id=record_id,
+        status=RecordReviewStatus.approved,
+        actor=actor,
+    )
+    assert review.first_approved_at is not None
+
+
+def _make_bundle(session, tag: str) -> _Bundle:
+    reactant_species = make_species(session, inchi_key=next_inchi_key(f"{tag}R"))
+    product_species = make_species(session, inchi_key=next_inchi_key(f"{tag}P"))
+    reactant_entry = make_species_entry(session, reactant_species)
+    product_entry = make_species_entry(session, product_species)
+    reaction = make_chem_reaction(
+        session,
+        reactants=[reactant_species],
+        products=[product_species],
+    )
+    reaction_entry = make_reaction_entry(
+        session,
+        reaction=reaction,
+        reactant_entries=[reactant_entry],
+        product_entries=[product_entry],
+    )
+    transition_state = make_transition_state(session, reaction_entry=reaction_entry)
+    transition_state_entry = make_transition_state_entry(
+        session,
+        transition_state=transition_state,
+    )
+    participant = session.scalars(
+        select(ReactionEntryStructureParticipant).where(
+            ReactionEntryStructureParticipant.reaction_entry_id == reaction_entry.id,
+            ReactionEntryStructureParticipant.role == ReactionRole.reactant,
+        )
+    ).one()
+
+    reactant_geometry = make_geometry(session, natoms=len(_SYMBOLS))
+    attach_geometry_atoms(
+        session,
+        geometry=reactant_geometry,
+        symbols=list(_SYMBOLS),
+        coords=[list(row) for row in _COORDS],
+    )
+    ts_geometry = make_geometry(session, natoms=len(_SYMBOLS))
+    attach_geometry_atoms(
+        session,
+        geometry=ts_geometry,
+        symbols=list(_SYMBOLS),
+        coords=[list(row) for row in _COORDS],
+    )
+
+    atom_map = ReactionAtomMap(
+        reaction_entry_id=reaction_entry.id,
+        transition_state_entry_id=transition_state_entry.id,
+        transition_state_geometry_id=ts_geometry.id,
+        source=AtomMapSource.declared,
+    )
+    session.add(atom_map)
+    session.flush()
+    pair = ReactionAtomMapPair(
+        atom_map_id=atom_map.id,
+        side=ReactionRole.reactant,
+        structure_participant_id=participant.id,
+        geometry_id=reactant_geometry.id,
+        atom_index=1,
+        transition_state_geometry_id=ts_geometry.id,
+        ts_atom_index=1,
+        element="H",
+        ts_element="H",
+    )
+    session.add(pair)
+    session.flush()
+    return _Bundle(
+        transition_state=transition_state,
+        transition_state_entry=transition_state_entry,
+        atom_map=atom_map,
+        pair=pair,
+        participant=participant,
+        geometries=(reactant_geometry, ts_geometry),
+    )
+
+
+def _second_pair(bundle: _Bundle) -> ReactionAtomMapPair:
+    """A pair the unique constraints admit, so only the guard can refuse it."""
+
+    return ReactionAtomMapPair(
+        atom_map_id=bundle.atom_map.id,
+        side=ReactionRole.reactant,
+        structure_participant_id=bundle.participant.id,
+        geometry_id=bundle.reactant_geometry.id,
+        atom_index=2,
+        transition_state_geometry_id=bundle.ts_geometry.id,
+        ts_atom_index=2,
+        element="H",
+        ts_element="H",
+    )
+
+
+def test_map_of_approved_transition_state_entry_cannot_be_rewritten(db_session) -> None:
+    actor = _curator(db_session)
+    bundle = _make_bundle(db_session, "AMFRZ")
+    _approve(db_session, bundle.transition_state_entry.id, actor)
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.atom_map.note = "second thoughts"
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.atom_map.equivalent_map_count = 4
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(bundle.atom_map)
+        db_session.flush()
+
+
+def test_pairs_of_approved_transition_state_entry_cannot_be_rewritten(db_session) -> None:
+    actor = _curator(db_session)
+    bundle = _make_bundle(db_session, "AMPAIR")
+    _approve(db_session, bundle.transition_state_entry.id, actor)
+
+    # A valid remap: atom 1 of the reactant becomes atom 2 of the saddle point.
+    # Every foreign key and unique constraint still holds; only the guard
+    # stands between this statement and a rewritten mechanism claim.
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.pair.ts_atom_index = 2
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(_second_pair(bundle))
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(bundle.pair)
+        db_session.flush()
+
+
+def test_new_map_cannot_be_attached_to_an_approved_transition_state_entry(db_session) -> None:
+    """Adding a claim to an accepted record changes what was accepted."""
+
+    actor = _curator(db_session)
+    bundle = _make_bundle(db_session, "AMLATE")
+    db_session.delete(bundle.pair)
+    db_session.delete(bundle.atom_map)
+    db_session.flush()
+    _approve(db_session, bundle.transition_state_entry.id, actor)
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(
+            ReactionAtomMap(
+                reaction_entry_id=bundle.transition_state.reaction_entry_id,
+                transition_state_entry_id=bundle.transition_state_entry.id,
+                transition_state_geometry_id=bundle.ts_geometry.id,
+                source=AtomMapSource.declared,
+            )
+        )
+        db_session.flush()
+
+
+def test_map_of_unapproved_transition_state_entry_stays_editable(db_session) -> None:
+    """The freeze is acceptance-triggered, not a write ban on the table."""
+
+    bundle = _make_bundle(db_session, "AMOPEN")
+
+    bundle.atom_map.note = "corrected before review"
+    bundle.atom_map.equivalent_map_count = 2
+    bundle.pair.ts_atom_index = 2
+    db_session.flush()
+
+    assert bundle.atom_map.note == "corrected before review"
+    assert bundle.pair.ts_atom_index == 2
+
+    # The saddle-point index the original pair vacated is free again, so the
+    # second leg can be completed in place.
+    extra = ReactionAtomMapPair(
+        atom_map_id=bundle.atom_map.id,
+        side=ReactionRole.reactant,
+        structure_participant_id=bundle.participant.id,
+        geometry_id=bundle.reactant_geometry.id,
+        atom_index=2,
+        transition_state_geometry_id=bundle.ts_geometry.id,
+        ts_atom_index=1,
+        element="H",
+        ts_element="H",
+    )
+    db_session.add(extra)
+    db_session.flush()
+
+    db_session.delete(extra)
+    db_session.flush()
+
+    stored = db_session.scalars(
+        select(ReactionAtomMapPair).where(ReactionAtomMapPair.atom_map_id == bundle.atom_map.id)
+    ).all()
+    assert [(row.atom_index, row.ts_atom_index) for row in stored] == [(1, 2)]
+
+
+def test_truncate_cannot_bypass_the_atom_map_guard(db_session) -> None:
+    for table in ("reaction_atom_map_pair", "reaction_atom_map"):
+        with pytest.raises(DBAPIError), db_session.begin_nested():
+            db_session.execute(text(f"TRUNCATE {table}"))
+
+
+def test_a_wrong_map_is_corrected_by_superseding_its_transition_state_entry(
+    client,
+    db_session,
+    login_as,
+    _api_curator_user,
+) -> None:
+    """The correction path, end to end through the curator route.
+
+    The wrong map stays exactly as deposited -- that is the point of the
+    freeze -- and the record that carries the right one is a new
+    ``transition_state_entry`` under the same ``transition_state``, joined to
+    the old one by a supersession edge.
+    """
+
+    curator = db_session.get(AppUser, _api_curator_user)
+    wrong = _make_bundle(db_session, "AMSUP")
+    _approve(db_session, wrong.transition_state_entry.id, curator)
+
+    replacement_entry = make_transition_state_entry(
+        db_session,
+        transition_state=wrong.transition_state,
+    )
+    corrected_map = ReactionAtomMap(
+        reaction_entry_id=wrong.transition_state.reaction_entry_id,
+        transition_state_entry_id=replacement_entry.id,
+        transition_state_geometry_id=wrong.ts_geometry.id,
+        source=AtomMapSource.declared,
+        note="reactant atom 1 becomes saddle-point atom 2, not atom 1",
+    )
+    db_session.add(corrected_map)
+    db_session.flush()
+    db_session.add(
+        ReactionAtomMapPair(
+            atom_map_id=corrected_map.id,
+            side=ReactionRole.reactant,
+            structure_participant_id=wrong.participant.id,
+            geometry_id=wrong.reactant_geometry.id,
+            atom_index=1,
+            transition_state_geometry_id=wrong.ts_geometry.id,
+            ts_atom_index=2,
+            element="H",
+            ts_element="H",
+        )
+    )
+    db_session.flush()
+    _approve(db_session, replacement_entry.id, curator)
+
+    login_as(_api_curator_user)
+    response = client.post(
+        "/api/v1/curation/scientific-record-supersessions",
+        json={
+            "record_type": SubmissionRecordType.transition_state_entry.value,
+            "superseded_record_id": wrong.transition_state_entry.id,
+            "superseding_record_id": replacement_entry.id,
+            "reason": "the declared atom map identified the wrong saddle-point atom",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["record_type"] == SubmissionRecordType.transition_state_entry.value
+    assert body["superseded_record_id"] == wrong.transition_state_entry.id
+    assert body["superseding_record_id"] == replacement_entry.id
+
+    edge = db_session.scalars(
+        select(ScientificRecordSupersession).where(ScientificRecordSupersession.id == body["id"])
+    ).one()
+    assert edge.superseding_record_id == replacement_entry.id
+
+    superseding_entry = db_session.scalars(
+        select(TransitionStateEntry).where(TransitionStateEntry.id == edge.superseding_record_id)
+    ).one()
+    assert [pair.ts_atom_index for pair in superseding_entry.atom_maps[0].pairs] == [2]
+
+    # The superseded claim is preserved verbatim rather than repaired.
+    db_session.expire(wrong.atom_map)
+    assert wrong.atom_map.note is None
+    assert [pair.ts_atom_index for pair in wrong.atom_map.pairs] == [1]
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        wrong.atom_map.note = "still frozen after supersession"
+        db_session.flush()
+
+    assert (
+        db_session.scalars(select(TransitionState).where(TransitionState.id == wrong.transition_state.id)).one().id
+        == superseding_entry.transition_state_id
+    )


### PR DESCRIPTION
`c6f2a9d4e7b1` made accepted scientific records immutable in the database: once a `record_review` row for a supported root has ever reached `approved`, the root and the rows carrying its scientific meaning can no longer be updated, deleted, or added to, and corrections go through `scientific_record_supersession` instead of through mutation. Seventy tables live under that rule.

`d3a7f1c9b284` added `reaction_atom_map` and `reaction_atom_map_pair` after it shipped, and did not join it. Neither table carried a `trg_as_*` trigger. So a declared atom map — a depositor's statement about which atom of the reactants is which atom of the saddle point, which ADR 0011 frames as a claim they are answerable for — was rewritable in place under an accepted transition state, with no supersession edge and no review event, while `calc_freq_mode` beside it could not be touched. That reads as an oversight rather than a considered exemption.

## Which acceptance freezes a map

`transition_state_entry`.

A map names three things: a `reaction_entry`, a `transition_state_entry`, and the `geometry` both legs index into.

- **`transition_state_entry`** is the only accepted-science root among them. It is `NOT NULL` on every map, and one TS entry determines exactly one reaction entry (`transition_state_entry -> transition_state -> reaction_entry`), so nothing unrelated can freeze a map by being approved. Scientifically it is the same claim: approving a TS entry asserts that this saddle point connects the declared reactants and products, and ADR 0011 says the atom map is what "converts that assertion into something a reader can check". The map is not adjacent to that assertion — it is its content.
- **`reaction_entry`** is not an accepted-science root at all. `tckdb_is_accepted_science_type` does not admit it and `tckdb_lock_scientific_record` has no branch for it, so a guard hung there would raise `22023` instead of protecting anything. Making it a root is a change to the whole regime, not to atom maps.
- **The transition-state `geometry`, via its calculation**, would freeze a map when a calculation that merely shares the geometry is approved — acceptance of something unrelated. The geometry's own immutability is already `tckdb_guard_calculation_geometry`'s job, and that is a different question: whether the coordinates may move, not whether the map over them may be rewritten.

## What the migration does

Pure DDL, no `UPDATE`. `reaction_atom_map` gets `tckdb_guard_accepted_child('transition_state_entry', 'transition_state_entry_id')`; `reaction_atom_map_pair`, which names no TS entry of its own, gets `tckdb_guard_accepted_via_child` through the map it belongs to. Both get the statement-level `TRUNCATE` refusal the rest of the regime carries. No existing trigger is disabled, weakened, or worked around.

Insertion is guarded as well as update and delete, which is what `tckdb_guard_accepted_child` does everywhere else: attaching a mechanism claim to a record reviewers already accepted without one changes what was accepted. Neither live write path can hit that — `computed_reaction.py` and `network_pdep.py` both create a fresh `TransitionStateEntry` in the same transaction as the map, and a row that does not exist yet cannot have been approved — so this is a guard against the `psql` prompt and the next write path, exactly as `e7d1c4b8a3f5` argued for its own.

It also replaces `e7d1c4b8a3f5`'s source-immutability function to correct the operator hint. That function told an operator to "delete it and deposit the real one", which stops being true the moment the freeze lands; same condition, same error, corrected `HINT`, and `downgrade()` restores the original text verbatim (asserted identical to `e7d1c4b8a3f5._FUNCTION_SQL` at import).

`downgrade()` drops the four triggers and destroys nothing — unlike `d3a7f1c9b284`'s, which refuses while any map exists, because no map is read, written, or removed here.

## The correction path

`transition_state_entry` is already in `ck_scientific_record_supersession_supported_type` and in `app.services.accepted_science.supersession_subject`, so nothing had to be added: a wrong map is corrected by depositing a new TS entry under the same `transition_state` carrying the right one, approving it, and posting a `transition_state_entry` supersession. `test_a_wrong_map_is_corrected_by_superseding_its_transition_state_entry` walks that end to end through `POST /api/v1/curation/scientific-record-supersessions` and asserts the superseded map is preserved verbatim rather than repaired.

## Proving the guard fires

`backend/tests/db/test_atom_map_immutability.py` pins both halves — an approved TS entry makes its map and pairs refuse update, delete, extension and creation; an unapproved one leaves them fully editable, so the freeze is acceptance-triggered rather than a blanket write ban. The pair test performs a *valid* remap (reactant atom 1 -> saddle-point atom 2, every foreign key and unique constraint satisfied), so only the guard can refuse it.

Mutation-checked, three times, each against the whole complement gate. Removing a guard from *both* the registry and the DDL — the silent removal the registry parity test cannot catch by construction, since it derives `expected` from the same registry — is detected only by the behavioural tests, and it is:

| mutation | result |
|---|---|
| baseline | 3870 passed, 14 skipped |
| `reaction_atom_map` child guard removed | **3 failed**, 3867 passed |
| `reaction_atom_map_pair` via guard removed | **1 failed**, 3869 passed |
| both `TRUNCATE` guards removed | **1 failed**, 3869 passed |

Every failure is in `tests/db/test_atom_map_immutability.py` and nothing else moves. The map test deletes its pair before approving so all three of its statements reach the map's own guard — with the pair still attached, a map delete would cascade into it and be refused by the *pair* guard, leaving the test green with the map's trigger missing entirely.

`tests/db/test_accepted_science_trigger_registry.py` is extended to cover the new registry, still asserts set equality against `pg_trigger`, and additionally checks that every record type a new guard names is one `tckdb_lock_scientific_record` can actually lock (a guard naming an unsupported type raises `22023` instead of protecting anything, and would only surface on the first guarded write).

## Verification

- `scripts/test-rest.sh`: 3870 passed, 14 skipped
- `scripts/test-api.sh`: 2543 passed (matches the `43f25cff` baseline)
- `alembic upgrade head` -> `downgrade -1` -> `upgrade head` on a scratch `tckdb_test_*` database; `alembic check` reports no drift
- Pre-state confirmed by querying `pg_trigger` directly: zero `trg_as_*` triggers on either table before this revision, 70 tables carrying them
