### PR TITLE
Let accepted science be cited, not just copied

### DIFF
--- a/backend/alembic/versions/d4e9b1c7a253_scf_stability_provenance_is_not_ownership.py
+++ b/backend/alembic/versions/d4e9b1c7a253_scf_stability_provenance_is_not_ownership.py
@@ -1,0 +1,148 @@
+"""Stop freezing SCF-stability evidence on the calculation it merely cites.
+
+``c6f2a9d4e7b1`` states the rule its registry follows, immediately above the
+registry itself: "Each child is protected by the accepted root that owns its
+scientific meaning. Cross-domain provenance FKs are intentionally not treated
+as ownership (for example ``thermo_source_calculation.calculation_id``)." It
+then registered ``calc_scf_stability`` under two columns:
+
+* ``calculation_id`` -- ``NOT NULL``, the table's primary key, the calculation
+  whose wavefunction the row describes. Ownership, correctly guarded.
+* ``source_calculation_id`` -- nullable, no part of any key, the *other*
+  calculation the stability analysis was read out of. Provenance, and the one
+  entry in the whole regime where the stated rule was written down and then
+  not applied.
+
+What the extra argument actually did
+------------------------------------
+``tckdb_guard_accepted_child`` draws no distinction between the columns handed
+to it. It collects every non-NULL value from every argument column in OLD and
+NEW, and refuses the write if any of those ids has ever been approved. With
+both columns registered, ``trg_as_child_19`` therefore refused this:
+
+    INSERT INTO calc_scf_stability (calculation_id, status, source_calculation_id)
+    VALUES (<unapproved calculation A>, 'stable', <approved calculation B>);
+
+with ``accepted calculation record B is immutable`` -- while the identical
+insert leaving ``source_calculation_id`` NULL succeeded. Nothing about A was
+approved; nothing about B was written. The refusal was triggered purely by the
+act of *naming* accepted science, on a row belonging to a record no reviewer
+had looked at.
+
+That is the incentive inverted. Approving a calculation is the act of saying
+"this is a result others may build on", and building on it is exactly what
+citing it in the provenance of a later analysis is. A regime that refuses the
+citation and permits the uncited copy rewards depositing evidence with its
+origin stripped off -- the opposite of what an immutability guard is for. It
+also over-covers in the direction that does no good: freezing B's *dependents*
+protects nothing about B, whose own rows are already frozen by
+``trg_as_root_calculation``.
+
+``a1f6c3e9b527`` had reached this conclusion explicitly, ten revisions later,
+for the identically shaped ``network_solve_state_energy.source_calculation_id``
+-- "``source_calculation_id`` is provenance, and is excluded for the same
+reason ``thermo_source_calculation.calculation_id`` is". This revision brings
+``c6f2a9d4e7b1``'s own registry into line with the rule it wrote, so that the
+regime says one thing rather than two.
+
+What is *not* relaxed
+---------------------
+``calculation_id`` stays registered, so the guard is unchanged in every case it
+was meant for: under an approved calculation, its SCF-stability row still
+cannot be inserted, updated or deleted, and the correction path is still a new
+calculation approved on its own terms with a
+``scientific_record_supersession`` edge. The trigger keeps its name, keeps
+firing ``BEFORE INSERT OR UPDATE OR DELETE``, and keeps its position in the
+``trg_as_child_NN`` sequence; only the argument list narrows. The TRUNCATE
+refusal on the table is untouched.
+
+Why the trigger is replaced rather than renamed
+-----------------------------------------------
+``trg_as_child_19`` is the name ``c6f2a9d4e7b1`` gives the twentieth
+``(table, record_type)`` group in its registry, which is ``calc_scf_stability``
+under ``calculation``. That numbering belongs to that revision and is asserted
+against ``pg_trigger`` by
+``tests/db/test_accepted_science_trigger_registry.py``; a new name here would
+either break that assertion or force the numbering to be recomputed from two
+files at once. Dropping and recreating under the same name keeps one revision
+in charge of the sequence.
+
+The DROP is deliberately written without ``IF EXISTS``. If the trigger is not
+found on ``calc_scf_stability`` this revision must fail loudly rather than
+succeed while leaving the defective guard installed, which is the one outcome
+that would be indistinguishable from success and would put the wrong argument
+list back into service.
+
+No rows are touched
+-------------------
+Pure DDL. Dropping and creating a trigger evaluates nothing against existing
+rows, so this is safe whatever a deployment holds and there is no backfill to
+design. Rows that could not be written while the extra argument was installed
+were refused, not stored wrong, so there is nothing to repair -- and this is a
+guard-registration correction, not a data repair, so ``accepted_science_repair``
+is not involved.
+
+``downgrade()`` reinstalls the two-argument form exactly as ``c6f2a9d4e7b1``
+created it.
+
+Revision ID: d4e9b1c7a253
+Revises: c5a1f8e3d074
+Create Date: 2026-08-12
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d4e9b1c7a253"
+down_revision: Union[str, Sequence[str], None] = "c5a1f8e3d074"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: The trigger ``c6f2a9d4e7b1`` created for the ``calc_scf_stability`` /
+#: ``calculation`` group. See the module docstring for why the name is reused.
+_TRIGGER = "trg_as_child_19"
+_TABLE = "calc_scf_stability"
+_RECORD_TYPE = "calculation"
+
+#: ``(table, record_type, column)`` entries this revision removes from the
+#: effective accepted-science registry. Read by
+#: ``tests/db/test_accepted_science_trigger_registry.py`` so the registry the
+#: tests reason about is the one the database actually has, rather than
+#: ``c6f2a9d4e7b1``'s frozen text.
+_REMOVED_CHILDREN: tuple[tuple[str, str, str], ...] = ((_TABLE, _RECORD_TYPE, "source_calculation_id"),)
+
+#: The argument lists before and after, spelled out rather than derived, so
+#: ``upgrade()`` and ``downgrade()`` are each readable on their own.
+_OWNERSHIP_ONLY: tuple[str, ...] = ("calculation_id",)
+_ORIGINAL: tuple[str, ...] = ("calculation_id", "source_calculation_id")
+
+
+def _install(columns: tuple[str, ...]) -> None:
+    """Replace the guard on ``calc_scf_stability`` with one over ``columns``."""
+
+    arguments = ", ".join(f"'{column}'" for column in columns)
+    op.execute(f"DROP TRIGGER {_TRIGGER} ON public.{_TABLE}")
+    op.execute(
+        f"""
+        CREATE TRIGGER {_TRIGGER}
+        BEFORE INSERT OR UPDATE OR DELETE ON public.{_TABLE}
+        FOR EACH ROW
+        EXECUTE FUNCTION public.tckdb_guard_accepted_child(
+            '{_RECORD_TYPE}', {arguments}
+        )
+        """
+    )
+
+
+def upgrade() -> None:
+    """Guard SCF-stability evidence on its own calculation only."""
+
+    _install(_OWNERSHIP_ONLY)
+
+
+def downgrade() -> None:
+    """Restore ``c6f2a9d4e7b1``'s two-argument guard exactly."""
+
+    _install(_ORIGINAL)

