### PR TITLE
Freeze the evidence behind an accepted saddle point, and say what its indices count into

### DIFF
--- a/backend/alembic/versions/a1f6c3e9b527_freeze_evidence_under_accepted_roots.py
+++ b/backend/alembic/versions/a1f6c3e9b527_freeze_evidence_under_accepted_roots.py
@@ -1,0 +1,188 @@
+"""Close the accepted-science immutability gap on five evidence tables.
+
+``c6f2a9d4e7b1`` made every accepted scientific record immutable in the
+database, and ``b6c1f4a8e703`` extended that regime to the atom-map tables
+``d3a7f1c9b284`` had added after it. Both left an asymmetry standing.
+
+An atom map *elaborates* the claim that a saddle point connects its declared
+endpoints; ``transition_state_validation_evidence`` is the IRC record that
+*backs* the same claim, and
+``app.services.reaction_atom_map.validate_atom_map_agrees_with_irc_evidence``
+holds the two against each other. After ``b6c1f4a8e703`` the elaboration was
+frozen once its transition-state entry was approved while the evidence stayed
+editable in place — so the check comparing them could be satisfied at deposit
+and then quietly falsified afterwards by rewriting the half that was still
+writable, with no supersession edge and no review event. Two surfaces bearing
+one claim under two mutability regimes is not a position either can defend.
+
+Four more tables are in the same class: an ownership foreign key to an
+accepted-science root, carrying result-grade content, and no ``trg_as_*``
+guard. They are frozen here as one batch because the argument is identical for
+all five and splitting it would leave the same asymmetry behind under a
+different name.
+
+Which acceptance freezes each table
+-----------------------------------
+The rule ``c6f2a9d4e7b1`` set is that a child is guarded by the accepted root
+that owns its *scientific meaning*, and that cross-domain provenance foreign
+keys are not ownership. Applying it:
+
+``transition_state_validation_evidence`` → **transition_state_entry**, via
+``transition_state_entry_id``. It is ``NOT NULL``, and the row is exactly the
+evidence for that entry's saddle point: ``uq_ts_validation_evidence_kind``
+makes it at most one IRC record *per entry*. Its other root reference,
+``reconstruction_calculation_id``, is provenance — the calculation the path
+was reconstructed by. Guarding on that would freeze the evidence when an IRC
+calculation is approved, which is acceptance of the *input*, and would leave
+it thawed when the entry the evidence is about is approved, which is the case
+that matters. Approving a TS entry is precisely the act of accepting "this
+saddle point connects these endpoints"; this table holds what that acceptance
+rested on.
+
+``network_solve_channel_barrier`` and ``network_solve_state_energy`` →
+**network_solve**, via ``solve_id``. Both are ``NOT NULL`` and part of each
+table's primary key. These are the barriers and state energies a solve was
+*run with*: change one after the fact and the stored ``network_kinetics``
+k(T,P) no longer follows from the inputs recorded beside it, while
+``network_kinetics`` and its Chebyshev/PLOG children are already frozen by
+this same root. Freezing the outputs of a solve and not its inputs makes the
+solve unreproducible in exactly the way the regime exists to prevent. Their
+``transition_state_entry_id``, ``channel_id``, ``reaction_entry_id`` and
+``state_id`` references identify *which* path or well a number belongs to and
+are not ownership; ``source_calculation_id`` is provenance, and is excluded
+for the same reason ``thermo_source_calculation.calculation_id`` is.
+
+``kinetics_interpretation_assignment`` and
+``kinetics_tunneling_application`` → **kinetics**, via ``kinetics_id``. Both
+are ``NOT NULL`` and part of the primary key, and both sit beside
+``kinetics_arrhenius_entry`` and ``kinetics_plog``, which ``c6f2a9d4e7b1``
+already froze under this root. The assignment names the exact statistical-
+mechanics interpretation and conventions a rate was computed under, and the
+tunneling row names the correction applied to it — rewrite either and the
+stored rate constant stops being the number those inputs produce. Their
+``statmech_id``, ``conformer_selection_id`` and ``transition_state_entry_id``
+references say *what was used*, not who owns the row.
+
+No root is added and no root type changes, so
+``tckdb_lock_scientific_record`` needs no new branch: all three record types
+named here are already in ``c6f2a9d4e7b1``'s ``_ROOT_TYPES``.
+
+Insertion is guarded too
+------------------------
+``tckdb_guard_accepted_child`` fires on INSERT as well as UPDATE and DELETE,
+so none of these rows can be *added* to an already-accepted root. That is the
+rule ``calc_freq_result`` and ``network_state`` already live under, and it is
+the right one here for the same reason ``b6c1f4a8e703`` gave: attaching
+evidence, an input, or an interpretation to a record reviewers accepted
+without it changes what was accepted. The correction path is a new record
+approved on its own terms with a ``scientific_record_supersession`` edge —
+supported for ``transition_state_entry``, ``kinetics`` and ``network_solve``
+alike by ``ck_scientific_record_supersession_supported_type``.
+
+TRUNCATE bypasses row triggers entirely, so all five tables take the
+statement-level refusal the rest of the regime carries.
+
+No rows are touched
+-------------------
+Pure DDL. Creating a trigger does not evaluate it against existing rows, so
+this is safe whatever a deployment holds and there is no backfill to design.
+``f3b7d2c8a419``'s backfill of ``transition_state_validation_evidence`` runs
+*before* this revision, and must: the guard installed here would refuse those
+UPDATEs on any row under an approved entry. The two must not be reordered.
+
+``downgrade()`` drops the fifteen triggers and destroys nothing.
+
+Revision ID: a1f6c3e9b527
+Revises: f3b7d2c8a419
+Create Date: 2026-08-11
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a1f6c3e9b527"
+down_revision: Union[str, Sequence[str], None] = "f3b7d2c8a419"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: ``(table, record_type, column)`` — guarded by ``tckdb_guard_accepted_child``
+#: against the accepted root named directly on the row. Every entry names an
+#: ownership foreign key, never a provenance one; see the module docstring for
+#: the per-table argument.
+_DIRECT_CHILDREN: tuple[tuple[str, str, str], ...] = (
+    (
+        "transition_state_validation_evidence",
+        "transition_state_entry",
+        "transition_state_entry_id",
+    ),
+    ("network_solve_channel_barrier", "network_solve", "solve_id"),
+    ("network_solve_state_energy", "network_solve", "solve_id"),
+    ("kinetics_interpretation_assignment", "kinetics", "kinetics_id"),
+    ("kinetics_tunneling_application", "kinetics", "kinetics_id"),
+)
+
+#: No table here reaches its root through a parent row, so this revision adds
+#: no ``tckdb_guard_accepted_via_child`` trigger. Declared empty rather than
+#: omitted so ``tests/db/test_accepted_science_trigger_registry.py`` can read
+#: the same three names off every revision in the regime.
+_VIA_CHILDREN: tuple[tuple[str, str, str, str, str, str], ...] = ()
+
+#: TRUNCATE bypasses row triggers entirely.
+_TRUNCATE_TABLES: tuple[str, ...] = tuple(table for table, _, _ in _DIRECT_CHILDREN)
+
+
+def _trigger_name(prefix: str, table: str) -> str:
+    """Mirror ``b6c1f4a8e703``'s naming, truncated to PostgreSQL's 63 bytes.
+
+    Suffixed with the table rather than with a positional index, for the
+    reason that revision gives: ``c6f2a9d4e7b1`` owns the ``trg_as_child_NN``
+    sequence, and appending to it from a third revision would make every
+    revision's numbering depend on the others'.
+    """
+
+    return f"trg_{prefix}_{table}"[:63]
+
+
+def _child_groups() -> list[tuple[str, str, tuple[str, ...]]]:
+    """Collapse the registry to one trigger per ``(table, record_type)``."""
+
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for table, record_type, column in _DIRECT_CHILDREN:
+        grouped.setdefault((table, record_type), []).append(column)
+    return [(table, record_type, tuple(columns)) for (table, record_type), columns in grouped.items()]
+
+
+def upgrade() -> None:
+    """Guard the five evidence tables with the accepted-science triggers."""
+
+    for table, record_type, columns in _child_groups():
+        arguments = ", ".join(f"'{column}'" for column in columns)
+        op.execute(
+            f"""
+            CREATE TRIGGER {_trigger_name("as_child", table)}
+            BEFORE INSERT OR UPDATE OR DELETE ON public.{table}
+            FOR EACH ROW
+            EXECUTE FUNCTION public.tckdb_guard_accepted_child(
+                '{record_type}', {arguments}
+            )
+            """
+        )
+    for table in _TRUNCATE_TABLES:
+        op.execute(
+            f"""
+            CREATE TRIGGER {_trigger_name("as_truncate", table)}
+            BEFORE TRUNCATE ON public.{table}
+            FOR EACH STATEMENT EXECUTE FUNCTION public.tckdb_reject_truncate()
+            """
+        )
+
+
+def downgrade() -> None:
+    """Drop the guards, restoring the prior state exactly."""
+
+    for table, _, _ in _child_groups():
+        op.execute(f"DROP TRIGGER IF EXISTS {_trigger_name('as_child', table)} ON public.{table}")
+    for table in _TRUNCATE_TABLES:
+        op.execute(f"DROP TRIGGER IF EXISTS {_trigger_name('as_truncate', table)} ON public.{table}")

--- a/backend/alembic/versions/f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py
+++ b/backend/alembic/versions/f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py
@@ -88,7 +88,7 @@ geometry bindings, which cannot be recovered from what remains — the same
 information loss the pre-upgrade schema had by construction.
 
 Revision ID: f3b7d2c8a419
-Revises: b6c1f4a8e703
+Revises: c8e2a7d41b96
 Create Date: 2026-08-11
 """
 
