### PR TITLE
Stop reading programs from stdin, and evict the nightly from the harness's namespace

### DIFF
--- a/.github/workflows/backend-nightly.yml
+++ b/.github/workflows/backend-nightly.yml
@@ -38,11 +38,11 @@ jobs:
         env:
           POSTGRES_USER: tckdb
           POSTGRES_PASSWORD: tckdb
-          POSTGRES_DB: tckdb_test_ci
+          POSTGRES_DB: tckdb_nightly_ci
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U tckdb -d tckdb_test_ci"
+          --health-cmd "pg_isready -U tckdb -d tckdb_nightly_ci"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
@@ -75,7 +75,18 @@ jobs:
       # PR (#64 cause 2, #92). Nothing should migrate this name. If a test
       # starts needing it migrated, that test is coupled to something no
       # fixture owns, and the fix belongs in the test.
-      DB_NAME: tckdb_test_ci
+      #
+      # `tckdb_nightly_ci`, not `tckdb_test_ci`: the `tckdb_test%` namespace
+      # belongs to the harness, and everything in it is by definition something
+      # a reclaimer may drop. This job's ambient database was inside it and was
+      # therefore reclaimable -- defended by naming it in the reclaim script's
+      # PROTECTED set (#126), which fixes this one name and leaves the class.
+      # A long-lived database that no fixture owns has no business in the
+      # harness's namespace at all, so it left, and PROTECTED lost its only
+      # non-obvious entry. See backend/scripts/dev/reclaim_leaked_test_databases.py.
+      # DB_TEST_NAME below stays inside `tckdb_test` on purpose: that one *is*
+      # the harness's, and must be reclaimable.
+      DB_NAME: tckdb_nightly_ci
       DB_CLIENT_ENCODING: utf8
       DB_TEST_NAME: tckdb_test_${{ github.run_id }}_${{ github.run_attempt }}
       # See the note in backend-ci.yml: 4 vCPUs on a standard runner, and each

--- a/backend/scripts/dev/reclaim_leaked_test_databases.py
+++ b/backend/scripts/dev/reclaim_leaked_test_databases.py
@@ -86,6 +86,17 @@ import psycopg
 
 # Databases that must never be dropped, whatever a manifest says.  Belt and
 # braces on top of the name pattern below.
