### PR TITLE
Name the calculation, do not guess its row id

### DIFF
--- a/backend/app/schemas/entities/statmech.py
+++ b/backend/app/schemas/entities/statmech.py
@@ -1,25 +1,23 @@
 """Statmech entity schemas.
 
-The create-side payloads (``StatmechSourceCalculationCreate``,
-``StatmechTorsionCreate``, ``StatmechTorsionCoordinateCreate``) and the
-``*Base`` field definitions they share now live in
-``tckdb_schemas.statmech_bits``: they are nested inside
-``ConformerUploadRequest.statmech``, which is a published contract. The
-``*Read`` / ``*Update`` schemas stay here — they carry ORM ids and
-``from_attributes=True`` and have no place on the wire.
+These are the **row-shaped** schemas: they speak in foreign keys
+(``calculation_id``, ``source_scan_calculation_id``) because they describe
+persisted rows for ORM reads and admin-side writes. They are deliberately
+backend-only. The published upload contracts address the same
+calculations by local key and live in ``tckdb_schemas.statmech_bits``
+(``StatmechSourceCalcIn``, ``StatmechTorsionIn``) — a depositor cannot
+know a row id, so no wire contract may ask for one.
+
+The atom-quartet coordinate shape has no id-versus-key distinction, so
+there is exactly one class for it repo-wide:
+``tckdb_schemas.statmech_bits.StatmechTorsionCoordinateIn``, reused here
+as both the create payload and the field home for the read schema.
 """
 
 from typing import Self
 
 from pydantic import BaseModel, Field, model_validator