--- a/backend/tests/db/test_accepted_science_trigger_registry.py
+++ b/backend/tests/db/test_accepted_science_trigger_registry.py
@@ -35,6 +35,14 @@ _EVIDENCE_REVISION = _VERSIONS / "a1f6c3e9b527_freeze_evidence_under_accepted_ro
 #: a fourth such revision is wired in by adding it here once.
 _EXTENSION_REVISIONS = (_ATOM_MAP_REVISION, _EVIDENCE_REVISION)
 
+#: ``d4e9b1c7a253`` narrows the regime instead of extending it: it removes one
+#: registered column from ``c6f2a9d4e7b1``'s ``calc_scf_stability`` guard. It
+#: is read separately from ``_EXTENSION_REVISIONS`` because it adds no trigger
+#: -- it rewrites an existing one's arguments under the same name -- so it
+#: subtracts from the registry the assertions below reason about rather than
+#: adding to it. A second narrowing revision joins by being added here.
+_CORRECTION_REVISIONS = (_VERSIONS / "d4e9b1c7a253_scf_stability_provenance_is_not_ownership.py",)
+
 
 def _revision_namespace() -> dict:
     return runpy.run_path(str(_REVISION))
@@ -42,6 +50,15 @@ def _revision_namespace() -> dict:
 
 def _extension_namespaces() -> list[dict]:
     return [runpy.run_path(str(path)) for path in _EXTENSION_REVISIONS]