@@ -99,7 +99,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "f3b7d2c8a419"
-down_revision: Union[str, Sequence[str], None] = "b6c1f4a8e703"
+down_revision: Union[str, Sequence[str], None] = "c8e2a7d41b96"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py
+++ b/backend/alembic/versions/f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py
@@ -1,0 +1,247 @@
+"""Make IRC evidence name the geometry its atom indices count into.
+
+``c1d2e3f4a5b6`` gave ``transition_state_validation_evidence`` two JSONB
+mappings — ``reactant_participant_mapping`` and
+``product_participant_mapping`` — whose values are saddle-point atom indices:
+"these atoms of the transition state become reactant 1". It did not record
+which saddle-point *geometry* those indices count into.
+
+An atom index is not a property of a transition state. ``geometry_atom
+.atom_index`` counts into one specific set of coordinates, and a
+``transition_state_entry`` can accumulate several geometries — re-optimised,
+recomputed at another level of theory — with nothing guaranteeing a later one
+lists its atoms in the same order. So "atom 3" with no geometry beside it does
+not identify an atom; it identifies a position in an ordering the reader has to
+infer, and an inference that lands on the wrong geometry silently means a
+different atom. That is the failure mode ADR 0011 calls "the hard part:
+indices relative to what", and it resolved it for ``reaction_atom_map`` by
+making the map name its geometries explicitly rather than by making one
+derivable.
+
+The two surfaces make the *same* claim in the *same* units: a
+``reaction_atom_map_pair``'s ``ts_atom_index`` and this table's mapping values
+both index the saddle point, and
+``app.services.reaction_atom_map.validate_atom_map_agrees_with_irc_evidence``
+already holds them against each other. Comparing two index sets is only
+meaningful once both say what they counted in, so this closes a gap in a check
+that already shipped, not only in a projection.
+
+What the column does not do
+---------------------------
+It carries no composite foreign key into ``geometry_atom``, unlike
+``reaction_atom_map_pair``'s two. The indices live inside JSONB rather than in
+a column, so there is nothing for a foreign key to point at; naming the
+geometry is the half that can be enforced declaratively. The bounds and
+element halves are unchanged and still run in
+``validate_ts_evidence_participant_composition`` against this same geometry.
+
+Nullable, with the rule carried by a CHECK
+------------------------------------------
+The mappings are optional: evidence may be a ``rationale`` and a ``passed``
+flag with no per-atom partition, and such a row has no indices and needs no
+geometry. Requiring one there would demand data the record does not use. What
+cannot be allowed is the unreadable combination, so
+``ck_transition_state_validation_evidence_mapping_names_geometry`` requires a
+geometry exactly when a mapping is present.
+
+"Present" is tested with ``jsonb_typeof``, not with ``IS NOT NULL``.
+SQLAlchemy's JSONB type persists a Python ``None`` as JSON ``null`` rather
+than as SQL NULL, so this column already holds both spellings of absence
+depending on whether the writer set the attribute to ``None`` or left it
+unset. A constraint reading only ``IS NULL`` would refuse every mapping-free
+row the service writes, and a backfill reading only ``IS NOT NULL`` would try
+to ``jsonb_each`` a JSON scalar and raise.
+
+Backfill, and the rows it deliberately declines to guess at
+-----------------------------------------------------------
+Existing mapped rows are resolved from the deposit paths' own construction:
+every calculation of a transition-state entry is linked to the saddle-point
+geometry through ``calculation_output_geometry`` (``persist_ts_calculations``
+passes one ``geometry_id`` to the primary opt and to every additional
+calculation), so an entry whose calculations reference exactly one distinct
+output geometry names that geometry unambiguously. Two further conditions
+apply before a row is written: the geometry's ``natoms`` must equal the number
+of distinct saddle-point indices the mapping actually uses, and the row must
+not already name a geometry. A row failing any of them is left NULL rather
+than filled with the most likely candidate — a wrong geometry here is exactly
+the silent atom substitution the column exists to prevent, and ADR 0011 is
+explicit that a mechanism claim is not a thing to guess at.
+
+The CHECK is therefore added ``NOT VALID`` and validated only if the backfill
+left nothing unresolved. On an empty or fully-resolvable database — every
+test database, and any deployment whose evidence was written by the three
+current paths — it ends up validated and indistinguishable from a plain
+CHECK. On one holding a mapped row whose geometry cannot be derived, the
+constraint still governs every insert and update from here on while the
+legacy row is left alone and reported, rather than the upgrade aborting on
+data nobody can reconstruct.
+
+Ordering against ``a1f6c3e9b527``
+---------------------------------
+That revision brings this table under the accepted-science immutability
+regime, whose ``BEFORE UPDATE`` guard would refuse the backfill above on any
+row under an approved transition-state entry. It is therefore a child of this
+one, and the two must not be reordered or merged.
+
+``downgrade()`` drops the constraint and the column. It loses the recorded
+geometry bindings, which cannot be recovered from what remains — the same
+information loss the pre-upgrade schema had by construction.
+
+Revision ID: f3b7d2c8a419
+Revises: b6c1f4a8e703
+Create Date: 2026-08-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f3b7d2c8a419"
+down_revision: Union[str, Sequence[str], None] = "b6c1f4a8e703"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "transition_state_validation_evidence"
+_CONSTRAINT = "ck_transition_state_validation_evidence_mapping_names_geometry"
+
+#: "Absent" has two spellings in these columns. SQLAlchemy's JSONB type
+#: persists a Python ``None`` as JSON ``null``, so a row written by
+#: ``persist_transition_state_validation_evidence`` with no mapping holds
+#: ``'null'::jsonb``; a row whose attribute was never set holds SQL NULL,
+#: because the column is then omitted from the INSERT altogether. Both mean
+#: the record partitions no atoms. Every predicate below goes through
+#: ``jsonb_typeof`` so neither spelling is mistaken for a real mapping -- a
+#: plain ``IS NOT NULL`` would treat ``'null'::jsonb`` as one, and
+#: ``jsonb_each`` on a JSON scalar raises rather than returning nothing.
+def _has_mapping(prefix: str = "") -> str:
+    """Predicate for a row carrying at least one real participant mapping.
+
+    :param prefix: Table alias and dot, where more than one table is in scope.
+
+    The two sides are tested independently rather than assuming the wire
+    schema's pairing, so a half-populated legacy row still counts as having
+    indices and still needs a geometry.
+    """
+
+    return (
+        f"(jsonb_typeof({prefix}reactant_participant_mapping) = 'object' "
+        f"OR jsonb_typeof({prefix}product_participant_mapping) = 'object')"
+    )
+
+
+_HAS_MAPPING = _has_mapping()
+_EVIDENCE_HAS_MAPPING = _has_mapping("evidence.")
+
+#: Distinct saddle-point indices a row's mappings actually use, across both
+#: sides. Compared against ``geometry.natoms`` so a candidate geometry that
+#: cannot be what the indices were counted in is rejected rather than assumed.
+#: The ``CASE`` normalises both spellings of absence, and a one-sided legacy
+#: row, to an empty object that contributes no indices.
+_MAPPED_INDEX_COUNT = """
+    SELECT count(DISTINCT element.value::bigint)
+    FROM (
+        SELECT evidence.reactant_participant_mapping AS mapping
+        UNION ALL
+        SELECT evidence.product_participant_mapping
+    ) AS side
+    CROSS JOIN LATERAL jsonb_each(
+        CASE WHEN jsonb_typeof(side.mapping) = 'object'
+             THEN side.mapping ELSE '{}'::jsonb END
+    ) AS mapped(participant_key, atom_indices)
+    CROSS JOIN LATERAL jsonb_array_elements_text(mapped.atom_indices)
+        AS element(value)
+"""
+
+_BACKFILL = f"""
+UPDATE {_TABLE} AS target
+SET transition_state_geometry_id = resolved.geometry_id
+FROM (
+    SELECT
+        evidence.id AS evidence_id,
+        min(output.geometry_id) AS geometry_id
+    FROM {_TABLE} AS evidence
+    JOIN calculation
+        ON calculation.transition_state_entry_id
+           = evidence.transition_state_entry_id
+    JOIN calculation_output_geometry AS output
+        ON output.calculation_id = calculation.id
+    JOIN geometry ON geometry.id = output.geometry_id
+    WHERE evidence.transition_state_geometry_id IS NULL
+      AND {_EVIDENCE_HAS_MAPPING}
+    GROUP BY evidence.id
+    HAVING count(DISTINCT output.geometry_id) = 1
+       AND min(geometry.natoms) = ({_MAPPED_INDEX_COUNT})
+) AS resolved
+WHERE target.id = resolved.evidence_id
+  AND target.transition_state_geometry_id IS NULL
+"""
+
+_VALIDATE_IF_CLEAN = f"""
+DO $$
+DECLARE
+    unresolved bigint;
+BEGIN
+    SELECT count(*) INTO unresolved
+    FROM {_TABLE}
+    WHERE {_HAS_MAPPING}
+      AND transition_state_geometry_id IS NULL;
+
+    IF unresolved = 0 THEN
+        ALTER TABLE public.{_TABLE} VALIDATE CONSTRAINT {_CONSTRAINT};
+    ELSE
+        RAISE WARNING
+            'transition_state_validation_evidence: % row(s) carry participant '
+            'mappings whose saddle-point geometry could not be derived, so '
+            '{_CONSTRAINT} stays NOT VALID. It governs every insert and update '
+            'from here on. To finish, set transition_state_geometry_id on those '
+            'rows from the geometry their indices were counted in, then run '
+            'ALTER TABLE public.{_TABLE} VALIDATE CONSTRAINT {_CONSTRAINT};',
+            unresolved;
+    END IF;
+END
+$$
+"""
+
+
+def upgrade() -> None:
+    """Add the geometry binding, backfill what is derivable, then constrain."""
+
+    op.add_column(
+        _TABLE,
+        sa.Column("transition_state_geometry_id", sa.BigInteger(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_ts_validation_evidence_ts_geometry",
+        _TABLE,
+        "geometry",
+        ["transition_state_geometry_id"],
+        ["id"],
+        deferrable=True,
+        initially="IMMEDIATE",
+    )
+    op.execute(_BACKFILL)
+    op.execute(
+        f"""
+        ALTER TABLE public.{_TABLE}
+        ADD CONSTRAINT {_CONSTRAINT}
+        CHECK (
+            (coalesce(jsonb_typeof(reactant_participant_mapping), 'null') = 'null'
+             AND coalesce(jsonb_typeof(product_participant_mapping), 'null') = 'null')
+            OR transition_state_geometry_id IS NOT NULL
+        ) NOT VALID
+        """
+    )
+    op.execute(_VALIDATE_IF_CLEAN)
+
+
+def downgrade() -> None:
+    """Drop the constraint and the column, restoring the unbound mappings."""
+
+    op.execute(f"ALTER TABLE public.{_TABLE} DROP CONSTRAINT IF EXISTS {_CONSTRAINT}")
+    op.drop_constraint(
+        "fk_ts_validation_evidence_ts_geometry", _TABLE, type_="foreignkey"
+    )
+    op.drop_column(_TABLE, "transition_state_geometry_id")

--- a/backend/alembic/versions/f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py
+++ b/backend/alembic/versions/f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py
@@ -124,11 +124,20 @@ def _has_mapping(prefix: str = "") -> str:
     The two sides are tested independently rather than assuming the wire
     schema's pairing, so a half-populated legacy row still counts as having
     indices and still needs a geometry.
+
+    This is the exact negation of the CHECK's "absent" arm, deliberately: the
+    two must partition every row between them. Were "present" written as
+    ``= 'object'`` instead, a mapping holding some other JSON type would be
+    absent to this predicate and present to the constraint, so it would be
+    neither backfilled nor counted as unresolved -- and ``VALIDATE CONSTRAINT``
+    would then run and abort the upgrade on it. Written as a negation, such a
+    row lands in the unresolved count and the constraint simply stays
+    ``NOT VALID``, which is the failure this revision is built to prefer.
     """
 
     return (
-        f"(jsonb_typeof({prefix}reactant_participant_mapping) = 'object' "
-        f"OR jsonb_typeof({prefix}product_participant_mapping) = 'object')"
+        f"(coalesce(jsonb_typeof({prefix}reactant_participant_mapping), 'null') <> 'null' "
+        f"OR coalesce(jsonb_typeof({prefix}product_participant_mapping), 'null') <> 'null')"
     )
 
 

--- a/backend/app/db/models/transition_state.py
+++ b/backend/app/db/models/transition_state.py
@@ -23,6 +23,7 @@ from app.db.types import RDKitMol
 
 if TYPE_CHECKING:
     from app.db.models.calculation import Calculation
+    from app.db.models.geometry import Geometry
     from app.db.models.reaction import ReactionEntry
     from app.db.models.reaction_atom_map import ReactionAtomMap
 
@@ -169,6 +170,41 @@ class TransitionStateValidationEvidence(Base, TimestampMixin, CreatedByMixin):
     exactly what this docstring forbids storing. What stays out of the
     database is a producer's *conclusion* about a mode, not the arithmetic
     anyone can redo from the matrix.
