### PR TITLE
Make the backup restorable, and prove the check can fail

### DIFF
--- a/backend/scripts/ops/tckdb_backup.sh
+++ b/backend/scripts/ops/tckdb_backup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Nightly TCKDB Postgres backup: dump from the db container, gzip, keep 14 days.
+#
+# ---------------------------------------------------------------------------
+# WHY --create IS NOT OPTIONAL
+# ---------------------------------------------------------------------------
+# Without it the dump carries no CREATE DATABASE, so whoever restores it makes
+# the target database by hand -- and a bare CREATE DATABASE inherits its
+# encoding from template1. On this cluster template1 was SQL_ASCII until
+# 2026-08-12 while the real database was UTF8, so restoring a UTF8 dump into a
+# hand-made target exited 0, printed no error, and silently mis-counted every
+# multi-byte character: length('em dash: <U+2014>') came back 12 instead of 10.
+#
+# `pg_dump --create` emits
+#     CREATE DATABASE tckdb WITH TEMPLATE = template0 ENCODING = 'UTF8' ...
+# which pins both the template and the encoding, so the restore cannot inherit
+# the wrong one no matter what template1 happens to be at the time.
+#
+# ---------------------------------------------------------------------------
+# WHY THE DUMP IS VERIFIED AND NOT MERELY WRITTEN
+# ---------------------------------------------------------------------------
+# A backup nobody has restored is a hypothesis. `exit 0` from pg_dump means
+# "the bytes were written", not "the bytes restore to the same data" -- and the
+# encoding bug above is invisible in exactly that gap. So every run restores
+# the archive it just wrote into a scratch database and compares.
+#
+# The two checks answer different questions and neither subsumes the other:
+#   (1) does the archive pin its own encoding and template?   [text check]
+#   (2) does the archive actually restore to identical data?  [round trip]
+#
+# The canary in (2) is length('em dash: <U+2014>') == 10, which is the exact
+# measurement the 2026-08-12 investigation used. It tests the restored
+# database's encoding rather than its contents, so it fires even on an empty
+# database and cannot be satisfied by accident.
+set -euo pipefail
+
+DEST=/home/calvin/tckdb_backups
+CONTAINER=tckdbv2-db-1
+SOURCE_DB=tckdb
+# Scratch databases on any TCKDB host must match tckdb_test* by convention.
+SCRATCH="tckdb_test_restore_check_$$"
+
+STAMP=$(date +%Y%m%d_%H%M%S)
+FILE="$DEST/tckdb_${STAMP}.sql.gz"
+
+psql_admin() { docker exec -i "$CONTAINER" psql -U tckdb -d postgres -v ON_ERROR_STOP=1 -tAq "$@"; }
+psql_scratch() { docker exec -i "$CONTAINER" psql -U tckdb -d "$SCRATCH" -v ON_ERROR_STOP=1 -tAq "$@"; }
+
+drop_scratch() { psql_admin -c "DROP DATABASE IF EXISTS \"$SCRATCH\"" >/dev/null 2>&1 || true; }
+# The scratch database must not outlive this script even on failure -- a
+# leaked one would be restored-into again next run and quietly diverge.
+trap drop_scratch EXIT
+
+mkdir -p "$DEST"
+
+# --- write the archive ------------------------------------------------------
+docker exec "$CONTAINER" pg_dump -U tckdb -d "$SOURCE_DB" --create | gzip >"$FILE"
+test -s "$FILE" || { echo "FAIL: dump is empty" >&2; exit 1; }
+
+# --- check (1): the archive pins encoding and template ----------------------
+header="$(zcat "$FILE" | grep -m1 '^CREATE DATABASE' || true)"
+if [[ -z "$header" ]]; then
+    echo "FAIL: archive contains no CREATE DATABASE -- --create was lost" >&2
+    exit 1
+fi
+if [[ "$header" != *"ENCODING = 'UTF8'"* || "$header" != *"TEMPLATE = template0"* ]]; then
+    echo "FAIL: CREATE DATABASE does not pin UTF8 from template0:" >&2
+    echo "      $header" >&2
+    exit 1
+fi
+
+# --- check (2): the archive restores to identical data ----------------------
+# Rewrite only the three lines that name the database, so the archive's own
+# CREATE DATABASE clause -- encoding and template included -- is what runs.
+# Restoring under a different name is the only way to test the real archive
+# against a live cluster that already holds the original.
+drop_scratch
+zcat "$FILE" \
+  | sed -e "s/^CREATE DATABASE ${SOURCE_DB} /CREATE DATABASE ${SCRATCH} /" \
+        -e "s/^ALTER DATABASE ${SOURCE_DB} /ALTER DATABASE ${SCRATCH} /" \
+        -e "s/^\\\\connect ${SOURCE_DB}\$/\\\\connect ${SCRATCH}/" \
+  | docker exec -i "$CONTAINER" psql -U tckdb -d postgres -v ON_ERROR_STOP=1 -q >/dev/null
+
+restored_encoding="$(psql_admin -c "SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname='${SCRATCH}'")"
+if [[ "$restored_encoding" != "UTF8" ]]; then
+    echo "FAIL: restored database is ${restored_encoding}, not UTF8" >&2
+    exit 1
+fi
+
+# The canary: a multi-byte character must measure 1, not 3.
+#
+# Written as the UTF-8 byte sequence for U+2014 decoded by the server rather
+# than as a literal em dash, for two reasons. A script whose job is to detect
+# an encoding fault must not itself depend on how its own file is decoded --
+# that is the same class of bug it exists to catch. And the repo lints
+# non-ASCII out of runtime strings, so the literal form could not be shared
+# with the versioned copy of this script.
+#
+# In UTF8 this is one character. In SQL_ASCII the same three bytes stay three
+# characters, so a restore that landed in the wrong encoding reports 3.
+canary="$(psql_scratch -c "SELECT length(convert_from('\\xe28094'::bytea, 'UTF8'))")"
+if [[ "$canary" != "1" ]]; then
+    echo "FAIL: multi-byte character measures ${canary}, expected 1 -- restored database is not UTF8" >&2
+    exit 1
+fi
+
+# Structural equality: re-dump both without --create and compare. If the
+# restore was faithful these are identical, and any text mangling changes them.
+sum_source="$(docker exec "$CONTAINER" pg_dump -U tckdb -d "$SOURCE_DB" | md5sum | cut -d' ' -f1)"
+sum_restored="$(docker exec "$CONTAINER" pg_dump -U tckdb -d "$SCRATCH" | md5sum | cut -d' ' -f1)"
+if [[ "$sum_source" != "$sum_restored" ]]; then
+    echo "FAIL: restored data differs from source (${sum_source} != ${sum_restored})" >&2
+    exit 1
+fi
+
+drop_scratch
+
+# --- prune ------------------------------------------------------------------
+find "$DEST" -name 'tckdb_*.sql.gz' -mtime +14 -delete
+
+echo "wrote $FILE ($(du -h "$FILE" | cut -f1)) -- verified: restores to UTF8, data identical"

