### PR TITLE
Name a constraint the way the model spells it, and measure the rule nobody could find

### DIFF
--- a/backend/alembic/versions/b7e4d1a9c026_name_constraints_the_way_the_model_spells_them.py
+++ b/backend/alembic/versions/b7e4d1a9c026_name_constraints_the_way_the_model_spells_them.py
@@ -1,0 +1,267 @@
+"""name constraints the way the model spells them
+
+Six CHECK constraints on deployed tables carry a name the ORM does not
+predict, and one unique index carries a name that describes less than it
+enforces. Neither is a live data problem: every one of them enforces the
+right rule right now. Both are traps for the next reader, and both have
+already been sprung once.
+
+**The six.** ``NAMING_CONVENTION`` in ``app/db/base.py`` spells check
+constraints ``ck_%(table_name)s_%(constraint_name)s``. Because that
+template interpolates ``%(constraint_name)s``, SQLAlchemy applies it to
+constraints that were given an explicit name as well as to anonymous
+ones -- unlike the ``uq``/``ix``/``fk`` templates, which key off column
+names and so leave an explicit name alone. A migration that hands
+``op.create_check_constraint`` a name already carrying the ``ck_<table>_``
+prefix therefore gets the prefix twice, and PostgreSQL truncates the
+result to 63 characters with a hash suffix. Three revisions did this:
+
+* ``a7c9e2f4b6d8`` -- two on ``calculation_artifact``
+* ``a8b9c0d1e2f3`` -- three on ``execution_environment_manifest``
+  (via ``sa.CheckConstraint(name=...)`` inside ``create_table``, which
+  takes the same path)
+* ``c2f7a4e8d1b6`` -- one on ``calc_freq_mode``
+
+leaving names like
+``ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2``. The
+cost is not enforcement, it is drift: ``alembic revision --autogenerate``
+compares catalog names against ``Base.metadata`` names, sees six it does
+not recognise and six it thinks are missing, and proposes dropping and
+recreating constraints that are already correct. Whoever next touches
+these tables gets handed that diff and has to work out from scratch
+whether it is real. ``e2a7c9d4b615`` and ``f3b7d2c8a419`` pass the short
+name and are unaffected, so the codebase currently holds both conventions
+at once -- which is worse than holding either.
+
+**The one.** ``statmech_torsion`` has enforced uniqueness of
+``(statmech_id, torsion_index)`` since ``d861dfd60891``, the initial
+schema, under the name ``uq_statmech_torsion_statmech_id``. That name
+mentions only the first of the two columns, so it reads as a uniqueness
+rule on ``statmech_id`` alone -- which would be absurd (one torsion per
+statmech record) and is therefore easy to skim past as a mistake rather
+than as the constraint you were looking for. It was read exactly that
+way: a duplicate ``torsion_index`` means one hindered rotor counted twice
+in a partition function, and the invariant was reported as unenforced at
+the database level on the strength of this name. It is enforced, and
+``tests/db/test_statmech_torsion_index_uniqueness.py`` now measures that
+rather than trusting either the name or the report. Renamed here to say
+both columns.
+
+**Renames, not drop-and-recreate.** ``ALTER TABLE ... RENAME
+CONSTRAINT`` and ``ALTER INDEX ... RENAME TO`` touch the catalog only.
+No row is read, no row is written, no table is scanned, and each rule
+stays enforced continuously -- there is no window in which a writer could
+slip past. Dropping and recreating ``ck_calculation_artifact_sha256``
+would instead revalidate every artifact row, and would leave the rule off
+the table while it did so. Renaming the unique index likewise keeps the
+index itself, so no ``REINDEX`` and no period during which duplicate
+torsion indices are accepted.
+
+This is also why there is no data-measurement guard of the kind
+``e2a7c9d4b615`` needed. That revision installed a *new* rule and had to
+ask the database whether the stored rows already satisfied it. This one
+installs nothing: every rule here is already in force and already
+validated, so the only thing that can differ between hosts is the name.
+That is what the guard below measures.
+
+**When the name is already right: no-op, deliberately.** A host built
+from scratch after ``e2a7c9d4b615``'s conventions took hold could
+conceivably already carry the short name, and a re-run of this revision
+certainly will. Refusing in that case would block a deploy on a database
+that is already in the state this revision exists to produce, which is
+the wrong trade: the goal is "the constraint is present under the model's
+name", and if that holds, the goal is met. So a constraint found already
+correctly named is skipped with a log line and the migration continues.
+
+The refusals are kept for the two cases that are *not* "already done":
+
+* **Neither name present.** The constraint is gone, not renamed. That is
+  real drift -- something dropped a rule this schema depends on -- and
+  silently continuing would leave the operator believing this revision
+  had put it back. It did not; it cannot; recreating it here would be
+  installing an unvalidated rule against unmeasured data, which is the
+  thing the paragraph above says this revision does not do.
+* **Both names present.** There are two constraints, and a rename cannot
+  merge them. Which to keep is a question about how the duplicate got
+  there, and only whoever made it can answer.
+
+Revision ID: b7e4d1a9c026
+Revises: e2a7c9d4b615
+Create Date: 2026-08-13
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b7e4d1a9c026"
+down_revision: Union[str, Sequence[str], None] = "e2a7c9d4b615"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+#: ``(table, deployed name, name the model predicts)`` for each CHECK.
+#:
+#: The deployed names are spelled out rather than discovered by pattern,
+#: and the hash suffixes are safe to hard-code: SQLAlchemy derives them
+#: deterministically from the over-long name, so every host that ran
+#: these three revisions produced the same six strings. Verified against
+#: both a from-scratch ``upgrade head`` and the deployed host.
+#:
+#: The three ``execution_environment_manifest`` entries are truncated to
+#: the point where the name no longer says which column each covers, so
+#: the pairing was taken from ``pg_get_constraintdef`` rather than read
+#: off the names; the definitions are quoted here so the mapping can be
+#: checked without a database to hand.
+_CHECK_RENAMES: tuple[tuple[str, str, str], ...] = (
+    # CHECK (imaginary_disposition IS NULL OR is_imaginary)
+    (
+        "calc_freq_mode",
+        "ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2",
+        "ck_calc_freq_mode_imaginary_disposition_requires_imaginary_mode",
+    ),
+    # CHECK (bytes > 0)
+    (
+        "calculation_artifact",
+        "ck_calculation_artifact_ck_calculation_artifact_bytes_gt_0",
+        "ck_calculation_artifact_bytes_gt_0",
+    ),
+    # CHECK (sha256 ~ '^[0-9a-f]{64}$')
+    (
+        "calculation_artifact",
+        "ck_calculation_artifact_ck_calculation_artifact_sha256__8107",
+        "ck_calculation_artifact_sha256_lower_hex",
+    ),
+    # CHECK (content_digest ~ '^sha256:[0-9a-f]{64}$')
+    (
+        "execution_environment_manifest",
+        "ck_execution_environment_manifest_ck_execution_environm_0a7b",
+        "ck_execution_environment_manifest_content_digest_sha256",
+    ),
+    # CHECK (jsonb_typeof(closure_json) = 'array')
+    (
+        "execution_environment_manifest",
+        "ck_execution_environment_manifest_ck_execution_environm_8159",
+        "ck_execution_environment_manifest_closure_json_array",
+    ),
+    # CHECK (jsonb_typeof(canonical_json) = 'object')
+    (
+        "execution_environment_manifest",
+        "ck_execution_environment_manifest_ck_execution_environm_8dbd",
+        "ck_execution_environment_manifest_canonical_json_object",
+    ),
+)
+
+#: ``(table, deployed name, name the model predicts)`` for the unique
+#: index. Unlike the CHECKs this one is not the naming-convention bug --
+#: ``d861dfd60891`` named it by hand and named it short -- it is just a
+#: name that stops one column early.
+_INDEX_RENAMES: tuple[tuple[str, str, str], ...] = (
+    (
+        "statmech_torsion",
+        "uq_statmech_torsion_statmech_id",
+        "uq_statmech_torsion_statmech_id_torsion_index",
+    ),
+)
+
+#: PostgreSQL's ``NAMEDATALEN - 1``. An identifier longer than this is
+#: silently truncated by ``RENAME``, which would land us back in the
+#: situation this revision is undoing -- a name the model does not
+#: predict -- without any error to say so.
+#: ``ck_calc_freq_mode_imaginary_disposition_requires_imaginary_mode`` is
+#: exactly 63 characters, so this is not a hypothetical margin.
+_MAX_IDENTIFIER_LENGTH = 63
+
+
+def _decide(kind: str, table: str, old: str, new: str) -> bool:
+    """Return whether to issue the rename, refusing if it is not a rename.
+
+    ``kind`` is ``"constraint"`` or ``"index"`` and appears only in
+    messages.
+    """
+    if len(new) > _MAX_IDENTIFIER_LENGTH:
+        raise RuntimeError(
+            f"{new!r} is {len(new)} characters; PostgreSQL truncates "
+            f"identifiers at {_MAX_IDENTIFIER_LENGTH} and would leave "
+            f"{table} carrying a name the ORM still does not predict. "
+            "Nothing was changed."
+        )
+
+    bind = op.get_bind()
+    if kind == "constraint":
+        query = sa.text(
+            "SELECT conname FROM pg_constraint"
+            " WHERE conrelid = CAST(:table AS regclass)"
+            " AND contype = 'c'"
+            " AND conname = ANY(:names)"
+        )
+    else:
+        query = sa.text(
+            "SELECT indexname AS conname FROM pg_indexes"
+            " WHERE schemaname = current_schema()"
+            " AND tablename = :table"
+            " AND indexname = ANY(:names)"
+        )
+    present = set(
+        bind.execute(query, {"table": table, "names": [old, new]}).scalars().all()
+    )
+
+    if old in present and new in present:
+        raise RuntimeError(
+            f"{table} carries both {old!r} and {new!r}. A rename cannot "
+            "merge two constraints, and which of them to keep depends on "
+            "how the second one got there -- this migration will not "
+            "guess. Nothing was changed; drop whichever is the duplicate "
+            "and re-run."
+        )
+    if new in present:
+        logger.info(
+            "%s.%s is already named as the model spells it; leaving it alone",
+            table,
+            new,
+        )
+        return False
+    if old not in present:
+        raise RuntimeError(
+            f"{table} carries neither {old!r} nor {new!r}: the {kind} is "
+            "not there to rename. Something dropped a rule this schema "
+            "relies on, and recreating it here would install it against "
+            "rows this migration has not measured. Nothing was changed; "
+            f"restore the missing {kind} and re-run."
+        )
+    return True
+
+
+def _rename(kind: str, table: str, old: str, new: str) -> None:
+    if not _decide(kind, table, old, new):
+        return
+    quoted_new = f'"{new}"'
+    if kind == "constraint":
+        op.execute(f'ALTER TABLE "{table}" RENAME CONSTRAINT "{old}" TO {quoted_new}')
+    else:
+        op.execute(f'ALTER INDEX "{old}" RENAME TO {quoted_new}')
+
+
+def upgrade() -> None:
+    """Give each rule the name its model declaration predicts."""
+    for table, old, new in _CHECK_RENAMES:
+        _rename("constraint", table, old, new)
+    for table, old, new in _INDEX_RENAMES:
+        _rename("index", table, old, new)
+
+
+def downgrade() -> None:
+    """Put back the names ``d861dfd60891`` and the three revisions left.
+
+    Not cosmetic: ``a7c9e2f4b6d8.downgrade()`` and
+    ``d861dfd60891.downgrade()`` drop these by the names they created, so
+    a downgrade that stopped here would break the next one down.
+    """
+    for table, old, new in _INDEX_RENAMES:
+        _rename("index", table, new, old)
+    for table, old, new in _CHECK_RENAMES:
+        _rename("constraint", table, new, old)

--- a/backend/app/db/models/statmech.py
+++ b/backend/app/db/models/statmech.py
@@ -295,8 +295,17 @@ class StatmechTorsion(Base):
             "symmetry_number IS NULL OR symmetry_number >= 1",
             name="symmetry_number_ge_1",
         ),
+        # One hindered rotor per (record, index). A duplicate
+        # ``torsion_index`` is not a constraint violation anyone would
+        # notice at read time -- it is one rotor contributing twice to a
+        # partition function, i.e. a wrong number rather than an error.
+        # Named for both columns since ``b7e4d1a9c026``: the previous
+        # name said only ``statmech_id``, and was read as a uniqueness
+        # rule on ``statmech_id`` alone, which made the real invariant
+        # look absent. Measured in
+        # ``tests/db/test_statmech_torsion_index_uniqueness.py``.
         Index(
-            "uq_statmech_torsion_statmech_id",
+            "uq_statmech_torsion_statmech_id_torsion_index",
             "statmech_id",
             "torsion_index",
             unique=True,

--- a/backend/schema.dbml
+++ b/backend/schema.dbml
@@ -3071,7 +3071,7 @@ Table statmech_torsion {
   source_scan_calculation_id bigint [ref: > calculation.id]
 
   indexes {
-    (statmech_id, torsion_index) [unique, name: 'uq_statmech_torsion_statmech_id']
+    (statmech_id, torsion_index) [unique, name: 'uq_statmech_torsion_statmech_id_torsion_index']
   }
 
   checks {

--- a/backend/tests/db/test_constraint_names_match_the_model.py
+++ b/backend/tests/db/test_constraint_names_match_the_model.py
@@ -1,0 +1,154 @@
+"""What the database calls a rule must be what the model calls it.
+
+A constraint whose catalog name the ORM does not predict enforces the
+right rule and still costs something real: ``alembic revision
+--autogenerate`` diffs catalog names against ``Base.metadata`` names, so
+it reads the mismatch as drift and proposes dropping and recreating a
+constraint that is already correct. The next person to touch the table is
+handed that diff and has to establish from scratch that it is spurious.
+Six constraints were in that state before ``b7e4d1a9c026``, across three
+revisions and eighteen months, and no test noticed -- which is the actual
+finding here: the names were never measured against anything.
+
+The mechanism, once, because it is not obvious and it will recur.
+``NAMING_CONVENTION`` spells checks ``ck_%(table_name)s_%(constraint_name)s``.
+That template interpolates ``%(constraint_name)s``, so SQLAlchemy applies
+it to constraints that were given an explicit name as well as to
+anonymous ones. Hand ``op.create_check_constraint`` (or
+``sa.CheckConstraint(name=...)``) a name that already starts
+``ck_<table>_`` and the prefix is applied a second time; over 63
+characters PostgreSQL truncates and appends a hash. The ``uq``, ``ix``
+and ``fk`` templates key off column names instead, so they do not do
+this -- which is why the trap catches only checks, and why it looks like
+nothing when you test one ``uq`` and generalise.
+
+``test_every_check_constraint_is_named_as_the_model_predicts`` is the
+guard that would have caught all six on the day each was written. It is
+deliberately a whole-schema sweep rather than an assertion about the six:
+the failure mode is a *new* revision repeating the mistake, and a test
+enumerating today's constraints would pass through that unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+import app.db.models  # noqa: F401  (populates Base.metadata)
+from app.db.base import Base
+
+#: ``ck_<table>_ck_<table>_...``, plus the truncated form where the
+#: doubled prefix has been cut short and hashed. Matching the shape
+#: rather than the six known names is the point: this catches the seventh.
+_DOUBLED_PREFIX = re.compile(r"^ck_(.+?)_ck_\1")
+
+
+def _named_check_constraints() -> set[tuple[str, str]]:
+    """``(table, name)`` for every explicitly named CHECK in the ORM."""
+    return {
+        (table.name, str(constraint.name))
+        for table in Base.metadata.tables.values()
+        for constraint in table.constraints
+        if isinstance(constraint, sa.CheckConstraint) and constraint.name is not None
+    }
+
+
+def test_every_check_constraint_is_named_as_the_model_predicts(db_session):
+    """Every CHECK the ORM declares exists in the catalog under that name.
+
+    Stated as a set difference in both directions, and reported as two
+    lists, because the two halves mean different things. A name the model
+    expects and the database lacks is a constraint that is missing, named
+    differently, or spelled differently. A ``ck_`` name the database has
+    and the model does not expect is the residue -- typically the same
+    constraint under its mis-expanded name. Seeing both at once is what
+    turns "autogenerate wants to change something" into a diagnosis.
+    """
+    expected = _named_check_constraints()
+    actual = {
+        (table, name)
+        for table, name in db_session.execute(
+            text(
+                "SELECT conrelid::regclass::text, conname"
+                "  FROM pg_constraint"
+                " WHERE contype = 'c'"
+                "   AND connamespace = current_schema()::regnamespace"
+                "   AND conname LIKE 'ck\\_%'"
+            )
+        ).all()
+    }
+
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    assert not missing and not unexpected, (
+        "the database and app/db/models disagree about CHECK constraint "
+        "names, so `alembic revision --autogenerate` will propose dropping "
+        "and recreating constraints that are already correct.\n"
+        f"  declared in the ORM, absent from the database: {missing}\n"
+        f"  present in the database, not declared in the ORM: {unexpected}\n"
+        "If a migration passed an already-expanded 'ck_<table>_...' name to "
+        "op.create_check_constraint, pass the short name instead -- "
+        "NAMING_CONVENTION adds the prefix. See b7e4d1a9c026."
+    )
+
+
+def test_no_constraint_carries_its_table_prefix_twice(db_session):
+    """The specific shape, named so the failure explains itself.
+
+    Redundant with the sweep above when both are green, and not when they
+    are not: this one fires on the doubled prefix alone, which is the
+    fingerprint of the mistake, so a reader who hits it knows what was
+    done wrong without diffing two lists.
+    """
+    doubled = [
+        f"{table}.{name}"
+        for table, name in db_session.execute(
+            text(
+                "SELECT conrelid::regclass::text, conname"
+                "  FROM pg_constraint"
+                " WHERE contype = 'c'"
+                "   AND connamespace = current_schema()::regnamespace"
+            )
+        ).all()
+        if _DOUBLED_PREFIX.match(name)
+    ]
+    assert not doubled, (
+        "these constraints carry their table prefix twice, which means a "
+        "migration passed op.create_check_constraint a name that already "
+        f"began 'ck_<table>_': {doubled}. Pass the short name; "
+        "NAMING_CONVENTION expands it."
+    )
+
+
+def test_every_index_the_model_declares_exists_by_name(db_session):
+    """The same guard for indexes, which the ``uq``/``ix`` templates spare.
+
+    Included because ``statmech_torsion``'s uniqueness rule is declared as
+    an ``Index`` rather than a ``UniqueConstraint`` -- so the check
+    constraint sweep above says nothing about it -- and because renaming
+    it in ``b7e4d1a9c026`` is exactly the kind of change that goes into a
+    model and not into a migration.
+    """
+    expected = {
+        (table.name, index.name)
+        for table in Base.metadata.tables.values()
+        for index in table.indexes
+        if index.name is not None
+    }
+    actual = {
+        (table, name)
+        for table, name in db_session.execute(
+            text(
+                "SELECT tablename, indexname FROM pg_indexes"
+                " WHERE schemaname = current_schema()"
+            )
+        ).all()
+    }
+    missing = sorted(expected - actual)
+    assert not missing, (
+        "these indexes are declared in app/db/models and are not in the "
+        f"database under that name: {missing}. A model-side rename needs a "
+        "migration carrying ALTER INDEX ... RENAME TO."
+    )