-from tckdb_schemas.statmech_bits import (
-    StatmechSourceCalculationBase,
-    StatmechSourceCalculationCreate,
-    StatmechTorsionBase,
-    StatmechTorsionCoordinateBase,
-    StatmechTorsionCoordinateCreate,
-    StatmechTorsionCreate,
-)
+from tckdb_schemas.statmech_bits import StatmechTorsionCoordinateIn
 
 from app.db.models.common import (
     RigidRotorKind,
@@ -41,8 +39,7 @@ __all__ = [
     "StatmechSourceCalculationRead",
     "StatmechSourceCalculationUpdate",
     "StatmechTorsionBase",
-    "StatmechTorsionCoordinateBase",
-    "StatmechTorsionCoordinateCreate",
+    "StatmechTorsionCoordinateIn",
     "StatmechTorsionCoordinateRead",
     "StatmechTorsionCoordinateUpdate",
     "StatmechTorsionCreate",
@@ -50,6 +47,26 @@ __all__ = [
     "StatmechTorsionUpdate",
     "StatmechUpdate",
 ]
+
+
+class StatmechSourceCalculationBase(BaseModel):
+    """Shared fields for a persisted statmech source-calculation link.
+
+    :param calculation_id: Referenced calculation row.
+    :param role: Semantic role of the source calculation.
+    """
+
+    calculation_id: int
+    role: StatmechCalculationRole
+
+
+class StatmechSourceCalculationCreate(StatmechSourceCalculationBase, SchemaBase):
+    """Row-level create payload for a statmech source-calculation link.
+
+    Backend-only. Upload paths use
+    ``tckdb_schemas.statmech_bits.StatmechSourceCalcIn`` and let the
+    workflow resolve the key to this ``calculation_id``.
+    """
 
 
 class StatmechSourceCalculationRead(StatmechSourceCalculationBase, ORMBaseSchema):
@@ -69,8 +86,12 @@ class StatmechSourceCalculationUpdate(SchemaBase):
     role: StatmechCalculationRole | None = None
 
 
-class StatmechTorsionCoordinateRead(StatmechTorsionCoordinateBase, ORMBaseSchema):
-    """Read schema for one torsional coordinate."""
+class StatmechTorsionCoordinateRead(StatmechTorsionCoordinateIn, ORMBaseSchema):
+    """Read schema for one torsional coordinate.
+
+    Inherits the five atom indices from the single coordinate class rather
+    than restating them; the only thing a read adds is the parent id.
+    """
 
     torsion_id: int
 
@@ -105,6 +126,62 @@ class StatmechTorsionCoordinateUpdate(SchemaBase):
         if all(value is not None for value in atom_indices):
             if len(set(atom_indices)) != 4:
                 raise ValueError("Torsion coordinate atom indices must be distinct.")
+        return self
+
+
+class StatmechTorsionBase(BaseModel):
+    """Shared fields for one persisted statmech torsion.
+
+    :param torsion_index: One-based torsion number within the statmech record.
+    :param symmetry_number: Optional torsional symmetry number.
+    :param treatment_kind: Optional torsion treatment kind.
+    :param dimension: Number of coupled torsional coordinates in this rotor.
+    :param top_description: Optional description of the rotating top.
+    :param invalidated_reason: Optional reason why the torsion was invalidated.
+    :param note: Optional free-text note.
+    :param source_scan_calculation_id: Optional principal scan calculation row.
+    """
+
+    torsion_index: int = Field(ge=1)
+    symmetry_number: int | None = Field(default=None, ge=1)
+    treatment_kind: TorsionTreatmentKind | None = None
+
+    dimension: int = Field(default=1, ge=1)
+    top_description: str | None = None
+    invalidated_reason: str | None = None
+    note: str | None = None
+
+    source_scan_calculation_id: int | None = None
+
+
+class StatmechTorsionCreate(StatmechTorsionBase, SchemaBase):
+    """Row-level create payload for one statmech torsion.
+
+    Backend-only. Upload paths use
+    ``tckdb_schemas.statmech_bits.StatmechTorsionIn``, which names the
+    rotor scan by local key instead of by row id.
+
+    :param coordinates: Ordered torsional coordinate definitions. The number of
+        coordinates must equal ``dimension``, and ``coordinate_index`` values
+        must run contiguously from ``1..dimension``.
+    """
+
+    coordinates: list[StatmechTorsionCoordinateIn] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_coordinates(self) -> Self:
+        if len(self.coordinates) != self.dimension:
+            raise ValueError("Number of torsion coordinates must equal dimension.")
+
+        coordinate_indices = [
+            coordinate.coordinate_index for coordinate in self.coordinates
+        ]
+        expected_indices = list(range(1, self.dimension + 1))
+        if sorted(coordinate_indices) != expected_indices:
+            raise ValueError(
+                "Torsion coordinate_index values must run contiguously from "
+                "1..dimension."
+            )
         return self
 
 

--- a/backend/app/schemas/workflows/statmech_upload.py
+++ b/backend/app/schemas/workflows/statmech_upload.py
@@ -1,14 +1,14 @@
 """Upload payloads for species-level statmech records.
 
-The nested statmech payload (``ConformerUploadStatmechPayload``) is
-submitted as a side effect of a conformer upload and accepts raw
-supporting-calculation DB ids from the surrounding workflow.
-
 ``StatmechUploadRequest`` is the standalone upload payload accepted by
-``POST /api/v1/uploads/statmech``. It carries the same scientific
-content as the nested path, but keeps the upload boundary FK-free:
-supporting calculations are declared inline and referenced by local
-string keys, and provenance refs use the existing upload fragments.
+``POST /api/v1/uploads/statmech``. Supporting calculations are declared
+inline and referenced by local string keys, and provenance refs use the
+existing upload fragments, so the upload boundary stays FK-free.
+
+The nested statmech payload (``ConformerUploadStatmechPayload``) now uses
+the same key-based reference components from
+``tckdb_schemas.statmech_bits``; it resolves those keys against the
+``key`` fields the conformer upload puts on its own calculations.
 """
 
 from __future__ import annotations
@@ -21,15 +21,14 @@ from tckdb_schemas.stationary_point import (
     raise_for_blocking_findings,
 )
 from tckdb_schemas.statmech_bits import (
-    StatmechTorsionCoordinateIn,
+    StatmechSourceCalcIn,
+    StatmechTorsionIn,
 )
 
 from app.db.models.common import (
     RigidRotorKind,
     ScientificOriginKind,
-    StatmechCalculationRole,
     StatmechTreatmentKind,
-    TorsionTreatmentKind,
 )
 from app.schemas.common import SchemaBase
 from app.schemas.fragments.calculation import CalculationWithResultsPayload
@@ -60,64 +59,10 @@ class StatmechCalculationIn(SchemaBase):
     calculation: CalculationWithResultsPayload
 
 
-class StatmechSourceCalculationIn(SchemaBase):
-    """Link between a statmech upload and a supporting calculation by key.
-
-    :param calculation_key: Local key of a calculation declared in
-        ``StatmechUploadRequest.calculations``.
-    :param role: Scientific role the calculation plays for this statmech.
-    """
-
-    calculation_key: str = Field(min_length=1)
-    role: StatmechCalculationRole
-
-
-class StatmechTorsionIn(SchemaBase):
-    """Torsion definition for a standalone statmech upload.
-
-    Unlike the nested-create schema, the principal scan calculation is
-    addressed by a local string key rather than a raw calculation id.
-
-    :param torsion_index: One-based torsion number within the record.
-    :param symmetry_number: Optional torsional symmetry number.
-    :param treatment_kind: Optional torsion treatment classification.
-    :param dimension: Number of coupled torsional coordinates.
-    :param top_description: Optional description of the rotating top.
-    :param invalidated_reason: Optional invalidation reason.
-    :param note: Optional free-text note.
-    :param source_scan_calculation_key: Optional local key referencing an
-        inline calculation declared in ``StatmechUploadRequest.calculations``.
-    :param coordinates: Ordered torsional coordinate definitions.
-    """
-
-    torsion_index: int = Field(ge=1)
-    symmetry_number: int | None = Field(default=None, ge=1)
-    treatment_kind: TorsionTreatmentKind | None = None
-
-    dimension: int = Field(default=1, ge=1)
-    top_description: str | None = None
-    invalidated_reason: str | None = None
-    note: str | None = None
-
-    source_scan_calculation_key: str | None = None
-
-    coordinates: list[StatmechTorsionCoordinateIn] = Field(default_factory=list)
-
-    @model_validator(mode="after")
-    def validate_coordinates(self) -> Self:
-        if len(self.coordinates) != self.dimension:
-            raise ValueError(
-                "Number of torsion coordinates must equal dimension."
-            )
-
-        indices = [c.coordinate_index for c in self.coordinates]
-        expected = list(range(1, self.dimension + 1))
-        if sorted(indices) != expected:
-            raise ValueError(
-                "Torsion coordinate_index values must run contiguously "
-                "from 1..dimension."
-            )
-        return self
+#: Statmech → calculation link by local key. Was a class of its own here;
+#: it is now the shared wire component, because the conformer, bundle and
+#: standalone paths all express this link identically.
+StatmechSourceCalculationIn = StatmechSourceCalcIn
 
 
 class StatmechUploadRequest(SchemaBase):

--- a/backend/app/schemas/workflows/statmech_upload.py
+++ b/backend/app/schemas/workflows/statmech_upload.py
@@ -13,7 +13,7 @@ the same key-based reference components from
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Self, TypeAlias
 
 from pydantic import Field, model_validator
 from tckdb_schemas.stationary_point import (
@@ -61,8 +61,10 @@ class StatmechCalculationIn(SchemaBase):
 
 #: Statmech → calculation link by local key. Was a class of its own here;
 #: it is now the shared wire component, because the conformer, bundle and
-#: standalone paths all express this link identically.
-StatmechSourceCalculationIn = StatmechSourceCalcIn
+#: standalone paths all express this link identically. Spelled as an
+#: explicit ``TypeAlias``: a bare ``X = SomeClass`` assignment is a
+#: *variable* to mypy, and annotating with it is an error.
+StatmechSourceCalculationIn: TypeAlias = StatmechSourceCalcIn
 
 
 class StatmechUploadRequest(SchemaBase):

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -2,9 +2,17 @@
 
 Statmech is a result table — every upload creates a new row.
 No deduplication against existing records.
+
+Upload payloads name their supporting calculations by **local key**, never
+by row id. Turning a key into a real ``calculation.id`` happens here, from
+the ``calculations_by_key`` map the calling workflow builds after it has
+persisted the request's own calculations. That is the whole reason the
+schema layer never needs to know a primary key.
 """
 
 from __future__ import annotations
+
+from collections.abc import Mapping
 
 from sqlalchemy.orm import Session
 
@@ -22,12 +30,37 @@ from app.services.literature_resolution import resolve_or_create_literature
 from app.services.software_resolution import resolve_software_release_ref
 
 
+def _resolve_calculation_key(
+    key: str,
+    calculations_by_key: Mapping[str, int],
+    *,
+    context: str,
+) -> int:
+    """Translate one local calculation key into a persisted row id.
+
+    The schema layer of every upload path already refuses a key it cannot
+    match, so reaching this error means a workflow built an incomplete
+    map. It is still raised rather than allowed to ``KeyError``: a missing
+    provenance link must be a named failure, not a 500.
+
+    :raises ValueError: if the key is absent from ``calculations_by_key``.
+    """
+    calculation_id = calculations_by_key.get(key)
+    if calculation_id is None:
+        raise ValueError(
+            f"{context}: calculation_key '{key}' does not name a calculation "
+            f"declared in this upload."
+        )
+    return calculation_id
+
+
 def resolve_or_create_statmech(
     session: Session,
     payload: ConformerUploadStatmechPayload,
     *,
     species_entry_id: int,
     uploaded_calculation_id: int | None = None,
+    calculations_by_key: Mapping[str, int] | None = None,
     created_by: int | None = None,
 ) -> Statmech:
     """Create a statmech record and attach nested provenance.
@@ -46,11 +79,17 @@ def resolve_or_create_statmech(
     :param uploaded_calculation_id: Optional calculation id produced by
         the caller workflow; linked as a source calculation only when
         ``payload.uploaded_calculation_role`` is also set.
+    :param calculations_by_key: Local calculation key → persisted
+        ``calculation.id``, for the request's own calculations. Required
+        whenever the payload carries ``source_calculations`` or a torsion
+        ``source_scan_calculation_key``.
     :param created_by: Optional application user id for newly created rows.
     :returns: Newly created ``Statmech`` row with linked sources/torsions.
     :raises ValueError: If ``uploaded_calculation_role`` is set but
-        ``uploaded_calculation_id`` is not supplied.
+        ``uploaded_calculation_id`` is not supplied, or if a local
+        calculation key does not resolve.
     """
+    key_map: Mapping[str, int] = calculations_by_key or {}
 
     literature = (
         resolve_or_create_literature(session, payload.literature)
@@ -122,17 +161,31 @@ def resolve_or_create_statmech(
             )
         )
 
-    for source in payload.source_calculations:
+    for index, source in enumerate(payload.source_calculations):
         session.add(
             StatmechSourceCalculation(
                 statmech_id=statmech.id,
-                calculation_id=source.calculation_id,
+                calculation_id=_resolve_calculation_key(
+                    source.calculation_key,
+                    key_map,
+                    context=f"statmech.source_calculations[{index}]",
+                ),
                 role=source.role,
             )
         )
 
     # Attach torsions and coordinates
-    for torsion_payload in payload.torsions:
+    for torsion_index, torsion_payload in enumerate(payload.torsions):
+        scan_calculation_id: int | None = None
+        if torsion_payload.source_scan_calculation_key is not None:
+            scan_calculation_id = _resolve_calculation_key(
+                torsion_payload.source_scan_calculation_key,
+                key_map,
+                context=(
+                    f"statmech.torsions[{torsion_index}]"
+                    f".source_scan_calculation_key"
+                ),
+            )
         torsion = StatmechTorsion(
             statmech_id=statmech.id,
             torsion_index=torsion_payload.torsion_index,
@@ -142,7 +195,7 @@ def resolve_or_create_statmech(
             top_description=torsion_payload.top_description,
             invalidated_reason=torsion_payload.invalidated_reason,
             note=torsion_payload.note,
-            source_scan_calculation_id=torsion_payload.source_scan_calculation_id,
+            source_scan_calculation_id=scan_calculation_id,
         )
         session.add(torsion)
         session.flush()

--- a/backend/app/workflows/conformer.py
+++ b/backend/app/workflows/conformer.py
@@ -167,6 +167,18 @@ def persist_conformer_upload(
     for child_calc in additional_calcs:
         child_calc.conformer_observation_id = observation.id
 
+    # The nested statmech block names its supporting calculations by the
+    # local ``key`` this request put on them, so build that namespace from
+    # the rows just persisted. The schema layer has already refused any
+    # key that was never declared.
+    calculations_by_key: dict[str, int] = {}
+    for payload_calc, calc_row in [
+        (request.calculation, calculation),
+        *zip(request.additional_calculations, additional_calcs, strict=True),
+    ]:
+        if payload_calc.key is not None:
+            calculations_by_key[payload_calc.key] = calc_row.id
+
     statmech_row = None
     if request.statmech is not None:
         statmech_row = resolve_or_create_statmech(
@@ -174,6 +186,7 @@ def persist_conformer_upload(
             request.statmech,
             species_entry_id=species_entry.id,
             uploaded_calculation_id=calculation.id,
+            calculations_by_key=calculations_by_key,
             created_by=created_by,
         )
 

--- a/backend/app/workflows/statmech.py
+++ b/backend/app/workflows/statmech.py
@@ -1,10 +1,10 @@
 """Standalone statmech upload workflow orchestrator.
 
 Persists statmech records submitted independently of a conformer
-upload. Inline supporting calculations are resolved via their local
-string keys to real calculation ids, and the resulting scientific
-payload is routed through the canonical
-:func:`resolve_or_create_statmech` service used by nested uploads.
+upload. Inline supporting calculations are persisted first and handed to
+the canonical :func:`resolve_or_create_statmech` service as a local
+key → ``calculation.id`` map; the service does the key resolution, the
+same way it does for the nested conformer path.
 """
 
 from __future__ import annotations
@@ -16,11 +16,6 @@ from sqlalchemy.orm import Session
 from app.db.models.calculation import Calculation
 from app.db.models.common import SubmissionRecordType
 from app.db.models.statmech import Statmech
-from app.schemas.entities.statmech import (
-    StatmechSourceCalculationCreate,
-    StatmechTorsionCoordinateCreate,
-    StatmechTorsionCreate,
-)
 from app.schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
 from app.schemas.workflows.statmech_upload import StatmechUploadRequest
 from app.services.calculation_resolution import (
@@ -81,9 +76,8 @@ def persist_statmech_upload(
     """Persist a complete standalone statmech upload workflow.
 
     Resolves the target species entry, persists any inline supporting
-    calculations, translates local calculation keys into real ids for
-    both source-calculation links and torsion source scans, and routes
-    the resulting payload through the canonical statmech resolution
+    calculations, and routes the payload plus its local key →
+    ``calculation.id`` map through the canonical statmech resolution
     service so there is a single persistence implementation.
 
     Statmech is append-only: repeated uploads against the same species
@@ -118,50 +112,12 @@ def persist_statmech_upload(
         )
         calculations_by_key[calc_in.key] = calc_row
 
-    # Resolve source-calculation links from local keys to real ids.
-    resolved_sources = [
-        StatmechSourceCalculationCreate(
-            calculation_id=calculations_by_key[sc.calculation_key].id,
-            role=sc.role,
-        )
-        for sc in request.source_calculations
-    ]
-
-    # Resolve torsion source scans from local keys and translate torsions
-    # to the nested-create shape expected by the canonical service.
-    resolved_torsions: list[StatmechTorsionCreate] = []
-    for torsion_in in request.torsions:
-        scan_id: int | None = None
-        if torsion_in.source_scan_calculation_key is not None:
-            scan_id = calculations_by_key[
-                torsion_in.source_scan_calculation_key
-            ].id
-        resolved_torsions.append(
-            StatmechTorsionCreate(
-                torsion_index=torsion_in.torsion_index,
-                symmetry_number=torsion_in.symmetry_number,
-                treatment_kind=torsion_in.treatment_kind,
-                dimension=torsion_in.dimension,
-                top_description=torsion_in.top_description,
-                invalidated_reason=torsion_in.invalidated_reason,
-                note=torsion_in.note,
-                source_scan_calculation_id=scan_id,
-                coordinates=[
-                    StatmechTorsionCoordinateCreate(
-                        coordinate_index=c.coordinate_index,
-                        atom1_index=c.atom1_index,
-                        atom2_index=c.atom2_index,
-                        atom3_index=c.atom3_index,
-                        atom4_index=c.atom4_index,
-                    )
-                    for c in torsion_in.coordinates
-                ],
-            )
-        )
-
     # Build the canonical statmech payload and route through the shared
-    # resolution service. No uploaded_calculation_id here — standalone
-    # uploads have no implicit "freshly uploaded" anchor calculation.
+    # resolution service. The source-calculation links and torsions travel
+    # as-is: both paths now speak the same key-based components, so there
+    # is nothing to translate here — only a key → id map to hand over.
+    # No uploaded_calculation_id here — standalone uploads have no
+    # implicit "freshly uploaded" anchor calculation.
     core_payload = ConformerUploadStatmechPayload(
         scientific_origin=request.scientific_origin,
         literature=request.literature,
@@ -177,8 +133,8 @@ def persist_statmech_upload(
         optical_isomers=request.optical_isomers,
         note=request.note,
         uploaded_calculation_role=None,
-        source_calculations=resolved_sources,
-        torsions=resolved_torsions,
+        source_calculations=request.source_calculations,
+        torsions=request.torsions,
         electronic_levels=request.electronic_levels,
     )
 
@@ -187,6 +143,9 @@ def persist_statmech_upload(
         core_payload,
         species_entry_id=species_entry.id,
         uploaded_calculation_id=None,
+        calculations_by_key={
+            key: calc.id for key, calc in calculations_by_key.items()
+        },
         created_by=created_by,
     )
 

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -2748,7 +2748,7 @@
           },
           "source_calculations": {
             "items": {
-              "$ref": "#/components/schemas/StatmechSourceCalcInBundle"
+              "$ref": "#/components/schemas/StatmechSourceCalcIn"
             },
             "title": "Source Calculations",
             "type": "array"
@@ -10214,6 +10214,238 @@
         "title": "ConformerCalculationEvidenceSummary",
         "type": "object"
       },
+      "ConformerCalculationIn": {
+        "additionalProperties": false,
+        "description": "A conformer-upload calculation that can be named by a local key.\n\nThe key is what the nested statmech block points at. It exists so a\ndepositor can say \"the statmech's vibrational basis is *that* freq\njob\" using a name they chose, rather than a calculation row id they\nwould have to query for (DR-0029 Requirement 1).\n\nOptional by design: a payload with no statmech cross-references never\nneeds one, and every payload written before keys existed stays valid.\n\n:param key: Optional local name for this calculation, unique within\n    the request. Referenced from\n    ``statmech.source_calculations[*].calculation_key`` and\n    ``statmech.torsions[*].source_scan_calculation_key``.",
+        "properties": {
+          "constraints": {
+            "description": "Coordinate constraints held fixed during this calculation. Generic across opt, freq, sp, irc, path_search, scan, and any other constrained run — these are input/provenance metadata and do not require a result block. For scan calculations, frozen coordinates may be declared here while the stepped coordinate is declared on the scan_result.coordinates list.",
+            "items": {
+              "$ref": "#/components/schemas/CalculationConstraintCreate"
+            },
+            "title": "Constraints",
+            "type": "array"
+          },
+          "execution_environment": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExecutionEnvironmentManifestPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "freq_result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FreqResultPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hessian": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HessianPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "input_geometries": {
+            "description": "Geometries this calculation was run on. When empty, the workflow falls back to the conformer's reference geometry for calculation types in {freq, sp}; opt skips. List order maps to input_order = 1, 2, 3, ... in the database.",
+            "items": {
+              "$ref": "#/components/schemas/GeometryPayload"
+            },
+            "title": "Input Geometries",
+            "type": "array"
+          },
+          "irc_result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IRCResultPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "key": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "level_of_theory": {
+            "$ref": "#/components/schemas/LevelOfTheoryRef"
+          },
+          "literature_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Literature Id"
+          },
+          "opt_result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OptResultPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_geometries": {
+            "description": "Geometries this calculation produced or reported. When empty, the workflow falls back to the conformer's reference geometry as a single (role=final, output_order=1) row for calc types in the narrow set {opt}. Freq, sp, and all other types get zero rows when the producer leaves this empty. List order maps to output_order = 1, 2, 3, ... in the database.",
+            "items": {
+              "$ref": "#/components/schemas/OutputGeometryEntry"
+            },
+            "title": "Output Geometries",
+            "type": "array"
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CalculationParameterObservation"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parameters"
+          },
+          "parameters_extracted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parameters Extracted At"
+          },
+          "parameters_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parameters Json"
+          },
+          "parameters_parser_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parameters Parser Version"
+          },
+          "path_search_result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PathSearchResultPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "quality": {
+            "$ref": "#/components/schemas/CalculationQuality",
+            "default": "raw"
+          },
+          "scf_stability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SCFStabilityPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "software_release": {
+            "$ref": "#/components/schemas/SoftwareReleaseRef"
+          },
+          "sp_result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SPResultPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "spin_diagnostic": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpinDiagnosticPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "$ref": "#/components/schemas/CalculationType"
+          },
+          "wavefunction_diagnostic": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WavefunctionDiagnosticPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "workflow_tool_release": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowToolReleaseRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "software_release",
+          "level_of_theory"
+        ],
+        "title": "ConformerCalculationIn",
+        "type": "object"
+      },
       "ConformerCalculationSummary": {
         "description": "Compact calculation projection embedded under conformer records.\n\nSame shape conventions as the per-calc summary on the TS surface\n(``calculation_ref`` + type + quality + review + LoT / software /\nworkflow). Heavy include sections (results, parameters, geometry\nvalidation, scan/IRC/path-search points) remain available on the\ncalculation detail endpoint and are not surfaced here.",
         "properties": {
@@ -11332,7 +11564,7 @@
         "properties": {
           "additional_calculations": {
             "items": {
-              "$ref": "#/components/schemas/CalculationWithResultsPayload"
+              "$ref": "#/components/schemas/ConformerCalculationIn"
             },
             "title": "Additional Calculations",
             "type": "array"
@@ -11345,7 +11577,7 @@
             "type": "array"
           },
           "calculation": {
-            "$ref": "#/components/schemas/CalculationWithResultsPayload"
+            "$ref": "#/components/schemas/ConformerCalculationIn"
           },
           "geometry": {
             "$ref": "#/components/schemas/GeometryPayload"
@@ -11470,7 +11702,7 @@
       },
       "ConformerUploadStatmechPayload": {
         "additionalProperties": false,
-        "description": "Workflow-facing statmech payload nested under conformer upload.\n\nThe backend resolves referenced software/workflow provenance, creates or\nreuses the owning ``Statmech`` row for the resolved species entry, and links\nthe newly created upload calculation as a source calculation when requested.",
+        "description": "Workflow-facing statmech payload nested under conformer upload.\n\nThe backend resolves referenced software/workflow provenance, creates or\nreuses the owning ``Statmech`` row for the resolved species entry, and links\nthe newly created upload calculation as a source calculation when requested.\n\n``source_calculations`` and ``torsions[*].source_scan_calculation_key``\naddress calculations by the local ``key`` the enclosing\n``ConformerUploadRequest`` put on its own primary/additional\ncalculations — never by row id. ``ConformerUploadRequest`` validates\nthat every such key was declared, so an unresolvable reference is a\n422 rather than a silently dropped provenance link.",
         "properties": {
           "electronic_levels": {
             "items": {
@@ -11582,7 +11814,7 @@
           },
           "source_calculations": {
             "items": {
-              "$ref": "#/components/schemas/StatmechSourceCalculationCreate"
+              "$ref": "#/components/schemas/StatmechSourceCalcIn"
             },
             "title": "Source Calculations",
             "type": "array"
@@ -11599,7 +11831,7 @@
           },
           "torsions": {
             "items": {
-              "$ref": "#/components/schemas/StatmechTorsionCreate"
+              "$ref": "#/components/schemas/StatmechTorsionIn"
             },
             "title": "Torsions",
             "type": "array"
@@ -36602,7 +36834,7 @@
           },
           "source_calculations": {
             "items": {
-              "$ref": "#/components/schemas/StatmechSourceCalcInBundle"
+              "$ref": "#/components/schemas/StatmechSourceCalcIn"
             },
             "title": "Source Calculations",
             "type": "array"
@@ -37131,9 +37363,9 @@
         "title": "StatmechSearchRequest",
         "type": "object"
       },
-      "StatmechSourceCalcInBundle": {
+      "StatmechSourceCalcIn": {
         "additionalProperties": false,
-        "description": "Statmech → calc link by local key.\n\nMirrors ``ThermoSourceCalcInBundle``: only ``calculation_key`` is\naccepted inside the bundle (DR-0029 Requirement 1). The key resolves\nagainst the bundle's global calc-key namespace and is then attached\nto the persisted statmech row as a ``StatmechSourceCalculation`` row\nwith the supplied scientific role.",
+        "description": "Statmech → calculation link, by local calculation key.\n\nOnly a key is accepted (DR-0029 Requirement 1). The key resolves\nagainst whichever calc-key namespace the enclosing request defines —\nthe bundle's global namespace, the standalone statmech upload's\ninline ``calculations`` list, or the keys a conformer upload put on\nits own primary/additional calculations — and the resolved row is\nattached as a ``statmech_source_calculation`` row with this role.\n\n:param calculation_key: Local key of a calculation declared in the\n    same request.\n:param role: Scientific role the calculation plays for this statmech.",
         "properties": {
           "calculation_key": {
             "minLength": 1,
@@ -37148,46 +37380,7 @@
           "calculation_key",
           "role"
         ],
-        "title": "StatmechSourceCalcInBundle",
-        "type": "object"
-      },
-      "StatmechSourceCalculationCreate": {
-        "additionalProperties": false,
-        "description": "Nested create payload for a statmech source-calculation link.",
-        "properties": {
-          "calculation_id": {
-            "title": "Calculation Id",
-            "type": "integer"
-          },
-          "role": {
-            "$ref": "#/components/schemas/StatmechCalculationRole"
-          }
-        },
-        "required": [
-          "calculation_id",
-          "role"
-        ],
-        "title": "StatmechSourceCalculationCreate",
-        "type": "object"
-      },
-      "StatmechSourceCalculationIn": {
-        "additionalProperties": false,
-        "description": "Link between a statmech upload and a supporting calculation by key.\n\n:param calculation_key: Local key of a calculation declared in\n    ``StatmechUploadRequest.calculations``.\n:param role: Scientific role the calculation plays for this statmech.",
-        "properties": {
-          "calculation_key": {
-            "minLength": 1,
-            "title": "Calculation Key",
-            "type": "string"
-          },
-          "role": {
-            "$ref": "#/components/schemas/StatmechCalculationRole"
-          }
-        },
-        "required": [
-          "calculation_key",
-          "role"
-        ],
-        "title": "StatmechSourceCalculationIn",
+        "title": "StatmechSourceCalcIn",
         "type": "object"
       },
       "StatmechSourceCalculationRead": {
@@ -37379,49 +37572,9 @@
         "title": "StatmechSpeciesContext",
         "type": "object"
       },
-      "StatmechTorsionCoordinateCreate": {
-        "additionalProperties": false,
-        "description": "Nested create payload for one torsional coordinate.",
-        "properties": {
-          "atom1_index": {
-            "minimum": 1.0,
-            "title": "Atom1 Index",
-            "type": "integer"
-          },
-          "atom2_index": {
-            "minimum": 1.0,
-            "title": "Atom2 Index",
-            "type": "integer"
-          },
-          "atom3_index": {
-            "minimum": 1.0,
-            "title": "Atom3 Index",
-            "type": "integer"
-          },
-          "atom4_index": {
-            "minimum": 1.0,
-            "title": "Atom4 Index",
-            "type": "integer"
-          },
-          "coordinate_index": {
-            "minimum": 1.0,
-            "title": "Coordinate Index",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "coordinate_index",
-          "atom1_index",
-          "atom2_index",
-          "atom3_index",
-          "atom4_index"
-        ],
-        "title": "StatmechTorsionCoordinateCreate",
-        "type": "object"
-      },
       "StatmechTorsionCoordinateIn": {
         "additionalProperties": false,
-        "description": "Atom indices for one torsional coordinate in a standalone upload.\n\n:param coordinate_index: One-based coordinate number within the rotor.\n:param atom1_index: First atom index.\n:param atom2_index: Second atom index.\n:param atom3_index: Third atom index.\n:param atom4_index: Fourth atom index.",
+        "description": "Atom indices for one torsional coordinate.\n\n:param coordinate_index: One-based coordinate number within the rotor.\n:param atom1_index: First atom index.\n:param atom2_index: Second atom index.\n:param atom3_index: Third atom index.\n:param atom4_index: Fourth atom index.",
         "properties": {
           "atom1_index": {
             "minimum": 1.0,
@@ -37460,7 +37613,8 @@
         "type": "object"
       },
       "StatmechTorsionCoordinateRead": {
-        "description": "Read schema for one torsional coordinate.",
+        "additionalProperties": false,
+        "description": "Read schema for one torsional coordinate.\n\nInherits the five atom indices from the single coordinate class rather\nthan restating them; the only thing a read adds is the parent id.",
         "properties": {
           "atom1_index": {
             "minimum": 1.0,
@@ -37537,104 +37691,9 @@
         "title": "StatmechTorsionCoordinateSummary",
         "type": "object"
       },
-      "StatmechTorsionCreate": {
-        "additionalProperties": false,
-        "description": "Nested create payload for one statmech torsion.\n\n:param coordinates: Ordered torsional coordinate definitions. The number of\n    coordinates must equal ``dimension``, and ``coordinate_index`` values\n    must run contiguously from ``1..dimension``.",
-        "properties": {
-          "coordinates": {
-            "items": {
-              "$ref": "#/components/schemas/StatmechTorsionCoordinateCreate"
-            },
-            "title": "Coordinates",
-            "type": "array"
-          },
-          "dimension": {
-            "default": 1,
-            "minimum": 1.0,
-            "title": "Dimension",
-            "type": "integer"
-          },
-          "invalidated_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Invalidated Reason"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          },
-          "source_scan_calculation_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Scan Calculation Id"
-          },
-          "symmetry_number": {
-            "anyOf": [
-              {
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symmetry Number"
-          },
-          "top_description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Top Description"
-          },
-          "torsion_index": {
-            "minimum": 1.0,
-            "title": "Torsion Index",
-            "type": "integer"
-          },
-          "treatment_kind": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TorsionTreatmentKind"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "torsion_index"
-        ],
-        "title": "StatmechTorsionCreate",
-        "type": "object"
-      },
       "StatmechTorsionIn": {
         "additionalProperties": false,
-        "description": "Torsion definition for a standalone statmech upload.\n\nUnlike the nested-create schema, the principal scan calculation is\naddressed by a local string key rather than a raw calculation id.\n\n:param torsion_index: One-based torsion number within the record.\n:param symmetry_number: Optional torsional symmetry number.\n:param treatment_kind: Optional torsion treatment classification.\n:param dimension: Number of coupled torsional coordinates.\n:param top_description: Optional description of the rotating top.\n:param invalidated_reason: Optional invalidation reason.\n:param note: Optional free-text note.\n:param source_scan_calculation_key: Optional local key referencing an\n    inline calculation declared in ``StatmechUploadRequest.calculations``.\n:param coordinates: Ordered torsional coordinate definitions.",
+        "description": "One statmech torsion, with its rotor scan addressed by local key.\n\n:param torsion_index: One-based torsion number within the statmech record.\n:param symmetry_number: Optional torsional symmetry number.\n:param treatment_kind: Optional torsion treatment kind.\n:param dimension: Number of coupled torsional coordinates in this rotor.\n:param top_description: Optional description of the rotating top.\n:param invalidated_reason: Optional reason why the torsion was invalidated.\n:param note: Optional free-text note.\n:param source_scan_calculation_key: Optional local key of the\n    calculation that produced this rotor's scan. Resolves against the\n    same calc-key namespace as ``StatmechSourceCalcIn``.\n:param coordinates: Ordered torsional coordinate definitions. The\n    number of coordinates must equal ``dimension``, and\n    ``coordinate_index`` values must run contiguously from\n    ``1..dimension``.",
         "properties": {
           "coordinates": {
             "items": {
@@ -37674,6 +37733,7 @@
           "source_scan_calculation_key": {
             "anyOf": [
               {
+                "minLength": 1,
                 "type": "string"
               },
               {
@@ -38306,7 +38366,7 @@
           },
           "source_calculations": {
             "items": {
-              "$ref": "#/components/schemas/StatmechSourceCalculationIn"
+              "$ref": "#/components/schemas/StatmechSourceCalcIn"
             },
             "title": "Source Calculations",
             "type": "array"

--- a/backend/tests/api/test_wire_only_upload_contracts.py
+++ b/backend/tests/api/test_wire_only_upload_contracts.py
@@ -83,7 +83,7 @@ from tckdb_schemas.workflows import (
 )
 from tckdb_schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
 from tckdb_schemas.workflows.transport_upload import TransportUploadPayload
-from tckdb_schemas.statmech_bits import StatmechTorsionCreate
+from tckdb_schemas.statmech_bits import StatmechTorsionIn
 
 SOFTWARE = {"name": "Gaussian", "version": "16"}
 LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
@@ -92,12 +92,14 @@ conformer = ConformerUploadRequest(
     species_entry={"smiles": "[H]", "charge": 0, "multiplicity": 2},
     geometry={"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
     calculation={
+        "key": "h_sp",
         "type": "sp",
         "software_release": SOFTWARE,
         "level_of_theory": LOT,
     },
     additional_calculations=[
         {
+            "key": "h_freq",
             "type": "freq",
             "software_release": SOFTWARE,
             "level_of_theory": LOT,
@@ -110,6 +112,10 @@ conformer = ConformerUploadRequest(
         is_linear=False,
         optical_isomers=1,
         electronic_levels=[{"level_index": 1, "energy_cm1": 0.0, "degeneracy": 2}],
+        # The whole point of the contract: the statmech cites a
+        # calculation by a name this payload chose, not by a row id it
+        # would have had to query the database for.
+        source_calculations=[{"calculation_key": "h_freq", "role": "freq"}],
     ),
     transport=TransportUploadPayload(
         sigma_angstrom=2.05,
@@ -163,7 +169,7 @@ transition_state = TransitionStateUploadRequest(
 
 # Nested wire types that used to be backend-only, exercised for
 # constructibility even where the smoke payloads above do not carry them.
-StatmechTorsionCreate(
+StatmechTorsionIn(
     torsion_index=1,
     dimension=1,
     coordinates=[
@@ -200,6 +206,31 @@ try:
                 "freq_result": {"n_imag": 1, "imag_freq_cm1": -400.0},
             }
         ],
+    )
+except ValueError:
+    rejected += 1
+try:
+    # A statmech source calc naming a key nobody declared. Accepting it
+    # would persist a statmech with no provenance link at all.
+    ConformerUploadRequest(
+        species_entry={"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        geometry={"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+        calculation={
+            "key": "h_sp",
+            "type": "sp",
+            "software_release": SOFTWARE,
+            "level_of_theory": LOT,
+        },
+        statmech=ConformerUploadStatmechPayload(
+            source_calculations=[{"calculation_key": "never_declared", "role": "sp"}],
+        ),
+    )
+except ValueError:
+    rejected += 1
+try:
+    # And the field it replaced is gone, not quietly tolerated.
+    ConformerUploadStatmechPayload(
+        source_calculations=[{"calculation_id": 1, "role": "sp"}],
     )
 except ValueError:
     rejected += 1
@@ -248,7 +279,7 @@ def test_wire_only_process_never_touched_the_backend(wire_only_payloads) -> None
 
 def test_wire_only_models_enforce_their_own_contracts(wire_only_payloads) -> None:
     """Validation travelled with the models, not just the field names."""
-    assert wire_only_payloads["rejected"] == 2
+    assert wire_only_payloads["rejected"] == 4
 
 
 def test_live_conformer_route_accepts_a_wire_only_payload(
@@ -259,6 +290,66 @@ def test_live_conformer_route_accepts_a_wire_only_payload(
     )
     assert resp.status_code == 201, resp.text
     assert "conformer_group_id" in resp.json()
+
+
+def test_conformer_payload_carries_no_calculation_row_ids(
+    wire_only_payloads,
+) -> None:
+    """The statmech block names calculations, and names only.
+
+    Reading the JSON rather than the model: a depositor who never queried
+    TCKDB has to be able to write this body, so no serialized field may
+    be a calculation primary key.
+    """
+    statmech = wire_only_payloads["conformer"]["statmech"]
+    assert statmech["source_calculations"] == [
+        {"calculation_key": "h_freq", "role": "freq"}
+    ]
+    for entry in statmech["source_calculations"]:
+        assert "calculation_id" not in entry
+    for torsion in statmech.get("torsions", []):
+        assert "source_scan_calculation_id" not in torsion
+
+
+def test_live_conformer_route_links_statmech_by_key_not_id(
+    client, wire_only_payloads
+) -> None:
+    """End to end: the key in the body became the right FK in the row.
+
+    A payload that validates is not a payload that persists. This asserts
+    the ``statmech_source_calculation`` row points at the *additional*
+    freq calculation named ``h_freq`` — not at the primary sp
+    calculation, which is what a workflow that ignored the key and reused
+    the "uploaded calculation" shortcut would have linked.
+    """
+    from app.db.models.calculation import Calculation
+    from app.db.models.common import CalculationType
+    from app.db.models.statmech import Statmech, StatmechSourceCalculation
+
+    resp = client.post(
+        "/api/v1/uploads/conformers", json=wire_only_payloads["conformer"]
+    )
+    assert resp.status_code == 201, resp.text
+
+    session = client._db_session
+    statmech = (
+        session.query(Statmech)
+        .order_by(Statmech.id.desc())
+        .first()
+    )
+    assert statmech is not None
+    links = (
+        session.query(StatmechSourceCalculation)
+        .filter(StatmechSourceCalculation.statmech_id == statmech.id)
+        .all()
+    )
+    linked_types = {
+        session.get(Calculation, link.calculation_id).type for link in links
+    }
+    assert CalculationType.freq in linked_types, (
+        "statmech.source_calculations[0].calculation_key='h_freq' did not "
+        "resolve to the freq calculation declared in the same upload"
+    )
 
 
 def test_live_transition_state_route_accepts_a_wire_only_payload(

--- a/backend/tests/api/test_wire_only_upload_contracts.py
+++ b/backend/tests/api/test_wire_only_upload_contracts.py
@@ -323,7 +323,7 @@ def test_live_conformer_route_links_statmech_by_key_not_id(
     the "uploaded calculation" shortcut would have linked.
     """
     from app.db.models.calculation import Calculation
-    from app.db.models.common import CalculationType
+    from app.db.models.common import CalculationType, StatmechCalculationRole
     from app.db.models.statmech import Statmech, StatmechSourceCalculation
 
     resp = client.post(
@@ -343,12 +343,16 @@ def test_live_conformer_route_links_statmech_by_key_not_id(
         .filter(StatmechSourceCalculation.statmech_id == statmech.id)
         .all()
     )
-    linked_types = {
-        session.get(Calculation, link.calculation_id).type for link in links
+    linked = {
+        (session.get(Calculation, link.calculation_id).type, link.role)
+        for link in links
     }
-    assert CalculationType.freq in linked_types, (
+    # Exactly one link, to the freq calc, with the declared role. The
+    # payload sets no ``uploaded_calculation_role``, so the primary sp
+    # calculation must not appear.
+    assert linked == {(CalculationType.freq, StatmechCalculationRole.freq)}, (
         "statmech.source_calculations[0].calculation_key='h_freq' did not "
-        "resolve to the freq calculation declared in the same upload"
+        f"resolve to the freq calculation declared in the same upload: {linked}"
     )
 
 

--- a/backend/tests/schemas/test_conformer_upload_schema.py
+++ b/backend/tests/schemas/test_conformer_upload_schema.py
@@ -91,3 +91,173 @@ def test_conformer_upload_statmech_accepts_literature_submission_payload() -> No
     assert request.statmech is not None
     assert request.statmech.literature is not None
     assert request.statmech.literature.doi == "10.1234/h-atom"
+
+
+# ---------------------------------------------------------------------------
+# Statmech source calculations: local keys, never row ids (#118, DR-0029 Req 1)
+# ---------------------------------------------------------------------------
+
+
+def _keyed_conformer_request(**statmech_overrides) -> dict:
+    """A conformer upload that names its own calculations.
+
+    The primary sp is ``h_sp`` and one additional freq is ``h_freq``, so
+    statmech cross-references have something real to point at.
+    """
+    return {
+        "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        "geometry": {"xyz_text": "1\ncomment\nH 0.0 0.0 0.0"},
+        "calculation": {
+            "key": "h_sp",
+            "type": "sp",
+            "software_release": {"name": "Gaussian", "version": "16"},
+            "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+        },
+        "additional_calculations": [
+            {
+                "key": "h_freq",
+                "type": "freq",
+                "software_release": {"name": "Gaussian", "version": "16"},
+                "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+                "freq_result": {"n_imag": 0},
+            }
+        ],
+        "statmech": {"statmech_treatment": "rrho", **statmech_overrides},
+    }
+
+
+def test_statmech_source_calculation_rejects_raw_calculation_id() -> None:
+    """The published contract must not accept a calculation primary key.
+
+    A depositor cannot know one. Before #118 this field was
+    ``calculation_id: int`` and was the only way to declare the link.
+    """
+    payload = _keyed_conformer_request(
+        source_calculations=[{"calculation_id": 7, "role": "freq"}]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "calculation_id" in str(exc_info.value)
+
+
+def test_statmech_torsion_rejects_raw_source_scan_calculation_id() -> None:
+    payload = _keyed_conformer_request(
+        statmech_treatment="rrho_1d",
+        torsions=[
+            {
+                "torsion_index": 1,
+                "dimension": 1,
+                "source_scan_calculation_id": 7,
+                "coordinates": [
+                    {
+                        "coordinate_index": 1,
+                        "atom1_index": 1,
+                        "atom2_index": 2,
+                        "atom3_index": 3,
+                        "atom4_index": 4,
+                    }
+                ],
+            }
+        ],
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "source_scan_calculation_id" in str(exc_info.value)
+
+
+def test_statmech_source_calculation_accepts_a_declared_key() -> None:
+    request = ConformerUploadRequest(
+        **_keyed_conformer_request(
+            source_calculations=[{"calculation_key": "h_freq", "role": "freq"}]
+        )
+    )
+    assert request.statmech is not None
+    assert request.statmech.source_calculations[0].calculation_key == "h_freq"
+    assert request.declared_calculation_keys() == ["h_sp", "h_freq"]
+
+
+def test_statmech_source_calculation_key_must_be_declared() -> None:
+    """An unresolvable key is a 422, not a silently dropped provenance link."""
+    payload = _keyed_conformer_request(
+        source_calculations=[{"calculation_key": "nowhere", "role": "freq"}]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "does not name a calculation declared in this upload" in str(
+        exc_info.value
+    )
+
+
+def test_torsion_source_scan_calculation_key_must_be_declared() -> None:
+    payload = _keyed_conformer_request(
+        statmech_treatment="rrho_1d",
+        torsions=[
+            {
+                "torsion_index": 1,
+                "dimension": 1,
+                "source_scan_calculation_key": "nowhere",
+                "coordinates": [
+                    {
+                        "coordinate_index": 1,
+                        "atom1_index": 1,
+                        "atom2_index": 2,
+                        "atom3_index": 3,
+                        "atom4_index": 4,
+                    }
+                ],
+            }
+        ],
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "source_scan_calculation_key" in str(exc_info.value)
+
+
+def test_duplicate_calculation_keys_rejected() -> None:
+    payload = _keyed_conformer_request()
+    payload["additional_calculations"][0]["key"] = "h_sp"
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "unique" in str(exc_info.value)
+
+
+def test_calculation_keys_are_optional() -> None:
+    """A payload with no statmech cross-references needs no keys at all."""
+    request = ConformerUploadRequest(**_minimal_conformer_request())
+    assert request.calculation.key is None
+    assert request.declared_calculation_keys() == []
+
+
+def test_duplicate_source_calculation_pairs_rejected() -> None:
+    """(calculation_key, role) is the source link's primary key in the DB."""
+    payload = _keyed_conformer_request(
+        source_calculations=[
+            {"calculation_key": "h_freq", "role": "freq"},
+            {"calculation_key": "h_freq", "role": "freq"},
+        ]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "unique by (calculation_key, role)" in str(exc_info.value)
+
+
+def test_duplicate_torsion_indices_rejected() -> None:
+    coordinates = [
+        {
+            "coordinate_index": 1,
+            "atom1_index": 1,
+            "atom2_index": 2,
+            "atom3_index": 3,
+            "atom4_index": 4,
+        }
+    ]
+    payload = _keyed_conformer_request(
+        statmech_treatment="rrho_1d",
+        torsions=[
+            {"torsion_index": 1, "dimension": 1, "coordinates": coordinates},
+            {"torsion_index": 1, "dimension": 1, "coordinates": coordinates},
+        ],
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "torsion_index values must be unique" in str(exc_info.value)

--- a/backend/tests/schemas/test_conformer_upload_schema.py
+++ b/backend/tests/schemas/test_conformer_upload_schema.py
@@ -241,6 +241,29 @@ def test_duplicate_source_calculation_pairs_rejected() -> None:
     assert "unique by (calculation_key, role)" in str(exc_info.value)
 
 
+def test_primary_calculation_cannot_be_linked_twice() -> None:
+    """``uploaded_calculation_role`` plus the same key/role is one PK, twice."""
+    payload = _keyed_conformer_request(
+        uploaded_calculation_role="sp",
+        source_calculations=[{"calculation_key": "h_sp", "role": "sp"}],
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        ConformerUploadRequest(**payload)
+    assert "uploaded_calculation_role already links" in str(exc_info.value)
+
+
+def test_primary_calculation_may_be_linked_under_a_different_role() -> None:
+    """A distinct role is a distinct row, so it is allowed."""
+    request = ConformerUploadRequest(
+        **_keyed_conformer_request(
+            uploaded_calculation_role="sp",
+            source_calculations=[{"calculation_key": "h_sp", "role": "composite"}],
+        )
+    )
+    assert request.statmech is not None
+    assert len(request.statmech.source_calculations) == 1
+
+
 def test_duplicate_torsion_indices_rejected() -> None:
     coordinates = [
         {

--- a/backend/tests/schemas/test_conformer_upload_schema.py
+++ b/backend/tests/schemas/test_conformer_upload_schema.py
@@ -126,6 +126,26 @@ def _keyed_conformer_request(**statmech_overrides) -> dict:
     }
 
 
+def _assert_field_forbidden(exc_info, field: str) -> None:
+    """Assert the failure is specifically "this field may not be sent".
+
+    Matching on ``str(exc_info.value)`` is not enough: Pydantic echoes the
+    whole offending input into the message, so the field name appears in
+    the text even when the model happily accepted it and failed for some
+    unrelated reason. Only ``extra_forbidden`` on that exact location says
+    the contract refuses the field.
+    """
+    offending = [
+        error
+        for error in exc_info.value.errors()
+        if error["type"] == "extra_forbidden" and error["loc"][-1] == field
+    ]
+    assert offending, (
+        f"expected an extra_forbidden error on '{field}', got "
+        f"{[(e['type'], e['loc']) for e in exc_info.value.errors()]}"
+    )
+
+
 def test_statmech_source_calculation_rejects_raw_calculation_id() -> None:
     """The published contract must not accept a calculation primary key.
 
@@ -137,7 +157,7 @@ def test_statmech_source_calculation_rejects_raw_calculation_id() -> None:
     )
     with pytest.raises(ValidationError) as exc_info:
         ConformerUploadRequest(**payload)
-    assert "calculation_id" in str(exc_info.value)
+    _assert_field_forbidden(exc_info, "calculation_id")
 
 
 def test_statmech_torsion_rejects_raw_source_scan_calculation_id() -> None:
@@ -162,7 +182,7 @@ def test_statmech_torsion_rejects_raw_source_scan_calculation_id() -> None:
     )
     with pytest.raises(ValidationError) as exc_info:
         ConformerUploadRequest(**payload)
-    assert "source_scan_calculation_id" in str(exc_info.value)
+    _assert_field_forbidden(exc_info, "source_scan_calculation_id")
 
 
 def test_statmech_source_calculation_accepts_a_declared_key() -> None:

--- a/backend/tests/schemas/test_statmech_schema.py
+++ b/backend/tests/schemas/test_statmech_schema.py
@@ -5,7 +5,7 @@ import pytest
 from app.schemas.entities.statmech import (
     StatmechCreate,
     StatmechSourceCalculationCreate,
-    StatmechTorsionCoordinateCreate,
+    StatmechTorsionCoordinateIn,
     StatmechTorsionCoordinateUpdate,
     StatmechTorsionCreate,
 )
@@ -17,14 +17,14 @@ def test_statmech_torsion_create_requires_contiguous_coordinates() -> None:
             torsion_index=1,
             dimension=2,
             coordinates=[
-                StatmechTorsionCoordinateCreate(
+                StatmechTorsionCoordinateIn(
                     coordinate_index=1,
                     atom1_index=1,
                     atom2_index=2,
                     atom3_index=3,
                     atom4_index=4,
                 ),
-                StatmechTorsionCoordinateCreate(
+                StatmechTorsionCoordinateIn(
                     coordinate_index=3,
                     atom1_index=5,
                     atom2_index=6,
@@ -41,7 +41,7 @@ def test_statmech_torsion_create_requires_coordinate_count_to_match_dimension() 
             torsion_index=1,
             dimension=2,
             coordinates=[
-                StatmechTorsionCoordinateCreate(
+                StatmechTorsionCoordinateIn(
                     coordinate_index=1,
                     atom1_index=1,
                     atom2_index=2,
@@ -54,7 +54,7 @@ def test_statmech_torsion_create_requires_coordinate_count_to_match_dimension() 
 
 def test_statmech_torsion_coordinate_requires_distinct_atom_indices() -> None:
     with pytest.raises(ValueError, match="must be distinct"):
-        StatmechTorsionCoordinateCreate(
+        StatmechTorsionCoordinateIn(
             coordinate_index=1,
             atom1_index=1,
             atom2_index=2,
@@ -90,7 +90,7 @@ def test_statmech_create_supports_nested_torsions_and_source_calculations() -> N
                 torsion_index=1,
                 dimension=1,
                 coordinates=[
-                    StatmechTorsionCoordinateCreate(
+                    StatmechTorsionCoordinateIn(
                         coordinate_index=1,
                         atom1_index=1,
                         atom2_index=2,
@@ -117,7 +117,7 @@ def test_statmech_create_rejects_duplicate_torsion_indices() -> None:
                     torsion_index=1,
                     dimension=1,
                     coordinates=[
-                        StatmechTorsionCoordinateCreate(
+                        StatmechTorsionCoordinateIn(
                             coordinate_index=1,
                             atom1_index=1,
                             atom2_index=2,
@@ -130,7 +130,7 @@ def test_statmech_create_rejects_duplicate_torsion_indices() -> None:
                     torsion_index=1,
                     dimension=1,
                     coordinates=[
-                        StatmechTorsionCoordinateCreate(
+                        StatmechTorsionCoordinateIn(
                             coordinate_index=1,
                             atom1_index=5,
                             atom2_index=6,

--- a/backend/tests/schemas/test_statmech_schema.py
+++ b/backend/tests/schemas/test_statmech_schema.py
@@ -162,3 +162,50 @@ def test_statmech_create_rejects_duplicate_source_calculation_pairs() -> None:
                 ),
             ],
         )
+
+
+# ---------------------------------------------------------------------------
+# One concept, one component (#119)
+# ---------------------------------------------------------------------------
+
+
+def test_torsion_coordinate_has_exactly_one_definition() -> None:
+    """The atom quartet is defined once and inherited everywhere.
+
+    ``StatmechTorsionCoordinateIn``, ``StatmechTorsionCoordinateBase`` and
+    ``StatmechTorsionCoordinateCreate`` used to be field-for-field and
+    validator-for-validator identical, which a client generator turned
+    into two classes for one concept. The read schema now inherits the
+    one class instead of restating its fields.
+    """
+    from app.schemas.entities.statmech import StatmechTorsionCoordinateRead
+
+    assert StatmechTorsionCoordinateIn in StatmechTorsionCoordinateRead.__mro__
+    quartet = {
+        "coordinate_index",
+        "atom1_index",
+        "atom2_index",
+        "atom3_index",
+        "atom4_index",
+    }
+    assert quartet <= set(StatmechTorsionCoordinateIn.model_fields)
+    # The read schema adds only the parent link on top of the quartet.
+    assert set(StatmechTorsionCoordinateRead.model_fields) == quartet | {"torsion_id"}
+    # And declares none of the quartet itself -- inheriting it is the point.
+    assert quartet.isdisjoint(
+        StatmechTorsionCoordinateRead.__annotations__.keys()
+    )
+
+
+def test_retired_torsion_coordinate_spellings_are_gone() -> None:
+    """The duplicate names must not come back as import aliases either."""
+    import tckdb_schemas.statmech_bits as wire_bits
+
+    from app.schemas.entities import statmech as entity_statmech
+
+    for retired in (
+        "StatmechTorsionCoordinateBase",
+        "StatmechTorsionCoordinateCreate",
+    ):
+        assert not hasattr(wire_bits, retired), retired
+        assert not hasattr(entity_statmech, retired), retired

--- a/backend/tests/schemas/test_tckdb_schemas_shim_identity.py
+++ b/backend/tests/schemas/test_tckdb_schemas_shim_identity.py
@@ -119,7 +119,12 @@ def test_statmech_torsion_coordinate_in_shim_identity() -> None:
         StatmechTorsionCoordinateIn as ExtractedStatmechTorsionCoordinateIn,
     )
 
-    from app.schemas.workflows.statmech_upload import StatmechTorsionCoordinateIn
+    # The backend home for the coordinate class is the statmech entity
+    # module: it is now the single field definition behind both the create
+    # payload and ``StatmechTorsionCoordinateRead``. The standalone
+    # statmech upload no longer names it directly -- it takes the whole
+    # ``StatmechTorsionIn`` from the wire package instead.
+    from app.schemas.entities.statmech import StatmechTorsionCoordinateIn
 
     assert StatmechTorsionCoordinateIn is ExtractedStatmechTorsionCoordinateIn
 

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -22,6 +22,64 @@ that lives here can be pinned, and a breaking change to it forces a
 version bump a consumer can act on — which is the reason to put it here
 rather than inside the server.
 
+## Changelog
+
+### 0.24.0 — **BREAKING**: statmech source calculations are named, not numbered
+
+`ConformerUploadRequest.statmech` used to identify a supporting
+calculation by its database primary key. It no longer does, and payloads
+written against 0.23.0 that used those two fields will be rejected with a
+422 rather than silently reinterpreted.
+
+| Before (0.23.0) | After (0.24.0) |
+|---|---|
+| `statmech.source_calculations[].calculation_id: int` | `statmech.source_calculations[].calculation_key: str` |
+| `statmech.torsions[].source_scan_calculation_id: int \| None` | `statmech.torsions[].source_scan_calculation_key: str \| None` |
+
+A key names a calculation *declared in the same request*. To make that
+possible, `ConformerUploadRequest.calculation` and
+`additional_calculations[]` gained an optional `key`, and the request
+refuses a statmech reference to a key nobody declared. This is the shape
+the computed-species / computed-reaction bundles have always used; the
+conformer path was the odd one out, and a row id is not something a
+depositor can know.
+
+Migrating: put a `key` on the calculation you meant, and reference it.
+
+```python
+# 0.23.0 — only writable by something that had already queried TCKDB
+{"calculation": {...}, "statmech": {"source_calculations": [{"calculation_id": 4711, "role": "freq"}]}}
+
+# 0.24.0
+{"calculation": {"key": "h_sp", ...},
+ "additional_calculations": [{"key": "h_freq", "type": "freq", ...}],
+ "statmech": {"source_calculations": [{"calculation_key": "h_freq", "role": "freq"}]}}
+```
+
+Component renames (they affect generated client class names; the JSON
+shape of the bundle paths is unchanged):
+
+- `StatmechSourceCalculationCreate`, `StatmechSourceCalcInBundle` and the
+  server-side `StatmechSourceCalculationIn` collapse into one component,
+  `StatmechSourceCalcIn`. The old names remain importable as aliases.
+- `StatmechTorsionCreate` collapses into `StatmechTorsionIn`.
+- `StatmechTorsionCoordinateCreate` and `StatmechTorsionCoordinateBase`
+  are gone; `StatmechTorsionCoordinateIn` is the only spelling of an atom
+  quartet. They were field-for-field and validator-for-validator
+  identical, so a generator emitted two classes for one concept.
+- New: `ConformerCalculationIn` — a `CalculationWithResultsPayload` plus
+  the optional `key`.
+
+Also tightened, matching what the sibling upload paths already enforce:
+`statmech.source_calculations` must be unique by
+`(calculation_key, role)` (it is the row's primary key, so a duplicate
+used to surface as a 500), and `statmech.torsions[].torsion_index` must
+be unique.
+
+### 0.23.0
+
+Published `ConformerUploadRequest` and `TransitionStateUploadRequest`.
+
 ## Layout
 
 ```

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -79,11 +79,16 @@ The two removed `*Create` names still exist inside the TCKDB server, in
 row-shaped create payload that speaks `calculation_id`. They are not part
 of any wire contract and never were importable from here for that purpose.
 
-Also tightened, matching what the sibling upload paths already enforce:
-`statmech.source_calculations` must be unique by
-`(calculation_key, role)` (it is the row's primary key, so a duplicate
-used to surface as a 500), and `statmech.torsions[].torsion_index` must
-be unique.
+Also tightened, matching what the sibling upload paths already enforce.
+Each of these used to surface as a 500 rather than a 422:
+
+- `statmech.source_calculations` must be unique by
+  `(calculation_key, role)` — it is the row's primary key.
+- `statmech.torsions[].torsion_index` must be unique.
+- The primary calculation may not be linked twice: once implicitly via
+  `statmech.uploaded_calculation_role` and again in
+  `source_calculations` under the same role. A *different* role is a
+  different row and stays allowed.
 
 ### 0.23.0
 

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -61,14 +61,23 @@ shape of the bundle paths is unchanged):
 
 - `StatmechSourceCalculationCreate`, `StatmechSourceCalcInBundle` and the
   server-side `StatmechSourceCalculationIn` collapse into one component,
-  `StatmechSourceCalcIn`. The old names remain importable as aliases.
-- `StatmechTorsionCreate` collapses into `StatmechTorsionIn`.
+  `StatmechSourceCalcIn`. `StatmechSourceCalcInBundle` stays importable as
+  an alias — from `tckdb_schemas.statmech_bits` and from both bundle
+  modules — and is the same class object, so there is one component, not
+  two. `StatmechSourceCalculationCreate` is **removed** from this package.
+- `StatmechTorsionCreate` collapses into `StatmechTorsionIn` and is
+  **removed** from this package.
 - `StatmechTorsionCoordinateCreate` and `StatmechTorsionCoordinateBase`
-  are gone; `StatmechTorsionCoordinateIn` is the only spelling of an atom
-  quartet. They were field-for-field and validator-for-validator
+  are removed; `StatmechTorsionCoordinateIn` is the only spelling of an
+  atom quartet. They were field-for-field and validator-for-validator
   identical, so a generator emitted two classes for one concept.
 - New: `ConformerCalculationIn` — a `CalculationWithResultsPayload` plus
   the optional `key`.
+
+The two removed `*Create` names still exist inside the TCKDB server, in
+`app.schemas.entities.statmech`, where they mean something different: the
+row-shaped create payload that speaks `calculation_id`. They are not part
+of any wire contract and never were importable from here for that purpose.
 
 Also tightened, matching what the sibling upload paths already enforce:
 `statmech.source_calculations` must be unique by

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.23.0"
+version = "0.24.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/statmech_bits.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/statmech_bits.py
@@ -1,30 +1,48 @@
 """Shared statmech upload fragments.
 
-Carries ``StatmechTorsionCoordinateIn``, the slim atom-quartet definition
-reused by both the standalone statmech upload and the computed-species /
-computed-reaction bundle endpoints, plus the ``*Create`` payloads nested
-inside ``ConformerUploadRequest.statmech``.
+Every reference out of these fragments is a **local string key**, never a
+database row id (DR-0029 Requirement 1, and the "no FK IDs in upload
+schemas" rule). A depositor can name a calculation they declared in the
+same request; they cannot know its primary key, and a contract that asks
+for one is only usable by something that has already queried the
+database.
 
-The ``*Base`` classes here are plain ``BaseModel`` on purpose: the
-backend's ``*Read`` and ``*Update`` schemas still inherit from them while
-adding ``from_attributes=True`` ORM bases, so the field definitions have
-exactly one home even though only the create side is on the wire.
+Three components live here, and each is the single home for its concept
+across every upload path that carries statmech:
 
-The full ``StatmechUploadRequest`` (and its torsion/source-calc/etc.
-container classes) stay backend-side because they orchestrate
-service-layer resolution and ownership checks.
+``StatmechTorsionCoordinateIn``
+    The atom quartet defining one torsional coordinate. Shared by the
+    conformer, standalone-statmech and bundle paths, and reused as the
+    field home for the backend's ``*Read`` schema.
+
+``StatmechSourceCalcIn``
+    A statmech → calculation link, by local calculation key and
+    scientific role. ``StatmechSourceCalcInBundle`` is a backwards
+    compatible alias re-exported from the bundle modules.
+
+``StatmechTorsionIn``
+    One torsional mode, with its principal rotor scan addressed by local
+    key. Shared by the conformer and standalone-statmech paths; the
+    bundle keeps ``StatmechTorsionInBundle`` because it deliberately
+    allows ``coordinates`` to be omitted.
+
+The full ``StatmechUploadRequest`` (and its inline-calculation container)
+stay backend-side because they orchestrate service-layer resolution and
+ownership checks. The id-bearing ``*Base`` / ``*Read`` / ``*Update``
+schemas stay backend-side too, in ``app.schemas.entities.statmech`` —
+they describe persisted rows, which is not what a wire contract is for.
 """
 
 from typing import Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from tckdb_schemas.common import SchemaBase
 from tckdb_schemas.enums import StatmechCalculationRole, TorsionTreatmentKind
 
 
 class StatmechTorsionCoordinateIn(SchemaBase):
-    """Atom indices for one torsional coordinate in a standalone upload.
+    """Atom indices for one torsional coordinate.
 
     :param coordinate_index: One-based coordinate number within the rotor.
     :param atom1_index: First atom index.
@@ -52,59 +70,27 @@ class StatmechTorsionCoordinateIn(SchemaBase):
         return self
 
 
-class StatmechSourceCalculationBase(BaseModel):
-    """Shared fields for statmech source-calculation links.
+class StatmechSourceCalcIn(SchemaBase):
+    """Statmech → calculation link, by local calculation key.
 
-    :param calculation_id: Referenced calculation row.
-    :param role: Semantic role of the source calculation.
+    Only a key is accepted (DR-0029 Requirement 1). The key resolves
+    against whichever calc-key namespace the enclosing request defines —
+    the bundle's global namespace, the standalone statmech upload's
+    inline ``calculations`` list, or the keys a conformer upload put on
+    its own primary/additional calculations — and the resolved row is
+    attached as a ``statmech_source_calculation`` row with this role.
+
+    :param calculation_key: Local key of a calculation declared in the
+        same request.
+    :param role: Scientific role the calculation plays for this statmech.
     """
 
-    calculation_id: int
+    calculation_key: str = Field(min_length=1)
     role: StatmechCalculationRole
 
 
-class StatmechSourceCalculationCreate(StatmechSourceCalculationBase, SchemaBase):
-    """Nested create payload for a statmech source-calculation link."""
-
-
-class StatmechTorsionCoordinateBase(BaseModel):
-    """Shared fields for one torsional coordinate definition.
-
-    :param coordinate_index: One-based coordinate number within the coupled rotor.
-    :param atom1_index: First atom index in the torsion definition.
-    :param atom2_index: Second atom index in the torsion definition.
-    :param atom3_index: Third atom index in the torsion definition.
-    :param atom4_index: Fourth atom index in the torsion definition.
-    """
-
-    coordinate_index: int = Field(ge=1)
-    atom1_index: int = Field(ge=1)
-    atom2_index: int = Field(ge=1)
-    atom3_index: int = Field(ge=1)
-    atom4_index: int = Field(ge=1)
-
-    @model_validator(mode="after")
-    def validate_distinct_atoms(self) -> Self:
-        atom_indices = {
-            self.atom1_index,
-            self.atom2_index,
-            self.atom3_index,
-            self.atom4_index,
-        }
-        if len(atom_indices) != 4:
-            raise ValueError("Torsion coordinate atom indices must be distinct.")
-        return self
-
-
-class StatmechTorsionCoordinateCreate(
-    StatmechTorsionCoordinateBase,
-    SchemaBase,
-):
-    """Nested create payload for one torsional coordinate."""
-
-
-class StatmechTorsionBase(BaseModel):
-    """Shared fields for one statmech torsion.
+class StatmechTorsionIn(SchemaBase):
+    """One statmech torsion, with its rotor scan addressed by local key.
 
     :param torsion_index: One-based torsion number within the statmech record.
     :param symmetry_number: Optional torsional symmetry number.
@@ -113,7 +99,13 @@ class StatmechTorsionBase(BaseModel):
     :param top_description: Optional description of the rotating top.
     :param invalidated_reason: Optional reason why the torsion was invalidated.
     :param note: Optional free-text note.
-    :param source_scan_calculation_id: Optional principal scan calculation for this torsion.
+    :param source_scan_calculation_key: Optional local key of the
+        calculation that produced this rotor's scan. Resolves against the
+        same calc-key namespace as ``StatmechSourceCalcIn``.
+    :param coordinates: Ordered torsional coordinate definitions. The
+        number of coordinates must equal ``dimension``, and
+        ``coordinate_index`` values must run contiguously from
+        ``1..dimension``.
     """
 
     torsion_index: int = Field(ge=1)
@@ -125,18 +117,9 @@ class StatmechTorsionBase(BaseModel):
     invalidated_reason: str | None = None
     note: str | None = None
 
-    source_scan_calculation_id: int | None = None
+    source_scan_calculation_key: str | None = Field(default=None, min_length=1)
 
-
-class StatmechTorsionCreate(StatmechTorsionBase, SchemaBase):
-    """Nested create payload for one statmech torsion.
-
-    :param coordinates: Ordered torsional coordinate definitions. The number of
-        coordinates must equal ``dimension``, and ``coordinate_index`` values
-        must run contiguously from ``1..dimension``.
-    """
-
-    coordinates: list[StatmechTorsionCoordinateCreate] = Field(default_factory=list)
+    coordinates: list[StatmechTorsionCoordinateIn] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_coordinates(self) -> Self:
@@ -152,3 +135,9 @@ class StatmechTorsionCreate(StatmechTorsionBase, SchemaBase):
                 "Torsion coordinate_index values must run contiguously from 1..dimension."
             )
         return self
+
+
+#: Historical name for :class:`StatmechSourceCalcIn`, kept importable so
+#: bundle-facing code and docs that spell it this way keep working. It is
+#: the same class object, so there is one OpenAPI component, not two.
+StatmechSourceCalcInBundle = StatmechSourceCalcIn

--- a/schemas/python/tckdb-schemas/tckdb_schemas/statmech_bits.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/statmech_bits.py
@@ -33,7 +33,7 @@ schemas stay backend-side too, in ``app.schemas.entities.statmech`` —
 they describe persisted rows, which is not what a wire contract is for.
 """
 
-from typing import Self
+from typing import Self, TypeAlias
 
 from pydantic import Field, model_validator
 
@@ -140,4 +140,8 @@ class StatmechTorsionIn(SchemaBase):
 #: Historical name for :class:`StatmechSourceCalcIn`, kept importable so
 #: bundle-facing code and docs that spell it this way keep working. It is
 #: the same class object, so there is one OpenAPI component, not two.
-StatmechSourceCalcInBundle = StatmechSourceCalcIn
+#:
+#: Declared as an explicit ``TypeAlias`` because a bare ``X = SomeClass``
+#: assignment is a *variable* as far as a type checker is concerned, and
+#: annotating a field with it is an error rather than a synonym.
+StatmechSourceCalcInBundle: TypeAlias = StatmechSourceCalcIn

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -21,7 +21,6 @@ from tckdb_schemas.enums import (
     CalculationType,
     RigidRotorKind,
     ScientificOriginKind,
-    StatmechCalculationRole,
     StatmechTreatmentKind,
     ThermoCalculationRole,
     TorsionTreatmentKind,
@@ -51,7 +50,10 @@ from tckdb_schemas.fragments.refs import (
 )
 from tckdb_schemas.fragments.scan import CalculationScanResultCreate
 from tckdb_schemas.literature import LiteratureUploadRequest
-from tckdb_schemas.statmech_bits import StatmechTorsionCoordinateIn
+from tckdb_schemas.statmech_bits import (
+    StatmechSourceCalcIn,
+    StatmechTorsionCoordinateIn,
+)
 from tckdb_schemas.stationary_point import (
     StationaryPointFinding,
     evaluate_species_entry_frequency,
@@ -396,18 +398,14 @@ class ThermoInBundle(SchemaBase):
 # ---------------------------------------------------------------------------
 
 
-class StatmechSourceCalcInBundle(SchemaBase):
-    """Statmech → calc link by local key.
-
-    Mirrors ``ThermoSourceCalcInBundle``: only ``calculation_key`` is
-    accepted inside the bundle (DR-0029 Requirement 1). The key resolves
-    against the bundle's global calc-key namespace and is then attached
-    to the persisted statmech row as a ``StatmechSourceCalculation`` row
-    with the supplied scientific role.
-    """
-
-    calculation_key: str = Field(min_length=1)
-    role: StatmechCalculationRole
+#: Statmech → calc link by local key. Mirrors ``ThermoSourceCalcInBundle``:
+#: only ``calculation_key`` is accepted inside the bundle (DR-0029
+#: Requirement 1), resolving against the bundle's global calc-key
+#: namespace. This used to be a bundle-only class; it is now an alias for
+#: the shared :class:`~tckdb_schemas.statmech_bits.StatmechSourceCalcIn`,
+#: because the conformer and standalone-statmech paths express the same
+#: link the same way and one concept should be one wire component.
+StatmechSourceCalcInBundle = StatmechSourceCalcIn
 
 
 class StatmechTorsionInBundle(SchemaBase):

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -9,7 +9,7 @@ database FK ids are accepted anywhere** (DR-0029 Requirement 1).
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, TypeAlias
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -404,8 +404,10 @@ class ThermoInBundle(SchemaBase):
 #: namespace. This used to be a bundle-only class; it is now an alias for
 #: the shared :class:`~tckdb_schemas.statmech_bits.StatmechSourceCalcIn`,
 #: because the conformer and standalone-statmech paths express the same
-#: link the same way and one concept should be one wire component.
-StatmechSourceCalcInBundle = StatmechSourceCalcIn
+#: link the same way and one concept should be one wire component. A bare
+#: ``X = SomeClass`` assignment is a variable, not a type, to a type
+#: checker -- hence the explicit ``TypeAlias``.
+StatmechSourceCalcInBundle: TypeAlias = StatmechSourceCalcIn
 
 
 class StatmechTorsionInBundle(SchemaBase):

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
@@ -23,8 +23,8 @@ from tckdb_schemas.fragments.refs import (
 )
 from tckdb_schemas.literature import LiteratureUploadRequest
 from tckdb_schemas.statmech_bits import (
-    StatmechSourceCalculationCreate,
-    StatmechTorsionCreate,
+    StatmechSourceCalcIn,
+    StatmechTorsionIn,
 )
 from tckdb_schemas.stationary_point import (
     StationaryPointFinding,
@@ -54,6 +54,13 @@ class ConformerUploadStatmechPayload(SchemaBase):
     The backend resolves referenced software/workflow provenance, creates or
     reuses the owning ``Statmech`` row for the resolved species entry, and links
     the newly created upload calculation as a source calculation when requested.
+
+    ``source_calculations`` and ``torsions[*].source_scan_calculation_key``
+    address calculations by the local ``key`` the enclosing
+    ``ConformerUploadRequest`` put on its own primary/additional
+    calculations — never by row id. ``ConformerUploadRequest`` validates
+    that every such key was declared, so an unresolvable reference is a
+    422 rather than a silently dropped provenance link.
     """
 
     scientific_origin: ScientificOriginKind = ScientificOriginKind.computed
@@ -75,10 +82,8 @@ class ConformerUploadStatmechPayload(SchemaBase):
     note: str | None = None
 
     uploaded_calculation_role: StatmechCalculationRole | None = None
-    source_calculations: list[StatmechSourceCalculationCreate] = Field(
-        default_factory=list
-    )
-    torsions: list[StatmechTorsionCreate] = Field(default_factory=list)
+    source_calculations: list[StatmechSourceCalcIn] = Field(default_factory=list)
+    torsions: list[StatmechTorsionIn] = Field(default_factory=list)
     electronic_levels: list[ElectronicLevelIn] = Field(default_factory=list)
 
     @model_validator(mode="after")
@@ -93,6 +98,34 @@ class ConformerUploadStatmechPayload(SchemaBase):
         if len(set(indices)) != len(indices):
             raise ValueError(
                 "electronic_levels level_index values must be unique."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_unique_source_calculation_pairs(self) -> Self:
+        """Reject duplicate links the way the sibling paths already do.
+
+        ``statmech_source_calculation`` is keyed on
+        ``(statmech_id, calculation_id, role)``, so a repeated pair was a
+        primary-key violation surfacing as a 500. The bundle and
+        standalone statmech uploads validate this; the conformer path
+        did not.
+        """
+        pairs = [(sc.calculation_key, sc.role) for sc in self.source_calculations]
+        if len(set(pairs)) != len(pairs):
+            raise ValueError(
+                "statmech.source_calculations must be unique by "
+                "(calculation_key, role)."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_unique_torsion_indices(self) -> Self:
+        """One rotor per index, as the sibling upload paths already require."""
+        indices = [torsion.torsion_index for torsion in self.torsions]
+        if len(set(indices)) != len(indices):
+            raise ValueError(
+                "statmech.torsions torsion_index values must be unique."
             )
         return self
 
@@ -137,6 +170,26 @@ _ALLOWED_ADDITIONAL_TYPES = frozenset(
 )
 
 
+class ConformerCalculationIn(CalculationWithResultsPayload):
+    """A conformer-upload calculation that can be named by a local key.
+
+    The key is what the nested statmech block points at. It exists so a
+    depositor can say "the statmech's vibrational basis is *that* freq
+    job" using a name they chose, rather than a calculation row id they
+    would have to query for (DR-0029 Requirement 1).
+
+    Optional by design: a payload with no statmech cross-references never
+    needs one, and every payload written before keys existed stays valid.
+
+    :param key: Optional local name for this calculation, unique within
+        the request. Referenced from
+        ``statmech.source_calculations[*].calculation_key`` and
+        ``statmech.torsions[*].source_scan_calculation_key``.
+    """
+
+    key: str | None = Field(default=None, min_length=1)
+
+
 class ConformerUploadRequest(SchemaBase):
     """Workflow-facing conformer upload payload.
 
@@ -151,8 +204,8 @@ class ConformerUploadRequest(SchemaBase):
 
     species_entry: SpeciesEntryIdentityPayload
     geometry: GeometryPayload
-    calculation: CalculationWithResultsPayload
-    additional_calculations: list[CalculationWithResultsPayload] = Field(
+    calculation: ConformerCalculationIn
+    additional_calculations: list[ConformerCalculationIn] = Field(
         default_factory=list
     )
     statmech: ConformerUploadStatmechPayload | None = None
@@ -169,6 +222,54 @@ class ConformerUploadRequest(SchemaBase):
     def normalize_optional_text_fields(self) -> Self:
         self.note = normalize_optional_text(self.note)
         self.label = normalize_optional_text(self.label)
+        return self
+
+    def declared_calculation_keys(self) -> list[str]:
+        """Local keys this request put on its own calculations, in order."""
+        return [
+            calc.key
+            for calc in [self.calculation, *self.additional_calculations]
+            if calc.key is not None
+        ]
+
+    @model_validator(mode="after")
+    def validate_unique_calculation_keys(self) -> Self:
+        keys = self.declared_calculation_keys()
+        if len(set(keys)) != len(keys):
+            raise ValueError(
+                "Conformer upload calculation keys must be unique within "
+                "the request."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_statmech_calculation_keys_resolve(self) -> Self:
+        """Every statmech calc reference must name a calculation declared here.
+
+        The conformer upload has no other calc-key namespace to fall back
+        on, so an unrecognised key can only be a mistake. Refusing it is
+        the difference between a 422 the depositor can fix and a
+        provenance link that silently never existed.
+        """
+        if self.statmech is None:
+            return self
+        declared = set(self.declared_calculation_keys())
+        for index, source in enumerate(self.statmech.source_calculations):
+            if source.calculation_key not in declared:
+                raise ValueError(
+                    f"statmech.source_calculations[{index}].calculation_key "
+                    f"'{source.calculation_key}' does not name a calculation "
+                    f"declared in this upload. Put a matching 'key' on "
+                    f"'calculation' or on one of 'additional_calculations'."
+                )
+        for index, torsion in enumerate(self.statmech.torsions):
+            key = torsion.source_scan_calculation_key
+            if key is not None and key not in declared:
+                raise ValueError(
+                    f"statmech.torsions[{index}].source_scan_calculation_key "
+                    f"'{key}' does not name a calculation declared in this "
+                    f"upload."
+                )
         return self
 
     @model_validator(mode="after")

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
@@ -273,6 +273,31 @@ class ConformerUploadRequest(SchemaBase):
         return self
 
     @model_validator(mode="after")
+    def validate_primary_calculation_not_linked_twice(self) -> Self:
+        """One link per (calculation, role), counting the implicit one.
+
+        ``uploaded_calculation_role`` already links the primary
+        calculation. Naming that same calculation again with the same role
+        in ``source_calculations`` asks for two rows with one primary key,
+        which the database refuses — better said here, where the message
+        can name the field, than as a 500 mid-transaction.
+        """
+        if self.statmech is None:
+            return self
+        role = self.statmech.uploaded_calculation_role
+        primary_key = self.calculation.key
+        if role is None or primary_key is None:
+            return self
+        for index, source in enumerate(self.statmech.source_calculations):
+            if source.calculation_key == primary_key and source.role == role:
+                raise ValueError(
+                    f"statmech.source_calculations[{index}] links the primary "
+                    f"calculation '{primary_key}' with role '{role.value}', "
+                    f"which uploaded_calculation_role already links. Drop one."
+                )
+        return self
+
+    @model_validator(mode="after")
     def validate_additional_calculation_types(self) -> Self:
         for calc in self.additional_calculations:
             if calc.type not in _ALLOWED_ADDITIONAL_TYPES:


### PR DESCRIPTION
Closes #118. Closes #119.

`ConformerUploadRequest.statmech` asked a depositor for two database
primary keys:

- `StatmechSourceCalculationBase.calculation_id: int`
- `StatmechTorsionBase.source_scan_calculation_id: int | None`

#145 published both in `tckdb-schemas` 0.23.0 — correctly, since
relocating a contract and changing it are different acts — but a row id
is not something a depositor can know. The field was only usable by
something that had already queried the database, which is exactly the
coupling the "no FK IDs in upload schemas" rule and DR-0029 Requirement 1
exist to prevent. Fixing it now costs a contract correction; after a
client pins 0.23.0 it costs a deprecation path.

## What changed

**Keys, not ids.** Both fields become local string keys, matching what the
bundle path has always used:

```jsonc
// 0.23.0 — writable only by something holding calculation row ids
"statmech": {
  "source_calculations": [{"calculation_id": 4711, "role": "freq"}],
  "torsions": [{"torsion_index": 1, "dimension": 1,
                "source_scan_calculation_id": 4712, "coordinates": [...]}]
}

// 0.24.0
"calculation": {"key": "etoh_opt", "type": "opt", ...},
"additional_calculations": [
  {"key": "etoh_freq", "type": "freq", ...},
  {"key": "etoh_sp",   "type": "sp",   ...}
],
"statmech": {
  "source_calculations": [
    {"calculation_key": "etoh_freq", "role": "freq"},
    {"calculation_key": "etoh_sp",   "role": "sp"}
  ]
}
```

The conformer upload had no calc-key namespace to resolve against, so its
own calculations gained an optional `key` (`ConformerCalculationIn`), and
the request refuses a statmech reference to a key nobody declared — a 422
the depositor can act on, rather than a provenance link that silently
never existed. Key → row id resolution happens in
`resolve_or_create_statmech`, never in a schema.

**One concept, one component.** `StatmechTorsionCoordinateIn`,
`StatmechTorsionCoordinateBase` and `StatmechTorsionCoordinateCreate` were
field-for-field and validator-for-validator identical, so a generator
emitted two classes for one atom quartet. One class remains, and
`StatmechTorsionCoordinateRead` inherits it instead of restating the five
indices. Making the conformer path key-based left
`StatmechTorsionCreate` byte-identical to the standalone path's
`StatmechTorsionIn`, and three identical source-calc classes; those
collapsed too rather than shipping a fresh duplicate.

**Also tightened**, matching what the sibling upload paths already
enforce (each of these was a 500, not a 422, before):

- `statmech.source_calculations` unique by `(calculation_key, role)` — it
  is the row's primary key.
- `statmech.torsions[].torsion_index` unique.
- The primary calculation cannot be linked twice, once implicitly via
  `uploaded_calculation_role` and once explicitly with the same role.

## OpenAPI components

Removed 5, added 2, no path changed:

| Removed | Replaced by |
|---|---|
| `StatmechSourceCalculationCreate` | `StatmechSourceCalcIn` |
| `StatmechSourceCalcInBundle` | `StatmechSourceCalcIn` (alias kept importable) |
| `StatmechSourceCalculationIn` | `StatmechSourceCalcIn` (alias kept importable) |
| `StatmechTorsionCreate` | `StatmechTorsionIn` |
| `StatmechTorsionCoordinateCreate` | `StatmechTorsionCoordinateIn` |

Added: `StatmechSourceCalcIn`, `ConformerCalculationIn`.
Changed in place: `BundleStatmechIn`, `ConformerUploadRequest`,
`ConformerUploadStatmechPayload`, `StatmechInBundle`,
`StatmechTorsionCoordinateIn` (docstring), `StatmechTorsionCoordinateRead`
(docstring), `StatmechTorsionIn` (`source_scan_calculation_key` gained
`minLength: 1`), `StatmechUploadRequest`.

## Versions

- `tckdb-schemas` 0.23.0 → **0.24.0**, with a BREAKING changelog entry in
  the package README carrying the migration snippet.
- `tckdb-client` stays at 0.35.0: it imports only
  `tckdb_schemas.fragments.execution_environment`, constructs no conformer
  statmech payload, and emits `calculation_key` already on the bundle
  paths. Its `tckdb-schemas>=0.10.0` floor still holds.

No migration: this is a contract change, not a schema change. Alembic head
is unchanged at `d4e9b1c7a253`.

## Verification

Three gates, plus the snapshot step CI runs separately:

| Gate | Result |
|---|---|
| `test-rest.sh` | 4143 passed, 14 skipped |
| `test-api.sh` | 2572 passed |
| `test-scientific.sh` | 2039 passed |
| `test_openapi_snapshot.py` | 3 passed |
| `schemas/python/tckdb-schemas/tests` | 38 passed |

Beyond validation, `test_live_conformer_route_links_statmech_by_key_not_id`
POSTs a statmech-bearing conformer body — built in a subprocess where
`app` is not importable, so it is genuinely wire-only — through
`POST /api/v1/uploads/conformers` and asserts the persisted
`statmech_source_calculation` set is exactly
`{(freq calc, role=freq)}`. Not "a freq link exists": exactly that one, so
a workflow that ignored the key and linked the primary sp calculation
instead goes red.

Mutation-checked, one mutation at a time, each reverted:

| Mutation | Went red | Else moved |
|---|---|---|
| `calculation_id` re-added to `StatmechSourceCalcIn` | `test_statmech_source_calculation_rejects_raw_calculation_id` | nothing (667 other tests green) |
| conformer workflow maps every key to the primary calc id | `test_live_conformer_route_links_statmech_by_key_not_id` | nothing |
| `StatmechTorsionCoordinateRead` restates its fields instead of inheriting | both #119 guards + the golden snapshot | nothing |

The first mutation is why the FK-rejection test no longer matches on
`str(ValidationError)`: Pydantic echoes the offending input into the
message, so `"calculation_id" in str(exc)` stayed true even with the field
accepted. It now requires an `extra_forbidden` error at that exact
location.

## Not in this PR

Adjacent findings, deliberately left for their own tasks:

- `backend/app/workflows/conformer.py:205` — `applied_energy_corrections`
  `source_conformer_key` / `source_calculation_key` are only tested for
  non-`None`; any string resolves to the primary observation/calculation.
  A real namespace now exists to resolve them against.
- `schemas/.../computed_species_upload.py:411` and
  `schemas/.../computed_reaction_upload.py:320` —
  `StatmechTorsionInBundle` and `BundleStatmechTorsionIn` are identical,
  field-for-field and validator-for-validator. #119 one level up.
- Statmech source links have no role↔calculation-type compatibility check;
  thermo has one (`backend/app/workflows/thermo.py:64`, DR-0028 Req 1).
- `backend/app/db/models/statmech.py:251` — no unique constraint on
  `(statmech_id, torsion_index)`; all three upload paths now reject it,
  but no other writer is stopped.

## One more thing CI caught that local mypy did not

The compatibility aliases were first written as bare assignments
(`StatmechSourceCalculationIn = StatmechSourceCalcIn`). To a type checker
that is a *variable*, so `list[StatmechSourceCalculationIn]` is not a
valid annotation and the element type is lost entirely. Local mypy 2.1
was silent; CI's 2.3 was not. They are now explicit `TypeAlias`
declarations, in the backend module and in both spellings inside the wire
package.

