### PR TITLE
Say on the page that this registry entry was superseded

### DIFF
--- a/backend/alembic/versions/c6f2a9d4e7b1_enforce_accepted_science_immutability.py
+++ b/backend/alembic/versions/c6f2a9d4e7b1_enforce_accepted_science_immutability.py
@@ -57,6 +57,16 @@ _DIRECT_CHILDREN = (
     ("calculation_parameter", "calculation", "calculation_id"),
     ("calc_geometry_validation", "calculation", "calculation_id"),
     ("calc_scf_stability", "calculation", "calculation_id"),
+    # SUPERSEDED by revision d4e9b1c7a253 (2026-08-13). This entry is wrong and
+    # is retained only because this revision is deployed and what it ran cannot
+    # be rewritten. `source_calculation_id` is a PROVENANCE pointer -- the
+    # calculation whose stability this row cites -- not the calculation the row
+    # belongs to. Registering it as an ownership guard meant an unapproved
+    # calculation could not record SCF-stability evidence citing an approved
+    # one: a legitimate write, refused. d4e9b1c7a253 replaces trg_as_child_19
+    # with the ownership column alone and lists this triple in its
+    # `_REMOVED_CHILDREN`, which the registry test subtracts. Read that
+    # revision, not this line, for the registry the database actually has.
     ("calc_scf_stability", "calculation", "source_calculation_id"),
     ("calc_hessian", "calculation", "calculation_id"),
     ("calc_wavefunction_diagnostic", "calculation", "calculation_id"),


### PR DESCRIPTION
Closes #121.

## What

One comment, in `backend/alembic/versions/c6f2a9d4e7b1_enforce_accepted_science_immutability.py`, above the `calc_scf_stability` / `source_calculation_id` entry in `_DIRECT_CHILDREN`.

## Why it could not simply be fixed

The entry is wrong: `source_calculation_id` is a **provenance** pointer — the calculation whose stability the row cites — not the calculation the row belongs to. Registering it as an ownership guard meant an unapproved calculation could not record SCF-stability evidence citing an approved one. A legitimate write, refused.

PR #144 fixed that in the database (`d4e9b1c7a253` replaces `trg_as_child_19` with the ownership column alone) and lists the triple in its `_REMOVED_CHILDREN`, which the registry test subtracts. But the wrong entry is still physically present in `c6f2a9d4e7b1`, because that revision is deployed and what it ran cannot be rewritten.

So until now the only marker that the entry was superseded lived in a *different file*. Anyone opening `c6f2a9d4e7b1` alone — the natural thing to do when asking "what does this guard protect?" — read the wrong registry with nothing warning them.

## The rule this depends on

`.claude/rules/migration-rules.md` now permits **comment-only** edits to a deployed revision. The reasoning: the no-mutation rule exists so a deployed database and the file describing it never disagree about what was *run*. A comment changes nothing that ran, so it cannot create that disagreement — while forbidding it creates a worse one, a revision correct only as history with nothing on the page saying so.

The limits are stated there too: nothing executable may change, the comment must name what superseded it, and "change a value and just note it" is the forbidden case.

## Verification

Nothing executable changed, and that is the whole claim:

- `tests/db/test_accepted_science_trigger_registry.py` and `tests/db/test_scf_stability_provenance_guard.py` — **8 passed**, unmoved.
- `alembic heads` unchanged at `b7e4d1a9c026`.