+
+
+def _removed_children() -> set[tuple[str, str, str]]:
+    """``(table, record_type, column)`` entries the corrections took back out."""
+
+    removed: set[tuple[str, str, str]] = set()
+    for path in _CORRECTION_REVISIONS:
+        removed.update(runpy.run_path(str(path))["_REMOVED_CHILDREN"])
+    return removed
 
 
 def _referenced_tables(tables, table: str, column: str, *, hops: int) -> set[str]:
@@ -66,11 +83,17 @@ def test_registry_references_real_metadata_and_short_identifiers() -> None:
     tables = Base.metadata.tables
     root_types = revision["_ROOT_TYPES"]
 
-    direct_children = revision["_DIRECT_CHILDREN"]
+    removed = _removed_children()
+    direct_children = tuple(entry for entry in revision["_DIRECT_CHILDREN"] if entry not in removed)
     via_children = revision["_VIA_CHILDREN"]
     for extension in extensions:
         direct_children = direct_children + extension["_DIRECT_CHILDREN"]
         via_children = via_children + extension["_VIA_CHILDREN"]
+
+    # A correction may only take back out something that was in. An entry that
+    # matches nothing is a typo that would silently narrow no guard while
+    # reading as though it had.
+    assert removed <= set(revision["_DIRECT_CHILDREN"])
 
     for table in root_types.values():
         assert table in tables
@@ -108,20 +131,38 @@ def test_registry_references_real_metadata_and_short_identifiers() -> None:
         target = root_types[record_type]
         assert target in _referenced_tables(tables, table, column, hops=2), (table, column, target)
 
-    # ``tckdb_guard_accepted_child`` reads each column it is given and does
-    # nothing where the value is NULL, so a group whose columns are *all*
-    # nullable yields a trigger that skips whole rows. At least one column per
-    # ``(table, record_type)`` group must therefore be NOT NULL. It is asserted
-    # per group rather than per column because a nullable column can be a
-    # deliberate second binding beside a NOT NULL one --
+    # Every guarded column must be NOT NULL, and the rule is now stated that
+    # way rather than per ``(table, record_type)`` group.
+    #
+    # This comment previously recorded the opposite. It read: a nullable
+    # column can be a deliberate second binding beside a NOT NULL one --
     # ``calc_scf_stability`` is guarded on both its own ``calculation_id`` and
