### PR TITLE
Stop letting n_imag travel alone, and close the tau-basis vocabulary

### DIFF
--- a/backend/alembic/versions/e2a7c9d4b615_close_the_tau_basis_vocabulary.py
+++ b/backend/alembic/versions/e2a7c9d4b615_close_the_tau_basis_vocabulary.py
@@ -1,0 +1,145 @@
+"""close the tau-basis vocabulary at the write side
+
+``c2f7a4e8d1b6`` added ``calc_freq_result.imaginary_mode_tau_basis`` as
+plain ``TEXT``. It carries which row of ADR 0012's protocol table set the
+tolerance a record's imaginary modes were judged at, and the only thing
+that has ever written it is ``TauBasis(...).value`` -- so every stored
+value is one of five tokens by construction and by nothing else. Nothing
+in the schema said so, which means a typo in a future write path, a bulk
+loader, or a restore from a hand-edited dump reaches a reader as a
+tolerance basis that no protocol table row corresponds to. A reader
+cannot tell that from a basis a newer TCKDB knows about and this one does
+not, and the two want opposite responses.
+
+This revision closes the vocabulary at the write side only. The read side
+deliberately stays open: ``imaginary_mode_tau_basis`` remains ``str`` on
+the wire, never the enum, so a value this build does not recognise is
+*displayed* rather than made to refuse the whole record. ADR 0012's
+argument for accepting a flagged record instead of refusing it is the
+same argument, one level down.
+
+**A CHECK, not a native enum.** Three reasons, in order of weight. The
+ORM column stays ``TEXT`` (above), and a native enum type under a
+``TEXT`` mapping is a mismatch waiting to surprise a writer. A CHECK,
+unlike a foreign key, still holds under
+``session_replication_role = replica`` -- which is what bulk loaders and
+restore paths run under, and those are exactly the writers this exists
+for (``tests/db/test_element_symbol_canonicality.py`` measures that
+split). And extending the vocabulary later is a constraint swap in one
+revision with a working ``downgrade()``, where ``ALTER TYPE ... ADD
+VALUE`` cannot be undone.
+
+**No backfill, and a refusal instead of one.** ``upgrade()`` first asks
+the database what it actually holds. Every value it finds must be one of
+the five, or NULL; anything else and the migration raises with the
+offending values named, rather than deleting them, coercing them to
+``protocol_not_recorded`` (which would be a claim about how a record was
+judged, and a false one), or dropping the constraint. There is no honest
+repair available at migration time for a tolerance basis nobody
+recognises: only the writer that produced it knows what it meant.
+
+Measured before choosing the vocabulary, and this is what the measurement
+was: the column has existed only since ``c2f7a4e8d1b6``, which added it
+nullable and backfilled nothing; ``app/services/calculation_resolution.py``
+is its sole writer and writes ``tau.basis.value``; and ``TauBasis``'s five
+members have never been renamed or removed since they were introduced in
+the same commit. So the expected finding on every database is "five
+tokens or NULL" -- and the guard is there because "expected" is not
+"verified on a machine this migration has not seen".
+
+Revision ID: e2a7c9d4b615
+Revises: d4e9b1c7a253
+Create Date: 2026-08-12
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e2a7c9d4b615"
+down_revision: Union[str, Sequence[str], None] = "d4e9b1c7a253"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "calc_freq_result"
+_COLUMN = "imaginary_mode_tau_basis"
+
+#: The **short** name, as the model spells it. ``alembic/env.py`` hands
+#: Alembic ``Base.metadata``, whose ``NAMING_CONVENTION`` expands this to
+#: ``ck_calc_freq_result_imaginary_mode_tau_basis_known``. Passing the
+#: already-expanded name here instead expands it a second time and
+#: PostgreSQL truncates the result to 63 characters with a hash suffix --
+#: which is what ``c2f7a4e8d1b6`` did, leaving
+#: ``ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2`` on
+#: ``calc_freq_mode``. That constraint enforces the right rule under the
+#: wrong name; this one is spelled so the database agrees with the model.
+_CONSTRAINT = "imaginary_mode_tau_basis_known"
+
+#: What the database ends up calling it, for the error messages and the
+#: tests that read ``pg_constraint``.
+_CONSTRAINT_IN_DB = f"ck_{_TABLE}_{_CONSTRAINT}"
+
+#: ``tckdb_schemas.stationary_point.TauBasis``, spelled out rather than
+#: imported: a migration must keep meaning what it meant when it ran, and
+#: an import would let a later edit to the enum silently change what this
+#: revision did. Mirrored in
+#: ``app.db.models.common.IMAGINARY_MODE_TAU_BASIS_VALUES``; the two are
+#: pinned together by
+#: ``tests/db/test_imaginary_mode_tau_basis_constraint.py``.
+_TAU_BASIS_VALUES: tuple[str, ...] = (
+    "analytic_tight",
+    "analytic_default",
+    "finite_difference_gradient",
+    "finite_difference_energy",
+    "protocol_not_recorded",
+)
+
+
+def _condition() -> str:
+    values = ", ".join(f"'{value}'" for value in _TAU_BASIS_VALUES)
+    return f"{_COLUMN} IS NULL OR {_COLUMN} IN ({values})"
+
+
+def _refuse_unclassifiable_values() -> None:
+    """Stop rather than guess if the column holds something unexpected.
+
+    Named in full in the error, because the next question anyone asks is
+    "which values?" and a migration that answers it is a migration whose
+    failure is actionable.
+    """
+    bind = op.get_bind()
+    unknown = bind.execute(
+        sa.text(
+            f"SELECT DISTINCT {_COLUMN} FROM {_TABLE} "
+            f"WHERE {_COLUMN} IS NOT NULL "
+            f"AND {_COLUMN} <> ALL(:known) "
+            f"ORDER BY {_COLUMN}"
+        ),
+        {"known": list(_TAU_BASIS_VALUES)},
+    ).scalars().all()
+    if unknown:
+        raise RuntimeError(
+            f"{_TABLE}.{_COLUMN} holds {len(unknown)} value(s) that are not "
+            f"rows of ADR 0012's protocol table: {unknown!r}. This migration "
+            "will not guess what they meant: coercing them to "
+            "'protocol_not_recorded' would assert that those records were "
+            "judged at the conservative tolerance, which is a claim about "
+            "their science that only whatever wrote them can make. Repair "
+            "the rows (or add the value to _TAU_BASIS_VALUES in this "
+            "revision, if it is a legitimate basis this branch predates) and "
+            "re-run."
+        )
+
+
+def upgrade() -> None:
+    """Constrain ``imaginary_mode_tau_basis`` to ADR 0012's five bases."""
+    _refuse_unclassifiable_values()
+    op.create_check_constraint(_CONSTRAINT, _TABLE, _condition())
+
+
+def downgrade() -> None:
+    """Reopen the column to free text, as ``c2f7a4e8d1b6`` left it."""
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")

--- a/backend/alembic/versions/e2a7c9d4b615_close_the_tau_basis_vocabulary.py
+++ b/backend/alembic/versions/e2a7c9d4b615_close_the_tau_basis_vocabulary.py
@@ -78,8 +78,10 @@ _COLUMN = "imaginary_mode_tau_basis"
 #: wrong name; this one is spelled so the database agrees with the model.
 _CONSTRAINT = "imaginary_mode_tau_basis_known"
 
-#: What the database ends up calling it, for the error messages and the
-#: tests that read ``pg_constraint``.
+#: What the database ends up calling it, once the convention has expanded
+#: the short name. Named in the refusal below so an operator reading the
+#: failure knows which constraint is *not* installed, and read back by
+#: ``tests/db/test_imaginary_mode_tau_basis_constraint.py``.
 _CONSTRAINT_IN_DB = f"ck_{_TABLE}_{_CONSTRAINT}"
 
 #: ``tckdb_schemas.stationary_point.TauBasis``, spelled out rather than
@@ -127,8 +129,9 @@ def _refuse_unclassifiable_values() -> None:
             "will not guess what they meant: coercing them to "
             "'protocol_not_recorded' would assert that those records were "
             "judged at the conservative tolerance, which is a claim about "
-            "their science that only whatever wrote them can make. Repair "
-            "the rows (or add the value to _TAU_BASIS_VALUES in this "
+            "their science that only whatever wrote them can make. "
+            f"{_CONSTRAINT_IN_DB} was not installed and nothing was changed. "
+            "Repair the rows (or add the value to _TAU_BASIS_VALUES in this "
             "revision, if it is a legitimate basis this branch predates) and "
             "re-run."
         )

