### PR TITLE
Make the path-filtered test gates requireable

### DIFF
--- a/.github/workflows/repo-gate.yml
+++ b/.github/workflows/repo-gate.yml
@@ -58,3 +58,63 @@ jobs:
 
       - name: Every test file is run by a required job
         run: python -m pytest --noconftest -q backend/tests/scripts/test_gate_coverage.py
+
+      # Runs here too, and not only in the backend complement gate, because
+      # this file is the mechanism by which the *other* workflows become
+      # requireable. A defect in it is a defect in the gate that reports
+      # them, and the complement gate is one of the things it reports on --
+      # so a change that breaks the aggregator must not depend on the
+      # aggregator's own subject running to be noticed.
+      - name: The aggregate gate can still tell the three states apart
+        run: python -m pytest --noconftest -q backend/tests/scripts/test_aggregate_pr_gates.py
+
+  required-gates:
+    # THE REQUIRED CHECK. This job's name is the context listed in branch
+    # protection, so renaming it silently un-requires every test suite in
+    # the repository -- test_required_gates_job_is_named_and_unconditional
+    # in backend/tests/scripts/test_gate_coverage.py pins the name.
+    #
+    # It deliberately has no `needs:` and no `if:`. A job that GitHub skips
+    # reports the conclusion "skipped", which branch protection accepts as
+    # satisfying a required check -- so any condition here is a way for the
+    # gate to pass without running. The one event test lives inside the
+    # script, where it is a code path with a test rather than an
+    # expression nothing evaluates.
+    name: Required gates
+    runs-on: ubuntu-latest
+    # The backend gates cap at 90 minutes each; the script gives up at 95
+    # and reports failure, so this outer cap only fires if the script
+    # itself wedges -- in which case GitHub fails the job, which is the
+    # direction we want.
+    timeout-minutes: 100
+
+    permissions:
+      contents: read
+      # Read the conclusions of the path-filtered workflow runs.
+      actions: read
+      # Read the pull request's changed-file list, which is what decides
+      # whether an absent run is legitimate.
+      pull-requests: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install check dependencies
+        run: python -m pip install "PyYAML>=6"
+
+      - name: Report the path-filtered gates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          python backend/scripts/aggregate_pr_gates.py
+          --repo "${{ github.repository }}"
+          --pr-number "${{ github.event.pull_request.number || 0 }}"
+          --head-sha "${{ github.event.pull_request.head.sha || github.sha }}"
+          --run-id "${{ github.run_id }}"
+          --event-name "${{ github.event_name }}"