-    # the optional ``source_calculation_id`` it was derived from, and both
-    # land in one trigger.
-    grouped_columns: dict[tuple[str, str], list[str]] = {}
+    # the optional ``source_calculation_id`` it was derived from -- and so the
+    # NOT NULL requirement was asserted per group, which the pair satisfied
+    # through ``calculation_id`` alone. That reading was wrong, and writing it
+    # down here is what kept it from being questioned for three revisions.
+    #
+    # ``source_calculation_id`` is not a second way of naming the row's owner.
+    # It names a *different* calculation: the one the stability analysis was
+    # read out of. Because ``tckdb_guard_accepted_child`` treats every argument
+    # column alike, registering it meant an unapproved calculation could not
+    # record SCF-stability evidence citing an approved one, while the identical
+    # row citing nothing was accepted -- the database refusing provenance that
+    # points at accepted science. ``c6f2a9d4e7b1`` had excluded cross-domain
+    # provenance FKs from the regime in the sentence directly above its own
+    # registry, and ``a1f6c3e9b527`` excluded the identically shaped
+    # ``network_solve_state_energy.source_calculation_id`` by name;
+    # ``d4e9b1c7a253`` removes the entry, and
+    # ``tests/db/test_scf_stability_provenance_guard.py`` holds the behaviour
+    # that a registry-derived assertion cannot.
+    #
+    # Nullability now carries the distinction the prose used to: an ownership
+    # FK is the column without which the row has no subject, so it is NOT
+    # NULL, and a guarded column that is nullable is a provenance pointer
+    # miscategorised. Asserted per column, so a repeat needs this comment
+    # rewritten again rather than merely being absorbed by a group.
     for table, record_type, column in direct_children:
-        grouped_columns.setdefault((table, record_type), []).append(column)
-    for (table, record_type), columns in grouped_columns.items():
-        assert any(not tables[table].c[column].nullable for column in columns), (table, record_type, columns)
+        assert not tables[table].c[column].nullable, (table, record_type, column)
 
     constraints = tables["scientific_record_supersession"].constraints
     assert all(constraint.name is None or len(constraint.name) <= 63 for constraint in constraints)