--- a/backend/app/db/models/calculation.py
+++ b/backend/app/db/models/calculation.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 
 from app.db.base import Base, CreatedByMixin, PublicRefMixin, TimestampMixin
 from app.db.models.common import (
+    IMAGINARY_MODE_TAU_BASIS_VALUES,
     ArtifactIntegrityDetectionContext,
     ArtifactIntegrityFinding,
     ArtifactKind,
@@ -516,6 +517,18 @@ class CalculationFreqResult(Base):
     #: every historical record, and ADR 0012's whole point is that a
     #: reader can see what was decided and on what basis.
     imaginary_mode_tau_cm1: Mapped[Optional[float]] = mapped_column(nullable=True)
+    #: Typed ``str`` rather than the ``TauBasis`` enum **on purpose**, and
+    #: only on the wire: a reader must be shown a basis this build does
+    #: not recognise rather than have the whole record refused for it.
+    #: That argument does not extend to the write side, where an
+    #: unrecognised value is a typo rather than a newer writer, so the
+    #: vocabulary is constrained in the database by
+    #: ``imaginary_mode_tau_basis_known`` below. A CHECK rather than a
+    #: native enum because the column stays ``TEXT`` in the ORM — and
+    #: because a CHECK, unlike a foreign key, still holds under
+    #: ``session_replication_role = replica``, which is what bulk loaders
+    #: and restore paths run under (see
+    #: ``tests/db/test_element_symbol_canonicality.py``).
     imaginary_mode_tau_basis: Mapped[Optional[str]] = mapped_column(
         Text, nullable=True
     )
@@ -537,6 +550,15 @@ class CalculationFreqResult(Base):
         ),
         order_by="CalculationFreqMode.mode_index",
         viewonly=True,
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "imaginary_mode_tau_basis IS NULL OR imaginary_mode_tau_basis IN ("
+            + ", ".join(f"'{value}'" for value in IMAGINARY_MODE_TAU_BASIS_VALUES)
+            + ")",
+            name="imaginary_mode_tau_basis_known",
+        ),
     )
 
 

--- a/backend/app/db/models/common.py
+++ b/backend/app/db/models/common.py
@@ -92,6 +92,32 @@ class HessianMethod(str, Enum):
     finite_difference_energy = "finite_difference_energy"
 
 
+#: Every value ``calc_freq_result.imaginary_mode_tau_basis`` may hold --
+#: which row of ADR 0012's protocol table set the tolerance this record
+#: was judged at. A tuple rather than an ``Enum`` because the column is
+#: deliberately ``TEXT`` in the ORM and ``str`` on the wire: a reader must
+#: be shown a basis this build does not recognise rather than have the
+#: record refused for it. The vocabulary is nonetheless closed at the
+#: *write* side, by a CHECK constraint built from this tuple in
+#: :class:`app.db.models.calculation.CalculationFreqResult`, because an
+#: unrecognised value written by *this* build is a typo and not a newer
+#: writer.
+#:
+#: Mirrors ``tckdb_schemas.stationary_point.TauBasis``, which is the sole
+#: producer of the stored values. Duplicated rather than imported, for
+#: the same reason the enums above are duplicated; the two are pinned
+#: together by ``tests/db/test_imaginary_mode_tau_basis_constraint.py``,
+#: so adding a ``TauBasis`` member without migrating the constraint fails
+#: there rather than at the first upload that uses it.
+IMAGINARY_MODE_TAU_BASIS_VALUES: tuple[str, ...] = (
+    "analytic_tight",
+    "analytic_default",
+    "finite_difference_gradient",
+    "finite_difference_energy",
+    "protocol_not_recorded",
+)
+
+
 class ConformerSelectionKind(str, Enum):
     display_default = "display_default"
     curator_pick = "curator_pick"

--- a/backend/app/schemas/reads/scientific_calculation.py
+++ b/backend/app/schemas/reads/scientific_calculation.py
@@ -243,12 +243,87 @@ class CalculationFreqResultSummary(BaseModel):
     Per-mode arrays are intentionally omitted here; the full per-mode
     array is served under the dedicated ``include=freq_modes`` heavy
     include (see :class:`CalculationFreqModeSummary`).