--- a/backend/tests/db/test_constraint_rename_migration.py
+++ b/backend/tests/db/test_constraint_rename_migration.py
@@ -1,0 +1,214 @@
+"""What ``b7e4d1a9c026`` does when the names are not what it expects.
+
+The migration renames six CHECK constraints and one unique index. On the
+database it was written against, every one of the seven is found under
+the old name and renamed -- which is a branch the round trip already
+covers, and which says nothing about the three cases where the rename is
+not simply available.
+
+Those cases are not hypothetical in the way a defensive branch usually
+is. This is a *rename*, and hosts reach a given name by different routes:
+a database built from scratch after the conventions changed, a re-run of
+the revision, a restore from a dump taken mid-flight, a constraint
+dropped by hand during an incident. Each of the three is measured here
+against a catalog deliberately put into that state, because none of them
+runs on a clean upgrade and so none of them would otherwise ever execute.
+
+The choice under test, stated once: **already correctly named is a
+no-op**, and the two genuine ambiguities refuse. The goal of the
+revision is "the rule is present under the name the model predicts". If
+that already holds, the goal is met and failing the deploy would be
+punishing a database for being correct. If the rule is *absent*
+entirely, or present twice, the migration cannot reach that goal by
+renaming and will not pretend otherwise -- recreating a dropped
+constraint would mean installing a rule against rows it has not
+measured, and merging two is a question only whoever made the second one
+can answer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from alembic import command
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_PREVIOUS_HEAD = "e2a7c9d4b615"
+_CURRENT_HEAD = "b7e4d1a9c026"
+
+#: The pair exercised here. ``calculation_artifact.bytes > 0`` is chosen
+#: for having a one-clause definition that can be spelled out below
+#: without ambiguity; the migration treats all seven identically, and
+#: ``_OTHER_TABLE`` below checks that it really does by watching a
+#: different one roll back.
+_TABLE = "calculation_artifact"
+_OLD = "ck_calculation_artifact_ck_calculation_artifact_bytes_gt_0"
+_NEW = "ck_calculation_artifact_bytes_gt_0"
+_DEFINITION = "bytes > 0"
+
+#: Renamed *before* ``_TABLE`` in the migration's list, so if a refusal
+#: on ``_TABLE`` left this one renamed, the migration would be applying
+#: changes it then declined to finish.
+_OTHER_OLD = "ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2"
+
+
+@pytest.fixture
+def alembic_at_previous_head(db_engine, monkeypatch):
+    """Hold the database one revision below head for the duration.
+
+    Restores head in teardown whatever the test did to the catalog, so a
+    failure here fails this test rather than every test that follows it.
+    """
+    url = db_engine.url.render_as_string(hide_password=False)
+    for key, value in (
+        ("DB_NAME", db_engine.url.database),
+        ("DB_USER", "tckdb"),
+        ("DB_PASSWORD", "tckdb"),
+        ("DB_HOST", "127.0.0.1"),
+        ("DB_PORT", "5432"),
+    ):
+        monkeypatch.setenv(key, value)
+    db_engine.dispose()
+
+    config = Config(str(_BACKEND_ROOT / "alembic.ini"))
+    engine = create_engine(url)
+    command.downgrade(config, _PREVIOUS_HEAD)
+    try:
+        yield config, engine
+    finally:
+        _restore_pre_upgrade_names(engine)
+        command.upgrade(config, _CURRENT_HEAD)
+        engine.dispose()
+
+
+def _constraint_names(engine) -> set[str]:
+    with engine.connect() as connection:
+        return set(
+            connection.execute(
+                text(
+                    "SELECT conname FROM pg_constraint"
+                    " WHERE conrelid = CAST(:table AS regclass) AND contype = 'c'"
+                ),
+                {"table": _TABLE},
+            )
+            .scalars()
+            .all()
+        )
+
+
+def _execute(engine, statement: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(text(statement))
+
+
+def _restore_pre_upgrade_names(engine) -> None:
+    """Put the catalog back into the shape the downgrade left it in."""
+    names = _constraint_names(engine)
+    if _NEW in names and _OLD in names:
+        _execute(engine, f'ALTER TABLE {_TABLE} DROP CONSTRAINT "{_NEW}"')
+    elif _NEW in names:
+        _execute(
+            engine, f'ALTER TABLE {_TABLE} RENAME CONSTRAINT "{_NEW}" TO "{_OLD}"'
+        )
+    elif _OLD not in names:
+        _execute(
+            engine,
+            f'ALTER TABLE {_TABLE} ADD CONSTRAINT "{_OLD}" CHECK ({_DEFINITION})',
+        )
+
+
+def test_a_constraint_already_correctly_named_is_left_alone(alembic_at_previous_head):
+    """The re-run and the built-from-scratch host: no-op, deploy proceeds.
+
+    Refusing here would block an upgrade on a database that is already in
+    the state this revision exists to produce.
+    """
+    config, engine = alembic_at_previous_head
+    _execute(engine, f'ALTER TABLE {_TABLE} RENAME CONSTRAINT "{_OLD}" TO "{_NEW}"')
+
+    command.upgrade(config, _CURRENT_HEAD)
+
+    names = _constraint_names(engine)
+    assert _NEW in names, "the correctly named constraint was disturbed"
+    assert _OLD not in names, "the old name came back"
+    assert sum(1 for name in names if name.endswith("bytes_gt_0")) == 1, (
+        f"the rule ended up on the table more than once: {sorted(names)}"
+    )
+
+
+def test_a_missing_constraint_is_refused_rather_than_recreated(
+    alembic_at_previous_head,
+):
+    """Neither name present means a rule was dropped, not renamed.
+
+    Recreating it here would install an unmeasured rule and, worse, would
+    report success -- leaving an operator believing the schema is intact
+    when something in their environment is dropping constraints.
+    """
+    config, engine = alembic_at_previous_head
+    _execute(engine, f'ALTER TABLE {_TABLE} DROP CONSTRAINT "{_OLD}"')
+
+    with pytest.raises(RuntimeError) as excinfo:
+        command.upgrade(config, _CURRENT_HEAD)
+
+    message = str(excinfo.value)
+    assert _OLD in message and _NEW in message, (
+        f"the refusal must name both spellings it looked for: {message}"
+    )
+    assert _TABLE in message
+
+    # Nothing was installed, and nothing that had already been renamed in
+    # the same run survived: the migration is all-or-nothing.
+    assert _NEW not in _constraint_names(engine)
+    with engine.connect() as connection:
+        still_old = connection.scalar(
+            text("SELECT count(*) FROM pg_constraint WHERE conname = :name"),
+            {"name": _OTHER_OLD},
+        )
+    assert still_old == 1, (
+        "a constraint renamed earlier in the same upgrade was not rolled "
+        "back when a later one refused"
+    )
+
+    # Repaired the way an operator would -- by restoring the rule -- the
+    # same migration goes through.
+    _execute(
+        engine,
+        f'ALTER TABLE {_TABLE} ADD CONSTRAINT "{_OLD}" CHECK ({_DEFINITION})',
+    )
+    command.upgrade(config, _CURRENT_HEAD)
+    assert _NEW in _constraint_names(engine)
+
+
+def test_both_names_present_is_refused_rather_than_merged(alembic_at_previous_head):
+    """A rename cannot merge two constraints, so it declines to try.
+
+    Which of the two to keep depends on how the second one arrived, and
+    the migration has no way to find that out. Dropping either would
+    discard a rule somebody added on purpose.
+    """
+    config, engine = alembic_at_previous_head
+    _execute(
+        engine,
+        f'ALTER TABLE {_TABLE} ADD CONSTRAINT "{_NEW}" CHECK ({_DEFINITION})',
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        command.upgrade(config, _CURRENT_HEAD)
+
+    message = str(excinfo.value)
+    assert _OLD in message and _NEW in message, (
+        f"the refusal must name both constraints it found: {message}"
+    )
+
+    # Both are still there: the migration changed nothing on its way out.
+    names = _constraint_names(engine)
+    assert _OLD in names and _NEW in names
+
+    _execute(engine, f'ALTER TABLE {_TABLE} DROP CONSTRAINT "{_NEW}"')
+    command.upgrade(config, _CURRENT_HEAD)
+    assert _NEW in _constraint_names(engine)

--- a/backend/tests/db/test_constraint_rename_migration.py
+++ b/backend/tests/db/test_constraint_rename_migration.py
@@ -62,6 +62,18 @@ def alembic_at_previous_head(db_engine, monkeypatch):
 
     Restores head in teardown whatever the test did to the catalog, so a
     failure here fails this test rather than every test that follows it.
+
+    The teardown runs ``downgrade`` before ``upgrade``, and that ordering
+    is load-bearing rather than defensive. Two of the tests below finish
+    by repairing the catalog and letting the migration through, which
+    leaves ``alembic_version`` at head -- so a teardown that only put the
+    *names* back and then called ``upgrade`` would find nothing to run,
+    and would hand the next test on this worker a database carrying the
+    doubled name under a version stamp claiming it had been renamed.
+    That is not hypothetical: it is what the first version of this file
+    did, and ``test_constraint_names_match_the_model.py`` caught it in CI
+    as a schema-wide sweep failure with no obvious author. Forcing the
+    version back down first makes the final ``upgrade`` real work again.
     """
     url = db_engine.url.render_as_string(hide_password=False)
     for key, value in (
@@ -80,8 +92,13 @@ def alembic_at_previous_head(db_engine, monkeypatch):
     try:
         yield config, engine
     finally:
+        # Order matters; see the docstring. Names first so the downgrade
+        # meets a catalog it can act on, then the version stamp back down
+        # so the final upgrade actually runs the rename.
         _restore_pre_upgrade_names(engine)
+        command.downgrade(config, _PREVIOUS_HEAD)
         command.upgrade(config, _CURRENT_HEAD)
+        _assert_left_at_head(engine)
         engine.dispose()
 
 
@@ -119,6 +136,28 @@ def _restore_pre_upgrade_names(engine) -> None:
             engine,
             f'ALTER TABLE {_TABLE} ADD CONSTRAINT "{_OLD}" CHECK ({_DEFINITION})',
         )