+
+    Indices relative to what
+    ------------------------
+    ``reactant_participant_mapping`` and ``product_participant_mapping`` say
+    which saddle-point atoms become which declared participant, by index. An
+    atom index is a property of a *geometry*, not of a transition state:
+    ``geometry_atom.atom_index`` counts into one specific set of coordinates,
+    and a TS entry can accumulate several geometries as it is re-optimised or
+    recalculated at another level of theory, with no guarantee that a later
+    one lists its atoms in the same order. So an index with no geometry named
+    beside it does not identify an atom — it identifies a position in an
+    ordering the reader has to guess, and a wrong guess silently means a
+    different atom.
+
+    ``transition_state_geometry_id`` closes that, the same way ADR 0011
+    settled it for ``reaction_atom_map``: the map names the geometry it is
+    written against rather than relying on one being derivable. It is the
+    identical claim in the identical units — ``reaction_atom_map``'s
+    ``ts_atom_index`` and this table's mapping values both index the saddle
+    point — and ``validate_atom_map_agrees_with_irc_evidence`` already holds
+    the two against each other, which is only meaningful once both say which
+    geometry they counted in.
+
+    The column is nullable because the mappings are: evidence may be a
+    ``rationale`` and a ``passed`` flag with no per-atom partition at all, and
+    such a row has no indices and so needs no geometry. What is refused is the
+    combination that cannot be read —
+    ``ck_transition_state_validation_evidence_mapping_names_geometry`` requires
+    a geometry exactly when a mapping is present. No composite foreign key
+    into ``geometry_atom`` is possible here, unlike
+    ``reaction_atom_map_pair``, because the indices live inside JSONB rather
+    than in a column; naming the geometry is the half that can be enforced
+    declaratively, and the bounds and element checks run in
+    ``validate_ts_evidence_participant_composition`` against this same
+    geometry.
     """
 
     __tablename__ = "transition_state_validation_evidence"
@@ -182,11 +218,44 @@ class TransitionStateValidationEvidence(Base, TimestampMixin, CreatedByMixin):
     # machine-readable; a free-text mapping cannot be validated or replayed.
     reactant_participant_mapping: Mapped[Optional[dict[str, list[int]]]] = mapped_column(JSONB, nullable=True)
     product_participant_mapping: Mapped[Optional[dict[str, list[int]]]] = mapped_column(JSONB, nullable=True)
+    #: The saddle-point geometry the two mappings' atom indices count into.
+    #: Required whenever either mapping is present; see the class docstring.
+    transition_state_geometry_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "geometry.id",
+            name="fk_ts_validation_evidence_ts_geometry",
+            deferrable=True,
+            initially="IMMEDIATE",
+        ),
+        nullable=True,
+    )
     transition_state_entry: Mapped["TransitionStateEntry"] = relationship(back_populates="validation_evidence")
     reconstruction_calculation: Mapped["Calculation"] = relationship()
+    transition_state_geometry: Mapped[Optional["Geometry"]] = relationship()
     __table_args__ = (
         CheckConstraint("kind IN ('irc')", name="ts_validation_kind"),
         UniqueConstraint(
             "transition_state_entry_id", "kind", name="uq_ts_validation_evidence_kind"
+        ),
+        # An atom index with no geometry named beside it does not identify an
+        # atom. Enforced by the database rather than by the service because
+        # three deposit paths write this table and a fourth would inherit the
+        # rule for free.
+        #
+        # "Absent" has two spellings in this column and the constraint has to
+        # admit both. SQLAlchemy's JSONB type persists a Python ``None`` as
+        # JSON ``null`` rather than as SQL NULL, so a row written through
+        # ``persist_transition_state_validation_evidence`` with no mapping
+        # holds ``'null'::jsonb``, while one whose attribute was never set at
+        # all -- the column is simply omitted from the INSERT -- holds SQL
+        # NULL. Both mean "this record partitions no atoms", and a constraint
+        # testing only ``IS NULL`` would refuse every mapping-free row the
+        # service writes.
+        CheckConstraint(
+            "(coalesce(jsonb_typeof(reactant_participant_mapping), 'null') = 'null' "
+            "AND coalesce(jsonb_typeof(product_participant_mapping), 'null') = 'null') "
+            "OR transition_state_geometry_id IS NOT NULL",
+            name="mapping_names_geometry",
         ),
     )

--- a/backend/app/schemas/reads/scientific_transition_state.py
+++ b/backend/app/schemas/reads/scientific_transition_state.py
@@ -184,7 +184,17 @@ class TransitionStateCalculationEvidenceSummary(BaseModel):
 
 
 class TransitionStateValidationEvidenceSummary(BaseModel):
-    """Structured IRC validation evidence with a replayable source link."""
+    """Structured IRC validation evidence with a replayable source link.
+
+    The two participant mappings say which saddle-point atoms become which
+    declared participant, by index, and those indices count into
+    ``transition_state_geometry_ref`` -- not into "the transition state",
+    which has no atom order of its own. It is ``None`` exactly when both
+    mappings are, since a record that partitions no atoms binds no indices.
+    Named to match ``ReactionAtomMapDetail.transition_state_geometry_ref``,
+    which is the same geometry playing the same role for the other surface
+    that indexes the saddle point.
+    """
 
     kind: str
     passed: bool
@@ -192,6 +202,7 @@ class TransitionStateValidationEvidenceSummary(BaseModel):
     reconstruction_calculation_ref: str | None = None
     reactant_participant_mapping: dict[str, list[int]] | None = None
     product_participant_mapping: dict[str, list[int]] | None = None
+    transition_state_geometry_ref: str | None = None
 
 
 class TransitionStateValidationDescriptor(BaseModel):

--- a/backend/app/services/scientific_read/transition_states.py
+++ b/backend/app/services/scientific_read/transition_states.py
@@ -820,10 +820,20 @@ def _build_validation_evidence(
         select(
             TransitionStateValidationEvidence,
             Calculation.public_ref.label("calculation_ref"),
+            # The geometry the participant mappings' atom indices count into.
+            # Projected beside them rather than left in the database: an index
+            # a reader cannot resolve to a geometry does not identify an atom,
+            # so shipping the mappings without this would ship numbers
+            # relative to an ordering the caller has to guess at.
+            Geometry.public_ref.label("geometry_ref"),
         )
         .outerjoin(
             Calculation,
             Calculation.id == TransitionStateValidationEvidence.reconstruction_calculation_id,
+        )
+        .outerjoin(
+            Geometry,
+            Geometry.id == TransitionStateValidationEvidence.transition_state_geometry_id,
         )
         .where(TransitionStateValidationEvidence.transition_state_entry_id == entry_id)
         .order_by(TransitionStateValidationEvidence.id.asc())
@@ -836,6 +846,7 @@ def _build_validation_evidence(
             reconstruction_calculation_ref=row.calculation_ref,
             reactant_participant_mapping=row.TransitionStateValidationEvidence.reactant_participant_mapping,
             product_participant_mapping=row.TransitionStateValidationEvidence.product_participant_mapping,
+            transition_state_geometry_ref=row.geometry_ref,
         )
         for row in rows
     ]

--- a/backend/app/services/transition_state_validation.py
+++ b/backend/app/services/transition_state_validation.py
@@ -69,7 +69,11 @@ def persist_transition_state_validation_evidence(
         than optional: it is what lets the element check below run on *every*
         path, and a default would let a new path silently opt out of it.
     :param transition_state_geometry_id: Saddle-point geometry the mappings'
-        atom indices count into. ``None`` where the path has no geometry, which
+        atom indices count into. It is both checked against and *recorded* on
+        every row that carries a mapping, so a reader can tell which ordering
+        the indices were counted in rather than having to guess at one; a
+        record with no mapping has no indices and stores no geometry. ``None``
+        is accepted only for a path with no geometry and no mappings, which
         skips the element check as an absence.
     :param warnings: Optional sink for the absent-evidence warning.
     :returns: The persisted rows.
@@ -105,6 +109,24 @@ def persist_transition_state_validation_evidence(
                 f"Transition state '{subject_label}' validation evidence could not "
                 "be linked to the irc calculation that produced it."
             )
+        # A mapping's values are ``geometry_atom.atom_index`` values counted
+        # into the saddle-point geometry, so a record carrying one must say
+        # which geometry that is. The database refuses the combination too
+        # (``ck_transition_state_validation_evidence_mapping_names_geometry``);
+        # raising here turns a caller's omission into a sentence naming the
+        # argument that is missing rather than a constraint name.
+        has_mapping = (
+            record.reactant_participant_mapping is not None
+            or record.product_participant_mapping is not None
+        )
+        if has_mapping and transition_state_geometry_id is None:
+            raise ValueError(
+                f"Transition state '{subject_label}' {field_path} carries "
+                "participant mappings but no transition_state_geometry_id. The "
+                "mappings' atom indices count into the saddle-point geometry, "
+                "and an index with no geometry named beside it does not "
+                "identify an atom."
+            )
         row = TransitionStateValidationEvidence(
             transition_state_entry_id=transition_state_entry_id,
             kind=record.kind,
@@ -113,6 +135,9 @@ def persist_transition_state_validation_evidence(
             reconstruction_calculation_id=calculation_id,
             reactant_participant_mapping=record.reactant_participant_mapping,
             product_participant_mapping=record.product_participant_mapping,
+            transition_state_geometry_id=(
+                transition_state_geometry_id if has_mapping else None
+            ),
             created_by=created_by,
         )
         session.add(row)

--- a/backend/app/workflows/transition_state.py
+++ b/backend/app/workflows/transition_state.py
@@ -19,6 +19,7 @@ from app.schemas.workflows.transition_state_upload import (
     TransitionStateUploadRequest,
 )
 from app.services.geometry_resolution import resolve_geometry_payload
+from app.services.reaction_atom_map import persist_reaction_atom_map
 from app.services.reaction_resolution import (
     validate_transition_state_composition,
 )
@@ -35,6 +36,24 @@ from app.services.transition_state_validation import (
     persist_transition_state_validation_evidence,
 )
 from app.workflows.reaction import persist_reaction_upload
+
+#: Closing sentence of the atom-map absence warning on this path.
+#:
+#: A map indexes into a geometry per participant (ADR 0011: geometry-relative,
+#: with the geometries named explicitly), and this payload describes its
+#: reactants and products by *identity* alone -- a ``SpeciesEntryIdentityPayload``
+#: carries no coordinates. So there is nothing here for a participant leg to be
+#: written against, and the gap cannot be closed on this path, only reported.
+#: The wording follows ``network_pdep._PDEP_ABSENCE_REMEDY`` for the same
+#: reason it exists there: a remedy naming a field this schema does not have
+#: would send a depositor looking for somewhere to put the map that does not
+#: exist.
+_STANDALONE_TS_ABSENCE_REMEDY = (
+    "The standalone transition-state upload describes its reactants and "
+    "products by identity and carries no geometry for them, so it cannot "
+    "carry a map: to record one for this micro reaction, deposit it through "
+    "the computed-reaction upload, which accepts 'atom_map' (ADR 0011)."
+)
 
 
 def persist_transition_state_upload(
@@ -53,12 +72,15 @@ def persist_transition_state_upload(
     3. Resolve the saddle-point geometry.
     4. Persist the primary opt calculation and additional calculations,
        linking output geometries and dependency edges.
+    5. Persist structured IRC validation evidence, or report its absence.
+    6. Report the absence of an atom map, which this path cannot carry.
 
     :param session: Active SQLAlchemy session.
     :param request: Upload-facing transition-state payload.
     :param created_by: Optional application user id for newly created rows.
-    :param warnings: Optional sink for non-blocking upload warnings (a TS
-        deposited without passing IRC validation evidence).
+    :param warnings: Optional sink for non-blocking upload warnings: a TS
+        deposited without passing IRC validation evidence, and the atom map
+        this path can report the absence of but cannot carry.
     :returns: Newly created ``TransitionStateEntry`` row.
     """
 
