### PR TITLE
Refuse a role the calculation cannot play, and a key that names nothing

### DIFF
--- a/backend/app/services/energy_correction_resolution.py
+++ b/backend/app/services/energy_correction_resolution.py
@@ -6,9 +6,12 @@ and creates applied correction rows with resolved FK IDs.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.db.models.energy_correction import (
     AppliedEnergyCorrection,
     AppliedEnergyCorrectionComponent,
@@ -29,6 +32,74 @@ from app.services.calculation_resolution import (
 )
 from app.services.literature_resolution import resolve_or_create_literature
 from app.services.software_resolution import resolve_software
+
+#: An applied correction names a source the enclosing upload never declared.
+W_APPLIED_CORRECTION_SOURCE_KEY_UNDECLARED = (
+    "applied_energy_correction_source_key_undeclared"
+)
+
+
+# ---------------------------------------------------------------------------
+# Local key resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_applied_correction_source_key(
+    key: str | None,
+    declared: Mapping[str, int],
+    *,
+    field: str,
+    declares: str,
+) -> int | None:
+    """Turn one applied-correction source key into the row it names.
+
+    Blocking, and ADR 0008 permits it because this asserts a *contract*
+    rather than an expectation: a local key is a promise that the same
+    upload declared something under that name, and if it did not, no
+    correct payload can make the link mean what it says. The alternative
+    is worse than silence -- a key that resolves to whatever happens to be
+    at hand attaches a correction to a calculation the depositor never
+    chose, and they have no way to notice.
+
+    ``declared`` is the namespace the enclosing request built from its own
+    payload, so its keys are strings the depositor wrote. They are echoed
+    into the message on purpose: naming what *is* declared is what turns
+    the refusal into something fixable. Row ids never appear -- they are
+    values of this map, not part of any message.
+
+    :param key: The key the payload wrote, or ``None`` for no link.
+    :param declared: Declared local name -> persisted row id.
+    :param field: Field path naming the offending key, echoed verbatim.
+    :param declares: How a depositor declares a name in this namespace,
+        phrased as the remedy sentence's object.
+    :returns: The row id the key names, or ``None`` when ``key`` is
+        ``None``.
+    :raises CodedValueError: if ``key`` is set but names nothing declared.
+    """
+    if key is None:
+        return None
+    row_id = declared.get(key)
+    if row_id is not None:
+        return row_id
+
+    known = sorted(declared)
+    if known:
+        available = "Declared names here: " + ", ".join(repr(k) for k in known) + "."
+    else:
+        available = "This upload declares no such name at all."
+    raise CodedValueError(
+        W_APPLIED_CORRECTION_SOURCE_KEY_UNDECLARED,
+        f"{field}='{key}' does not name anything declared in this upload. "
+        f"{available} {declares} An energy correction whose source cannot be "
+        f"named is a correction nobody can trace back to what it corrected.",
+        context={
+            "field": field,
+            "key": key,
+            "declared_keys": known,
+        },
+        message_prefix=False,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Scheme resolution

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -12,10 +12,14 @@ schema layer never needs to know a primary key.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
+from app.db.models.calculation import Calculation
+from app.db.models.common import CalculationType, StatmechCalculationRole
 from app.db.models.statmech import (
     Statmech,
     StatmechElectronicLevel,
@@ -28,6 +32,27 @@ from app.services.calculation_resolution import resolve_workflow_tool_release_re
 from app.services.energy_correction_resolution import resolve_or_create_freq_scale_factor_ref
 from app.services.literature_resolution import resolve_or_create_literature
 from app.services.software_resolution import resolve_software_release_ref
+
+logger = logging.getLogger(__name__)
+
+#: A statmech source link names a calculation the upload never declared.
+W_STATMECH_CALCULATION_KEY_UNDECLARED = "statmech_calculation_key_undeclared"
+
+#: A statmech source link declares a role the resolved calculation cannot
+#: play, because its ``Calculation.type`` is a different kind of job.
+W_STATMECH_SOURCE_ROLE_TYPE_MISMATCH = "statmech_source_role_type_mismatch"
+
+#: Roles that name a specific kind of job, and the ``CalculationType`` each
+#: one requires. ``composite`` and ``imported`` are deliberately absent:
+#: they describe a scientific origin rather than a job type, so no single
+#: ``CalculationType`` is the right one for them (the same carve-out
+#: ``_THERMO_ROLE_TO_CALC_TYPE`` makes in :mod:`app.workflows.thermo`).
+_STATMECH_ROLE_TO_CALC_TYPE: dict[StatmechCalculationRole, CalculationType] = {
+    StatmechCalculationRole.opt: CalculationType.opt,
+    StatmechCalculationRole.freq: CalculationType.freq,
+    StatmechCalculationRole.sp: CalculationType.sp,
+    StatmechCalculationRole.scan: CalculationType.scan,
+}
 
 
 def _resolve_calculation_key(
@@ -43,15 +68,107 @@ def _resolve_calculation_key(
     map. It is still raised rather than allowed to ``KeyError``: a missing
     provenance link must be a named failure, not a 500.
 
-    :raises ValueError: if the key is absent from ``calculations_by_key``.
+    :raises CodedValueError: if the key is absent from
+        ``calculations_by_key``. The sentence is unchanged from when this
+        rejection carried no code; only the envelope's ``code`` moves,
+        from the generic ``validation_error`` to one a client can branch
+        on.
     """
     calculation_id = calculations_by_key.get(key)
     if calculation_id is None:
-        raise ValueError(
+        raise CodedValueError(
+            W_STATMECH_CALCULATION_KEY_UNDECLARED,
             f"{context}: calculation_key '{key}' does not name a calculation "
-            f"declared in this upload."
+            f"declared in this upload.",
+            context={"field": context, "calculation_key": key},
+            message_prefix=False,
         )
     return calculation_id
+
+
+def assert_statmech_role_compatible(
+    calculation: Calculation,
+    *,
+    role: StatmechCalculationRole,
+    context: str,
+) -> None:
+    """Refuse a statmech source link whose role contradicts the calc's type.
+
+    Blocking, and ADR 0008 permits that here because this asserts a
+    *contract* rather than an expectation: ``role='freq'`` is the claim
+    that the linked job produced the vibrational frequencies this
+    partition function was built from, and an ``sp`` job did not produce
+    any. No correct calculation can satisfy the link as written, so there
+    is nothing to warn about — the record would assert evidence that does
+    not exist.
+
+    This is DR-0028 Requirement 1, applied to the path it was written for
+    but never reached: thermo has enforced it since DR-0028
+    (``app.workflows.thermo._assert_calculation_role_compatible``) while
+    statmech accepted any pairing. Local string keys made the gap sharper
+    than row ids did — a plausible-looking wrong key resolves silently
+    where a wrong integer would more often have failed a foreign key.
+
+    ``composite`` and ``imported`` accept any type, as they do for thermo:
+    they name where a number came from, not which job produced it.
+
+    :param calculation: The resolved source calculation row.
+    :param role: The role the upload declared for it.
+    :param context: Field path naming the offending link, copied verbatim
+        into the 422 body — so it must name the caller's own key, never a
+        row id.
+    :raises CodedValueError: if ``role`` names a job type and the
+        calculation is not of that type.
+    """
+    expected = _STATMECH_ROLE_TO_CALC_TYPE.get(role)
+    if expected is None or calculation.type == expected:
+        return
+    # The row id is the operator's handle, not the depositor's: it goes to
+    # the log, while the 422 names only the key the depositor wrote.
+    logger.info(
+        "statmech role/type mismatch at %s: calculation id=%s type=%s, role=%s",
+        context,
+        calculation.id,
+        calculation.type.value,
+        role.value,
+    )
+    raise CodedValueError(
+        W_STATMECH_SOURCE_ROLE_TYPE_MISMATCH,
+        f"{context}: role='{role.value}' claims a "
+        f"'{expected.value}' calculation, but the calculation it names has "
+        f"type '{calculation.type.value}'. A statmech record must not claim "
+        f"evidence it does not have. Point the link at the "
+        f"'{expected.value}' calculation, or declare the role the named "
+        f"calculation actually played.",
+        context={
+            "field": context,
+            "declared_role": role.value,
+            "expected_calculation_type": expected.value,
+            "actual_calculation_type": calculation.type.value,
+        },
+        message_prefix=False,
+    )
+
+
+def _assert_role_compatible_by_id(
+    session: Session,
+    calculation_id: int,
+    *,
+    role: StatmechCalculationRole,
+    context: str,
+) -> None:
+    """Load a source calculation and run :func:`assert_statmech_role_compatible`.
+
+    Every id reaching here was either persisted by the calling workflow in
+    this same session or handed over as its uploaded calculation, so the
+    ``session.get`` is an identity-map hit rather than a query. A row that
+    is genuinely absent is left to the foreign key: this function's job is
+    the role/type contract, not existence.
+    """
+    calculation = session.get(Calculation, calculation_id)
+    if calculation is None:  # pragma: no cover - FK enforces existence
+        return
+    assert_statmech_role_compatible(calculation, role=role, context=context)
 
 
 def resolve_or_create_statmech(
@@ -86,8 +203,9 @@ def resolve_or_create_statmech(
     :param created_by: Optional application user id for newly created rows.
     :returns: Newly created ``Statmech`` row with linked sources/torsions.
     :raises ValueError: If ``uploaded_calculation_role`` is set but
-        ``uploaded_calculation_id`` is not supplied, or if a local
-        calculation key does not resolve.
+        ``uploaded_calculation_id`` is not supplied.
+    :raises CodedValueError: If a local calculation key does not resolve,
+        or if a declared role contradicts the resolved calculation's type.
     """
     key_map: Mapping[str, int] = calculations_by_key or {}
 
@@ -146,13 +264,22 @@ def resolve_or_create_statmech(
             )
         )
 
-    # Attach source calculations
+    # Attach source calculations. Every link is role/type checked here
+    # rather than in each calling workflow, so all three statmech upload
+    # paths -- nested conformer, standalone statmech, and the bundle via
+    # ``_persist_statmech_block`` -- inherit the same refusal.
     if payload.uploaded_calculation_role is not None:
         if uploaded_calculation_id is None:
             raise ValueError(
                 "uploaded_calculation_role is set but no uploaded_calculation_id "
                 "was provided to resolve_or_create_statmech."
             )
+        _assert_role_compatible_by_id(
+            session,
+            uploaded_calculation_id,
+            role=payload.uploaded_calculation_role,
+            context="statmech.uploaded_calculation_role",
+        )
         session.add(
             StatmechSourceCalculation(
                 statmech_id=statmech.id,
@@ -162,14 +289,22 @@ def resolve_or_create_statmech(
         )
 
     for index, source in enumerate(payload.source_calculations):
+        context = f"statmech.source_calculations[{index}]"
+        calculation_id = _resolve_calculation_key(
+            source.calculation_key,
+            key_map,
+            context=context,
+        )
+        _assert_role_compatible_by_id(
+            session,
+            calculation_id,
+            role=source.role,
+            context=f"{context}.calculation_key='{source.calculation_key}'",
+        )
         session.add(
             StatmechSourceCalculation(
                 statmech_id=statmech.id,
-                calculation_id=_resolve_calculation_key(
-                    source.calculation_key,
-                    key_map,
-                    context=f"statmech.source_calculations[{index}]",
-                ),
+                calculation_id=calculation_id,
                 role=source.role,
             )
         )

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -93,6 +93,7 @@ from app.services.sp_energy_extraction import (
     try_reconcile_sp_energy_from_output_upload,
 )
 from app.services.species_resolution import resolve_species_entry
+from app.services.statmech_resolution import assert_statmech_role_compatible
 from app.services.transition_state_validation import (
     persist_transition_state_validation_evidence,
 )
@@ -887,6 +888,17 @@ def persist_computed_reaction_upload(
                         f"calculation_key='{sc.calculation_key}': "
                         f"refers to a calculation {flavor}."
                     )
+                # The fourth statmech write path, and the one ARC actually
+                # deposits through. Same DR-0028 Requirement 1 as the other
+                # three, from the same shared service.
+                assert_statmech_role_compatible(
+                    calc_row,
+                    role=sc.role,
+                    context=(
+                        f"species[{sp.key!r}].statmech.source_calculations[{i}]."
+                        f"calculation_key='{sc.calculation_key}'"
+                    ),
+                )
                 session.add(
                     StatmechSourceCalculation(
                         statmech_id=statmech.id,

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -89,6 +89,7 @@ from app.services.sp_energy_extraction import (
     try_reconcile_sp_energy_from_output_upload,
 )
 from app.services.species_resolution import resolve_species_entry
+from app.services.statmech_resolution import assert_statmech_role_compatible
 from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
 from app.workflows.thermo import assert_thermo_role_matches_calculation_type
 
@@ -892,6 +893,18 @@ def _persist_statmech_block(
                 f"statmech.source_calculations calculation_key="
                 f"'{sc.calculation_key}': refers to a calculation owned by a different subject."
             )
+        # The third statmech write path, and the third to need DR-0028
+        # Requirement 1: a declared role must match the type of the job it
+        # names. Shared with the conformer and standalone paths through
+        # the statmech resolution service so all three refuse alike.
+        assert_statmech_role_compatible(
+            calc_row,
+            role=sc.role,
+            context=(
+                f"statmech.source_calculations.calculation_key="
+                f"'{sc.calculation_key}'"
+            ),
+        )
         session.add(
             StatmechSourceCalculation(
                 statmech_id=statmech.id,

--- a/backend/app/workflows/conformer.py
+++ b/backend/app/workflows/conformer.py
@@ -17,7 +17,10 @@ from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
 )
 from app.services.conformer_resolution import resolve_conformer_group
-from app.services.energy_correction_resolution import create_applied_energy_correction
+from app.services.energy_correction_resolution import (
+    create_applied_energy_correction,
+    resolve_applied_correction_source_key,
+)
 from app.services.geometry_resolution import resolve_geometry_payload
 from app.services.record_review import (
     RecordRef,
@@ -80,6 +83,10 @@ def persist_conformer_upload(
         the basin-level group may be reused.
     :raises ValueError:
         If species identity or geometry parsing fails during upload resolution.
+    :raises CodedValueError:
+        If an applied energy correction names a source key this request
+        never declared, or a statmech source link declares a role the
+        calculation it names cannot play.
     """
 
     species_entry = resolve_species_entry(
@@ -199,19 +206,44 @@ def persist_conformer_upload(
             created_by=created_by,
         )
 
+    # The one name this request gives the conformer it is depositing. A
+    # conformer upload creates exactly one observation, and ``label`` is
+    # the only string the depositor attaches to it, so it is the whole
+    # conformer namespace here -- unlike the bundle, where every
+    # ``ConformerInBundle`` carries a required ``key``.
+    conformers_by_key: dict[str, int] = (
+        {request.label: observation.id} if request.label is not None else {}
+    )
+
     applied_corrections: list = []
-    for correction_payload in request.applied_energy_corrections:
-        # Resolve local string keys to IDs.
-        # source_conformer_key always resolves to the observation just created.
-        source_conf_id = (
-            observation.id
-            if correction_payload.source_conformer_key is not None
-            else None
+    for index, correction_payload in enumerate(request.applied_energy_corrections):
+        # Resolve local string keys against the namespaces this request
+        # actually declared. Both keys used to be tested for `is not None`
+        # alone, so any string at all resolved to the primary
+        # observation/calculation and a typo attached the correction to
+        # something the depositor never named. The calc-key namespace is
+        # the one the statmech block already points at (DR-0029 Req 1).
+        source_conf_id = resolve_applied_correction_source_key(
+            correction_payload.source_conformer_key,
+            conformers_by_key,
+            field=(
+                f"applied_energy_corrections[{index}].source_conformer_key"
+            ),
+            declares=(
+                "A conformer upload names its conformer with the "
+                "request's 'label'."
+            ),
         )
-        source_calc_id = (
-            calculation.id
-            if correction_payload.source_calculation_key is not None
-            else None
+        source_calc_id = resolve_applied_correction_source_key(
+            correction_payload.source_calculation_key,
+            calculations_by_key,
+            field=(
+                f"applied_energy_corrections[{index}].source_calculation_key"
+            ),
+            declares=(
+                "Put a matching 'key' on 'calculation' or on one of "
+                "'additional_calculations'."
+            ),
         )
         applied_corrections.append(
             create_applied_energy_correction(

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -1,0 +1,298 @@
+"""A local key must name something the upload declared, and a role must fit.
+
+Two contracts, both about the same failure mode: an upload naming
+provenance it does not have, and getting away with it.
+
+* **A declared role must match the calculation's type.** Thermo has
+  enforced this since DR-0028 Requirement 1
+  (``app.workflows.thermo._assert_calculation_role_compatible``). Statmech
+  did not, on any of its three write paths, so
+  ``{"calculation_key": "my_sp_job", "role": "freq"}`` persisted happily
+  and the statmech record then claimed a frequency calculation it never
+  had.
+
+* **A declared key must name something declared.** The conformer upload's
+  applied energy corrections tested both of their source keys for
+  ``is not None`` and resolved either one to the primary
+  observation/calculation whatever it said — a key that cannot be wrong
+  is not a key, it is a boolean spelled as a string.
+
+The assertions here are on the envelope's ``code`` field, never on
+substring presence in ``detail``. That is not stylistic: Pydantic echoes
+rejected input back into its error string, so ``assert "role" in
+resp.text`` is true even when the field was wrongly *accepted*. Only
+``body["code"] == ...`` distinguishes a refusal from an echo.
+"""
+
+from __future__ import annotations
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+_ROLE_TYPE_MISMATCH = "statmech_source_role_type_mismatch"
+_KEY_UNDECLARED = "applied_energy_correction_source_key_undeclared"
+
+
+def _assert_code(response, expected: str) -> dict:
+    """The response is a 422 that names *expected* in its ``code`` field."""
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert set(body) >= {"code", "detail"}, body
+    assert body["code"] == expected, (
+        f"expected code={expected!r}, got {body['code']!r}. "
+        f"detail={body['detail']!r}"
+    )
+    return body
+
+
+def _sp_calc() -> dict:
+    return {
+        "type": "sp",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "sp_result": {"electronic_energy_hartree": -76.437},
+    }
+
+
+def _freq_calc() -> dict:
+    return {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "freq_result": {"n_imag": 0, "zpe_hartree": 0.021},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Path 1 of 3: the standalone statmech upload
+# ---------------------------------------------------------------------------
+
+
+def _standalone_statmech_payload(**overrides) -> dict:
+    base: dict = {
+        "species_entry": {"smiles": "CO", "charge": 0, "multiplicity": 1},
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestStandaloneStatmechRoleMatchesType:
+    def test_freq_role_on_an_sp_calculation_is_refused(self, client):
+        payload = _standalone_statmech_payload(
+            calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "freq"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/statmech", json=payload)
+        body = _assert_code(resp, _ROLE_TYPE_MISMATCH)
+        # The offending key is named; no row id is disclosed.
+        assert body["context"]["declared_role"] == "freq"
+        assert body["context"]["actual_calculation_type"] == "sp"
+        assert body["context"]["expected_calculation_type"] == "freq"
+
+    def test_matching_role_still_uploads(self, client):
+        """The green half: the same shape with the role told truthfully."""
+        payload = _standalone_statmech_payload(
+            species_entry={"smiles": "CCO", "charge": 0, "multiplicity": 1},
+            calculations=[
+                {"key": "my_sp_job", "calculation": _sp_calc()},
+                {"key": "my_freq_job", "calculation": _freq_calc()},
+            ],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "sp"},
+                {"calculation_key": "my_freq_job", "role": "freq"},
+            ],
+        )
+        resp = client.post("/api/v1/uploads/statmech", json=payload)
+        assert resp.status_code == 201, resp.text
+
+    def test_imported_role_accepts_any_type(self, client):
+        """``imported`` names an origin, not a job type — as for thermo."""
+        payload = _standalone_statmech_payload(
+            species_entry={"smiles": "CCC", "charge": 0, "multiplicity": 1},
+            calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "imported"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/statmech", json=payload)
+        assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Path 2 of 3: statmech nested under a conformer upload
+# ---------------------------------------------------------------------------
+
+
+def _conformer_payload(label: str, **overrides) -> dict:
+    base: dict = {
+        "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        "geometry": {"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+        "calculation": dict(_sp_calc(), key="my_sp_job"),
+        "label": label,
+        "note": "key/role contract test",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNestedStatmechRoleMatchesType:
+    def test_uploaded_calculation_role_must_match_the_uploaded_calc(
+        self, client
+    ):
+        payload = _conformer_payload(
+            "conf-role-implicit",
+            statmech={"uploaded_calculation_role": "freq"},
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        body = _assert_code(resp, _ROLE_TYPE_MISMATCH)
+        assert body["context"]["field"] == "statmech.uploaded_calculation_role"
+
+    def test_source_calculation_role_must_match_the_key_it_names(self, client):
+        payload = _conformer_payload(
+            "conf-role-explicit",
+            statmech={
+                "source_calculations": [
+                    {"calculation_key": "my_sp_job", "role": "freq"}
+                ]
+            },
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        _assert_code(resp, _ROLE_TYPE_MISMATCH)
+
+    def test_truthful_role_still_uploads(self, client):
+        payload = _conformer_payload(
+            "conf-role-ok",
+            statmech={"uploaded_calculation_role": "sp"},
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Path 3 of 3: statmech inside a computed-species bundle
+# ---------------------------------------------------------------------------
+
+
+def _bundle_payload(**overrides) -> dict:
+    base: dict = {
+        "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": {"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "level_of_theory": _LOT,
+                    "software_release": _SOFTWARE,
+                    "opt_result": {"converged": True},
+                },
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBundleStatmechRoleMatchesType:
+    def test_freq_role_on_an_opt_calculation_is_refused(self, client):
+        payload = _bundle_payload(
+            statmech={
+                "external_symmetry": 1,
+                "source_calculations": [
+                    {"calculation_key": "opt0", "role": "freq"}
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        _assert_code(resp, _ROLE_TYPE_MISMATCH)
+
+    def test_truthful_role_still_uploads(self, client):
+        payload = _bundle_payload(
+            statmech={
+                "external_symmetry": 1,
+                "source_calculations": [
+                    {"calculation_key": "opt0", "role": "opt"}
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# The conformer upload's applied energy corrections
+# ---------------------------------------------------------------------------
+
+
+def _zpe_correction(**overrides) -> dict:
+    """One scale-factor correction, naming a declared calculation by default.
+
+    The payload schema already requires a scale-factor correction to name
+    the frequency calculation it was applied to, so the default here is a
+    declared key; the tests vary it to exercise *resolution*.
+    """
+    base: dict = {
+        "frequency_scale_factor": {
+            "level_of_theory": _LOT,
+            "scale_kind": "zpe",
+            "value": 0.977,
+        },
+        "application_role": "zpe",
+        "value": 0.0215,
+        "value_unit": "hartree",
+        "source_calculation_key": "my_sp_job",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestConformerCorrectionSourceKeys:
+    def test_undeclared_calculation_key_is_refused(self, client):
+        payload = _conformer_payload(
+            "conf-aec-ghost-calc",
+            applied_energy_corrections=[
+                _zpe_correction(source_calculation_key="my_sp_jbo")
+            ],
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert body["context"]["key"] == "my_sp_jbo"
+        # The remedy names what *is* declared, so the fix is mechanical.
+        assert body["context"]["declared_keys"] == ["my_sp_job"]
+
+    def test_declared_calculation_key_is_accepted(self, client):
+        payload = _conformer_payload(
+            "conf-aec-good-calc",
+            applied_energy_corrections=[
+                _zpe_correction(source_calculation_key="my_sp_job")
+            ],
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+
+    def test_conformer_key_that_is_not_the_label_is_refused(self, client):
+        payload = _conformer_payload(
+            "conf-aec-label",
+            applied_energy_corrections=[
+                _zpe_correction(source_conformer_key="some-other-conformer")
+            ],
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert body["context"]["declared_keys"] == ["conf-aec-label"]
+
+    def test_conformer_key_matching_the_label_is_accepted(self, client):
+        payload = _conformer_payload(
+            "conf-aec-good-label",
+            applied_energy_corrections=[
+                _zpe_correction(source_conformer_key="conf-aec-good-label")
+            ],
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -26,6 +26,7 @@ from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.db.models.app_user import AppUser
 from app.db.models.calculation import (
     Calculation,
@@ -3632,3 +3633,32 @@ def test_bundle_ts_evidence_enforces_full_atom_coverage() -> None:
                 product_participant_mapping={"product:1": [1, 2, 3]}
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# A statmech role must match the type of the job it names (DR-0028 Req 1)
+#
+# This is the fourth statmech write path and the one ARC deposits through.
+# ---------------------------------------------------------------------------
+
+
+def test_statmech_source_role_must_match_calculation_type(db_conn) -> None:
+    payload = _minimal_payload()
+    payload["species"][0]["statmech"] = {
+        "is_linear": False,
+        "external_symmetry": 6,
+        "statmech_treatment": "rrho",
+        # ``ch3-freq`` is a freq job; calling it the single-point is the
+        # claim this refuses.
+        "source_calculations": [{"calculation_key": "ch3-freq", "role": "sp"}],
+    }
+
+    with _isolated_session(db_conn) as session:
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_computed_reaction_upload(
+                session, ComputedReactionUploadRequest(**payload)
+            )
+
+    assert excinfo.value.code == "statmech_source_role_type_mismatch"
+    assert excinfo.value.context["declared_role"] == "sp"
+    assert excinfo.value.context["actual_calculation_type"] == "freq"

--- a/backend/tests/workflows/test_conformer_upload.py
+++ b/backend/tests/workflows/test_conformer_upload.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.db.models.calculation import (
     Calculation,
     CalculationDependency,
@@ -17,6 +18,7 @@ from app.db.models.common import (
     CalculationGeometryRole,
     CalculationType,
 )
+from app.db.models.energy_correction import AppliedEnergyCorrection
 from app.db.models.geometry import Geometry
 from app.db.models.species import (
     ConformerGroup,
@@ -166,10 +168,16 @@ def test_persist_conformer_upload_creates_linked_statmech_record(db_conn) -> Non
         geometry={
             "xyz_text": "1\nH atom\nH 0.0 0.0 0.0",
         },
+        # A freq job, because the statmech block below claims it as the
+        # record's frequency basis. This said ``sp`` until statmech began
+        # enforcing DR-0028 Requirement 1: the subject of the test is that
+        # the statmech row is created and linked, not that a role may
+        # contradict the type of the job it names.
         calculation={
-            "type": "sp",
+            "type": "freq",
             "software_release": {"name": "Gaussian", "version": "16"},
             "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+            "freq_result": {"n_imag": 0},
         },
         label="conf-stat",
         statmech={
@@ -668,3 +676,160 @@ def test_conformer_upload_rejects_irc_additional() -> None:
                 },
             ],
         )
+
+
+# ---------------------------------------------------------------------------
+# Applied energy corrections: the source keys must name what they say
+#
+# Both keys used to be tested for ``is not None`` alone, so *any* string
+# resolved to the primary observation/calculation. The test that matters is
+# therefore not the rejection but the acceptance: a correction naming the
+# additional freq calculation must land on that row, not on the primary.
+# ---------------------------------------------------------------------------
+
+
+def _correction_request(
+    *,
+    label: str,
+    source_calculation_key: str | None = "primary_sp",
+    source_conformer_key: str | None = None,
+) -> ConformerUploadRequest:
+    """A conformer upload carrying one frequency-scale-factor correction.
+
+    ``source_calculation_key`` defaults to a declared key because the
+    payload schema already requires a scale-factor correction to name the
+    frequency calculation it was applied to; the tests below vary it to
+    exercise resolution, not that requirement.
+    """
+    correction: dict = {
+        "frequency_scale_factor": {
+            "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+            "scale_kind": "zpe",
+            "value": 0.977,
+        },
+        "application_role": "zpe",
+        "value": 0.0215,
+        "value_unit": "hartree",
+    }
+    if source_calculation_key is not None:
+        correction["source_calculation_key"] = source_calculation_key
+    if source_conformer_key is not None:
+        correction["source_conformer_key"] = source_conformer_key
+    return ConformerUploadRequest(
+        species_entry={"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        geometry={"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+        calculation={
+            "key": "primary_sp",
+            "type": "sp",
+            "software_release": {"name": "Gaussian", "version": "16"},
+            "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+            "sp_result": {"electronic_energy_hartree": -0.5},
+        },
+        additional_calculations=[
+            {
+                "key": "the_freq_job",
+                "type": "freq",
+                "software_release": {"name": "Gaussian", "version": "16"},
+                "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+                "freq_result": {"n_imag": 0},
+            },
+        ],
+        label=label,
+        applied_energy_corrections=[correction],
+    )
+
+
+def test_correction_calculation_key_links_the_calculation_it_names(
+    db_conn,
+) -> None:
+    """The named key wins over the primary calculation.
+
+    This is the assertion the old code could not pass: it resolved every
+    non-null key to ``calculation.id``, so a correction naming the freq
+    job was silently attached to the primary sp job instead.
+    """
+    with Session(db_conn) as session, session.begin():
+        outcome = persist_conformer_upload(
+            session,
+            _correction_request(
+                label="aec-names-freq", source_calculation_key="the_freq_job"
+            ),
+        )
+        freq_id = outcome.additional_calculations[0].calculation_id
+        primary_id = outcome.primary_calculation.calculation_id
+
+        applied = session.scalars(
+            select(AppliedEnergyCorrection).where(
+                AppliedEnergyCorrection.source_conformer_observation_id.is_(None)
+            )
+        ).all()
+        assert len(applied) == 1
+        assert applied[0].source_calculation_id == freq_id
+        assert applied[0].source_calculation_id != primary_id
+
+
+def test_correction_conformer_key_links_the_observation_it_names(
+    db_conn,
+) -> None:
+    with Session(db_conn) as session, session.begin():
+        outcome = persist_conformer_upload(
+            session,
+            _correction_request(
+                label="aec-names-label", source_conformer_key="aec-names-label"
+            ),
+        )
+        applied = session.scalars(
+            select(AppliedEnergyCorrection).where(
+                AppliedEnergyCorrection.source_conformer_observation_id
+                == outcome.observation.id
+            )
+        ).all()
+        assert len(applied) == 1
+
+
+def test_correction_with_undeclared_calculation_key_is_refused(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_conformer_upload(
+                session,
+                _correction_request(
+                    label="aec-ghost-calc",
+                    source_calculation_key="the_freq_jbo",
+                ),
+            )
+    assert (
+        excinfo.value.code == "applied_energy_correction_source_key_undeclared"
+    )
+    assert excinfo.value.context["key"] == "the_freq_jbo"
+    assert excinfo.value.context["declared_keys"] == [
+        "primary_sp",
+        "the_freq_job",
+    ]
+
+
+def test_correction_with_undeclared_conformer_key_is_refused(db_conn) -> None:
+    with Session(db_conn) as session, session.begin():
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_conformer_upload(
+                session,
+                _correction_request(
+                    label="aec-ghost-conf",
+                    source_conformer_key="a-different-conformer",
+                ),
+            )
+    assert (
+        excinfo.value.code == "applied_energy_correction_source_key_undeclared"
+    )
+    assert excinfo.value.context["declared_keys"] == ["aec-ghost-conf"]
+
+
+def test_correction_conformer_key_with_no_label_is_refused(db_conn) -> None:
+    """No label means the request named no conformer at all."""
+    with Session(db_conn) as session, session.begin():
+        request = _correction_request(
+            label="aec-no-label", source_conformer_key="anything"
+        )
+        request.label = None
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_conformer_upload(session, request)
+    assert excinfo.value.context["declared_keys"] == []


### PR DESCRIPTION
Closes #126. Closes #127.

Two workflow-layer key-resolution defects, both letting an upload assert provenance it does not have. Neither is a new design decision: #126 applies DR-0028 Requirement 1 to the paths it was written for but never reached, and #127 resolves against the calc-key namespace PR #148 built.

## #126 — statmech accepted a role its calculation contradicts

Thermo has refused a role/type mismatch since DR-0028 Req 1 (`app/workflows/thermo.py::_assert_calculation_role_compatible`). Statmech refused nothing, so `{"calculation_key": "my_sp_job", "role": "freq"}` persisted and the record then claimed a frequency calculation it never had.

The check now lives once, in `app/services/statmech_resolution.py::assert_statmech_role_compatible`, and is called from **all four** statmech write paths — the brief named three:

| path | site |
|---|---|
| nested conformer upload | `services/statmech_resolution.py` (`resolve_or_create_statmech`), both `uploaded_calculation_role` and `source_calculations[*]` |
| standalone statmech upload | same service |
| computed-species bundle | `workflows/computed_species.py::_persist_statmech_block` |
| **computed-reaction bundle** | `workflows/computed_reaction.py` — the fourth path, and the one real ARC payloads use |

`opt`/`freq`/`sp`/`scan` require an exact `CalculationType` match. `composite` and `imported` accept any type, the same carve-out thermo makes: they name a scientific origin, not a job.

```
POST /api/v1/uploads/statmech
{"calculations": [{"key": "my_sp_job", "calculation": {"type": "sp", ...}}],
 "source_calculations": [{"calculation_key": "my_sp_job", "role": "freq"}]}

422 {
  "code": "statmech_source_role_type_mismatch",
  "detail": "statmech.source_calculations[0].calculation_key='my_sp_job': role='freq' claims a 'freq' calculation, but the calculation it names has type 'sp'. A statmech record must not claim evidence it does not have. Point the link at the 'freq' calculation, or declare the role the named calculation actually played.",
  "context": {"field": "statmech.source_calculations[0].calculation_key='my_sp_job'",
              "declared_role": "freq", "expected_calculation_type": "freq",
              "actual_calculation_type": "sp"}
}
```

## #127 — energy-correction keys resolved to the primary record whatever they said

`workflows/conformer.py` tested both source keys for `is not None` alone, so any string resolved to the observation/calculation just created. A key that cannot be wrong is not a key.

Both now resolve against a namespace the request actually declared: `source_calculation_key` against the `ConformerCalculationIn.key` namespace from #148, and `source_conformer_key` against the request's own `label` — the only name a conformer upload gives its single conformer. An undeclared key is refused, and the message names what *is* declared.

```
POST /api/v1/uploads/conformers      (calculation.key == "my_sp_job")
{"applied_energy_corrections": [{..., "source_calculation_key": "my_sp_jbo"}]}

422 {
  "code": "applied_energy_correction_source_key_undeclared",
  "detail": "applied_energy_corrections[0].source_calculation_key='my_sp_jbo' does not name anything declared in this upload. Declared names here: 'my_sp_job'. Put a matching 'key' on 'calculation' or on one of 'additional_calculations'. An energy correction whose source cannot be named is a correction nobody can trace back to what it corrected.",
  "context": {"field": "applied_energy_corrections[0].source_calculation_key",
              "key": "my_sp_jbo", "declared_keys": ["my_sp_job"]}
}
```

## Tiering and error contract

Both block, and ADR 0008 permits that because both assert **contracts**, not expectations: no correct calculation can satisfy `role='freq'` on an sp job, and no correct payload can name something it never declared. Each site says so in its docstring.

Both carry a machine-readable code with structured context. **No row id reaches a 422** — the statmech mismatch logs `calculation.id` server-side at INFO instead. The pre-existing undeclared-statmech-key rejection also gained a code (`statmech_calculation_key_undeclared`) with its sentence unchanged.

These are deliberately **not** `scientific_checks` register entries: the register's inclusion test is "could this check be wrong in an interesting way?", and a provenance contract is not a chemistry position a referee would argue with. Thermo's sibling check is not registered either.

## Tests

New: `backend/tests/api/test_api_upload_key_and_role_contracts.py` (12) plus 6 in `tests/workflows/test_conformer_upload.py` and 1 in `tests/workflows/test_computed_reaction_upload.py`. Assertions are on the envelope's `code` and on `context`, never on substring presence in `detail` — Pydantic echoes rejected input into its error string, so `"role" in resp.text` is true even when the field is wrongly accepted.

The conformer path's applied energy corrections had **zero** test coverage before this, which is why the defect survived.

One existing test changed: `test_persist_conformer_upload_creates_linked_statmech_record` declared `uploaded_calculation_role="freq"` over a primary calculation of type `sp` — it encoded the defect. Its primary calculation is now a freq job, so every assertion it makes is unchanged and the record it builds is now truthful. Nothing was weakened, skipped or xfailed.

## Verification

Gates on the rebased branch: rest 4178 passed / 14 skipped, api 2589 passed, scientific 2045 passed.

Mutation-checked one fix at a time. Reverting the role check: exactly 4 api tests + 1 rest test go red, nothing else moves. Reverting the key resolution: exactly 4 rest + 2 api tests go red, nothing else moves.

No Alembic revision; no schema or wire-package change (the OpenAPI snapshot test is unchanged).