--- a/backend/scripts/aggregate_pr_gates.py
+++ b/backend/scripts/aggregate_pr_gates.py
@@ -1,0 +1,474 @@
+"""Report the outcome of the path-filtered CI gates as one always-present check.
+
+WHY THIS EXISTS
+---------------
+A required status check that is path-filtered never reports on a pull
+request outside its paths, and GitHub blocks the merge indefinitely
+waiting for it. Every test workflow in this repository is path-filtered
+-- correctly, because the backend suite costs about thirteen minutes of
+runner time and a change to ``paper/`` cannot break it. So none of them
+can be listed in branch protection, and until this script existed the
+only required check was the coverage guard in ``repo-gate.yml``: the one
+workflow with no ``paths:`` filter.
+
+The result was a repository whose test suites gated nothing. They ran,
+they went red, and a merge was never blocked by one.
+
+This script is run by a job in ``repo-gate.yml`` -- which always runs --
+and reports, as a single check, whether the filtered gates passed. It has
+to distinguish three states:
+
+  1. the gates ran and passed                     -> success
+  2. the gates ran and failed                     -> failure
+  3. the gates legitimately did not run, because
+     the pull request touched none of their paths -> success
+
+WHY (3) IS THE HARD ONE
+-----------------------
+Through the Actions API, a workflow that will never run for this event
+and a workflow that has not been created yet look identical: both are an
+absence. Reading an absence as "not applicable" too eagerly gives a false
+pass; reading it as "still pending" forever gives a hang. This repository
+has already shipped four separate guards that could not fail (#79, #82,
+#93, #95), two of them written to close that very family, so the
+mechanism here is built to make absence *provable* rather than assumed:
+
+  * Absence is never interpreted at all until the run listing for this
+    head SHA contains **this job's own run id**. Our run and the gate
+    runs are created by GitHub from the same event, together; once we can
+    see ourselves in the listing, the listing enumerates that event.
+    Before that, everything is pending. This also validates that the head
+    SHA we are querying is the one the runs are attached to -- if it were
+    not, we would never find ourselves and would fail on the deadline
+    rather than pass on an empty list.
+
+  * Even then, absence is only accepted when the workflow's own
+    ``paths:`` filter, evaluated here against the files this pull request
+    changes, says the workflow could not have been triggered. Absence
+    that the filter does not explain stays pending and ends as a
+    *failure* on the deadline. There is no code path in which "I did not
+    find it" becomes a pass on its own.
+
+  * The converse disagreement resolves the safe way too: if a run exists
+    for a workflow this script did not expect, it is waited for and its
+    conclusion is used. A bug in the glob matching below can therefore
+    cost an unnecessary wait, but it cannot manufacture a pass.
+
+A run that exists and concluded anything other than ``success`` -- including
+``skipped``, which for a whole run means every job was skipped and no gate
+actually executed -- is a failure.
+
+RE-RUNS
+-------
+Branch protection reads the latest check for a context. If you re-run a
+gate workflow after a failure, re-run this job too ("Re-run failed jobs"
+on the Repo Gate run); it will re-read the gates' current conclusions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parent
+
+#: The path-filtered workflows whose outcome this check reports.
+#:
+#: ``repo-gate.yml`` is deliberately absent: it is this script's own
+#: workflow, it has no path filter, and its coverage job is required
+#: directly. Aggregating it would mean waiting for ourselves.
+#:
+#: ``backend/tests/scripts/test_gate_coverage.py`` pins this tuple against
+#: its ``REQUIRED_WORKFLOWS``, so the two lists cannot drift apart: a
+#: workflow that is required but not aggregated here is a gate nothing
+#: waits for.
+AGGREGATED_WORKFLOWS = (
+    ".github/workflows/backend-ci.yml",
+    ".github/workflows/python-client-ci.yml",
+)
+
+#: GitHub stops evaluating ``paths:`` filters on very large pull requests
+#: and runs the workflow instead. Past this many changed files this script
+#: stops trusting its own filter evaluation and expects every workflow to
+#: run, which is the safe direction: it waits rather than excuses.
+PATH_FILTER_FILE_LIMIT = 300
+
+PENDING = "pending"
+PASSED = "passed"
+FAILED = "failed"
+NOT_APPLICABLE = "not-applicable"
+
+#: Conclusions that mean the gate ran and was fine. Everything else that
+#: is terminal is a failure, listed nowhere: an allow-list here is the one
+#: place a new GitHub conclusion string could quietly become a pass.
+SUCCESSFUL_CONCLUSIONS = frozenset({"success"})
+
+
+# ---------------------------------------------------------------------------
+# Path filters
+#
+# Shared with backend/tests/scripts/test_gate_coverage.py, which imports
+# these rather than keeping a second copy. Two implementations of "would
+# this workflow trigger" is two answers to the only question that matters
+# here.
+# ---------------------------------------------------------------------------
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """GitHub path-filter glob -> regex. ``**`` spans separators, ``*`` does not."""
+    out: list[str] = []
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif char == "*":
+            out.append("[^/]*")
+            index += 1
+        elif char == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(char))
+            index += 1
+    return re.compile("".join(out) + r"\Z")
+
+
+def load_workflow(workflow_rel: str, repo_root: Path | None = None) -> dict:
+    root = repo_root if repo_root is not None else REPO_ROOT
+    return yaml.safe_load((root / workflow_rel).read_text(encoding="utf-8"))
+
+
+def workflow_triggers(workflow: dict) -> dict:
+    """The ``on:`` block of a parsed workflow.
+
+    PyYAML is a YAML 1.1 parser, in which the bare key ``on`` is the
+    boolean ``True``. Reading ``workflow["on"]`` returns nothing, every
+    path filter silently reads as absent, and every workflow looks
+    unfiltered -- which here would mean "expect everything to run" and, in
+    test_gate_coverage.py, "every file is reachable". One spelling of this
+    mistake hangs, the other is vacuous.
+    """
+    block = workflow.get("on", workflow.get(True))
+    return block if isinstance(block, dict) else {}
+
+
+def workflow_triggers_on(workflow: dict, rel_path: str) -> bool:
+    """Would editing ``rel_path`` start this workflow's pull_request run?"""
+    triggers = workflow_triggers(workflow)
+    if "pull_request" not in triggers:
+        return False
+    pull_request = triggers["pull_request"]
+    if not isinstance(pull_request, dict):
+        # ``pull_request:`` with an empty body means every pull request.
+        return True
+    ignored = pull_request.get("paths-ignore")
+    if ignored and any(glob_to_regex(pattern).match(rel_path) for pattern in ignored):
+        return False
+    included = pull_request.get("paths")
+    if not included:
+        return True
+    return any(glob_to_regex(pattern).match(rel_path) for pattern in included)
+
+
+def workflow_is_expected(workflow: dict, changed_files: list[str], *, files_truncated: bool = False) -> bool:
+    """Would this pull request's file list start this workflow?"""
+    if files_truncated:
+        return True
+    return any(workflow_triggers_on(workflow, path) for path in changed_files)
+
+
+# ---------------------------------------------------------------------------
+# Decision core -- pure, so that it can be tested without a network
+# ---------------------------------------------------------------------------
+
+
+def _latest_run(runs: list[dict], workflow_rel: str) -> dict | None:
+    """The most recent pull_request run of ``workflow_rel`` in ``runs``.
+
+    Restricted to ``event == "pull_request"`` so that a manual
+    ``workflow_dispatch`` re-run at the same commit cannot stand in for
+    the run this pull request actually produced.
+    """
+    mine = [run for run in runs if run.get("path") == workflow_rel and run.get("event") == "pull_request"]
+    if not mine:
+        return None
+    return max(mine, key=lambda run: (str(run.get("run_started_at") or ""), int(run.get("id") or 0)))
+
+
+def classify_workflow(
+    workflow_rel: str,
+    *,
+    runs: list[dict],
+    path_expected: bool,
+    listing_settled: bool,
+) -> tuple[str, str]:
+    """One workflow's state, as (state, human-readable reason).
+
+    ``listing_settled`` is the interlock described in the module
+    docstring: True only once the caller has seen its own run in the same
+    listing. While it is False no absence means anything and everything
+    unseen is pending.
+    """
+    run = _latest_run(runs, workflow_rel)
+    if run is not None:
+        status = run.get("status")
+        if status != "completed":
+            return PENDING, f"run {run.get('id')} is {status}"
+        conclusion = run.get("conclusion")
+        if conclusion is None:
+            # Completed with no conclusion is a transient state of the API,
+            # not an outcome. Waiting is right; treating it as anything
+            # else is guessing.
+            return PENDING, f"run {run.get('id')} is completed with no conclusion yet"
+        if conclusion in SUCCESSFUL_CONCLUSIONS:
+            return PASSED, f"run {run.get('id')} concluded {conclusion}"
+        return FAILED, f"run {run.get('id')} concluded {conclusion}"
+
+    if not listing_settled:
+        return PENDING, "the run listing does not yet contain this job's own run"
+    if path_expected:
+        return PENDING, "this pull request matches its paths: filter but no run has appeared"
+    return NOT_APPLICABLE, "no file in this pull request matches its paths: filter"
+
+
+def overall_state(states: dict[str, tuple[str, str]]) -> str:
+    """Fold per-workflow states into one.
+
+    Failure beats pending beats success, so a gate that has already failed
+    is reported without waiting out the rest.
+    """
+    values = {state for state, _ in states.values()}
+    if FAILED in values:
+        return FAILED
+    if PENDING in values:
+        return PENDING
+    return PASSED
+
+
+# ---------------------------------------------------------------------------
+# GitHub API
+# ---------------------------------------------------------------------------
+
+
+def _api_fetch(base_url: str, token: str | None) -> Callable[[str], object]:
+    def fetch(path: str) -> object:
+        request = urllib.request.Request(f"{base_url}{path}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        request.add_header("User-Agent", "tckdb-aggregate-pr-gates")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    return fetch
+
+
+def fetch_changed_files(
+    fetch: Callable[[str], object],
+    repo: str,
+    pr_number: int,
+    *,
+    limit: int = PATH_FILTER_FILE_LIMIT,
+) -> tuple[list[str], bool]:
+    """(paths changed by the pull request, whether the list hit ``limit``)."""
+    files: list[str] = []
+    page = 1
+    while len(files) < limit:
+        payload = fetch(f"/repos/{repo}/pulls/{pr_number}/files?per_page=100&page={page}")
+        if not isinstance(payload, list) or not payload:
+            return files, False
+        for entry in payload:
+            filename = entry.get("filename")
+            if filename:
+                files.append(filename)
+            previous = entry.get("previous_filename")
+            if previous:
+                # A rename changes two paths as far as a filter is concerned.
+                files.append(previous)
+        if len(payload) < 100:
+            return files, False
+        page += 1
+    return files, True
+
+
+def fetch_runs(fetch: Callable[[str], object], repo: str, head_sha: str) -> list[dict]:
+    runs: list[dict] = []
+    page = 1
+    while True:
+        payload = fetch(f"/repos/{repo}/actions/runs?head_sha={head_sha}&per_page=100&page={page}")
+        if not isinstance(payload, dict):
+            return runs
+        batch = payload.get("workflow_runs") or []
+        runs.extend(batch)
+        if len(batch) < 100:
+            return runs
+        page += 1
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def aggregate(
+    *,
+    fetch: Callable[[str], object],
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    own_run_id: int,
+    workflows: tuple[str, ...] = AGGREGATED_WORKFLOWS,
+    repo_root: Path | None = None,
+    deadline_seconds: float = 95 * 60,
+    poll_seconds: float = 20.0,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    log: Callable[[str], None] = print,
+) -> tuple[bool, dict[str, tuple[str, str]]]:
+    """Poll until every aggregated workflow is decided. (ok, per-workflow states)."""
+    parsed = {rel: load_workflow(rel, repo_root) for rel in workflows}
+
+    changed_files, files_truncated = fetch_changed_files(fetch, repo, pr_number)
+    log(f"pull request #{pr_number} changes {len(changed_files)} path(s) at head {head_sha}")
+    if files_truncated:
+        log(
+            f"more than {PATH_FILTER_FILE_LIMIT} changed paths; GitHub stops evaluating "
+            "paths: filters on pull requests this large, so every gate is expected to run"
+        )
+    for path in sorted(set(changed_files))[:50]:
+        log(f"  changed: {path}")
+
+    expected = {
+        rel: workflow_is_expected(parsed[rel], changed_files, files_truncated=files_truncated) for rel in workflows
+    }
+    for rel in workflows:
+        log(f"paths: filter for {rel} -> {'expected to run' if expected[rel] else 'not triggered by this pull request'}")
+
+    started = now()
+    states: dict[str, tuple[str, str]] = {}
+    announced: dict[str, str] = {}
+
+    while True:
+        runs = fetch_runs(fetch, repo, head_sha)
+        listing_settled = any(int(run.get("id") or 0) == own_run_id for run in runs)
+        states = {
+            rel: classify_workflow(
+                rel,
+                runs=runs,
+                path_expected=expected[rel],
+                listing_settled=listing_settled,
+            )
+            for rel in workflows
+        }
+        for rel, (state, reason) in states.items():
+            if announced.get(rel) != state:
+                log(f"{rel}: {state} ({reason})")
+                announced[rel] = state
+
+        overall = overall_state(states)
+        if overall != PENDING:
+            return overall == PASSED, states
+
+        if now() - started >= deadline_seconds:
+            log(
+                "deadline reached with gates undecided. This is a failure, not a "
+                "pass: an absent run that the paths: filter does not explain has "
+                "no benign reading."
+            )
+            return False, states
+
+        if not listing_settled:
+            log(f"waiting: run {own_run_id} (this job) is not in the run listing for {head_sha} yet")
+        sleep(poll_seconds)
+
+
+def _write_summary(states: dict[str, tuple[str, str]], ok: bool) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    lines = ["## Required gates", "", "| Workflow | State | Detail |", "| --- | --- | --- |"]
+    for rel, (state, reason) in sorted(states.items()):
+        lines.append(f"| `{rel}` | {state} | {reason} |")
+    lines.append("")
+    lines.append("Result: **" + ("success" if ok else "failure") + "**")
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--run-id", type=int, default=int(os.environ.get("GITHUB_RUN_ID") or 0))
+    parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", ""))
+    parser.add_argument("--deadline-minutes", type=float, default=95.0)
+    parser.add_argument("--poll-seconds", type=float, default=20.0)
+    args = parser.parse_args(argv)
+
+    if args.event_name != "pull_request":
+        # Required status checks are evaluated on pull requests. On a push
+        # to main every gate workflow fires under its own push trigger and
+        # is visible on the commit directly, so there is nothing here to
+        # aggregate. This branch is unreachable on the event this check
+        # exists for.
+        print(f"event is {args.event_name!r}, not 'pull_request'; nothing to aggregate")
+        return 0
+
+    missing = [
+        name
+        for name, value in (
+            ("--repo", args.repo),
+            ("--pr-number", args.pr_number),
+            ("--head-sha", args.head_sha),
+            ("--run-id", args.run_id),
+        )
+        if not value
+    ]
+    if missing:
+        print(f"refusing to report on incomplete input; missing {', '.join(missing)}", file=sys.stderr)
+        return 2
+
+    fetch = _api_fetch(os.environ.get("GITHUB_API_URL", "https://api.github.com"), os.environ.get("GITHUB_TOKEN"))
+    try:
+        ok, states = aggregate(
+            fetch=fetch,
+            repo=args.repo,
+            pr_number=args.pr_number,
+            head_sha=args.head_sha,
+            own_run_id=args.run_id,
+            deadline_seconds=args.deadline_minutes * 60,
+            poll_seconds=args.poll_seconds,
+        )
+    except urllib.error.HTTPError as error:
+        print(f"GitHub API error {error.code} for {error.url}", file=sys.stderr)
+        return 2
+
+    _write_summary(states, ok)
+    print("")
+    for rel, (state, reason) in sorted(states.items()):
+        print(f"{rel}: {state} -- {reason}")
+    if not ok:
+        failed = [rel for rel, (state, _) in states.items() if state != PASSED and state != NOT_APPLICABLE]
+        print(f"required gates did not pass: {', '.join(sorted(failed))}", file=sys.stderr)
+        return 1
+    print("all required gates passed or do not apply to this pull request")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())