+
+    **``n_imag`` does not travel alone.** ADR 0012 retired counting
+    imaginary modes in favour of judging them by magnitude against the
+    protocol that produced them, and requires that wherever ``n_imag``
+    is reported it is accompanied by the tolerance applied, how that
+    tolerance was chosen, and the count above it. It is reported here
+    anyway — it is what the ESS printed — but a consumer that filters on
+    ``n_imag == 1`` and stops is selecting on a quantity ADR 0012 shows
+    is a property of the method, grid and Hessian algorithm as much as of
+    the structure: two correct calculations of the same saddle point can
+    return 1 and 3.
+
+    ``imaginary_mode_structural_flag`` is the field that makes that
+    filter safe, and it is the reason these fields are on the *cheap*
+    projection rather than behind an opt-in include. It is ADR 0012's
+    structural exclusion signal: true means the record carries an
+    imaginary mode at or above tau beyond its designated reaction
+    coordinate, so it is a genuine higher-order saddle — accepted,
+    because that can be correct chemistry, but excluded from default
+    transition-state consumption. A flag a consumer has to know to ask
+    for does not protect the consumer who did not know.
+
+    Every field here is read straight off the stored row. Nothing is
+    re-resolved: ADR 0012 requires tau to be *stored* precisely so that a
+    later parser improvement cannot silently re-decide a historical
+    judgement, and recomputing it to fill this block would be that
+    defect. The one derived field is
+    :attr:`n_imag_at_or_above_tau`, which compares stored magnitudes
+    against the stored tau and resolves nothing.
+
+    ``imaginary_mode_tau_basis`` is typed ``str``, not the ``TauBasis``
+    enum, deliberately: a value this build of the API does not recognise
+    must be *displayed* rather than rejected, because the record is what
+    it is and a reader is owed it. The vocabulary is nonetheless
+    constrained at the database level
+    (``ck_calc_freq_result_imaginary_mode_tau_basis_known``), so an
+    unrecognised value means a newer writer, never a typo.
+
+    All four ADR 0012 fields are ``None`` together on a record deposited
+    before that decision shipped. That is "never judged under ADR 0012",
+    which is a different fact from "judged and not flagged" and is not
+    collapsed into ``false``/``0`` here any more than it was backfilled
+    in the migration that added the columns.
     """
 
     n_imag: int | None = None
     imag_freq_cm1: float | None = None
     zpe_hartree: float | None = None
     zpe_uncertainty_hartree: float | None = None
+
+    #: ``mode_index`` of the mode the depositor designated the reaction
+    #: coordinate. ADR 0012 makes designating exactly one mode the
+    #: contract that replaced the ``n_imag == 1`` gate, so its absence on
+    #: a multi-imaginary-mode transition state is a finding.
+    reaction_coordinate_mode_index: int | None = None
+
+    #: The ADR 0012 tolerance actually applied to this record (cm-1) and
+    #: which row of the protocol table chose it. Two records with the
+    #: same frequency list and different tau were judged differently, and
+    #: neither is wrong: tau is a statement about the noise floor of the
+    #: protocol, not about the chemistry.
+    imaginary_mode_tau_cm1: float | None = None
+    imaginary_mode_tau_basis: str | None = None
+
+    #: ADR 0012's structural flag. See the class docstring: this is the
+    #: exclusion signal, and null means "never judged", not "clean".
+    imaginary_mode_structural_flag: bool | None = None
+
+    #: How many of the stored imaginary modes have ``|omega| >= tau``,
+    #: counting the designated reaction coordinate. The one derived field
+    #: on this projection, and derived only by comparing two persisted
+    #: numbers — the same bare comparison
+    #: :class:`TauRankedModeEntry.at_or_above_tau` reports per mode.
+    #:
+    #: ``None`` where the count cannot honestly be taken: when no tau is
+    #: stored (nothing to compare against), or when the record reports
+    #: imaginary modes but stores no per-mode rows to count (``n_imag``
+    #: without a frequency list). ``0`` is a measurement — tau was known
+    #: and nothing reached it — and is not returned in either of those
+    #: cases.
+    n_imag_at_or_above_tau: int | None = None
 
 
 class CalculationFreqModeSummary(BaseModel):

--- a/backend/app/services/scientific_read/calculations.py
+++ b/backend/app/services/scientific_read/calculations.py
@@ -1000,9 +1000,46 @@ def _build_opt_summary(
 def _build_freq_summary(
     session: Session, calculation_id: int
 ) -> CalculationResultSummary | None:
-    row = session.get(CalculationFreqResult, calculation_id)
-    if row is None:
+    """Project ``calc_freq_result``, ADR 0012 judgement included.
+
+    One statement per record, which is what it cost before ADR 0012's
+    fields joined the projection: the two mode counts ride along as
+    correlated aggregates on the same SELECT rather than as a second
+    round trip, because this builder runs once per record on a search
+    page and a second round trip here would be multiplied by the page
+    size. See ``tests/services/scientific_read/
+    test_record_builder_statement_cost.py``.
+    """
+    imaginary = (
+        CalculationFreqMode.calculation_id == CalculationFreqResult.calculation_id,
+        CalculationFreqMode.is_imaginary.is_(True),
+    )
+    stored_imaginary_modes = (
+        select(func.count())
+        .select_from(CalculationFreqMode)
+        .where(*imaginary)
+        .correlate(CalculationFreqResult)
+        .scalar_subquery()
+    )
+    at_or_above_tau = (
+        select(func.count())
+        .select_from(CalculationFreqMode)
+        .where(
+            *imaginary,
+            func.abs(CalculationFreqMode.frequency_cm1)
+            >= CalculationFreqResult.imaginary_mode_tau_cm1,
+        )
+        .correlate(CalculationFreqResult)
+        .scalar_subquery()
+    )
+    fetched = session.execute(
+        select(CalculationFreqResult, stored_imaginary_modes, at_or_above_tau).where(
+            CalculationFreqResult.calculation_id == calculation_id
+        )
+    ).first()
+    if fetched is None:
         return None
+    row, stored_imaginary, above_tau = fetched
     return CalculationResultSummary(
         kind="freq",
         freq=CalculationFreqResultSummary(
@@ -1010,8 +1047,48 @@ def _build_freq_summary(
             imag_freq_cm1=row.imag_freq_cm1,
             zpe_hartree=row.zpe_hartree,
             zpe_uncertainty_hartree=row.zpe_uncertainty_hartree,
+            reaction_coordinate_mode_index=row.reaction_coordinate_mode_index,
+            imaginary_mode_tau_cm1=row.imaginary_mode_tau_cm1,
+            imaginary_mode_tau_basis=row.imaginary_mode_tau_basis,
+            imaginary_mode_structural_flag=row.imaginary_mode_structural_flag,
+            n_imag_at_or_above_tau=_count_at_or_above_tau(
+                tau_cm1=row.imaginary_mode_tau_cm1,
+                n_imag=row.n_imag,
+                stored_imaginary_modes=stored_imaginary,
+                at_or_above_tau=above_tau,
+            ),
         ),
     )
+
+
+def _count_at_or_above_tau(
+    *,
+    tau_cm1: float | None,
+    n_imag: int | None,
+    stored_imaginary_modes: int,
+    at_or_above_tau: int,
+) -> int | None:
+    """ADR 0012's "count above tau", or ``None`` where it cannot be taken.
+
+    Two ways it cannot be taken, and both would otherwise be reported as
+    a confident ``0``:
+
+    - **No tau is stored.** The record was never judged under ADR 0012
+      (every column it added is nullable and nothing was backfilled), so
+      there is no threshold to count against. Counting against a tau
+      resolved *now* is exactly what ADR 0012 forbids — it would let a
+      parser improvement silently re-decide a historical record.
+    - **No per-mode rows.** ``calc_freq_mode`` is optional: an upload may
+      carry ``n_imag`` with no frequency list. SQL then counts zero modes
+      at or above tau, which is true of the stored rows and false of the
+      record. ``n_imag == 0`` is the one case where the absence of rows
+      is itself the answer.
+    """
+    if tau_cm1 is None:
+        return None
+    if stored_imaginary_modes == 0 and n_imag != 0:
+        return None
+    return at_or_above_tau
 
 
 def _build_scan_summary(

--- a/backend/docs/specs/scientific_calculation_reads.md
+++ b/backend/docs/specs/scientific_calculation_reads.md
@@ -334,7 +334,7 @@ page a caller reached with `include=all`. Unknown tokens → 422
 
 | Include | Adds field(s) | Backed by |
 |---|---|---|
-| `results` | `results: CalculationResultSummary` (one of `sp\|opt\|freq\|scan\|irc\|path_search`) | `calc_*_result` tables |
+| `results` | `results: CalculationResultSummary` (one of `sp\|opt\|freq\|scan\|irc\|path_search`). The `freq` block carries ADR 0012's judgement alongside `n_imag`, not behind an opt-in: `imaginary_mode_tau_cm1`, `imaginary_mode_tau_basis`, `reaction_coordinate_mode_index`, `imaginary_mode_structural_flag` and the derived `n_imag_at_or_above_tau`. See §4.5.1. | `calc_*_result` tables |
 | `dependencies` | `dependencies: list[CalculationDependencySummary]` (parent + child links with role + ref) | `calculation_dependency` |
 | `parameters` | `parameters: list[CalculationParameterSummary]` (raw + canonical) | `calculation_parameter` |
 | `constraints` | `constraints: list[CalculationConstraintSummary]` | `calculation_constraint` |
@@ -359,6 +359,43 @@ stable across opt-in expansions).
 When a section **is** in the include set but the underlying table has no
 rows for this calculation, the field is present with the empty value
 (`[]` for arrays, `null` for nullable singletons).
+
+#### 4.5.1 `results.freq` — `n_imag` never travels alone
+
+ADR 0012 retired counting imaginary modes in favour of judging them by
+magnitude against the protocol that produced them, and requires that
+wherever `n_imag` is reported it is accompanied by the tolerance applied,
+how that tolerance was chosen, and the count above it. The `freq` block
+therefore carries all of it:
+
+| Field | Meaning |
+|---|---|
+| `n_imag`, `imag_freq_cm1` | What the ESS printed. `n_imag` alone is **not** a safe filter: two correct calculations of the same saddle point can report 1 and 3. |
+| `reaction_coordinate_mode_index` | The `mode_index` the depositor designated the reaction coordinate. ADR 0012 makes designating exactly one mode the contract that replaced the `n_imag == 1` gate. |
+| `imaginary_mode_tau_cm1` | The tolerance actually applied, in cm⁻¹. |
+| `imaginary_mode_tau_basis` | Which row of ADR 0012's protocol table chose it. Typed `str`, **not** an enum, so a value a newer writer produced is displayed rather than made to refuse the record; the vocabulary is closed at the database instead (`ck_calc_freq_result_imaginary_mode_tau_basis_known`, revision `e2a7c9d4b615`). |
+| `imaginary_mode_structural_flag` | ADR 0012's structural exclusion signal: an imaginary mode at or above τ beyond the designated reaction coordinate. **This is the field that makes an `n_imag == 1` filter safe**, which is why it is on the cheap projection rather than behind an include — a flag a consumer must know to ask for does not protect the consumer who did not know. |
+| `n_imag_at_or_above_tau` | How many stored imaginary modes have `\|ω\| >= τ`, counting the reaction coordinate. The same bare comparison `tau_context.modes[].at_or_above_tau` reports per mode. |
+
+All four persisted fields are `null` together on a record deposited before
+ADR 0012 shipped — "never judged", which is a different fact from "judged
+and not flagged" and is not collapsed into `false`/`0` here any more than
+it was backfilled by `c2f7a4e8d1b6`. `n_imag_at_or_above_tau` is also
+`null` where no τ is stored, and where the record reports imaginary modes
+but stores no `calc_freq_mode` rows to count (there, `0` would describe
+the stored rows and misdescribe the record).
+
+Nothing here is re-resolved at read time: ADR 0012 requires τ to be
+*stored* precisely so a later parser improvement cannot silently
+re-decide a historical judgement. The single derived field compares two
+persisted numbers.
+
+Cost: **zero additional statements.** The four columns were already on the
+row this projection loads, and the count rides along as a correlated
+aggregate on the same `SELECT` rather than a second round trip — this
+builder runs once per record, so a second round trip here is multiplied by
+the page size. Pinned by
+`tests/services/scientific_read/test_record_builder_statement_cost.py::test_the_adr_0012_fields_cost_no_extra_statement_per_record`.
 
 ### 4.6 Review/trust behavior
 

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -973,6 +973,10 @@ Table calc_freq_result {
   imaginary_mode_tau_cm1 double
   imaginary_mode_tau_basis text
   imaginary_mode_structural_flag boolean
+
+  checks {
+    `imaginary_mode_tau_basis IS NULL OR imaginary_mode_tau_basis IN ('analytic_tight', 'analytic_default', 'finite_difference_gradient', 'finite_difference_energy', 'protocol_not_recorded')` [name: 'ck_calc_freq_result_imaginary_mode_tau_basis_known']
+  }
 }
 
 Table calc_geometry_validation {

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -4210,7 +4210,7 @@
         "type": "object"
       },
       "CalculationFreqResultSummary": {
-        "description": "Summary projection of a ``calc_freq_result`` row.\n\nPer-mode arrays are intentionally omitted here; the full per-mode\narray is served under the dedicated ``include=freq_modes`` heavy\ninclude (see :class:`CalculationFreqModeSummary`).",
+        "description": "Summary projection of a ``calc_freq_result`` row.\n\nPer-mode arrays are intentionally omitted here; the full per-mode\narray is served under the dedicated ``include=freq_modes`` heavy\ninclude (see :class:`CalculationFreqModeSummary`).\n\n**``n_imag`` does not travel alone.** ADR 0012 retired counting\nimaginary modes in favour of judging them by magnitude against the\nprotocol that produced them, and requires that wherever ``n_imag``\nis reported it is accompanied by the tolerance applied, how that\ntolerance was chosen, and the count above it. It is reported here\nanyway — it is what the ESS printed — but a consumer that filters on\n``n_imag == 1`` and stops is selecting on a quantity ADR 0012 shows\nis a property of the method, grid and Hessian algorithm as much as of\nthe structure: two correct calculations of the same saddle point can\nreturn 1 and 3.\n\n``imaginary_mode_structural_flag`` is the field that makes that\nfilter safe, and it is the reason these fields are on the *cheap*\nprojection rather than behind an opt-in include. It is ADR 0012's\nstructural exclusion signal: true means the record carries an\nimaginary mode at or above tau beyond its designated reaction\ncoordinate, so it is a genuine higher-order saddle — accepted,\nbecause that can be correct chemistry, but excluded from default\ntransition-state consumption. A flag a consumer has to know to ask\nfor does not protect the consumer who did not know.\n\nEvery field here is read straight off the stored row. Nothing is\nre-resolved: ADR 0012 requires tau to be *stored* precisely so that a\nlater parser improvement cannot silently re-decide a historical\njudgement, and recomputing it to fill this block would be that\ndefect. The one derived field is\n:attr:`n_imag_at_or_above_tau`, which compares stored magnitudes\nagainst the stored tau and resolves nothing.\n\n``imaginary_mode_tau_basis`` is typed ``str``, not the ``TauBasis``\nenum, deliberately: a value this build of the API does not recognise\nmust be *displayed* rather than rejected, because the record is what\nit is and a reader is owed it. The vocabulary is nonetheless\nconstrained at the database level\n(``ck_calc_freq_result_imaginary_mode_tau_basis_known``), so an\nunrecognised value means a newer writer, never a typo.\n\nAll four ADR 0012 fields are ``None`` together on a record deposited\nbefore that decision shipped. That is \"never judged under ADR 0012\",\nwhich is a different fact from \"judged and not flagged\" and is not\ncollapsed into ``false``/``0`` here any more than it was backfilled\nin the migration that added the columns.",
         "properties": {
           "imag_freq_cm1": {
             "anyOf": [
@@ -4223,6 +4223,39 @@
             ],
             "title": "Imag Freq Cm1"
           },
+          "imaginary_mode_structural_flag": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imaginary Mode Structural Flag"
+          },
+          "imaginary_mode_tau_basis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imaginary Mode Tau Basis"
+          },
+          "imaginary_mode_tau_cm1": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imaginary Mode Tau Cm1"
+          },
           "n_imag": {
             "anyOf": [
               {
@@ -4233,6 +4266,28 @@
               }
             ],
             "title": "N Imag"
+          },
+          "n_imag_at_or_above_tau": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N Imag At Or Above Tau"
+          },
+          "reaction_coordinate_mode_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reaction Coordinate Mode Index"
           },
           "zpe_hartree": {
             "anyOf": [

--- a/backend/tests/api/scientific/test_api_freq_result_adr0012_fields.py
+++ b/backend/tests/api/scientific/test_api_freq_result_adr0012_fields.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 
+from app.db.models.calculation import CalculationFreqResult
 from app.db.models.common import CalculationType, ImaginaryModeDisposition
 from tests.services.scientific_read._factories import (
     attach_freq_result,
@@ -180,6 +181,43 @@ def test_never_judged_reports_nulls_rather_than_a_clean_bill(client, db_session)
     assert freq["imaginary_mode_tau_basis"] is None
     assert freq["imaginary_mode_structural_flag"] is None
     assert freq["n_imag_at_or_above_tau"] is None
+
+
+def test_a_count_with_nothing_to_count_over_is_null_not_zero(client, db_session):
+    """``n_imag`` without a frequency list: the count is not takeable.
+
+    ``calc_freq_mode`` is optional -- an upload may carry ``n_imag`` and
+    no per-mode rows -- and the count above tau is taken over those rows.
+    SQL answers 0, which is true of the stored rows and false of the
+    record, and 0 here would read as "one imaginary mode, none of them
+    above tau", i.e. a clean soft mode. This is the branch that separates
+    "measured nothing above tau" from "had nothing to measure", and it is
+    unreachable through the factory's ordinary path, so the row is built
+    directly.
+    """
+    calc = _freq_calc(db_session)
+    db_session.add(
+        CalculationFreqResult(
+            calculation_id=calc.id,
+            n_imag=1,
+            imag_freq_cm1=-58.0,
+            imaginary_mode_tau_cm1=30.0,
+            imaginary_mode_tau_basis="analytic_default",
+            imaginary_mode_structural_flag=False,
+        )
+    )
+    db_session.flush()
+
+    freq = _read_freq_block(client, calc)
+
+    assert freq["n_imag"] == 1
+    assert freq["imaginary_mode_tau_cm1"] == 30.0
+    assert freq["n_imag_at_or_above_tau"] is None, (
+        "58 cm-1 is above the stored tau of 30, but no mode row says so: "
+        "the count must not claim to have counted"
+    )
+    # The flag is a stored judgement and is unaffected by the missing rows.
+    assert freq["imaginary_mode_structural_flag"] is False
 
 
 def test_a_minimum_counts_zero_against_its_tau(client, db_session):

--- a/backend/tests/api/scientific/test_api_freq_result_adr0012_fields.py
+++ b/backend/tests/api/scientific/test_api_freq_result_adr0012_fields.py
@@ -1,0 +1,205 @@
+"""``n_imag`` never travels alone on an ordinary frequency read.
+
+ADR 0012 §"What a record must carry" says ``n_imag`` must be accompanied
+by the count above tau, the tau used, and how tau was chosen. Until this
+file, the ordinary ``include=results`` projection of ``calc_freq_result``
+carried ``n_imag`` and ``imag_freq_cm1`` and none of the rest; the tau,
+its basis and the structural flag were reachable only through the
+``include=imaginary_mode_projections`` heavy include, and only down its
+*not determinable* branch.
+
+The sharp end is the structural flag. It is the signal that excludes a
+record from default transition-state consumption, so a consumer filtering
+on ``n_imag == 1`` was being handed records ADR 0012 considers excluded
+with nothing in the payload saying so. That is the specific defect these
+tests pin, and it is the reason the fields go on the *cheap* projection
+rather than a second opt-in block: a flag a consumer has to ask for is a
+flag that does not protect the consumer who did not know to ask.
+
+Nothing here is recomputed. Every field is read straight off
+``calc_freq_result`` as the upload wrote it, which is ADR 0012's own
+requirement -- recomputing tau at read time would let a parser
+improvement silently re-decide a historical record.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.db.models.common import CalculationType, ImaginaryModeDisposition
+from tests.services.scientific_read._factories import (
+    attach_freq_result,
+    make_calculation,
+    make_species,
+    make_species_entry,
+    next_inchi_key,
+)
+
+#: Every field ADR 0012 requires to travel with ``n_imag``, plus the two
+#: that already did. Asserted as an exact key set rather than field by
+#: field: the failure mode this file exists to prevent is a field that is
+#: silently *absent*, and only an exact comparison catches a rename.
+_EXPECTED_FREQ_KEYS = {
+    "n_imag",
+    "imag_freq_cm1",
+    "zpe_hartree",
+    "zpe_uncertainty_hartree",
+    "reaction_coordinate_mode_index",
+    "imaginary_mode_tau_cm1",
+    "imaginary_mode_tau_basis",
+    "imaginary_mode_structural_flag",
+    "n_imag_at_or_above_tau",
+}
+
+
+def _freq_calc(db_session):
+    species = make_species(db_session, inchi_key=next_inchi_key("FRQ"))
+    entry = make_species_entry(db_session, species)
+    return make_calculation(
+        db_session,
+        type=CalculationType.freq,
+        species_entry_id=entry.id,
+    )
+
+
+def _read_freq_block(client, calc):
+    resp = client.get(
+        f"/api/v1/scientific/calculations/{calc.public_ref}?include=results"
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()["record"]["results"]
+    assert results["kind"] == "freq"
+    freq = results["freq"]
+    print(json.dumps(freq, indent=2, sort_keys=True))
+    return freq
+
+
+def test_default_results_read_carries_the_whole_adr_0012_judgement(
+    client, db_session
+):
+    """ADR 0012's motivating record, read the ordinary way.
+
+    -1300 / -42 / -13 cm-1: a correct saddle point whose reaction
+    coordinate is mode 1, judged at tau = 15 cm-1 on the analytic-tight
+    row of the protocol table, and flagged because -42 sits above that
+    tau with a declared disposition. Every one of those facts is on the
+    cheap projection.
+    """
+    calc = _freq_calc(db_session)
+    attach_freq_result(
+        db_session,
+        calculation=calc,
+        frequencies_cm1=[-1300.0, -42.0, -13.0, 620.0],
+        zpe_hartree=0.0431,
+        imaginary_dispositions=[
+            None,
+            ImaginaryModeDisposition.torsion,
+            ImaginaryModeDisposition.rigid_body_residue,
+            None,
+        ],
+        reaction_coordinate_mode_index=1,
+        imaginary_mode_tau_cm1=15.0,
+        imaginary_mode_tau_basis="analytic_tight",
+        imaginary_mode_structural_flag=True,
+    )
+
+    freq = _read_freq_block(client, calc)
+
+    assert set(freq) == _EXPECTED_FREQ_KEYS
+    assert freq["n_imag"] == 3
+    assert freq["imag_freq_cm1"] == -1300.0
+    assert freq["reaction_coordinate_mode_index"] == 1
+    assert freq["imaginary_mode_tau_cm1"] == 15.0
+    assert freq["imaginary_mode_tau_basis"] == "analytic_tight"
+    assert freq["imaginary_mode_structural_flag"] is True
+    # -1300 and -42 are at or above tau; -13 is below it.
+    assert freq["n_imag_at_or_above_tau"] == 2
+
+
+def test_a_flagged_first_order_saddle_says_so_without_an_opt_in(
+    client, db_session
+):
+    """The case the flag exists for, and the one that was invisible.
+
+    A consumer filtering on ``n_imag == 1`` is selecting records it
+    believes are clean first-order saddles. A record can report
+    ``n_imag == 1`` *and* carry the structural flag -- ADR 0012's whole
+    argument is that the count is a property of the protocol, not of the
+    structure -- and before this change the ordinary read gave that
+    consumer no way to tell the two apart.
+    """
+    calc = _freq_calc(db_session)
+    attach_freq_result(
+        db_session,
+        calculation=calc,
+        frequencies_cm1=[-870.0, 410.0],
+        reaction_coordinate_mode_index=1,
+        imaginary_mode_tau_cm1=50.0,
+        imaginary_mode_tau_basis="finite_difference_gradient",
+        imaginary_mode_structural_flag=True,
+    )
+
+    freq = _read_freq_block(client, calc)
+
+    assert freq["n_imag"] == 1
+    assert freq["imaginary_mode_structural_flag"] is True, (
+        "a record excluded from default transition-state consumption must "
+        "say so on the projection a consumer actually reads"
+    )
+    assert freq["imaginary_mode_tau_cm1"] == 50.0
+    assert freq["imaginary_mode_tau_basis"] == "finite_difference_gradient"
+    assert freq["n_imag_at_or_above_tau"] == 1
+
+
+def test_never_judged_reports_nulls_rather_than_a_clean_bill(client, db_session):
+    """A record deposited before ADR 0012 was never judged under it.
+
+    All four persisted fields are NULL on such a record, and the
+    projection reports NULL rather than ``false``/``0``: "not judged" and
+    "judged and not flagged" are different facts and collapsing them
+    would be exactly the claim the migration refused to backfill.
+
+    ``n_imag_at_or_above_tau`` is null for the same reason -- there is no
+    tau to count against -- even though ``n_imag`` and the mode rows are
+    both present.
+    """
+    calc = _freq_calc(db_session)
+    attach_freq_result(
+        db_session,
+        calculation=calc,
+        frequencies_cm1=[-412.0, 700.0],
+        zpe_hartree=0.01,
+    )
+
+    freq = _read_freq_block(client, calc)
+
+    assert set(freq) == _EXPECTED_FREQ_KEYS
+    assert freq["n_imag"] == 1
+    assert freq["reaction_coordinate_mode_index"] is None
+    assert freq["imaginary_mode_tau_cm1"] is None
+    assert freq["imaginary_mode_tau_basis"] is None
+    assert freq["imaginary_mode_structural_flag"] is None
+    assert freq["n_imag_at_or_above_tau"] is None
+
+
+def test_a_minimum_counts_zero_against_its_tau(client, db_session):
+    """Tau recorded, no imaginary modes: the count is 0, not null.
+
+    The distinction matters in the opposite direction from the test
+    above. Here tau *is* known, so "nothing above it" is a measurement
+    and reporting null would understate what the record says.
+    """
+    calc = _freq_calc(db_session)
+    attach_freq_result(
+        db_session,
+        calculation=calc,
+        frequencies_cm1=[120.0, 700.0, 3100.0],
+        imaginary_mode_tau_cm1=30.0,
+        imaginary_mode_tau_basis="analytic_default",
+    )
+
+    freq = _read_freq_block(client, calc)
+
+    assert freq["n_imag"] == 0
+    assert freq["n_imag_at_or_above_tau"] == 0
+    assert freq["imaginary_mode_tau_basis"] == "analytic_default"

--- a/backend/tests/db/test_imaginary_mode_tau_basis_constraint.py
+++ b/backend/tests/db/test_imaginary_mode_tau_basis_constraint.py
@@ -1,0 +1,357 @@
+"""A tolerance basis nobody recognises must not be able to reach a reader.
+
+``calc_freq_result.imaginary_mode_tau_basis`` says which row of ADR 0012's
+protocol table set the tolerance a record's imaginary modes were judged
+at. It is ``TEXT``, and until ``e2a7c9d4b615`` nothing but convention kept
+it to the five rows that exist: ``app/services/calculation_resolution.py``
+writes ``TauBasis(...).value`` and always has, but a second write path, a
+bulk loader, or a restore from a hand-edited dump could put anything
+there.
+
+Why that matters more than a typo usually does. The column is *read* as
+``str`` on purpose -- an unrecognised basis is displayed rather than made
+to refuse the whole record, so that a reader of a record written by a
+newer TCKDB is shown what it says. That openness is only safe if a value
+this build does not recognise really does mean "newer writer". A typo
+wearing the same costume turns a deliberate forward-compatibility choice
+into silent corruption, and the reader has no way to tell which they are
+looking at.
+
+What is pinned here:
+
+1. **Every ``TauBasis`` value is accepted**, so the constraint cannot
+   refuse a record the upload path legitimately produces. NULL too: the
+   column is NULL on every record deposited before ADR 0012, and nothing
+   was backfilled.
+2. **Nothing else is**, including the near misses -- wrong case, hyphen
+   for underscore, empty string.
+3. **It holds under ``session_replication_role = replica``**, which is
+   what bulk loaders and restore paths run under. This is the reason the
+   change is a CHECK and not a foreign key onto a vocabulary table; the
+   same measurement is made for element symbols in
+   ``test_element_symbol_canonicality.py``.
+4. **The database's vocabulary and ``TauBasis`` are the same set.** This
+   is the drift guard: adding a ``TauBasis`` member without migrating the
+   constraint fails here, rather than at the first upload that resolves
+   to it -- which would be a 500 on a scientifically valid deposit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from tckdb_schemas.stationary_point import TauBasis
+
+from alembic import command
+from app.db.models.common import IMAGINARY_MODE_TAU_BASIS_VALUES, CalculationType
+from tests.services.scientific_read._factories import (
+    make_calculation,
+    make_lot,
+    make_species,
+    make_species_entry,
+    next_inchi_key,
+)
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_PREVIOUS_HEAD = "d4e9b1c7a253"
+_CURRENT_HEAD = "e2a7c9d4b615"
+_CONSTRAINT = "ck_calc_freq_result_imaginary_mode_tau_basis_known"
+
+#: Values that are not rows of ADR 0012's protocol table. The first three
+#: are the realistic typos; ``""`` is the one a form-driven writer
+#: produces; ``analytic`` is a ``HessianMethod`` value, which is the
+#: adjacent vocabulary most likely to be written here by mistake.
+_NOT_A_BASIS = (
+    "analytic-tight",
+    "ANALYTIC_TIGHT",
+    "analytic_tigth",
+    "",
+    "analytic",
+    "protocol not recorded",
+)
+
+
+@pytest.fixture
+def calculation_id(db_session) -> int:
+    """A bare ``freq`` calculation to hang provocations on."""
+    lot = make_lot(db_session, method="taubasis", basis="def2tzvp")
+    entry = make_species_entry(
+        db_session, make_species(db_session, inchi_key=next_inchi_key("TAU"))
+    )
+    calc = make_calculation(
+        db_session,
+        type=CalculationType.freq,
+        lot_id=lot.id,
+        species_entry_id=entry.id,
+    )
+    return calc.id
+
+
+def _values_in(definition: str) -> set[str]:
+    """Every single-quoted literal in a ``pg_get_constraintdef`` string.
+
+    PostgreSQL rewrites ``IN (...)`` to ``= ANY (ARRAY[...])`` and stamps
+    each literal with ``::text``, and which of those two shapes it prints
+    is not the point of the assertion. Pulling the quoted literals out
+    directly reads either.
+    """
+    return set(re.findall(r"'([^']*)'::text", definition)) or set(
+        re.findall(r"'([^']*)'", definition)
+    )
+
+
+def _insert_freq_result(db_session, calculation_id: int, basis: str | None) -> None:
+    db_session.execute(
+        text(
+            "INSERT INTO calc_freq_result"
+            " (calculation_id, n_imag, imaginary_mode_tau_cm1,"
+            " imaginary_mode_tau_basis)"
+            " VALUES (:c, 1, 15.0, :b)"
+        ),
+        {"c": calculation_id, "b": basis},
+    )
+    db_session.flush()
+
+
+@pytest.mark.parametrize("basis", [member.value for member in TauBasis] + [None])
+def test_every_basis_the_upload_path_can_resolve_is_accepted(
+    db_session, calculation_id, basis
+):
+    """The five rows of the protocol table, and "never judged" as NULL.
+
+    Parametrised over ``TauBasis`` itself rather than a hand-written list,
+    so a member added to the enum shows up here as a failure to accept
+    it rather than as a list nobody updated.
+    """
+    savepoint = db_session.begin_nested()
+    try:
+        _insert_freq_result(db_session, calculation_id, basis)
+        stored = db_session.scalar(
+            text(
+                "SELECT imaginary_mode_tau_basis FROM calc_freq_result"
+                " WHERE calculation_id = :c"
+            ),
+            {"c": calculation_id},
+        )
+        assert stored == basis
+    finally:
+        savepoint.rollback()
+
+
+@pytest.mark.parametrize("basis", _NOT_A_BASIS)
+def test_a_value_that_is_not_a_protocol_table_row_is_refused(
+    db_session, calculation_id, basis
+):
+    savepoint = db_session.begin_nested()
+    try:
+        with pytest.raises(IntegrityError) as excinfo:
+            _insert_freq_result(db_session, calculation_id, basis)
+        assert _CONSTRAINT in str(excinfo.value), (
+            f"{basis!r} was refused by something other than {_CONSTRAINT}: "
+            f"{excinfo.value}"
+        )
+    finally:
+        savepoint.rollback()
+
+
+def test_the_constraint_holds_under_a_bulk_load_session(db_session, calculation_id):
+    """The measured fact that decided CHECK over a vocabulary table.
+
+    Both halves together, because the claim is the *difference*: with
+    system triggers suspended the foreign key onto ``calculation`` stops
+    holding, and the CHECK on the same row in the same session does not.
+    """
+    savepoint = db_session.begin_nested()
+    try:
+        db_session.execute(text("SET LOCAL session_replication_role = replica"))
+
+        # The foreign key: not enforced. A result row for a calculation
+        # that does not exist is accepted.
+        db_session.execute(
+            text(
+                "INSERT INTO calc_freq_result (calculation_id, n_imag)"
+                " VALUES (-1, 0)"
+            )
+        )
+        db_session.flush()
+
+        # The CHECK: still enforced, same table, same session.
+        with pytest.raises(IntegrityError) as excinfo:
+            _insert_freq_result(db_session, calculation_id, "analytic-tight")
+        assert _CONSTRAINT in str(excinfo.value)
+    finally:
+        savepoint.rollback()
+
+
+def test_the_database_vocabulary_is_exactly_taubasis(db_session):
+    """The drift guard, read off the live constraint definition.
+
+    Asserted against ``pg_get_constraintdef`` rather than by provocation:
+    provocation shows that the values tested are accepted or refused, and
+    what has to be pinned is that the *set* matches -- a sixth value
+    quietly present in the constraint and in no test would otherwise be
+    invisible.
+    """
+    definition = db_session.scalar(
+        text(
+            "SELECT pg_get_constraintdef(oid) FROM pg_constraint"
+            " WHERE conname = :name"
+            " AND conrelid = 'calc_freq_result'::regclass"
+        ),
+        {"name": _CONSTRAINT},
+    )
+    assert definition is not None, f"{_CONSTRAINT} is not on calc_freq_result"
+
+    quoted = _values_in(definition)
+    expected = {member.value for member in TauBasis}
+    assert quoted == expected, (
+        f"the database accepts {sorted(quoted)} but TauBasis is "
+        f"{sorted(expected)}; constraint definition: {definition}"
+    )
+    assert set(IMAGINARY_MODE_TAU_BASIS_VALUES) == expected, (
+        "app.db.models.common.IMAGINARY_MODE_TAU_BASIS_VALUES has drifted "
+        f"from TauBasis: {sorted(IMAGINARY_MODE_TAU_BASIS_VALUES)} vs "
+        f"{sorted(expected)}"
+    )
+
+
+def test_the_constraint_is_validated(db_session):
+    """A ``NOT VALID`` CHECK says nothing about the rows already stored.
+
+    ``e2a7c9d4b615`` adds it validated in one statement, having first
+    refused to run at all if the column held anything it could not
+    classify. A future revision that swapped in ``NOT VALID`` to dodge a
+    table scan, and forgot the ``VALIDATE``, would look identical to
+    every other test in this file.
+    """
+    convalidated = db_session.scalar(
+        text(
+            "SELECT convalidated FROM pg_constraint"
+            " WHERE conname = :name"
+            " AND conrelid = 'calc_freq_result'::regclass"
+        ),
+        {"name": _CONSTRAINT},
+    )
+    assert convalidated is True
+
+
+# ---------------------------------------------------------------------------
+# What the migration does when it meets a value it cannot classify
+# ---------------------------------------------------------------------------
+
+
+def test_the_migration_refuses_rather_than_guesses(db_engine, monkeypatch):
+    """``e2a7c9d4b615`` stops, naming the values, and changes nothing.
+
+    The alternatives were all worse and all quiet. Coercing an
+    unrecognised basis to ``protocol_not_recorded`` asserts the record was
+    judged at the conservative tolerance, which is a claim about its
+    science that only whatever wrote it can make; deleting the value
+    throws away the only trace of that writer; adding the constraint
+    ``NOT VALID`` leaves a rule that binds new writes and says nothing
+    about the rows already there.
+
+    Measured against a planted row rather than argued, because the guard
+    is a branch that never runs on a clean database -- which is every
+    database this migration is expected to meet, and exactly why it would
+    otherwise never be exercised at all.
+    """
+    db_name = db_engine.url.database
+    url = db_engine.url.render_as_string(hide_password=False)
+    db_engine.dispose()
+    for key, value in (
+        ("DB_NAME", db_name),
+        ("DB_USER", "tckdb"),
+        ("DB_PASSWORD", "tckdb"),
+        ("DB_HOST", "127.0.0.1"),
+        ("DB_PORT", "5432"),
+    ):
+        monkeypatch.setenv(key, value)
+    config = Config(str(_BACKEND_ROOT / "alembic.ini"))
+    engine = create_engine(url)
+    planted = "DELETE FROM calc_freq_result WHERE calculation_id IN (-901, -902)"
+
+    try:
+        command.downgrade(config, _PREVIOUS_HEAD)
+
+        # One unclassifiable value and one legitimate one. The foreign key
+        # onto ``calculation`` is suspended rather than satisfied: what is
+        # under test is the migration's reaction to the *column*, and a
+        # bulk-load session is precisely the writer that could have put an
+        # unrecognised value there.
+        with engine.begin() as connection:
+            connection.execute(text("SET LOCAL session_replication_role = replica"))
+            connection.execute(
+                text(
+                    "INSERT INTO calc_freq_result (calculation_id, n_imag,"
+                    " imaginary_mode_tau_basis) VALUES"
+                    " (-901, 1, 'nonsense-basis'), (-902, 1, 'analytic_tight')"
+                )
+            )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            command.upgrade(config, _CURRENT_HEAD)
+        message = str(excinfo.value)
+        assert "nonsense-basis" in message, (
+            "the migration must name what it refused to classify; it said: "
+            f"{message}"
+        )
+        assert "analytic_tight" not in message, (
+            f"a legitimate value was reported as unclassifiable: {message}"
+        )
+
+        # Nothing changed on the way out: the row is still there, still
+        # saying what it said, and no constraint was installed.
+        with engine.connect() as connection:
+            still_there = connection.scalar(
+                text(
+                    "SELECT imaginary_mode_tau_basis FROM calc_freq_result"
+                    " WHERE calculation_id = -901"
+                )
+            )
+            assert still_there == "nonsense-basis"
+            assert _constraint_count(connection) == 0
+
+        # Repaired the way an operator would -- by deciding what the row
+        # meant -- the same migration goes through.
+        _purge_planted_rows(engine, planted)
+        command.upgrade(config, _CURRENT_HEAD)
+        with engine.connect() as connection:
+            assert _constraint_count(connection) == 1
+    finally:
+        # Leave the database at head whatever happened, so a failure here
+        # fails this test and not every test that follows it.
+        _purge_planted_rows(engine, planted)
+        command.upgrade(config, _CURRENT_HEAD)
+        engine.dispose()
+
+
+def _purge_planted_rows(engine, statement: str) -> None:
+    """Remove the planted rows, triggers and all.
+
+    ``session_replication_role`` again, on the way out as well as in:
+    ``calc_freq_result`` is under the accepted-science immutability guard,
+    which refuses to *delete* a row whose parent calculation does not
+    exist just as firmly as it refused to insert one. The suite's
+    committed-row leak check fails this test if anything survives, which
+    is how a botched cleanup announces itself here rather than as an
+    order-dependent failure somewhere else.
+    """
+    with engine.begin() as connection:
+        connection.execute(text("SET LOCAL session_replication_role = replica"))
+        connection.execute(text(statement))
+
+
+def _constraint_count(connection) -> int:
+    return connection.scalar(
+        text(
+            "SELECT count(*) FROM pg_constraint WHERE conname = :name"
+            " AND conrelid = 'calc_freq_result'::regclass"
+        ),
+        {"name": _CONSTRAINT},
+    )

--- a/backend/tests/services/scientific_read/test_record_builder_statement_cost.py
+++ b/backend/tests/services/scientific_read/test_record_builder_statement_cost.py
@@ -28,10 +28,12 @@ from app.schemas.reads.scientific_calculation_search import (
 from app.services.scientific_read.calculations_search import search_calculations
 from tests.services.scientific_read._factories import (
     attach_artifact,
+    attach_freq_result,
     make_calculation,
     make_lot,
     make_species,
     make_species_entry,
+    next_inchi_key,
 )
 
 #: Statements ``build_record`` issues for one more record on a page of the
@@ -265,4 +267,137 @@ def test_the_integrity_load_costs_exactly_one_statement_per_artifact_load(
     assert (large_integrity - small_integrity) <= (20 - 4), (
         f"{(large_integrity - small_integrity) / 16} custody statements per "
         "additional record"
+    )
+
+
+# ---------------------------------------------------------------------------
+# What ADR 0012's fields cost on the frequency-result projection
+# ---------------------------------------------------------------------------
+
+#: Statements that *load* a ``calc_freq_result`` row, per record on an
+#: ``include=results`` page. One: the projection loads the row it projects
+#: and nothing else.
+#:
+#: ADR 0012 requires ``n_imag`` to travel with the tolerance it was judged
+#: at, how that tolerance was chosen, and the count above it. The first two
+#: are columns on the row that was already being loaded and are free. The
+#: count is not stored -- it is taken over ``calc_freq_mode`` -- and the
+#: obvious way to get it is a second round trip, which this builder runs
+#: once per record and would therefore multiply by the page size. It rides
+#: along as a correlated aggregate on the same SELECT instead, so the cost
+#: of ADR 0012 compliance on this projection is measurably zero statements.
+_FREQ_RESULT_STATEMENTS_PER_RECORD = 1
+
+_FREQ_SMALL_PAGE = 5
+_FREQ_LARGE_PAGE = 20
+
+#: A column only the projection's SELECT list names. The
+#: provenance/available-sections probe also mentions ``calc_freq_result``
+#: -- once per record, inside its own combined statement, and it did so
+#: before ADR 0012's fields existed -- so counting the table name would
+#: measure two unrelated statements as one number and hide a change in
+#: either.
+_PROJECTION_MARKER = "imaginary_mode_tau_basis"
+
+
+def _freq_statements_for_page(
+    session: Session, *, method: str, limit: int
+) -> tuple[int, int]:
+    """Return (statements loading calc_freq_result, extra mode statements).
+
+    The second number is the one that would move if the mode count became
+    its own query: a statement touching ``calc_freq_mode`` and *not*
+    ``calc_freq_result`` is a second round trip, where the correlated
+    aggregates appear inside the ``calc_freq_result`` statement itself and
+    the ``has_freq_modes`` probe mentions both tables at once.
+    """
+    freq_result = 0
+    freq_mode = 0
+    engine = session.connection().engine
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        nonlocal freq_result, freq_mode
+        if _PROJECTION_MARKER in statement:
+            freq_result += 1
+        elif "calc_freq_mode" in statement and "calc_freq_result" not in statement:
+            freq_mode += 1
+
+    try:
+        response = search_calculations(
+            session,
+            CalculationsSearchRequest(
+                calculation_type=CalculationType.freq,
+                method=method,
+                limit=limit,
+                include=["results"],
+            ),
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", _before)
+
+    assert len(response.records) == limit, "page must be full to be comparable"
+    return freq_result, freq_mode
+
+
+def _freq_page(db_session, *, method: str, calcs: int) -> None:
+    """A page of frequency calculations, each with a judged freq result."""
+    lot = make_lot(db_session, method=method, basis="def2tzvp")
+    entry = make_species_entry(
+        db_session,
+        make_species(db_session, inchi_key=next_inchi_key(f"FRQ{abs(hash(method)) % 900}")),
+    )
+    for _ in range(calcs):
+        calc = make_calculation(
+            db_session,
+            type=CalculationType.freq,
+            species_entry_id=entry.id,
+            lot_id=lot.id,
+        )
+        attach_freq_result(
+            db_session,
+            calculation=calc,
+            frequencies_cm1=[-1300.0, -42.0, -13.0, 620.0],
+            reaction_coordinate_mode_index=1,
+            imaginary_mode_tau_cm1=15.0,
+            imaginary_mode_tau_basis="analytic_tight",
+            imaginary_mode_structural_flag=True,
+        )
+
+
+def test_the_adr_0012_fields_cost_no_extra_statement_per_record(db_session):
+    """The count above tau is aggregated in the statement already there.
+
+    Two claims, and the second is the one that would regress silently.
+    The ``calc_freq_result`` slope stays at one statement per record --
+    unchanged by the four ADR 0012 columns joining the projection, because
+    they were always on the row being loaded. And no statement touches
+    ``calc_freq_mode`` on its own: the count above tau is a correlated
+    aggregate, not a second trip. A future edit that reaches for
+    ``row.modes`` instead would pass every other assertion in the suite
+    and double the cost of every frequency record on every search page.
+    """
+    _freq_page(db_session, method="freq-cost-small", calcs=_FREQ_SMALL_PAGE)
+    _freq_page(db_session, method="freq-cost-large", calcs=_FREQ_LARGE_PAGE)
+
+    small_result, small_mode = _freq_statements_for_page(
+        db_session, method="freq-cost-small", limit=_FREQ_SMALL_PAGE
+    )
+    large_result, large_mode = _freq_statements_for_page(
+        db_session, method="freq-cost-large", limit=_FREQ_LARGE_PAGE
+    )
+
+    assert small_result >= 1, (
+        "the frequency-result projection must actually load its row -- "
+        "an assertion over zero statements proves nothing"
+    )
+    slope = (large_result - small_result) / (_FREQ_LARGE_PAGE - _FREQ_SMALL_PAGE)
+    assert slope <= _FREQ_RESULT_STATEMENTS_PER_RECORD, (
+        f"{slope} calc_freq_result statements per record, expected at most "
+        f"{_FREQ_RESULT_STATEMENTS_PER_RECORD} ({small_result} statements for "
+        f"{_FREQ_SMALL_PAGE} records, {large_result} for {_FREQ_LARGE_PAGE})"
+    )
+    assert (small_mode, large_mode) == (0, 0), (
+        f"{small_mode} / {large_mode} standalone calc_freq_mode statements: "
+        "the count above tau has become a second round trip per record"
     )


### PR DESCRIPTION
## What this fixes

ADR 0012 §"What a record must carry" requires that `n_imag` never travel alone: it must be accompanied by the count above τ, the τ used, and how τ was chosen. `CalculationFreqResultSummary` — the ordinary `include=results` projection of `calc_freq_result` — carried `n_imag` and `imag_freq_cm1` and none of the rest. Everything else was reachable only through `include=imaginary_mode_projections`, and only down that block's *not determinable* branch.

**The sharp end is the structural flag.** It is the signal that excludes a record from default transition-state consumption, and a default read never showed it. A consumer filtering on `n_imag == 1` was being handed records ADR 0012 considers excluded, with nothing in the payload saying so — while ADR 0012's own argument is that two scientifically correct calculations of the same saddle point can report `n_imag = 1` and `n_imag = 3`. A flag a consumer has to know to ask for does not protect the consumer who did not know.

## Before / after

Same record — ADR 0012's motivating case, −1300 / −42 / −13 cm⁻¹, reaction coordinate designated as mode 1, judged at τ = 15 on the analytic-tight row, flagged. `GET /api/v1/scientific/calculations/{ref}?include=results` → `record.results.freq`:

**Before**

```json
{
  "imag_freq_cm1": -1300.0,
  "n_imag": 3,
  "zpe_hartree": 0.0431,
  "zpe_uncertainty_hartree": null
}
```

**After**

```json
{
  "imag_freq_cm1": -1300.0,
  "imaginary_mode_structural_flag": true,
  "imaginary_mode_tau_basis": "analytic_tight",
  "imaginary_mode_tau_cm1": 15.0,
  "n_imag": 3,
  "n_imag_at_or_above_tau": 2,
  "reaction_coordinate_mode_index": 1,
  "zpe_hartree": 0.0431,
  "zpe_uncertainty_hartree": null
}
```

And the case the flag exists for — a record that reports `n_imag = 1` *and* is structurally excluded — now says so on the projection a consumer actually reads:

```json
{
  "imag_freq_cm1": -870.0,
  "imaginary_mode_structural_flag": true,
  "imaginary_mode_tau_basis": "finite_difference_gradient",
  "imaginary_mode_tau_cm1": 50.0,
  "n_imag": 1,
  "n_imag_at_or_above_tau": 1,
  "reaction_coordinate_mode_index": 1,
  "zpe_hartree": null,
  "zpe_uncertainty_hartree": null
}
```

A record deposited before ADR 0012 reports all four persisted fields as `null` — "never judged", which is a different fact from "judged and not flagged" and is not collapsed into `false`/`0` here any more than `c2f7a4e8d1b6` backfilled it.

## `n_imag_at_or_above_tau`, and what it cost

ADR 0012 asks for the count above τ, which is the one required field that is **not** stored — it is taken over `calc_freq_mode`. It is derived by comparing stored magnitudes against the stored τ, which resolves nothing: recomputing τ itself at read time is what ADR 0012 forbids, because a parser improvement would then silently re-decide every historical record.

It is `null`, not `0`, where the count cannot honestly be taken: no τ stored (nothing to compare against), or `n_imag` reported with no per-mode rows to count (`calc_freq_mode` is optional, and SQL would confidently answer 0 there — true of the stored rows and false of the record).

**Measured cost: zero additional statements.** A `freq` search page with `include=results`, statements counted with a `before_cursor_execute` listener, pages of 5 and 20 records:

| | before | after |
|---|---|---|
| total statements, 5 records | 29 | 29 |
| total statements, 20 records | 104 | 104 |
| slope, total | 5.0 / record | 5.0 / record |
| slope, statements touching `calc_freq_result` | 2.0 / record | 2.0 / record |
| standalone `calc_freq_mode` statements | 0 | 0 |

The two `calc_freq_result` statements per record are the pre-existing provenance/available-sections probe plus the projection's own row load. The mode counts ride along as correlated aggregates on the projection's `SELECT` rather than a second round trip — which matters because this builder runs once per record, so a second trip is multiplied by the page size. Pinned by `test_the_adr_0012_fields_cost_no_extra_statement_per_record`, which asserts the projection slope stays at 1 and that no statement touches `calc_freq_mode` alone.

## `imaginary_mode_tau_basis` at the database level

`e2a7c9d4b615` adds `ck_calc_freq_result_imaginary_mode_tau_basis_known`, constraining the column to `TauBasis`'s five values or NULL.

The column stays `str` on the wire — that part is deliberate and unchanged. A basis a newer TCKDB wrote must be *displayed* rather than made to refuse the whole record. That argument does not extend to the write side, where an unrecognised value is a typo and not a newer writer; and the read-side openness is only safe if that distinction holds.

**What is actually stored, and how it chose the constraint.** The column has existed only since `c2f7a4e8d1b6` (2026-08-08), which added it nullable and backfilled nothing. `app/services/calculation_resolution.py:726` is its sole writer and writes `tau.basis.value`. `TauBasis`'s five members have never been renamed or removed since they were introduced in that same commit. So every stored value is one of five tokens or NULL — by construction, and by nothing else. The local dev database holds zero `calc_freq_result` rows; the deployed database was out of bounds for this task, so `upgrade()` asks rather than assumes: it selects the distinct values that are not classifiable and **raises, naming them**, rather than deleting them, coercing them to `protocol_not_recorded` (which would assert those records were judged at the conservative tolerance — a claim about their science), or adding the constraint `NOT VALID`. Exercised against a planted row in `test_the_migration_refuses_rather_than_guesses`, which also asserts nothing changed on the way out.

**A CHECK rather than a native enum**, in order of weight: the ORM column stays `TEXT`; a CHECK, unlike a foreign key, still holds under `session_replication_role = replica`, which is what bulk loaders and restore paths run under and exactly the writers this exists for; and extending the vocabulary later is a constraint swap with a working `downgrade()`, where `ALTER TYPE … ADD VALUE` cannot be undone.

## Mutation check

Two mutations, both measured.

**Whole projection reverted** (`app/schemas/reads/scientific_calculation.py` + `app/services/scientific_read/calculations.py`), full scientific gate: **4 failed, 2041 passed** — exactly the new API tests that existed at that point, nothing else moved. Each failure prints the payload the checker actually saw, which is the "before" JSON above. Restored: 2045 passed.

**Just the null-guard in `_count_at_or_above_tau`** replaced with `return at_or_above_tau`: **2 failed, 3 passed** — `test_never_judged_reports_nulls_rather_than_a_clean_bill` (τ absent → would have reported 0) and `test_a_count_with_nothing_to_count_over_is_null_not_zero` (no mode rows → would have reported 0, reading as a clean soft mode). The guard is load-bearing rather than decorative, and both of its branches are reached.

The statement-cost test deliberately does *not* move under the first revert — `session.get` selected the same columns — because it is a cost guard, not a proof of the projection. It does fail when the cost claim is wrong: it caught the first constant I wrote for it (1 vs the actual 2 statements per record touching the table).

## Gates

| gate | result | baseline at `70fd9ff4` |
|---|---|---|
| `test-scientific.sh` | 2045 passed | ~2039 → +6 (5 API + 1 cost test) |
| `test-api.sh` | 2574 passed (2575 with the fifth API test, added after that run) | ~2566 → mine plus ~4 from `main` advancing past the baseline commit |
| `test-rest.sh` | 4146 passed, 14 skipped | ~4130 → +16 (the constraint tests) |

`schema.dbml` and the OpenAPI golden are regenerated; both diffs are exactly this change.

## Not fixed here

- **`c2f7a4e8d1b6` double-prefixed two constraint names.** `alembic/env.py` hands Alembic `Base.metadata`, whose `NAMING_CONVENTION` expands a short `ck` name — so passing the already-expanded name to `op.create_check_constraint` expands it twice and PostgreSQL truncates with a hash suffix. `backend/alembic/versions/c2f7a4e8d1b6_imaginary_modes_by_magnitude.py:97` therefore left `ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2` on the deployed database. It enforces the right rule under the wrong name; renaming it on a deployed table is its own revision and its own decision. This revision spells the short name, so its constraint matches the model.
- **The appendix sketch in the read spec still names `CalculationResultFreqSummary`** (`backend/docs/specs/scientific_calculation_reads.md:744`), a class that does not exist — the real one is `CalculationFreqResultSummary`. Pre-existing drift in an illustrative block; the authoritative shape is now §4.5.1.