@@ -146,6 +168,33 @@ def persist_transition_state_upload(
         field_path="validation_evidence",
         reaction_entry_id=reaction_entry.id,
         transition_state_geometry_id=geometry.id,
+        created_by=created_by,
+        warnings=warnings,
+    )
+
+    # 6. Atom map (ADR 0011). This path cannot carry one -- see
+    #    ``_STANDALONE_TS_ABSENCE_REMEDY`` -- so the call passes ``None``
+    #    unconditionally and exists to report the gap, exactly as the
+    #    pressure-dependent network bundle does. A saddle point deposited here
+    #    is as unmapped as one deposited anywhere else, and the ADR requires
+    #    the absence be loud enough that a depositor who *has* the mapping
+    #    notices they are being asked for it; reporting it on two of the three
+    #    paths that can carry a transition state would make the warning a
+    #    property of the route rather than of the record.
+    persist_reaction_atom_map(
+        session,
+        None,
+        reaction_entry_id=reaction_entry.id,
+        transition_state_entry_id=ts_entry.id,
+        transition_state_geometry_id=geometry.id,
+        participants=(),
+        geometry_id_by_key={},
+        # The map belongs to the micro reaction (ADR 0011), and ``reaction``
+        # is the field on this payload that describes it. Naming a real field
+        # matters for a client that highlights ``field``; there is no
+        # ``atom_map`` here to point at.
+        field_path="reaction",
+        absence_remedy=_STANDALONE_TS_ABSENCE_REMEDY,
         created_by=created_by,
         warnings=warnings,
     )

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -3349,6 +3349,7 @@ Table transition_state_validation_evidence {
   reconstruction_calculation_id bigint [not null, ref: > calculation.id]
   reactant_participant_mapping jsonb
   product_participant_mapping jsonb
+  transition_state_geometry_id bigint [ref: > geometry.id]
   created_at timestamp [not null, default: 'now']
   created_by bigint [ref: > app_user.id]
 
@@ -3357,6 +3358,7 @@ Table transition_state_validation_evidence {
   }
 
   checks {
+    `(coalesce(jsonb_typeof(reactant_participant_mapping), 'null') = 'null' AND coalesce(jsonb_typeof(product_participant_mapping), 'null') = 'null') OR transition_state_geometry_id IS NOT NULL` [name: 'ck_transition_state_validation_evidence_mapping_names_geometry']
     `kind IN ('irc')` [name: 'ck_transition_state_validation_evidence_ts_validation_kind']
   }
 

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -30,6 +30,7 @@ enum ArtifactIntegrityDetectionContext {
   parameter_extraction
   archive
   reproducibility_verification
+  reclaim_restore
 }
 
 enum ArtifactIntegrityFinding {

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -43056,7 +43056,7 @@
         "type": "object"
       },
       "TransitionStateValidationEvidenceSummary": {
-        "description": "Structured IRC validation evidence with a replayable source link.",
+        "description": "Structured IRC validation evidence with a replayable source link.\n\nThe two participant mappings say which saddle-point atoms become which\ndeclared participant, by index, and those indices count into\n``transition_state_geometry_ref`` -- not into \"the transition state\",\nwhich has no atom order of its own. It is ``None`` exactly when both\nmappings are, since a record that partitions no atoms binds no indices.\nNamed to match ``ReactionAtomMapDetail.transition_state_geometry_ref``,\nwhich is the same geometry playing the same role for the other surface\nthat indexes the saddle point.",
         "properties": {
           "kind": {
             "title": "Kind",
@@ -43114,6 +43114,17 @@
               }
             ],
             "title": "Reconstruction Calculation Ref"
+          },
+          "transition_state_geometry_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transition State Geometry Ref"
           }
         },
         "required": [

--- a/backend/tests/api/scientific/test_api_scientific_transition_states.py
+++ b/backend/tests/api/scientific/test_api_scientific_transition_states.py
@@ -560,6 +560,10 @@ def test_tse_detail_includes_structured_irc_validation_evidence(
     _, _, _, entries = _make_reaction_with_ts(db_session)
     tse = entries[0]
     calc = _attach_calc(db_session, tse=tse, calc_type=CalculationType.irc)
+    # The saddle-point geometry those participant mappings index into. A
+    # mapping that does not name one is refused by the database, because an
+    # atom index counted into an unnamed ordering does not identify an atom.
+    ts_geometry = make_geometry(db_session, natoms=2)
     db_session.add(
         TransitionStateValidationEvidence(
             transition_state_entry_id=tse.id,
@@ -569,6 +573,7 @@ def test_tse_detail_includes_structured_irc_validation_evidence(
             reconstruction_calculation_id=calc.id,
             reactant_participant_mapping={"reactant:1": [1, 2]},
             product_participant_mapping={"product:1": [1, 2]},
+            transition_state_geometry_id=ts_geometry.id,
         )
     )
     db_session.flush()

--- a/backend/tests/api/scientific/test_api_scientific_transition_states.py
+++ b/backend/tests/api/scientific/test_api_scientific_transition_states.py
@@ -588,6 +588,9 @@ def test_tse_detail_includes_structured_irc_validation_evidence(
     assert evidence[0]["kind"] == "irc"
     assert evidence[0]["reconstruction_calculation_ref"] == calc.public_ref
     assert evidence[0]["reactant_participant_mapping"] == {"reactant:1": [1, 2]}
+    # The mappings' indices count into a named geometry, and the reader is
+    # told which one rather than having to pick among the entry's geometries.
+    assert evidence[0]["transition_state_geometry_ref"] == ts_geometry.public_ref
     # NMD evidence is not a TCKDB concept; no such field survives.
     assert "mode_index" not in evidence[0]
     assert "displacement_artifact_sha256" not in evidence[0]

--- a/backend/tests/db/test_accepted_science_trigger_registry.py
+++ b/backend/tests/db/test_accepted_science_trigger_registry.py
@@ -22,30 +22,63 @@ _REVISION = _VERSIONS / "c6f2a9d4e7b1_enforce_accepted_science_immutability.py"
 #: without being created fails as well.
 _ATOM_MAP_REVISION = _VERSIONS / "b6c1f4a8e703_freeze_declared_atom_maps.py"
 
+#: ``a1f6c3e9b527`` extends it again, to the five evidence tables that carry an
+#: ownership foreign key to an accepted root and had no guard — the IRC
+#: evidence backing the same claim ``b6c1f4a8e703``'s atom maps elaborate, the
+#: barriers and state energies a network solve ran with, and the interpretation
+#: and tunneling rows a rate constant was computed under. Checked here on the
+#: same terms.
+_EVIDENCE_REVISION = _VERSIONS / "a1f6c3e9b527_freeze_evidence_under_accepted_roots.py"
+
+#: The revisions that extend ``c6f2a9d4e7b1``'s regime by adding guards under
+#: their own ``_trigger_name``. Both halves of this test iterate this list, so
+#: a fourth such revision is wired in by adding it here once.
+_EXTENSION_REVISIONS = (_ATOM_MAP_REVISION, _EVIDENCE_REVISION)
+
 
 def _revision_namespace() -> dict:
     return runpy.run_path(str(_REVISION))
 
 
-def _atom_map_revision_namespace() -> dict:
-    return runpy.run_path(str(_ATOM_MAP_REVISION))
+def _extension_namespaces() -> list[dict]:
+    return [runpy.run_path(str(path)) for path in _EXTENSION_REVISIONS]
+
+
+def _referenced_tables(tables, table: str, column: str, *, hops: int) -> set[str]:
+    """Tables a column's value identifies, following foreign keys ``hops`` deep."""
+
+    reached: set[str] = set()
+    frontier = {(table, column)}
+    for _ in range(hops):
+        next_frontier: set[tuple[str, str]] = set()
+        for current_table, current_column in frontier:
+            for foreign_key in tables[current_table].c[current_column].foreign_keys:
+                referent = foreign_key.column
+                reached.add(referent.table.name)
+                next_frontier.add((referent.table.name, referent.name))
+        frontier = next_frontier
+    return reached
 
 
 def test_registry_references_real_metadata_and_short_identifiers() -> None:
     revision = _revision_namespace()
-    atom_map_revision = _atom_map_revision_namespace()
+    extensions = _extension_namespaces()
     tables = Base.metadata.tables
     root_types = revision["_ROOT_TYPES"]
+
+    direct_children = revision["_DIRECT_CHILDREN"]
+    via_children = revision["_VIA_CHILDREN"]
+    for extension in extensions:
+        direct_children = direct_children + extension["_DIRECT_CHILDREN"]
+        via_children = via_children + extension["_VIA_CHILDREN"]
 
     for table in root_types.values():
         assert table in tables
         assert "id" in tables[table].c
-    for table, _, column in revision["_DIRECT_CHILDREN"] + atom_map_revision["_DIRECT_CHILDREN"]:
+    for table, _, column in direct_children:
         assert table in tables
         assert column in tables[table].c
-    for table, _, child_column, parent, parent_pk, root_column in (
-        revision["_VIA_CHILDREN"] + atom_map_revision["_VIA_CHILDREN"]
-    ):
+    for table, _, child_column, parent, parent_pk, root_column in via_children:
         assert table in tables
         assert child_column in tables[table].c
         assert parent in tables
@@ -56,10 +89,39 @@ def test_registry_references_real_metadata_and_short_identifiers() -> None:
     # knows how to lock. One that does not raises 22023 at runtime rather than
     # protecting anything, and the failure would only surface the first time a
     # guarded row was written.
-    for _, record_type, *_rest in atom_map_revision["_DIRECT_CHILDREN"] + atom_map_revision["_VIA_CHILDREN"]:
-        assert record_type in root_types
-    for table in atom_map_revision["_TRUNCATE_TABLES"]:
-        assert table in tables
+    for extension in extensions:
+        for _, record_type, *_rest in extension["_DIRECT_CHILDREN"] + extension["_VIA_CHILDREN"]:
+            assert record_type in root_types
+        for table in extension["_TRUNCATE_TABLES"]:
+            assert table in tables
+
+    # Every guarded column must actually hold an id of the root table it
+    # claims. Without this, a guard naming a column of the wrong table would
+    # fail only at runtime, on the first write it was supposed to refuse.
+    #
+    # One hop is allowed because ``calc_scan_point_coordinate_value`` reaches
+    # ``calculation`` through the composite foreign keys into
+    # ``calc_scan_point`` and ``calc_scan_coordinate`` rather than declaring a
+    # second single-column one of its own. The column is still a calculation
+    # id; only the declaration is indirect.
+    for table, record_type, column in direct_children:
+        target = root_types[record_type]
+        assert target in _referenced_tables(tables, table, column, hops=2), (table, column, target)
+
+    # ``tckdb_guard_accepted_child`` reads each column it is given and does
+    # nothing where the value is NULL, so a group whose columns are *all*
+    # nullable yields a trigger that skips whole rows. At least one column per
+    # ``(table, record_type)`` group must therefore be NOT NULL. It is asserted
+    # per group rather than per column because a nullable column can be a
+    # deliberate second binding beside a NOT NULL one --
+    # ``calc_scf_stability`` is guarded on both its own ``calculation_id`` and
+    # the optional ``source_calculation_id`` it was derived from, and both
+    # land in one trigger.
+    grouped_columns: dict[tuple[str, str], list[str]] = {}
+    for table, record_type, column in direct_children:
+        grouped_columns.setdefault((table, record_type), []).append(column)
+    for (table, record_type), columns in grouped_columns.items():
+        assert any(not tables[table].c[column].nullable for column in columns), (table, record_type, columns)
 
     constraints = tables["scientific_record_supersession"].constraints
     assert all(constraint.name is None or len(constraint.name) <= 63 for constraint in constraints)
@@ -109,15 +171,13 @@ def test_database_trigger_set_matches_registry(db_session) -> None:
     )
     expected.update((table, f"trg_as_truncate_{index:02d}") for index, table in enumerate(truncate_tables))
 
-    atom_map_revision = _atom_map_revision_namespace()
-    atom_map_trigger_name = atom_map_revision["_trigger_name"]
-    expected.update(
-        (table, atom_map_trigger_name("as_child", table)) for table, _, _ in atom_map_revision["_child_groups"]()
-    )
-    expected.update((item[0], atom_map_trigger_name("as_via", item[0])) for item in atom_map_revision["_VIA_CHILDREN"])
-    expected.update(
-        (table, atom_map_trigger_name("as_truncate", table)) for table in atom_map_revision["_TRUNCATE_TABLES"]
-    )
+    for extension in _extension_namespaces():
+        extension_trigger_name = extension["_trigger_name"]
+        expected.update(
+            (table, extension_trigger_name("as_child", table)) for table, _, _ in extension["_child_groups"]()
+        )
+        expected.update((item[0], extension_trigger_name("as_via", item[0])) for item in extension["_VIA_CHILDREN"])
+        expected.update((table, extension_trigger_name("as_truncate", table)) for table in extension["_TRUNCATE_TABLES"])
 
     actual = {
         (row.table_name, row.trigger_name)

--- a/backend/tests/db/test_evidence_immutability.py
+++ b/backend/tests/db/test_evidence_immutability.py
@@ -1,0 +1,545 @@
+"""Evidence tables are frozen by the acceptance of the root that owns them.
+
+``a1f6c3e9b527`` brings five tables under ``c6f2a9d4e7b1``'s accepted-science
+regime: the IRC evidence backing a saddle point's claim, the barriers and state
+energies a network solve ran with, and the interpretation and tunneling rows a
+rate constant was computed under. Each carried an ownership foreign key to an
+accepted-science root and no ``trg_as_*`` guard, so each could be rewritten in
+place under an accepted record with no supersession edge and no review event.
+
+Why this file exists beside ``test_accepted_science_trigger_registry.py``
+------------------------------------------------------------------------
+That test derives its expected trigger set from the same revision registries it
+compares against ``pg_trigger``. It therefore catches a trigger present in the
+database but undeclared, and one declared but not created -- but a guard
+deleted from *both* the registry and the DDL leaves it green, because the
+expectation shrinks with the reality. Only a test that writes a row and demands
+a refusal can catch that, which is what every test below does.
+
+The tests pin both halves of the rule for every table, because a guard that is
+present but never fires is the failure mode that matters:
+
+* under an **approved** root, the row cannot be updated, deleted, or inserted;
+* under an **unapproved** root it is fully editable, so the freeze is
+  acceptance-triggered rather than a blanket write ban on the table.
+
+None of these five tables has children of its own, so unlike
+``test_atom_map_immutability`` there is no cascade that could let a child's
+guard absorb a refusal the parent's guard was supposed to make. Each refusal
+below is attributable to the trigger the revision put on that table: removing
+that one trigger, and only that one, turns the corresponding test red.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.models.app_user import AppUser
+from app.db.models.common import (
+    AppUserRole,
+    EnergyCorrectionConvention,
+    EnergyZeroConvention,
+    KineticsDegeneracyInterpretation,
+    KineticsEnsemblePolicy,
+    KineticsStandardStateConvention,
+    NetworkChannelKind,
+    NetworkStateKind,
+    RecordReviewStatus,
+    SubmissionRecordType,
+    TunnelingModel,
+)
+from app.db.models.kinetics import (
+    KineticsInterpretationAssignment,
+    KineticsTunnelingApplication,
+)
+from app.db.models.network_pdep import (
+    NetworkSolveChannelBarrier,
+    NetworkSolveStateEnergy,
+)
+from app.db.models.transition_state import TransitionStateValidationEvidence
+from app.services.record_review import ensure_record_review, set_record_review_status
+from tests.services.scientific_read._factories import (
+    make_calculation,
+    make_chem_reaction,
+    make_kinetics,
+    make_network,
+    make_network_channel,
+    make_network_solve,
+    make_network_state,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    make_statmech,
+    make_transition_state,
+    make_transition_state_entry,
+    next_inchi_key,
+)
+
+#: Every table below is guarded against this record type via the column named
+#: beside it in ``a1f6c3e9b527._DIRECT_CHILDREN``.
+_ROOTS = (
+    SubmissionRecordType.transition_state_entry,
+    SubmissionRecordType.network_solve,
+    SubmissionRecordType.kinetics,
+)
+
+_GUARDED_TABLES = (
+    "transition_state_validation_evidence",
+    "network_solve_channel_barrier",
+    "network_solve_state_energy",
+    "kinetics_interpretation_assignment",
+    "kinetics_tunneling_application",
+)
+
+
+def _curator(session, username: str) -> AppUser:
+    actor = AppUser(username=username, role=AppUserRole.curator)
+    session.add(actor)
+    session.flush()
+    return actor
+
+
+def _approve(session, *, record_type: SubmissionRecordType, record_id: int, actor: AppUser) -> None:
+    assert record_type in _ROOTS
+    ensure_record_review(session, record_type=record_type, record_id=record_id)
+    review = set_record_review_status(
+        session,
+        record_type=record_type,
+        record_id=record_id,
+        status=RecordReviewStatus.approved,
+        actor=actor,
+    )
+    assert review.first_approved_at is not None
+
+
+def _reaction_entry(session, tag: str):
+    reactant = make_species(session, inchi_key=next_inchi_key(f"{tag}R"))
+    product = make_species(session, inchi_key=next_inchi_key(f"{tag}P"))
+    reaction = make_chem_reaction(session, reactants=[reactant], products=[product])
+    return (
+        make_reaction_entry(
+            session,
+            reaction=reaction,
+            reactant_entries=[make_species_entry(session, reactant)],
+            product_entries=[make_species_entry(session, product)],
+        ),
+        reactant,
+        product,
+    )
+
+
+# ---------------------------------------------------------------------------
+# transition_state_validation_evidence -> transition_state_entry
+# ---------------------------------------------------------------------------
+
+
+def _ts_evidence(session, tag: str):
+    reaction_entry, _, _ = _reaction_entry(session, tag)
+    ts_entry = make_transition_state_entry(
+        session,
+        transition_state=make_transition_state(session, reaction_entry=reaction_entry),
+    )
+    calculation = make_calculation(session, transition_state_entry_id=ts_entry.id)
+    evidence = TransitionStateValidationEvidence(
+        transition_state_entry_id=ts_entry.id,
+        kind="irc",
+        passed=True,
+        rationale="the reconstructed path reaches both declared endpoints",
+        reconstruction_calculation_id=calculation.id,
+    )
+    session.add(evidence)
+    session.flush()
+    return ts_entry, evidence, calculation
+
+
+def test_irc_evidence_of_approved_transition_state_entry_is_frozen(db_session) -> None:
+    """The evidence backing the claim is now as immutable as the atom map.
+
+    ``b6c1f4a8e703`` froze ``reaction_atom_map`` under this same root while
+    leaving this table writable, so the agreement
+    ``validate_atom_map_agrees_with_irc_evidence`` establishes at deposit could
+    afterwards be falsified by rewriting whichever half was still mutable.
+    """
+
+    actor = _curator(db_session, "irc-evidence-curator")
+    ts_entry, evidence, _ = _ts_evidence(db_session, "IRCFRZ")
+    _approve(
+        db_session,
+        record_type=SubmissionRecordType.transition_state_entry,
+        record_id=ts_entry.id,
+        actor=actor,
+    )
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        evidence.passed = False
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        evidence.rationale = "on reflection the path went somewhere else"
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(evidence)
+        db_session.flush()
+
+
+def test_irc_evidence_cannot_be_attached_to_an_approved_transition_state_entry(
+    db_session,
+) -> None:
+    """Adding evidence to an accepted record changes what was accepted."""
+
+    actor = _curator(db_session, "irc-late-curator")
+    ts_entry, evidence, calculation = _ts_evidence(db_session, "IRCLATE")
+    db_session.delete(evidence)
+    db_session.flush()
+    _approve(
+        db_session,
+        record_type=SubmissionRecordType.transition_state_entry,
+        record_id=ts_entry.id,
+        actor=actor,
+    )
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(
+            TransitionStateValidationEvidence(
+                transition_state_entry_id=ts_entry.id,
+                kind="irc",
+                passed=True,
+                rationale="evidence produced after review closed",
+                reconstruction_calculation_id=calculation.id,
+            )
+        )
+        db_session.flush()
+
+
+def test_irc_evidence_of_unapproved_transition_state_entry_stays_editable(db_session) -> None:
+    _, evidence, _ = _ts_evidence(db_session, "IRCOPEN")
+
+    evidence.rationale = "corrected before review"
+    evidence.passed = False
+    db_session.flush()
+    assert evidence.rationale == "corrected before review"
+
+    db_session.delete(evidence)
+    db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# network_solve_channel_barrier / network_solve_state_energy -> network_solve
+# ---------------------------------------------------------------------------
+
+
+class _SolveBundle:
+    def __init__(self, *, solve, barrier, state_energy, channel, reaction_entry, ts_entry, state):
+        self.solve = solve
+        self.barrier = barrier
+        self.state_energy = state_energy
+        self.channel = channel
+        self.reaction_entry = reaction_entry
+        self.ts_entry = ts_entry
+        self.state = state
+
+
+def _solve_bundle(db_session, tag: str) -> _SolveBundle:
+    reaction_entry, reactant, product = _reaction_entry(db_session, tag)
+    ts_entry = make_transition_state_entry(
+        db_session,
+        transition_state=make_transition_state(db_session, reaction_entry=reaction_entry),
+    )
+    network = make_network(db_session, name=f"network-{tag}")
+    source = make_network_state(
+        db_session,
+        network=network,
+        kind=NetworkStateKind.well,
+        composition_hash=f"{tag}-source",
+    )
+    sink = make_network_state(
+        db_session,
+        network=network,
+        kind=NetworkStateKind.bimolecular,
+        composition_hash=f"{tag}-sink",
+    )
+    channel = make_network_channel(
+        db_session,
+        network=network,
+        source_state=source,
+        sink_state=sink,
+        kind=NetworkChannelKind.dissociation,
+    )
+    solve = make_network_solve(db_session, network=network)
+
+    barrier = NetworkSolveChannelBarrier(
+        solve_id=solve.id,
+        channel_id=channel.id,
+        reaction_entry_id=reaction_entry.id,
+        transition_state_entry_id=ts_entry.id,
+        forward_barrier_kj_mol=112.5,
+        reverse_barrier_kj_mol=64.25,
+        energy_zero_convention=EnergyZeroConvention.entrance_channel,
+        correction_convention=EnergyCorrectionConvention.electronic_plus_zpe,
+    )
+    state_energy = NetworkSolveStateEnergy(
+        solve_id=solve.id,
+        state_id=source.id,
+        energy_kj_mol=-31.75,
+        energy_zero_convention=EnergyZeroConvention.entrance_channel,
+        correction_convention=EnergyCorrectionConvention.electronic_plus_zpe,
+    )
+    db_session.add_all([barrier, state_energy])
+    db_session.flush()
+    return _SolveBundle(
+        solve=solve,
+        barrier=barrier,
+        state_energy=state_energy,
+        channel=channel,
+        reaction_entry=reaction_entry,
+        ts_entry=ts_entry,
+        state=sink,
+    )
+
+
+def test_solve_inputs_of_an_approved_solve_are_frozen(db_session) -> None:
+    """A solve's own inputs are as immutable as the k(T,P) it produced.
+
+    ``network_kinetics`` and its Chebyshev/PLOG children were already frozen
+    under ``network_solve``. Leaving the barriers and state energies the solve
+    ran with editable meant the stored rate could stop following from the
+    inputs recorded beside it without either row admitting to a change.
+    """
+
+    actor = _curator(db_session, "solve-curator")
+    bundle = _solve_bundle(db_session, "SLVFRZ")
+    _approve(
+        db_session,
+        record_type=SubmissionRecordType.network_solve,
+        record_id=bundle.solve.id,
+        actor=actor,
+    )
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.barrier.forward_barrier_kj_mol = 98.0
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(bundle.barrier)
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.state_energy.energy_kj_mol = 0.0
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(bundle.state_energy)
+        db_session.flush()
+
+
+def test_solve_inputs_cannot_be_added_to_an_approved_solve(db_session) -> None:
+    actor = _curator(db_session, "solve-late-curator")
+    bundle = _solve_bundle(db_session, "SLVLATE")
+    _approve(
+        db_session,
+        record_type=SubmissionRecordType.network_solve,
+        record_id=bundle.solve.id,
+        actor=actor,
+    )
+
+    # A second state energy, for the well the bundle left without one. Every
+    # key and constraint admits it; only the guard stands in the way.
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(
+            NetworkSolveStateEnergy(
+                solve_id=bundle.solve.id,
+                state_id=bundle.state.id,
+                energy_kj_mol=12.5,
+                energy_zero_convention=EnergyZeroConvention.entrance_channel,
+                correction_convention=EnergyCorrectionConvention.electronic_plus_zpe,
+            )
+        )
+        db_session.flush()
+
+
+def test_solve_inputs_of_an_unapproved_solve_stay_editable(db_session) -> None:
+    bundle = _solve_bundle(db_session, "SLVOPEN")
+
+    bundle.barrier.forward_barrier_kj_mol = 98.0
+    bundle.state_energy.energy_kj_mol = 0.0
+    db_session.flush()
+    assert bundle.barrier.forward_barrier_kj_mol == 98.0
+
+    db_session.delete(bundle.barrier)
+    db_session.delete(bundle.state_energy)
+    db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# kinetics_interpretation_assignment / kinetics_tunneling_application -> kinetics
+# ---------------------------------------------------------------------------
+
+
+class _KineticsBundle:
+    def __init__(self, *, kinetics, assignment, tunneling, statmech, ts_entry):
+        self.kinetics = kinetics
+        self.assignment = assignment
+        self.tunneling = tunneling
+        self.statmech = statmech
+        self.ts_entry = ts_entry
+
+
+def _kinetics_bundle(db_session, tag: str) -> _KineticsBundle:
+    reaction_entry, reactant, _ = _reaction_entry(db_session, tag)
+    ts_entry = make_transition_state_entry(
+        db_session,
+        transition_state=make_transition_state(db_session, reaction_entry=reaction_entry),
+    )
+    statmech = make_statmech(
+        db_session,
+        species_entry=make_species_entry(db_session, reactant),
+    )
+    kinetics = make_kinetics(db_session, reaction_entry=reaction_entry)
+
+    assignment = KineticsInterpretationAssignment(
+        kinetics_id=kinetics.id,
+        subject_key="reactant:1",
+        role="reactant",
+        statmech_id=statmech.id,
+        ensemble_policy=KineticsEnsemblePolicy.lowest_energy_conformer,
+        standard_state_convention=KineticsStandardStateConvention.ideal_gas_1_bar,
+        degeneracy_interpretation=(KineticsDegeneracyInterpretation.reaction_path_degeneracy),
+    )
+    tunneling = KineticsTunnelingApplication(
+        kinetics_id=kinetics.id,
+        model=TunnelingModel.eckart,
+        transition_state_entry_id=ts_entry.id,
+        imaginary_frequency_cm1=-1204.0,
+        forward_barrier_kj_mol=45.5,
+        reverse_barrier_kj_mol=88.25,
+    )
+    db_session.add_all([assignment, tunneling])
+    db_session.flush()
+    return _KineticsBundle(
+        kinetics=kinetics,
+        assignment=assignment,
+        tunneling=tunneling,
+        statmech=statmech,
+        ts_entry=ts_entry,
+    )
+
+
+def test_rate_interpretation_of_approved_kinetics_is_frozen(db_session) -> None:
+    """The conventions a rate was computed under move with the rate.
+
+    ``kinetics_arrhenius_entry`` and ``kinetics_plog`` -- the coefficients --
+    were already frozen under this root. The interpretation names the ensemble,
+    standard state and degeneracy treatment those coefficients mean something
+    only relative to, and the tunneling row names the correction applied to
+    them; either rewritten silently makes the stored number stop being what
+    the recorded inputs produce.
+    """
+
+    actor = _curator(db_session, "kinetics-curator")
+    bundle = _kinetics_bundle(db_session, "KINFRZ")
+    _approve(
+        db_session,
+        record_type=SubmissionRecordType.kinetics,
+        record_id=bundle.kinetics.id,
+        actor=actor,
+    )
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.assignment.ensemble_policy = KineticsEnsemblePolicy.single_structure
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(bundle.assignment)
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        bundle.tunneling.forward_barrier_kj_mol = 12.0
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(bundle.tunneling)
+        db_session.flush()
+
+
+def test_rate_interpretation_cannot_be_added_to_approved_kinetics(db_session) -> None:
+    actor = _curator(db_session, "kinetics-late-curator")
+    bundle = _kinetics_bundle(db_session, "KINLATE")
+    _approve(
+        db_session,
+        record_type=SubmissionRecordType.kinetics,
+        record_id=bundle.kinetics.id,
+        actor=actor,
+    )
+
+    # The transition-state slot the bundle left unassigned. The composite
+    # primary key and ``ck_kinetics_interpretation_assignment_subject_shape``
+    # both admit this row.
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(
+            KineticsInterpretationAssignment(
+                kinetics_id=bundle.kinetics.id,
+                subject_key="transition_state",
+                role="transition_state",
+                statmech_id=bundle.statmech.id,
+                transition_state_entry_id=bundle.ts_entry.id,
+                ensemble_policy=KineticsEnsemblePolicy.single_structure,
+                standard_state_convention=(KineticsStandardStateConvention.ideal_gas_1_bar),
+                degeneracy_interpretation=(KineticsDegeneracyInterpretation.external_symmetry_number),
+            )
+        )
+        db_session.flush()
+
+
+def test_rate_interpretation_of_unapproved_kinetics_stays_editable(db_session) -> None:
+    bundle = _kinetics_bundle(db_session, "KINOPEN")
+
+    bundle.assignment.ensemble_policy = KineticsEnsemblePolicy.single_structure
+    bundle.tunneling.forward_barrier_kj_mol = 12.0
+    db_session.flush()
+    assert bundle.tunneling.forward_barrier_kj_mol == 12.0
+
+    db_session.delete(bundle.assignment)
+    db_session.delete(bundle.tunneling)
+    db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Statement-level bypass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("table", _GUARDED_TABLES)
+def test_truncate_cannot_bypass_the_evidence_guards(db_session, table: str) -> None:
+    """TRUNCATE fires no row trigger, so each table carries its own refusal."""
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.execute(text(f"TRUNCATE {table}"))
+
+
+def test_every_guarded_table_refuses_a_write_under_an_approved_root(db_session) -> None:
+    """One assertion that names all five tables, so none can be dropped quietly.
+
+    The registry parity test compares ``pg_trigger`` against the revision's own
+    registry, so deleting a table from both leaves it green. This list is
+    written out by hand for exactly that reason: it is the copy of the intent
+    that does not shrink when the registry does.
+    """
+
+    guarded = {
+        row.table_name
+        for row in db_session.execute(
+            text(
+                """
+                SELECT relation.relname AS table_name
+                FROM pg_trigger AS trigger
+                JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+                WHERE NOT trigger.tgisinternal
+                  AND trigger.tgname LIKE 'trg_as_child_%'
+                """
+            )
+        )
+    }
+    assert set(_GUARDED_TABLES) <= guarded

--- a/backend/tests/db/test_ts_evidence_geometry_binding.py
+++ b/backend/tests/db/test_ts_evidence_geometry_binding.py
@@ -19,6 +19,7 @@ rows it could not.
 
 from __future__ import annotations
 
+import runpy
 import subprocess
 from pathlib import Path
 
@@ -41,10 +42,29 @@ from tests.services.scientific_read._factories import (
 
 _CONSTRAINT = "ck_transition_state_validation_evidence_mapping_names_geometry"
 
-#: The revision immediately before the one under test, so the fixture rows
-#: below can be written in the shape that predates the column.
-_BASE_REVISION = "b6c1f4a8e703"
 _GEOMETRY_REVISION = "f3b7d2c8a419"
+
+
+def _base_revision() -> str:
+    """The revision immediately before the one under test.
+
+    Read off the migration rather than written down here. A revision's
+    ``down_revision`` moves whenever the branch is rebased onto a head that
+    another migration reached first, and a hardcoded copy would then upgrade
+    to some earlier point and write the fixture rows below in whatever shape
+    that point happened to have -- or, if the column already existed there,
+    silently stop testing the backfill at all.
+    """
+
+    namespace = runpy.run_path(
+        str(
+            Path(__file__).resolve().parents[2]
+            / "alembic"
+            / "versions"
+            / "f3b7d2c8a419_name_the_geometry_irc_indices_count_into.py"
+        )
+    )
+    return namespace["down_revision"]
 
 _MAPPING = {"reactant:1": [1], "reactant:2": [2, 3]}
 _PRODUCT_MAPPING = {"product:1": [3], "product:2": [1, 2]}
@@ -244,7 +264,7 @@ def test_backfill_resolves_what_it_can_and_declines_to_guess() -> None:
         admin_conn.execute(text(f'CREATE DATABASE "{db_name}"'))
 
         env = _db_env(db_name)
-        engine = run_revision(_BASE_REVISION, engine)
+        engine = run_revision(_base_revision(), engine)
 
         with engine.begin() as conn:
             assert (

--- a/backend/tests/db/test_ts_evidence_geometry_binding.py
+++ b/backend/tests/db/test_ts_evidence_geometry_binding.py
@@ -1,0 +1,386 @@
+"""IRC evidence must name the geometry its atom indices count into.
+
+``c1d2e3f4a5b6`` gave ``transition_state_validation_evidence`` two JSONB
+participant mappings whose values are saddle-point atom indices, and recorded
+nothing about which geometry those indices count into. An atom index is a
+property of a geometry -- a transition-state entry can accumulate several as it
+is re-optimised, with no guarantee any two order their atoms alike -- so an
+index with no geometry beside it identifies a position in an ordering the
+reader has to infer, and an inference landing on the wrong geometry silently
+means a different atom. ``f3b7d2c8a419`` closes that the way ADR 0011 closed it
+for ``reaction_atom_map``: the record names the geometry rather than leaving
+one to be derived.
+
+Two things are tested here, because the column is only worth having if both
+hold: the rule is enforced by the database on every write, and the revision
+that introduced it resolved the rows it could while declining to guess at the
+rows it could not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.models.transition_state import TransitionStateValidationEvidence
+from tests.services.scientific_read._factories import (
+    make_calculation,
+    make_chem_reaction,
+    make_geometry,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    make_transition_state,
+    make_transition_state_entry,
+    next_inchi_key,
+)
+
+_CONSTRAINT = "ck_transition_state_validation_evidence_mapping_names_geometry"
+
+#: The revision immediately before the one under test, so the fixture rows
+#: below can be written in the shape that predates the column.
+_BASE_REVISION = "b6c1f4a8e703"
+_GEOMETRY_REVISION = "f3b7d2c8a419"
+
+_MAPPING = {"reactant:1": [1], "reactant:2": [2, 3]}
+_PRODUCT_MAPPING = {"product:1": [3], "product:2": [1, 2]}
+
+
+def _evidence_fixture(db_session, tag: str):
+    reactant = make_species(db_session, inchi_key=next_inchi_key(f"{tag}R"))
+    product = make_species(db_session, inchi_key=next_inchi_key(f"{tag}P"))
+    reaction_entry = make_reaction_entry(
+        db_session,
+        reaction=make_chem_reaction(db_session, reactants=[reactant], products=[product]),
+        reactant_entries=[make_species_entry(db_session, reactant)],
+        product_entries=[make_species_entry(db_session, product)],
+    )
+    ts_entry = make_transition_state_entry(
+        db_session,
+        transition_state=make_transition_state(db_session, reaction_entry=reaction_entry),
+    )
+    calculation = make_calculation(db_session, transition_state_entry_id=ts_entry.id)
+    geometry = make_geometry(db_session, natoms=3)
+    return ts_entry, calculation, geometry
+
+
+def test_a_mapping_without_a_geometry_is_refused(db_session) -> None:
+    """The rule is the database's, not one deposit path's.
+
+    Three workflows write this table, and a fourth would inherit the rule for
+    free. The row below is otherwise complete and its mappings are internally
+    well formed; what it cannot say is what its indices were counted in.
+    """
+
+    ts_entry, calculation, _ = _evidence_fixture(db_session, "TSGEOM")
+
+    with pytest.raises(DBAPIError) as excinfo, db_session.begin_nested():
+        db_session.add(
+            TransitionStateValidationEvidence(
+                transition_state_entry_id=ts_entry.id,
+                kind="irc",
+                passed=True,
+                rationale="IRC reaches both endpoints",
+                reconstruction_calculation_id=calculation.id,
+                reactant_participant_mapping=_MAPPING,
+                product_participant_mapping=_PRODUCT_MAPPING,
+            )
+        )
+        db_session.flush()
+
+    assert _CONSTRAINT in str(excinfo.value)
+
+
+def test_one_sided_mapping_also_needs_a_geometry(db_session) -> None:
+    """A half-populated row still has indices, so it still needs a geometry.
+
+    The wire schema pairs the two sides, but the constraint does not lean on
+    that: it tests each side independently, so a row reaching the table by any
+    other route cannot carry indices anonymously.
+    """
+
+    ts_entry, calculation, _ = _evidence_fixture(db_session, "TSGEOM1S")
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(
+            TransitionStateValidationEvidence(
+                transition_state_entry_id=ts_entry.id,
+                kind="irc",
+                passed=False,
+                rationale="only one side was resolved",
+                reconstruction_calculation_id=calculation.id,
+                reactant_participant_mapping=_MAPPING,
+            )
+        )
+        db_session.flush()
+
+
+def test_evidence_without_a_mapping_needs_no_geometry(db_session) -> None:
+    """Evidence may be a rationale and a verdict, and then partitions no atoms.
+
+    Both spellings of absence are accepted, which is not a formality: the
+    JSONB type persists an explicitly-assigned ``None`` as JSON ``null`` rather
+    than as SQL NULL, so the service's own rows take the second branch of the
+    constraint and a rule written as ``IS NULL`` would refuse them all.
+    """
+
+    ts_entry, calculation, _ = _evidence_fixture(db_session, "TSGEOMNONE")
+
+    unset = TransitionStateValidationEvidence(
+        transition_state_entry_id=ts_entry.id,
+        kind="irc",
+        passed=True,
+        rationale="the path was followed but the partition was not resolved",
+        reconstruction_calculation_id=calculation.id,
+    )
+    db_session.add(unset)
+    db_session.flush()
+    assert unset.transition_state_geometry_id is None
+
+    stored = db_session.execute(
+        text(
+            "SELECT jsonb_typeof(reactant_participant_mapping) AS assigned_null "
+            "FROM transition_state_validation_evidence WHERE id = :id"
+        ),
+        {"id": unset.id},
+    ).one()
+    # SQL NULL here; the service's explicit ``None`` produces JSON 'null'.
+    assert stored.assigned_null is None
+
+    db_session.execute(
+        text(
+            "UPDATE transition_state_validation_evidence "
+            "SET reactant_participant_mapping = 'null'::jsonb, "
+            "product_participant_mapping = 'null'::jsonb WHERE id = :id"
+        ),
+        {"id": unset.id},
+    )
+    db_session.flush()
+
+
+def test_a_mapping_that_names_its_geometry_is_accepted(db_session) -> None:
+    ts_entry, calculation, geometry = _evidence_fixture(db_session, "TSGEOMOK")
+
+    row = TransitionStateValidationEvidence(
+        transition_state_entry_id=ts_entry.id,
+        kind="irc",
+        passed=True,
+        rationale="IRC reaches both endpoints",
+        reconstruction_calculation_id=calculation.id,
+        reactant_participant_mapping=_MAPPING,
+        product_participant_mapping=_PRODUCT_MAPPING,
+        transition_state_geometry_id=geometry.id,
+    )
+    db_session.add(row)
+    db_session.flush()
+
+    stored = db_session.scalars(
+        select(TransitionStateValidationEvidence).where(TransitionStateValidationEvidence.id == row.id)
+    ).one()
+    assert stored.transition_state_geometry_id == geometry.id
+
+
+def test_the_constraint_is_validated_on_a_normally_migrated_database(db_session) -> None:
+    """``NOT VALID`` is the fallback for unresolvable legacy rows, not the norm.
+
+    The revision validates the constraint whenever its backfill leaves nothing
+    unresolved, which is every database that has no legacy evidence at all --
+    including this one. Asserting it here keeps the escape hatch from silently
+    becoming the permanent state: a constraint left ``NOT VALID`` forever would
+    still govern new writes, but would stop being evidence about what the table
+    contains.
+    """
+
+    validated = db_session.execute(
+        text("SELECT convalidated FROM pg_constraint WHERE conname = :name"),
+        {"name": _CONSTRAINT},
+    ).scalar_one()
+    assert validated is True
+
+
+def test_backfill_resolves_what_it_can_and_declines_to_guess() -> None:
+    """The revision's backfill contract, on a real disposable database.
+
+    Three rows written in the pre-column shape:
+
+    * one whose transition-state entry has exactly one output geometry, of the
+      right size -- derivable, and derived;
+    * one whose entry has two distinct output geometries -- ambiguous, and left
+      NULL rather than filled with whichever the query happened to see first,
+      because a wrong geometry here is precisely the silent atom substitution
+      the column exists to prevent;
+    * one with no mapping at all -- nothing to bind, nothing written.
+
+    Because a row is left unresolved the constraint stays ``NOT VALID``, and
+    the last assertion pins the property that makes that acceptable: it still
+    refuses new violations.
+    """
+
+    from conftest import _database_url, _db_env, scratch_database_name
+
+    db_name = scratch_database_name("ts_evidence_geometry")
+    admin = create_engine(_database_url("postgres"), isolation_level="AUTOCOMMIT", pool_pre_ping=True)
+    admin_conn = None
+    engine = None
+    root = Path(__file__).resolve().parents[2]
+
+    def run_revision(revision: str, current_engine):
+        if current_engine is not None:
+            current_engine.dispose()
+        subprocess.run(
+            ["conda", "run", "-n", "tckdb_env", "alembic", "upgrade", revision],
+            cwd=root,
+            env=env,
+            check=True,
+        )
+        return create_engine(_database_url(db_name), pool_pre_ping=True)
+
+    try:
+        admin_conn = admin.connect()
+        admin_conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+        env = _db_env(db_name)
+        engine = run_revision(_BASE_REVISION, engine)
+
+        with engine.begin() as conn:
+            assert (
+                conn.scalar(
+                    text(
+                        "SELECT count(*) FROM information_schema.columns "
+                        "WHERE table_name = 'transition_state_validation_evidence' "
+                        "AND column_name = 'transition_state_geometry_id'"
+                    )
+                )
+                == 0
+            ), "fixture rows must be written in the shape that predates the column"
+
+            reaction_id = conn.scalar(
+                text("INSERT INTO chem_reaction (reversible) VALUES (true) RETURNING id")
+            )
+            reaction_entry_id = conn.scalar(
+                text("INSERT INTO reaction_entry (reaction_id) VALUES (:r) RETURNING id"),
+                {"r": reaction_id},
+            )
+
+            evidence_ids: dict[str, int] = {}
+            geometry_ids: dict[str, int] = {}
+            for tag, geometry_count, natoms, mapped in (
+                ("derivable", 1, 3, True),
+                ("ambiguous", 2, 3, True),
+                ("unmapped", 1, 3, False),
+            ):
+                ts_id = conn.scalar(
+                    text("INSERT INTO transition_state (reaction_entry_id) VALUES (:r) RETURNING id"),
+                    {"r": reaction_entry_id},
+                )
+                ts_entry_id = conn.scalar(
+                    text(
+                        "INSERT INTO transition_state_entry "
+                        "(transition_state_id, charge, multiplicity) "
+                        "VALUES (:ts, 0, 2) RETURNING id"
+                    ),
+                    {"ts": ts_id},
+                )
+                calculation_id = conn.scalar(
+                    text(
+                        "INSERT INTO calculation (type, transition_state_entry_id) "
+                        "VALUES ('opt', :e) RETURNING id"
+                    ),
+                    {"e": ts_entry_id},
+                )
+                for order in range(1, geometry_count + 1):
+                    geometry_id = conn.scalar(
+                        text(
+                            "INSERT INTO geometry (natoms, geom_hash) "
+                            "VALUES (:n, :h) RETURNING id"
+                        ),
+                        {"n": natoms, "h": f"{tag}-geom-{order}"},
+                    )
+                    conn.execute(
+                        text(
+                            "INSERT INTO calculation_output_geometry "
+                            "(calculation_id, geometry_id, output_order) "
+                            "VALUES (:c, :g, :o)"
+                        ),
+                        {"c": calculation_id, "g": geometry_id, "o": order},
+                    )
+                    if order == 1:
+                        geometry_ids[tag] = geometry_id
+                evidence_ids[tag] = conn.scalar(
+                    text(
+                        "INSERT INTO transition_state_validation_evidence "
+                        "(transition_state_entry_id, kind, passed, rationale, "
+                        " reconstruction_calculation_id, reactant_participant_mapping, "
+                        " product_participant_mapping) "
+                        "VALUES (:e, 'irc', true, :why, :c, "
+                        "        CAST(:reactants AS jsonb), CAST(:products AS jsonb)) "
+                        "RETURNING id"
+                    ),
+                    {
+                        "e": ts_entry_id,
+                        "why": f"{tag} legacy evidence",
+                        "c": calculation_id,
+                        "reactants": (
+                            '{"reactant:1": [1], "reactant:2": [2, 3]}' if mapped else None
+                        ),
+                        "products": (
+                            '{"product:1": [3], "product:2": [1, 2]}' if mapped else None
+                        ),
+                    },
+                )
+
+        engine = run_revision(_GEOMETRY_REVISION, engine)
+
+        with engine.begin() as conn:
+            bound = dict(
+                conn.execute(
+                    text(
+                        "SELECT id, transition_state_geometry_id "
+                        "FROM transition_state_validation_evidence"
+                    )
+                ).all()
+            )
+            # Derived exactly, from the single output geometry of the entry's
+            # calculations -- not from whichever row sorted first.
+            assert bound[evidence_ids["derivable"]] == geometry_ids["derivable"]
+            # Two candidates, so the revision writes neither.
+            assert bound[evidence_ids["ambiguous"]] is None
+            # No indices, so nothing to bind.
+            assert bound[evidence_ids["unmapped"]] is None
+
+            assert (
+                conn.scalar(
+                    text("SELECT convalidated FROM pg_constraint WHERE conname = :name"),
+                    {"name": _CONSTRAINT},
+                )
+                is False
+            ), "an unresolved legacy row must leave the constraint NOT VALID"
+
+            # NOT VALID skips the existing rows; it does not stop governing
+            # new ones. Without this the fallback would be a silent opt-out.
+            with pytest.raises(DBAPIError):
+                conn.execute(
+                    text(
+                        "INSERT INTO transition_state_validation_evidence "
+                        "(transition_state_entry_id, kind, passed, rationale, "
+                        " reconstruction_calculation_id, reactant_participant_mapping, "
+                        " product_participant_mapping) "
+                        "SELECT transition_state_entry_id, 'irc', true, 'new row', "
+                        "       reconstruction_calculation_id, "
+                        "       CAST('{\"reactant:1\": [1]}' AS jsonb), "
+                        "       CAST('{\"product:1\": [1]}' AS jsonb) "
+                        "FROM transition_state_validation_evidence WHERE id = :id"
+                    ),
+                    {"id": evidence_ids["ambiguous"]},
+                )
+    finally:
+        if engine is not None:
+            engine.dispose()
+        if admin_conn is not None:
+            admin_conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)'))
+            admin_conn.close()
+        admin.dispose()

--- a/backend/tests/services/archive/test_archive.py
+++ b/backend/tests/services/archive/test_archive.py
@@ -575,6 +575,10 @@ def test_archive_round_trip_preserves_stage2_pdep_and_kinetics_evidence(
     irc_calc = make_calculation(
         db_session, type=CalculationType.irc, transition_state_entry_id=ts_entry.id
     )
+    # The saddle-point geometry the IRC evidence's participant mappings index
+    # into. Named on the evidence row itself, because an atom index counted
+    # into an unnamed geometry survives the round trip meaning nothing.
+    ts_geometry = make_geometry(db_session, natoms=2)
     statmech = make_statmech(db_session, species_entry=reactant_entry)
     kinetics = make_kinetics(db_session, reaction_entry=reaction_entry)
 
@@ -659,6 +663,7 @@ def test_archive_round_trip_preserves_stage2_pdep_and_kinetics_evidence(
                 reconstruction_calculation_id=irc_calc.id,
                 reactant_participant_mapping={"reactant:1": [1, 2]},
                 product_participant_mapping={"product:1": [1, 2]},
+                transition_state_geometry_id=ts_geometry.id,
             ),
         ]
     )
@@ -669,6 +674,7 @@ def test_archive_round_trip_preserves_stage2_pdep_and_kinetics_evidence(
         "solve_id": solve.id,
         "channel_id": channel.id,
         "ts_entry_id": ts_entry.id,
+        "ts_geometry_id": ts_geometry.id,
         "reaction_entry_id": reaction_entry.id,
         "state_a_id": state_a.id,
         "forward_hex": (-8.125).hex(),
@@ -738,6 +744,9 @@ def test_archive_round_trip_preserves_stage2_pdep_and_kinetics_evidence(
     assert evidence.kind == "irc"
     assert evidence.passed is True
     assert evidence.reactant_participant_mapping == {"reactant:1": [1, 2]}
+    # The geometry those indices count into survives too. Restoring the
+    # mappings without it would restore atom indices relative to nothing.
+    assert evidence.transition_state_geometry_id == original["ts_geometry_id"]
 
 
 def test_binary_codec_round_trips_frozen_release_artifact_bytes() -> None:

--- a/backend/tests/workflows/test_atom_map_irc_agreement.py
+++ b/backend/tests/workflows/test_atom_map_irc_agreement.py
@@ -558,6 +558,13 @@ def test_the_verdict_does_not_depend_on_which_surface_is_written_first(
                 reconstruction_calculation_id=_irc_calculation_id(session, result),
                 reactant_participant_mapping=_IRC_METHYL_IS_1235,
                 product_participant_mapping=_IRC_PRODUCTS,
+                # Both surfaces index the same saddle point, so the evidence
+                # names the geometry the map already named. Comparing two sets
+                # of indices only means something once both say what they
+                # counted in, which is the whole reason this column exists.
+                transition_state_geometry_id=session.get(
+                    ReactionAtomMap, result["atom_map_id"]
+                ).transition_state_geometry_id,
             )
         )
         session.flush()

--- a/backend/tests/workflows/test_transition_state_upload.py
+++ b/backend/tests/workflows/test_transition_state_upload.py
@@ -33,6 +33,7 @@ from app.db.models.common import (
     IRCDirection,
     PathSearchMethod,
 )
+from app.db.models.geometry import Geometry
 from app.db.models.transition_state import TransitionState
 from app.schemas.fragments.calculation import (
     CalculationWithResultsPayload,
@@ -656,8 +657,39 @@ def test_standalone_ts_upload_persists_irc_evidence(db_conn) -> None:
         linked = session.get(Calculation, rows[0].reconstruction_calculation_id)
         assert linked is not None
         assert linked.type == CalculationType.irc
-        # Passing evidence produces no absent-evidence warning...
-        assert warnings == []
+        # The mapping's atom indices count into the saddle-point geometry, and
+        # the row says so rather than leaving a reader to work out which of the
+        # entry's geometries was meant (ADR 0011, "indices relative to what").
+        # That geometry is the primary opt's output -- the saddle point itself,
+        # not the IRC's endpoints -- and it has exactly the atoms the two
+        # mappings partition, so the indices land on real atoms of it.
+        saddle_point_geometry_id = session.scalar(
+            select(CalculationOutputGeometry.geometry_id)
+            .join(Calculation, Calculation.id == CalculationOutputGeometry.calculation_id)
+            .where(
+                Calculation.transition_state_entry_id == ts_entry.id,
+                Calculation.type == CalculationType.opt,
+            )
+        )
+        assert saddle_point_geometry_id is not None
+        assert rows[0].transition_state_geometry_id == saddle_point_geometry_id
+        mapped_indices = {
+            index
+            for side in (
+                rows[0].reactant_participant_mapping,
+                rows[0].product_participant_mapping,
+            )
+            for indices in side.values()
+            for index in indices
+        }
+        assert mapped_indices == {1, 2, 3}
+        assert (
+            session.get(Geometry, saddle_point_geometry_id).natoms
+            == len(mapped_indices)
+        )
+        # Passing evidence produces no absent-evidence warning; the only gap
+        # this deposit has is the atom map, which this path cannot carry.
+        assert [w.code for w in warnings] == ["reaction_atom_map_absent"]
         # ... and the read surface now says "present" rather than "absent".
         assert _build_validation_descriptor(session, ts_entry.id).irc == "present"
 
@@ -697,13 +729,46 @@ def test_standalone_ts_upload_without_evidence_warns(db_conn) -> None:
         )
         session.flush()
         assert [w.code for w in warnings] == [
-            "transition_state_missing_irc_evidence"
+            "transition_state_missing_irc_evidence",
+            "reaction_atom_map_absent",
         ]
         from app.services.scientific_read.transition_states import (
             _build_validation_descriptor,
         )
 
         assert _build_validation_descriptor(session, ts_entry.id).irc == "absent"
+
+
+def test_standalone_ts_upload_reports_the_absent_atom_map(db_conn) -> None:
+    """ADR 0011's absence warning is a property of the record, not the route.
+
+    The computed-reaction bundle reported it and the PDep bundle reported it;
+    the standalone upload -- the third and last path that can carry a
+    transition state -- did not, so the same unmapped saddle point was
+    annotated or silent depending only on which endpoint deposited it. That is
+    exactly the split the ADR asks the warning to make visible.
+
+    This path cannot *carry* a map: it describes its reactants and products by
+    identity alone, and a map indexes into a geometry per participant. So the
+    remedy must not name an ``atom_map`` field this schema does not have.
+    """
+    with Session(db_conn) as session, session.begin():
+        warnings: list = []
+        persist_transition_state_upload(
+            session, _basic_ts_request(), warnings=warnings
+        )
+        session.flush()
+
+        absent = [w for w in warnings if w.code == "reaction_atom_map_absent"]
+        assert len(absent) == 1
+        # A field a client can actually highlight, and the object the map
+        # belongs to.
+        assert absent[0].field == "reaction"
+        assert "atom_map" not in absent[0].field
+        # The remedy sends the depositor to the path that accepts a map,
+        # rather than to a field that does not exist here.
+        assert "computed-reaction upload" in absent[0].message
+        assert "ADR 0011" in absent[0].message
 
 
 def test_standalone_ts_evidence_requires_exactly_one_irc_calculation() -> None:


### PR DESCRIPTION
Three findings about the evidence behind a transition state, all of the same shape: something the record depends on was not held to the standard the thing beside it was.

## The immutability asymmetry (#97)

[#129](https://github.com/TCKDB/TCKDB/pull/129) froze `reaction_atom_map` and its pairs once their `transition_state_entry` is approved. `transition_state_validation_evidence` — the IRC record that a saddle point actually connects the declared endpoints — carries `transition_state_entry_id NOT NULL`, is owned by that entry, and had no guard. So the atom map *elaborating* a claim became immutable while the evidence *backing* it stayed editable in place, with no supersession edge and no review event.

That is not merely untidy. `validate_atom_map_agrees_with_irc_evidence` holds the two surfaces against each other at deposit. With one half frozen and the other not, the agreement could be established and then quietly falsified afterwards by rewriting whichever half was still writable.

An audit of every foreign key from a non-root table into an accepted-science root turned up 21 candidates. Sixteen are cross-domain provenance FKs that `c6f2a9d4e7b1` explicitly declines to treat as ownership (`thermo_source_calculation.calculation_id` is named in its own comment). The remaining five are ownership, and all five are frozen here in one batch, because the argument is identical for each and splitting it would leave the asymmetry standing under another name:

| table | frozen by | why that root |
|---|---|---|
| `transition_state_validation_evidence` | `transition_state_entry` | Approving a TS entry *is* accepting "this saddle point connects these endpoints"; this table holds what that acceptance rested on. Its `reconstruction_calculation_id` is provenance — guarding on it would freeze the evidence when its *input* is approved and leave it thawed when the entry it is about is. |
| `network_solve_channel_barrier` | `network_solve` | The barriers a solve ran with. `network_kinetics` and its Chebyshev/PLOG children — the solve's *outputs* — were already frozen under this root; freezing outputs and not inputs makes the solve unreproducible in exactly the way the regime exists to prevent. |
| `network_solve_state_energy` | `network_solve` | Same, for well and bimolecular energies. |
| `kinetics_interpretation_assignment` | `kinetics` | The ensemble, standard state and degeneracy treatment the rate means something only relative to. `kinetics_arrhenius_entry` and `kinetics_plog` — the coefficients — were already frozen under this root. |
| `kinetics_tunneling_application` | `kinetics` | The correction applied to those coefficients. |

No new root type, so `tckdb_lock_scientific_record` needs no new branch. INSERT is guarded as well as UPDATE and DELETE, on #129's reasoning: attaching evidence to a record reviewers accepted without it changes what was accepted. TRUNCATE takes the statement-level refusal.

**No trigger is disabled anywhere.** The archive restore already sequences `record_review` last (`included_tables_in_fk_order`), so the five new INSERT guards cannot fire during a restore — nothing is approved yet at that point.

## Indices relative to what (#58)

`transition_state_validation_evidence` holds two JSONB participant mappings whose values are saddle-point atom indices, and recorded nothing about which geometry those indices count into. An atom index is a property of a geometry — a TS entry can accumulate several as it is re-optimised, with nothing guaranteeing any two order their atoms alike — so an unbound index names a position in an ordering the reader has to infer, and an inference landing on the wrong geometry silently means a different atom. This is ADR 0011's "the hard part: indices relative to what", and the shape it chose for `reaction_atom_map` applies unchanged: the record names its geometry rather than leaving one to be derived.

The two surfaces make the same claim in the same units, so this closes a gap in a check that already shipped, not only in a projection — comparing two index sets is meaningful only once both say what they counted in.

Nullable, because the mappings are: evidence may be a rationale and a verdict with no per-atom partition, and such a row has no indices to bind. `ck_transition_state_validation_evidence_mapping_names_geometry` requires a geometry exactly when a mapping is present. No composite foreign key into `geometry_atom` is possible, unlike `reaction_atom_map_pair`'s two, because the indices live inside JSONB; naming the geometry is the half that can be enforced declaratively, and the bounds and element halves already run against this same geometry in `validate_ts_evidence_participant_composition`.

**"Absent" turned out to have two spellings.** SQLAlchemy's JSONB type persists an explicitly assigned `None` as JSON `null`, not SQL NULL, so rows written by the service hold `'null'::jsonb` while rows whose attribute was never set hold SQL NULL. A constraint reading `IS NULL` would have refused every mapping-free row the service writes; a backfill reading `IS NOT NULL` would have called `jsonb_each` on a JSON scalar and raised. Every predicate goes through `jsonb_typeof`, and the presence predicate is written as the exact negation of the constraint's absence arm so no row can fall between them and abort `VALIDATE`.

The backfill derives what it can — an entry whose calculations reference exactly one distinct output geometry, of the right `natoms` — and **declines to guess at the rest**. A wrong geometry here is precisely the silent atom substitution the column exists to prevent. The CHECK therefore goes in `NOT VALID` and validates itself when the backfill leaves nothing unresolved, which is every test database and any deployment written by the three current paths. Where a legacy row cannot be resolved the constraint still governs every insert and update while the row is left alone and reported by name, rather than the upgrade aborting on data nobody can reconstruct.

## A warning that was a property of the route (#59)

ADR 0011 says an absent atom map warns, and asks that the warning be loud enough that a depositor who *has* the mapping notices. The computed-reaction bundle reported it and the PDep bundle reported it; the standalone transition-state upload — the third and last path that can carry a saddle point — did not. The same unmapped record was annotated or silent depending only on which endpoint deposited it.

It now reports it. Like the PDep bundle it cannot *carry* a map: it describes reactants and products by identity, and a map indexes into a geometry per participant, so there is nothing here for a participant leg to be written against. The remedy therefore points at the computed-reaction upload rather than at an `atom_map` field this schema does not have, and `field` names `reaction` — a real field, and the object ADR 0011 says the map belongs to.

## The binding is projected, not only stored

`TransitionStateValidationEvidenceSummary` gains `transition_state_geometry_ref`, filled by one outer join. Storing the binding and not returning it would have left the read surface shipping atom indices relative to an ordering the caller still had to guess at — the same defect one layer out. The name matches `ReactionAtomMapDetail.transition_state_geometry_ref`, which is the same geometry in the same role for the other surface that indexes the saddle point. `None` exactly when both mappings are.

The golden OpenAPI snapshot is regenerated on top of #133's, not merged with it; the diff is the one new property and the docstring.

## Tests

Two traps from #129, not repeated.

`test_accepted_science_trigger_registry.py` derives its expected trigger set from the same registries it compares against `pg_trigger`, so it catches present-but-undeclared and declared-but-absent but **never a guard deleted from both**. `tests/db/test_evidence_immutability.py` is behavioural throughout and carries a hand-written list of the five tables for exactly that reason — the copy of the intent that does not shrink when the registry does.

In #129 the map test initially had to delete its child before approving, because deleting the parent cascaded into the child and was refused by the *child's* guard, leaving the test green with the parent's own trigger missing. None of these five tables has children, so no refusal can be absorbed by a neighbour; and the mutation check below confirms each refusal is attributable to the trigger this PR added.

The registry test also grew two structural assertions it did not have: every guarded column must actually reach the root table it claims (one FK hop allowed — `calc_scan_point_coordinate_value` reaches `calculation` only through its composite keys), and every `(table, record_type)` group must contain at least one NOT NULL column, since `tckdb_guard_accepted_child` silently skips a NULL and a wholly-nullable group would yield a trigger that skips rows.

**Mutation check.** Each guard removed from *both* the registry and the DDL, database rebuilt, `tests/db/test_evidence_immutability.py` + `test_accepted_science_trigger_registry.py` re-run (17 pass clean):

| guard removed | result |
|---|---|
| `transition_state_validation_evidence` | 4 failed, 13 passed |
| `network_solve_channel_barrier` | 3 failed, 14 passed |
| `network_solve_state_energy` | 4 failed, 13 passed |
| `kinetics_interpretation_assignment` | 4 failed, 13 passed |
| `kinetics_tunneling_application` | 3 failed, 14 passed |

Skipping the CHECK in `f3b7d2c8a419`: 4 of 6 in `test_ts_evidence_geometry_binding.py` fail. Removing the absence-warning call from the standalone workflow: 3 of 15 in `test_transition_state_upload.py` fail.

The backfill contract is pinned on a real disposable database — three rows written in the pre-column shape, one derivable, one ambiguous, one unmapped — asserting that the derivable one is derived exactly, the ambiguous one is left NULL, and the constraint left `NOT VALID` still refuses new violations.

## Migrations

    c8e2a7d41b96  (#132, on main)
      └── f3b7d2c8a419  column, backfill, CHECK
            └── a1f6c3e9b527  the five guards        <- single head

`f3b7d2c8a419` originally revised `b6c1f4a8e703`, which is also what #132's `c8e2a7d41b96` took while this branch was in flight; merging that way would have produced **two heads** and broken `alembic upgrade head` for every deployment and test run. Re-pointed onto `c8e2a7d41b96` after rebasing, and `alembic heads` reports exactly one.

The order of the two new revisions is load-bearing and **must not be reordered**: `a1f6c3e9b527`'s `BEFORE UPDATE` guard would refuse `f3b7d2c8a419`'s backfill on any row under an approved entry. Both implement `upgrade()` and `downgrade()`; round-tripped `upgrade head` → `downgrade -2` → `upgrade head` on a scratch database, `alembic check` reports no new upgrade operations.

The disposable-database backfill test no longer hardcodes the revision it upgrades to first — it reads `down_revision` off the migration. A written-down copy goes stale on exactly this kind of re-point, and a stale one would either build its fixture rows in the wrong shape or, if the column already existed at that point, silently stop testing the backfill.

## Gates

`test-api.sh` **2558 passed** · `test-rest.sh` **3952 passed, 14 skipped** · `test-scientific.sh` **2022 passed** · zero failures, measured on the rebased branch with the host otherwise idle (6 of 100 Postgres connections in use). Ruff clean over `app tests scripts`. `docs/guides/scientific_check_register.md` regenerates byte-identical — this branch adds no `ScientificCheck`.

`schema.dbml` regeneration also picks up #132's `reclaim_restore` enum value, which that revision added to the model without regenerating the file. One line, not authored here.

## Known gaps, filed not fixed

- The JSONB `null` / SQL NULL split in the mapping columns is left as found (`app/db/models/transition_state.py:183`). Normalising it needs `none_as_null=True` plus a data migration.
- `calc_scf_stability.source_calculation_id` is a nullable *provenance* FK registered as an ownership guard in `c6f2a9d4e7b1`, contrary to that revision's own stated rule. Harmless today because the same trigger also names the NOT NULL `calculation_id`, but it is either a deliberate second binding that should say so or a mistake.
- Neither the PDep bundle nor the standalone upload can carry a map, only report its absence.