--- a/backend/scripts/aggregate_pr_gates.py
+++ b/backend/scripts/aggregate_pr_gates.py
@@ -340,6 +340,13 @@ def aggregate(
     log: Callable[[str], None] = print,
 ) -> tuple[bool, dict[str, tuple[str, str]]]:
     """Poll until every aggregated workflow is decided. (ok, per-workflow states)."""
+    if not workflows:
+        # An empty list folds to success over nothing, which is the purest
+        # form of the defect this whole file is built against: a required
+        # check that passes because it checked nothing. The guard in
+        # test_gate_coverage.py would catch the tuple being emptied, but a
+        # gate should not depend on a test elsewhere to refuse to be vacuous.
+        raise ValueError("no workflows to aggregate; a check over nothing is not a check")
     parsed = {rel: load_workflow(rel, repo_root) for rel in workflows}
 
     changed_files, files_truncated = fetch_changed_files(fetch, repo, pr_number)

--- a/backend/tests/scripts/test_aggregate_pr_gates.py
+++ b/backend/tests/scripts/test_aggregate_pr_gates.py
@@ -1,0 +1,434 @@
+"""The aggregate gate must be able to fail.
+
+``backend/scripts/aggregate_pr_gates.py`` is the check that branch
+protection lists, so every test suite in this repository gates a merge
+through it and nothing else. That makes the interesting property not
+"does it pass on a good pull request" but "is there any pull request on
+which it passes without having checked anything". This repository has
+shipped four guards that could not fail (#79 a nightly red nobody read,
+#82 a sweep that verified nothing and exited 0, #93 a step that never
+executed, #95 three suites run by no job), and two of the guards written
+to close that family shipped containing it. So the tests below are
+weighted toward the three ways this one could join them:
+
+  * an absent workflow run read as "legitimately skipped" when it is
+    merely late -- a false pass;
+  * a failing gate whose conclusion is not one of the strings the folder
+    treats as failure -- a false pass;
+  * a gate that never appears being waited on forever -- a hang, which
+    on a required check is indistinguishable from a block.
+
+The decision core is pure and the API is a callable, so all three are
+reachable here without a network.
+
+Run under ``--noconftest`` by ``.github/workflows/repo-gate.yml`` as well
+as by the backend complement gate, hence the importlib loader below
+rather than ``from scripts import ...``: the repo gate has no backend
+rootdir and no conftest, and inserting ``backend/scripts`` onto
+``sys.path`` there would put ``lib``, ``dev``, ``ops`` and ``validation``
+ahead of real packages.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_ROOT.parent
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gates = _load_module("aggregate_pr_gates", BACKEND_ROOT / "scripts" / "aggregate_pr_gates.py")
+
+BACKEND_CI = ".github/workflows/backend-ci.yml"
+CLIENT_CI = ".github/workflows/python-client-ci.yml"
+
+OWN_RUN_ID = 999
+
+
+def run(path: str, *, status: str = "completed", conclusion: str | None = "success", run_id: int = 1, **extra):
+    payload = {
+        "id": run_id,
+        "path": path,
+        "event": "pull_request",
+        "status": status,
+        "conclusion": conclusion,
+        "run_started_at": "2026-08-12T00:00:00Z",
+    }
+    payload.update(extra)
+    return payload
+
+
+def own_run():
+    """The repo-gate run this job is executing in, as the API reports it."""
+    return run(".github/workflows/repo-gate.yml", status="in_progress", conclusion=None, run_id=OWN_RUN_ID)
+
+
+# ---------------------------------------------------------------------------
+# The three states, at the level of one workflow
+# ---------------------------------------------------------------------------
+
+
+def test_a_passing_run_passes():
+    state, _ = gates.classify_workflow(
+        BACKEND_CI, runs=[own_run(), run(BACKEND_CI)], path_expected=True, listing_settled=True
+    )
+    assert state == gates.PASSED
+
+
+@pytest.mark.parametrize(
+    "conclusion",
+    ["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale", "neutral", "skipped"],
+)
+def test_every_non_success_conclusion_is_a_failure(conclusion):
+    """The fold is an allow-list of one, on purpose.
+
+    ``skipped`` is in this list and is the subtle one: a *run* concluding
+    skipped means every job in it was skipped, so the gate did not
+    execute. Reading that as "fine, nothing to do" is precisely the shape
+    of #93.
+    """
+    state, _ = gates.classify_workflow(
+        BACKEND_CI,
+        runs=[own_run(), run(BACKEND_CI, conclusion=conclusion)],
+        path_expected=True,
+        listing_settled=True,
+    )
+    assert state == gates.FAILED, f"{conclusion!r} must not be read as success"
+
+
+def test_an_absent_run_the_filter_explains_is_not_applicable():
+    state, _ = gates.classify_workflow(CLIENT_CI, runs=[own_run()], path_expected=False, listing_settled=True)
+    assert state == gates.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# Skipped vs not started -- the distinction the whole design turns on
+# ---------------------------------------------------------------------------
+
+
+def test_absence_means_nothing_until_this_job_can_see_its_own_run():
+    """The interlock. Before it, an empty listing is pending, never a pass.
+
+    Without this, a listing that has not yet been populated for the event
+    reads as "no gates ran" and every pull request passes instantly --
+    the false pass that a required check makes invisible, because a green
+    check is what everyone expects to see.
+    """
+    state, reason = gates.classify_workflow(CLIENT_CI, runs=[], path_expected=False, listing_settled=False)
+    assert state == gates.PENDING
+    assert "own run" in reason
+
+
+def test_an_absent_run_the_filter_does_not_explain_stays_pending():
+    """Expected but missing is never excused; it waits and then fails."""
+    state, _ = gates.classify_workflow(BACKEND_CI, runs=[own_run()], path_expected=True, listing_settled=True)
+    assert state == gates.PENDING
+
+
+def test_a_run_that_exists_is_honoured_even_when_the_filter_did_not_expect_it():
+    """Filter disagreement resolves toward checking, not toward excusing.
+
+    A bug in the glob matcher can cost a wait. It must not be able to buy
+    a pass for a workflow that actually ran and failed.
+    """
+    state, _ = gates.classify_workflow(
+        BACKEND_CI,
+        runs=[own_run(), run(BACKEND_CI, conclusion="failure")],
+        path_expected=False,
+        listing_settled=True,
+    )
+    assert state == gates.FAILED
+
+
+def test_an_unfinished_run_is_pending_not_passed():
+    for status in ("queued", "in_progress", "waiting", "requested", "pending"):
+        state, _ = gates.classify_workflow(
+            BACKEND_CI,
+            runs=[own_run(), run(BACKEND_CI, status=status, conclusion=None)],
+            path_expected=True,
+            listing_settled=True,
+        )
+        assert state == gates.PENDING, status
+
+
+def test_completed_without_a_conclusion_is_pending():
+    state, _ = gates.classify_workflow(
+        BACKEND_CI,
+        runs=[own_run(), run(BACKEND_CI, conclusion=None)],
+        path_expected=True,
+        listing_settled=True,
+    )
+    assert state == gates.PENDING
+
+
+def test_the_latest_run_for_a_workflow_wins():
+    stale = run(BACKEND_CI, conclusion="failure", run_id=1, run_started_at="2026-08-12T00:00:00Z")
+    fresh = run(BACKEND_CI, conclusion="success", run_id=2, run_started_at="2026-08-12T01:00:00Z")
+    state, _ = gates.classify_workflow(
+        BACKEND_CI, runs=[own_run(), stale, fresh], path_expected=True, listing_settled=True
+    )
+    assert state == gates.PASSED
+
+
+def test_a_dispatch_run_does_not_stand_in_for_the_pull_request_run():
+    """Otherwise a green manual re-run at the same commit launders a red PR."""
+    state, _ = gates.classify_workflow(
+        BACKEND_CI,
+        runs=[own_run(), run(BACKEND_CI, event="workflow_dispatch")],
+        path_expected=True,
+        listing_settled=True,
+    )
+    assert state == gates.PENDING
+
+
+def test_another_workflows_run_is_not_mistaken_for_this_one():
+    state, _ = gates.classify_workflow(
+        BACKEND_CI,
+        runs=[own_run(), run(CLIENT_CI, conclusion="success")],
+        path_expected=True,
+        listing_settled=True,
+    )
+    assert state == gates.PENDING
+
+
+# ---------------------------------------------------------------------------
+# The fold
+# ---------------------------------------------------------------------------
+
+
+def test_failure_beats_pending_beats_success():
+    assert gates.overall_state({"a": (gates.PASSED, ""), "b": (gates.FAILED, "")}) == gates.FAILED
+    assert gates.overall_state({"a": (gates.PENDING, ""), "b": (gates.FAILED, "")}) == gates.FAILED
+    assert gates.overall_state({"a": (gates.PASSED, ""), "b": (gates.PENDING, "")}) == gates.PENDING
+    assert gates.overall_state({"a": (gates.PASSED, ""), "b": (gates.NOT_APPLICABLE, "")}) == gates.PASSED
+
+
+# ---------------------------------------------------------------------------
+# Path filters against the real workflows in this repository
+# ---------------------------------------------------------------------------
+
+
+def _real(rel: str) -> dict:
+    return gates.load_workflow(rel, REPO_ROOT)
+
+
+def test_a_paper_only_change_expects_no_gate():
+    """Case 3 of the bite tests, as a unit."""
+    changed = ["paper/manuscript.tex"]
+    for rel in gates.AGGREGATED_WORKFLOWS:
+        assert not gates.workflow_is_expected(_real(rel), changed), rel
+
+
+def test_a_markdown_only_change_outside_docs_expects_no_gate():
+    assert not gates.workflow_is_expected(_real(BACKEND_CI), ["README.md"])
+    assert not gates.workflow_is_expected(_real(CLIENT_CI), ["README.md"])
+
+
+def test_a_backend_change_expects_the_backend_gate_and_not_the_client_gate():
+    changed = ["backend/app/api/routes/health.py"]
+    assert gates.workflow_is_expected(_real(BACKEND_CI), changed)
+    assert not gates.workflow_is_expected(_real(CLIENT_CI), changed)
+
+
+def test_a_client_change_expects_the_client_gate():
+    changed = ["clients/python/src/tckdb_client/client.py"]
+    assert gates.workflow_is_expected(_real(CLIENT_CI), changed)
+    assert not gates.workflow_is_expected(_real(BACKEND_CI), changed)
+
+
+def test_a_shared_schemas_change_expects_both():
+    changed = ["schemas/python/tckdb-schemas/tckdb_schemas/enums.py"]
+    for rel in gates.AGGREGATED_WORKFLOWS:
+        assert gates.workflow_is_expected(_real(rel), changed), rel
+
+
+def test_a_rename_counts_both_of_its_paths():
+    """A file moved out of backend/ still changed backend/."""
+    fetched = []
+
+    def fetch(path: str):
+        fetched.append(path)
+        if "/files" in path:
+            if "page=1" in path:
+                return [{"filename": "docs/moved.py", "previous_filename": "backend/app/moved.py"}]
+            return []
+        return {"workflow_runs": []}
+
+    files, truncated = gates.fetch_changed_files(fetch, "o/r", 1)
+    assert not truncated
+    assert files == ["docs/moved.py", "backend/app/moved.py"]
+    assert gates.workflow_is_expected(_real(BACKEND_CI), files)
+
+
+def test_a_very_large_pull_request_expects_everything():
+    """GitHub stops evaluating paths: filters past its own limit; so do we."""
+    assert gates.workflow_is_expected(_real(CLIENT_CI), ["paper/x.tex"], files_truncated=True)
+
+
+def test_glob_star_does_not_cross_a_separator():
+    assert gates.glob_to_regex("docs/*.md").match("docs/a.md")
+    assert not gates.glob_to_regex("docs/*.md").match("docs/nested/a.md")
+    assert gates.glob_to_regex("docs/**").match("docs/nested/a.md")
+    assert not gates.glob_to_regex("backend/**").match("backendish/a.py")
+
+
+def test_the_on_key_is_read_despite_yaml_1_1_booleans():
+    """``on:`` parses as the boolean True. Missing that makes every filter absent.
+
+    In this module the failure direction is a hang rather than a false
+    pass -- but only because absence is also cross-checked. Pin it anyway.
+    """
+    parsed = yaml.safe_load("on:\n  pull_request:\n    paths:\n      - 'backend/**'\n")
+    assert "on" not in parsed or parsed.get("on") is None
+    assert gates.workflow_triggers(parsed)["pull_request"]["paths"] == ["backend/**"]
+
+
+def test_a_workflow_without_a_pull_request_trigger_never_expects_to_run():
+    parsed = yaml.safe_load("on:\n  schedule:\n    - cron: '0 0 * * *'\n")
+    assert not gates.workflow_triggers_on(parsed, "backend/app/x.py")
+
+
+def test_paths_ignore_is_honoured():
+    parsed = yaml.safe_load("on:\n  pull_request:\n    paths-ignore:\n      - '**.md'\n")
+    assert not gates.workflow_triggers_on(parsed, "backend/README.md")
+    assert gates.workflow_triggers_on(parsed, "backend/app/x.py")
+
+
+# ---------------------------------------------------------------------------
+# The driver, end to end, against a scripted API
+# ---------------------------------------------------------------------------
+
+
+class FakeApi:
+    """A GitHub whose run listing changes between polls."""
+
+    def __init__(self, changed: list[str], run_sequence: list[list[dict]]):
+        self.changed = changed
+        self.run_sequence = run_sequence
+        self.run_calls = 0
+
+    def __call__(self, path: str):
+        if "/files" in path:
+            return [{"filename": name} for name in self.changed] if "page=1" in path else []
+        index = min(self.run_calls, len(self.run_sequence) - 1)
+        self.run_calls += 1
+        return {"workflow_runs": self.run_sequence[index]}
+
+
+def drive(api: FakeApi, *, deadline_seconds: float = 600.0):
+    clock = {"t": 0.0}
+
+    def now():
+        return clock["t"]
+
+    def sleep(seconds: float):
+        clock["t"] += seconds
+
+    return gates.aggregate(
+        fetch=api,
+        repo="o/r",
+        pr_number=1,
+        head_sha="deadbeef",
+        own_run_id=OWN_RUN_ID,
+        repo_root=REPO_ROOT,
+        deadline_seconds=deadline_seconds,
+        poll_seconds=20.0,
+        now=now,
+        sleep=sleep,
+        log=lambda _message: None,
+    )
+
+
+def test_docs_only_pull_request_passes_without_waiting_for_anything():
+    api = FakeApi(["paper/manuscript.tex"], [[own_run()]])
+    ok, states = drive(api)
+    assert ok
+    assert {state for state, _ in states.values()} == {gates.NOT_APPLICABLE}
+
+
+def test_docs_only_pull_request_does_not_pass_before_the_listing_settles():
+    """The first poll sees an empty listing; passing there would be the bug."""
+    api = FakeApi(["paper/manuscript.tex"], [[], [], [own_run()]])
+    ok, _ = drive(api)
+    assert ok
+    assert api.run_calls == 3, "it must not have concluded on the empty listings"
+
+
+def test_a_backend_pull_request_waits_and_then_fails_on_a_red_gate():
+    api = FakeApi(
+        ["backend/app/x.py"],
+        [
+            [own_run()],
+            [own_run(), run(BACKEND_CI, status="in_progress", conclusion=None)],
+            [own_run(), run(BACKEND_CI, conclusion="failure")],
+        ],
+    )
+    ok, states = drive(api)
+    assert not ok
+    assert states[BACKEND_CI][0] == gates.FAILED
+    assert states[CLIENT_CI][0] == gates.NOT_APPLICABLE
+
+
+def test_a_backend_pull_request_passes_on_a_green_gate():
+    api = FakeApi(["backend/app/x.py"], [[own_run()], [own_run(), run(BACKEND_CI, conclusion="success")]])
+    ok, states = drive(api)
+    assert ok
+    assert states[BACKEND_CI][0] == gates.PASSED
+
+
+def test_a_gate_that_never_appears_fails_on_the_deadline_rather_than_passing():
+    """The hang is converted into a failure. It is never converted into a pass."""
+    api = FakeApi(["backend/app/x.py"], [[own_run()]])
+    ok, states = drive(api, deadline_seconds=60.0)
+    assert not ok
+    assert states[BACKEND_CI][0] == gates.PENDING
+
+
+def test_a_listing_that_never_settles_fails_on_the_deadline():
+    """If the head SHA were wrong we would never see ourselves. That must fail."""
+    api = FakeApi(["paper/manuscript.tex"], [[]])
+    ok, _ = drive(api, deadline_seconds=60.0)
+    assert not ok
+
+
+def test_a_red_gate_short_circuits_the_wait():
+    """Failure is reported without waiting out a sibling that is still running."""
+    api = FakeApi(
+        ["schemas/python/tckdb-schemas/x.py"],
+        [[own_run(), run(BACKEND_CI, conclusion="failure"), run(CLIENT_CI, status="in_progress", conclusion=None)]],
+    )
+    ok, _ = drive(api)
+    assert not ok
+    assert api.run_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_pull_request_event_reports_nothing_and_does_not_pretend_to():
+    assert gates.main(["--event-name", "push", "--repo", "o/r"]) == 0
+
+
+def test_incomplete_input_is_refused_rather_than_passed():
+    """Missing arguments must not become "no gates found, all good"."""
+    assert gates.main(["--event-name", "pull_request", "--repo", "o/r", "--pr-number", "0"]) == 2
+    assert (
+        gates.main(
+            ["--event-name", "pull_request", "--repo", "", "--pr-number", "3", "--head-sha", "x", "--run-id", "1"]
+        )
+        == 2
+    )

--- a/backend/tests/scripts/test_aggregate_pr_gates.py
+++ b/backend/tests/scripts/test_aggregate_pr_gates.py
@@ -403,6 +403,22 @@ def test_a_listing_that_never_settles_fails_on_the_deadline():
     assert not ok
 
 
+def test_aggregating_nothing_is_refused_rather_than_folded_to_success():
+    """A fold over an empty list returns success. That must not be reachable."""
+    api = FakeApi(["backend/app/x.py"], [[own_run()]])
+    with pytest.raises(ValueError, match="not a check"):
+        gates.aggregate(
+            fetch=api,
+            repo="o/r",
+            pr_number=1,
+            head_sha="deadbeef",
+            own_run_id=OWN_RUN_ID,
+            workflows=(),
+            repo_root=REPO_ROOT,
+            log=lambda _message: None,
+        )
+
+
 def test_a_red_gate_short_circuits_the_wait():
     """Failure is reported without waiting out a sibling that is still running."""
     api = FakeApi(

--- a/backend/tests/scripts/test_gate_coverage.py
+++ b/backend/tests/scripts/test_gate_coverage.py
@@ -54,17 +54,42 @@ exists rather than the next time somebody audits a list.
 
 from __future__ import annotations
 
-import re
+import importlib.util
 import shlex
 import tomllib
 from pathlib import Path
 
 import pytest
-import yaml
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 REPO_ROOT = BACKEND_ROOT.parent
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def _load_module(name: str, path: Path):
+    """Import by path, without putting ``backend/scripts`` on ``sys.path``.
+
+    This file is run by the repo gate with ``--noconftest`` and no backend
+    rootdir, so the usual ``from scripts import ...`` is unavailable; and
+    ``backend/scripts`` contains ``lib``, ``dev``, ``ops`` and
+    ``validation``, which have no business shadowing anything.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+#: The path-filter reader lives with the aggregate gate that depends on it
+#: at runtime (``backend/scripts/aggregate_pr_gates.py``) and is imported
+#: here rather than reimplemented. Two answers to "would this workflow
+#: trigger on this file" is one answer too many: the aggregate excuses an
+#: absent run when the filter says it could not have started, and this
+#: file asserts a covered file can reach the job that covers it. If those
+#: two disagreed, a file could be declared reachable here and excused
+#: there.
+gates = _load_module("aggregate_pr_gates", BACKEND_ROOT / "scripts" / "aggregate_pr_gates.py")
 
 #: The workflows whose jobs gate a pull request. Everything else under
 #: ``.github/workflows/`` is a schedule, a deploy, or a docs build, and a
