### PR TITLE
Declare a repair to accepted science before making it, and let the database check the claim

### DIFF
--- a/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
+++ b/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
@@ -287,6 +287,29 @@ def _create_tables() -> None:
 
 def _create_functions() -> None:
     guard_functions = ", ".join(f"'{name}'" for name in _GUARD_FUNCTIONS)
+
+    # Split out of ``tckdb_raise_if_accepted`` so the guards can ask the cheap
+    # question first. ``to_jsonb(OLD)`` and ``to_jsonb(NEW)`` are function
+    # arguments, which PL/pgSQL evaluates eagerly, so passing them
+    # unconditionally would serialise both row versions on *every* update to
+    # every guarded table -- including ``calc_hessian``'s packed matrix -- to
+    # answer a question that is almost always "no".
+    op.execute(
+        """
+        CREATE FUNCTION public.tckdb_record_is_accepted(
+            p_type public.submission_record_type, p_record_id bigint
+        ) RETURNS boolean
+        LANGUAGE sql STABLE
+        SET search_path = pg_catalog, public
+        AS $$
+            SELECT EXISTS (
+                SELECT 1 FROM public.record_review
+                WHERE record_type = p_type AND record_id = p_record_id
+                  AND first_approved_at IS NOT NULL
+            )
+        $$
+        """
+    )
     op.execute(
         f"""
         CREATE FUNCTION public.tckdb_validate_accepted_science_repair()
@@ -609,11 +632,7 @@ def _create_functions() -> None:
         SET search_path = pg_catalog, public
         AS $$
         BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM public.record_review
-                WHERE record_type = p_type AND record_id = p_record_id
-                  AND first_approved_at IS NOT NULL
-            ) THEN
+            IF NOT public.tckdb_record_is_accepted(p_type, p_record_id) THEN
                 RETURN;
             END IF;
             IF public.tckdb_repair_permits(
@@ -656,12 +675,16 @@ def _replace_guards() -> None:
             PERFORM public.tckdb_lock_scientific_record(
                 TG_ARGV[0]::public.submission_record_type, record_id
             );
-            PERFORM public.tckdb_raise_if_accepted(
-                TG_ARGV[0]::public.submission_record_type, record_id,
-                TG_TABLE_SCHEMA, TG_TABLE_NAME,
-                CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
-                CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
-            );
+            IF public.tckdb_record_is_accepted(
+                TG_ARGV[0]::public.submission_record_type, record_id
+            ) THEN
+                PERFORM public.tckdb_raise_if_accepted(
+                    TG_ARGV[0]::public.submission_record_type, record_id,
+                    TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                );
+            END IF;
             IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
         END;
         $$
@@ -707,12 +730,14 @@ def _replace_guards() -> None:
                 PERFORM public.tckdb_lock_scientific_record(
                     'calculation', calculation_id
                 );
-                PERFORM public.tckdb_raise_if_accepted(
-                    'calculation', calculation_id,
-                    TG_TABLE_SCHEMA, TG_TABLE_NAME,
-                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
-                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
-                );
+                IF public.tckdb_record_is_accepted('calculation', calculation_id) THEN
+                    PERFORM public.tckdb_raise_if_accepted(
+                        'calculation', calculation_id,
+                        TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                    );
+                END IF;
             END LOOP;
             IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
         END;
@@ -752,12 +777,16 @@ def _replace_guards() -> None:
                 PERFORM public.tckdb_lock_scientific_record(
                     TG_ARGV[0]::public.submission_record_type, record_id
                 );
-                PERFORM public.tckdb_raise_if_accepted(
-                    TG_ARGV[0]::public.submission_record_type, record_id,
-                    TG_TABLE_SCHEMA, TG_TABLE_NAME,
-                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
-                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
-                );
+                IF public.tckdb_record_is_accepted(
+                    TG_ARGV[0]::public.submission_record_type, record_id
+                ) THEN
+                    PERFORM public.tckdb_raise_if_accepted(
+                        TG_ARGV[0]::public.submission_record_type, record_id,
+                        TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                    );
+                END IF;
             END LOOP;
             IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
         END;
@@ -790,12 +819,16 @@ def _replace_guards() -> None:
                     PERFORM public.tckdb_lock_scientific_record(
                         TG_ARGV[0]::public.submission_record_type, record_id
                     );
-                    PERFORM public.tckdb_raise_if_accepted(
-                        TG_ARGV[0]::public.submission_record_type, record_id,
-                        TG_TABLE_SCHEMA, TG_TABLE_NAME,
-                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
-                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
-                    );
+                    IF public.tckdb_record_is_accepted(
+                        TG_ARGV[0]::public.submission_record_type, record_id
+                    ) THEN
+                        PERFORM public.tckdb_raise_if_accepted(
+                            TG_ARGV[0]::public.submission_record_type, record_id,
+                            TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                            CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                            CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                        );
+                    END IF;
                 END IF;
             END LOOP;
             IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
@@ -1045,6 +1078,7 @@ def downgrade() -> None:
         "DROP FUNCTION IF EXISTS public.tckdb_repair_permits("
         "public.submission_record_type, bigint, text, text, jsonb, jsonb)"
     )
+    op.execute("DROP FUNCTION IF EXISTS public.tckdb_record_is_accepted(public.submission_record_type, bigint)")
     op.execute("DROP FUNCTION IF EXISTS public.tckdb_validate_accepted_science_repair_change()")
     op.execute("DROP FUNCTION IF EXISTS public.tckdb_validate_accepted_science_repair()")
     op.drop_table("accepted_science_repair_change", schema="public")

--- a/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
+++ b/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
@@ -45,7 +45,8 @@ an atom.
 The check is column-level and not row-level, deliberately: a repair of this
 kind is corpus-wide by nature and enumerating rows in advance would be a
 worse-founded claim than enumerating columns. What makes that acceptable is
-that every row it reaches is recorded individually.
+that every row whose value it changes is recorded individually -- see "What an
+auditor can reconstruct" below for exactly how far that reaches.
 
 Only UPDATE. INSERT and DELETE under an accepted root stay unconditionally
 refused, because adding or removing a row changes what reviewers accepted
@@ -117,9 +118,27 @@ For any repair: the declaring role and login, the transaction, the revision,
 the stated reason, the declared columns -- and then, per accepted root and per
 row, the primary key of the row, the columns that changed, and their values on
 both sides. "The record did not change scientifically" stops being a docstring
-and becomes a join. The completeness property that makes it an audit rather
-than a sample: under an accepted root, an UPDATE either raises or appends a
-change row. There is no third outcome.
+and becomes a join.
+
+The property that makes that an audit rather than a sample, stated as narrowly
+as the code enforces it: under an accepted root, a write that changes a
+**value** is either refused or recorded. It is not true that *every* write is
+one or the other. The comparison is ``to_jsonb(OLD)`` against
+``to_jsonb(NEW)``, and ``to_jsonb`` renders numbers as JSON numerics, which
+carry no signed zero and compare without regard to trailing scale. So a write
+that changes only the *representation* of an equal value passes with no change
+row: ``UPDATE ... SET x = -0.0`` over a stored ``0.0`` succeeds silently under
+an ``element``-only declaration, because ``changed_columns`` comes back empty.
+
+That is nothing scientifically, which is why it is documented rather than
+closed. No genuinely different number can hide behind it -- ``float8`` renders
+round-trip, so ``0.1`` and the next representable double compare distinct --
+and text, enum, timestamp, ``mol`` and ``jsonb`` columns all serialise exactly.
+Normalising every value before comparing would put a cost on the path *every*
+UPDATE to a guarded table takes, to catch a class of change that moves nothing
+a reader can observe. The absolute version of this sentence was written first
+and is recorded here as wrong, because it is the kind of claim that lets a
+later reader skip checking.
 
 Not touched
 -----------

--- a/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
+++ b/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
@@ -1,0 +1,1051 @@
+"""Declare a repair before making it, and let the database check the claim.
+
+``c6f2a9d4e7b1`` made every accepted scientific record immutable in the
+database, and ``b6c1f4a8e703`` and ``a1f6c3e9b527`` extended that regime to
+twelve more tables. ADR 0003 is the position it enforces and it is the right
+one: a corrected *number* forks identity, because a citation has to keep
+resolving to what was cited.
+
+It left one thing with no route through it. A repair that changes no science
+-- the letter case of an element symbol in a derived index column, with
+``geom_hash``, ``xyz_text``, coordinates, isotopes and atom ordering provably
+untouched -- is not a correction of a scientific claim, and forking identity
+for it re-keys a citable public ref to fix a shift key. ``b4e7c1d20f83`` is
+the worked example: it canonicalises ``geometry_atom.element``, it deliberately
+leaves ``trg_as_geometry_atom`` standing, and it therefore fails loudly on any
+deployment holding a non-canonical row under an accepted calculation. That is
+the correct outcome for a migration that cannot ask anybody. It is not an
+answer for the operator who *has* such a row.
+
+The only mechanical option that operator had was ``ALTER TABLE ... DISABLE
+TRIGGER``, the work, and ``ENABLE`` -- which the first draft of #118 did and
+review rejected, correctly. After the fact that operation is invisible.
+Nothing records that the guard was stood down, over which rows, or on what
+justification, and the claim "the record did not change scientifically" lived
+in a migration docstring, which is prose rather than an assertion.
+
+What this revision adds is not permission. It is a record, and a check.
+
+A repair is declared before it is made
+--------------------------------------
+``accepted_science_repair`` holds one row per repair: the table it will
+change, the exact set of columns it may change, the Alembic revision doing it,
+and why. ``accepted_science_repair_change`` holds one row per accepted record
+per changed row: which root, which row (by primary key), which columns, and
+the values before and after.
+
+While a declaration is in force, ``tckdb_raise_if_accepted`` permits an UPDATE
+to the declared table -- **only if the columns that actually changed are a
+subset of the declared set**. That is a comparison of OLD against NEW inside a
+``BEFORE UPDATE`` trigger, so it is enforced rather than promised: an UPDATE
+that touches one undeclared column is refused by name, and the whole
+transaction with it. A declaration for ``geometry_atom(element)`` cannot move
+an atom.
+
+The check is column-level and not row-level, deliberately: a repair of this
+kind is corpus-wide by nature and enumerating rows in advance would be a
+worse-founded claim than enumerating columns. What makes that acceptable is
+that every row it reaches is recorded individually.
+
+Only UPDATE. INSERT and DELETE under an accepted root stay unconditionally
+refused, because adding or removing a row changes what reviewers accepted
+rather than how it is spelled. The row count under an accepted root therefore
+remains invariant under every repair this mechanism can express.
+
+It cannot be left open
+----------------------
+Scope is the transaction. ``xact_id`` defaults to ``pg_current_xact_id()`` and
+the guard matches on it, so a declaration is inert the instant its transaction
+ends -- there is no close step to forget, no flag to reset, and a committed
+row can never be reused. A second, independent bound is wall-clock:
+``expires_at`` defaults to one hour out and is capped at 24, and an expired
+declaration raises rather than silently permitting, so a wedged transaction
+cannot hold the door open either. The two timestamps are ``timestamptz``
+rather than the naive timestamps used elsewhere in this schema, because an
+expiry compared against ``clock_timestamp()`` must not depend on the session's
+``TimeZone``.
+
+At most one declaration per table per transaction, enforced on insert. Two
+would make "the declaration in force" a question rather than a fact.
+
+It confers no authority anybody lacked
+--------------------------------------
+Only a role that owns the target table may declare a repair to it
+(``pg_has_role(current_user, relowner, 'USAGE')``, which superusers pass). That
+is exactly the set of roles that could already have run ``ALTER TABLE ...
+DISABLE TRIGGER``. So this adds no power to anyone; it converts an
+already-available and unrecorded capability into a recorded one, which is the
+entire argument for building it. In the deployment posture of
+``backend/docs/deployment/database_roles.md`` the runtime role owns nothing and
+is refused here for the same reason it is refused there.
+
+The same owner test guards ``accepted_science_repair_change``, which is what
+stops the *record* being forged rather than the repair. The runtime role holds
+blanket ``INSERT`` on tables in ``public`` -- granted by the default privileges
+in ``configure_database_roles.py``, which run before this table exists and so
+cannot exempt it -- and a forged audit row is exactly the failure this table
+is built against. So the guarantee is carried entirely by triggers and depends
+on no grant: a change row must name a declaration made in the *same*
+transaction, for the same table, with columns the declaration covers, and be
+inserted by an owner of that table. Every one of those holds by construction
+when ``tckdb_repair_permits`` writes it.
+
+Both tables are append-only and un-truncatable, on the same terms as
+``record_review_event`` and ``scientific_record_supersession``: a record of a
+repair that the repairer can edit afterwards is not a record.
+
+A declaration must name something that is actually guarded
+----------------------------------------------------------
+The insert-time validation refuses a target that is not a table, that carries
+no ``trg_as_*`` guard, that lacks a primary key, or that does not have every
+declared column. The first three would each produce a row that looks like a
+control and is not: a declaration against an unguarded table permits nothing
+because nothing was refusing, and a table with no primary key cannot have its
+changed rows named in the record, which is the only reason the permission is
+defensible.
+
+It also refuses a declaration that names a primary-key column, for the second
+half of that reason: the change record identifies the row by its primary key,
+so a repair that rewrote one could not say which row it changed -- and a row
+under a new identity is a different row, which is what supersession is for.
+Neither ``geometry_atom.element`` nor ``reaction_atom_map_pair.element``, the
+motivating columns, is part of its table's key.
+
+What an auditor can reconstruct
+-------------------------------
+For any repair: the declaring role and login, the transaction, the revision,
+the stated reason, the declared columns -- and then, per accepted root and per
+row, the primary key of the row, the columns that changed, and their values on
+both sides. "The record did not change scientifically" stops being a docstring
+and becomes a join. The completeness property that makes it an audit rather
+than a sample: under an accepted root, an UPDATE either raises or appends a
+change row. There is no third outcome.
+
+Not touched
+-----------
+``record_review`` and its guard are outside this mechanism; approval history
+is not repairable. ``b4e7c1d20f83`` is not retrofitted -- it is deployed, and
+its argument for leaving the guard standing is unchanged. Nothing in this
+revision repairs anything; it is the path the next repair takes.
+
+Revision ID: e2c9a4f7b163
+Revises: a1f6c3e9b527
+Create Date: 2026-08-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e2c9a4f7b163"
+down_revision: Union[str, Sequence[str], None] = "a1f6c3e9b527"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: The trigger functions that constitute the accepted-science regime. A repair
+#: may only be declared against a table one of these is attached to.
+_GUARD_FUNCTIONS = (
+    "tckdb_guard_accepted_root",
+    "tckdb_guard_accepted_child",
+    "tckdb_guard_accepted_via_child",
+    "tckdb_guard_calculation_geometry",
+)
+
+
+def _create_tables() -> None:
+    op.create_table(
+        "accepted_science_repair",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "target_schema",
+            sa.Text(),
+            server_default=sa.text("'public'"),
+            nullable=False,
+        ),
+        sa.Column("target_table", sa.Text(), nullable=False),
+        sa.Column(
+            "declared_columns",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("alembic_revision", sa.Text(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "declared_by_role",
+            sa.Text(),
+            server_default=sa.text("CURRENT_USER"),
+            nullable=False,
+        ),
+        sa.Column(
+            "declared_by_login",
+            sa.Text(),
+            server_default=sa.text("SESSION_USER"),
+            nullable=False,
+        ),
+        sa.Column(
+            "xact_id",
+            sa.BigInteger(),
+            server_default=sa.text("((pg_current_xact_id())::text)::bigint"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("clock_timestamp()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("clock_timestamp() + interval '1 hour'"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_accepted_science_repair")),
+        sa.CheckConstraint(
+            "length(btrim(target_schema)) > 0 AND length(btrim(target_table)) > 0",
+            name=op.f("ck_accepted_science_repair_target_nonblank"),
+        ),
+        sa.CheckConstraint(
+            "cardinality(declared_columns) > 0 AND array_position(declared_columns, NULL) IS NULL",
+            name=op.f("ck_accepted_science_repair_columns_declared"),
+        ),
+        sa.CheckConstraint(
+            "length(btrim(alembic_revision)) > 0",
+            name=op.f("ck_accepted_science_repair_revision_nonblank"),
+        ),
+        sa.CheckConstraint(
+            "length(btrim(reason)) > 0",
+            name=op.f("ck_accepted_science_repair_reason_nonblank"),
+        ),
+        sa.CheckConstraint(
+            "expires_at > created_at AND expires_at <= created_at + interval '24 hours'",
+            name=op.f("ck_accepted_science_repair_expiry_window"),
+        ),
+        schema="public",
+    )
+    op.create_index(
+        "ix_accepted_science_repair_target",
+        "accepted_science_repair",
+        ["target_schema", "target_table", "xact_id"],
+        unique=False,
+        schema="public",
+    )
+
+    op.create_table(
+        "accepted_science_repair_change",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("repair_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "record_type",
+            postgresql.ENUM(name="submission_record_type", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("record_id", sa.BigInteger(), nullable=False),
+        sa.Column("target_schema", sa.Text(), nullable=False),
+        sa.Column("target_table", sa.Text(), nullable=False),
+        sa.Column("row_identity", postgresql.JSONB(), nullable=False),
+        sa.Column("changed_columns", postgresql.ARRAY(sa.Text()), nullable=False),
+        sa.Column("before_json", postgresql.JSONB(), nullable=False),
+        sa.Column("after_json", postgresql.JSONB(), nullable=False),
+        sa.Column(
+            "recorded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("clock_timestamp()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_accepted_science_repair_change")),
+        sa.ForeignKeyConstraint(
+            ["repair_id"],
+            ["public.accepted_science_repair.id"],
+            name="fk_repair_change_repair",
+        ),
+        sa.CheckConstraint(
+            "cardinality(changed_columns) > 0",
+            name=op.f("ck_accepted_science_repair_change_columns_changed"),
+        ),
+        schema="public",
+    )
+    op.create_index(
+        "ix_accepted_science_repair_change_repair_id",
+        "accepted_science_repair_change",
+        ["repair_id"],
+        unique=False,
+        schema="public",
+    )
+    op.create_index(
+        "ix_accepted_science_repair_change_record",
+        "accepted_science_repair_change",
+        ["record_type", "record_id"],
+        unique=False,
+        schema="public",
+    )
+
+
+def _create_functions() -> None:
+    guard_functions = ", ".join(f"'{name}'" for name in _GUARD_FUNCTIONS)
+    op.execute(
+        f"""
+        CREATE FUNCTION public.tckdb_validate_accepted_science_repair()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE
+            target_oid oid;
+            target_owner oid;
+            unknown_columns text[];
+        BEGIN
+            SELECT relation.oid, relation.relowner
+              INTO target_oid, target_owner
+              FROM pg_class AS relation
+              JOIN pg_namespace AS namespace
+                ON namespace.oid = relation.relnamespace
+             WHERE namespace.nspname = NEW.target_schema
+               AND relation.relname = NEW.target_table
+               AND relation.relkind IN ('r', 'p');
+            IF target_oid IS NULL THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = format(
+                        'repair target %I.%I is not a table',
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+
+            -- A declaration against a table nothing guards permits nothing,
+            -- and would read afterwards as though a control had been stood
+            -- down when none was ever in the way.
+            IF NOT EXISTS (
+                SELECT 1
+                  FROM pg_trigger AS guard
+                  JOIN pg_proc AS guard_function ON guard_function.oid = guard.tgfoid
+                 WHERE guard.tgrelid = target_oid
+                   AND NOT guard.tgisinternal
+                   AND guard_function.proname IN ({guard_functions})
+            ) THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = format(
+                        'repair target %I.%I carries no accepted-science guard',
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+
+            IF EXISTS (
+                SELECT 1
+                  FROM unnest(NEW.declared_columns) AS column_name
+                 GROUP BY column_name
+                HAVING count(*) > 1
+            ) THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = 'repair declares the same column twice';
+            END IF;
+
+            SELECT array_agg(column_name ORDER BY column_name)
+              INTO unknown_columns
+              FROM unnest(NEW.declared_columns) AS column_name
+             WHERE NOT EXISTS (
+                SELECT 1
+                  FROM pg_attribute AS attribute
+                 WHERE attribute.attrelid = target_oid
+                   AND attribute.attname = column_name
+                   AND attribute.attnum > 0
+                   AND NOT attribute.attisdropped
+             );
+            IF unknown_columns IS NOT NULL THEN
+                RAISE EXCEPTION USING ERRCODE = '42703',
+                    MESSAGE = format(
+                        'repair declares column(s) %s that %I.%I does not have',
+                        array_to_string(unknown_columns, ', '),
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+
+            -- Every changed row is recorded by primary key. A table without
+            -- one cannot be audited, so it cannot be repaired either.
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_index AS index_
+                 WHERE index_.indrelid = target_oid AND index_.indisprimary
+            ) THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = format(
+                        'repair target %I.%I has no primary key',
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+
+            -- ...and for the same reason, the key itself is off limits. The
+            -- change record names the row by its primary key, so a repair
+            -- that rewrote one could not say which row it changed -- and a
+            -- row under a new identity is a different row, which is what
+            -- supersession is for.
+            SELECT array_agg(attribute.attname ORDER BY attribute.attname)
+              INTO unknown_columns
+              FROM pg_index AS index_
+              JOIN pg_attribute AS attribute
+                ON attribute.attrelid = index_.indrelid
+               AND attribute.attnum = ANY (index_.indkey)
+             WHERE index_.indrelid = target_oid
+               AND index_.indisprimary
+               AND attribute.attname = ANY (NEW.declared_columns);
+            IF unknown_columns IS NOT NULL THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = format(
+                        'repair declares primary-key column(s) %s of %I.%I',
+                        array_to_string(unknown_columns, ', '),
+                        NEW.target_schema, NEW.target_table
+                    ),
+                    HINT = 'A row under a new identity is a different row; record a supersession.';
+            END IF;
+
+            -- Exactly the roles that could already have run
+            -- ALTER TABLE ... DISABLE TRIGGER. This grants nothing new; it
+            -- makes an existing capability recordable.
+            IF NOT pg_catalog.pg_has_role(current_user, target_owner, 'USAGE') THEN
+                RAISE EXCEPTION USING ERRCODE = '42501',
+                    MESSAGE = format(
+                        'only an owner of %I.%I may declare a repair to it',
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+
+            IF NEW.xact_id <> (pg_current_xact_id())::text::bigint THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = 'a repair declaration cannot name another transaction';
+            END IF;
+
+            IF EXISTS (
+                SELECT 1 FROM public.accepted_science_repair
+                 WHERE target_schema = NEW.target_schema
+                   AND target_table = NEW.target_table
+                   AND xact_id = NEW.xact_id
+            ) THEN
+                RAISE EXCEPTION USING ERRCODE = '55000',
+                    MESSAGE = format(
+                        'a repair to %I.%I is already declared in this transaction',
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+            RETURN NEW;
+        END;
+        $$
+        """
+    )
+
+    op.execute(
+        """
+        CREATE FUNCTION public.tckdb_validate_accepted_science_repair_change()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE
+            declaration public.accepted_science_repair%ROWTYPE;
+            target_owner oid;
+        BEGIN
+            SELECT * INTO declaration
+              FROM public.accepted_science_repair
+             WHERE id = NEW.repair_id;
+            IF NOT FOUND THEN
+                RAISE EXCEPTION USING ERRCODE = '23503',
+                    MESSAGE = 'repair change names no declaration';
+            END IF;
+            IF declaration.xact_id <> (pg_current_xact_id())::text::bigint THEN
+                RAISE EXCEPTION USING ERRCODE = '55000',
+                    MESSAGE = 'a repair change may only be recorded in the transaction that declared it';
+            END IF;
+            IF NEW.target_schema IS DISTINCT FROM declaration.target_schema
+               OR NEW.target_table IS DISTINCT FROM declaration.target_table THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = 'repair change names a different table than its declaration';
+            END IF;
+            IF NOT (NEW.changed_columns <@ declaration.declared_columns) THEN
+                RAISE EXCEPTION USING ERRCODE = '22023',
+                    MESSAGE = 'repair change names columns its declaration does not cover';
+            END IF;
+
+            SELECT relation.relowner
+              INTO target_owner
+              FROM pg_class AS relation
+              JOIN pg_namespace AS namespace
+                ON namespace.oid = relation.relnamespace
+             WHERE namespace.nspname = NEW.target_schema
+               AND relation.relname = NEW.target_table;
+            IF target_owner IS NULL
+               OR NOT pg_catalog.pg_has_role(current_user, target_owner, 'USAGE') THEN
+                RAISE EXCEPTION USING ERRCODE = '42501',
+                    MESSAGE = format(
+                        'only an owner of %I.%I may record a repair change to it',
+                        NEW.target_schema, NEW.target_table
+                    );
+            END IF;
+            RETURN NEW;
+        END;
+        $$
+        """
+    )
+
+    op.execute(
+        """
+        CREATE FUNCTION public.tckdb_repair_permits(
+            p_type public.submission_record_type,
+            p_record_id bigint,
+            p_schema text,
+            p_table text,
+            p_old jsonb,
+            p_new jsonb
+        ) RETURNS boolean
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE
+            declaration public.accepted_science_repair%ROWTYPE;
+            changed_columns text[];
+            undeclared_columns text[];
+            row_identity jsonb;
+        BEGIN
+            -- INSERT and DELETE are never repairable: p_old or p_new is NULL
+            -- for them, and a repair may not change how many rows an accepted
+            -- record is made of.
+            IF p_old IS NULL OR p_new IS NULL OR p_table IS NULL THEN
+                RETURN false;
+            END IF;
+
+            SELECT * INTO declaration
+              FROM public.accepted_science_repair
+             WHERE target_schema = p_schema
+               AND target_table = p_table
+               AND xact_id = (pg_current_xact_id())::text::bigint;
+            IF NOT FOUND THEN
+                RETURN false;
+            END IF;
+            IF clock_timestamp() >= declaration.expires_at THEN
+                RAISE EXCEPTION USING ERRCODE = '55000',
+                    MESSAGE = format(
+                        'repair declaration %s for %I.%I expired at %s',
+                        declaration.id, p_schema, p_table, declaration.expires_at
+                    ),
+                    HINT = 'A declaration is not a standing permission; declare the repair again.';
+            END IF;
+
+            SELECT coalesce(array_agg(entry.key ORDER BY entry.key), ARRAY[]::text[])
+              INTO changed_columns
+              FROM jsonb_each(p_old) AS entry
+             WHERE entry.value IS DISTINCT FROM (p_new -> entry.key);
+
+            SELECT array_agg(column_name ORDER BY column_name)
+              INTO undeclared_columns
+              FROM unnest(changed_columns) AS column_name
+             WHERE NOT (column_name = ANY (declaration.declared_columns));
+            IF undeclared_columns IS NOT NULL THEN
+                RAISE EXCEPTION USING ERRCODE = '55000',
+                    MESSAGE = format(
+                        'repair declaration %s for %I.%I does not declare column(s) %s',
+                        declaration.id, p_schema, p_table,
+                        array_to_string(undeclared_columns, ', ')
+                    ),
+                    HINT = 'A repair may only change the columns it declared.';
+            END IF;
+            IF cardinality(changed_columns) = 0 THEN
+                RETURN true;
+            END IF;
+
+            SELECT jsonb_object_agg(attribute.attname, p_old -> attribute.attname)
+              INTO row_identity
+              FROM pg_index AS index_
+              JOIN pg_attribute AS attribute
+                ON attribute.attrelid = index_.indrelid
+               AND attribute.attnum = ANY (index_.indkey)
+             WHERE index_.indrelid = format('%I.%I', p_schema, p_table)::regclass
+               AND index_.indisprimary;
+            IF row_identity IS NULL THEN
+                RAISE EXCEPTION USING ERRCODE = '55000',
+                    MESSAGE = format(
+                        'cannot record a repair to %I.%I: it has no primary key',
+                        p_schema, p_table
+                    );
+            END IF;
+
+            INSERT INTO public.accepted_science_repair_change (
+                repair_id, record_type, record_id, target_schema, target_table,
+                row_identity, changed_columns, before_json, after_json
+            ) VALUES (
+                declaration.id, p_type, p_record_id, p_schema, p_table,
+                row_identity, changed_columns,
+                (
+                    SELECT coalesce(jsonb_object_agg(name, p_old -> name), '{}'::jsonb)
+                      FROM unnest(changed_columns) AS name
+                ),
+                (
+                    SELECT coalesce(jsonb_object_agg(name, p_new -> name), '{}'::jsonb)
+                      FROM unnest(changed_columns) AS name
+                )
+            );
+            RETURN true;
+        END;
+        $$
+        """
+    )
+
+    # Replaces c6f2a9d4e7b1's two-argument version. It stays the single owner
+    # of both the acceptance question and the immutability message; what it
+    # gains is the row context needed to consult a declaration. The extra
+    # arguments default to NULL so a caller that supplies none gets exactly the
+    # old behaviour.
+    op.execute("DROP FUNCTION IF EXISTS public.tckdb_raise_if_accepted(public.submission_record_type, bigint)")
+    op.execute(
+        """
+        CREATE FUNCTION public.tckdb_raise_if_accepted(
+            p_type public.submission_record_type,
+            p_record_id bigint,
+            p_schema text DEFAULT NULL,
+            p_table text DEFAULT NULL,
+            p_old jsonb DEFAULT NULL,
+            p_new jsonb DEFAULT NULL
+        ) RETURNS void
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM public.record_review
+                WHERE record_type = p_type AND record_id = p_record_id
+                  AND first_approved_at IS NOT NULL
+            ) THEN
+                RETURN;
+            END IF;
+            IF public.tckdb_repair_permits(
+                p_type, p_record_id, p_schema, p_table, p_old, p_new
+            ) THEN
+                RETURN;
+            END IF;
+            RAISE EXCEPTION USING ERRCODE = '55000',
+                MESSAGE = format(
+                    'accepted %s record %s is immutable', p_type, p_record_id
+                ),
+                HINT = 'Create and approve a replacement, then record a supersession. '
+                       'A repair that changes no science must first declare its table '
+                       'and columns in accepted_science_repair.';
+        END;
+        $$
+        """
+    )
+
+
+def _replace_guards() -> None:
+    """Hand each guard the row context ``tckdb_raise_if_accepted`` now takes.
+
+    Bodies are otherwise unchanged from ``c6f2a9d4e7b1``. The triggers bind to
+    the function by OID, so replacing the body is enough and no trigger is
+    recreated here.
+    """
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_accepted_root()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE record_id bigint;
+        BEGIN
+            IF TG_OP = 'INSERT' THEN RETURN NEW; END IF;
+            record_id := OLD.id;
+            PERFORM public.tckdb_lock_scientific_record(
+                TG_ARGV[0]::public.submission_record_type, record_id
+            );
+            PERFORM public.tckdb_raise_if_accepted(
+                TG_ARGV[0]::public.submission_record_type, record_id,
+                TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+            );
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_calculation_geometry()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE geometry_ids bigint[] := ARRAY[]::bigint[]; calculation_id bigint;
+        BEGIN
+            IF TG_TABLE_NAME = 'geometry' THEN
+                IF TG_OP = 'INSERT' THEN RETURN NEW; END IF;
+                IF TG_OP = 'DELETE' THEN
+                    geometry_ids := ARRAY[OLD.id];
+                ELSE
+                    geometry_ids := ARRAY[OLD.id, NEW.id];
+                END IF;
+            ELSE
+                IF TG_OP <> 'INSERT' THEN
+                    geometry_ids := array_append(geometry_ids, OLD.geometry_id);
+                END IF;
+                IF TG_OP <> 'DELETE' THEN
+                    geometry_ids := array_append(geometry_ids, NEW.geometry_id);
+                END IF;
+            END IF;
+            FOR calculation_id IN
+                SELECT DISTINCT linked.calculation_id
+                FROM (
+                    SELECT cig.calculation_id
+                    FROM public.calculation_input_geometry cig
+                    WHERE cig.geometry_id = ANY(geometry_ids)
+                    UNION
+                    SELECT cog.calculation_id
+                    FROM public.calculation_output_geometry cog
+                    WHERE cog.geometry_id = ANY(geometry_ids)
+                ) AS linked
+                ORDER BY linked.calculation_id
+            LOOP
+                PERFORM public.tckdb_lock_scientific_record(
+                    'calculation', calculation_id
+                );
+                PERFORM public.tckdb_raise_if_accepted(
+                    'calculation', calculation_id,
+                    TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                );
+            END LOOP;
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_accepted_child()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE record_ids bigint[] := ARRAY[]::bigint[];
+                argument_index integer; record_id bigint;
+        BEGIN
+            FOR argument_index IN 1..TG_NARGS - 1 LOOP
+                IF TG_OP <> 'INSERT' THEN
+                    record_ids := array_append(
+                        record_ids,
+                        (to_jsonb(OLD)->>TG_ARGV[argument_index])::bigint
+                    );
+                END IF;
+                IF TG_OP <> 'DELETE' THEN
+                    record_ids := array_append(
+                        record_ids,
+                        (to_jsonb(NEW)->>TG_ARGV[argument_index])::bigint
+                    );
+                END IF;
+            END LOOP;
+            FOR record_id IN
+                SELECT DISTINCT value
+                FROM unnest(record_ids) AS value
+                WHERE value IS NOT NULL
+                ORDER BY value
+            LOOP
+                PERFORM public.tckdb_lock_scientific_record(
+                    TG_ARGV[0]::public.submission_record_type, record_id
+                );
+                PERFORM public.tckdb_raise_if_accepted(
+                    TG_ARGV[0]::public.submission_record_type, record_id,
+                    TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                );
+            END LOOP;
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_accepted_via_child()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE parent_id bigint; record_id bigint;
+        BEGIN
+            FOR parent_id IN
+                SELECT DISTINCT value::bigint
+                FROM unnest(ARRAY[
+                    CASE WHEN TG_OP <> 'INSERT' THEN to_jsonb(OLD)->>TG_ARGV[1] END,
+                    CASE WHEN TG_OP <> 'DELETE' THEN to_jsonb(NEW)->>TG_ARGV[1] END
+                ]) AS value
+                WHERE value IS NOT NULL
+                ORDER BY value::bigint
+            LOOP
+                EXECUTE format(
+                    'SELECT %I FROM public.%I WHERE %I = $1',
+                    TG_ARGV[4], TG_ARGV[2], TG_ARGV[3]
+                ) INTO record_id USING parent_id;
+                IF record_id IS NOT NULL THEN
+                    PERFORM public.tckdb_lock_scientific_record(
+                        TG_ARGV[0]::public.submission_record_type, record_id
+                    );
+                    PERFORM public.tckdb_raise_if_accepted(
+                        TG_ARGV[0]::public.submission_record_type, record_id,
+                        TG_TABLE_SCHEMA, TG_TABLE_NAME,
+                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+                        CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) END
+                    );
+                END IF;
+            END LOOP;
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+
+
+def _restore_guards() -> None:
+    """Restore ``c6f2a9d4e7b1``'s bodies verbatim."""
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_accepted_root()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE record_id bigint;
+        BEGIN
+            IF TG_OP = 'INSERT' THEN RETURN NEW; END IF;
+            record_id := OLD.id;
+            PERFORM public.tckdb_lock_scientific_record(
+                TG_ARGV[0]::public.submission_record_type, record_id
+            );
+            PERFORM public.tckdb_raise_if_accepted(
+                TG_ARGV[0]::public.submission_record_type, record_id
+            );
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_calculation_geometry()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE geometry_ids bigint[] := ARRAY[]::bigint[]; calculation_id bigint;
+        BEGIN
+            IF TG_TABLE_NAME = 'geometry' THEN
+                IF TG_OP = 'INSERT' THEN RETURN NEW; END IF;
+                IF TG_OP = 'DELETE' THEN
+                    geometry_ids := ARRAY[OLD.id];
+                ELSE
+                    geometry_ids := ARRAY[OLD.id, NEW.id];
+                END IF;
+            ELSE
+                IF TG_OP <> 'INSERT' THEN
+                    geometry_ids := array_append(geometry_ids, OLD.geometry_id);
+                END IF;
+                IF TG_OP <> 'DELETE' THEN
+                    geometry_ids := array_append(geometry_ids, NEW.geometry_id);
+                END IF;
+            END IF;
+            FOR calculation_id IN
+                SELECT DISTINCT linked.calculation_id
+                FROM (
+                    SELECT cig.calculation_id
+                    FROM public.calculation_input_geometry cig
+                    WHERE cig.geometry_id = ANY(geometry_ids)
+                    UNION
+                    SELECT cog.calculation_id
+                    FROM public.calculation_output_geometry cog
+                    WHERE cog.geometry_id = ANY(geometry_ids)
+                ) AS linked
+                ORDER BY linked.calculation_id
+            LOOP
+                PERFORM public.tckdb_lock_scientific_record(
+                    'calculation', calculation_id
+                );
+                PERFORM public.tckdb_raise_if_accepted(
+                    'calculation', calculation_id
+                );
+            END LOOP;
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_accepted_child()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE record_ids bigint[] := ARRAY[]::bigint[];
+                argument_index integer; record_id bigint;
+        BEGIN
+            FOR argument_index IN 1..TG_NARGS - 1 LOOP
+                IF TG_OP <> 'INSERT' THEN
+                    record_ids := array_append(
+                        record_ids,
+                        (to_jsonb(OLD)->>TG_ARGV[argument_index])::bigint
+                    );
+                END IF;
+                IF TG_OP <> 'DELETE' THEN
+                    record_ids := array_append(
+                        record_ids,
+                        (to_jsonb(NEW)->>TG_ARGV[argument_index])::bigint
+                    );
+                END IF;
+            END LOOP;
+            FOR record_id IN
+                SELECT DISTINCT value
+                FROM unnest(record_ids) AS value
+                WHERE value IS NOT NULL
+                ORDER BY value
+            LOOP
+                PERFORM public.tckdb_lock_scientific_record(
+                    TG_ARGV[0]::public.submission_record_type, record_id
+                );
+                PERFORM public.tckdb_raise_if_accepted(
+                    TG_ARGV[0]::public.submission_record_type, record_id
+                );
+            END LOOP;
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.tckdb_guard_accepted_via_child()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        DECLARE parent_id bigint; record_id bigint;
+        BEGIN
+            FOR parent_id IN
+                SELECT DISTINCT value::bigint
+                FROM unnest(ARRAY[
+                    CASE WHEN TG_OP <> 'INSERT' THEN to_jsonb(OLD)->>TG_ARGV[1] END,
+                    CASE WHEN TG_OP <> 'DELETE' THEN to_jsonb(NEW)->>TG_ARGV[1] END
+                ]) AS value
+                WHERE value IS NOT NULL
+                ORDER BY value::bigint
+            LOOP
+                EXECUTE format(
+                    'SELECT %I FROM public.%I WHERE %I = $1',
+                    TG_ARGV[4], TG_ARGV[2], TG_ARGV[3]
+                ) INTO record_id USING parent_id;
+                IF record_id IS NOT NULL THEN
+                    PERFORM public.tckdb_lock_scientific_record(
+                        TG_ARGV[0]::public.submission_record_type, record_id
+                    );
+                    PERFORM public.tckdb_raise_if_accepted(
+                        TG_ARGV[0]::public.submission_record_type, record_id
+                    );
+                END IF;
+            END LOOP;
+            IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+        END;
+        $$
+        """
+    )
+
+
+def _create_triggers() -> None:
+    op.execute(
+        """
+        CREATE TRIGGER trg_accepted_science_repair_validate
+        BEFORE INSERT ON public.accepted_science_repair
+        FOR EACH ROW
+        EXECUTE FUNCTION public.tckdb_validate_accepted_science_repair()
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_accepted_science_repair_change_validate
+        BEFORE INSERT ON public.accepted_science_repair_change
+        FOR EACH ROW
+        EXECUTE FUNCTION public.tckdb_validate_accepted_science_repair_change()
+        """
+    )
+    for table in ("accepted_science_repair", "accepted_science_repair_change"):
+        op.execute(
+            f"""
+            CREATE TRIGGER trg_append_only_{table}
+            BEFORE UPDATE OR DELETE ON public.{table}
+            FOR EACH ROW EXECUTE FUNCTION public.tckdb_reject_mutation()
+            """
+        )
+        op.execute(
+            f"""
+            CREATE TRIGGER trg_as_truncate_{table}
+            BEFORE TRUNCATE ON public.{table}
+            FOR EACH STATEMENT EXECUTE FUNCTION public.tckdb_reject_truncate()
+            """
+        )
+
+
+def upgrade() -> None:
+    """Add the declared, checked and recorded repair path."""
+
+    _create_tables()
+    _create_functions()
+    _replace_guards()
+    _create_triggers()
+
+
+def downgrade() -> None:
+    """Remove the repair path and restore the unconditional refusal."""
+
+    for table in ("accepted_science_repair", "accepted_science_repair_change"):
+        op.execute(f"DROP TRIGGER IF EXISTS trg_append_only_{table} ON public.{table}")
+        op.execute(f"DROP TRIGGER IF EXISTS trg_as_truncate_{table} ON public.{table}")
+    op.execute("DROP TRIGGER IF EXISTS trg_accepted_science_repair_validate ON public.accepted_science_repair")
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_accepted_science_repair_change_validate ON public.accepted_science_repair_change"
+    )
+    _restore_guards()
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.tckdb_raise_if_accepted("
+        "public.submission_record_type, bigint, text, text, jsonb, jsonb)"
+    )
+    op.execute(
+        """
+        CREATE FUNCTION public.tckdb_raise_if_accepted(
+            p_type public.submission_record_type, p_record_id bigint
+        ) RETURNS void
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog, public
+        AS $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM public.record_review
+                WHERE record_type = p_type AND record_id = p_record_id
+                  AND first_approved_at IS NOT NULL
+            ) THEN
+                RAISE EXCEPTION USING ERRCODE = '55000',
+                    MESSAGE = format(
+                        'accepted %s record %s is immutable', p_type, p_record_id
+                    ),
+                    HINT = 'Create and approve a replacement, then record a supersession.';
+            END IF;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.tckdb_repair_permits("
+        "public.submission_record_type, bigint, text, text, jsonb, jsonb)"
+    )
+    op.execute("DROP FUNCTION IF EXISTS public.tckdb_validate_accepted_science_repair_change()")
+    op.execute("DROP FUNCTION IF EXISTS public.tckdb_validate_accepted_science_repair()")
+    op.drop_table("accepted_science_repair_change", schema="public")
+    op.drop_table("accepted_science_repair", schema="public")

--- a/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
+++ b/backend/alembic/versions/e2c9a4f7b163_record_accepted_science_repairs.py
@@ -2,7 +2,7 @@
 
 ``c6f2a9d4e7b1`` made every accepted scientific record immutable in the
 database, and ``b6c1f4a8e703`` and ``a1f6c3e9b527`` extended that regime to
-twelve more tables. ADR 0003 is the position it enforces and it is the right
+seven more tables. ADR 0003 is the position it enforces and it is the right
 one: a corrected *number* forks identity, because a citation has to keep
 resolving to what was cited.
 

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -8,6 +8,7 @@ from app.services.public_refs import (
 )
 
 from . import (
+    accepted_science_repair,
     api_key,
     app_user,
     author,
@@ -48,6 +49,7 @@ _install_public_ref_listener()
 
 
 __all__ = [
+    "accepted_science_repair",
     "api_key",
     "app_user",
     "author",

--- a/backend/app/db/models/accepted_science_repair.py
+++ b/backend/app/db/models/accepted_science_repair.py
@@ -1,0 +1,130 @@
+"""Declared, checked and recorded repairs to accepted scientific records.
+
+Both tables are written by the database itself, never by this application.
+``accepted_science_repair`` is inserted by a migration running as the schema
+owner -- an insert-time trigger refuses any other role, because the owner is
+exactly the set that could already have run ``ALTER TABLE ... DISABLE
+TRIGGER``. ``accepted_science_repair_change`` is appended by
+``tckdb_repair_permits`` from inside the accepted-science guards.
+
+They are mapped here so ``Base.metadata`` stays a complete picture of the
+schema and so read paths and tests can query them; there is deliberately no
+service that writes either. See ``e2c9a4f7b163`` and
+``backend/docs/specs/accepted_science_immutability.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, CheckConstraint, DateTime, ForeignKey, Index, Text, text
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.models.common import SubmissionRecordType
+
+
+class AcceptedScienceRepair(Base):
+    """One declaration: which table, which columns, which revision, and why."""
+
+    __tablename__ = "accepted_science_repair"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    target_schema: Mapped[str] = mapped_column(Text, server_default=text("'public'"), nullable=False)
+    target_table: Mapped[str] = mapped_column(Text, nullable=False)
+    #: The only columns an UPDATE under this declaration may change. Enforced
+    #: by comparing OLD against NEW in the guard, not by convention.
+    declared_columns: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False)
+    alembic_revision: Mapped[str] = mapped_column(Text, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    declared_by_role: Mapped[str] = mapped_column(Text, server_default=text("CURRENT_USER"), nullable=False)
+    declared_by_login: Mapped[str] = mapped_column(Text, server_default=text("SESSION_USER"), nullable=False)
+    #: The transaction the declaration is valid in, and only in. A committed
+    #: declaration can never be reused, so there is no close step to forget.
+    xact_id: Mapped[int] = mapped_column(
+        BigInteger,
+        server_default=text("((pg_current_xact_id())::text)::bigint"),
+        nullable=False,
+    )
+    #: ``timestamptz`` rather than this schema's usual naive timestamps: an
+    #: expiry compared against ``clock_timestamp()`` must not depend on the
+    #: session's ``TimeZone``.
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("clock_timestamp()"),
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("clock_timestamp() + interval '1 hour'"),
+        nullable=False,
+    )
+
+    changes: Mapped[list["AcceptedScienceRepairChange"]] = relationship(
+        back_populates="repair",
+        order_by="AcceptedScienceRepairChange.id",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "length(btrim(target_schema)) > 0 AND length(btrim(target_table)) > 0",
+            name="target_nonblank",
+        ),
+        CheckConstraint(
+            "cardinality(declared_columns) > 0 AND array_position(declared_columns, NULL) IS NULL",
+            name="columns_declared",
+        ),
+        CheckConstraint("length(btrim(alembic_revision)) > 0", name="revision_nonblank"),
+        CheckConstraint("length(btrim(reason)) > 0", name="reason_nonblank"),
+        CheckConstraint(
+            "expires_at > created_at AND expires_at <= created_at + interval '24 hours'",
+            name="expiry_window",
+        ),
+        Index(
+            "ix_accepted_science_repair_target",
+            "target_schema",
+            "target_table",
+            "xact_id",
+        ),
+    )
+
+
+class AcceptedScienceRepairChange(Base):
+    """One accepted record's view of one row a repair rewrote."""
+
+    __tablename__ = "accepted_science_repair_change"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    repair_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("accepted_science_repair.id", name="fk_repair_change_repair"),
+        nullable=False,
+    )
+    #: The accepted root whose immutability was stood down for this row.
+    record_type: Mapped[SubmissionRecordType] = mapped_column(
+        SAEnum(SubmissionRecordType, name="submission_record_type"),
+        nullable=False,
+    )
+    record_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    target_schema: Mapped[str] = mapped_column(Text, nullable=False)
+    target_table: Mapped[str] = mapped_column(Text, nullable=False)
+    #: Primary key of the changed row, as ``{column: value}``.
+    row_identity: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    changed_columns: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False)
+    before_json: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    after_json: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("clock_timestamp()"),
+        nullable=False,
+    )
+
+    repair: Mapped["AcceptedScienceRepair"] = relationship(back_populates="changes")
+
+    __table_args__ = (
+        CheckConstraint("cardinality(changed_columns) > 0", name="columns_changed"),
+        Index("ix_accepted_science_repair_change_repair_id", "repair_id"),
+        Index("ix_accepted_science_repair_change_record", "record_type", "record_id"),
+    )

--- a/backend/app/services/archive/registry.py
+++ b/backend/app/services/archive/registry.py
@@ -146,7 +146,22 @@ INCLUDED_TABLES: frozenset[str] = frozenset(
 )
 
 
+# ``accepted_science_repair`` and its change record are the account of a
+# declared repair to an accepted record (ADR 0015). They are excluded not
+# because that account is unimportant but because the row cannot be
+# transplanted: its meaning is carried by ``xact_id``, a transaction id from
+# *this* cluster's counter, and every check deciding whether a declaration is
+# live compares it against ``pg_current_xact_id()``. Restored into a fresh
+# cluster whose counter starts near zero, an archived declaration names a
+# transaction larger than any the new database has issued -- inert by
+# construction and misleading by shape. The repaired *value* travels with the
+# science, which is what a restored database has to get right; the operational
+# account of how it got there stays with the deployment that performed it and
+# with that deployment's backup, which ADR 0001 already separates from this
+# projection.
 EXCLUDED_TABLES: Mapping[str, str] = {
+    "accepted_science_repair": "deployment-local repair record keyed on a cluster transaction id",
+    "accepted_science_repair_change": "deployment-local repair record keyed on a cluster transaction id",
     "api_key": "authentication credential state",
     "idempotency_record": "ephemeral HTTP retry state",
     "upload_job": "ephemeral worker queue state",

--- a/backend/docs/deployment/migrations.md
+++ b/backend/docs/deployment/migrations.md
@@ -315,6 +315,57 @@ SELECT count(*) FROM network_solve WHERE kind = 'reported' AND literature_id IS 
 
 ---
 
+## Repairing an accepted record (revision `e2c9a4f7b163`)
+
+Some migrations rewrite a value that carries no scientific content — the letter
+case of an element symbol in `geometry_atom.element` (`b4e7c1d20f83`) is the
+worked example. On a database holding a non-canonical row under an **accepted**
+calculation, such a migration fails with the accepted-science guard's own
+`accepted calculation record N is immutable`. That failure is correct: the
+decision to rewrite a value inside approved science belongs to the operator, not
+to a migration file.
+
+**Do not disable the trigger.** Declare the repair instead, in the same
+transaction as the rewrite:
+
+```sql
+BEGIN;
+INSERT INTO accepted_science_repair
+    (target_table, declared_columns, alembic_revision, reason)
+VALUES ('geometry_atom', ARRAY['element'], 'b4e7c1d20f83',
+        'canonicalise element symbol case; geom_hash, xyz_text and '
+        'coordinates are not touched');
+
+UPDATE geometry_atom
+   SET element = upper(substr(btrim(element), 1, 1)) || lower(substr(btrim(element), 2))
+ WHERE btrim(element) <> upper(substr(btrim(element), 1, 1)) || lower(substr(btrim(element), 2));
+
+-- Read back what was actually changed before committing.
+SELECT record_type, record_id, row_identity, before_json, after_json
+  FROM accepted_science_repair_change;
+COMMIT;
+```
+
+The declaration permits an UPDATE to that table **only** for the columns it
+names — an UPDATE that touches anything else is refused by name and the whole
+transaction rolls back — and every changed row is recorded against the accepted
+record it sits under. The declaration is dead the moment the transaction ends,
+so there is nothing to close. Run this as the migration owner (`DB_OWNER_USER`);
+the runtime account is refused. Full semantics and limits:
+[`../specs/accepted_science_immutability.md`](../specs/accepted_science_immutability.md)
+and [ADR 0015](../../../docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md).
+
+Two things this cannot do, deliberately. It cannot INSERT or DELETE rows under
+an accepted record, and it cannot rewrite a primary key. Both are changes to
+*what* was accepted rather than to how it is spelled, and both need a
+replacement record and a `scientific_record_supersession` edge.
+
+The repair record is **not** carried by `tckdb.archive.v1` — it is keyed on this
+cluster's transaction id. Keep the `pg_dump` from the upgrade if the account of
+the repair matters to you.
+
+---
+
 ## Self-hosted / Raspberry Pi note
 
 Single-node and Raspberry-Pi deployments follow the same flow as any other deployed DB. Two extra notes:

--- a/backend/docs/specs/accepted_science_immutability.md
+++ b/backend/docs/specs/accepted_science_immutability.md
@@ -73,9 +73,75 @@ provisions a restricted runtime account and a separate migration owner. The
 guarantee applies only after its read-only role-contract check passes on the
 target deployment.
 
-There is deliberately no bypass GUC or normal maintenance escape hatch. Data
-repair after acceptance must use replacement records and supersession. Schema
-migrations run as the separate owner role.
+There is deliberately no bypass GUC and no maintenance escape hatch. A change
+to what a record *says* — any corrected number — must use a replacement record
+and a supersession edge. Schema migrations run as the separate owner role.
+
+## Repairing what a record does not say (`e2c9a4f7b163`)
+
+Supersession is the right answer when the science changes, because forking
+identity is what keeps a citation resolving to what was cited. It is the wrong
+answer for a change that alters no scientific content — the letter case of an
+element symbol in the derived `geometry_atom.element` index column, with
+`geom_hash`, `xyz_text`, coordinates, isotopes and atom ordering untouched
+(`b4e7c1d20f83`). Forking identity there re-keys a citable public ref to fix a
+shift key.
+
+Before this, the only mechanical route was `ALTER TABLE … DISABLE TRIGGER`,
+which leaves nothing behind: no record that the guard was stood down, over
+which rows, or on what justification. A repair is now declared first, and the
+database checks the declaration.
+
+**Declare.** Insert one row into `accepted_science_repair` naming
+`target_table`, the exact `declared_columns` the repair may change, the
+`alembic_revision` doing it, and a nonblank `reason`:
+
+```sql
+INSERT INTO accepted_science_repair
+    (target_table, declared_columns, alembic_revision, reason)
+VALUES ('geometry_atom', ARRAY['element'], 'b4e7c1d20f83',
+        'canonicalise element symbol case; geom_hash, xyz_text and '
+        'coordinates are not touched');
+```
+
+**Then repair, in the same transaction.** While the declaration is in force,
+`tckdb_raise_if_accepted` permits an UPDATE to that table only if the columns
+that actually changed are a **subset** of the declared set. The comparison is
+`OLD` against `NEW` inside the existing `BEFORE UPDATE` guard, so a statement
+that also touches one undeclared column is refused by name and the whole
+transaction with it.
+
+**What is recorded.** Each changed row appends a row to
+`accepted_science_repair_change` per accepted root it sits under: the root's
+`record_type`/`record_id`, the changed row's primary key as `row_identity`,
+`changed_columns`, and `before_json`/`after_json`. Under an accepted root an
+UPDATE either raises or appends a change row — there is no third outcome — so
+"the record did not change scientifically" is a query rather than a docstring.
+
+**What it cannot do.**
+
+- **INSERT and DELETE stay unconditionally refused**, declaration or not. The
+  row count under an accepted root is invariant under every repair.
+- **Primary-key columns cannot be declared.** The record names the row by its
+  key, and a row under a new identity is a different row.
+- **It cannot be left open.** The declaration is matched on
+  `pg_current_xact_id()`, so it is inert the moment its transaction ends —
+  there is no close step. A second bound, `expires_at` (default 1 hour, capped
+  at 24), raises rather than silently permitting, so a wedged transaction
+  cannot hold it open either. At most one declaration per table per
+  transaction.
+- **It confers no authority.** Only a role owning the target table may declare
+  a repair or record a change to it — exactly the roles that could already have
+  run `DISABLE TRIGGER`. The runtime role of
+  [`../deployment/database_roles.md`](../deployment/database_roles.md) owns
+  nothing and is refused, even holding the blanket `INSERT` its default
+  privileges grant. The guarantee is carried by triggers and depends on no
+  grant.
+- **The record cannot be edited.** Both tables are append-only and
+  un-truncatable, on the same terms as `record_review_event`.
+
+`record_review` is outside this mechanism entirely; approval history is not
+repairable.
 
 ## v1 limitation
 

--- a/backend/docs/specs/accepted_science_immutability.md
+++ b/backend/docs/specs/accepted_science_immutability.md
@@ -114,9 +114,20 @@ transaction with it.
 **What is recorded.** Each changed row appends a row to
 `accepted_science_repair_change` per accepted root it sits under: the root's
 `record_type`/`record_id`, the changed row's primary key as `row_identity`,
-`changed_columns`, and `before_json`/`after_json`. Under an accepted root an
-UPDATE either raises or appends a change row — there is no third outcome — so
-"the record did not change scientifically" is a query rather than a docstring.
+`changed_columns`, and `before_json`/`after_json`. Under an accepted root, a
+write that changes a **value** is either refused or recorded, so "the record
+did not change scientifically" is a query rather than a docstring.
+
+Precisely, because the absolute version of that sentence is not true: the
+comparison is `to_jsonb(OLD)` against `to_jsonb(NEW)`, and `to_jsonb` renders
+numbers as JSON numerics, which have no signed zero and ignore trailing scale.
+A write that changes only the *representation* of an equal value therefore
+passes with no change row — `SET x = -0.0` over a stored `0.0` under an
+`element`-only declaration succeeds and records nothing. Nothing a reader can
+observe moves; no genuinely different number can hide, since `float8` renders
+round-trip; and text, enum, timestamp, `mol` and `jsonb` serialise exactly.
+Normalising before comparison would cost every UPDATE to a guarded table more
+than the case is worth, so this is documented rather than closed.
 
 **What it cannot do.**
 

--- a/backend/docs/specs/tckdb_archive_v1.md
+++ b/backend/docs/specs/tckdb_archive_v1.md
@@ -19,6 +19,18 @@ every manifest. All other classified rows are preserved, including primary
 keys, foreign keys, public references, timestamps, submissions, review history,
 machine/reproducibility assessments, and supersession links.
 
+`accepted_science_repair` and `accepted_science_repair_change` (ADR 0015) are
+excluded as well, and for a different kind of reason than the four above. They
+are not ephemeral: they are the durable account of a declared repair to an
+accepted record. What they cannot survive is the *move*. A declaration's
+meaning is carried by `xact_id`, a transaction id from the source cluster's
+counter, and every check that decides whether one is live compares it against
+`pg_current_xact_id()` — so restored into a fresh cluster it names a
+transaction larger than any the new database has issued. The repaired *value*
+travels with the science; the account of who repaired it, under what
+declaration, stays with the deployment that performed it and with that
+deployment's `pg_dump`.
+
 Calculation artifacts are included once per content digest. Their bytes,
 SHA-256 digest, length, filename, and database metadata are preserved. On
 restore, `calculation_artifact.uri` is rewritten to the destination's

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -719,6 +719,59 @@ enum ValidationStatus {
   fail
 }
 
+Table accepted_science_repair {
+  id bigint [pk, not null]
+  target_schema text [not null, default: 'public']
+  target_table text [not null]
+  declared_columns array [not null]
+  alembic_revision text [not null]
+  reason text [not null]
+  declared_by_role text [not null, default: 'CURRENT_USER']
+  declared_by_login text [not null, default: 'SESSION_USER']
+  xact_id bigint [not null, default: '((pg_current_xact_id())::text)::bigint']
+  created_at timestamp [not null, default: 'clock_timestamp()']
+  expires_at timestamp [not null, default: 'clock_timestamp() + interval '1 hour']
+
+  indexes {
+    (target_schema, target_table, xact_id) [name: 'ix_accepted_science_repair_target']
+  }
+
+  checks {
+    `cardinality(declared_columns) > 0 AND array_position(declared_columns, NULL) IS NULL` [name: 'ck_accepted_science_repair_columns_declared']
+    `expires_at > created_at AND expires_at <= created_at + interval '24 hours'` [name: 'ck_accepted_science_repair_expiry_window']
+    `length(btrim(reason)) > 0` [name: 'ck_accepted_science_repair_reason_nonblank']
+    `length(btrim(alembic_revision)) > 0` [name: 'ck_accepted_science_repair_revision_nonblank']
+    `length(btrim(target_schema)) > 0 AND length(btrim(target_table)) > 0` [name: 'ck_accepted_science_repair_target_nonblank']
+  }
+
+  Note: 'One declaration: which table, which columns, which revision, and why.'
+}
+
+Table accepted_science_repair_change {
+  id bigint [pk, not null]
+  repair_id bigint [not null, ref: > accepted_science_repair.id]
+  record_type SubmissionRecordType [not null]
+  record_id bigint [not null]
+  target_schema text [not null]
+  target_table text [not null]
+  row_identity jsonb [not null]
+  changed_columns array [not null]
+  before_json jsonb [not null]
+  after_json jsonb [not null]
+  recorded_at timestamp [not null, default: 'clock_timestamp()']
+
+  indexes {
+    (record_type, record_id) [name: 'ix_accepted_science_repair_change_record']
+    repair_id [name: 'ix_accepted_science_repair_change_repair_id']
+  }
+
+  checks {
+    `cardinality(changed_columns) > 0` [name: 'ck_accepted_science_repair_change_columns_changed']
+  }
+
+  Note: 'One accepted record\'s view of one row a repair rewrote.'
+}
+
 Table api_key {
   id bigint [pk, not null]
   user_id bigint [not null, ref: > app_user.id]

--- a/backend/tests/db/test_accepted_science_repair.py
+++ b/backend/tests/db/test_accepted_science_repair.py
@@ -512,25 +512,45 @@ def test_every_guarded_table_is_declarable(db_session) -> None:
     }
     assert len(guarded) > 40
 
+    columns = text(
+        "SELECT attribute.attname, EXISTS ("
+        "  SELECT 1 FROM pg_index AS index_ "
+        "   WHERE index_.indrelid = attribute.attrelid AND index_.indisprimary "
+        "     AND attribute.attnum = ANY (index_.indkey)) AS in_key "
+        "FROM pg_attribute AS attribute "
+        "WHERE attribute.attrelid = format('public.%I', cast(:table as text))::regclass "
+        "AND attribute.attnum > 0 AND NOT attribute.attisdropped "
+        "ORDER BY attribute.attnum"
+    )
+    all_key_tables: list[str] = []
     for table in sorted(guarded):
-        # Any non-key column will do; the key itself is deliberately not
-        # declarable, which the test above pins.
-        column = db_session.execute(
-            text(
-                "SELECT attribute.attname FROM pg_attribute AS attribute "
-                "WHERE attribute.attrelid = format('public.%I', cast(:table as text))::regclass "
-                "AND attribute.attnum > 0 AND NOT attribute.attisdropped "
-                "AND NOT EXISTS ("
-                "  SELECT 1 FROM pg_index AS index_ "
-                "   WHERE index_.indrelid = attribute.attrelid AND index_.indisprimary "
-                "     AND attribute.attnum = ANY (index_.indkey)) "
-                "ORDER BY attribute.attnum LIMIT 1"
-            ),
-            {"table": table},
-        ).scalar_one()
+        rows = db_session.execute(columns, {"table": table}).all()
+        repairable = [name for name, in_key in rows if not in_key]
+        if not repairable:
+            # A pure junction row -- every column is part of its own key, so
+            # there is nothing about it to respell. It is guarded, and by
+            # construction it is not repairable; the declaration is refused
+            # for naming a key column rather than for naming this table.
+            all_key_tables.append(table)
+            with pytest.raises(DBAPIError, match="primary-key column"), db_session.begin_nested():
+                _declare(db_session, table=table, columns=(rows[0][0],))
+            continue
         with db_session.begin_nested() as nested:
-            _declare(db_session, table=table, columns=(column,))
+            _declare(db_session, table=table, columns=(repairable[0],))
             nested.rollback()
+
+    # Named rather than merely tolerated: these are the guarded tables that no
+    # repair can ever touch, and a table leaving or joining that set is a fact
+    # about the regime worth failing on.
+    assert all_key_tables == [
+        "kinetics_source_calculation",
+        "network_reaction",
+        "network_solve_source_calculation",
+        "network_species",
+        "statmech_source_calculation",
+        "thermo_source_calculation",
+        "transport_source_calculation",
+    ]
 
 
 def test_a_role_without_insert_cannot_declare(db_session) -> None:

--- a/backend/tests/db/test_accepted_science_repair.py
+++ b/backend/tests/db/test_accepted_science_repair.py
@@ -1,0 +1,546 @@
+"""A repair to accepted science is declared, checked column by column, recorded.
+
+``e2c9a4f7b163`` opens the only route through ``c6f2a9d4e7b1``'s refusal, and
+the whole value of it is that the database *checks* the claim rather than
+accepting a justification string. So the tests below pin all four halves of
+that, because any one of them missing turns the mechanism into a bypass with
+paperwork:
+
+* an accepted row **cannot** be updated with no declaration in force;
+* it **can** be updated for a column the declaration names, and the change is
+  recorded with enough detail to audit it afterwards;
+* an update that touches a column *outside* the declared set is refused --
+  including one that changes a declared column in the same statement, which is
+  the case a column check that only looked at the SET list would let through;
+* the declaration does not outlive its scope, in either direction: not past
+  its transaction, and not past its expiry.
+
+The declaration itself is checked on the way in as well: it must name a table
+something actually guards, columns that exist, and it must come from a role
+that could already have run ``ALTER TABLE ... DISABLE TRIGGER``. Otherwise the
+row is a record of a permission nobody needed, which is worse than no row.
+
+``geometry_atom.element`` is the target throughout because it is the case this
+mechanism was built for -- ``b4e7c1d20f83``, the letter case of an element
+symbol in a derived index column -- and because it reaches its accepted root
+(``calculation``) through ``tckdb_guard_calculation_geometry``, the guard with
+the most indirection between the changed row and the record that freezes it.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError, ProgrammingError
+
+from app.db.models.app_user import AppUser
+from app.db.models.common import AppUserRole, RecordReviewStatus, SubmissionRecordType
+from app.db.models.geometry import GeometryAtom
+from app.services.record_review import ensure_record_review, set_record_review_status
+from tests.services.scientific_read._factories import (
+    attach_geometry_atoms,
+    attach_input_geometry,
+    make_calculation,
+    make_geometry,
+    make_species,
+    make_species_entry,
+    next_inchi_key,
+)
+
+_REVISION = "e2c9a4f7b163"
+
+
+def _curator(session, username: str) -> AppUser:
+    actor = AppUser(username=username, role=AppUserRole.curator)
+    session.add(actor)
+    session.flush()
+    return actor
+
+
+def _accepted_atom(session, tag: str):
+    """An accepted calculation whose input geometry has one shouted atom."""
+    actor = _curator(session, f"repair-{tag}-{uuid4().hex[:8]}")
+    species = make_species(session, inchi_key=next_inchi_key(f"REP{tag}"))
+    entry = make_species_entry(session, species)
+    calculation = make_calculation(session, species_entry_id=entry.id)
+    geometry = make_geometry(session, natoms=1, xyz_text="1\n\nCL 0.0 0.0 0.0")
+    atom = attach_geometry_atoms(
+        session,
+        geometry=geometry,
+        symbols=["CL"],
+        coords=[[0.0, 0.0, 0.0]],
+    )[0]
+    attach_input_geometry(session, calculation=calculation, geometry=geometry)
+    ensure_record_review(
+        session,
+        record_type=SubmissionRecordType.calculation,
+        record_id=calculation.id,
+    )
+    review = set_record_review_status(
+        session,
+        record_type=SubmissionRecordType.calculation,
+        record_id=calculation.id,
+        status=RecordReviewStatus.approved,
+        actor=actor,
+    )
+    assert review.first_approved_at is not None
+    return calculation, geometry, atom
+
+
+def _declare(
+    session,
+    *,
+    table: str = "geometry_atom",
+    columns: tuple[str, ...] = ("element",),
+    reason: str = "canonicalise element symbol case; no coordinate changes",
+    ages: tuple[str, str] | None = None,
+) -> int:
+    """Insert a repair declaration and return its id.
+
+    ``ages`` overrides ``(created_at, expires_at)`` with SQL interval
+    expressions relative to ``clock_timestamp()``, so a test can build a
+    declaration that has already expired.
+    """
+    if ages is None:
+        timestamps = ""
+        values = ""
+    else:
+        timestamps = ", created_at, expires_at"
+        values = f", clock_timestamp() {ages[0]}, clock_timestamp() {ages[1]}"
+    return session.execute(
+        text(
+            "INSERT INTO accepted_science_repair "
+            f"(target_table, declared_columns, alembic_revision, reason{timestamps}) "
+            f"VALUES (:table, :columns, :revision, :reason{values}) RETURNING id"
+        ),
+        {
+            "table": table,
+            "columns": list(columns),
+            "revision": _REVISION,
+            "reason": reason,
+        },
+    ).scalar_one()
+
+
+def _changes(session) -> list[dict]:
+    rows = session.execute(
+        text(
+            "SELECT repair_id, record_type::text AS record_type, record_id, "
+            "target_schema, target_table, row_identity, changed_columns, "
+            "before_json, after_json "
+            "FROM accepted_science_repair_change ORDER BY id"
+        )
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def test_accepted_atom_refuses_an_update_with_no_declaration(db_session) -> None:
+    """The regime this revision opens a route through is still closed by default."""
+    _, _, atom = _accepted_atom(db_session, "NODECL")
+
+    with pytest.raises(DBAPIError, match="is immutable"), db_session.begin_nested():
+        atom.element = "Cl"
+        db_session.flush()
+
+
+def test_a_declaration_permits_its_column_and_records_the_change(db_session) -> None:
+    calculation, geometry, atom = _accepted_atom(db_session, "PERMIT")
+    repair_id = _declare(db_session)
+
+    db_session.execute(
+        text("UPDATE geometry_atom SET element = 'Cl' WHERE geometry_id = :geometry_id AND atom_index = :atom_index"),
+        {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+    )
+
+    stored = db_session.execute(
+        text("SELECT btrim(element) FROM geometry_atom WHERE geometry_id = :geometry_id AND atom_index = :atom_index"),
+        {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+    ).scalar_one()
+    assert stored == "Cl"
+
+    recorded = _changes(db_session)
+    assert len(recorded) == 1
+    change = recorded[0]
+    assert change["repair_id"] == repair_id
+    # The accepted record whose immutability was stood down -- reached from a
+    # geometry_atom row through two joins, which is the part worth pinning.
+    assert change["record_type"] == SubmissionRecordType.calculation.value
+    assert change["record_id"] == calculation.id
+    assert change["target_schema"] == "public"
+    assert change["target_table"] == "geometry_atom"
+    assert change["row_identity"] == {
+        "geometry_id": geometry.id,
+        "atom_index": atom.atom_index,
+    }
+    assert change["changed_columns"] == ["element"]
+    # ``element`` is character(2), so the stored value is blank-padded. What
+    # matters is that both sides are recorded verbatim rather than normalised.
+    assert change["before_json"]["element"].strip() == "CL"
+    assert change["after_json"]["element"].strip() == "Cl"
+
+
+def test_an_undeclared_column_is_still_refused_under_a_declaration(db_session) -> None:
+    _, geometry, atom = _accepted_atom(db_session, "OTHERCOL")
+    _declare(db_session)
+
+    with pytest.raises(DBAPIError, match="does not declare column"), db_session.begin_nested():
+        db_session.execute(
+            text("UPDATE geometry_atom SET x = 9.0 WHERE geometry_id = :geometry_id AND atom_index = :atom_index"),
+            {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+        )
+    assert _changes(db_session) == []
+
+
+def test_a_declared_column_does_not_carry_an_undeclared_one(db_session) -> None:
+    """The subset check is over what *changed*, not over what was declared.
+
+    A repair that rewrites its declared column and quietly moves an atom in
+    the same statement is the failure mode a permissive check would allow, and
+    it is the one that matters: the declared change is the alibi.
+    """
+    _, geometry, atom = _accepted_atom(db_session, "SMUGGLE")
+    _declare(db_session)
+
+    with pytest.raises(DBAPIError, match="does not declare column\\(s\\) x"), db_session.begin_nested():
+        db_session.execute(
+            text(
+                "UPDATE geometry_atom SET element = 'Cl', x = 9.0 "
+                "WHERE geometry_id = :geometry_id AND atom_index = :atom_index"
+            ),
+            {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+        )
+
+    stored = db_session.execute(
+        text(
+            "SELECT btrim(element), x FROM geometry_atom WHERE geometry_id = :geometry_id AND atom_index = :atom_index"
+        ),
+        {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+    ).one()
+    assert stored == ("CL", 0.0)
+    assert _changes(db_session) == []
+
+
+def test_writing_a_declared_column_back_to_its_own_value_is_not_a_change(
+    db_session,
+) -> None:
+    """A no-op UPDATE is permitted and records nothing.
+
+    Recording it would put rows in the audit that assert a repair happened
+    when nothing moved, which is the same dilution the change log exists to
+    avoid.
+    """
+    _, geometry, atom = _accepted_atom(db_session, "NOOP")
+    _declare(db_session)
+
+    db_session.execute(
+        text(
+            "UPDATE geometry_atom SET element = element WHERE geometry_id = :geometry_id AND atom_index = :atom_index"
+        ),
+        {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+    )
+    assert _changes(db_session) == []
+
+
+def test_a_declaration_covers_one_table_only(db_session) -> None:
+    calculation, _, _ = _accepted_atom(db_session, "ONETABLE")
+    _declare(db_session)
+
+    with pytest.raises(DBAPIError, match="is immutable"), db_session.begin_nested():
+        db_session.execute(
+            text("UPDATE calculation SET quality = 'curated' WHERE id = :id"),
+            {"id": calculation.id},
+        )
+
+
+def test_insert_and_delete_stay_refused_under_a_declaration(db_session) -> None:
+    """A repair may change how a value is spelled, never how many rows exist."""
+    _, geometry, atom = _accepted_atom(db_session, "ROWCOUNT")
+    _declare(db_session)
+
+    with pytest.raises(DBAPIError, match="is immutable"), db_session.begin_nested():
+        db_session.add(
+            GeometryAtom(
+                geometry_id=geometry.id,
+                atom_index=atom.atom_index + 1,
+                element="H",
+                x=0.0,
+                y=0.0,
+                z=0.0,
+            )
+        )
+        db_session.flush()
+
+    with pytest.raises(DBAPIError, match="is immutable"), db_session.begin_nested():
+        db_session.execute(
+            text("DELETE FROM geometry_atom WHERE geometry_id = :geometry_id AND atom_index = :atom_index"),
+            {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+        )
+
+
+def test_an_expired_declaration_permits_nothing(db_session) -> None:
+    """The wall-clock bound, independent of the transaction bound.
+
+    It exists so a wedged transaction cannot hold the door open, and it raises
+    rather than falling through to the ordinary refusal so an operator is told
+    what actually happened.
+    """
+    _, geometry, atom = _accepted_atom(db_session, "EXPIRED")
+    _declare(db_session, ages=("- interval '2 hours'", "- interval '1 hour'"))
+
+    with pytest.raises(DBAPIError, match="expired at"), db_session.begin_nested():
+        db_session.execute(
+            text(
+                "UPDATE geometry_atom SET element = 'Cl' WHERE geometry_id = :geometry_id AND atom_index = :atom_index"
+            ),
+            {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+        )
+
+
+def test_an_expiry_beyond_a_day_is_refused(db_session) -> None:
+    with pytest.raises(DBAPIError, match="expiry_window"), db_session.begin_nested():
+        _declare(db_session, ages=("- interval '0 seconds'", "+ interval '48 hours'"))
+
+
+def test_a_second_declaration_for_one_table_is_refused(db_session) -> None:
+    """ "The declaration in force" has to be a fact, not a resolution rule."""
+    _declare(db_session)
+
+    with pytest.raises(DBAPIError, match="already declared in this transaction"), db_session.begin_nested():
+        _declare(db_session, columns=("x",))
+
+
+def test_a_declaration_must_name_a_guarded_table(db_session) -> None:
+    """A declaration against an unguarded table records a permission nobody needed."""
+    with pytest.raises(DBAPIError, match="carries no accepted-science guard"), db_session.begin_nested():
+        _declare(db_session, table="app_user", columns=("username",))
+
+
+def test_a_declaration_must_name_columns_the_table_has(db_session) -> None:
+    with pytest.raises(DBAPIError, match="does not have"), db_session.begin_nested():
+        _declare(db_session, columns=("element", "no_such_column"))
+
+
+def test_a_declaration_may_not_name_a_primary_key_column(db_session) -> None:
+    """The record names the changed row by its key, so the key cannot move."""
+    with pytest.raises(DBAPIError, match="primary-key column\\(s\\) atom_index"), db_session.begin_nested():
+        _declare(db_session, columns=("atom_index", "element"))
+
+
+def test_a_declaration_must_name_a_real_table(db_session) -> None:
+    with pytest.raises(DBAPIError, match="is not a table"), db_session.begin_nested():
+        _declare(db_session, table="no_such_table")
+
+
+def test_a_blank_reason_is_refused(db_session) -> None:
+    with pytest.raises(DBAPIError, match="reason_nonblank"), db_session.begin_nested():
+        _declare(db_session, reason="   ")
+
+
+def test_only_an_owner_of_the_target_may_declare_a_repair(db_session) -> None:
+    """The authority test that makes this a record rather than a new power.
+
+    The runtime role of ``backend/docs/deployment/database_roles.md`` owns
+    nothing, so it fails here even holding the blanket ``INSERT`` that role's
+    default privileges grant. A role that *could* declare could equally have
+    run ``ALTER TABLE ... DISABLE TRIGGER`` and left no trace at all.
+    """
+    role = f"tckdb_repair_probe_{uuid4().hex[:8]}"
+    db_session.execute(text(f'CREATE ROLE "{role}" NOLOGIN'))
+    db_session.execute(text(f'GRANT USAGE ON SCHEMA public TO "{role}"'))
+    db_session.execute(text(f'GRANT SELECT, INSERT ON public.accepted_science_repair TO "{role}"'))
+    db_session.execute(text(f'GRANT USAGE, SELECT ON SEQUENCE public.accepted_science_repair_id_seq TO "{role}"'))
+    try:
+        db_session.execute(text(f'SET LOCAL ROLE "{role}"'))
+        with pytest.raises(DBAPIError, match="only an owner of"), db_session.begin_nested():
+            _declare(db_session)
+    finally:
+        db_session.execute(text("RESET ROLE"))
+
+
+def test_the_repair_record_is_append_only_and_untruncatable(db_session) -> None:
+    _, geometry, atom = _accepted_atom(db_session, "APPENDONLY")
+    _declare(db_session)
+    db_session.execute(
+        text("UPDATE geometry_atom SET element = 'Cl' WHERE geometry_id = :geometry_id AND atom_index = :atom_index"),
+        {"geometry_id": geometry.id, "atom_index": atom.atom_index},
+    )
+    assert len(_changes(db_session)) == 1
+
+    for statement, message in (
+        ("UPDATE accepted_science_repair SET reason = 'rewritten'", "append-only"),
+        ("DELETE FROM accepted_science_repair_change", "append-only"),
+        (
+            "UPDATE accepted_science_repair_change SET after_json = '{}'::jsonb",
+            "append-only",
+        ),
+        ("TRUNCATE accepted_science_repair_change", "cannot be truncated"),
+        (
+            "TRUNCATE accepted_science_repair, accepted_science_repair_change",
+            "cannot be truncated",
+        ),
+    ):
+        with pytest.raises(DBAPIError, match=message), db_session.begin_nested():
+            db_session.execute(text(statement))
+
+
+def test_a_change_row_cannot_be_forged(db_session) -> None:
+    """The audit is only worth having if the audited party cannot write it.
+
+    Every check here holds by construction when ``tckdb_repair_permits``
+    appends the row, and none of them holds for a row written by hand to make
+    a repair look narrower than it was.
+    """
+    repair_id = _declare(db_session)
+    insert = text(
+        "INSERT INTO accepted_science_repair_change "
+        "(repair_id, record_type, record_id, target_schema, target_table, "
+        " row_identity, changed_columns, before_json, after_json) "
+        "VALUES (:repair_id, 'calculation', 1, 'public', :table, "
+        " '{\"geometry_id\": 1}'::jsonb, :columns, '{}'::jsonb, '{}'::jsonb)"
+    )
+
+    with pytest.raises(DBAPIError, match="does not cover"), db_session.begin_nested():
+        db_session.execute(
+            insert,
+            {"repair_id": repair_id, "table": "geometry_atom", "columns": ["x"]},
+        )
+    with pytest.raises(DBAPIError, match="different table"), db_session.begin_nested():
+        db_session.execute(
+            insert,
+            {"repair_id": repair_id, "table": "geometry", "columns": ["element"]},
+        )
+    with pytest.raises(DBAPIError, match="names no declaration"), db_session.begin_nested():
+        db_session.execute(
+            insert,
+            {
+                "repair_id": repair_id + 10_000_000,
+                "table": "geometry_atom",
+                "columns": ["element"],
+            },
+        )
+
+
+def test_a_declaration_cannot_name_another_transaction(db_session) -> None:
+    """The transaction binding, on the write side.
+
+    ``tckdb_repair_permits`` matches on ``xact_id``, so a declaration that
+    could name a transaction other than its own would be a standing permission
+    with a timestamp on it.
+    """
+    with pytest.raises(DBAPIError, match="cannot name another transaction"), db_session.begin_nested():
+        db_session.execute(
+            text(
+                "INSERT INTO accepted_science_repair "
+                "(target_table, declared_columns, alembic_revision, reason, xact_id) "
+                "VALUES ('geometry_atom', ARRAY['element'], :revision, 'forged', "
+                "(pg_current_xact_id())::text::bigint + 1)"
+            ),
+            {"revision": _REVISION},
+        )
+
+
+def test_the_declaration_records_who_made_it(db_session) -> None:
+    repair_id = _declare(db_session)
+    row = (
+        db_session.execute(
+            text(
+                "SELECT declared_by_role, declared_by_login, alembic_revision, reason, "
+                "declared_columns, xact_id = (pg_current_xact_id())::text::bigint AS mine "
+                "FROM accepted_science_repair WHERE id = :id"
+            ),
+            {"id": repair_id},
+        )
+        .mappings()
+        .one()
+    )
+    assert row["declared_by_role"] == row["declared_by_login"]
+    assert row["alembic_revision"] == _REVISION
+    assert "canonicalise" in row["reason"]
+    assert row["declared_columns"] == ["element"]
+    assert row["mine"] is True
+
+
+def test_the_runtime_role_cannot_reach_the_guard_functions_by_name(db_session) -> None:
+    """``tckdb_repair_permits`` is not an escape hatch a caller can invoke.
+
+    It returns ``true`` only after appending a change row, and the change
+    row's own validation refuses a caller who does not own the target. Calling
+    it directly therefore cannot launder an update -- but the update it would
+    have to launder still has to pass the same function from inside the
+    trigger, so this pins that the direct call is not a shortcut around the
+    recording.
+    """
+    _declare(db_session)
+    permitted = db_session.execute(
+        text(
+            "SELECT public.tckdb_repair_permits('calculation', 1, 'public', 'geometry_atom', NULL::jsonb, NULL::jsonb)"
+        )
+    ).scalar_one()
+    assert permitted is False
+    assert _changes(db_session) == []
+
+
+def test_every_guarded_table_is_declarable(db_session) -> None:
+    """A declaration must be possible for exactly the tables the regime guards.
+
+    Read off ``pg_trigger`` rather than off a list in this file, so a table
+    that joins the regime later is covered here the day it does. The check is
+    that the validation's notion of "guarded" is the same set the guards are
+    actually installed on -- a mismatch either way leaves a table frozen with
+    no route through, or a declaration that permits nothing.
+    """
+    guarded = {
+        row[0]
+        for row in db_session.execute(
+            text(
+                """
+                SELECT DISTINCT relation.relname
+                FROM pg_trigger AS guard
+                JOIN pg_proc AS guard_function ON guard_function.oid = guard.tgfoid
+                JOIN pg_class AS relation ON relation.oid = guard.tgrelid
+                WHERE NOT guard.tgisinternal
+                  AND guard_function.proname IN (
+                      'tckdb_guard_accepted_root', 'tckdb_guard_accepted_child',
+                      'tckdb_guard_accepted_via_child',
+                      'tckdb_guard_calculation_geometry'
+                  )
+                """
+            )
+        )
+    }
+    assert len(guarded) > 40
+
+    for table in sorted(guarded):
+        # Any non-key column will do; the key itself is deliberately not
+        # declarable, which the test above pins.
+        column = db_session.execute(
+            text(
+                "SELECT attribute.attname FROM pg_attribute AS attribute "
+                "WHERE attribute.attrelid = format('public.%I', cast(:table as text))::regclass "
+                "AND attribute.attnum > 0 AND NOT attribute.attisdropped "
+                "AND NOT EXISTS ("
+                "  SELECT 1 FROM pg_index AS index_ "
+                "   WHERE index_.indrelid = attribute.attrelid AND index_.indisprimary "
+                "     AND attribute.attnum = ANY (index_.indkey)) "
+                "ORDER BY attribute.attnum LIMIT 1"
+            ),
+            {"table": table},
+        ).scalar_one()
+        with db_session.begin_nested() as nested:
+            _declare(db_session, table=table, columns=(column,))
+            nested.rollback()
+
+
+def test_a_role_without_insert_cannot_declare(db_session) -> None:
+    """Belt to the owner check's braces: the grant matters too, where it holds."""
+    role = f"tckdb_repair_nogrant_{uuid4().hex[:8]}"
+    db_session.execute(text(f'CREATE ROLE "{role}" NOLOGIN'))
+    db_session.execute(text(f'GRANT USAGE ON SCHEMA public TO "{role}"'))
+    try:
+        db_session.execute(text(f'SET LOCAL ROLE "{role}"'))
+        with pytest.raises(ProgrammingError, match="permission denied"), db_session.begin_nested():
+            _declare(db_session)
+    finally:
+        db_session.execute(text("RESET ROLE"))

--- a/backend/tests/db/test_accepted_science_repair.py
+++ b/backend/tests/db/test_accepted_science_repair.py
@@ -359,6 +359,42 @@ def test_only_an_owner_of_the_target_may_declare_a_repair(db_session) -> None:
         db_session.execute(text("RESET ROLE"))
 
 
+def test_only_an_owner_of_the_target_may_record_a_change(db_session) -> None:
+    """The third check on the record, behind the declaration and the transaction.
+
+    Contrived on purpose: a non-owner cannot make a declaration and cannot see
+    a live one from another transaction, so reaching this check at all takes an
+    owner declaring and then dropping to a lesser role inside the same
+    transaction. It is the arm that still holds if either of the first two is
+    ever relaxed, and a guard nothing exercises is the failure mode this file
+    exists to avoid.
+    """
+    repair_id = _declare(db_session)
+    role = f"tckdb_repair_change_{uuid4().hex[:8]}"
+    db_session.execute(text(f'CREATE ROLE "{role}" NOLOGIN'))
+    db_session.execute(text(f'GRANT USAGE ON SCHEMA public TO "{role}"'))
+    db_session.execute(text(f'GRANT SELECT, INSERT ON public.accepted_science_repair_change TO "{role}"'))
+    db_session.execute(
+        text(f'GRANT USAGE, SELECT ON SEQUENCE public.accepted_science_repair_change_id_seq TO "{role}"')
+    )
+    db_session.execute(text(f'GRANT SELECT ON public.accepted_science_repair TO "{role}"'))
+    try:
+        db_session.execute(text(f'SET LOCAL ROLE "{role}"'))
+        with pytest.raises(DBAPIError, match="may record a repair change"), db_session.begin_nested():
+            db_session.execute(
+                text(
+                    "INSERT INTO accepted_science_repair_change "
+                    "(repair_id, record_type, record_id, target_schema, target_table, "
+                    " row_identity, changed_columns, before_json, after_json) "
+                    "VALUES (:repair_id, 'calculation', 1, 'public', 'geometry_atom', "
+                    " '{\"geometry_id\": 1}'::jsonb, ARRAY['element'], '{}'::jsonb, '{}'::jsonb)"
+                ),
+                {"repair_id": repair_id},
+            )
+    finally:
+        db_session.execute(text("RESET ROLE"))
+
+
 def test_the_repair_record_is_append_only_and_untruncatable(db_session) -> None:
     _, geometry, atom = _accepted_atom(db_session, "APPENDONLY")
     _declare(db_session)
@@ -462,15 +498,14 @@ def test_the_declaration_records_who_made_it(db_session) -> None:
     assert row["mine"] is True
 
 
-def test_the_runtime_role_cannot_reach_the_guard_functions_by_name(db_session) -> None:
-    """``tckdb_repair_permits`` is not an escape hatch a caller can invoke.
+def test_the_permit_function_refuses_a_row_it_cannot_compare(db_session) -> None:
+    """INSERT and DELETE reach ``tckdb_repair_permits`` with a NULL row version.
 
-    It returns ``true`` only after appending a change row, and the change
-    row's own validation refuses a caller who does not own the target. Calling
-    it directly therefore cannot launder an update -- but the update it would
-    have to launder still has to pass the same function from inside the
-    trigger, so this pins that the direct call is not a shortcut around the
-    recording.
+    That is how the function tells them from an UPDATE, and it is the only
+    thing standing between a live declaration and an INSERT under an accepted
+    root. Called with either side missing it returns false -- the guard then
+    raises -- and it records nothing, because there is no before-and-after to
+    record.
     """
     _declare(db_session)
     permitted = db_session.execute(

--- a/backend/tests/db/test_accepted_science_repair_lifetime.py
+++ b/backend/tests/db/test_accepted_science_repair_lifetime.py
@@ -1,0 +1,232 @@
+"""A repair declaration dies with its transaction, and its record does not.
+
+This is the property that makes ``e2c9a4f7b163`` a repair path rather than a
+bypass: there is no close step to forget and no flag to reset, because the
+declaration is matched on ``pg_current_xact_id()`` and a committed transaction
+can never present that id again. Its symmetric half is that the *record* has
+to survive the same commit, since an audit trail scoped to a transaction would
+be no trail at all.
+
+Neither half can be shown on the shared test database, which rolls every test
+back and whose committed-row tripwire exists precisely to stop a test writing
+through that rollback. So this file builds a throwaway database, migrates it,
+and commits on it -- the only arrangement in which "what is true after COMMIT"
+is a question that can be asked at all.
+
+It is one database and one migration run (about four seconds) shared by every
+test here, rather than one per test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import DBAPIError
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def committed_engine() -> Iterator:
+    from conftest import _database_url, _db_env, scratch_database_name
+
+    db_name = scratch_database_name("repair_lifetime")
+    admin = create_engine(_database_url("postgres"), isolation_level="AUTOCOMMIT")
+    with admin.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+    engine = None
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-m", "alembic", "upgrade", "head"],
+            cwd=os.fspath(_BACKEND_ROOT),
+            env=_db_env(db_name),
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, completed.stderr
+        engine = create_engine(_database_url(db_name), pool_pre_ping=True)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        with admin.connect() as connection:
+            connection.execute(
+                text("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = :name"),
+                {"name": db_name},
+            )
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin.dispose()
+
+
+def _seed_accepted_atom(connection) -> dict[str, int]:
+    """One accepted calculation over one geometry with one shouted atom."""
+    suffix = uuid4().hex[:8]
+    # Species identity is (smiles, charge, multiplicity), and this database
+    # outlives each test in the module, so the SMILES has to be distinct per
+    # call rather than a literal.
+    smiles = "C" * (1 + connection.scalar(text("SELECT count(*) FROM species")))
+    species_id = connection.scalar(
+        text(
+            "INSERT INTO species (kind, smiles, inchi_key, charge, multiplicity, stereo_kind) "
+            "VALUES ('molecule', :smiles, :inchi_key, 0, 1, 'achiral') RETURNING id"
+        ),
+        {"smiles": smiles, "inchi_key": f"REPAIRLIFE{suffix}AAAAAAAAAAA"[:27]},
+    )
+    species_entry_id = connection.scalar(
+        text("INSERT INTO species_entry (species_id, unmapped_smiles) VALUES (:species_id, :smiles) RETURNING id"),
+        {"species_id": species_id, "smiles": smiles},
+    )
+    geometry_id = connection.scalar(
+        text("INSERT INTO geometry (natoms, geom_hash, xyz_text) VALUES (1, :geom_hash, '1\n\nCL 0 0 0') RETURNING id"),
+        {"geom_hash": uuid4().hex + uuid4().hex},
+    )
+    connection.execute(
+        text(
+            "INSERT INTO geometry_atom (geometry_id, atom_index, element, x, y, z) "
+            "VALUES (:geometry_id, 1, 'CL', 0, 0, 0)"
+        ),
+        {"geometry_id": geometry_id},
+    )
+    calculation_id = connection.scalar(
+        text("INSERT INTO calculation (type, species_entry_id) VALUES ('opt', :species_entry_id) RETURNING id"),
+        {"species_entry_id": species_entry_id},
+    )
+    connection.execute(
+        text(
+            "INSERT INTO calculation_input_geometry (calculation_id, geometry_id, input_order) "
+            "VALUES (:calculation_id, :geometry_id, 1)"
+        ),
+        {"calculation_id": calculation_id, "geometry_id": geometry_id},
+    )
+    reviewer_id = connection.scalar(
+        text("INSERT INTO app_user (username, role) VALUES (:username, 'curator') RETURNING id"),
+        {"username": f"repair-lifetime-{suffix}"},
+    )
+    connection.execute(
+        text(
+            "INSERT INTO record_review "
+            "(record_type, record_id, status, reviewed_by, reviewed_at, first_approved_at) "
+            "VALUES ('calculation', :calculation_id, 'approved', :reviewer_id, now(), now())"
+        ),
+        {"calculation_id": calculation_id, "reviewer_id": reviewer_id},
+    )
+    return {"geometry_id": geometry_id, "calculation_id": calculation_id}
+
+
+_DECLARE = text(
+    "INSERT INTO accepted_science_repair "
+    "(target_table, declared_columns, alembic_revision, reason) "
+    "VALUES ('geometry_atom', ARRAY['element'], 'e2c9a4f7b163', "
+    " 'canonicalise element symbol case; no coordinate change') RETURNING id"
+)
+
+_REPAIR = text("UPDATE geometry_atom SET element = 'Cl' WHERE geometry_id = :geometry_id")
+
+
+def test_a_declaration_does_not_survive_its_own_commit(committed_engine) -> None:
+    with committed_engine.begin() as connection:
+        seeded = _seed_accepted_atom(connection)
+        repair_id = connection.scalar(_DECLARE)
+        connection.execute(_REPAIR, {"geometry_id": seeded["geometry_id"]})
+
+    # A second transaction, with the declaration committed and visible.
+    with committed_engine.connect() as connection:
+        with connection.begin():
+            assert (
+                connection.scalar(
+                    text("SELECT count(*) FROM accepted_science_repair WHERE id = :id"),
+                    {"id": repair_id},
+                )
+                == 1
+            )
+
+        with pytest.raises(DBAPIError, match="is immutable"):
+            with connection.begin():
+                connection.execute(
+                    text("UPDATE geometry_atom SET element = 'CL' WHERE geometry_id = :geometry_id"),
+                    {"geometry_id": seeded["geometry_id"]},
+                )
+
+        # And it cannot be re-armed by pointing a fresh change row at it,
+        # which is what would make the committed row a standing permission.
+        with pytest.raises(DBAPIError, match="only be recorded in the transaction that declared it"):
+            with connection.begin():
+                connection.execute(
+                    text(
+                        "INSERT INTO accepted_science_repair_change "
+                        "(repair_id, record_type, record_id, target_schema, target_table, "
+                        " row_identity, changed_columns, before_json, after_json) "
+                        "VALUES (:repair_id, 'calculation', :calculation_id, 'public', "
+                        " 'geometry_atom', '{\"geometry_id\": 1}'::jsonb, ARRAY['element'], "
+                        " '{}'::jsonb, '{}'::jsonb)"
+                    ),
+                    {"repair_id": repair_id, "calculation_id": seeded["calculation_id"]},
+                )
+
+
+def test_the_record_of_a_repair_survives_the_commit(committed_engine) -> None:
+    """What an auditor can reconstruct, read back after the fact."""
+    with committed_engine.begin() as connection:
+        seeded = _seed_accepted_atom(connection)
+        repair_id = connection.scalar(_DECLARE)
+        connection.execute(_REPAIR, {"geometry_id": seeded["geometry_id"]})
+
+    with committed_engine.connect() as connection:
+        declaration = (
+            connection.execute(
+                text(
+                    "SELECT target_schema, target_table, declared_columns, alembic_revision, "
+                    "reason, declared_by_role FROM accepted_science_repair WHERE id = :id"
+                ),
+                {"id": repair_id},
+            )
+            .mappings()
+            .one()
+        )
+        assert declaration["target_table"] == "geometry_atom"
+        assert declaration["declared_columns"] == ["element"]
+        assert declaration["alembic_revision"] == "e2c9a4f7b163"
+        assert "canonicalise" in declaration["reason"]
+        assert declaration["declared_by_role"]
+
+        change = (
+            connection.execute(
+                text(
+                    "SELECT record_type::text AS record_type, record_id, target_table, "
+                    "row_identity, changed_columns, before_json, after_json "
+                    "FROM accepted_science_repair_change WHERE repair_id = :id"
+                ),
+                {"id": repair_id},
+            )
+            .mappings()
+            .one()
+        )
+        assert change["record_type"] == "calculation"
+        assert change["record_id"] == seeded["calculation_id"]
+        assert change["row_identity"] == {
+            "geometry_id": seeded["geometry_id"],
+            "atom_index": 1,
+        }
+        assert change["changed_columns"] == ["element"]
+        assert change["before_json"]["element"].strip() == "CL"
+        assert change["after_json"]["element"].strip() == "Cl"
+
+        # The evidence the repair claims not to have touched, still untouched.
+        geometry = (
+            connection.execute(
+                text("SELECT geom_hash, xyz_text FROM geometry WHERE id = :id"),
+                {"id": seeded["geometry_id"]},
+            )
+            .mappings()
+            .one()
+        )
+        assert "CL" in geometry["xyz_text"]
+        assert geometry["geom_hash"]

--- a/backend/tests/db/test_accepted_science_trigger_registry.py
+++ b/backend/tests/db/test_accepted_science_trigger_registry.py
@@ -146,6 +146,29 @@ def test_database_trigger_set_matches_registry(db_session) -> None:
                 "scientific_record_supersession",
                 "trg_scientific_supersession_validate",
             ),
+            # ``e2c9a4f7b163``'s recorded repair path. The declaration and its
+            # change record are append-only and un-truncatable on the same
+            # terms as the review and supersession history, and each is
+            # validated on insert. Listed here so removing one of the four
+            # fails this test as well as the behavioural ones.
+            (
+                "accepted_science_repair",
+                "trg_accepted_science_repair_validate",
+            ),
+            (
+                "accepted_science_repair_change",
+                "trg_accepted_science_repair_change_validate",
+            ),
+            ("accepted_science_repair", "trg_append_only_accepted_science_repair"),
+            (
+                "accepted_science_repair_change",
+                "trg_append_only_accepted_science_repair_change",
+            ),
+            ("accepted_science_repair", "trg_as_truncate_accepted_science_repair"),
+            (
+                "accepted_science_repair_change",
+                "trg_as_truncate_accepted_science_repair_change",
+            ),
             (
                 "record_review_event",
                 trigger_name("append_only", "record_review_event"),
@@ -193,6 +216,7 @@ def test_database_trigger_set_matches_registry(db_session) -> None:
                       OR trigger.tgname LIKE 'trg_append_only_%'
                       OR trigger.tgname = 'trg_guard_record_review'
                       OR trigger.tgname = 'trg_scientific_supersession_validate'
+                      OR trigger.tgname LIKE 'trg_accepted_science_repair%'
                   )
                 """
             )

--- a/docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md
+++ b/docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md
@@ -81,9 +81,36 @@ by hand to make a repair look narrower than it was.
 Both tables are append-only and un-truncatable, on 0003's own terms: a record of
 a repair that the repairer can edit afterwards is not a record.
 
+## The record does not travel, and that is a consequence rather than an omission
+
+`tckdb.archive.v1` excludes both tables. Not because the account is
+unimportant — [0014](0014-custody-of-stored-evidence-is-recorded-not-logged.md)
+made the opposite call for `artifact_integrity_event` on the grounds that a
+restore dropping it would resurrect condemned records as sound, and that
+reasoning is right. It does not transfer here, and the difference is
+structural. A custody observation is a fact about an *object*, and objects move
+with the archive. A declaration's meaning is carried by `xact_id`, a
+transaction id from the source cluster's counter, and every check deciding
+whether it is live compares that against `pg_current_xact_id()`. Restored into
+a fresh cluster whose counter starts near zero, an archived declaration names a
+transaction larger than any the new database has issued: a row that is inert by
+construction and misleading by shape. Relaxing the comparison to make it
+transplantable would relax the one check that stops a declaration being minted
+for a transaction that has not happened yet.
+
+The repaired *value* travels with the science, which is what a restored
+database has to get right. The account of how it got there stays with the
+deployment that performed it and with that deployment's `pg_dump`, which
+[0001](0001-separate-archive-projection-and-backup.md) already separates from
+this projection.
+
 ## What this does not cover
 
 `record_review` is outside the mechanism; approval history is not repairable.
+Seven guarded tables are pure junction rows whose every column is part of their
+own primary key — the `*_source_calculation` links, `network_reaction` and
+`network_species` — so nothing about them can be respelled and no repair can
+name them. That falls out of the key rule rather than being a separate one.
 `b4e7c1d20f83` is **not** retrofitted — it is deployed, and its decision to
 leave the guard standing and fail loudly on a non-canonical accepted row remains
 the correct outcome for a migration that cannot ask anybody. What changes is

--- a/docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md
+++ b/docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md
@@ -1,0 +1,95 @@
+# A repair to accepted science is declared before it is made
+
+[0003](0003-freeze-ever-approved-science.md) froze every ever-approved record and
+routed corrections through supersession. That is right, and this decision does
+not weaken it: a corrected *number* forks identity, because a citation has to
+keep resolving to what was cited. What 0003 did not have a position on is a
+change that alters nothing a record says. The worked case is `b4e7c1d20f83` —
+the letter case of an element symbol in `geometry_atom.element`, the derived
+index column every element comparison joins against, with `geom_hash`,
+`xyz_text`, coordinates, isotopes and atom ordering provably untouched.
+Superseding there re-keys a citable public ref to fix a shift key, and the
+replacement record would differ from the original in no scientific respect at
+all — a fork that asserts a distinction that does not exist.
+
+So the operator holding such a row had exactly one mechanical option:
+`ALTER TABLE … DISABLE TRIGGER`, the work, `ENABLE`. The first draft of #118 did
+that and review rejected it, correctly. The objection was not that the change
+was wrong. It is that **after the fact the operation is invisible**. Nothing
+records that a scientific-integrity control was stood down, over which rows, or
+on what grounds; the claim "the record did not change scientifically" lived in a
+migration docstring, and a docstring is prose, not an assertion anything checks.
+
+## The alternative to an escape hatch is not a justification string
+
+A repair table whose only content is free text would be the same bypass with
+paperwork. It would record an intention, and the database would still have no
+opinion about whether the repair matched it. The reason this is worth building
+is that the claim is **checked**:
+
+A repair declares, up front and in a row, the table it will change, the exact
+columns it may change, the revision doing it, and why. While that declaration is
+in force, the existing `BEFORE UPDATE` guard permits an UPDATE to that table
+**only if the set of columns that actually changed is a subset of the declared
+set** — computed by comparing `OLD` against `NEW`, which is why it is
+enforceable rather than promised. A declaration for `geometry_atom(element)`
+cannot move an atom, and an UPDATE that rewrites `element` *and* nudges `x` in
+one statement is refused naming `x`. That case is the one that matters: the
+declared change is the alibi for the undeclared one.
+
+The check is over columns rather than rows, deliberately. A repair of this kind
+is corpus-wide by nature, and a list of row keys written in advance would be a
+worse-founded claim than a list of columns. What makes that acceptable is that
+every row it reaches is recorded individually — the root it sits under, the
+row's primary key, the columns that changed, and the values on both sides. "The
+record did not change scientifically" becomes a join.
+
+Only UPDATE. INSERT and DELETE under an accepted root stay unconditionally
+refused, because adding or removing a row changes what reviewers accepted rather
+than how it is spelled; the row count under an accepted root is invariant under
+every repair this can express. Primary-key columns cannot be declared, for the
+same reason the record is keyed on them: a row under a new identity is a
+different row, which is what supersession is for.
+
+## It cannot be left open, and it confers no authority
+
+A permission that can outlive its use is a bypass on a delay. The scope here is
+the transaction: the declaration carries `pg_current_xact_id()` and the guard
+matches on it, so it is inert the instant its transaction ends. There is no
+close step to forget, no flag to reset, and a committed row can never be
+presented again. A second and independent bound is wall-clock — one hour by
+default, capped at 24 — which raises rather than silently permitting, so a
+wedged transaction cannot hold the door open either. This follows
+[0014](0014-custody-of-stored-evidence-is-recorded-not-logged.md)'s age floors:
+a guard any invocation may satisfy by doing nothing is not a guard.
+
+The other half is that nobody gains anything. Only a role that owns the target
+table may declare a repair to it — which is exactly the set of roles that could
+already have run `DISABLE TRIGGER` and left no trace. This adds no power to
+anyone; it converts an available and unrecorded capability into a recorded one,
+which is the entire argument. In the deployment posture of
+`backend/docs/deployment/database_roles.md` the runtime role owns nothing and is
+refused, even holding the blanket `INSERT` that role's default privileges grant.
+That grant is why the *record* is protected the same way rather than by a
+revoke: default privileges cover tables created by later migrations, so a
+grant-based defence would have to be re-applied after every one. A change row
+must name a declaration made in the same transaction, for the same table, with
+columns that declaration covers, and come from an owner of that table. All four
+hold by construction when the guard writes it and none holds for a row written
+by hand to make a repair look narrower than it was.
+
+Both tables are append-only and un-truncatable, on 0003's own terms: a record of
+a repair that the repairer can edit afterwards is not a record.
+
+## What this does not cover
+
+`record_review` is outside the mechanism; approval history is not repairable.
+`b4e7c1d20f83` is **not** retrofitted — it is deployed, and its decision to
+leave the guard standing and fail loudly on a non-canonical accepted row remains
+the correct outcome for a migration that cannot ask anybody. What changes is
+that the operator who hits that failure now has somewhere to go that is not a
+disabled trigger.
+
+Nothing in the shipping revision repairs anything. It is the path the next
+repair takes, and the first thing an auditor will ask of that repair is what it
+declared.

--- a/docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md
+++ b/docs/adr/0015-a-repair-to-accepted-science-is-declared-before-it-is-made.md
@@ -37,12 +37,38 @@ cannot move an atom, and an UPDATE that rewrites `element` *and* nudges `x` in
 one statement is refused naming `x`. That case is the one that matters: the
 declared change is the alibi for the undeclared one.
 
+That check turns out to be enforced on two independent paths, which was not
+designed and is worth knowing before anyone simplifies either one: the change
+row carries its own `changed_columns`, and the trigger that writes it refuses a
+set the declaration does not cover. Removing the check inside the permit
+function alone still refuses the smuggling case, with a different message.
+
 The check is over columns rather than rows, deliberately. A repair of this kind
 is corpus-wide by nature, and a list of row keys written in advance would be a
 worse-founded claim than a list of columns. What makes that acceptable is that
-every row it reaches is recorded individually — the root it sits under, the
-row's primary key, the columns that changed, and the values on both sides. "The
-record did not change scientifically" becomes a join.
+every row whose value it changes is recorded individually — the root it sits
+under, the row's primary key, the columns that changed, and the values on both
+sides. "The record did not change scientifically" becomes a join.
+
+**The recording claim is narrower than "everything is recorded", and the
+narrowness belongs here** rather than in a follow-up, because this is the
+paragraph someone reads in two years before deciding whether to widen this
+door. What is enforced is that a write which changes a *value* is either
+refused or recorded. The comparison runs `to_jsonb(OLD)` against
+`to_jsonb(NEW)`, and JSON numerics have no signed zero and ignore trailing
+scale, so a write that changes only the representation of an equal value passes
+with no change row — `SET x = -0.0` over a stored `0.0` succeeds silently under
+an `element`-only declaration.
+
+Scientifically that is nothing, and the reasoning is worth keeping rather than
+just the conclusion. Only value-equal representations collapse; no genuinely
+different number can hide, because `float8` renders round-trip; and text, enum,
+timestamp, `mol` and `jsonb` all serialise exactly. Closing it would mean
+normalising every value before comparing, on the path *every* UPDATE to a
+guarded table takes, to catch a change that moves nothing a reader can observe.
+The absolute phrasing was written first, and is recorded as wrong rather than
+quietly corrected: an ADR that overstates a guarantee is exactly what lets the
+next reader skip the check.
 
 Only UPDATE. INSERT and DELETE under an accepted root stay unconditionally
 refused, because adding or removing a row changes what reviewers accepted rather


### PR DESCRIPTION
Closes #74.

## The gap

`c6f2a9d4e7b1` refuses any UPDATE to a record attached to an accepted calculation, and after #129 and #134 it covers seven more tables. That is correct and load-bearing. It also has no escape hatch, so a genuine repair had exactly one mechanical option: `ALTER TABLE … DISABLE TRIGGER`, the work, `ENABLE`. The first draft of #118 did that and review rejected it, correctly — **after the fact the operation is invisible.** Nothing records that the guard was stood down, over which rows, or on what justification, and "the accepted record did not change scientifically" lived in a migration docstring, which is prose rather than an assertion.

Supersession is the right answer when the *science* changes: it forks identity, which is what a corrected number needs. It is the wrong answer for `b4e7c1d20f83`'s case — the letter case of an element symbol in a derived index column, with `geom_hash`, `xyz_text`, coordinates, isotopes and atom ordering provably untouched. Forking identity there re-keys a citable public ref to fix a shift key.

## What this builds — the strong version

**The column-subset check is enforced, not promised.** A repair declares, in a row, the table it will change, the exact columns it may change, the revision doing it, and why. While that declaration is in force the existing `BEFORE UPDATE` guard permits an UPDATE to that table **only if the set of columns that actually changed is a subset of the declared set** — computed by comparing `to_jsonb(OLD)` against `to_jsonb(NEW)` inside the trigger. A declaration for `geometry_atom(element)` cannot move an atom, and an UPDATE that rewrites `element` *and* nudges `x` in one statement is refused naming `x`. That last case is the one that matters: the declared change is the alibi for the undeclared one.

```sql
BEGIN;
INSERT INTO accepted_science_repair (target_table, declared_columns, alembic_revision, reason)
VALUES ('geometry_atom', ARRAY['element'], 'b4e7c1d20f83',
        'canonicalise element symbol case; geom_hash, xyz_text and coordinates are not touched');
UPDATE geometry_atom SET element = … ;
SELECT record_type, record_id, row_identity, before_json, after_json FROM accepted_science_repair_change;
COMMIT;
```

**Every changed row is recorded**, once per accepted root it sits under: the root's `record_type`/`record_id`, the row's primary key as `row_identity`, `changed_columns`, and `before_json`/`after_json`. Under an accepted root, a write that changes a **value** is either refused or recorded, so the claim becomes a join rather than a docstring.

That is stated narrowly on purpose. The comparison is `to_jsonb(OLD)` against `to_jsonb(NEW)`, and JSON numerics carry no signed zero and ignore trailing scale, so a write that changes only the *representation* of an equal value passes with no change row — `SET x = -0.0` over a stored `0.0` succeeds silently under an `element`-only declaration. Verified. Nothing a reader can observe moves: only value-equal representations collapse, `float8` renders round-trip so no genuinely different number can hide, and text, enum, timestamp, `mol` and `jsonb` serialise exactly. Normalising before comparison would cost every UPDATE to a guarded table more than the case is worth, so it is written down rather than closed — in ADR 0015, the spec and the migration docstring alike.

**It cannot be left open.** Scope is the transaction: `xact_id` defaults to `pg_current_xact_id()` and the guard matches on it, so a declaration is inert the instant its transaction ends. There is no close step to forget and a committed row can never be presented again. `expires_at` (1 hour, capped at 24) is a second, independent bound that raises rather than silently permitting, so a wedged transaction cannot hold the door open either. At most one declaration per table per transaction.

**It confers no authority.** Only a role owning the target table may declare a repair or record a change to it — exactly the set that could already have run `DISABLE TRIGGER` and left no trace. The runtime role of `database_roles.md` owns nothing and is refused even holding the blanket `INSERT` its default privileges grant; the guarantee is carried by triggers and depends on no grant, because default privileges cover tables created by later migrations. Both tables are append-only and un-truncatable.

**The subset check is enforced twice**, which was not designed. The change row carries its own `changed_columns` and the trigger that writes it refuses a set the declaration does not cover, so removing the check inside the permit function alone still refuses the smuggling case — with a different message. Confirmed by mutation.

**What it deliberately cannot do.** INSERT and DELETE under an accepted root stay unconditionally refused, so the row count under an accepted record is invariant under every repair this can express. Primary-key columns cannot be declared: the record names the row by its key, and a row under a new identity is a different row. Seven guarded tables are pure junction rows whose every column is part of their own key — nothing about them can be respelled, and the tests name them.

Nothing here repairs anything. `b4e7c1d20f83` is **not** retrofitted; it is deployed, and its decision to leave the guard standing and fail loudly remains correct for a migration that cannot ask anybody. What changes is that the operator who hits that failure now has somewhere to go.

## Also in this PR

- **ADR 0015** and the `accepted_science_immutability.md` spec section, which previously said "no maintenance escape hatch" without qualification.
- The migration playbook now carries the declare-then-repair transaction, since that runbook is where an operator lands when a revision fails with `accepted calculation record N is immutable`.
- The acceptance predicate is split into `tckdb_record_is_accepted` so the guards ask the cheap question first. `to_jsonb(OLD)`/`to_jsonb(NEW)` are function arguments, which PL/pgSQL evaluates eagerly — passing them unconditionally would have serialised both row versions on every UPDATE to all 73 guarded tables, `calc_hessian`'s packed matrix included, to answer a question that is almost always "no".
- The archive registry classifies the two new tables as **excluded**, and the reason is not that they are unimportant: a declaration's meaning is carried by `xact_id`, a transaction id from *this* cluster's counter, so restored into a fresh cluster it names a transaction larger than any the new database has issued.

## Verification

`test-rest.sh` on `5abef25b`: 3952 passed / 14 skipped. On this branch: **3979 passed / 14 skipped** (27 new tests). `test-api.sh` 2558 passed, `test-scientific.sh` 2022 passed.

Migration round-tripped on a scratch DB (`upgrade head` → `downgrade -1` → `upgrade head`); `alembic heads` single at `e2c9a4f7b163`.

**Mutation checks** over `tests/db/` (156 tests, all passing unmutated) — each arm removed, the suite re-run, the arm restored:

| arm removed from the migration | `tests/db/` result |
|---|---|
| *(none — baseline)* | 156 passed |
| the column-subset check | **2 failed**, 154 passed: `test_an_undeclared_column_is_still_refused_under_a_declaration`, `test_a_declared_column_does_not_carry_an_undeclared_one` |
| the transaction scope (`xact_id = pg_current_xact_id()` in the guard's lookup) | **2 failed**, 154 passed: both in `test_accepted_science_repair_lifetime.py` |
| the wall-clock expiry | **1 failed**, 155 passed: `test_an_expired_declaration_permits_nothing` |
| the declaration owner check | **1 failed**, 155 passed: `test_only_an_owner_of_the_target_may_declare_a_repair` |
| the guarded-target check | **1 failed**, 155 passed: `test_a_declaration_must_name_a_guarded_table` |
| the primary-key-column check | **2 failed**, 154 passed: `test_a_declaration_may_not_name_a_primary_key_column`, `test_every_guarded_table_is_declarable` |
| the change-row table match | **1 failed**, 155 passed: `test_a_change_row_cannot_be_forged` |
| "INSERT and DELETE are never repairable" | **2 failed**, 154 passed: `test_insert_and_delete_stay_refused_under_a_declaration`, `test_the_permit_function_refuses_a_row_it_cannot_compare` |
| the change-row owner check *(baseline 157)* | **1 failed**, 156 passed: `test_only_an_owner_of_the_target_may_record_a_change` |

Every arm turns exactly the tests that name it red and nothing else. The last row is there because the first eight found it: no test reached the change-row owner check, so a guard was shipping unexercised. `test_only_an_owner_of_the_target_may_record_a_change` was added and the arm re-checked, which is why its baseline is one higher.

## Two side questions from the issue

**#73 is not blocked by this, and needs nothing from it.** Verified on a scratch database: over an accepted, guarded `geometry_atom` row, `ALTER TABLE … ADD CONSTRAINT … CHECK … NOT VALID` followed by `VALIDATE CONSTRAINT` succeeded and left `pg_constraint.convalidated = t`. Neither statement is an INSERT, UPDATE or DELETE, so no row trigger fires. With a *non-canonical* accepted row present, `VALIDATE` fails with `check constraint … is violated by some row` — a data error, never the guard's message. #73 can be unblocked.

**`c6f2a9d4e7b1:62`'s `calc_scf_stability.source_calculation_id` is a mistake, not a deliberate second binding** — but not fixed here. See below.

## Follow-ups not fixed here

- **`backend/alembic/versions/c6f2a9d4e7b1_enforce_accepted_science_immutability.py:60`** registers `calc_scf_stability.source_calculation_id` — a nullable *provenance* FK — as an ownership guard, contradicting that revision's own rule at `:34-36` and `a1f6c3e9b527`'s explicit exclusion of the identically-named, identically-shaped `network_solve_state_energy.source_calculation_id` (`a1f6c3e9b527:52`). It is **not** harmless: verified on a scratch DB, an *unapproved* calculation A cannot record SCF-stability evidence naming an *approved* calculation B as its source, while the same INSERT without the pointer succeeds. Recording provenance that points at accepted science is exactly what accepted science is for. Left out of this PR because relaxing an integrity guard deserves its own argument and its own review rather than riding along with the PR that opens a repair path. `backend/tests/db/test_accepted_science_trigger_registry.py:116-119` currently documents it as deliberate and would need to change with it.
- **`backend/app/services/archive/registry.py:149`** — if the repair history should survive an archive round trip, it needs a restore-shaped representation. `xact_id` is cluster-local, so no comparison against the destination's `pg_current_xact_id()` can be made meaningful; a separate "historical repair" projection without liveness fields would be the shape.