+
+
+def _assert_left_at_head(engine) -> None:
+    """Fail loudly here rather than quietly somewhere downstream.
+
+    This file is the only thing in the suite that alters the schema of
+    the worker's database, so a teardown that half-worked does not show
+    up as a failure in this file -- it shows up as an unrelated test
+    somewhere else reading a catalog nobody expected. Checking the exit
+    state keeps the blame local.
+    """
+    names = _constraint_names(engine)
+    assert _NEW in names and _OLD not in names, (
+        "teardown left calculation_artifact carrying "
+        f"{sorted(n for n in names if n.endswith('bytes_gt_0'))}; the next "
+        "test on this worker would see a schema this file broke"
+    )
+    with engine.connect() as connection:
+        version = connection.scalar(text("SELECT version_num FROM alembic_version"))
+    assert version == _CURRENT_HEAD, (
+        f"teardown left alembic_version at {version!r}, not {_CURRENT_HEAD!r}"
+    )
 
 
 def test_a_constraint_already_correctly_named_is_left_alone(alembic_at_previous_head):

--- a/backend/tests/db/test_statmech_torsion_index_uniqueness.py
+++ b/backend/tests/db/test_statmech_torsion_index_uniqueness.py
@@ -1,0 +1,187 @@
+"""One hindered rotor per ``(statmech record, torsion index)``, in the database.
+
+A duplicate ``statmech_torsion.torsion_index`` is not the kind of defect
+that announces itself. Nothing rejects the record, nothing logs, and no
+reader sees an error: the second row is simply a second rotor, and the
+partition function it feeds counts one internal rotation twice. Every
+downstream number -- entropy, heat capacity, the rate constant that used
+them -- is wrong by a factor nobody can spot from the outputs.
+
+All three upload paths refuse duplicates at validation time
+(``computed_species_upload``, ``computed_reaction_upload``,
+``conformer_upload``). That covers writers that arrive as a request, and
+it is the whole of the coverage that a reading of the *schema* would find
+if it went looking for a ``UniqueConstraint`` on the model, because there
+isn't one -- there is a unique ``Index``, which is the same enforcement
+wearing a different declaration. Its name until ``b7e4d1a9c026`` was
+``uq_statmech_torsion_statmech_id``, mentioning only the first of its two
+columns, which reads as a rule about ``statmech_id`` alone. That is how
+the invariant came to be reported as unenforced below the request layer.
+
+This file settles it by provocation rather than by reading either the
+name or the declaration:
+
+1. The database refuses the duplicate.
+2. It refuses it under ``session_replication_role = replica`` -- the mode
+   bulk loaders, importers and ``pg_restore`` run in, which suspends
+   triggers and foreign keys. Those are exactly the writers that do not
+   pass through an upload schema, and the reason a unique index is worth
+   more here than any amount of validation.
+3. The legitimate shapes still go in, so the rule is not over-broad.
+4. The index still spans both columns and is still unique, read out of
+   ``pg_index``. A future migration that narrowed it to ``statmech_id``,
+   or dropped ``unique``, would keep every provocation above passing on a
+   table that happened to have no second torsion in it; this reads the
+   catalog instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models.statmech import StatmechTorsion
+from tests.services.scientific_read._factories import (
+    make_species,
+    make_species_entry,
+    make_statmech,
+    next_inchi_key,
+)
+
+_INDEX = "uq_statmech_torsion_statmech_id_torsion_index"
+
+
+@pytest.fixture
+def statmech_ids(db_session) -> tuple[int, int]:
+    """Two independent statmech records, to separate "same" from "any"."""
+    ids = []
+    for tag in ("TORA", "TORB"):
+        entry = make_species_entry(
+            db_session, make_species(db_session, inchi_key=next_inchi_key(tag))
+        )
+        ids.append(make_statmech(db_session, species_entry=entry).id)
+    return ids[0], ids[1]
+
+
+def _add_torsion(db_session, statmech_id: int, torsion_index: int) -> None:
+    db_session.add(
+        StatmechTorsion(
+            statmech_id=statmech_id,
+            torsion_index=torsion_index,
+            dimension=1,
+        )
+    )
+    db_session.flush()
+
+
+def test_a_repeated_torsion_index_is_refused(db_session, statmech_ids):
+    """The rotor cannot be counted twice, whatever wrote it."""
+    statmech_id, _ = statmech_ids
+    savepoint = db_session.begin_nested()
+    try:
+        _add_torsion(db_session, statmech_id, 1)
+        with pytest.raises(IntegrityError) as excinfo:
+            _add_torsion(db_session, statmech_id, 1)
+        assert _INDEX in str(excinfo.value), (
+            "the duplicate was refused by something other than "
+            f"{_INDEX}: {excinfo.value}"
+        )
+    finally:
+        savepoint.rollback()
+
+
+def test_the_shapes_that_are_not_duplicates_are_accepted(db_session, statmech_ids):
+    """Two rotors on one record, and rotor 1 on each of two records.
+
+    Both are ordinary. Asserted so that a constraint tightened by mistake
+    -- unique on ``statmech_id``, or on ``torsion_index`` -- fails here
+    rather than at the first two-rotor species someone uploads.
+    """
+    first, second = statmech_ids
+    savepoint = db_session.begin_nested()
+    try:
+        _add_torsion(db_session, first, 1)
+        _add_torsion(db_session, first, 2)
+        _add_torsion(db_session, second, 1)
+        stored = db_session.scalar(
+            text(
+                "SELECT count(*) FROM statmech_torsion"
+                " WHERE statmech_id IN (:a, :b)"
+            ),
+            {"a": first, "b": second},
+        )
+        assert stored == 3
+    finally:
+        savepoint.rollback()
+
+
+def test_the_index_holds_under_a_bulk_load_session(db_session, statmech_ids):
+    """The measurement that answers "is validation the only thing stopping it".
+
+    Both halves together, because the claim is the *difference*. With
+    system triggers suspended the foreign key onto ``statmech`` stops
+    holding -- a torsion for a record that does not exist is accepted --
+    and the unique index on the same table in the same session does not
+    stop holding. An importer or a restore is therefore not able to
+    produce the duplicate, which is the specific thing that was in doubt.
+    """
+    savepoint = db_session.begin_nested()
+    try:
+        db_session.execute(text("SET LOCAL session_replication_role = replica"))
+
+        # The foreign key: not enforced.
+        db_session.execute(
+            text(
+                "INSERT INTO statmech_torsion"
+                " (statmech_id, torsion_index, dimension)"
+                " VALUES (-1, 1, 1)"
+            )
+        )
+        db_session.flush()
+
+        # The unique index: still enforced, same table, same session.
+        with pytest.raises(IntegrityError) as excinfo:
+            db_session.execute(
+                text(
+                    "INSERT INTO statmech_torsion"
+                    " (statmech_id, torsion_index, dimension)"
+                    " VALUES (-1, 1, 1)"
+                )
+            )
+            db_session.flush()
+        assert _INDEX in str(excinfo.value)
+    finally:
+        savepoint.rollback()
+
+
+def test_the_index_is_unique_and_spans_both_columns(db_session):
+    """Read off ``pg_index``, not off the name or the model declaration.
+
+    The name is what misled a reader once already, and the model
+    declaration is not what the database enforces -- the catalog is.
+    """
+    row = db_session.execute(
+        text(
+            "SELECT i.indisunique,"
+            "       array_agg(a.attname ORDER BY k.ord) AS cols"
+            "  FROM pg_index i"
+            "  JOIN pg_class c ON c.oid = i.indexrelid"
+            "  JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)"
+            "       ON TRUE"
+            "  JOIN pg_attribute a"
+            "       ON a.attrelid = i.indrelid AND a.attnum = k.attnum"
+            " WHERE c.relname = :name"
+            " GROUP BY i.indisunique"
+        ),
+        {"name": _INDEX},
+    ).one_or_none()
+
+    assert row is not None, f"{_INDEX} is not on statmech_torsion"
+    indisunique, columns = row
+    assert indisunique is True, f"{_INDEX} exists but is not unique"
+    assert list(columns) == ["statmech_id", "torsion_index"], (
+        f"{_INDEX} covers {list(columns)}; a rotor is unique within a "
+        "statmech record, so it must cover exactly statmech_id and "
+        "torsion_index"
+    )


### PR DESCRIPTION
Closes #134. Answers #130 — see "#130 was already enforced" below; its premise does not hold and no migration was warranted.

One new revision, `b7e4d1a9c026`, chained onto `e2a7c9d4b615`. Head stays single.

## #134, and the five others like it

The reported constraint is real:

```
ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2
```

Sweeping `pg_constraint` on a from-scratch `alembic upgrade head` found **six**, not one, from three revisions:

| table | deployed name | model predicts |
|---|---|---|
| `calc_freq_mode` | `..._ck_calc_freq_mode_imaginary_dispositi_ddc2` | `ck_calc_freq_mode_imaginary_disposition_requires_imaginary_mode` |
| `calculation_artifact` | `ck_calculation_artifact_ck_calculation_artifact_bytes_gt_0` | `ck_calculation_artifact_bytes_gt_0` |
| `calculation_artifact` | `ck_calculation_artifact_ck_calculation_artifact_sha256__8107` | `ck_calculation_artifact_sha256_lower_hex` |
| `execution_environment_manifest` | `..._ck_execution_environm_0a7b` | `ck_execution_environment_manifest_content_digest_sha256` |
| `execution_environment_manifest` | `..._ck_execution_environm_8159` | `ck_execution_environment_manifest_closure_json_array` |
| `execution_environment_manifest` | `..._ck_execution_environm_8dbd` | `ck_execution_environment_manifest_canonical_json_object` |

Cause: `NAMING_CONVENTION` spells checks `ck_%(table_name)s_%(constraint_name)s`. That template interpolates `%(constraint_name)s`, so SQLAlchemy applies it to *explicitly named* constraints as well as anonymous ones — unlike `uq`/`ix`/`fk`, which key off column names and leave an explicit name alone. Hand `op.create_check_constraint` (or `sa.CheckConstraint(name=...)` inside `create_table`) a name already carrying the prefix and it lands twice; over 63 characters PostgreSQL truncates and hashes.

The three hashed `execution_environment_manifest` names are truncated past the point of saying which column each covers, so the pairing was taken from `pg_get_constraintdef`, not read off the names. The definitions are quoted in the revision so the mapping is checkable without a database.

Fixed with `ALTER TABLE ... RENAME CONSTRAINT`, both directions. Renames rather than drop-and-recreate: catalog-only, no table scan (recreating `ck_calculation_artifact_sha256` would revalidate every artifact row), and no window in which a rule is off the table. All six remain `convalidated = true` across the round trip.

## When the name is already right: no-op

Chosen over refusal. The revision's goal is "the rule is present under the name the model predicts"; if that already holds, the goal is met, and failing the deploy would punish a database for being correct. A re-run, or a host that reached the short name another way, proceeds with a log line.

Refusal is kept for the two cases that are *not* "already done", each naming both spellings it looked for and changing nothing:

- **Neither name present** — a rule was dropped, not renamed. Recreating it here would install a constraint against rows this migration has not measured, and would report success while the operator's real problem (something is dropping constraints) went unmentioned.
- **Both present** — a rename cannot merge two constraints, and which to keep depends on how the second arrived.

## #130 was already enforced

The premise does not hold. `statmech_torsion` has enforced uniqueness of `(statmech_id, torsion_index)` since `d861dfd60891` — the initial schema, deployed — as a unique **index** rather than a unique **constraint**:

```
uq_statmech_torsion_statmech_id | CREATE UNIQUE INDEX ... USING btree (statmech_id, torsion_index)
```

Both columns are `NOT NULL`, so there is no NULL escape, and the index holds under `session_replication_role = replica` — measured, not assumed:

```
SET session_replication_role = replica;
INSERT ... VALUES (900001, 1, 1);   -- INSERT 0 1
INSERT ... VALUES (900001, 1, 1);   -- ERROR: duplicate key value violates
                                    -- unique constraint "uq_statmech_torsion_..."
```

That is the bulk-loader / importer / `pg_restore` path the issue was worried about. No migration was warranted, and adding a redundant `UniqueConstraint` to a deployed table would have been churn with no enforcement gain.

**Why it read as absent.** The name said `uq_statmech_torsion_statmech_id` — one of its two columns — which parses as a uniqueness rule on `statmech_id` alone (absurd: one torsion per record), so it skims as a mistake rather than as the constraint you were looking for. Renamed to `uq_statmech_torsion_statmech_id_torsion_index` in the same revision, since it is the same defect class: a name that misdescribes what it names, and this one had already cost a reader a false bug report. `schema.dbml` regenerated (one line).

## Tests

The finding behind the finding: **nothing pinned any of these names**, which is how six drifted across three revisions unnoticed.

- `test_constraint_names_match_the_model.py` — whole-schema sweep, both directions, of `Base.metadata` CHECK names against `pg_constraint`, plus a `ck_<table>_ck_<table>_` shape check and the same guard for indexes. Deliberately not an assertion about today's six: the failure mode is a *new* revision repeating the mistake, and an enumerating test passes straight through that.
- `test_constraint_rename_migration.py` — the three catalog states the rename is not simply available in, each planted deliberately. Also asserts a constraint renamed earlier in the same run is rolled back when a later one refuses.
- `test_statmech_torsion_index_uniqueness.py` — the duplicate refused, refused under `replica`, the non-duplicate shapes accepted, and the index read out of `pg_index` as unique over exactly those two columns.

## Verification

Round trip on a scratch DB (`upgrade head` → `downgrade -1` → `upgrade head`), reading `pg_constraint` at each step: six correct names at head, six doubled names after downgrade, zero `ck_.*_ck_` matches after re-upgrade. `alembic heads` → `b7e4d1a9c026` alone. ORM-vs-catalog diff is empty in both directions.

Gates: rest **4172 passed**, api **2577 passed**, scientific **2045 passed**. The +10 over `main` is exactly the new tests (main collects 4176 in the rest gate; the 4149 baseline predates #148/#149).

Mutation check: neutering `upgrade()` turns 8 of the 10 red; reverting only the model-side index rename turns exactly 1 red (`test_every_index_the_model_declares_exists_by_name`) and moves nothing else.

## The sweep earned its keep on day one

The first push was green locally and red in CI, in a file that had not caused it: `test_every_check_constraint_is_named_as_the_model_predicts` and `test_no_constraint_carries_its_table_prefix_twice` failed on `calculation_artifact.ck_calculation_artifact_ck_calculation_artifact_bytes_gt_0`.

Cause was `test_constraint_rename_migration.py`'s own teardown. Two of its cases end by repairing the catalog and letting the migration through, which leaves `alembic_version` at head — so a teardown that restored the *names* and then called `upgrade` found nothing to run, and released a worker database carrying the doubled name under a version stamp claiming it had been renamed. Every later test on that worker read it.

Fixed in f586f37d: teardown forces the version back down so the final `upgrade` is real work, and asserts its exit state before releasing the database, so a half-worked teardown fails locally instead of somewhere downstream. Reproduced deterministically by running the two files in the CI order (`rename` before `names`), and confirmed by reverting the teardown alone — same two tests, same constraint.

Worth noting for its own sake: the schema-wide sweep caught a shared-state defect it was not written for, on the first day it existed, in a file other than the one at fault. An enumerating test over today's six constraints would have stayed green.

## For the operator

Nothing to run before deploying. `upgrade()` reads `pg_constraint`/`pg_indexes` and issues `RENAME`; it does not read, write, scan or lock a single data row, so no data can fail it and the Pi's contents are unaffected either way. The only precondition is on names, and the migration measures that itself and refuses rather than guessing.