@@ -75,11 +100,30 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 #: in branch settings, not in the tree. Everything downstream of it (which
 #: files exist, which jobs run them, which paths reach those jobs) is
 #: derived rather than listed.
+#:
+#: Two of these three are required *indirectly*. Both are path-filtered,
+#: and a path-filtered check cannot be listed in branch protection: it
+#: never reports on a pull request outside its paths and GitHub waits for
+#: it forever, so listing ``Backend CI`` would make every ``paper/`` typo
+#: permanently unmergeable. They gate a merge through the "Required gates"
+#: job in ``repo-gate.yml``, which always runs and reports their
+#: conclusions. ``test_every_required_workflow_is_actually_required``
+#: below is what keeps this list and that job's list the same list.
 REQUIRED_WORKFLOWS = (
     ".github/workflows/repo-gate.yml",
     ".github/workflows/backend-ci.yml",
     ".github/workflows/python-client-ci.yml",
 )
+
+#: The workflow holding the checks branch protection lists by name. Every
+#: other required workflow reaches branch protection through it.
+DIRECTLY_REQUIRED_WORKFLOW = ".github/workflows/repo-gate.yml"
+
+#: The job names branch protection lists as required contexts. Renaming a
+#: job silently un-requires whatever it gates, because a context that
+#: never reports is a context GitHub stops waiting for only if an admin
+#: removes it -- and an admin who removes it removes the gate.
+REQUIRED_CONTEXTS = ("CI gate coverage", "Required gates")
 
 #: The gate scripts the backend workflow is required to invoke. Their union
 #: is supposed to cover ``backend/tests/`` between them; deleting one of