--- a/backend/tests/db/test_scf_stability_provenance_guard.py
+++ b/backend/tests/db/test_scf_stability_provenance_guard.py
@@ -1,0 +1,230 @@
+"""``calc_scf_stability`` is frozen by its own calculation, not by the one it cites.
+
+``c6f2a9d4e7b1`` states the rule its registry follows at the head of
+``_DIRECT_CHILDREN``: a child is guarded by the accepted root that owns its
+*scientific meaning*, and cross-domain provenance foreign keys are not
+ownership. It then registered ``calc_scf_stability`` twice -- once on the
+``NOT NULL`` ``calculation_id`` that owns the row, and once on the nullable
+``source_calculation_id``, which is the calculation the stability analysis was
+*read from*. The second registration is the one this file exists to keep out.
+
+``tckdb_guard_accepted_child`` makes no distinction between the columns it is
+given: every non-NULL value in every argument column is looked up in
+``record_review`` and, if ever approved, the write is refused. So while both
+columns were registered, naming an approved calculation as the source of a
+stability analysis was itself the refusable act -- on a row belonging to a
+calculation nobody had reviewed. The database refused to record provenance
+pointing at accepted science, and the identical insert with the pointer left
+NULL succeeded. Citing nothing was the compliant move, which is backwards:
+accepted science exists precisely to be pointed at.
+
+``a1f6c3e9b527`` had already drawn this line explicitly for the identically
+shaped ``network_solve_state_energy.source_calculation_id``, excluding it "for
+the same reason ``thermo_source_calculation.calculation_id`` is". The entry
+removed by ``d4e9b1c7a253`` was the one place the rule was stated and then not
+followed.
+
+Why this file rather than the registry parity test
+--------------------------------------------------
+``test_accepted_science_trigger_registry.py`` derives its expectation from the
+same revision registries it checks, so it cannot see a guard that should not
+exist: the expectation and the reality move together. It also compares trigger
+*names*, and this defect lived in a trigger *argument*, inside a trigger whose
+name was and remains correct. Only writing the row and demanding it land
+catches this, which is what ``test_provenance_pointer_at_accepted_science_is_allowed``
+does.
+
+The tests below pin both halves, because a guard removed too broadly is as
+wrong as one registered too broadly:
+
+* the ownership guard on ``calculation_id`` still refuses insert, update and
+  delete under an approved calculation;
+* the provenance pointer in ``source_calculation_id`` is not a guarded column,
+  on insert or on update, whatever the cited calculation's review state.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.db.models.app_user import AppUser
+from app.db.models.calculation import CalculationSCFStability
+from app.db.models.common import (
+    AppUserRole,
+    RecordReviewStatus,
+    SCFStabilityStatus,
+    SubmissionRecordType,
+)
+from app.services.record_review import ensure_record_review, set_record_review_status
+from tests.services.scientific_read._factories import (
+    make_calculation,
+    make_species,
+    make_species_entry,
+    next_inchi_key,
+)
+
+
+def _curator(session, username: str) -> AppUser:
+    actor = AppUser(username=username, role=AppUserRole.curator)
+    session.add(actor)
+    session.flush()
+    return actor
+
+
+def _approve(session, *, record_id: int, actor: AppUser) -> None:
+    ensure_record_review(
+        session,
+        record_type=SubmissionRecordType.calculation,
+        record_id=record_id,
+    )
+    review = set_record_review_status(
+        session,
+        record_type=SubmissionRecordType.calculation,
+        record_id=record_id,
+        status=RecordReviewStatus.approved,
+        actor=actor,
+    )
+    assert review.first_approved_at is not None
+
+
+def _calculation(session, tag: str):
+    species = make_species(session, inchi_key=next_inchi_key(tag))
+    entry = make_species_entry(session, species)
+    return make_calculation(session, species_entry_id=entry.id)
+
+
+def _stability(**kwargs) -> CalculationSCFStability:
+    return CalculationSCFStability(status=SCFStabilityStatus.stable, **kwargs)
+
+
+def test_provenance_pointer_at_accepted_science_is_allowed(db_session) -> None:
+    """An unapproved calculation may cite an approved one as its source.
+
+    This is the behaviour the removed registry entry denied. The owning
+    calculation is untouched by review; only the calculation named in
+    ``source_calculation_id`` is approved, and that must not make the row
+    unwritable.
+    """
+
+    actor = _curator(db_session, "scf-provenance-curator")
+    owner = _calculation(db_session, "SCFOWNER")
+    source = _calculation(db_session, "SCFSOURCE")
+    _approve(db_session, record_id=source.id, actor=actor)
+
+    db_session.add(
+        _stability(
+            calculation_id=owner.id,
+            source_calculation_id=source.id,
+            note="read from an accepted calculation",
+        )
+    )
+    db_session.flush()
+
+    stored = db_session.get(CalculationSCFStability, owner.id)
+    assert stored is not None
+    assert stored.source_calculation_id == source.id
+
+
+def test_provenance_pointer_may_be_set_by_update(db_session) -> None:
+    """The pointer is equally unguarded when it arrives on an UPDATE.
+
+    ``tckdb_guard_accepted_child`` reads OLD *and* NEW for every argument
+    column, so a registered column refuses the update that introduces the
+    reference as well as the insert that carries it. Both directions are
+    pinned so a partial re-registration cannot pass.
+    """
+
+    actor = _curator(db_session, "scf-provenance-update-curator")
+    owner = _calculation(db_session, "SCFUPDOWNER")
+    source = _calculation(db_session, "SCFUPDSOURCE")
+    _approve(db_session, record_id=source.id, actor=actor)
+
+    row = _stability(calculation_id=owner.id)
+    db_session.add(row)
+    db_session.flush()
+
+    row.source_calculation_id = source.id
+    db_session.flush()
+    db_session.expire(row)
+    assert row.source_calculation_id == source.id
+
+
+def test_pointer_free_insert_is_not_the_only_thing_allowed(db_session) -> None:
+    """The NULL-pointer insert succeeded before the fix too.
+
+    Kept beside the test above so the pair reads as the comparison that
+    identified the defect: identical rows, differing only in whether they
+    named their source, and only the one that named it was refused.
+    """
+
+    owner = _calculation(db_session, "SCFNULLPTR")
+    db_session.add(_stability(calculation_id=owner.id))
+    db_session.flush()
+
+    stored = db_session.get(CalculationSCFStability, owner.id)
+    assert stored is not None
+    assert stored.source_calculation_id is None
+
+
+def test_stability_of_accepted_calculation_cannot_be_inserted(db_session) -> None:
+    """The ownership guard survives: no new evidence under an approved root."""
+
+    actor = _curator(db_session, "scf-owner-insert-curator")
+    owner = _calculation(db_session, "SCFOWNINS")
+    _approve(db_session, record_id=owner.id, actor=actor)
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.add(_stability(calculation_id=owner.id))
+        db_session.flush()
+
+
+def test_stability_of_accepted_calculation_cannot_be_updated_or_deleted(
+    db_session,
+) -> None:
+    """The ownership guard survives on UPDATE and DELETE as well."""
+
+    actor = _curator(db_session, "scf-owner-mutate-curator")
+    owner = _calculation(db_session, "SCFOWNMUT")
+    row = _stability(calculation_id=owner.id, note="before approval")
+    db_session.add(row)
+    db_session.flush()
+    _approve(db_session, record_id=owner.id, actor=actor)
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        row.note = "after approval"
+        db_session.flush()
+
+    with pytest.raises(DBAPIError), db_session.begin_nested():
+        db_session.delete(row)
+        db_session.flush()
+
+
+def test_scf_stability_guard_names_only_the_ownership_column(db_session) -> None:
+    """The installed trigger's arguments, read from the database itself.
+
+    Asserted against a literal rather than against any revision's registry:
+    a registry-derived expectation shrinks along with the reality it is
+    supposed to constrain, which is how the extra argument survived review in
+    the first place. ``tgargs`` is a NUL-separated bytea of the C-string
+    arguments, so the trailing empty element is stripped.
+    """
+
+    arguments = db_session.execute(
+        text(
+            """
+            SELECT trigger.tgargs
+            FROM pg_trigger AS trigger
+            JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+            WHERE NOT trigger.tgisinternal
+              AND relation.relname = 'calc_scf_stability'
+              AND trigger.tgfoid = 'public.tckdb_guard_accepted_child'::regproc
+            """
+        )
+    ).scalar_one()
+
+    assert bytes(arguments).decode("utf-8").split("\x00")[:-1] == [
+        "calculation",
+        "calculation_id",
+    ]


### PR DESCRIPTION
## The defect

`c6f2a9d4e7b1` states the rule its registry follows in the sentence directly above the registry itself: a child is guarded by the accepted root that owns its **scientific meaning**, and cross-domain provenance foreign keys are not ownership. It then registered `calc_scf_stability` under two columns:

| column | shape | what it names |
|---|---|---|
| `calculation_id` | `NOT NULL`, primary key | the calculation whose wavefunction the row describes — ownership |
| `source_calculation_id` | nullable, no part of any key | the *other* calculation the analysis was read out of — provenance |

`tckdb_guard_accepted_child` draws no distinction between the columns handed to it: it collects every non-NULL value from every argument column in OLD and NEW and refuses the write if any of those ids has ever been approved. So `trg_as_child_19` refused this —

```
INSERT INTO calc_scf_stability (calculation_id, status, source_calculation_id)
VALUES (<unapproved calculation A>, 'stable', <approved calculation B>);
-- ERROR:  accepted calculation record 2 is immutable
```

— while the identical insert with the pointer left NULL succeeded. Nothing about A was approved. Nothing about B was written. **Naming accepted science was itself the refusable act**, on a row belonging to a record no reviewer had looked at.

That inverts the incentive the regime exists to create. Approving a calculation is the act of saying "this is a result others may build on"; citing it in the provenance of a later analysis is what building on it looks like. A guard that refuses the citation and permits the uncited copy rewards depositing evidence with its origin stripped off. It also protects nothing: B's own rows are already frozen by `trg_as_root_calculation`, so freezing B's *dependents* buys no immutability it did not already have.

`a1f6c3e9b527:52` had already drawn this line by name, for the identically shaped `network_solve_state_energy.source_calculation_id` — "provenance, and is excluded for the same reason `thermo_source_calculation.calculation_id` is". This entry was the one place in the regime where the rule was written down and then not applied.

## The change

`d4e9b1c7a253` drops `source_calculation_id` from the guard's argument list.

- **Reuses `trg_as_child_19`** rather than renaming. That name is `c6f2a9d4e7b1`'s numbering of its twentieth `(table, record_type)` group, asserted against `pg_trigger` by the registry test; a new name would force the sequence to be recomputed from two files at once. Drop-and-recreate under the same name keeps one revision in charge of it.
- **`DROP TRIGGER` without `IF EXISTS`.** A missing trigger must fail the migration loudly — the alternative outcome, succeeding while leaving the defective guard installed, is the one indistinguishable from success.
- **Nothing is relaxed.** `calculation_id` stays registered: under an approved calculation the row still cannot be inserted, updated or deleted, and the correction path is still a new calculation approved on its own terms with a supersession edge. The TRUNCATE refusal is untouched.
- Pure DDL, no rows read or written, `downgrade()` reinstalls the two-argument form exactly. Rows blocked by the extra argument were *refused*, not stored wrong, so there is nothing to repair — and this is a guard-registration correction, not a data repair, so `accepted_science_repair` is not involved.

## Why the registry test could not catch this

`test_accepted_science_trigger_registry.py` derives `expected` from the same registries it compares against `pg_trigger`, and compares trigger *names* — while this defect lived in a trigger *argument*, inside a trigger whose name was and remains correct.

That test's comment at the nullability assertion documented the pair as deliberate: "a nullable column can be a deliberate second binding beside a NOT NULL one". It is the sentence that kept the entry from being questioned for three revisions, so it is corrected in place rather than deleted, the way #136 corrected ADR 0015. The per-group NOT NULL requirement it justified weakening is restored **per column**: an ownership FK is the column without which the row has no subject, so it is `NOT NULL`, and a guarded column that is nullable is a provenance pointer miscategorised.

`tests/db/test_scf_stability_provenance_guard.py` carries what a registry-derived assertion cannot: it writes the row and demands it land, and reads the installed trigger's arguments back out of `pg_trigger` against a literal.

## Scanning the rest of the registry

Every `(table, record_type, column)` across `c6f2a9d4e7b1`, `b6c1f4a8e703` and `a1f6c3e9b527` — 58 direct entries and 7 via-parent entries — checked against ORM metadata for the shape in the rule. `calc_scf_stability.source_calculation_id` was the **only** nullable guarded column in the regime. Every other one is `NOT NULL` and is the column the row is about. No via-parent entry has a nullable child column or root column either. The new per-column assertion now holds that line.

One entry considered and deliberately left alone: `calculation_dependency.parent_calculation_id` / `child_calculation_id`, both registered, both `NOT NULL` and both halves of the primary key. A DAG edge has no existence apart from either endpoint, so both are ownership; this is not the same shape.

## Verification

| gate | result |
|---|---|
| `test-rest.sh` | 4130 passed, 14 skipped (baseline 4124 + the 6 added here) |
| `test-api.sh` | 2560 passed |
| `test-scientific.sh` | 2034 passed |

`alembic heads` is single. Round-tripped on a scratch DB: `upgrade head` installs `calculation, calculation_id`; `downgrade -1` restores `calculation, calculation_id, source_calculation_id`; re-upgrade narrows it again.

**Mutation check.** Restoring `source_calculation_id` to the argument list and re-running the full `test-rest.sh`: **3 failed, 4127 passed** — all three failures in `test_scf_stability_provenance_guard.py`, nothing else in the suite moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)