### PR TITLE
Refuse an electron with coordinates, and let both bundle roots record what produced their numbers

### DIFF
--- a/backend/app/schemas/fragments/calculation.py
+++ b/backend/app/schemas/fragments/calculation.py
@@ -21,6 +21,7 @@ from tckdb_schemas.fragments.calculation import (
     OutputGeometryEntry,
     PathSearchPointPayload,
     PathSearchResultPayload,
+    SCFStabilityContent,
     SCFStabilityPayload,
     SpinDiagnosticPayload,
     SPResultPayload,

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -31,7 +31,12 @@ from app.db.models.statmech import (
     StatmechTorsion,
     StatmechTorsionDefinition,
 )
-from app.db.models.thermo import Thermo, ThermoNASA, ThermoPoint
+from app.db.models.thermo import (
+    Thermo,
+    ThermoNASA,
+    ThermoPoint,
+    ThermoSourceCalculation,
+)
 from app.db.models.transition_state import TransitionState, TransitionStateEntry
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.workflows.computed_reaction_upload import (
@@ -91,6 +96,7 @@ from app.services.species_resolution import resolve_species_entry
 from app.services.transition_state_validation import (
     persist_transition_state_validation_evidence,
 )
+from app.workflows.thermo import assert_thermo_role_matches_calculation_type
 
 
 def _persist_calculation(
@@ -716,21 +722,47 @@ def persist_computed_reaction_upload(
             species_entry = species_key_to_entry[sp.key]
             t = sp.thermo
 
+            # Per-thermo provenance overrides the bundle-level default.
+            # The bundle value describes the run; a species whose thermo
+            # came out of a different code or a paper says so here, and
+            # falling back only when it stays silent keeps every deposit
+            # written before these fields existed reading the same way.
+            thermo_software_release = (
+                resolve_software_release_ref(session, t.software_release)
+                if t.software_release is not None
+                else bundle_analysis_software_release
+            )
+            thermo_workflow_tool_release = (
+                resolve_workflow_tool_release_ref(session, t.workflow_tool_release)
+                if t.workflow_tool_release is not None
+                else bundle_workflow_tool_release
+            )
+            thermo_literature = (
+                resolve_or_create_literature(session, t.literature)
+                if t.literature is not None
+                else None
+            )
+
             thermo = Thermo(
                 species_entry_id=species_entry.id,
                 scientific_origin=t.scientific_origin,
+                literature_id=(
+                    thermo_literature.id if thermo_literature is not None else None
+                ),
                 software_release_id=(
-                    bundle_analysis_software_release.id
-                    if bundle_analysis_software_release
+                    thermo_software_release.id
+                    if thermo_software_release
                     else None
                 ),
                 workflow_tool_release_id=(
-                    bundle_workflow_tool_release.id
-                    if bundle_workflow_tool_release
+                    thermo_workflow_tool_release.id
+                    if thermo_workflow_tool_release
                     else None
                 ),
                 h298_kj_mol=t.h298_kj_mol,
                 s298_j_mol_k=t.s298_j_mol_k,
+                h298_uncertainty_kj_mol=t.h298_uncertainty_kj_mol,
+                s298_uncertainty_j_mol_k=t.s298_uncertainty_j_mol_k,
                 tmin_k=t.tmin_k,
                 tmax_k=t.tmax_k,
                 note=t.note,
@@ -740,6 +772,36 @@ def persist_computed_reaction_upload(
             session.flush()
             thermo_ids.append(thermo.id)
             thermo_by_species_key[sp.key] = thermo
+
+            # Which calculations produced this number. The schema already
+            # refused a key that names nothing in the bundle; ownership is
+            # checked here because this is the layer that knows which
+            # species entry each key resolved to.
+            for index, sc in enumerate(t.source_calculations):
+                source_calc_id = calculation_key_to_id[sc.calculation_key]
+                source_calc = session.get(Calculation, source_calc_id)
+                if source_calc.species_entry_id != species_entry.id:
+                    raise ValueError(
+                        f"species[{sp.key!r}].thermo.source_calculations"
+                        f"[{index}].calculation_key="
+                        f"'{sc.calculation_key}': refers to a calculation "
+                        f"that is not owned by this species entry."
+                    )
+                assert_thermo_role_matches_calculation_type(
+                    source_calc,
+                    role=sc.role,
+                    context=(
+                        f"species[{sp.key!r}].thermo.source_calculations"
+                        f"[{index}].calculation_key='{sc.calculation_key}'"
+                    ),
+                )
+                session.add(
+                    ThermoSourceCalculation(
+                        thermo_id=thermo.id,
+                        calculation_id=source_calc_id,
+                        role=sc.role,
+                    )
+                )
 
             if t.nasa is not None:
                 session.add(ThermoNASA(thermo_id=thermo.id, **t.nasa.model_dump()))

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -19,7 +19,6 @@ from app.db.models.common import (
     CalculationType,
     ScientificOriginKind,
     SubmissionRecordType,
-    ThermoCalculationRole,
 )
 from app.db.models.species import ConformerObservation
 from app.db.models.statmech import (
@@ -88,36 +87,12 @@ from app.services.sp_energy_extraction import (
 )
 from app.services.species_resolution import resolve_species_entry
 from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
+from app.workflows.thermo import assert_thermo_role_matches_calculation_type
 
 # ---------------------------------------------------------------------------
 # Thermo role/type compatibility (mirror DR-0028 helpers in workflows/thermo)
 # ---------------------------------------------------------------------------
 
-_THERMO_ROLE_TO_CALC_TYPE: dict[ThermoCalculationRole, CalculationType] = {
-    ThermoCalculationRole.opt: CalculationType.opt,
-    ThermoCalculationRole.freq: CalculationType.freq,
-    ThermoCalculationRole.sp: CalculationType.sp,
-}
-
-
-def _assert_thermo_role_type_compatible(
-    calc: Calculation,
-    role: ThermoCalculationRole,
-    *,
-    context: str,
-) -> None:
-    """Verify a thermo source calc's type is compatible with the role.
-
-    Mirrors ``app.workflows.thermo._assert_calculation_role_compatible``.
-    """
-    expected = _THERMO_ROLE_TO_CALC_TYPE.get(role)
-    if expected is None:
-        return
-    if calc.type != expected:
-        raise ValueError(
-            f"{context}: role='{role.value}' is incompatible with the "
-            f"resolved calculation type."
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +153,7 @@ def _to_calc_with_results_payload(
         path_search_result=calc_in.path_search_result,
         wavefunction_diagnostic=calc_in.wavefunction_diagnostic,
         spin_diagnostic=calc_in.spin_diagnostic,
+        scf_stability=calc_in.scf_stability,
         hessian=calc_in.hessian,
         input_geometries=calc_in.input_geometries,
         output_geometries=calc_in.output_geometries,
@@ -718,9 +694,9 @@ def _persist_thermo_block(
                 f"'{sc.calculation_key}': refers to a calculation owned "
                 f"by a different species entry."
             )
-        _assert_thermo_role_type_compatible(
+        assert_thermo_role_matches_calculation_type(
             calc_row,
-            sc.role,
+            role=sc.role,
             context=(
                 f"thermo.source_calculations calculation_key="
                 f"'{sc.calculation_key}'"

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -29,7 +29,10 @@ from app.db.models.statmech import (
 )
 from app.db.models.thermo import Thermo
 from app.schemas.entities.thermo import ThermoSourceCalculationCreate
-from app.schemas.fragments.calculation import CalculationWithResultsPayload
+from app.schemas.fragments.calculation import (
+    CalculationWithResultsPayload,
+    SCFStabilityPayload,
+)
 from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.workflows.computed_species_upload import (
     CalculationInBundle,
@@ -147,7 +150,11 @@ def _to_calc_with_results_payload(
         path_search_result=calc_in.path_search_result,
         wavefunction_diagnostic=calc_in.wavefunction_diagnostic,
         spin_diagnostic=calc_in.spin_diagnostic,
-        scf_stability=calc_in.scf_stability,
+        scf_stability=(
+            None
+            if calc_in.scf_stability is None
+            else SCFStabilityPayload(**calc_in.scf_stability.model_dump())
+        ),
         hessian=calc_in.hessian,
         input_geometries=calc_in.input_geometries,
         output_geometries=calc_in.output_geometries,

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -90,12 +90,6 @@ from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
 from app.workflows.thermo import assert_thermo_role_matches_calculation_type
 
 # ---------------------------------------------------------------------------
-# Thermo role/type compatibility (mirror DR-0028 helpers in workflows/thermo)
-# ---------------------------------------------------------------------------
-
-
-
-# ---------------------------------------------------------------------------
 # Outcome dataclasses
 # ---------------------------------------------------------------------------
 

--- a/backend/app/workflows/thermo.py
+++ b/backend/app/workflows/thermo.py
@@ -61,13 +61,21 @@ def _assert_calculation_owned_by(
         )
 
 
-def _assert_calculation_role_compatible(
+def assert_thermo_role_matches_calculation_type(
     calculation: Calculation,
     *,
     role: ThermoCalculationRole,
     context: str,
 ) -> None:
     """Verify resolved ``Calculation.type`` is compatible with declared role.
+
+    The single owner of this rule, for every route that links thermo to a
+    supporting calculation: the standalone ``/uploads/thermo`` endpoint,
+    the computed-species bundle and the computed-reaction bundle. It was
+    written twice before — once here and once in ``computed_species`` —
+    and a third copy went in with the reaction route's ``thermo.
+    source_calculations``, at which point three copies of one rule could
+    disagree about the same deposit.
 
     DR-0028 Requirement 1: a single typo in ``existing_calculation_id`` (or
     a mis-keyed inline calc) would otherwise silently link thermo to the
@@ -124,7 +132,7 @@ def _resolve_source_calculation(
             context=context,
         )
 
-    _assert_calculation_role_compatible(
+    assert_thermo_role_matches_calculation_type(
         calc_row,
         role=entry.role,
         context=context,

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -2894,7 +2894,7 @@
       },
       "BundleThermoIn": {
         "additionalProperties": false,
-        "description": "Thermo data attached to a species in this bundle.\n\n:param scientific_origin: Scientific origin category.\n:param h298_kj_mol: Enthalpy at 298 K in kJ/mol.\n:param s298_j_mol_k: Entropy at 298 K in J/(mol*K).\n:param tmin_k: Minimum temperature in K.\n:param tmax_k: Maximum temperature in K.\n:param nasa: Optional NASA polynomial coefficients.\n:param points: Optional tabulated thermo data points.\n:param note: Optional note.",
+        "description": "Thermo data attached to a species in this bundle.\n\nThe reaction route's thermo carries the same provenance the species\nroute's ``ThermoInBundle`` carries, because it is the same claim about\nthe same kind of row. The two models were written three days apart in\nApril 2026 and diverged from the start — this one first, with eight\nfields, and never touched since; ``ThermoInBundle`` three days later\nwith fifteen. Nothing recorded a reason, and the gap was not visible\nfrom either model, so a depositor putting thermo on a reaction bundle\nsilently lost the record of which calculations produced it while the\nsame deposit on the species route kept it.\n\n``applied_energy_corrections`` is deliberately **not** here. The\nreaction bundle already declares applied corrections one level up, on\n:class:`BundleSpeciesIn`, against the same resolved species entry.\nAdding a second place to say it would let one deposit make the claim\ntwice, and the answer to \"which one counts\" would have to be invented.\n\n:param scientific_origin: Scientific origin category.\n:param literature: Optional literature provenance for this thermo.\n:param software_release: Optional analysis-code provenance. Overrides\n    the bundle-level ``analysis_software_release`` for this species.\n:param workflow_tool_release: Optional workflow-tool provenance.\n    Overrides the bundle-level value for this species.\n:param h298_kj_mol: Enthalpy at 298 K in kJ/mol.\n:param s298_j_mol_k: Entropy at 298 K in J/(mol*K).\n:param h298_uncertainty_kj_mol: Optional uncertainty on ``h298_kj_mol``.\n:param s298_uncertainty_j_mol_k: Optional uncertainty on\n    ``s298_j_mol_k``.\n:param tmin_k: Minimum temperature in K.\n:param tmax_k: Maximum temperature in K.\n:param nasa: Optional NASA polynomial coefficients.\n:param points: Optional tabulated thermo data points.\n:param source_calculations: Thermo → calc links by bundle-local\n    calculation key. Each key must resolve in the bundle's global\n    calc-key namespace and must name a calculation owned by this\n    species entry; the workflow rejects both failures.\n:param note: Optional note.",
         "properties": {
           "h298_kj_mol": {
             "anyOf": [
@@ -2906,6 +2906,28 @@
               }
             ],
             "title": "H298 Kj Mol"
+          },
+          "h298_uncertainty_kj_mol": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "H298 Uncertainty Kj Mol"
+          },
+          "literature": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LiteratureUploadRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "nasa": {
             "anyOf": [
@@ -2946,9 +2968,38 @@
             ],
             "title": "S298 J Mol K"
           },
+          "s298_uncertainty_j_mol_k": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "S298 Uncertainty J Mol K"
+          },
           "scientific_origin": {
             "$ref": "#/components/schemas/ScientificOriginKind",
             "default": "computed"
+          },
+          "software_release": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SoftwareReleaseRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source_calculations": {
+            "items": {
+              "$ref": "#/components/schemas/ThermoSourceCalcInBundle"
+            },
+            "title": "Source Calculations",
+            "type": "array"
           },
           "tmax_k": {
             "anyOf": [
@@ -2973,6 +3024,16 @@
               }
             ],
             "title": "Tmin K"
+          },
+          "workflow_tool_release": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowToolReleaseRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "title": "BundleThermoIn",
@@ -5283,6 +5344,16 @@
             "$ref": "#/components/schemas/CalculationQuality",
             "default": "raw"
           },
+          "scf_stability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SCFStabilityPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "software_release": {
             "$ref": "#/components/schemas/SoftwareReleaseRef"
           },
@@ -5517,6 +5588,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/CalculationScanResultCreate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scf_stability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SCFStabilityPayload"
               },
               {
                 "type": "null"
@@ -9640,6 +9721,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/CalculationScanResultCreate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scf_stability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SCFStabilityPayload"
               },
               {
                 "type": "null"

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -5347,7 +5347,7 @@
           "scf_stability": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SCFStabilityPayload"
+                "$ref": "#/components/schemas/SCFStabilityContent"
               },
               {
                 "type": "null"
@@ -5597,7 +5597,7 @@
           "scf_stability": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SCFStabilityPayload"
+                "$ref": "#/components/schemas/SCFStabilityContent"
               },
               {
                 "type": "null"
@@ -9730,7 +9730,7 @@
           "scf_stability": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SCFStabilityPayload"
+                "$ref": "#/components/schemas/SCFStabilityContent"
               },
               {
                 "type": "null"
@@ -30278,9 +30278,79 @@
         "title": "RoleChangeRequest",
         "type": "object"
       },
+      "SCFStabilityContent": {
+        "additionalProperties": false,
+        "description": "Optional inline SCF wavefunction stability evidence.\n\nAttaches to any calculation type — there is no calc_type restriction.\nProducers must only emit ``status = stable`` when an actual\nSCF/wavefunction stability analysis was observed; ordinary SCF\nconvergence does NOT qualify. When unsure whether a stability\nanalysis was performed, omit the block — the read API will project\n``not_checked``. Use ``status = inconclusive`` only when a stability\nanalysis was clearly attempted but its result could not be parsed.\n\n:param status: Persisted status. ``not_checked`` is NOT a valid\n    stored value — omit the block to express that.\n:param lowest_eigenvalue: Smallest eigenvalue from the stability\n    Hessian (software-specific).\n:param instability_count: Number of distinct instabilities found.\n:param instability_type: Free-text describing the instability class\n    (e.g. ``\"RHF→UHF\"``, ``\"internal\"``).\n:param reoptimized_wavefunction: Whether a stable wavefunction was\n    obtained by stability optimisation / reoptimisation.\n\nHolds the stability finding and nothing that names another database\nrow, which is what lets a bundle carry it. A bundle upload identifies\neverything by local key; the two FK fields on\n:class:`SCFStabilityPayload` below would put raw primary keys back on\na surface a depositor is meant to be able to write without ever\nhaving queried TCKDB.",
+        "properties": {
+          "instability_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instability Count"
+          },
+          "instability_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instability Type"
+          },
+          "lowest_eigenvalue": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lowest Eigenvalue"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "reoptimized_wavefunction": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reoptimized Wavefunction"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SCFStabilityStatus-Input"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "SCFStabilityContent",
+        "type": "object"
+      },
       "SCFStabilityPayload": {
         "additionalProperties": false,
-        "description": "Optional inline SCF wavefunction stability evidence.\n\nAttaches to any calculation type — there is no calc_type restriction.\nProducers must only emit ``status = stable`` when an actual\nSCF/wavefunction stability analysis was observed; ordinary SCF\nconvergence does NOT qualify. When unsure whether a stability\nanalysis was performed, omit the block — the read API will project\n``not_checked``. Use ``status = inconclusive`` only when a stability\nanalysis was clearly attempted but its result could not be parsed.\n\n:param status: Persisted status. ``not_checked`` is NOT a valid\n    stored value — omit the block to express that.\n:param lowest_eigenvalue: Smallest eigenvalue from the stability\n    Hessian (software-specific).\n:param instability_count: Number of distinct instabilities found.\n:param instability_type: Free-text describing the instability class\n    (e.g. ``\"RHF→UHF\"``, ``\"internal\"``).\n:param reoptimized_wavefunction: Whether a stable wavefunction was\n    obtained by stability optimisation / reoptimisation.\n:param source_calculation_id: Optional FK to the calculation whose\n    log carries the stability evidence (when separate from the\n    owning calculation).\n:param source_artifact_id: Optional FK to a ``calculation_artifact``\n    row holding the stability log bytes (e.g. an ``ancillary`` or\n    ``output_log`` artifact).",
+        "description": "SCF stability evidence that may cite rows outside its own record.\n\nThe primitive upload routes take this shape. They already accept\ndatabase ids as a deliberate programmatic-chaining mechanism, so\nnaming the calculation or artifact that carries the stability log is\nthe same kind of claim they already support.\n\nBundle roots take :class:`SCFStabilityContent` instead. Not because\nthe citation is unwanted there, but because a bundle has no way to\nmake it: a bundle names things by local key, and the calculation this\nblock hangs off is persisted before its siblings exist, so a key\npointing sideways could not be resolved at the moment it is read. A\ndepositor who needs the citation has the primitive routes; a\ndepositor who has only what a parser found — a status, an eigenvalue,\na count — can now say it from a bundle, which is what they could not\ndo at all before.\n\n:param source_calculation_id: Optional FK to the calculation whose\n    log carries the stability evidence (when separate from the\n    owning calculation).\n:param source_artifact_id: Optional FK to a ``calculation_artifact``\n    row holding the stability log bytes (e.g. an ``ancillary`` or\n    ``output_log`` artifact).",
         "properties": {
           "instability_count": {
             "anyOf": [

--- a/backend/tests/api/test_api_bundle_thermo_and_scf_provenance.py
+++ b/backend/tests/api/test_api_bundle_thermo_and_scf_provenance.py
@@ -1,0 +1,424 @@
+"""What a bundle upload can say about where its numbers came from.
+
+Two gaps, both invisible from the payload a depositor writes, both closed by
+widening a model rather than by changing what the database can hold.
+
+``scf_stability`` existed only on ``CalculationWithResultsPayload``, so the
+primitive routes (``/uploads/conformers``, ``/thermo``, ``/statmech``, ...)
+could record whether an SCF solution had been tested for stability and the
+two bundle roots could not. ``SchemaBase`` is ``extra="forbid"``, so a bundle
+that tried got a 422 rather than a silent drop — the depositor was told no,
+without being told why or where else to put it.
+
+``BundleThermoIn`` carried eight fields against ``ThermoInBundle``'s fifteen,
+so a reaction bundle's per-species thermo could not record which calculations
+produced it. The two models were written three days apart in April 2026 —
+the narrow one first — and never reconciled; the shared ``persist_thermo``
+helper the species and standalone routes use has always written every one of
+the missing columns, and the reaction workflow is the only one of the three
+that hand-rolled its own lossy ORM construction instead.
+
+Both are asserted against the database, not the response body: a 201 proves
+the payload was accepted, not that anything was stored.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.db.models.calculation import Calculation, CalculationSCFStability
+from app.db.models.common import SCFStabilityStatus, ThermoCalculationRole
+from app.db.models.thermo import Thermo, ThermoSourceCalculation
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2 = "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+
+#: A stability job that found one instability and then resolved it. Chosen
+#: over the bare ``stable`` because it exercises the cross-field validator
+#: and the two table check constraints rather than the zero case.
+_SCF_STABILITY = {
+    "status": "stabilized",
+    "instability_count": 1,
+    "lowest_eigenvalue": -0.0123,
+    "reoptimized_wavefunction": True,
+    "note": "internal instability, reoptimized",
+}
+
+
+# ---------------------------------------------------------------------------
+# scf_stability, through the species bundle
+# ---------------------------------------------------------------------------
+
+
+def _species_bundle(**overrides) -> dict:
+    base: dict = {
+        "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": {"xyz_text": _XYZ_H},
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_result": {"converged": True},
+                },
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _stability_rows(db_session, calc_key_to_id: dict[str, int]):
+    return {
+        key: db_session.get(CalculationSCFStability, calc_id)
+        for key, calc_id in calc_key_to_id.items()
+    }
+
+
+def test_computed_species_bundle_records_scf_stability(client, db_session):
+    """The species bundle can now say the SCF was checked, and it is stored."""
+    payload = _species_bundle()
+    payload["conformers"][0]["primary_calculation"]["scf_stability"] = dict(
+        _SCF_STABILITY
+    )
+
+    resp = client.post("/api/v1/uploads/computed-species", json=payload)
+    assert resp.status_code == 201, resp.text[:800]
+
+    calc_id = resp.json()["conformers"][0]["primary_calculation"]["calculation_id"]
+    row = db_session.get(CalculationSCFStability, calc_id)
+    assert row is not None, "no calc_scf_stability row was written"
+    assert row.status is SCFStabilityStatus.stabilized
+    assert row.instability_count == 1
+    assert row.reoptimized_wavefunction is True
+    assert row.lowest_eigenvalue == -0.0123
+
+
+def test_computed_species_bundle_without_scf_stability_writes_no_row(
+    client, db_session
+):
+    """Absence stays absence.
+
+    ``not_checked`` is deliberately not a storable status — no row is the
+    encoding — so a bundle that says nothing must not acquire a default.
+    """
+    resp = client.post("/api/v1/uploads/computed-species", json=_species_bundle())
+    assert resp.status_code == 201, resp.text[:800]
+
+    calc_id = resp.json()["conformers"][0]["primary_calculation"]["calculation_id"]
+    assert db_session.get(CalculationSCFStability, calc_id) is None
+
+
+def test_an_inconsistent_scf_stability_block_is_refused_at_the_seam(client):
+    """``stable`` and ``reoptimized_wavefunction`` contradict each other.
+
+    The validator that says so has existed since the field was written; what
+    is new is that a bundle payload can now reach it. Reaching it as a 422
+    is the point — the same contradiction reaches the table as a check
+    constraint, and an ``IntegrityError`` cannot name the field.
+    """
+    payload = _species_bundle()
+    payload["conformers"][0]["primary_calculation"]["scf_stability"] = {
+        "status": "stable",
+        "reoptimized_wavefunction": True,
+    }
+    resp = client.post("/api/v1/uploads/computed-species", json=payload)
+    assert resp.status_code == 422, resp.text[:800]
+
+    errors = resp.json()["detail"]
+    assert isinstance(errors, list), resp.text[:800]
+    assert any(
+        e.get("type") == "value_error"
+        and "inconsistent with reoptimized_wavefunction" in e.get("msg", "")
+        for e in errors
+    ), errors
+
+
+# ---------------------------------------------------------------------------
+# scf_stability and thermo provenance, through the reaction bundle
+# ---------------------------------------------------------------------------
+
+
+def _reaction_species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [
+            {
+                "key": f"{key}-freq",
+                "type": "freq",
+                "geometry_key": f"{key}-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 0,
+                "freq_zpe_hartree": 0.01,
+            },
+            {
+                "key": f"{key}-sp",
+                "type": "sp",
+                "geometry_key": f"{key}-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "sp_electronic_energy_hartree": -1.5,
+            },
+        ],
+    }
+
+
+def _reaction_bundle() -> dict:
+    """``H + H -> H2``. Balanced, no transition state, no atom map needed."""
+    return {
+        "species": [
+            _reaction_species("h", "[H]", 2, _XYZ_H),
+            _reaction_species("h2", "[H][H]", 1, _XYZ_H2),
+        ],
+        "reversible": True,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+    }
+
+
+def test_computed_reaction_bundle_records_scf_stability(client, db_session):
+    """The reaction bundle reaches the same seam through the shared adapter."""
+    bundle = _reaction_bundle()
+    bundle["species"][0]["calculations"][1]["scf_stability"] = dict(_SCF_STABILITY)
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    calc_id = resp.json()["calculation_keys"]["h-sp"]
+    row = db_session.get(CalculationSCFStability, calc_id)
+    assert row is not None, "no calc_scf_stability row was written"
+    assert row.status is SCFStabilityStatus.stabilized
+    assert row.instability_count == 1
+
+    # Only the calculation that declared it got a row.
+    other_id = resp.json()["calculation_keys"]["h-opt"]
+    assert db_session.get(CalculationSCFStability, other_id) is None
+
+
+def test_reaction_bundle_thermo_records_its_source_calculations(client, db_session):
+    """The headline gap: which calculations produced this thermo.
+
+    Before, ``BundleThermoIn`` had no ``source_calculations`` field at all
+    and the reaction workflow wrote no ``thermo_source_calculation`` rows, so
+    the provenance the species route keeps was dropped on this path with
+    nothing in the payload to suggest it had been.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "s298_j_mol_k": 114.7,
+        "h298_uncertainty_kj_mol": 0.006,
+        "s298_uncertainty_j_mol_k": 0.02,
+        "source_calculations": [
+            {"calculation_key": "h-opt", "role": "opt"},
+            {"calculation_key": "h-freq", "role": "freq"},
+            {"calculation_key": "h-sp", "role": "sp"},
+        ],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    thermo_ids = resp.json()["thermo_ids"]
+    assert len(thermo_ids) == 1, thermo_ids
+    thermo = db_session.get(Thermo, thermo_ids[0])
+
+    assert thermo.h298_uncertainty_kj_mol == 0.006
+    assert thermo.s298_uncertainty_j_mol_k == 0.02
+
+    links = db_session.scalars(
+        select(ThermoSourceCalculation).where(
+            ThermoSourceCalculation.thermo_id == thermo.id
+        )
+    ).all()
+    calc_keys = resp.json()["calculation_keys"]
+    assert {(link.calculation_id, link.role) for link in links} == {
+        (calc_keys["h-opt"], ThermoCalculationRole.opt),
+        (calc_keys["h-freq"], ThermoCalculationRole.freq),
+        (calc_keys["h-sp"], ThermoCalculationRole.sp),
+    }
+
+
+def test_reaction_bundle_thermo_source_role_must_match_calculation_type(client):
+    """A freq calculation is not the ``sp`` the thermo says it is.
+
+    Same rule the species route and the standalone thermo route apply — now
+    owned once by ``app.workflows.thermo`` rather than copied per route,
+    because three copies of one rule can disagree about one deposit.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "source_calculations": [{"calculation_key": "h-freq", "role": "sp"}],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code != 201, resp.text[:800]
+    assert "incompatible with the resolved calculation type" in resp.text
+
+
+def test_reaction_bundle_thermo_source_must_belong_to_its_own_species(client):
+    """H2's calculation cannot be what produced H's enthalpy.
+
+    The key resolves — it is in the bundle's global calc namespace — so the
+    schema cannot catch this one; the workflow is the layer that knows which
+    species entry each calculation landed on.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "source_calculations": [{"calculation_key": "h2-sp", "role": "sp"}],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code != 201, resp.text[:800]
+    assert "not owned by this species entry" in resp.text
+
+
+def test_reaction_bundle_thermo_source_key_must_exist(client):
+    """A typo is refused at the schema seam, where it can name the key."""
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "source_calculations": [{"calculation_key": "h-spp", "role": "sp"}],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 422, resp.text[:800]
+
+    errors = resp.json()["detail"]
+    assert any(
+        e.get("type") == "value_error"
+        and "thermo.source_calculations[0]" in e.get("msg", "")
+        and "'h-spp'" in e.get("msg", "")
+        for e in errors
+    ), errors
+
+
+def test_reaction_bundle_thermo_provenance_overrides_the_bundle_default(
+    client, db_session
+):
+    """Per-thermo provenance wins; silence still falls back to the bundle.
+
+    Both halves matter. Without the override a species whose thermo came out
+    of a different code cannot say so; without the fallback every deposit
+    written before these fields existed would start reading differently.
+    """
+    bundle = _reaction_bundle()
+    bundle["analysis_software_release"] = {"name": "Arkane", "version": "3.1.0"}
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "software_release": {"name": "MultiWell", "version": "2023"},
+    }
+    bundle["species"][1]["thermo"] = {"h298_kj_mol": 0.0}
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    thermo_ids = resp.json()["thermo_ids"]
+    assert len(thermo_ids) == 2, thermo_ids
+    releases = {
+        db_session.get(Thermo, tid).software_release.software.name
+        for tid in thermo_ids
+    }
+    assert releases == {"MultiWell", "Arkane"}, releases
+
+
+def test_reaction_bundle_thermo_records_its_literature(client, db_session):
+    """A thermo value taken from a paper can name the paper on this route."""
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "scientific_origin": "experimental",
+        "h298_kj_mol": 217.998,
+        "literature": {
+            "kind": "article",
+            "title": "Enthalpy of formation of the hydrogen atom",
+            "year": 2020,
+            "journal": "J. Chem. Phys.",
+            "doi": "10.1000/tckdb.bundle.thermo.lit",
+        },
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    thermo = db_session.get(Thermo, resp.json()["thermo_ids"][0])
+    assert thermo.literature_id is not None
+    assert thermo.literature.doi == "10.1000/tckdb.bundle.thermo.lit"
+
+
+def test_a_calculation_still_owns_one_thermo_role_once(client):
+    """The same (calculation, role) pair may be claimed once.
+
+    Mirrors ``ThermoInBundle``'s rule so the two routes cannot disagree
+    about the table constraint they both write into.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "source_calculations": [
+            {"calculation_key": "h-sp", "role": "sp"},
+            {"calculation_key": "h-sp", "role": "sp"},
+        ],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 422, resp.text[:800]
+    assert any(
+        "must not repeat the same" in e.get("msg", "")
+        for e in resp.json()["detail"]
+    ), resp.text[:800]
+
+
+def test_calculation_rows_are_shared_not_duplicated_by_thermo_links(
+    client, db_session
+):
+    """A source link points at the calculation the bundle already created.
+
+    Guards the shape of the fix: resolving a local key must reuse the row,
+    not mint a second calculation to hang the link off.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "h298_kj_mol": 217.998,
+        "source_calculations": [{"calculation_key": "h-sp", "role": "sp"}],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    calc_keys = resp.json()["calculation_keys"]
+    total = db_session.scalar(
+        select(Calculation.id).where(Calculation.id == calc_keys["h-sp"])
+    )
+    link = db_session.scalars(
+        select(ThermoSourceCalculation).where(
+            ThermoSourceCalculation.thermo_id == resp.json()["thermo_ids"][0]
+        )
+    ).one()
+    assert link.calculation_id == total

--- a/backend/tests/api/test_api_electron_carries_no_structure.py
+++ b/backend/tests/api/test_api_electron_carries_no_structure.py
@@ -1,0 +1,247 @@
+"""A free electron may be deposited; its coordinates may not.
+
+``molecule_kind: electron`` was bound to a SMILES sentinel, a charge and a
+multiplicity, but not to having no structure, so a computed-reaction bundle
+could declare an electron and hang a one-atom conformer off it. The atom-map
+fragment already treats "a free electron has no geometry anywhere in the
+deposit" as an invariant — it refuses a ``geometry_key`` beside an empty
+``atom_to_ts`` on exactly that ground — and that invariant held only because
+no depositor had tried the other door.
+
+Two doors, not one. A conformer geometry was already refused, but late and
+elsewhere: ``resolve_species_entry`` composition-checks it and returns
+``species_geometry_composition_mismatch`` from inside the transaction. A
+*calculation* geometry reached no composition check on any path — that
+function's own docstring says so — so an electron carrying
+``input_geometries`` was accepted and the structure stored. The rule here
+covers both, at the seam, before any species is resolved.
+
+These tests go through the real route rather than the model, because a schema
+that rejects in isolation and a route that rejects are different claims, and
+the second is the one a depositor meets. The reaction is
+``OH- + H -> H2O + e-``: charge -1 on both sides, OH2 on both sides, the
+electron contributing neither. It is the reaction the electron participant
+work was really about, so the accepting cases here are not hypothetical
+payloads invented to be refused.
+"""
+
+from __future__ import annotations
+
+from tckdb_schemas.fragments.identity import ELECTRON_SMILES
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+_XYZ_OH = "2\nhydroxide\nO 0.0 0.0 0.0\nH 0.0 0.0 0.97"
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2O = (
+    "3\nwater\n"
+    "O  0.000  0.000  0.000\n"
+    "H  0.758  0.000  0.587\n"
+    "H -0.758  0.000  0.587"
+)
+
+_ELECTRON_IDENTITY = {
+    "molecule_kind": "electron",
+    "smiles": ELECTRON_SMILES,
+    "charge": -1,
+    "multiplicity": 2,
+}
+
+
+def _conformer(key: str, xyz: str) -> dict:
+    return {
+        "key": f"{key}-conf",
+        "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+        "calculation": {
+            "key": f"{key}-opt",
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "opt_converged": True,
+        },
+    }
+
+
+def _species(key: str, identity: dict, xyz: str | None) -> dict:
+    species: dict = {"key": key, "species_entry": dict(identity)}
+    if xyz is not None:
+        species["conformers"] = [_conformer(key, xyz)]
+    return species
+
+
+def _bundle(*, electron_xyz: str | None = None, electron_calculations=None) -> dict:
+    electron = _species("e", _ELECTRON_IDENTITY, electron_xyz)
+    if electron_calculations is not None:
+        electron["calculations"] = electron_calculations
+    return {
+        "species": [
+            _species("oh", {"smiles": "[OH-]", "charge": -1, "multiplicity": 1}, _XYZ_OH),
+            _species("h", {"smiles": "[H]", "charge": 0, "multiplicity": 2}, _XYZ_H),
+            _species("h2o", {"smiles": "O", "charge": 0, "multiplicity": 1}, _XYZ_H2O),
+            electron,
+        ],
+        "reversible": False,
+        "reactant_keys": ["oh", "h"],
+        "product_keys": ["h2o", "e"],
+    }
+
+
+def _post(client, bundle: dict):
+    return client.post("/api/v1/uploads/computed-reaction", json=bundle)
+
+
+# ---------------------------------------------------------------------------
+# The door stays open
+# ---------------------------------------------------------------------------
+
+
+def test_an_electron_without_structure_still_deposits(client):
+    """The control. If this ever fails, the refusal below has gone too far.
+
+    An electron is a legitimate participant with nothing to say about
+    geometry, and a check that also refused *this* would have closed the
+    door the electron-participant work opened.
+    """
+    resp = _post(client, _bundle())
+    assert resp.status_code == 201, resp.text[:800]
+
+
+def test_a_molecule_with_the_same_conformer_still_deposits(client):
+    """The other control: the conformer shape itself is not what is refused.
+
+    The refused payload below differs from an accepted one only in the
+    ``molecule_kind`` of the species the conformer hangs off.
+    """
+    bundle = _bundle()
+    assert bundle["species"][0]["conformers"], "control needs a real conformer"
+    resp = _post(client, bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# ...and coordinates do not come through it
+# ---------------------------------------------------------------------------
+
+
+def test_an_electron_carrying_a_conformer_is_refused(client):
+    """One atom of structure deposited under a participant known to have none.
+
+    This particular payload did not get through before: the conformer
+    geometry reached ``assert_geometry_composition_matches_identity`` via
+    ``resolve_species_entry`` and came back as
+    ``species_geometry_composition_mismatch``. What changes is *where* — a
+    422 naming ``species['e'].conformers['e-conf'].geometry`` at the schema
+    seam, instead of a composition error raised part-way through a
+    transaction that had already resolved three other species. The rule is
+    also now stated once for every geometry an electron could carry, rather
+    than holding for conformers alone.
+
+    Asserted on the error's *location* and type, not on a substring of the
+    message: pydantic echoes rejected input back into its error string, so
+    ``"electron" in resp.text`` is true whether the payload was refused for
+    the right reason, the wrong reason, or accepted and refused later for
+    something else entirely.
+    """
+    resp = _post(client, _bundle(electron_xyz=_XYZ_H))
+    assert resp.status_code == 422, resp.text[:800]
+
+    errors = resp.json()["detail"]
+    assert isinstance(errors, list), resp.text[:800]
+    atomless = [
+        e
+        for e in errors
+        if e.get("type") == "value_error"
+        and "has no atoms, but carries structure" in e.get("msg", "")
+    ]
+    assert atomless, f"no atomless-structure error in {errors}"
+
+    # It names the species and the field that carried the structure, so the
+    # depositor does not have to guess which of four species was wrong.
+    message = atomless[0]["msg"]
+    assert "Species 'e'" in message, message
+    assert "conformers['e-conf'].geometry" in message, message
+
+    # And it is the *species* model that refused, not something downstream.
+    assert atomless[0]["loc"][:2] == ["body", "species"], atomless[0]["loc"]
+
+
+def test_an_electron_carrying_a_calculation_geometry_is_refused(client):
+    """The quieter door, and the one no other layer closes.
+
+    Conformer geometries reach a composition check in
+    ``resolve_species_entry`` — before this rule existed, an electron with a
+    conformer was already refused there, mid-transaction, as
+    ``species_geometry_composition_mismatch``. Calculation geometries reach
+    no composition check on any path, by that function's own explicit
+    account, so this payload was **accepted** and the structure stored.
+
+    An ``opt`` calculation is used deliberately: it is the one type that may
+    omit ``geometry_key``, so this probes the composition gap rather than
+    tripping the pre-existing "geometry_key must name one of this species's
+    conformers" validator, which would refuse the payload for an unrelated
+    reason and prove nothing.
+    """
+    resp = _post(
+        client,
+        _bundle(
+            electron_calculations=[
+                {
+                    "key": "e-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                    "input_geometries": [{"xyz_text": _XYZ_H}],
+                }
+            ]
+        ),
+    )
+    assert resp.status_code == 422, resp.text[:800]
+
+    errors = resp.json()["detail"]
+    assert isinstance(errors, list), resp.text[:800]
+    atomless = [
+        e
+        for e in errors
+        if e.get("type") == "value_error"
+        and "has no atoms, but carries structure" in e.get("msg", "")
+    ]
+    assert atomless, f"no atomless-structure error in {errors}"
+    message = atomless[0]["msg"]
+    assert "calculations['e-opt'].input_geometries" in message, message
+
+
+def test_a_pseudo_participant_may_still_carry_a_geometry():
+    """``pseudo`` is not ``electron``, and this is where that has to hold.
+
+    A lumped construct's composition is *unknown*, not empty. Refusing a
+    geometry under one would refuse a real molecule's coordinates on the
+    grounds that nobody had said which molecule it was — the opposite of
+    what the atomless rule asserts. ``ATOMLESS_MOLECULE_KINDS`` omits
+    ``pseudo`` deliberately; this test is what notices if it stops.
+
+    Asserted against the model rather than the route because the route
+    cannot reach the question: the computed-reaction bundle resolves every
+    participant's identity through RDKit, so a lumped construct's
+    unparseable SMILES is refused for *that* reason well before any
+    atomless check runs. Going through the route here would therefore pass
+    on a 422 that has nothing to do with the rule under test — which is
+    exactly the failure mode the rest of this file is written to avoid.
+    """
+    from tckdb_schemas.workflows.computed_reaction_upload import BundleSpeciesIn
+
+    species = BundleSpeciesIn.model_validate(
+        _species(
+            "lump",
+            {
+                "molecule_kind": "pseudo",
+                "smiles": "lumped_sink_0001",
+                "charge": -1,
+                "multiplicity": 2,
+            },
+            _XYZ_H,
+        )
+    )
+    # The geometry survived validation rather than being stripped.
+    assert [c.geometry.xyz_text for c in species.conformers] == [_XYZ_H.strip()]

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,63 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.25.0 — bundle roots gain SCF stability and thermo provenance; an atomless participant may not carry coordinates
+
+Three additions and one new refusal. Nothing is renamed or removed, so a
+0.24.0 payload keeps validating — **unless** it declared a free electron
+and hung a geometry off it, which is the refusal below.
+
+**`scf_stability` now reaches the bundle roots.** The field existed only
+on `CalculationWithResultsPayload`, so `/uploads/conformers`,
+`/transition-states`, `/statmech`, `/thermo` and `/transport` could record
+whether an SCF solution had been tested for stability, and
+`/uploads/computed-species`, `/uploads/computed-reaction` and
+`/networks/pdep` could not. Models are `extra="forbid"`, so a bundle that
+tried got a 422 rather than a silent drop. Added to `CalculationInBundle`
+and to the shared `CalculationIn`, and forwarded by both adapters.
+
+```python
+{"key": "h_sp", "type": "sp", ...,
+ "scf_stability": {"status": "stabilized", "instability_count": 1,
+                   "reoptimized_wavefunction": True}}
+```
+
+**`BundleThermoIn` gains the provenance `ThermoInBundle` already had.**
+The reaction route's per-species thermo could not record which
+calculations produced it. It now takes `source_calculations`,
+`literature`, `software_release`, `workflow_tool_release`,
+`h298_uncertainty_kj_mol` and `s298_uncertainty_j_mol_k`, and the
+workflow persists them — including the `thermo_source_calculation` rows
+that route wrote none of. `software_release` / `workflow_tool_release`
+override the bundle-level values for that species and fall back to them
+when omitted, so existing payloads read exactly as before.
+
+`applied_energy_corrections` is deliberately **not** added: the reaction
+bundle already declares those on `BundleSpeciesIn`, against the same
+resolved species entry, and a second place to say it would need a rule
+for which one counts.
+
+```python
+{"key": "h", "species_entry": {...},
+ "thermo": {"h298_kj_mol": 218.0,
+            "source_calculations": [{"calculation_key": "h_sp", "role": "sp"}]}}
+```
+
+**An atomless participant may no longer carry coordinates.** A species
+declaring `molecule_kind: electron` is now refused, as a 422 naming the
+field, if it carries a conformer, or a `geometry_key`, `input_geometries`
+or `output_geometries` on any of its calculations. A conformer geometry
+was already refused — later, and as
+`species_geometry_composition_mismatch` from mid-transaction — but a
+*calculation* geometry reached no composition check on any path and was
+accepted, so an electron's coordinates could be stored. Definitional
+under ADR 0008: a record of an electron's coordinates cannot be what it
+says it is, so this rejects no correct calculation.
+
+`molecule_kind: pseudo` is unaffected and stays that way. A lumped
+construct's composition is *unknown*, not empty, and a geometry deposited
+under one is an under-described molecule rather than a contradiction.
+
 ### 0.24.0 — **BREAKING**: statmech source calculations are named, not numbered
 
 `ConformerUploadRequest.statmech` used to identify a supporting

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -36,8 +36,24 @@ on `CalculationWithResultsPayload`, so `/uploads/conformers`,
 whether an SCF solution had been tested for stability, and
 `/uploads/computed-species`, `/uploads/computed-reaction` and
 `/networks/pdep` could not. Models are `extra="forbid"`, so a bundle that
-tried got a 422 rather than a silent drop. Added to `CalculationInBundle`
-and to the shared `CalculationIn`, and forwarded by both adapters.
+tried got a 422 rather than a silent drop.
+
+`SCFStabilityPayload` is now split so the bundles can carry it without
+carrying database ids with it. The new `SCFStabilityContent` holds the
+finding — `status`, `lowest_eigenvalue`, `instability_count`,
+`instability_type`, `reoptimized_wavefunction`, `note` — and
+`SCFStabilityPayload` extends it with the two FK fields
+(`source_calculation_id`, `source_artifact_id`) the primitive routes
+already accept as programmatic chaining. `CalculationInBundle` and the
+shared `CalculationIn` take the content class; the primitive routes are
+unchanged, so a 0.24.0 payload to any of them still validates.
+
+The FK fields are not merely omitted for tidiness. A bundle names
+everything by local key, `source_calculation_id` is already in the
+bundle's own `_FORBIDDEN_DB_ID_FIELDS`, and a sideways local key could
+not be resolved anyway: the block is persisted with the calculation it
+hangs off, before that calculation's siblings exist. A depositor who
+needs to cite another row has the primitive routes.
 
 ```python
 {"key": "h_sp", "type": "sp", ...,

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.24.0"
+version = "0.25.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
@@ -311,7 +311,7 @@ class SPResultPayload(SchemaBase):
     electronic_energy_hartree: float | None = None
 
 
-class SCFStabilityPayload(SchemaBase):
+class SCFStabilityContent(SchemaBase):
     """Optional inline SCF wavefunction stability evidence.
 
     Attaches to any calculation type — there is no calc_type restriction.
@@ -331,12 +331,13 @@ class SCFStabilityPayload(SchemaBase):
         (e.g. ``"RHF→UHF"``, ``"internal"``).
     :param reoptimized_wavefunction: Whether a stable wavefunction was
         obtained by stability optimisation / reoptimisation.
-    :param source_calculation_id: Optional FK to the calculation whose
-        log carries the stability evidence (when separate from the
-        owning calculation).
-    :param source_artifact_id: Optional FK to a ``calculation_artifact``
-        row holding the stability log bytes (e.g. an ``ancillary`` or
-        ``output_log`` artifact).
+
+    Holds the stability finding and nothing that names another database
+    row, which is what lets a bundle carry it. A bundle upload identifies
+    everything by local key; the two FK fields on
+    :class:`SCFStabilityPayload` below would put raw primary keys back on
+    a surface a depositor is meant to be able to write without ever
+    having queried TCKDB.
     """
 
     status: SCFStabilityStatus
@@ -344,8 +345,6 @@ class SCFStabilityPayload(SchemaBase):
     instability_count: int | None = Field(default=None, ge=0)
     instability_type: str | None = None
     reoptimized_wavefunction: bool | None = None
-    source_calculation_id: int | None = None
-    source_artifact_id: int | None = None
     note: str | None = None
 
     @model_validator(mode="after")
@@ -392,6 +391,36 @@ class SCFStabilityPayload(SchemaBase):
                 "wavefunction was subsequently obtained."
             )
         return self
+
+
+class SCFStabilityPayload(SCFStabilityContent):
+    """SCF stability evidence that may cite rows outside its own record.
+
+    The primitive upload routes take this shape. They already accept
+    database ids as a deliberate programmatic-chaining mechanism, so
+    naming the calculation or artifact that carries the stability log is
+    the same kind of claim they already support.
+
+    Bundle roots take :class:`SCFStabilityContent` instead. Not because
+    the citation is unwanted there, but because a bundle has no way to
+    make it: a bundle names things by local key, and the calculation this
+    block hangs off is persisted before its siblings exist, so a key
+    pointing sideways could not be resolved at the moment it is read. A
+    depositor who needs the citation has the primitive routes; a
+    depositor who has only what a parser found — a status, an eigenvalue,
+    a count — can now say it from a bundle, which is what they could not
+    do at all before.
+
+    :param source_calculation_id: Optional FK to the calculation whose
+        log carries the stability evidence (when separate from the
+        owning calculation).
+    :param source_artifact_id: Optional FK to a ``calculation_artifact``
+        row holding the stability log bytes (e.g. an ``ancillary`` or
+        ``output_log`` artifact).
+    """
+
+    source_calculation_id: int | None = None
+    source_artifact_id: int | None = None
 
 
 class HessianPayload(SchemaBase):

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
@@ -15,6 +15,7 @@ Backend-only read/CRUD species-entry schemas remain in the backend
 package and continue to import the mixin from this module via the shim.
 """
 
+from collections.abc import Sequence
 from typing import Self
 
 from pydantic import Field, field_validator, model_validator
@@ -94,6 +95,51 @@ def participant_has_no_atoms(molecule_kind: MoleculeKind) -> bool:
     """
 
     return molecule_kind in ATOMLESS_MOLECULE_KINDS
+
+
+def raise_for_atomless_structure(
+    molecule_kind: MoleculeKind,
+    *,
+    subject: str,
+    structure_locations: Sequence[str],
+) -> None:
+    """Refuse coordinates deposited against a participant known to have no atoms.
+
+    A free electron has no geometry anywhere in the deposit — that is not a
+    convention, it is what "no atoms" means, and the atom-map fragment next
+    door already reads it as an invariant when it refuses a ``geometry_key``
+    beside an empty ``atom_to_ts``. Until now the invariant held only because
+    no depositor had tried: nothing stopped a bundle declaring
+    ``molecule_kind: electron`` and hanging a one-atom conformer off it, and
+    the species row kept the geometry even after the atom map declined to use
+    it. A record of an electron's coordinates cannot be what it says it is, so
+    refusing it rejects no correct calculation — definitional, therefore
+    blocking under ADR 0008, rather than a warning.
+
+    ``pseudo`` is out of scope here for the same reason it is absent from
+    :data:`ATOMLESS_MOLECULE_KINDS`: a lumped construct's composition is
+    unknown, not empty, and a geometry deposited against one is an
+    under-described molecule rather than a contradiction.
+
+    :param molecule_kind: What the payload declares this participant to be.
+    :param subject: How to name the offending participant in the message,
+        already quoted for the reader (e.g. ``"Species 'e'"``).
+    :param structure_locations: Field paths, relative to the participant, at
+        which structure was actually supplied. Empty means nothing to refuse.
+    """
+
+    if not participant_has_no_atoms(molecule_kind):
+        return
+    locations = list(structure_locations)
+    if not locations:
+        return
+    raise ValueError(
+        f"{subject} declares molecule_kind="
+        f"{molecule_kind.value!r}, which has no atoms, but carries structure "
+        f"at {', '.join(locations)}. A participant with no atoms has no "
+        f"geometry anywhere in the deposit; remove the structure, or declare "
+        f"the participant as what it actually is."
+    )
 
 
 class SpeciesIdentityPayload(SchemaBase):

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
@@ -108,13 +108,20 @@ def raise_for_atomless_structure(
     A free electron has no geometry anywhere in the deposit — that is not a
     convention, it is what "no atoms" means, and the atom-map fragment next
     door already reads it as an invariant when it refuses a ``geometry_key``
-    beside an empty ``atom_to_ts``. Until now the invariant held only because
-    no depositor had tried: nothing stopped a bundle declaring
-    ``molecule_kind: electron`` and hanging a one-atom conformer off it, and
-    the species row kept the geometry even after the atom map declined to use
-    it. A record of an electron's coordinates cannot be what it says it is, so
-    refusing it rejects no correct calculation — definitional, therefore
-    blocking under ADR 0008, rather than a warning.
+    beside an empty ``atom_to_ts``. A record of an electron's coordinates
+    cannot be what it says it is, so refusing it rejects no correct
+    calculation — definitional, therefore blocking under ADR 0008, rather
+    than a warning.
+
+    The invariant was previously enforced for one kind of geometry and not
+    the other. A *conformer* geometry reaches
+    ``assert_geometry_composition_matches_identity`` through
+    ``resolve_species_entry``, which refused it mid-transaction. A
+    *calculation* geometry — ``geometry_key``, ``input_geometries``,
+    ``output_geometries`` — reaches no composition check on any path, by
+    that function's own account, so an electron carrying one was accepted
+    and the structure stored. Stating the rule here covers both, names the
+    field that was wrong, and answers before any species is resolved.
 
     ``pseudo`` is out of scope here for the same reason it is absent from
     :data:`ATOMLESS_MOLECULE_KINDS`: a lumped construct's composition is

--- a/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
@@ -27,6 +27,7 @@ from tckdb_schemas.fragments.calculation import (
     FrequencyModePayload,
     HessianPayload,
     OptResultPayload,
+    SCFStabilityPayload,
     SpinDiagnosticPayload,
     SPResultPayload,
     WavefunctionDiagnosticPayload,
@@ -114,6 +115,11 @@ class CalculationIn(SchemaBase):
     # Optional inline post-hoc diagnostics (forwarded to the shared seam).
     wavefunction_diagnostic: WavefunctionDiagnosticPayload | None = None
     spin_diagnostic: SpinDiagnosticPayload | None = None
+
+    #: Whether the SCF solution was tested for stability, and what the test
+    #: found. Absence means the test was not run — ``not_checked`` is
+    #: deliberately not a storable status, so no row is the encoding.
+    scf_stability: SCFStabilityPayload | None = None
 
     # Parsed execution-control parameters (routed through the shared seam).
     parameters: list[CalculationParameterObservation] | None = None
@@ -275,6 +281,7 @@ def calculation_in_to_with_results_payload(
         hessian=calc_in.hessian,
         wavefunction_diagnostic=calc_in.wavefunction_diagnostic,
         spin_diagnostic=calc_in.spin_diagnostic,
+        scf_stability=calc_in.scf_stability,
         parameters=calc_in.parameters,
         parameters_json=calc_in.parameters_json,
         parameters_parser_version=calc_in.parameters_parser_version,

--- a/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
@@ -27,6 +27,7 @@ from tckdb_schemas.fragments.calculation import (
     FrequencyModePayload,
     HessianPayload,
     OptResultPayload,
+    SCFStabilityContent,
     SCFStabilityPayload,
     SpinDiagnosticPayload,
     SPResultPayload,
@@ -119,7 +120,7 @@ class CalculationIn(SchemaBase):
     #: Whether the SCF solution was tested for stability, and what the test
     #: found. Absence means the test was not run — ``not_checked`` is
     #: deliberately not a storable status, so no row is the encoding.
-    scf_stability: SCFStabilityPayload | None = None
+    scf_stability: SCFStabilityContent | None = None
 
     # Parsed execution-control parameters (routed through the shared seam).
     parameters: list[CalculationParameterObservation] | None = None
@@ -281,7 +282,11 @@ def calculation_in_to_with_results_payload(
         hessian=calc_in.hessian,
         wavefunction_diagnostic=calc_in.wavefunction_diagnostic,
         spin_diagnostic=calc_in.spin_diagnostic,
-        scf_stability=calc_in.scf_stability,
+        scf_stability=(
+            None
+            if calc_in.scf_stability is None
+            else SCFStabilityPayload(**calc_in.scf_stability.model_dump())
+        ),
         parameters=calc_in.parameters,
         parameters_json=calc_in.parameters_json,
         parameters_parser_version=calc_in.parameters_parser_version,

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -49,7 +49,10 @@ from tckdb_schemas.fragments.reaction_atom_map import (
     ReactionAtomMapIn,
     validate_reaction_atom_map,
 )
-from tckdb_schemas.fragments.identity import SpeciesEntryIdentityPayload
+from tckdb_schemas.fragments.identity import (
+    SpeciesEntryIdentityPayload,
+    raise_for_atomless_structure,
+)
 from tckdb_schemas.fragments.refs import (
     FreqScaleFactorRef,
     SoftwareReleaseRef,
@@ -81,6 +84,7 @@ from tckdb_schemas.workflows.computed_species_upload import (
     AppliedEnergyCorrectionInBundle,
     CalculationDependencyInBundle,
     StatmechSourceCalcInBundle,
+    ThermoSourceCalcInBundle,
 )
 
 
@@ -277,24 +281,78 @@ class ConformerIn(SchemaBase):
 class BundleThermoIn(SchemaBase):
     """Thermo data attached to a species in this bundle.
 
+    The reaction route's thermo carries the same provenance the species
+    route's ``ThermoInBundle`` carries, because it is the same claim about
+    the same kind of row. The two models were written three days apart in
+    April 2026 and diverged from the start — this one first, with eight
+    fields, and never touched since; ``ThermoInBundle`` three days later
+    with fifteen. Nothing recorded a reason, and the gap was not visible
+    from either model, so a depositor putting thermo on a reaction bundle
+    silently lost the record of which calculations produced it while the
+    same deposit on the species route kept it.
+
+    ``applied_energy_corrections`` is deliberately **not** here. The
+    reaction bundle already declares applied corrections one level up, on
+    :class:`BundleSpeciesIn`, against the same resolved species entry.
+    Adding a second place to say it would let one deposit make the claim
+    twice, and the answer to "which one counts" would have to be invented.
+
     :param scientific_origin: Scientific origin category.
+    :param literature: Optional literature provenance for this thermo.
+    :param software_release: Optional analysis-code provenance. Overrides
+        the bundle-level ``analysis_software_release`` for this species.
+    :param workflow_tool_release: Optional workflow-tool provenance.
+        Overrides the bundle-level value for this species.
     :param h298_kj_mol: Enthalpy at 298 K in kJ/mol.
     :param s298_j_mol_k: Entropy at 298 K in J/(mol*K).
+    :param h298_uncertainty_kj_mol: Optional uncertainty on ``h298_kj_mol``.
+    :param s298_uncertainty_j_mol_k: Optional uncertainty on
+        ``s298_j_mol_k``.
     :param tmin_k: Minimum temperature in K.
     :param tmax_k: Maximum temperature in K.
     :param nasa: Optional NASA polynomial coefficients.
     :param points: Optional tabulated thermo data points.
+    :param source_calculations: Thermo → calc links by bundle-local
+        calculation key. Each key must resolve in the bundle's global
+        calc-key namespace and must name a calculation owned by this
+        species entry; the workflow rejects both failures.
     :param note: Optional note.
     """
 
     scientific_origin: ScientificOriginKind = ScientificOriginKind.computed
+
+    literature: LiteratureUploadRequest | None = None
+    software_release: SoftwareReleaseRef | None = None
+    workflow_tool_release: WorkflowToolReleaseRef | None = None
+
     h298_kj_mol: float | None = None
     s298_j_mol_k: float | None = None
+    h298_uncertainty_kj_mol: float | None = Field(default=None, ge=0)
+    s298_uncertainty_j_mol_k: float | None = Field(default=None, ge=0)
     tmin_k: float | None = Field(default=None, gt=0)
     tmax_k: float | None = Field(default=None, gt=0)
     nasa: ThermoNASACreate | None = None
     points: list[ThermoPointCreate] = Field(default_factory=list)
+    source_calculations: list[ThermoSourceCalcInBundle] = Field(
+        default_factory=list
+    )
     note: str | None = None
+
+    @model_validator(mode="after")
+    def validate_unique_source_calculation_pairs(self) -> Self:
+        """One (calculation, role) pair may be claimed once.
+
+        Mirrors ``ThermoInBundle``: the same rule guards the same table
+        constraint, and two upload routes disagreeing about it would mean
+        one of them turns a nameable 422 into an ``IntegrityError``.
+        """
+        seen = {(sc.calculation_key, sc.role) for sc in self.source_calculations}
+        if len(seen) != len(self.source_calculations):
+            raise ValueError(
+                "thermo.source_calculations must not repeat the same "
+                "(calculation_key, role) pair."
+            )
+        return self
 
     @model_validator(mode="after")
     def normalize_text(self) -> Self:
@@ -499,6 +557,64 @@ class BundleSpeciesIn(SchemaBase):
             "owned by this species."
         ),
     )
+
+    def structure_locations(self) -> list[str]:
+        """Field paths at which this species actually supplied coordinates.
+
+        Every way a geometry can reach the database through this model, in one
+        place, so the atomless check below judges what would really be stored
+        rather than the one field that prompted it. A conformer always carries
+        a geometry, so its mere presence is structure; a calculation carries
+        structure when it names one, ran on one, or reported one.
+        """
+
+        locations: list[str] = []
+        for conformer in self.conformers:
+            locations.append(f"conformers['{conformer.key}'].geometry")
+        for conformer in self.conformers:
+            locations.extend(
+                self._calculation_structure_locations(
+                    conformer.calculation,
+                    path=f"conformers['{conformer.key}'].calculation",
+                )
+            )
+        for calc in self.calculations:
+            locations.extend(
+                self._calculation_structure_locations(
+                    calc, path=f"calculations['{calc.key}']"
+                )
+            )
+        return locations
+
+    @staticmethod
+    def _calculation_structure_locations(
+        calc: ComputedReactionCalculationIn, *, path: str
+    ) -> list[str]:
+        locations: list[str] = []
+        if calc.geometry_key is not None:
+            locations.append(f"{path}.geometry_key")
+        if calc.input_geometries:
+            locations.append(f"{path}.input_geometries")
+        if calc.output_geometries:
+            locations.append(f"{path}.output_geometries")
+        return locations
+
+    @model_validator(mode="after")
+    def validate_atomless_species_carries_no_structure(self) -> Self:
+        """Refuse a geometry deposited against a participant with no atoms.
+
+        Definitional, therefore blocking (ADR 0008). This model is where a
+        declared ``molecule_kind`` and the conformers deposited under it are
+        both in hand for the first time, so it is the earliest place the
+        contradiction can be named with the key that caused it.
+        """
+
+        raise_for_atomless_structure(
+            self.species_entry.molecule_kind,
+            subject=f"Species '{self.key}'",
+            structure_locations=self.structure_locations(),
+        )
+        return self
 
     @model_validator(mode="after")
     def validate_calc_geometry_keys(self) -> Self:
@@ -1246,6 +1362,21 @@ class ComputedReactionUploadRequest(SchemaBase):
             )
             for calc in self.transition_state.calculations:
                 all_calc_keys_to_types[calc.key] = calc.type
+
+        # Per-species thermo source_calculation keys, same contract as
+        # statmech's above: typos caught here as a 422 that can name the
+        # key, owner-consistency left to the workflow, which is the layer
+        # that knows which species entry each calculation resolved to.
+        for sp in self.species:
+            if sp.thermo is None:
+                continue
+            for i, sc in enumerate(sp.thermo.source_calculations):
+                if sc.calculation_key not in all_calc_keys:
+                    raise ValueError(
+                        f"species[{sp.key!r}].thermo.source_calculations[{i}]."
+                        f"calculation_key references undefined "
+                        f"calculation_key '{sc.calculation_key}'."
+                    )
 
         for sp in self.species:
             if sp.statmech is None:

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -36,7 +36,7 @@ from tckdb_schemas.fragments.calculation import (
     OptResultPayload,
     OutputGeometryEntry,
     PathSearchResultPayload,
-    SCFStabilityPayload,
+    SCFStabilityContent,
     SpinDiagnosticPayload,
     SPResultPayload,
     WavefunctionDiagnosticPayload,
@@ -154,7 +154,7 @@ class CalculationInBundle(SchemaBase):
 
     wavefunction_diagnostic: WavefunctionDiagnosticPayload | None = None
     spin_diagnostic: SpinDiagnosticPayload | None = None
-    scf_stability: SCFStabilityPayload | None = None
+    scf_stability: SCFStabilityContent | None = None
     hessian: HessianPayload | None = None
 
     input_geometries: list[GeometryPayload] = Field(

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -36,6 +36,7 @@ from tckdb_schemas.fragments.calculation import (
     OptResultPayload,
     OutputGeometryEntry,
     PathSearchResultPayload,
+    SCFStabilityPayload,
     SpinDiagnosticPayload,
     SPResultPayload,
     WavefunctionDiagnosticPayload,
@@ -153,6 +154,7 @@ class CalculationInBundle(SchemaBase):
 
     wavefunction_diagnostic: WavefunctionDiagnosticPayload | None = None
     spin_diagnostic: SpinDiagnosticPayload | None = None
+    scf_stability: SCFStabilityPayload | None = None
     hessian: HessianPayload | None = None
 
     input_geometries: list[GeometryPayload] = Field(


### PR DESCRIPTION
Three tasks against `tckdb_schemas/workflows/`, combined because separately they would collide.

Two of the three were questions. The answers are below, with the evidence.

---

## #106 — an electron carrying a geometry

**The premise was half right, and the half that was wrong is the interesting half.**

A conformer geometry under `molecule_kind: electron` was *not* accepted. It reached
`assert_geometry_composition_matches_identity` through `resolve_species_entry` and came
back as `species_geometry_composition_mismatch` — mid-transaction, after three other
species had already resolved.

What *was* accepted, with a `201 Created` and a stored calculation row, is an electron
carrying `input_geometries` on an `opt` calculation. Calculation geometries reach no
composition check on any path — `species_resolution.py:405` says so of itself: *"benzene
coordinates can be attached as a calculation geometry under a `smiles: "C"` species entry
and the deposit is accepted."* For an electron there was nothing else to catch it.

Measured on this branch with the new rule neutered:

```
POST /api/v1/uploads/computed-reaction   →  201
{"species_entry_ids":[1,2,3,4],"calculation_keys":{...,"e-opt":4},"warnings":[]}
```

and with it in place:

```
422  loc=["body","species",3]  type=value_error
Species 'e' declares molecule_kind='electron', which has no atoms, but carries
structure at calculations['e-opt'].input_geometries. A participant with no atoms
has no geometry anywhere in the deposit; remove the structure, or declare the
participant as what it actually is.
```

`raise_for_atomless_structure` lives in `fragments/identity.py` beside
`participant_has_no_atoms`, and `BundleSpeciesIn` applies it over every path by which a
geometry can reach the database from one species: conformer geometries, and each
calculation's `geometry_key`, `input_geometries` and `output_geometries`. Definitional
under ADR 0008, so it blocks.

`pseudo` stays excluded, and there is a test pinning that.

## #114 — reaction-route thermo provenance

**Verdict: drift — but neither reading exactly. Widened.**

`git log` says the divergence is *congenital*, not copy-and-narrow:

| model | born | fields at birth | fields today |
|---|---|---|---|
| `BundleThermoIn` (reaction) | `c99665ee`, 2026-04-26 | 8 | 8 |
| `ThermoInBundle` (species) | `fd631ddd`, 2026-04-29 | 15 | 15 |

The narrow one came **first** and has never had a field changed —
`git log -L` over the class returns exactly one commit, the mechanical package move.
The rich one was written three days later already carrying all seven extra fields. So
there is no commit where the species model gained something the reaction model was
skipped for; the two were simply never reconciled in 3.5 months.

Three things rule out "deliberate":

1. No docstring, comment or DR says reaction-bundle thermo is incidental. Nothing anywhere.
2. The shared `persist_thermo` has always written every one of the missing columns. The
   species route and the standalone `/uploads/thermo` route both use it; `computed_reaction`
   is the only one of the three that hand-rolls a raw `Thermo(...)` and drops the rest.
3. `grep ThermoSourceCalculation backend/app/workflows/computed_reaction.py` returned
   nothing — that route wrote no provenance links at all.

Widened with `source_calculations`, `literature`, `software_release`,
`workflow_tool_release` and both uncertainties, and the workflow now persists them.
`software_release`/`workflow_tool_release` override the bundle-level value and fall back
to it, so existing deposits read unchanged.

`applied_energy_corrections` deliberately **not** added — the reaction bundle already
declares those on `BundleSpeciesIn` against the same species entry, and a second place
to say it would need an invented rule for which one wins. That is stated in the model
docstring.

## #115 — `scf_stability`

**Verdict: missing wiring, reading (1). But the field is not a phantom — it is written today.**

`backend/app/services/calculation_resolution.py:774-788` constructs
`CalculationSCFStability` inside `persist_calculation_result`. It is the only writer, and
it is live: reachable from `/uploads/conformers`, `/transition-states`, `/statmech`,
`/thermo` and `/transport`, all of which take `CalculationWithResultsPayload` or
`ConformerCalculationIn`.

So the premise "a depositor cannot record SCF stability" is too strong — they can, just
not from the two bundle roots. The whole thing landed in one commit, `5a8f350d`
(2026-05-09), and the read/search/trust surface has been extended repeatedly since while
the write side was never added to the newer bundle payloads.

One thing worth knowing before extending it: **no test anywhere posts `scf_stability`
through the wire.** Every existing test inserts the ORM row directly with
`db_session.add`. The wire → `persist_calculation_result` → DB path was entirely
unexercised until this PR.

`CalculationInBundle`'s own docstring claims it *"carries everything the primitive
`CalculationWithResultsPayload` carries"* — `scf_stability` was the counterexample.

**The rest gate then caught something the plan did not anticipate.** Putting
`scf_stability` on the bundle roots dragged `SCFStabilityPayload.source_calculation_id`
and `.source_artifact_id` onto a no-FK-id surface, failing
`test_upload_schema_exposes_no_fk_ids_or_hashes`. `source_calculation_id` is already
listed in the computed-species bundle's own `_FORBIDDEN_DB_ID_FIELDS`, so the payload was
contradicting a rule written in the same file.

Split rather than allowlisted: `SCFStabilityContent` holds the finding, and
`SCFStabilityPayload` extends it with the two FK fields the primitive routes accept as
deliberate programmatic chaining. Bundles take the content class; the primitive routes
are untouched. Omitting the citation from bundles is not tidiness — the block is
persisted with the calculation it hangs off, *before* that calculation's siblings exist,
so a sideways local key could not be resolved even if offered.

---

## Verification

All three gates green on the rebased branch (main `567ba7f4`):

| gate | result |
|---|---|
| rest | 4172 passed, 14 skipped |
| api | 2594 passed |
| scientific | 2045 passed |

17 new tests, all through the real HTTP routes. Assertions are on error **type and
`loc`**, never on a substring of the response body — pydantic echoes rejected input into
its error string, so `"electron" in resp.text` is true whether the payload was refused
for the right reason, the wrong reason, or accepted and refused later for something else.

**Mutation-checked, each separately:**

| mutation | result |
|---|---|
| `raise_for_atomless_structure` → no-op | 2 refusal tests fail, 3 controls pass |
| shared adapter drops `scf_stability` | reaction stability test fails |
| species adapter drops `scf_stability` | species stability test fails |
| thermo `source_calculations` loop → empty | 4 thermo tests fail |

**Golden snapshot** moved deliberately. One component added
(`SCFStabilityContent`), none removed, no path changed. `BundleThermoIn` gained six
properties; `CalculationIn`, `CalculationInBundle` and `ComputedReactionCalculationIn`
each gained `scf_stability`. No property was lost from any component.

**Versions:** `tckdb-schemas` 0.24.0 → **0.25.0**, with a changelog entry naming what a
0.24.0 payload can no longer say. Not marked BREAKING: nothing is renamed or removed, and
the only newly-refused payload is one that could not be true.

**Alembic head** unchanged by this PR and single: `b7e4d1a9c026` (moved from
`e2a7c9d4b615` by #150 on main, not by this branch). No migration touched.

Also consolidated the thermo role/type rule, which existed in two copies and would have
become three; it is now owned once, publicly, by `app.workflows.thermo`.

---

## Not fixed — follow-ups

- **`tckdb-client` silently drops thermo `source_calculations` on the reaction path.**
  `clients/python/src/tckdb_client/builders/uploads.py:1244` passes
  `allow_source_calculations=False` because `BundleThermoIn` had no such field. It does
  now. Flipping the flag is one line, but it also requires retiring the
  `thermo_source_calculations_not_emitted_in_computed_reaction_bundle` diagnostic
  (`builders/diagnostics.py:63`), which is pinned by 7 tests across two demos, two
  notebooks and four docs. I implemented it, hit those 7 failures, and reverted — it is a
  clean standalone task, not a rider on this one. The client does not import anything I
  changed, so **no version bump was needed**; it stays at 0.35.0 with floor
  `tckdb-schemas>=0.10.0`. `clients/python/docs/builder_api_mvp.md:660` already says
  *"When the computed-reaction schema catches up, flip the same flag"* — it has.

- **`BundleStatmechIn` has the same gap as `BundleThermoIn`**, 12 fields against
  `StatmechInBundle`'s 18: missing `literature`, `software_release`,
  `workflow_tool_release` and `rotational_constant_{a,b,c}_cm1`. Half congenital
  (`17706cf7`), half a genuine one-sided omission in `264519f1` (2026-07-16, rotational
  constants added to the species model only) — directly against the precedent set two
  days earlier by `0ea9182f`, which correctly updated both. Not touched here because
  `backend/app/workflows/statmech.py` and `app/services/**` belong to another agent this
  round. `StatmechInBundle`'s docstring claims it *"mirrors computed-reaction's
  `BundleStatmechIn`"* while documenting six params that model does not have.

- **`backend/app/schemas/entities/calculation.py:558`** references a
  `CalculationSCFStabilityCreate` class that does not exist anywhere in the repo. Stale
  docstring; it survives into the golden OpenAPI description.

- **Calculation `input_geometries` are composition-checked on no path** for any species,
  not just electrons — `species_resolution.py:405` calls this "a genuine open gap" and
  declines to close it. Unchanged here; the atomless rule only closes it for participants
  known to have no atoms.

## Premise corrections

- `AGENTS.md` does not exist in the repo, though `CLAUDE.md` cites it as the authoritative
  contribution rules.
- #106's "is accepted" holds only for calculation geometries, not conformer geometries
  (detail above).
- #115's "a depositor cannot record SCF stability" is too strong — the five primitive
  upload routes can, and `calc_scf_stability` has a real production writer.