@@ -309,59 +353,19 @@ def _script_selection(script_rel: str) -> Selection:
 
 
 def _workflow(workflow_rel: str) -> dict:
-    return yaml.safe_load((REPO_ROOT / workflow_rel).read_text(encoding="utf-8"))
+    return gates.load_workflow(workflow_rel, REPO_ROOT)
 
 
-def _triggers(workflow: dict) -> dict:
-    """The ``on:`` block.
-
-    PyYAML is a YAML 1.1 parser, in which the bare key ``on`` is the
-    boolean ``True``. Reading ``workflow["on"]`` returns nothing and every
-    path filter silently reads as absent -- which would make the trigger
-    check pass unconditionally, the exact vacuity this file is built to
-    avoid.
-    """
-    block = workflow.get("on", workflow.get(True))
-    return block if isinstance(block, dict) else {}
-
-
-def _glob_to_regex(pattern: str) -> re.Pattern[str]:
-    """GitHub path-filter glob -> regex. ``**`` spans separators, ``*`` does not."""
-    out = []
-    index = 0
-    while index < len(pattern):
-        char = pattern[index]
-        if pattern.startswith("**", index):
-            out.append(".*")
-            index += 2
-        elif char == "*":
-            out.append("[^/]*")
-            index += 1
-        elif char == "?":
-            out.append("[^/]")
-            index += 1
-        else:
-            out.append(re.escape(char))
-            index += 1
-    return re.compile("".join(out) + r"\Z")
+#: The ``on:`` block. PyYAML is a YAML 1.1 parser, in which the bare key
+#: ``on`` is the boolean ``True``; reading ``workflow["on"]`` returns
+#: nothing and every path filter silently reads as absent, which would
+#: make the trigger check below pass unconditionally.
+_triggers = gates.workflow_triggers
 
 
 def _workflow_triggers_on(workflow_rel: str, rel_path: str) -> bool:
     """Would editing ``rel_path`` start this workflow's pull_request run?"""