+#
+# Every entry here is a name the pattern *cannot* match, which is the only
+# shape an exception list should ever have.  It briefly held one that could:
+# ``tckdb_test_ci``, the nightly job's ambient ``DB_NAME``, which sat inside
+# ``tckdb_test%`` and so was a genuine reclaim candidate on a self-hosted
+# runner.  Naming it here made that one database safe and left the class
+# behind -- the next long-lived database someone parks in the harness's
+# namespace is reclaimable again, and nothing says so until it is gone.  The
+# nightly's database was renamed to ``tckdb_nightly_ci`` instead, putting it
+# outside the namespace the reclaimers own, and the entry was removed.
+# ``backend/tests/test_scratch_database_names.py`` asserts that it stays out.
 PROTECTED = frozenset(
     {
         "postgres",
@@ -94,13 +105,6 @@ PROTECTED = frozenset(
         "tckdb",
         "tckdb_dev",
         "tckdb_prod",
-        # Not created by the harness and never carries its marker, so the
-        # in-process sweep leaves it alone -- but this script does not read
-        # markers, and the name is inside ``tckdb_test%``. It is the
-        # ``DB_NAME`` of the nightly CI job
-        # (``.github/workflows/backend-nightly.yml``), so on a self-hosted
-        # runner ``plan`` would otherwise offer up the job's own database.
-        "tckdb_test_ci",
     }
 )
 

--- a/backend/scripts/tckdb_auth.sh
+++ b/backend/scripts/tckdb_auth.sh
@@ -71,13 +71,27 @@ print_json() {
     fi
 }
 
-# Extract a string field from JSON on stdin, trying several common names.
-# Prints the first non-empty value found, or nothing if none match.
+# Extract a string field from the JSON document in $1, trying several common
+# names. Prints the first non-empty value found, or nothing if none match.
+#
+# The document arrives as an *argument*, never on stdin. This used to be
+#
+#     extract_api_key() { python3 - <<'PY' ... PY ; }
+#     api_key="$(printf '%s' "$response" | extract_api_key)"
+#
+# and a heredoc *is* the process's stdin, so the pipe was discarded outright:
+# `json.load(sys.stdin)` read EOF, raised, and the function returned empty for
+# every input. `create-key` therefore could not succeed on any response at all,
+# and reported "could not find an API key field" -- a diagnosis pointing at the
+# server for a bug in this file. Same shape as the CI heredocs in #93, where
+# `conda run` ate stdin instead of a heredoc: something upstream consumes the
+# stream, the program runs on nothing, and the failure names the wrong culprit.
+# Passing the payload by argv leaves no stdin for anything to eat.
 extract_api_key() {
-    python3 - <<'PY'
+    python3 -c '
 import json, sys
 try:
-    data = json.load(sys.stdin)
+    data = json.loads(sys.argv[1])
 except Exception:
     sys.exit(0)
 if not isinstance(data, dict):
@@ -87,7 +101,7 @@ for field in ("key", "api_key", "token", "plain_key", "secret"):
     if isinstance(value, str) and value:
         print(value)
         break
-PY
+' "$1"
 }
 
 # Mask "abcdef…wxyz" — never log the full key.
@@ -180,7 +194,7 @@ cmd_create_key() {
     }
 
     local api_key
-    api_key="$(printf '%s' "$response" | extract_api_key)"
+    api_key="$(extract_api_key "$response")"
     if [[ -z "$api_key" ]]; then
         echo "error: could not find an API key field in the response." >&2
         echo "tried fields: key, api_key, token, plain_key, secret" >&2

--- a/backend/tests/scripts/test_stdin_is_not_swallowed.py
+++ b/backend/tests/scripts/test_stdin_is_not_swallowed.py
@@ -1,0 +1,296 @@
+"""No script may take its program from stdin, and one that did is proved fixed.
+
+The defect
+----------
+``conda run`` does not forward the calling shell's stdin to the process it
+spawns. So::
+
+    conda run -n tckdb_env python - <<'PY'
+    ...
+    PY
+
+hands ``python`` an empty stdin: it reads EOF, executes nothing, and exits 0.
+The step runs, prints nothing, and is reported green. ``Initialize artifact
+bucket`` in both backend workflows was written that way and had therefore
+never provisioned a bucket on any green run (#93, fixed in #125).
+
+The same shape does not need ``conda run`` to appear. A heredoc *is* the
+process's stdin, so any program read from a heredoc has already consumed the
+stream that something else was relying on. ``tckdb_auth.sh``'s
+``extract_api_key`` was ``python3 - <<'PY'`` fed by ``printf ... | ...``: the
+pipe was discarded, ``json.load(sys.stdin)`` read EOF, and ``create-key``
+failed on every valid response while blaming the server for it.
+
+The rule
+--------
+A program is passed by path (write it to a file and run the file) or by
+``-c``. Never by stdin. That removes the whole class rather than the two
+instances of it, and it is cheap: both fixes were three lines.
+
+The second half of the rule is that such a step must **print something
+specific**, so that "did nothing" and "did the thing" stop looking alike. The
+workflows print ``created artifact bucket: <name>`` -- where the word
+``created``, rather than ``already present``, is itself the evidence the
+bucket had not existed. ``tckdb_auth.sh`` prints the masked key it minted.
+
+This file enforces the first half by scanning, and proves the second half by
+running the fixed script for real and reading what it printed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_ROOT.parent
+TCKDB_AUTH = BACKEND_ROOT / "scripts" / "tckdb_auth.sh"
+
+#: An interpreter told to read its program from stdin (``python -``), with the
+#: program supplied by a heredoc or by whatever the caller happened to leave on
+#: the stream. Both halves of the failure live here: the wrapper that eats
+#: stdin, and the heredoc that eats it.
+_PROGRAM_FROM_STDIN = re.compile(r"\b(?:python3?|bash|sh)\s+-\s*(?:<<|$)")
+
+#: Backtick-quoted spans are prose *about* the defect -- the comments in the
+#: workflows quote the broken form on purpose so the next reader knows what not
+#: to write. Quoting it is not doing it.
+_BACKTICKED = re.compile(r"`[^`]*`")
+
+_SCANNED_SUFFIXES = {".sh", ".yml", ".yaml", ".md", ".py"}
+_SCANNED_NAMES = {"Makefile"}
+
+#: This file names the form in order to forbid it.
+_EXEMPT = {Path(__file__).resolve().relative_to(REPO_ROOT)}
+
+
+def _tracked_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [Path(name) for name in out.split("\0") if name]
+
+
+def _scannable(rel: Path) -> bool:
+    if rel in _EXEMPT:
+        return False
+    return rel.suffix in _SCANNED_SUFFIXES or rel.name in _SCANNED_NAMES
+
+
+def _offending_lines(text: str) -> list[tuple[int, str]]:
+    hits = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.lstrip()
+        if stripped.startswith("#") or stripped.startswith("//"):
+            continue
+        if _PROGRAM_FROM_STDIN.search(_BACKTICKED.sub("", raw)):
+            hits.append((lineno, raw.strip()))
+    return hits
+
+
+def test_the_scan_covers_the_files_that_could_carry_the_defect() -> None:
+    """A scan that matches no files would pass forever.
+
+    Pinned to floors rather than exact counts so adding a script does not fail
+    this for the wrong reason -- the per-file check below is what judges.
+    """
+    scanned = [rel for rel in _tracked_files() if _scannable(rel)]
+    workflows = [rel for rel in scanned if rel.parts[:2] == (".github", "workflows")]
+    shell = [rel for rel in scanned if rel.suffix == ".sh"]
+
+    assert len(workflows) >= 5, f"expected the workflows to be scanned, saw {workflows}"
+    assert len(shell) >= 10, f"expected the shell scripts to be scanned, saw {len(shell)}"
+
+
+def test_the_scan_recognises_the_forms_that_actually_shipped() -> None:
+    """A pattern that matches nothing real would make the check decorative.
+
+    These are the two lines this repository actually shipped -- the workflow
+    step that provisioned no bucket, and the shell function that discarded its
+    input -- plus the shapes a fix must be allowed to keep.
+    """
+    shipped = [
+        "          conda run -n tckdb_env python - <<'PY'",
+        "    python3 - <<'PY'",
+    ]
+    for line in shipped:
+        assert _offending_lines(line), f"scan missed a form that shipped: {line}"
+
+    allowed = [
+        '          conda run -n tckdb_env python "${RUNNER_TEMP}/init_artifact_bucket.py"',
+        "    python3 -c 'import json' \"$1\"",
+        "        shell: bash -el {0}",
+        "          conda run -n tckdb_env python -m pip install --upgrade pip",
+        "TCKDB_CCCBDB_LIVE_TESTS=1 conda run -n tckdb_env \\",
+        "# NOT piped as `conda run python - <<'PY'`, which runs nothing",
+    ]
+    for line in allowed:
+        assert not _offending_lines(line), f"scan false-positived on: {line}"
+
+
+def test_no_script_reads_its_program_from_stdin() -> None:
+    """Write the program to a file and run it by path, or use ``-c``.
+
+    A heredoc or a stdin-eating wrapper turns "ran and did nothing" into an
+    exit status of 0, which no reviewer and no CI badge can tell from success.
+    """
+    offenders: list[str] = []
+    for rel in _tracked_files():
+        if not _scannable(rel):
+            continue
+        path = REPO_ROOT / rel
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in _offending_lines(text):
+            offenders.append(f"{rel}:{lineno}: {line}")
+
+    assert offenders == [], (
+        "a program is being read from stdin, which silently executes nothing "
+        "whenever anything upstream has consumed the stream:\n  "
+        + "\n  ".join(offenders)
+        + "\nWrite the program to a file and run it by path, or pass it with -c."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The script that carried the defect, exercised as a real process
+# ---------------------------------------------------------------------------
+
+
+class _AuthStub:
+    """A stand-in for /auth/api-keys that answers with a chosen body."""
+
+    def __init__(self, body: object, code: int = 200) -> None:
+        self.body = json.dumps(body).encode("utf-8")
+        self.code = code
+        self.requests: list[str] = []
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(length)
+                stub.requests.append(self.path)
+                self.send_response(stub.code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(stub.body)))
+                self.end_headers()
+                self.wfile.write(stub.body)
+
+            def log_message(self, *args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _AuthStub:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}/api/v1"
+
+
+def _run_create_key(stub: _AuthStub, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    if shutil.which("curl") is None:
+        # Not a skip. A skipped test is silence, and silence reading as
+        # success is the entire subject of this file.
+        pytest.fail("curl is not installed, so tckdb_auth.sh cannot be exercised")
+
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.write_text("# Netscape HTTP Cookie File\n", encoding="utf-8")
+    return subprocess.run(
+        ["bash", str(TCKDB_AUTH), "create-key", "--name", "regression"],
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(tmp_path),
+            "TCKDB_BASE_URL": stub.base_url,
+            "TCKDB_COOKIE_FILE": str(cookie_file),
+            "TCKDB_AUTH_ENV_FILE": str(tmp_path / "auth.env"),
+        },
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_create_key_extracts_the_key_the_server_returned(tmp_path: Path) -> None:
+    """The regression proper: this path could not succeed for any response.
+
+    ``extract_api_key`` read its program from a heredoc, so the piped response
+    never reached it and the function returned empty every time. The failure
+    surfaced as "could not find an API key field in the response", which points
+    at the server. Asserting on the *minted key file* rather than on an exit
+    status is what makes this non-vacuous -- the old code also exited, just
+    with the wrong status and the wrong story.
+    """
+    with _AuthStub({"key": "tckdb_sk_regression_value"}) as stub:
+        proc = _run_create_key(stub, tmp_path)
+
+    assert proc.returncode == 0, f"create-key failed:\n{proc.stdout}\n{proc.stderr}"
+    assert stub.requests == ["/api/v1/auth/api-keys"]
+
+    env_file = tmp_path / "auth.env"
+    assert env_file.exists(), "create-key reported success but wrote no env file"
+    assert "export TCKDB_API_KEY='tckdb_sk_regression_value'" in env_file.read_text(
+        encoding="utf-8"
+    )
+
+    # The second half of the rule: the step says what it did, and says enough
+    # of it to be checkable. The full key is never printed.
+    assert "API key minted" in proc.stdout
+    assert "tckdb_sk_regression_value" not in proc.stdout
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["key", "api_key", "token", "plain_key", "secret"],
+)
+def test_create_key_accepts_every_field_name_it_claims_to_try(
+    field: str, tmp_path: Path
+) -> None:
+    """The error message lists five field names; all five must actually work.
+
+    While the function was dead, that list was advertising capability the code
+    did not have for any of its entries.
+    """
+    with _AuthStub({field: f"value_via_{field}"}) as stub:
+        proc = _run_create_key(stub, tmp_path)
+
+    assert proc.returncode == 0, f"{field}: {proc.stdout}\n{proc.stderr}"
+    assert f"export TCKDB_API_KEY='value_via_{field}'" in (tmp_path / "auth.env").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_create_key_still_refuses_a_response_that_carries_no_key(tmp_path: Path) -> None:
+    """The honest failure must survive the fix.
+
+    A fix that made the extractor return something for every input would pass
+    the test above and break this one, which is the point of keeping both.
+    """
+    with _AuthStub({"id": 7, "label": "regression"}) as stub:
+        proc = _run_create_key(stub, tmp_path)
+
+    assert proc.returncode != 0
+    assert "could not find an API key field" in proc.stderr
+    assert not (tmp_path / "auth.env").exists()

--- a/backend/tests/test_scratch_database_names.py
+++ b/backend/tests/test_scratch_database_names.py
@@ -171,28 +171,65 @@ def _reclaim_script_pattern() -> re.Pattern[str]:
     return re.compile(match.group(1))
 
 
-def test_the_nightly_job_database_is_protected_from_the_reclaim_script() -> None:
-    """``tckdb_test_ci`` is a CI ``DB_NAME``, not a harness database.
+def _nightly_workflow_source() -> str:
+    return (
+        BACKEND_ROOT.parent / ".github" / "workflows" / "backend-nightly.yml"
+    ).read_text(encoding="utf-8")
 
-    The in-process sweep is safe from it by construction — no harness marker,
-    no reclaim. This script reads no markers, and the name sits inside
-    ``tckdb_test%``, so on a self-hosted runner ``plan`` would list the
-    nightly job's own database as a candidate.
+
+def test_the_nightly_ambient_database_is_outside_the_reclaimable_namespace() -> None:
+    """``tckdb_test%`` is the harness's namespace; nothing long-lived may sit in it.
+
+    The nightly job's ambient ``DB_NAME`` used to be ``tckdb_test_ci``, which
+    the reclaim script's pattern matches — so on a self-hosted runner ``plan``
+    would list the running job's own database as a candidate. That was first
+    fixed by naming it in ``PROTECTED``, which makes one name safe and leaves
+    the class: the next database parked in the namespace is reclaimable again,
+    and nothing complains until it is gone.
+
+    This asserts the class is closed instead: whatever the nightly calls its
+    ambient database, the reclaimers must be unable to see it *by pattern*,
+    with no exception entry involved. The name is read out of the workflow
+    rather than hardcoded, so renaming it again cannot make this vacuous.
+    """
+    workflow = _nightly_workflow_source()
+    match = re.search(r"^\s*DB_NAME:\s*(\S+)\s*$", workflow, re.MULTILINE)
+    assert match is not None, "backend-nightly.yml no longer declares a DB_NAME"
+    db_name = match.group(1)
+
+    assert _reclaim_script_pattern().fullmatch(db_name) is None, (
+        f"the nightly job's ambient database {db_name!r} is inside the "
+        "harness's reclaimable namespace; rename it outside 'tckdb_test' "
+        "rather than adding it to PROTECTED"
+    )
+    assert conftest._TEST_DATABASE_NAME.fullmatch(db_name) is None, (
+        f"the nightly job's ambient database {db_name!r} is inside the "
+        "in-process sweep's namespace"
+    )
+
+
+def test_protected_holds_only_names_the_pattern_cannot_match() -> None:
+    """``PROTECTED`` is belt-and-braces, not a place to park exceptions.
+
+    An entry the pattern *can* match means some database is safe only because
+    someone remembered to write it down — the failure mode #96 came from. Such
+    an entry is a signal to rename the database, not to lengthen this list.
     """
     source = (
         BACKEND_ROOT / "scripts" / "dev" / "reclaim_leaked_test_databases.py"
     ).read_text(encoding="utf-8")
-    protected = re.search(r"PROTECTED = frozenset\((.*?)\n\)", source, re.DOTALL)
+    protected = re.search(r"^PROTECTED = frozenset\((.*?)^\)", source, re.DOTALL | re.MULTILINE)
+    assert protected is not None, "could not locate PROTECTED in the reclaim script"
 
-    assert protected is not None
-    assert '"tckdb_test_ci"' in protected.group(1)
+    names = re.findall(r'"([^"]+)"', protected.group(1))
+    assert names, "PROTECTED parsed as empty; the regex above has drifted"
 
-    workflow = (
-        BACKEND_ROOT.parent / ".github" / "workflows" / "backend-nightly.yml"
-    ).read_text(encoding="utf-8")
-    # Non-vacuous: the protection is only worth anything while the nightly
-    # actually uses this name.
-    assert "DB_NAME: tckdb_test_ci" in workflow
+    pattern = _reclaim_script_pattern()
+    parked = [name for name in names if pattern.fullmatch(name) is not None]
+    assert parked == [], (
+        f"PROTECTED entries {parked} are inside the reclaimable name pattern. "
+        "Rename those databases outside 'tckdb_test' instead of excepting them."
+    )
 
 
 def test_both_reclaimers_use_the_same_name_pattern() -> None:

--- a/backend/tests/test_scratch_database_names.py
+++ b/backend/tests/test_scratch_database_names.py
@@ -193,19 +193,21 @@ def test_the_nightly_ambient_database_is_outside_the_reclaimable_namespace() -> 
     rather than hardcoded, so renaming it again cannot make this vacuous.
     """
     workflow = _nightly_workflow_source()
-    match = re.search(r"^\s*DB_NAME:\s*(\S+)\s*$", workflow, re.MULTILINE)
-    assert match is not None, "backend-nightly.yml no longer declares a DB_NAME"
-    db_name = match.group(1)
+    # ``findall``, not ``search``: a later step-level override would otherwise
+    # be checked by nobody while the job-level name kept this passing.
+    declared = re.findall(r"^\s*(?:DB_NAME|POSTGRES_DB):\s*(\S+)\s*$", workflow, re.MULTILINE)
+    assert declared, "backend-nightly.yml no longer declares an ambient database name"
 
-    assert _reclaim_script_pattern().fullmatch(db_name) is None, (
-        f"the nightly job's ambient database {db_name!r} is inside the "
-        "harness's reclaimable namespace; rename it outside 'tckdb_test' "
-        "rather than adding it to PROTECTED"
-    )
-    assert conftest._TEST_DATABASE_NAME.fullmatch(db_name) is None, (
-        f"the nightly job's ambient database {db_name!r} is inside the "
-        "in-process sweep's namespace"
-    )
+    for db_name in declared:
+        assert _reclaim_script_pattern().fullmatch(db_name) is None, (
+            f"the nightly job's ambient database {db_name!r} is inside the "
+            "harness's reclaimable namespace; rename it outside 'tckdb_test' "
+            "rather than adding it to PROTECTED"
+        )
+        assert conftest._TEST_DATABASE_NAME.fullmatch(db_name) is None, (
+            f"the nightly job's ambient database {db_name!r} is inside the "
+            "in-process sweep's namespace"
+        )
 
 
 def test_protected_holds_only_names_the_pattern_cannot_match() -> None:


### PR DESCRIPTION
Closes #93. Closes #96.

## #93 - the sweep, and the one live instance it found

`conda run` does not forward the calling shell's stdin. `conda run -n tckdb_env python - <<'PY'` therefore hands `python` an empty stream: it reads EOF, executes nothing, and exits 0. #125 fixed the two `Initialize artifact bucket` steps written that way, which had never provisioned a bucket on any green run. This is the sweep for the rest.

Verified on this machine before writing anything:

```
$ conda run -n tckdb_env python - <<'PY'
print("THIS LINE NEVER APPEARS")
PY
exit=0                      # and no output at all

$ conda run -n tckdb_env python proof.py
created artifact bucket: proof-bucket
exit=0
```

The second half matters as much as the first: `conda run` *does* forward stdout, so #125's "print what you did" is a real signal and not decoration.

**The sweep found one more instance, and it is not a CI step.** `backend/scripts/tckdb_auth.sh:77`:

```bash
extract_api_key() { python3 - <<'PY' ... json.load(sys.stdin) ... PY ; }
api_key="$(printf '%s' "$response" | extract_api_key)"
```

A heredoc *is* the process's stdin, so the pipe was discarded outright and `json.load(sys.stdin)` read EOF. `conda run` is not required for the defect - it is one of several things that can eat the stream. The function returned empty for **every** input, so `create-key` and `login-create-key` could not succeed against any response at all, and failed with

> error: could not find an API key field in the response.

which points at the server for a bug in this file. Confirmed dead against a valid response before the change and live after it. The payload now travels by argv, where nothing upstream can eat it.

Nothing in `.github/workflows/`, the `Makefile`, `backend/scripts/**` (outside the above), or any committed doc or runbook carries the form. The only remaining textual hits are the comments in the two workflows that quote the broken form in order to warn about it, and `backend/scripts/validation/arkane_statmech_roundtrip.py:428`, which already passes its payload by path and says why.

### Durable fixes

Both of the ones the issue asked for, plus enforcement:

1. **Program by path or by `-c`, never by stdin.** `tests/scripts/test_stdin_is_not_swallowed.py` scans every tracked script, workflow, Makefile and doc for an interpreter told to read its program from stdin, ignoring backticked prose and comments so the warnings in the workflows stay legal. The scan is itself checked against the two lines this repo actually shipped, and against the shapes a fix must be allowed to keep (`python -m pip`, `bash -el {0}`, run-by-path), so it cannot quietly stop matching.
2. **Say what you did.** The same file runs `tckdb_auth.sh create-key` as a real process against a stub server and asserts on the key it writes out - not on an exit status, because the old code also exited, just with the wrong status and the wrong story. A complementary test asserts a keyless response *still* fails, so a fix that returned something for every input would not pass both.

## #96 - the nightly's database leaves the namespace it was borrowing

`backend-nightly.yml` set `DB_NAME: tckdb_test_ci`, inside the `tckdb_test%` namespace that the in-process sweeper and `reclaim_leaked_test_databases.py` both treat as reclaimable. #126 defended it by adding the name to `PROTECTED`. That makes one database safe and leaves the class behind: the next long-lived database parked in the harness's namespace is reclaimable again, and nothing says so until it is gone.

It is now `tckdb_nightly_ci` - outside the namespace by construction - and `PROTECTED` is back to holding only names its own pattern cannot match. `DB_TEST_NAME` stays inside `tckdb_test` on purpose: that one *is* the harness's, and must be reclaimable.

Proved against a real Postgres rather than asserted:

```
$ createdb tckdb_nightly_ci ; createdb tckdb_test_c93_leftover
$ python backend/scripts/dev/reclaim_leaked_test_databases.py plan --output m.tsv
Wrote 3 candidate(s) ...
$ cat m.tsv
tckdb_test
tckdb_test_b97mig
tckdb_test_c93_leftover     <- reclaimer still works
                            <- tckdb_nightly_ci is absent
```

Two tests replace the one name-by-name guard, and both are stronger than it was: the nightly's `DB_NAME` is read out of the workflow (so renaming it again cannot make the check vacuous) and asserted unmatched by *both* reclaimers' patterns; and `PROTECTED` is asserted to contain no entry that its own pattern can match, so the next attempt to park an exception there fails with instructions to rename instead.

Everything that referenced the old name: `POSTGRES_DB`, the service health-cmd, and `DB_NAME` in `backend-nightly.yml`; the `PROTECTED` entry; and the guard test. `tests/test_db_name_resolution.py` uses the unrelated literal `tckdb_test_ci_job_42` as a `DB_TEST_NAME` fixture value, which must stay inside `tckdb_test` and is left alone.

## Verification

- `bash scripts/test-rest.sh` - **3917 passed, 14 skipped** (baseline at `7511b690`: 3906; +10 new guards, +1 net from replacing one guard test with two).
- `bash scripts/test-api.sh` - green.
- `ruff check app tests scripts` and `python scripts/check_runtime_ascii.py` clean, run from `backend/`.
- All eight workflow YAMLs re-parse.

## Follow-ups (not in this PR)

- `backend/scripts/dev_login.sh` has no CI coverage of any kind - it is not in the `Hygiene checks` `bash -n` list at `.github/workflows/backend-ci.yml:174`, and no test runs it. It mints credentials against the same `/auth` endpoints `tckdb_auth.sh` does, and `tckdb_auth.sh` is how we found out that being unexercised is not the same as being correct.
- `backend/tests/test_db_name_resolution.py:50` still uses `tckdb_test_ci_job_42`, an echo of the old nightly name in an unrelated role. Cosmetic.