--- a/backend/tests/scripts/test_backup_restores_verifiably.py
+++ b/backend/tests/scripts/test_backup_restores_verifiably.py
@@ -1,0 +1,160 @@
+"""A backup that restores to different data is not a backup.
+
+``~/tckdb_backup.sh`` on the live deployment was a plain ``pg_dump`` with no
+``--create``, so whoever restored it made the target database by hand -- and a
+bare ``CREATE DATABASE`` inherits its encoding from ``template1``.  On that
+host ``template1`` was ``SQL_ASCII`` while the real database was ``UTF8``
+(measured 2026-08-12), so restoring a ``UTF8`` dump into a hand-made target
+**exited 0, printed no error**, and silently mis-counted every multi-byte
+character.
+
+That is the worst available failure shape: the check that a restore worked --
+its exit status -- cannot fail.  ``backend/scripts/ops/tckdb_backup.sh`` is the
+versioned replacement, and this file is what keeps its two guarantees true.
+
+The first test is the load-bearing one.  It does not read the script at all: it
+builds a ``SQL_ASCII`` database and a ``UTF8`` one and runs the script's own
+canary query against both, proving the canary *discriminates*.  A canary that
+returns the same answer either way would let the script pass while restoring
+into the wrong encoding, which is precisely the bug being guarded.
+
+The second test is a deliberately crude text scan, in the same spirit as
+``tests/test_scratch_database_names.py``: it cannot prove the script is
+correct, only that the specific properties whose absence caused the incident
+are still present.  Both are needed -- the first proves the mechanism works,
+the second proves the script still uses it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import conftest
+from conftest import scratch_database_name
+from sqlalchemy import create_engine, text
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+BACKUP_SCRIPT = BACKEND_ROOT / "scripts" / "ops" / "tckdb_backup.sh"
+
+#: The UTF-8 bytes of U+2014 EM DASH, decoded by the server rather than written
+#: as a literal.  A check for an encoding fault must not itself depend on how
+#: its own source file is decoded -- that is the same class of bug it exists to
+#: catch -- and the repo lints non-ASCII out of runtime strings besides.
+CANARY_SQL = "SELECT length(convert_from('\\xe28094'::bytea, 'UTF8'))"
+
+
+def _admin_engine():
+    return create_engine(
+        conftest._database_url("postgres"), future=True, isolation_level="AUTOCOMMIT"
+    )
+
+
+def _scalar_in(db_name: str, sql: str):
+    engine = create_engine(conftest._database_url(db_name), future=True)
+    try:
+        with engine.connect() as connection:
+            return connection.execute(text(sql)).scalar()
+    finally:
+        engine.dispose()
+
+
+def _create(db_name: str, encoding: str) -> None:
+    # TEMPLATE template0 is required to choose an encoding at all: template1
+    # may already carry data in another one, and Postgres refuses rather than
+    # guess.  LC_COLLATE/LC_CTYPE 'C' is what makes SQL_ASCII expressible on a
+    # cluster whose template0 has a UTF-8 locale.
+    engine = _admin_engine()
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+            connection.execute(
+                text(
+                    f'CREATE DATABASE "{db_name}" ENCODING \'{encoding}\' '
+                    "TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C'"
+                )
+            )
+    finally:
+        engine.dispose()
+
+
+def _drop(db_name: str) -> None:
+    engine = _admin_engine()
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+    except Exception:  # pragma: no cover - cleanup must not mask a real failure
+        pass
+    finally:
+        engine.dispose()
+
+
+def test_the_encoding_canary_can_actually_fail() -> None:
+    """The canary must give different answers in UTF8 and SQL_ASCII.
+
+    This is the assertion the whole guard rests on.  If both encodings agreed,
+    the backup script would verify nothing while appearing to verify
+    everything.
+    """
+    utf8_db = scratch_database_name("backup_canary_utf8")
+    ascii_db = scratch_database_name("backup_canary_sqlascii")
+    try:
+        _create(utf8_db, "UTF8")
+        _create(ascii_db, "SQL_ASCII")
+
+        in_utf8 = _scalar_in(utf8_db, CANARY_SQL)
+        in_sql_ascii = _scalar_in(ascii_db, CANARY_SQL)
+
+        assert in_utf8 == 1, (
+            "In a UTF8 database the three bytes of U+2014 must measure one "
+            f"character; got {in_utf8!r}. The canary is broken."
+        )
+        assert in_sql_ascii == 3, (
+            "In a SQL_ASCII database the same bytes must measure three "
+            f"characters; got {in_sql_ascii!r}. The canary cannot detect the "
+            "encoding fault it exists to detect."
+        )
+        assert in_utf8 != in_sql_ascii
+    finally:
+        _drop(utf8_db)
+        _drop(ascii_db)
+
+
+def test_the_backup_script_pins_and_verifies_its_restore() -> None:
+    """The properties whose absence caused the 2026-08-12 drift must persist."""
+    assert BACKUP_SCRIPT.is_file(), f"{BACKUP_SCRIPT} is missing"
+    body = BACKUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "--create" in body, (
+        "pg_dump must run with --create. Without it the archive carries no "
+        "CREATE DATABASE, the restore target is made by hand, and it inherits "
+        "template1's encoding -- which is the original defect."
+    )
+    assert "ENCODING = 'UTF8'" in body and "TEMPLATE = template0" in body, (
+        "The script must assert that its own archive pins both the encoding "
+        "and template0. pg_dump --create emits exactly that text, so checking "
+        "for it is how the script proves --create survived."
+    )
+    # Matched on the two pieces that carry the meaning rather than on the whole
+    # statement: the script escapes the backslash for its own shell quoting, so
+    # an equality check against CANARY_SQL would silently never match and the
+    # assertion would pass on its fallback forever.
+    assert "convert_from" in body and "e28094" in body, (
+        "The script must run the multi-byte canary against the restored "
+        "database. Verifying only that pg_dump exited 0 is the check that "
+        "cannot fail."
+    )
+    assert "md5sum" in body, (
+        "The script must compare source and restored data, not merely confirm "
+        "the restore ran."
+    )
+
+    non_ascii = [
+        (index, line)
+        for index, line in enumerate(body.splitlines(), start=1)
+        if any(ord(character) > 127 for character in line)
+    ]
+    assert not non_ascii, (
+        "The backup script must stay ASCII-clean: a script that detects an "
+        "encoding fault must not depend on the decoding of its own file. "
+        f"Offending lines: {[index for index, _ in non_ascii]}"
+    )


### PR DESCRIPTION
## The defect

`~/tckdb_backup.sh` on the live deployment is a plain `pg_dump` with **no `--create`**, so whoever restores it creates the target database by hand — and a bare `CREATE DATABASE` inherits its encoding from `template1`. On that host `template1` is `SQL_ASCII` while `tckdb` is `UTF8`, so restoring a UTF8 dump into a hand-made target **exits 0, prints no error**, and silently mis-counts every multi-byte character.

Measured on the deployed cluster, 2026-08-12:

| database encoding | `length(convert_from('\xe28094'::bytea,'UTF8'))` |
|---|---|
| UTF8 | 1 |
| SQL_ASCII | 3 |

The only check that a restore worked was `pg_dump`'s exit status, which cannot distinguish "restored faithfully" from "restored into the wrong encoding".

## What this adds

`backend/scripts/ops/tckdb_backup.sh` — the versioned replacement, beside `tckdb_deploy.sh`. It runs `pg_dump --create` (which emits `CREATE DATABASE ... WITH TEMPLATE = template0 ENCODING = 'UTF8'`, so the restore cannot inherit the wrong template), then verifies the archive it just wrote:

1. the archive pins both encoding and `template0`;
2. it restores into a scratch `tckdb_test*` database;
3. the restored database reports `UTF8`;
4. a multi-byte character measures 1, not 3;
5. a re-dump of source and restored data is byte-identical.

The scratch database is dropped by an `EXIT` trap so it cannot outlive the run.

## Why the canary is written in bytes

`convert_from('\xe28094'::bytea, 'UTF8')` rather than a literal em dash. A script whose job is to detect an encoding fault must not itself depend on how its own file is decoded — that is the same class of bug it exists to catch — and the repo lints non-ASCII out of runtime strings.

## Verification

`tests/scripts/test_backup_restores_verifiably.py`. The load-bearing test does not read the script at all: it creates a `SQL_ASCII` database and a `UTF8` one and runs the canary against both, asserting they **disagree**. A canary that returned the same answer either way would let the script verify nothing while appearing to verify everything. The second test is a deliberately crude text scan, in the spirit of `tests/test_scratch_database_names.py` — it cannot prove the script correct, only that the properties whose absence caused the incident are still present.

Both mutation-checked:

| mutation | result |
|---|---|
| remove `--create` | text guard fails: *"pg_dump must run with --create"* |
| canary → `SELECT 1` | database test fails: *"got 1 … cannot detect the encoding fault it exists to detect"* |

## Not covered here

- The Pi's own `~/tckdb_backup.sh` still needs swapping for this one, and `template1` still needs converting to UTF8. Both are writes to a deployed host, so they are operator actions — tracked as #124 and #109.
- Existing archives in `~/tckdb_backups/` were written without `--create` and carry the same restore hazard. Restoring one requires creating the target explicitly with `ENCODING 'UTF8' TEMPLATE template0`, which is now documented in the restore runbooks (#146).

Tracked as #124.