-    triggers = _triggers(_workflow(workflow_rel))
-    if "pull_request" not in triggers:
-        return False
-    pull_request = triggers["pull_request"]
-    if not isinstance(pull_request, dict):
-        # ``pull_request:`` with an empty body means every pull request.
-        return True
-    ignored = pull_request.get("paths-ignore")
-    if ignored and any(_glob_to_regex(pattern).match(rel_path) for pattern in ignored):
-        return False
-    included = pull_request.get("paths")
-    if not included:
-        return True
-    return any(_glob_to_regex(pattern).match(rel_path) for pattern in included)
+    return gates.workflow_triggers_on(_workflow(workflow_rel), rel_path)
 
 
 def _step_base(workflow: dict, job: dict, step: dict) -> str:
@@ -569,6 +573,107 @@ def test_repo_gate_is_not_path_filtered() -> None:
         "repo-gate.yml must run on every pull request. A path filter here is "
         "a hole shaped exactly like the ones this file exists to close."
     )
+
+
+# ---------------------------------------------------------------------------
+# The bridge from "required" (a GitHub setting) to "runs" (this tree)
+#
+# REQUIRED_WORKFLOWS above is an include-list because GitHub keeps
+# "required" in branch settings. Two of its three entries are path-filtered
+# and therefore cannot be listed there at all; they gate a merge only
+# because the "Required gates" job in repo-gate.yml waits for them. These
+# checks are what stop that sentence from quietly becoming false.
+# ---------------------------------------------------------------------------
+
+
+def _repo_gate_jobs() -> dict:
+    return _workflow(DIRECTLY_REQUIRED_WORKFLOW)["jobs"]
+
+
+def _job_named(name: str) -> dict:
+    jobs = [job for job in _repo_gate_jobs().values() if job.get("name") == name]
+    assert len(jobs) == 1, f"expected exactly one job named {name!r} in {DIRECTLY_REQUIRED_WORKFLOW}, found {len(jobs)}"
+    return jobs[0]
+
+
+@pytest.mark.parametrize("context", REQUIRED_CONTEXTS)
+def test_the_required_contexts_exist_as_job_names(context: str) -> None:
+    """Branch protection lists job names. A renamed job is an un-required gate.
+
+    GitHub matches a required status check by its context string. Rename
+    the job and the context stops reporting; the pull request then blocks
+    on a check that will never arrive, and the fix somebody reaches for
+    under pressure is to delete the requirement.
+    """
+    _job_named(context)
+
+
+def test_every_required_workflow_is_actually_required() -> None:
+    """The two lists have to be one list.
+
+    ``REQUIRED_WORKFLOWS`` says which workflows gate a merge; the
+    aggregate job's ``AGGREGATED_WORKFLOWS`` says which ones it waits for.
+    A workflow in the first and not the second is a suite this file
+    reports as gating a pull request while nothing blocks the merge on it
+    -- which is the state the whole repository was in until the aggregate
+    existed. A workflow in the second and not the first is a gate that
+    blocks merges without being declared.
+    """
+    aggregated = set(gates.AGGREGATED_WORKFLOWS)
+    declared = set(REQUIRED_WORKFLOWS) - {DIRECTLY_REQUIRED_WORKFLOW}
+    assert aggregated == declared, (
+        "backend/scripts/aggregate_pr_gates.py waits for "
+        f"{sorted(aggregated)} but REQUIRED_WORKFLOWS declares {sorted(declared)} "
+        "as gating a pull request indirectly."
+    )
+    assert DIRECTLY_REQUIRED_WORKFLOW not in aggregated, (
+        "the aggregate must not wait for its own workflow; it would never finish."
+    )
+
+
+def test_required_gates_job_is_named_and_unconditional() -> None:
+    """No ``needs:``, no ``if:``, on purpose.
+
+    A job GitHub skips reports the conclusion ``skipped``, and branch
+    protection accepts a skipped required check as satisfied. So any
+    condition on this job -- including a ``needs:`` on a sibling that
+    failed -- is a way for the gate to be satisfied without running. The
+    single event test the script does need lives in Python, where it is a
+    code path with a test against it rather than an expression nothing
+    evaluates.
+    """
+    job = _job_named("Required gates")
+    assert "needs" not in job, (
+        "a `needs:` here means a failed dependency skips this job, and a skipped "
+        "required check counts as satisfied."
+    )
+    assert "if" not in job, "an `if:` here is a way for the required check to pass by being skipped."
+
+
+def test_required_gates_job_can_read_what_it_reports_on() -> None:
+    permissions = _job_named("Required gates").get("permissions", {})
+    assert permissions.get("actions") == "read", "without actions: read it cannot see the gate conclusions"
+    assert permissions.get("pull-requests") == "read", (
+        "without pull-requests: read it cannot see the changed files, which is "
+        "what decides whether an absent run is legitimate"
+    )
+
+
+def test_the_aggregate_and_its_tests_both_run_in_the_unfiltered_workflow() -> None:
+    """The aggregate's own tests must not be gated by the aggregate.
+
+    ``backend/tests/scripts/`` is covered by the complement gate, which is
+    path-filtered on ``backend/**`` -- so a pull request that broke the
+    aggregator while touching backend/ would be reported on by the very
+    mechanism it broke. Running these two in the unfiltered workflow makes
+    the report independent of its subject.
+    """
+    text = (REPO_ROOT / DIRECTLY_REQUIRED_WORKFLOW).read_text(encoding="utf-8")
+    assert "backend/scripts/aggregate_pr_gates.py" in text, (
+        "repo-gate.yml must invoke the aggregate script; a required context "
+        "whose job runs nothing is the defect this repository keeps shipping."
+    )
+    assert "backend/tests/scripts/test_aggregate_pr_gates.py" in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Make the path-filtered test gates requireable

Branch protection lists one context, "CI gate coverage", and the reason
is structural rather than an oversight: every test workflow here is
path-filtered, and a required status check that is path-filtered never
reports on a pull request outside its paths -- GitHub blocks the merge
indefinitely waiting for it. Requiring "Backend CI" today would make
every docs-only or paper/-only pull request permanently unmergeable.

So the suites ran, went red, and blocked nothing. clients/python/tests/
test_openapi_parity.py sat red on main from #121 until #133 noticed by
hand, which is what that state looks like from the outside.

This adds a "Required gates" job to repo-gate.yml -- the one workflow
with no path filter -- which reports the filtered workflows' conclusions
for this head SHA as a single always-present check. Measured before
choosing: backend-ci is 591-804s over the last ten pull-request runs
(median 773s), the repo gate 17-46s (median 21s). Deleting the path
filters instead would put roughly thirteen minutes of runner time on
every typo fix in paper/, so the aggregate queries rather than the
filters being removed.

The hard part is the third state -- gates that legitimately did not run
-- because through the API a workflow that will never run and one that
has not been created yet are both an absence. Getting it wrong one way
deadlocks docs pull requests again; getting it wrong the other way adds
another check that cannot fail, which is the family #79, #82, #93 and
#95 spent three days closing, twice with guards that shipped containing
the defect themselves. So absence here is never assumed:

  * It is not interpreted at all until the run listing contains this
    job's own run id. Our run and the gate runs are created by GitHub
    from the same event; once we can see ourselves, the listing
    enumerates that event. This also catches a wrong head SHA, which
    would otherwise read as "no gates ran, all clear".

  * Even then it is only excused when the workflow's own paths: filter,
    evaluated against this pull request's changed files, says the
    workflow could not have started. Unexplained absence stays pending
    and ends as a failure on the deadline. No code path turns "not
    found" into a pass on its own.

  * The converse disagreement resolves the safe way: a run that exists
    but was not expected is waited for and its conclusion used, so a bug
    in the glob matcher costs a wait rather than buying a pass.

The job carries no needs: and no if:. A skipped job reports the
conclusion "skipped", which branch protection accepts as satisfying a
required check, so any condition on it is a way for the gate to pass
without running; the one event test that is genuinely needed lives in
Python where it has a test against it.

test_gate_coverage.py now imports the path-filter reader from the script
instead of keeping a second copy -- if the two disagreed, a file could be
declared reachable in one and excused in the other -- and pins the
bridge that the include-list depends on: the aggregate's workflow list
against REQUIRED_WORKFLOWS, the two required context strings against the
job names, and the absence of needs:/if:.

Eleven mutations of the new mechanism were run against the guards
(renaming the job, adding an if: or a needs:, dropping actions: read,
deleting the aggregate step, dropping a workflow from the aggregated
list, reading "skipped" as success, excusing absence before the listing
settles, excusing it regardless of the filter, reporting success on the
deadline, ignoring a run that exists). All eleven fail the guards.
