### PR TITLE
Let the reaction bundle's statmech say what the species bundle's already could, and warn when neither says it

### DIFF
--- a/backend/app/services/provenance_warnings.py
+++ b/backend/app/services/provenance_warnings.py
@@ -143,16 +143,91 @@ def _freq_scale_factor_warning(
     )
 
 
-def _computed_common_warnings(
+# ---------------------------------------------------------------------------
+# Request-agnostic core
+# ---------------------------------------------------------------------------
+
+
+class _NotApplicable:
+    """Sentinel: this record type has no such anchor, so do not judge it.
+
+    Distinct from ``None``, and the distinction is the point. ``None``
+    means *the depositor could have supplied this and did not* — a real
+    gap, worth a warning. ``NOT_APPLICABLE`` means *there is no field on
+    this payload to supply it through*, which is a fact about the schema
+    rather than about the deposit, and warning about it would tell a
+    depositor to do something they cannot do.
+
+    The concrete case is ``energy_level_of_theory`` on a bundle. On the
+    standalone kinetics route it is a real anchor: ``app.workflows.
+    kinetics`` uses it to auto-resolve source SP calculations. A bundle
+    names its source calculations by key instead and has no field for
+    it, so it is NOT_APPLICABLE there.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "NOT_APPLICABLE"
+
+
+NOT_APPLICABLE = _NotApplicable()
+
+
+def collect_provenance_warnings(
     *,
+    scientific_origin: ScientificOriginKind,
     software_release: object | None,
     workflow_tool_release: object | None,
+    literature: object | None,
+    freq_scale_factor: object | None = NOT_APPLICABLE,
+    energy_level_of_theory: object | None = NOT_APPLICABLE,
+    field_prefix: str = "",
 ) -> list[UploadWarning]:
+    """Warn about provenance anchors a record could carry and does not.
+
+    Request-agnostic, for the reason ``collect_statmech_content_warnings``
+    is: the standalone routes and the two bundle roots make the same
+    claim about the same rows, so they should report the same gaps in
+    the same shape. Before this, the bundle roots reported nothing at
+    all — the collectors existed and only the standalone routes called
+    them.
+
+    Callers pass the **effective** value, not the raw field. On the
+    reaction bundle a per-species ``software_release`` falls back to the
+    bundle-level ``analysis_software_release``, and the workflow
+    persists the fallback, so warning on the raw per-species field would
+    warn about provenance that was in fact recorded.
+
+    :param field_prefix: Dot-path prefix naming the subject, e.g.
+        ``"species['ch4'].statmech."``. A bundle carries many records
+        and a bare ``software_release`` on a twenty-species deposit
+        names none of them; ``UploadWarning.field`` is already
+        documented as a dot-path and already carries indexed paths from
+        the standalone kinetics route, so this needs no new machinery.
+    :param freq_scale_factor: Statmech's extra anchor, or
+        :data:`NOT_APPLICABLE` for record types that have none.
+    :param energy_level_of_theory: Kinetics' extra anchor, or
+        :data:`NOT_APPLICABLE`.
+    """
     warnings: list[UploadWarning] = []
-    if software_release is None:
-        warnings.append(_software_release_warning())
-    if workflow_tool_release is None:
-        warnings.append(_workflow_tool_release_warning())
+    if scientific_origin in _COMPUTATIONAL_ORIGINS:
+        if software_release is None:
+            warnings.append(
+                _software_release_warning(f"{field_prefix}software_release")
+            )
+        if workflow_tool_release is None:
+            warnings.append(
+                _workflow_tool_release_warning(f"{field_prefix}workflow_tool_release")
+            )
+        if freq_scale_factor is None:
+            warnings.append(
+                _freq_scale_factor_warning(f"{field_prefix}freq_scale_factor")
+            )
+        if energy_level_of_theory is None:
+            warnings.append(
+                _level_of_theory_warning(f"{field_prefix}energy_level_of_theory")
+            )
+    elif literature is None:
+        warnings.append(_literature_warning(f"{field_prefix}literature"))
     return warnings
 
 
@@ -165,28 +240,24 @@ def collect_thermo_provenance_warnings(
     request: ThermoUploadRequest,
 ) -> list[UploadWarning]:
     """Structured warnings for provenance absent from a thermo upload."""
-    if request.scientific_origin in _COMPUTATIONAL_ORIGINS:
-        return _computed_common_warnings(
-            software_release=request.software_release,
-            workflow_tool_release=request.workflow_tool_release,
-        )
-    if request.literature is None:
-        return [_literature_warning()]
-    return []
+    return collect_provenance_warnings(
+        scientific_origin=request.scientific_origin,
+        software_release=request.software_release,
+        workflow_tool_release=request.workflow_tool_release,
+        literature=request.literature,
+    )
 
 
 def collect_transport_provenance_warnings(
     request: TransportUploadRequest,
 ) -> list[UploadWarning]:
     """Structured warnings for provenance absent from a transport upload."""
-    if request.scientific_origin in _COMPUTATIONAL_ORIGINS:
-        return _computed_common_warnings(
-            software_release=request.software_release,
-            workflow_tool_release=request.workflow_tool_release,
-        )
-    if request.literature is None:
-        return [_literature_warning()]
-    return []
+    return collect_provenance_warnings(
+        scientific_origin=request.scientific_origin,
+        software_release=request.software_release,
+        workflow_tool_release=request.workflow_tool_release,
+        literature=request.literature,
+    )
 
 
 def collect_statmech_content_warnings(
@@ -271,19 +342,13 @@ def collect_statmech_provenance_warnings(
     anchor: a NULL value means "unknown/not recorded", and leaving it
     implicit erases a scientifically meaningful piece of the record.
     """
-    warnings: list[UploadWarning] = []
-    if request.scientific_origin in _COMPUTATIONAL_ORIGINS:
-        warnings.extend(
-            _computed_common_warnings(
-                software_release=request.software_release,
-                workflow_tool_release=request.workflow_tool_release,
-            )
-        )
-        if request.freq_scale_factor is None:
-            warnings.append(_freq_scale_factor_warning())
-    elif request.literature is None:
-        warnings.append(_literature_warning())
-    return warnings
+    return collect_provenance_warnings(
+        scientific_origin=request.scientific_origin,
+        software_release=request.software_release,
+        workflow_tool_release=request.workflow_tool_release,
+        literature=request.literature,
+        freq_scale_factor=request.freq_scale_factor,
+    )
 
 
 def collect_kinetics_provenance_warnings(
@@ -295,19 +360,13 @@ def collect_kinetics_provenance_warnings(
     without it, source SP calculations cannot be auto-resolved and the
     kinetics record loses its electronic-energy anchor.
     """
-    warnings: list[UploadWarning] = []
-    if request.scientific_origin in _COMPUTATIONAL_ORIGINS:
-        warnings.extend(
-            _computed_common_warnings(
-                software_release=request.software_release,
-                workflow_tool_release=request.workflow_tool_release,
-            )
-        )
-        if request.energy_level_of_theory is None:
-            warnings.append(_level_of_theory_warning())
-    elif request.literature is None:
-        warnings.append(_literature_warning())
-    return warnings
+    return collect_provenance_warnings(
+        scientific_origin=request.scientific_origin,
+        software_release=request.software_release,
+        workflow_tool_release=request.workflow_tool_release,
+        literature=request.literature,
+        energy_level_of_theory=request.energy_level_of_theory,
+    )
 
 
 def collect_kinetics_content_warnings(

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -75,6 +75,12 @@ from app.services.kinetics_resolution import (
     assert_kinetics_source_role_compatible,
 )
 from app.services.literature_resolution import resolve_or_create_literature
+from app.services.provenance_warnings import (
+    NOT_APPLICABLE,
+    collect_provenance_warnings,
+    collect_statmech_content_warnings,
+    statmech_has_rotational_structure,
+)
 from app.services.reaction_atom_map import (
     ResolvedAtomMapParticipant,
     persist_reaction_atom_map,
@@ -255,6 +261,131 @@ def _index_species_sp_calcs(
     return by_species
 
 
+def _collect_bundle_provenance_warnings(
+    request: ComputedReactionUploadRequest,
+) -> list[UploadWarning]:
+    """Report provenance this bundle's products could carry and do not.
+
+    The same warnings ``/uploads/thermo``, ``/uploads/statmech`` and
+    ``/uploads/kinetics`` have always returned, which this route returned
+    none of. A bundle deposit was therefore silently less complete than
+    the identical field-by-field deposit, with nothing saying so —
+    contrary to ADR 0011 and ADR 0008, under which absence is
+    incompleteness and incompleteness is annotated rather than refused.
+
+    Three things this has to get right that the standalone routes do not:
+
+    **Naming the subject.** A bundle carries many species. A bare
+    "missing workflow tool" on a twenty-species deposit is true and
+    useless, so every warning is prefixed with the species key it
+    concerns, in the ``species['ch4'].statmech.…`` form this payload's
+    own validators already use for error paths.
+
+    **Effective, not raw, values.** A per-species ``software_release``
+    falls back to the bundle-level ``analysis_software_release``, and the
+    workflow persists the fallback. Warning on the raw per-species field
+    would name provenance that was in fact recorded.
+
+    **Kinetics' level of theory is not applicable here.**
+    ``collect_kinetics_provenance_warnings`` asks the standalone route
+    for ``energy_level_of_theory``, and ``BundleKineticsIn`` has no such
+    field — nor does the bundle root, nor is it a column on ``kinetics``.
+    On the standalone route it is a resolution hint that
+    ``app.workflows.kinetics`` uses to auto-resolve source SP
+    calculations; a bundle names its source calculations by key and has
+    no use for it. Warning about it would be exactly the un-actionable
+    warning this wiring exists to avoid, so it is passed as
+    ``NOT_APPLICABLE`` rather than as ``None``.
+    """
+    warnings: list[UploadWarning] = []
+
+    for sp in request.species:
+        if sp.thermo is not None:
+            warnings.extend(
+                collect_provenance_warnings(
+                    scientific_origin=sp.thermo.scientific_origin,
+                    software_release=(
+                        sp.thermo.software_release or request.analysis_software_release
+                    ),
+                    workflow_tool_release=(
+                        sp.thermo.workflow_tool_release or request.workflow_tool_release
+                    ),
+                    literature=sp.thermo.literature,
+                    field_prefix=f"species[{sp.key!r}].thermo.",
+                )
+            )
+        if sp.statmech is not None:
+            warnings.extend(
+                collect_provenance_warnings(
+                    scientific_origin=sp.statmech.scientific_origin,
+                    software_release=(
+                        sp.statmech.software_release
+                        or request.analysis_software_release
+                    ),
+                    workflow_tool_release=(
+                        sp.statmech.workflow_tool_release
+                        or request.workflow_tool_release
+                    ),
+                    literature=sp.statmech.literature,
+                    freq_scale_factor=sp.statmech.freq_scale_factor,
+                    field_prefix=f"species[{sp.key!r}].statmech.",
+                )
+            )
+            # The species route has reported this since statmech landed
+            # there; the reaction route reported nothing, so the same
+            # untraceable partition function was named on one route and
+            # silent on the other.
+            #
+            # ``statmech_has_rotational_structure`` only became answerable
+            # on this route with #142: it reads the rotational constants,
+            # which ``BundleStatmechIn`` could not carry until now. Before
+            # that it could only ever see torsions, so a polyatomic
+            # deposited with constants and no torsions — the ordinary ARC
+            # shape — looked monatomic to it.
+            warnings.extend(
+                collect_statmech_content_warnings(
+                    scientific_origin=sp.statmech.scientific_origin,
+                    source_calculation_roles={
+                        item.role.value for item in sp.statmech.source_calculations
+                    },
+                    has_rotational_structure=statmech_has_rotational_structure(
+                        sp.statmech
+                    ),
+                    field=f"species[{sp.key!r}].statmech",
+                )
+            )
+
+    # Kinetics provenance is bundle-scoped, and the field paths say so.
+    # ``BundleKineticsIn`` carries no provenance fields at all; the workflow
+    # writes ``request.literature``, ``request.analysis_software_release`` and
+    # ``request.workflow_tool_release`` onto every kinetics row it creates.
+    # So the actionable field is the bundle root, and a path like
+    # ``kinetics[0].software_release`` would name a field that does not
+    # exist — ``SchemaBase`` is extra="forbid", so a depositor following
+    # that advice would get a 422. Naming the subject is not lost by using
+    # root paths: one bundle is one reaction, declared once at the root.
+    #
+    # Deduplicated because several fits share one set of root fields, and N
+    # identical warnings for one missing field is noise. Iterating the fits
+    # rather than testing a single origin keeps a mixed-origin bundle
+    # honest: a computed fit wants software provenance, a non-computed one
+    # wants a literature anchor, and a bundle carrying both should say both.
+    seen: set[tuple[str, str]] = set()
+    for kin in request.kinetics:
+        for warning in collect_provenance_warnings(
+            scientific_origin=kin.scientific_origin,
+            software_release=request.analysis_software_release,
+            workflow_tool_release=request.workflow_tool_release,
+            literature=request.literature,
+            energy_level_of_theory=NOT_APPLICABLE,
+        ):
+            if (warning.field, warning.code) not in seen:
+                seen.add((warning.field, warning.code))
+                warnings.append(warning)
+
+    return warnings
+
+
 def persist_computed_reaction_upload(
     session: Session,
     request: ComputedReactionUploadRequest,
@@ -278,6 +409,9 @@ def persist_computed_reaction_upload(
     applied_correction_ids: list[int] = []
     # Single-point energy reconciliation warnings from inline output logs.
     sp_energy_warnings: list[UploadWarning] = []
+    # Provenance-presence warnings for the scientific products this bundle
+    # carries. Request-derived only, so they are collected up front.
+    sp_energy_warnings.extend(_collect_bundle_provenance_warnings(request))
 
     # ------------------------------------------------------------------
     # 1. Resolve species + conformers + calculations
@@ -828,17 +962,38 @@ def persist_computed_reaction_upload(
                 )
                 fsf_id = fsf.id
 
+            # Per-species provenance overrides the bundle-level value, the
+            # same precedence thermo uses above. Falling back rather than
+            # replacing keeps every bundle that already relied on the
+            # bundle-level values persisting exactly what it did before.
+            statmech_software_release = (
+                resolve_software_release_ref(session, s.software_release)
+                if s.software_release is not None
+                else bundle_analysis_software_release
+            )
+            statmech_workflow_tool_release = (
+                resolve_workflow_tool_release_ref(session, s.workflow_tool_release)
+                if s.workflow_tool_release is not None
+                else bundle_workflow_tool_release
+            )
+            statmech_literature = (
+                resolve_or_create_literature(session, s.literature)
+                if s.literature is not None
+                else None
+            )
+
             statmech = Statmech(
                 species_entry_id=species_entry.id,
                 scientific_origin=s.scientific_origin,
+                literature_id=(
+                    statmech_literature.id if statmech_literature is not None else None
+                ),
                 software_release_id=(
-                    bundle_analysis_software_release.id
-                    if bundle_analysis_software_release
-                    else None
+                    statmech_software_release.id if statmech_software_release else None
                 ),
                 workflow_tool_release_id=(
-                    bundle_workflow_tool_release.id
-                    if bundle_workflow_tool_release
+                    statmech_workflow_tool_release.id
+                    if statmech_workflow_tool_release
                     else None
                 ),
                 is_linear=s.is_linear,
@@ -847,6 +1002,9 @@ def persist_computed_reaction_upload(
                 optical_isomers=s.optical_isomers,
                 point_group=s.point_group,
                 statmech_treatment=s.statmech_treatment,
+                rotational_constant_a_cm1=s.rotational_constant_a_cm1,
+                rotational_constant_b_cm1=s.rotational_constant_b_cm1,
+                rotational_constant_c_cm1=s.rotational_constant_c_cm1,
                 frequency_scale_factor_id=fsf_id,
                 uses_projected_frequencies=s.uses_projected_frequencies,
                 note=s.note,

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -77,6 +77,7 @@ from app.services.hessian_extraction import (
 )
 from app.services.literature_resolution import resolve_or_create_literature
 from app.services.provenance_warnings import (
+    collect_provenance_warnings,
     collect_statmech_content_warnings,
     statmech_has_rotational_structure,
 )
@@ -518,8 +519,42 @@ def persist_computed_species_upload(
     # delete them.
     bundle_stored_shas: list[str] = []
     # Non-blocking gaps surfaced on the upload response: single-point
-    # energy reconciliation, and absent statmech evidence.
+    # energy reconciliation, absent statmech evidence, and absent
+    # provenance on the scientific products this bundle carries.
     upload_warnings: list[UploadWarning] = []
+
+    # Provenance-presence warnings, the same ones /uploads/thermo and
+    # /uploads/statmech have always returned. They were never wired here,
+    # so a depositor using the bundle route — which is the route the ARC
+    # adapter uses — got neither the refusal nor the annotation ADR 0011
+    # and ADR 0008 promise, and their record was silently less complete
+    # than the identical field-by-field deposit.
+    #
+    # This bundle is one species, so ``thermo.``/``statmech.`` already
+    # names its subject unambiguously and matches the real payload path.
+    # The reaction bundle, which carries many species, prefixes with the
+    # species key instead.
+    if request.thermo is not None:
+        upload_warnings.extend(
+            collect_provenance_warnings(
+                scientific_origin=request.thermo.scientific_origin,
+                software_release=request.thermo.software_release,
+                workflow_tool_release=request.thermo.workflow_tool_release,
+                literature=request.thermo.literature,
+                field_prefix="thermo.",
+            )
+        )
+    if request.statmech is not None:
+        upload_warnings.extend(
+            collect_provenance_warnings(
+                scientific_origin=request.statmech.scientific_origin,
+                software_release=request.statmech.software_release,
+                workflow_tool_release=request.statmech.workflow_tool_release,
+                literature=request.statmech.literature,
+                freq_scale_factor=request.statmech.freq_scale_factor,
+                field_prefix="statmech.",
+            )
+        )
     try:
         for outcome in conformer_outcomes:
             for calc_in, calc_row in (

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -2663,7 +2663,7 @@
       },
       "BundleStatmechIn": {
         "additionalProperties": false,
-        "description": "Statistical mechanics properties for a species in this bundle.\n\n:param scientific_origin: Scientific origin category.\n:param is_linear: Whether the molecule is linear.\n:param rigid_rotor_kind: Rotational treatment classification.\n:param external_symmetry: External symmetry number.\n:param optical_isomers: Number of optical isomers (>= 1).\n:param point_group: Optional point-group label (e.g. ``\"C2v\"``).\n:param statmech_treatment: Overall statmech treatment classification.\n:param freq_scale_factor: Frequency scale factor applied.\n:param uses_projected_frequencies: Whether projected frequencies were used.\n:param source_calculations: Statmech → calc links by bundle-local\n    calculation key. Each referenced key must resolve into the\n    bundle's global calc-key namespace and must be owned by this\n    species entry (workflow-layer ownership check).\n:param torsions: Torsional modes.\n:param note: Optional note.",
+        "description": "Statistical mechanics properties for a species in this bundle.\n\nThe reaction route's statmech carries the same fields the species\nroute's ``StatmechInBundle`` carries, for the reason\n:class:`BundleThermoIn` gives: it is the same claim about the same\nkind of row, written against the same table.\n\nThe gap this closes had two distinct causes, and only one of them is\nthe same as thermo's. This model was born narrow in ``17706cf7`` --\ncongenital, like ``BundleThermoIn``. But the three rotational\nconstants were added to ``StatmechInBundle`` **only**, by\n``264519f1``, two days after ``0ea9182f`` had correctly updated both\nmodels in one commit. The habit was right and then it lapsed, and\nnothing in the tree could notice: no test compared the two field\nsets, so a one-sided addition read exactly like a deliberate one.\n``tests/schemas/test_bundle_root_model_symmetry.py`` is now that\ntest, and an intentional divergence has to be written down in its\nallowlist with a reason rather than merely happening.\n\nNothing is deliberately withheld here. ``applied_energy_corrections``\n-- the one field :class:`BundleThermoIn` refuses, because\n:class:`BundleSpeciesIn` already declares it against the same species\nentry -- is not on ``StatmechInBundle`` either, so it is not part of\nthis divergence and needs no exception.\n\n``literature``, ``software_release`` and ``workflow_tool_release``\nare per-species overrides of the bundle-level\n``analysis_software_release`` / ``workflow_tool_release`` /\n``literature``, exactly as thermo's are. Before this, a reaction\nbundle's statmech took the bundle-level values with no way to say\nthat one species' partition function came from a different analysis\ncode -- which is the ordinary case when one participant is taken\nfrom a paper and the rest were computed here.\n\n:param scientific_origin: Scientific origin category.\n:param literature: Optional literature provenance for this statmech.\n:param software_release: Optional analysis-code provenance. Overrides\n    the bundle-level ``analysis_software_release`` for this species.\n:param workflow_tool_release: Optional workflow-tool provenance.\n    Overrides the bundle-level value for this species.\n:param is_linear: Whether the molecule is linear.\n:param rigid_rotor_kind: Rotational treatment classification.\n:param external_symmetry: External symmetry number.\n:param optical_isomers: Number of optical isomers (>= 1).\n:param point_group: Optional point-group label (e.g. ``\"C2v\"``).\n:param statmech_treatment: Overall statmech treatment classification.\n:param rotational_constant_a_cm1: First reported principal rotational\n    constant (cm^-1), in source-provided order (conventionally\n    descending A >= B >= C). Optional.\n:param rotational_constant_b_cm1: Second reported principal rotational\n    constant (cm^-1). Optional.\n:param rotational_constant_c_cm1: Third reported principal rotational\n    constant (cm^-1). Optional.\n:param freq_scale_factor: Frequency scale factor applied.\n:param uses_projected_frequencies: Whether projected frequencies were used.\n:param source_calculations: Statmech → calc links by bundle-local\n    calculation key. Each referenced key must resolve into the\n    bundle's global calc-key namespace and must be owned by this\n    species entry (workflow-layer ownership check).\n:param torsions: Torsional modes.\n:param note: Optional note.",
         "properties": {
           "external_symmetry": {
             "anyOf": [
@@ -2697,6 +2697,16 @@
               }
             ],
             "title": "Is Linear"
+          },
+          "literature": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LiteratureUploadRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "note": {
             "anyOf": [
@@ -2742,9 +2752,55 @@
               }
             ]
           },
+          "rotational_constant_a_cm1": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotational Constant A Cm1"
+          },
+          "rotational_constant_b_cm1": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotational Constant B Cm1"
+          },
+          "rotational_constant_c_cm1": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotational Constant C Cm1"
+          },
           "scientific_origin": {
             "$ref": "#/components/schemas/ScientificOriginKind",
             "default": "computed"
+          },
+          "software_release": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SoftwareReleaseRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "source_calculations": {
             "items": {
@@ -2780,6 +2836,16 @@
               }
             ],
             "title": "Uses Projected Frequencies"
+          },
+          "workflow_tool_release": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowToolReleaseRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "title": "BundleStatmechIn",

--- a/backend/tests/api/test_api_bundle_provenance_warnings.py
+++ b/backend/tests/api/test_api_bundle_provenance_warnings.py
@@ -1,0 +1,681 @@
+"""The bundle routes must annotate absent provenance, not swallow it.
+
+``collect_thermo_provenance_warnings``, ``collect_statmech_provenance_warnings``
+and ``collect_kinetics_provenance_warnings`` existed and were called only
+from the standalone routes. On ``/uploads/computed-species`` and
+``/uploads/computed-reaction`` — the two routes the ARC adapter actually
+uses — omitting ``workflow_tool_release``, ``software_release``,
+``literature`` or a frequency scale factor produced no warning of any
+kind, while the identical omission field-by-field was reported.
+
+ADR 0011 and ADR 0008 both rest on the same principle: absence is
+incompleteness, and incompleteness is *annotated* rather than refused. A
+bundle depositor got neither the refusal nor the annotation, so their
+record was silently less complete than a field-by-field one and nothing
+told them.
+
+Every test here goes through the real route and asserts on the real
+response envelope, because a collector that is *called* and a warning a
+depositor *receives* are different claims — and the first was never in
+doubt.
+
+Assertions are on ``(field, code)`` pairs rather than on message
+substrings: the messages are shared with the standalone routes and
+rewording one should not break these, whereas a warning landing on the
+wrong species or under the wrong code should.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_ANALYSIS_SOFTWARE = {"name": "RMG-Py", "version": "3.2.0"}
+_WTR = {"name": "ARC", "version": "1.2.0"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+_FSF = {
+    "level_of_theory": _LOT,
+    "scale_kind": "fundamental",
+    "value": 0.97,
+}
+_LITERATURE = {
+    "kind": "article",
+    "title": "A rate for something",
+    "journal": "J. Test",
+    "year": 2026,
+    "doi": "10.1000/tckdb.bundle.provenance.warnings",
+}
+
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2 = "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+
+
+def _pairs(resp) -> set[tuple[str, str]]:
+    """``(field, code)`` for every warning on an upload response."""
+    return {(w["field"], w["code"]) for w in resp.json()["warnings"]}
+
+
+def _codes_under(resp, prefix: str) -> set[str]:
+    return {
+        w["code"] for w in resp.json()["warnings"] if w["field"].startswith(prefix)
+    }
+
+
+#: The provenance-absence codes, as distinct from the *content*-absence
+#: codes (untraceable statmech, missing tunneling evidence) that the same
+#: response carries. Kept separate so a "provenance is silent" assertion
+#: cannot be accidentally satisfied — or accidentally broken — by a
+#: content warning landing on the same field prefix.
+PROVENANCE_CODES = frozenset(
+    {
+        "missing_software_release_provenance",
+        "missing_workflow_tool_provenance",
+        "missing_literature_provenance",
+        "missing_frequency_scale_factor_provenance",
+        "missing_level_of_theory_provenance",
+    }
+)
+
+
+def _provenance_codes_under(resp, prefix: str) -> set[str]:
+    return _codes_under(resp, prefix) & PROVENANCE_CODES
+
+
+def _statmech_rows(db_session, resp) -> list:
+    """Statmech rows written by this reaction upload, in id order.
+
+    Read back through ``species_entry_ids`` rather than a ``statmech_ids``
+    field, because ``ComputedReactionUploadResult`` does not expose one —
+    it returns ``kinetics_ids`` and ``thermo_ids`` but not the statmech
+    ids the workflow already collects internally. Noted rather than
+    worked around silently; it is a response-shape gap, not a
+    persistence one.
+    """
+    from sqlalchemy import select
+
+    from app.db.models.statmech import Statmech
+
+    entry_ids = resp.json()["species_entry_ids"]
+    return list(
+        db_session.scalars(
+            select(Statmech)
+            .where(Statmech.species_entry_id.in_(entry_ids))
+            .order_by(Statmech.id)
+        ).all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# /uploads/computed-species
+# ---------------------------------------------------------------------------
+
+
+def _species_bundle(**overrides) -> dict:
+    base: dict = {
+        "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": {"xyz_text": _XYZ_H},
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_result": {"converged": True},
+                },
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_species_bundle_thermo_without_provenance_is_annotated(client: TestClient):
+    """The headline gap for the species route's thermo."""
+    bundle = _species_bundle(
+        thermo={"scientific_origin": "computed", "h298_kj_mol": 218.0}
+    )
+    resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert ("thermo.software_release", "missing_software_release_provenance") in _pairs(
+        resp
+    )
+    assert (
+        "thermo.workflow_tool_release",
+        "missing_workflow_tool_provenance",
+    ) in _pairs(resp)
+
+
+def test_species_bundle_thermo_with_provenance_is_not_annotated(client: TestClient):
+    """The control. Supplying it must silence exactly these warnings."""
+    bundle = _species_bundle(
+        thermo={
+            "scientific_origin": "computed",
+            "h298_kj_mol": 218.0,
+            "software_release": _ANALYSIS_SOFTWARE,
+            "workflow_tool_release": _WTR,
+        }
+    )
+    resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+    assert _codes_under(resp, "thermo.") == set(), resp.json()["warnings"]
+
+
+def test_species_bundle_statmech_without_provenance_is_annotated(client: TestClient):
+    """Statmech carries a third anchor the others do not: the scale factor."""
+    bundle = _species_bundle(
+        statmech={
+            "scientific_origin": "computed",
+            "statmech_treatment": "rrho",
+            "external_symmetry": 1,
+        }
+    )
+    resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert _codes_under(resp, "statmech.software_release") == {
+        "missing_software_release_provenance"
+    }
+    assert _codes_under(resp, "statmech.workflow_tool_release") == {
+        "missing_workflow_tool_provenance"
+    }
+    assert _codes_under(resp, "statmech.freq_scale_factor") == {
+        "missing_frequency_scale_factor_provenance"
+    }
+
+
+def test_species_bundle_statmech_with_provenance_is_not_annotated(client: TestClient):
+    bundle = _species_bundle(
+        statmech={
+            "scientific_origin": "computed",
+            "statmech_treatment": "rrho",
+            "external_symmetry": 1,
+            "software_release": _ANALYSIS_SOFTWARE,
+            "workflow_tool_release": _WTR,
+            "freq_scale_factor": _FSF,
+        }
+    )
+    resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    provenance_codes = {
+        "missing_software_release_provenance",
+        "missing_workflow_tool_provenance",
+        "missing_frequency_scale_factor_provenance",
+        "missing_literature_provenance",
+    }
+    assert _codes_under(resp, "statmech.") & provenance_codes == set(), resp.json()[
+        "warnings"
+    ]
+
+
+def test_a_non_computed_species_bundle_product_wants_literature_instead(
+    client: TestClient,
+):
+    """Origin selects which anchor is expected, on the bundle route too.
+
+    An experimental thermo has no software release to name, so demanding
+    one would fire on every correct deposit. What it should carry is the
+    paper it came out of.
+    """
+    bundle = _species_bundle(
+        thermo={"scientific_origin": "experimental", "h298_kj_mol": 218.0}
+    )
+    resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert _codes_under(resp, "thermo.") == {"missing_literature_provenance"}
+
+
+def test_a_species_bundle_with_no_products_gets_no_product_warnings(
+    client: TestClient,
+):
+    """A conformer-only deposit claims no thermo and no statmech.
+
+    Guards the shape of the fix rather than its content: warning about
+    absent provenance on a record that does not exist would make the
+    conformer-only upload path noisy for no reason.
+    """
+    resp = client.post("/api/v1/uploads/computed-species", json=_species_bundle())
+    assert resp.status_code == 201, resp.text[:800]
+
+    for field, _code in _pairs(resp):
+        assert not field.startswith(("thermo.", "statmech.")), (
+            f"warning on absent product: {field}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# /uploads/computed-reaction
+# ---------------------------------------------------------------------------
+
+
+def _reaction_species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [
+            {
+                "key": f"{key}-freq",
+                "type": "freq",
+                "geometry_key": f"{key}-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 0,
+                "freq_zpe_hartree": 0.01,
+            },
+        ],
+    }
+
+
+def _reaction_bundle(**overrides) -> dict:
+    """``H + H -> H2``. Balanced, no transition state, no atom map needed."""
+    base: dict = {
+        "species": [
+            _reaction_species("h", "[H]", 2, _XYZ_H),
+            _reaction_species("h2", "[H][H]", 1, _XYZ_H2),
+        ],
+        "reversible": True,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _kinetics(**overrides) -> dict:
+    base: dict = {
+        "scientific_origin": "computed",
+        "model_kind": "arrhenius",
+        "a": 1.0e13,
+        "a_units": "cm3_mol_s",
+        "n": 0.0,
+        "reported_ea": 10.0,
+        "reported_ea_units": "kj_mol",
+        "tmin_k": 300.0,
+        "tmax_k": 2000.0,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_reaction_bundle_warnings_name_the_species_they_concern(client: TestClient):
+    """The requirement a bundle adds over the standalone routes.
+
+    A flat "missing workflow tool" on a multi-species bundle is true and
+    useless. Both species here omit thermo provenance, and the two
+    warnings must be distinguishable — asserting on the *set* of fields
+    is what makes this fail if the species key is dropped, since two
+    unnamed warnings would collapse to one entry.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["thermo"] = {
+        "scientific_origin": "computed",
+        "h298_kj_mol": 218.0,
+    }
+    bundle["species"][1]["thermo"] = {
+        "scientific_origin": "computed",
+        "h298_kj_mol": 0.0,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    pairs = _pairs(resp)
+    assert (
+        "species['h'].thermo.software_release",
+        "missing_software_release_provenance",
+    ) in pairs
+    assert (
+        "species['h2'].thermo.software_release",
+        "missing_software_release_provenance",
+    ) in pairs
+    assert (
+        "species['h'].thermo.workflow_tool_release",
+        "missing_workflow_tool_provenance",
+    ) in pairs
+    assert (
+        "species['h2'].thermo.workflow_tool_release",
+        "missing_workflow_tool_provenance",
+    ) in pairs
+
+
+def test_reaction_bundle_statmech_without_provenance_is_annotated(client: TestClient):
+    bundle = _reaction_bundle()
+    bundle["species"][0]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert _provenance_codes_under(resp, "species['h'].statmech.") == {
+        "missing_software_release_provenance",
+        "missing_workflow_tool_provenance",
+        "missing_frequency_scale_factor_provenance",
+    }
+
+
+def test_bundle_level_provenance_silences_the_per_species_warning(
+    client: TestClient,
+):
+    """Warn on the effective value, not the raw field.
+
+    The reaction workflow falls a per-species ``software_release`` back to
+    the bundle-level ``analysis_software_release`` and persists the
+    fallback. Warning on the raw per-species field would name provenance
+    that was in fact recorded — a false report, and the fastest way to
+    teach depositors to ignore the warnings entirely.
+    """
+    bundle = _reaction_bundle(
+        analysis_software_release=_ANALYSIS_SOFTWARE,
+        workflow_tool_release=_WTR,
+    )
+    bundle["species"][0]["thermo"] = {
+        "scientific_origin": "computed",
+        "h298_kj_mol": 218.0,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert _codes_under(resp, "species['h'].thermo.") == set(), resp.json()["warnings"]
+
+
+def test_per_species_provenance_silences_it_without_a_bundle_default(
+    client: TestClient,
+):
+    """The other half of the fallback: the override alone is enough."""
+    bundle = _reaction_bundle()
+    bundle["species"][0]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+        "software_release": _ANALYSIS_SOFTWARE,
+        "workflow_tool_release": _WTR,
+        "freq_scale_factor": _FSF,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert _provenance_codes_under(resp, "species['h'].statmech.") == set(), (
+        resp.json()["warnings"]
+    )
+
+
+def test_reaction_bundle_kinetics_without_provenance_is_annotated(client: TestClient):
+    """Kinetics provenance is bundle-scoped, and the field paths say so.
+
+    ``BundleKineticsIn`` carries no provenance fields at all; the workflow
+    writes the bundle-root ``analysis_software_release`` /
+    ``workflow_tool_release`` / ``literature`` onto every kinetics row.
+    So the warning must point at the root fields — a path like
+    ``kinetics[0].software_release`` would name a field that does not
+    exist, and ``SchemaBase`` is extra="forbid", so a depositor following
+    that advice would get a 422.
+    """
+    bundle = _reaction_bundle(kinetics=[_kinetics()])
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    pairs = _pairs(resp)
+    assert ("software_release", "missing_software_release_provenance") in pairs
+    assert ("workflow_tool_release", "missing_workflow_tool_provenance") in pairs
+
+
+def test_kinetics_is_never_warned_about_a_level_of_theory_it_cannot_carry(
+    client: TestClient,
+):
+    """The failure mode this whole task exists to prevent.
+
+    ``collect_kinetics_provenance_warnings`` asks the standalone route for
+    ``energy_level_of_theory``. No bundle model has that field — not
+    ``BundleKineticsIn``, not the bundle root — and it is not a column on
+    ``kinetics`` either; on the standalone route it is a resolution hint
+    used to auto-resolve source SP calculations. Emitting it here would
+    tell a depositor to supply something they cannot supply, which is a
+    worse outcome than the silence it replaced.
+    """
+    bundle = _reaction_bundle(kinetics=[_kinetics()])
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    codes = {code for _field, code in _pairs(resp)}
+    assert "missing_level_of_theory_provenance" not in codes, (
+        "warned about energy_level_of_theory, which no bundle payload can carry"
+    )
+
+
+def test_bundle_kinetics_provenance_is_reported_once_not_once_per_fit(
+    client: TestClient,
+):
+    """Several fits share one set of root fields.
+
+    N identical warnings for one missing field is noise, and noise is how
+    a warnings list stops being read.
+    """
+    bundle = _reaction_bundle(
+        kinetics=[
+            _kinetics(),
+            _kinetics(tmin_k=200.0, tmax_k=300.0),
+        ]
+    )
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    software = [
+        w
+        for w in resp.json()["warnings"]
+        if w["code"] == "missing_software_release_provenance"
+        and w["field"] == "software_release"
+    ]
+    assert len(software) == 1, software
+
+
+def test_reaction_bundle_kinetics_with_provenance_is_not_annotated(
+    client: TestClient,
+):
+    bundle = _reaction_bundle(
+        kinetics=[_kinetics()],
+        analysis_software_release=_ANALYSIS_SOFTWARE,
+        workflow_tool_release=_WTR,
+        literature=_LITERATURE,
+    )
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    provenance_codes = {
+        "missing_software_release_provenance",
+        "missing_workflow_tool_provenance",
+        "missing_literature_provenance",
+        "missing_level_of_theory_provenance",
+    }
+    offenders = [
+        w
+        for w in resp.json()["warnings"]
+        if w["code"] in provenance_codes and "." not in w["field"]
+    ]
+    assert offenders == [], offenders
+
+
+def test_a_reaction_bundle_with_no_products_gets_no_provenance_warnings(
+    client: TestClient,
+):
+    """No thermo, no statmech, no kinetics — nothing to be missing."""
+    resp = client.post("/api/v1/uploads/computed-reaction", json=_reaction_bundle())
+    assert resp.status_code == 201, resp.text[:800]
+
+    provenance_codes = {
+        "missing_software_release_provenance",
+        "missing_workflow_tool_provenance",
+        "missing_literature_provenance",
+        "missing_frequency_scale_factor_provenance",
+        "missing_level_of_theory_provenance",
+    }
+    offenders = [
+        w for w in resp.json()["warnings"] if w["code"] in provenance_codes
+    ]
+    assert offenders == [], offenders
+
+
+def test_reaction_bundle_reports_untraceable_statmech_like_the_species_route(
+    client: TestClient,
+):
+    """The content gap, not just the provenance one.
+
+    ``collect_statmech_content_warnings`` was wired into the species
+    bundle and not the reaction bundle, so the same computed statmech
+    with nothing to trace it to was named on one route and silent on the
+    other.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert (
+        "species['h'].statmech.source_calculations",
+        "missing_statmech_source_calculations",
+    ) in _pairs(resp)
+
+
+def test_rotational_constants_make_the_frequency_source_gap_visible(
+    client: TestClient,
+):
+    """#142 and #113 meet here, which is why they are one PR.
+
+    ``statmech_has_rotational_structure`` reads the rotational constants
+    to decide whether a species has vibrational modes worth tracing. On
+    this route those constants did not exist as a field until #142, so
+    the check could only ever see torsions and a polyatomic deposited in
+    the ordinary ARC shape — constants, no torsions — looked monatomic
+    to it. Warning before the fields existed would have been the wrong
+    order.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][1]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 2,
+        "rotational_constant_a_cm1": 60.8,
+        "source_calculations": [{"calculation_key": "h2-opt", "role": "opt"}],
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    assert (
+        "species['h2'].statmech.source_calculations",
+        "missing_statmech_frequency_source",
+    ) in _pairs(resp)
+
+
+# ---------------------------------------------------------------------------
+# #142: the widened statmech, through the route
+# ---------------------------------------------------------------------------
+
+
+def test_reaction_bundle_statmech_persists_its_widened_fields(client, db_session):
+    """#142's fields must reach the row, not merely validate.
+
+    A schema that accepts a field and a workflow that stores it are
+    different claims, and the six fields added here had DB columns
+    waiting for them the whole time — the gap was purely in the contract
+    and the projection.
+    """
+    bundle = _reaction_bundle()
+    bundle["species"][0]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+        "software_release": _ANALYSIS_SOFTWARE,
+        "workflow_tool_release": _WTR,
+        "literature": _LITERATURE,
+        "rotational_constant_a_cm1": 10.5,
+        "rotational_constant_b_cm1": 8.25,
+        "rotational_constant_c_cm1": 4.75,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    rows = _statmech_rows(db_session, resp)
+    assert len(rows) == 1, rows
+    row = rows[0]
+
+    assert row.rotational_constant_a_cm1 == 10.5
+    assert row.rotational_constant_b_cm1 == 8.25
+    assert row.rotational_constant_c_cm1 == 4.75
+    assert row.literature_id is not None, "statmech literature was dropped"
+    assert row.software_release_id is not None
+    assert row.workflow_tool_release_id is not None
+
+
+def test_statmech_provenance_override_beats_the_bundle_default(client, db_session):
+    """The override must win, and the fallback must still work.
+
+    Before #142 the reaction route had no per-species statmech provenance
+    at all: every statmech row took the bundle-level analysis software.
+    That is the ordinary-case failure — one participant taken from a
+    paper, the rest computed here — so the precedence is worth pinning.
+    """
+    from app.db.models.software import SoftwareRelease
+
+    bundle = _reaction_bundle(analysis_software_release=_ANALYSIS_SOFTWARE)
+    bundle["species"][0]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+        "software_release": {"name": "MESS", "version": "2023.07"},
+    }
+    bundle["species"][1]["statmech"] = {
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 2,
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+
+    rows = _statmech_rows(db_session, resp)
+    assert len(rows) == 2, rows
+    names = {
+        db_session.get(SoftwareRelease, r.software_release_id).software.name
+        for r in rows
+    }
+    assert names == {"MESS", "RMG-Py"}, (
+        f"expected the override and the bundle default side by side, got {names}"
+    )

--- a/backend/tests/schemas/test_bundle_root_model_symmetry.py
+++ b/backend/tests/schemas/test_bundle_root_model_symmetry.py
@@ -196,9 +196,9 @@ ALLOWED_ASYMMETRIES: dict[tuple[str, str], str] = {
         "literature",
     ): (
         "Species-root only: an inline literature fragment resolved by the "
-        "workflow. The reaction root takes literature_id instead — see "
-        "the companion test below, which is why this pair is not simply "
-        "declared equivalent."
+        "workflow. The reaction root takes a literature_id instead, which "
+        "is a different contract rather than the same one spelled twice — "
+        "see the literature_id entry immediately below."
     ),
     (
         "calculation",

--- a/backend/tests/schemas/test_bundle_root_model_symmetry.py
+++ b/backend/tests/schemas/test_bundle_root_model_symmetry.py
@@ -1,0 +1,345 @@
+"""The two bundle roots must carry the same fields, or say why not.
+
+TCKDB has two bundle upload roots — ``ComputedSpeciesUploadRequest`` and
+``ComputedReactionUploadRequest`` — and several of their nested models are
+two spellings of one thing: the reaction bundle's per-species thermo and
+the species bundle's thermo describe the same ``thermo`` row, resolved by
+the same services, subject to the same table constraints. When one gains
+a field and the other does not, a depositor's record is silently less
+complete depending on which route they used, and nothing says so.
+
+That has now happened twice, for two different reasons:
+
+* **Congenital.** ``BundleThermoIn`` (8 fields) and ``ThermoInBundle``
+  (15) were written three days apart in April 2026 and never agreed.
+  Fixed in #151.
+* **Regression.** ``BundleStatmechIn`` was born narrow in ``17706cf7``,
+  but the three rotational constants were then added to
+  ``StatmechInBundle`` **only**, by ``264519f1`` — two days after
+  ``0ea9182f`` had correctly updated both models in a single commit. The
+  habit was right and then it lapsed. Fixed in #142.
+
+The second is the one this file exists for. Nothing in the tree could
+distinguish a one-sided addition from a deliberate asymmetry, so the
+regression was invisible at review time and stayed invisible for months.
+This test makes the two field sets an assertion: they must match, and a
+field that genuinely belongs to only one root has to be written into
+:data:`ALLOWED_ASYMMETRIES` with a stated reason. "Remember to update
+both" becomes something that fails.
+
+The allowlist is deliberately keyed by ``(pair, field)`` and deliberately
+requires prose. A bare set of names would let the next person silence a
+real regression by appending to it; having to write down *why* a field
+belongs to one root and not the other is the point where a mistake
+becomes visible.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tckdb_schemas.workflows import computed_reaction_upload as rx
+from tckdb_schemas.workflows import computed_species_upload as sp
+
+# ---------------------------------------------------------------------------
+# The pairs
+# ---------------------------------------------------------------------------
+
+#: ``(name, species-root model, reaction-root model)``.
+#:
+#: Only models that describe *the same database row* belong here. The two
+#: roots also share ``StatmechSourceCalcIn`` and ``ThermoSourceCalcInBundle``
+#: as literally the same class, which needs no test — there is no second
+#: definition to drift from.
+MODEL_PAIRS = [
+    ("thermo", sp.ThermoInBundle, rx.BundleThermoIn),
+    ("statmech", sp.StatmechInBundle, rx.BundleStatmechIn),
+    ("statmech_torsion", sp.StatmechTorsionInBundle, rx.BundleStatmechTorsionIn),
+    ("conformer", sp.ConformerInBundle, rx.ConformerIn),
+    ("calculation", sp.CalculationInBundle, rx.ComputedReactionCalculationIn),
+]
+
+#: ``(pair_name, field_name) -> reason``. Every entry is a claim that the
+#: asymmetry is deliberate, and the reason is the evidence for that claim.
+ALLOWED_ASYMMETRIES: dict[tuple[str, str], str] = {
+    # --- thermo ---------------------------------------------------------
+    (
+        "thermo",
+        "applied_energy_corrections",
+    ): (
+        "Species-root only, by #151's deliberate choice. The reaction "
+        "bundle already declares applied corrections one level up, on "
+        "BundleSpeciesIn, against the same resolved species entry. Adding "
+        "a second place to say it would let one deposit make the claim "
+        "twice and require inventing a rule for which one counts."
+    ),
+    # --- conformer ------------------------------------------------------
+    (
+        "conformer",
+        "primary_calculation",
+    ): (
+        "Species-root only. The species bundle's conformer distinguishes "
+        "the calculation that defines the conformer from the ones merely "
+        "run on it; the reaction bundle's conformer carries exactly one "
+        "('calculation') and hangs the rest off BundleSpeciesIn."
+        "calculations, which is a different decomposition of the same "
+        "data rather than a missing field."
+    ),
+    (
+        "conformer",
+        "additional_calculations",
+    ): (
+        "Species-root only, the other half of the same decomposition as "
+        "primary_calculation above."
+    ),
+    (
+        "conformer",
+        "calculation",
+    ): (
+        "Reaction-root only. The singular counterpart of the species "
+        "root's primary_calculation/additional_calculations split."
+    ),
+    (
+        "conformer",
+        "scientific_origin",
+    ): (
+        "Reaction-root only. The species bundle takes one species and "
+        "carries origin on the products (thermo/statmech) rather than on "
+        "the conformer. Not a gap this test should force closed: moving "
+        "it would change what the species route means, not just what it "
+        "can carry."
+    ),
+    # --- calculation ----------------------------------------------------
+    #
+    # The two calculation models diverge structurally, not by omission:
+    # the species root nests typed result payloads, the reaction root
+    # flattens the same numbers onto the calculation. Both write the same
+    # calc_*_result rows. Listed field-by-field rather than exempting the
+    # pair wholesale, so a genuinely new one-sided field is still caught.
+    (
+        "calculation",
+        "sp_result",
+    ): "Species-root nested payload; reaction root flattens to sp_electronic_energy_hartree.",
+    (
+        "calculation",
+        "opt_result",
+    ): "Species-root nested payload; reaction root flattens to opt_converged/opt_n_steps/opt_final_energy_hartree.",
+    (
+        "calculation",
+        "freq_result",
+    ): "Species-root nested payload; reaction root flattens to the freq_* fields.",
+    (
+        "calculation",
+        "sp_electronic_energy_hartree",
+    ): (
+        "Reaction-root flattening of the species root's sp_result payload; "
+        "both write the same calc_sp_result row."
+    ),
+    (
+        "calculation",
+        "opt_converged",
+    ): (
+        "Reaction-root flattening of the species root's opt_result payload; "
+        "both write the same calc_opt_result row."
+    ),
+    (
+        "calculation",
+        "opt_n_steps",
+    ): (
+        "Reaction-root flattening of the species root's opt_result payload; "
+        "both write the same calc_opt_result row."
+    ),
+    (
+        "calculation",
+        "opt_final_energy_hartree",
+    ): (
+        "Reaction-root flattening of the species root's opt_result payload; "
+        "both write the same calc_opt_result row."
+    ),
+    (
+        "calculation",
+        "freq_n_imag",
+    ): "Reaction-root flattening of freq_result.",
+    (
+        "calculation",
+        "freq_zpe_hartree",
+    ): "Reaction-root flattening of freq_result.",
+    (
+        "calculation",
+        "freq_frequencies_cm1",
+    ): "Reaction-root flattening of freq_result.",
+    (
+        "calculation",
+        "freq_imag_freq_cm1",
+    ): "Reaction-root flattening of freq_result.",
+    (
+        "calculation",
+        "freq_imaginary_dispositions",
+    ): "Reaction-root flattening of freq_result.",
+    (
+        "calculation",
+        "freq_reaction_coordinate_mode_index",
+    ): (
+        "Reaction-root only, and correctly so: it names which normal mode "
+        "is the reaction coordinate, which is meaningless without a "
+        "reaction."
+    ),
+    (
+        "calculation",
+        "geometry_key",
+    ): (
+        "Reaction-root only. The reaction bundle shares geometries across "
+        "species by key; the species bundle has one species and attaches "
+        "geometries to conformers directly."
+    ),
+    (
+        "calculation",
+        "literature",
+    ): (
+        "Species-root only: an inline literature fragment resolved by the "
+        "workflow. The reaction root takes literature_id instead — see "
+        "the companion test below, which is why this pair is not simply "
+        "declared equivalent."
+    ),
+    (
+        "calculation",
+        "literature_id",
+    ): (
+        "Reaction-root only, and flagged rather than endorsed. This is a "
+        "database FK on an upload surface; the species root's inline "
+        "'literature' fragment is the pattern the repo's no-FK-in-uploads "
+        "rule asks for. Tracked separately — this entry records the "
+        "asymmetry so the symmetry gate does not fire on it, and does not "
+        "claim it is right."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("pair_name", "species_model", "reaction_model"),
+    MODEL_PAIRS,
+    ids=[p[0] for p in MODEL_PAIRS],
+)
+def test_bundle_root_models_carry_the_same_fields(
+    pair_name, species_model, reaction_model
+):
+    """Neither root may gain a field the other lacks without a reason.
+
+    The failure message prints the offending names and the exact
+    allowlist key to add, because the correct response to this test going
+    red is usually "widen the other model", and occasionally "record why
+    not" — and the difference should be a decision, not a guess.
+    """
+    species_only = set(species_model.model_fields) - set(reaction_model.model_fields)
+    reaction_only = set(reaction_model.model_fields) - set(species_model.model_fields)
+
+    unexplained = sorted(
+        name
+        for name in species_only | reaction_only
+        if (pair_name, name) not in ALLOWED_ASYMMETRIES
+    )
+
+    assert not unexplained, (
+        f"{species_model.__name__} and {reaction_model.__name__} describe the "
+        f"same row but disagree on {len(unexplained)} field(s): {unexplained}.\n"
+        f"  only on {species_model.__name__}: {sorted(species_only)}\n"
+        f"  only on {reaction_model.__name__}: {sorted(reaction_only)}\n"
+        "Either widen the model that is missing them, or add "
+        f'ALLOWED_ASYMMETRIES[("{pair_name}", "<field>")] = "<why>" '
+        "in this file."
+    )
+
+
+def test_the_allowlist_describes_asymmetries_that_still_exist():
+    """A stale exemption is a hole, so the allowlist is checked both ways.
+
+    Without this, closing an asymmetry would leave its entry behind, and
+    the leftover entry would silently exempt the field if it were ever
+    removed from one root again. It also keeps the reasons honest: an
+    entry that no longer corresponds to anything cannot be reviewed.
+    """
+    live: set[tuple[str, str]] = set()
+    for pair_name, species_model, reaction_model in MODEL_PAIRS:
+        species_fields = set(species_model.model_fields)
+        reaction_fields = set(reaction_model.model_fields)
+        for name in species_fields ^ reaction_fields:
+            live.add((pair_name, name))
+
+    stale = sorted(set(ALLOWED_ASYMMETRIES) - live)
+    assert not stale, (
+        f"{len(stale)} allowlist entr(y/ies) name an asymmetry that no longer "
+        f"exists and should be deleted: {stale}"
+    )
+
+
+def test_every_allowlist_entry_states_a_reason():
+    """An exemption with no reason is the failure mode this file guards.
+
+    Cheap to assert, and it is the difference between an allowlist that
+    documents decisions and one that accumulates silence.
+    """
+    unreasoned = sorted(
+        key for key, reason in ALLOWED_ASYMMETRIES.items() if len(reason.strip()) < 40
+    )
+    assert not unreasoned, (
+        f"These allowlist entries have no substantive reason: {unreasoned}"
+    )
+
+
+def test_the_statmech_pair_needs_no_exemptions():
+    """#142's headline claim, asserted directly rather than by absence.
+
+    ``test_bundle_root_models_carry_the_same_fields`` would also pass if
+    somebody added six allowlist entries instead of six fields, so the
+    claim that statmech is now *actually* symmetric is worth its own
+    assertion. The six fields named here are precisely the ones
+    ``BundleStatmechIn`` could not carry before #142.
+    """
+    statmech_exemptions = {
+        field for (pair, field) in ALLOWED_ASYMMETRIES if pair == "statmech"
+    }
+    assert statmech_exemptions == set(), (
+        "statmech should be symmetric with no exemptions; found "
+        f"{sorted(statmech_exemptions)}"
+    )
+
+    reaction_fields = set(rx.BundleStatmechIn.model_fields)
+    for field in (
+        "literature",
+        "software_release",
+        "workflow_tool_release",
+        "rotational_constant_a_cm1",
+        "rotational_constant_b_cm1",
+        "rotational_constant_c_cm1",
+    ):
+        assert field in reaction_fields, (
+            f"BundleStatmechIn lost '{field}', which #142 added"
+        )
+
+
+def test_kinetics_and_transport_have_no_second_spelling():
+    """Recorded because "cover those too" needs an answer either way.
+
+    Kinetics exists only on the reaction root — a species bundle has no
+    reaction to have a rate for — and transport has no bundle model on
+    either root; it is a standalone route only. Neither is a pair, so
+    neither can drift. This asserts that rather than leaving the reader
+    to infer it from MODEL_PAIRS, and it will fail the day a second
+    spelling is introduced, which is the day it would need adding above.
+    """
+    assert not hasattr(sp, "KineticsInBundle"), (
+        "A species-root kinetics model now exists and should be added to "
+        "MODEL_PAIRS alongside BundleKineticsIn."
+    )
+    assert hasattr(rx, "BundleKineticsIn"), "reaction root lost its kinetics model"
+
+    for module, label in ((sp, "species"), (rx, "reaction")):
+        transport = [n for n in dir(module) if "Transport" in n]
+        assert not transport, (
+            f"the {label} bundle root gained transport model(s) {transport}; "
+            "if both roots now have one, add the pair to MODEL_PAIRS."
+        )

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.35.0"
+version = "0.35.1"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/builders/statmech.py
+++ b/clients/python/src/tckdb_client/builders/statmech.py
@@ -11,10 +11,18 @@ the assemblers on both endpoints emit the field — the
 and as a forward-compat lever, not as a per-endpoint gate today.
 
 This builder intentionally exposes only the common subset of fields
-(no ``literature`` / ``software_release`` / ``workflow_tool_release``
-on the computed-species variant, no ``freq_scale_factor`` ref object,
-no ``torsions``). Producers needing those still fall back to the raw
-payload form.
+(no ``literature`` / ``software_release`` / ``workflow_tool_release``,
+no ``rotational_constant_{a,b,c}_cm1``, no ``freq_scale_factor`` ref
+object, no ``torsions``). Producers needing those still fall back to the
+raw payload form.
+
+The "common subset" framing is no longer a constraint imposed by the two
+bundle shapes disagreeing: as of tckdb-schemas 0.26.0 the two statmech
+models carry identical field sets, so anything omitted here is omitted by
+this builder's own choice and can be added without a per-endpoint gate.
+Before 0.26.0, ``literature`` / ``software_release`` /
+``workflow_tool_release`` and the rotational constants existed on
+``StatmechInBundle`` only.
 """
 
 from __future__ import annotations
@@ -137,10 +145,12 @@ def _normalise_statmech_source_calculations(value: Any) -> list[tuple[str, Any]]
 class Statmech:
     """One statmech block attached to a species.
 
-    Field set is the common subset of the backend's two statmech
-    bundle shapes (``StatmechInBundle`` for computed-species and
-    ``BundleStatmechIn`` for computed-reaction). Producers needing
-    ``literature`` / ``software_release`` / ``freq_scale_factor`` /
+    Field set is a subset of the backend's two statmech bundle shapes
+    (``StatmechInBundle`` for computed-species and ``BundleStatmechIn``
+    for computed-reaction), which carry identical field sets as of
+    tckdb-schemas 0.26.0. Producers needing ``literature`` /
+    ``software_release`` / ``workflow_tool_release`` /
+    ``rotational_constant_{a,b,c}_cm1`` / ``freq_scale_factor`` /
     ``torsions`` should still use the raw payload form.
 
     ``source_calculations`` accepts the same three shapes as

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,58 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.26.0 — the reaction bundle's statmech gains the six fields the species bundle already had
+
+Purely additive. Nothing is renamed, removed, narrowed or newly refused,
+so **every 0.25.0 payload validates unchanged under 0.26.0** — this is a
+minor bump, not a breaking one. What changes is what a payload is
+*allowed to say*.
+
+`BundleStatmechIn` — the per-species statmech on
+`/uploads/computed-reaction` — carried 12 fields against the 18 on
+`StatmechInBundle`, the same block on `/uploads/computed-species`. Both
+describe the same `statmech` row, resolved by the same services, subject
+to the same table constraints. Six fields were reachable from one route
+and not the other:
+
+| field | what it records |
+|---|---|
+| `literature` | the paper this statmech came out of |
+| `software_release` | the analysis code, per species |
+| `workflow_tool_release` | the workflow tool, per species |
+| `rotational_constant_a_cm1` | first principal rotational constant |
+| `rotational_constant_b_cm1` | second principal rotational constant |
+| `rotational_constant_c_cm1` | third principal rotational constant |
+
+All six already had columns on the `statmech` table, so this is a
+contract and projection change with no migration.
+
+`literature`, `software_release` and `workflow_tool_release` are
+**per-species overrides** of the bundle-level `literature` /
+`analysis_software_release` / `workflow_tool_release`, exactly as
+`BundleThermoIn`'s equivalents became in 0.25.0. Absent, the bundle-level
+value is used, so a 0.25.0 payload persists precisely what it did before.
+The override is what makes the ordinary mixed deposit expressible: one
+participant taken from a paper, the rest computed here.
+
+Nothing is deliberately withheld. `applied_energy_corrections` — the one
+field `BundleThermoIn` refuses, because `BundleSpeciesIn` already
+declares it against the same species entry — is not on `StatmechInBundle`
+either, so it is not part of this divergence and needs no exception.
+
+The rotational constants are the interesting half of the history.
+`BundleStatmechIn` was born narrow, like `BundleThermoIn`. But the three
+constants were added to `StatmechInBundle` **only**, two days after an
+earlier commit had correctly updated both models together. The habit was
+right and then it lapsed, and nothing could tell a one-sided addition
+from a deliberate asymmetry. `backend/tests/schemas/test_bundle_root_model_symmetry.py`
+now asserts the two field sets match, with an allowlist that requires a
+written reason per exemption.
+
+Consumers do not need to change. If you are building reaction bundles by
+hand and want per-species statmech provenance or rotational constants,
+these are the field names; if you are not, nothing moves.
+
 ### 0.25.0 — bundle roots gain SCF stability and thermo provenance; an atomless participant may not carry coordinates
 
 Three additions and one new refusal. Nothing is renamed or removed, so a

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.25.0"
+version = "0.26.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -430,13 +430,57 @@ class BundleStatmechTorsionIn(SchemaBase):
 class BundleStatmechIn(SchemaBase):
     """Statistical mechanics properties for a species in this bundle.
 
+    The reaction route's statmech carries the same fields the species
+    route's ``StatmechInBundle`` carries, for the reason
+    :class:`BundleThermoIn` gives: it is the same claim about the same
+    kind of row, written against the same table.
+
+    The gap this closes had two distinct causes, and only one of them is
+    the same as thermo's. This model was born narrow in ``17706cf7`` --
+    congenital, like ``BundleThermoIn``. But the three rotational
+    constants were added to ``StatmechInBundle`` **only**, by
+    ``264519f1``, two days after ``0ea9182f`` had correctly updated both
+    models in one commit. The habit was right and then it lapsed, and
+    nothing in the tree could notice: no test compared the two field
+    sets, so a one-sided addition read exactly like a deliberate one.
+    ``tests/schemas/test_bundle_root_model_symmetry.py`` is now that
+    test, and an intentional divergence has to be written down in its
+    allowlist with a reason rather than merely happening.
+
+    Nothing is deliberately withheld here. ``applied_energy_corrections``
+    -- the one field :class:`BundleThermoIn` refuses, because
+    :class:`BundleSpeciesIn` already declares it against the same species
+    entry -- is not on ``StatmechInBundle`` either, so it is not part of
+    this divergence and needs no exception.
+
+    ``literature``, ``software_release`` and ``workflow_tool_release``
+    are per-species overrides of the bundle-level
+    ``analysis_software_release`` / ``workflow_tool_release`` /
+    ``literature``, exactly as thermo's are. Before this, a reaction
+    bundle's statmech took the bundle-level values with no way to say
+    that one species' partition function came from a different analysis
+    code -- which is the ordinary case when one participant is taken
+    from a paper and the rest were computed here.
+
     :param scientific_origin: Scientific origin category.
+    :param literature: Optional literature provenance for this statmech.
+    :param software_release: Optional analysis-code provenance. Overrides
+        the bundle-level ``analysis_software_release`` for this species.
+    :param workflow_tool_release: Optional workflow-tool provenance.
+        Overrides the bundle-level value for this species.
     :param is_linear: Whether the molecule is linear.
     :param rigid_rotor_kind: Rotational treatment classification.
     :param external_symmetry: External symmetry number.
     :param optical_isomers: Number of optical isomers (>= 1).
     :param point_group: Optional point-group label (e.g. ``"C2v"``).
     :param statmech_treatment: Overall statmech treatment classification.
+    :param rotational_constant_a_cm1: First reported principal rotational
+        constant (cm^-1), in source-provided order (conventionally
+        descending A >= B >= C). Optional.
+    :param rotational_constant_b_cm1: Second reported principal rotational
+        constant (cm^-1). Optional.
+    :param rotational_constant_c_cm1: Third reported principal rotational
+        constant (cm^-1). Optional.
     :param freq_scale_factor: Frequency scale factor applied.
     :param uses_projected_frequencies: Whether projected frequencies were used.
     :param source_calculations: Statmech → calc links by bundle-local
@@ -448,12 +492,22 @@ class BundleStatmechIn(SchemaBase):
     """
 
     scientific_origin: ScientificOriginKind = ScientificOriginKind.computed
+
+    literature: LiteratureUploadRequest | None = None
+    software_release: SoftwareReleaseRef | None = None
+    workflow_tool_release: WorkflowToolReleaseRef | None = None
+
     is_linear: bool | None = None
     rigid_rotor_kind: RigidRotorKind | None = None
     external_symmetry: int | None = Field(default=None, ge=1)
     optical_isomers: int | None = Field(default=None, ge=1)
     point_group: str | None = None
     statmech_treatment: StatmechTreatmentKind | None = None
+
+    rotational_constant_a_cm1: float | None = Field(default=None, gt=0)
+    rotational_constant_b_cm1: float | None = Field(default=None, gt=0)
+    rotational_constant_c_cm1: float | None = Field(default=None, gt=0)
+
     freq_scale_factor: FreqScaleFactorRef | None = None
     uses_projected_frequencies: bool | None = None
     source_calculations: list[StatmechSourceCalcInBundle] = Field(default_factory=list)


### PR DESCRIPTION
Closes #142. Closes #113.

One concern in two parts, in the only order that works: a bundle route could not *carry* provenance, and separately did not *warn* when provenance was missing. Warning before the fields existed would have told depositors to do something impossible.

## Part 1 (#142) — the reaction root's statmech was narrower than the species root's

`BundleStatmechIn` carried **12** fields against `StatmechInBundle`'s **18**, and the two describe the same `statmech` row, resolved by the same services, subject to the same constraints. Measured on `main`, not quoted.

Two different faults, and only one matches the thermo gap #151 closed:

* **Congenital** — the model was born narrow in `17706cf7`, like `BundleThermoIn`.
* **Regression** — `264519f1` added the three rotational constants to the species model **only**, two days after `0ea9182f` had correctly updated both in a single commit. The habit was right and then it lapsed.

Widened with all six: `literature`, `software_release`, `workflow_tool_release`, `rotational_constant_{a,b,c}_cm1`. Every one already had a `statmech` column, so this is a contract and projection change with **no migration**; the Alembic head stays single at `b7e4d1a9c026`.

The first three are **per-species overrides** of the bundle-level `literature` / `analysis_software_release` / `workflow_tool_release`, the precedence #151 gave thermo. Absent, the bundle-level value is still used, so every existing payload persists exactly what it did before.

Nothing was deliberately withheld. `applied_energy_corrections` — the field #151 kept off `BundleThermoIn`, because `BundleSpeciesIn` already declares it against the same species entry — is not on `StatmechInBundle` either, so it was never part of this divergence and needed no exception.

### The test that makes it hold

`backend/tests/schemas/test_bundle_root_model_symmetry.py`. Five model pairs; an allowlist keyed by `(pair, field)` that requires a written reason; and three meta-tests, because an allowlist is only as good as its discipline:

* stale entries are **rejected**, so closing an asymmetry cannot leave a silent exemption behind;
* reasons must be substantive (this one caught four of my own entries while I was writing them);
* `statmech` is asserted to need **zero** exemptions — otherwise the headline test would also pass if somebody added six allowlist entries instead of six fields.

Kinetics and transport are asserted to have no second spelling rather than left to inference: kinetics exists only on the reaction root, transport has no bundle model on either. That assertion fails the day either changes.

## Part 2 (#113) — the bundle routes warned about nothing

The three collectors were called only from the standalone routes. On `/uploads/computed-species` and `/uploads/computed-reaction` — the two routes the ARC adapter uses — omitting `software_release`, `workflow_tool_release`, `literature` or a frequency scale factor produced no warning at all, while the identical omission field-by-field was reported. ADR 0011 and ADR 0008 both hold that absence is incompleteness and incompleteness is *annotated*; a bundle depositor got neither the refusal nor the annotation.

Three things the bundle case needs that the standalone one does not:

**Warnings name their subject.** `UploadWarning.field` is already documented as a dot-path and the standalone kinetics route already emits indexed paths, so no new machinery was needed — checked rather than assumed. Reaction-bundle warnings read `species['h2'].thermo.software_release`, the form this payload's own validators already use for error paths.

**They judge the effective value, not the raw field.** A per-species release falls back to the bundle-level one and the workflow persists the fallback, so warning on the raw field would report provenance that *was* recorded — the fastest way to teach depositors to ignore warnings.

**The collectors now share one request-agnostic core** rather than a third copy of the same conditional. The three request-based entry points are thin wrappers; the standalone routes are behaviourally untouched.

### Kinetics: verified, not assumed

`BundleKineticsIn` carries **no** provenance fields at all. But the workflow writes the bundle-root `literature` / `analysis_software_release` / `workflow_tool_release` onto every kinetics row, so those three *are* actionable — and are reported against the **root** paths a depositor can actually set. A path like `kinetics[0].software_release` would name a field that does not exist, and `SchemaBase` is `extra="forbid"`, so a depositor following that advice would get a 422.

`energy_level_of_theory` is a different matter and is **not** emitted. No bundle model has it, `kinetics` has no such column, and on the standalone route it is a source-calc resolution hint. It is passed as `NOT_APPLICABLE` — a sentinel deliberately distinct from `None`, so "no field exists" cannot be confused with "the field is empty". A test asserts the code never appears.

### Also wired: the statmech *content* warning

`collect_statmech_content_warnings` was wired into the species bundle and not the reaction bundle. It only became answerable on the reaction route with Part 1: it reads the rotational constants to decide whether a species has vibrational modes worth tracing, so before this a polyatomic in the ordinary ARC shape — constants, no torsions — looked monatomic to it. This is why the two tasks are one PR.

## Proof, through the real route

Reaction bundle, provenance omitted (HTTP 201), abridged to `field` / `code`:

```
species['h'].thermo.software_release          missing_software_release_provenance
species['h'].thermo.workflow_tool_release     missing_workflow_tool_provenance
species['h'].statmech.software_release        missing_software_release_provenance
species['h'].statmech.workflow_tool_release   missing_workflow_tool_provenance
species['h'].statmech.freq_scale_factor       missing_frequency_scale_factor_provenance
species['h'].statmech.source_calculations     missing_statmech_source_calculations
species['h2'].thermo.software_release         missing_software_release_provenance
species['h2'].thermo.workflow_tool_release    missing_workflow_tool_provenance
software_release                              missing_software_release_provenance
workflow_tool_release                         missing_workflow_tool_provenance
```

The same bundle with provenance supplied returns `warnings: []`. On `main`, the first bundle also returns `[]` — that is the bug.

## Verification

All three gates green on the rebased branch: rest 4192 passed / 14 skipped, api 2625 passed, scientific 2045 passed. 28 new tests. `tckdb-schemas`' own suite 38 passed, including `test_import_boundaries` unchanged.

Mutation-checked separately:

* **Part 2 reverted** → 9 fail, all in the new file; full api gate shows 2616 passed and exactly those 9. All 9 symmetry tests stay green.
* **Part 1 reverted** → the symmetry test fails naming precisely the six historical fields, plus `test_the_statmech_pair_needs_no_exemptions`; 6 API tests fail.

mypy: 4 pre-existing errors in `network_pdep_upload.py`, byte-identical on `origin/main`. This branch adds none.

Golden snapshot: **no component added or removed, no path changed.** `BundleStatmechIn` gained six properties; that is the entire diff.

## Versions

`tckdb-schemas` 0.25.0 → **0.26.0**, with a changelog section. Additive only — nothing renamed, removed, narrowed or newly refused — so **minor, explicitly not breaking**; every 0.25.0 payload validates unchanged.

`tckdb-client` 0.35.0 → **0.35.1**, docstring only: it described the asymmetry this PR removes. Its `tckdb-schemas` floor is **unchanged**, since it emits none of the new fields.

## Findings not fixed

Each stated so it can be tracked.

1. **`ComputedSpeciesUploadRequest.workflow_tool_release` is never read.** Declared at `schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py:615`, undocumented in the class docstring, and `persist_computed_species_upload` resolves workflow-tool provenance only per-calculation, per-thermo and per-statmech. A depositor setting it at bundle level has it silently dropped. Not treated as a fallback here, deliberately: doing so would suppress a warning for something that genuinely is not persisted. The fix is either to honour it as a fallback (matching the reaction route) or to remove it.

2. **`ComputedReactionUploadResult` exposes no `statmech_ids`.** `backend/app/api/routes/uploads.py:163-165` returns `kinetics_ids` and `thermo_ids`; the workflow collects `statmech_ids` internally (`backend/app/workflows/computed_reaction.py:927`) and drops them. A client cannot address the statmech rows it just created without a second query. The new tests read back via `species_entry_ids` to work around it.

3. **`ComputedReactionCalculationIn.literature_id` is a database FK on an upload surface.** The species root takes an inline `literature` fragment instead. This contradicts the repo's no-FK-in-uploads rule; it is recorded in the symmetry allowlist so the gate does not fire on it, with an entry that explicitly does not claim it is correct.

4. **`collect_kinetics_content_warnings` is not wired into the reaction bundle**, and should not be until `BundleKineticsIn` can carry what it asks for. It reads `interpretation_assignments`, `network_kinetics_ref` and `tunneling_application`; `BundleKineticsIn` has none of the three, though it does have `tunneling_model`. So a bundle can declare `tunneling_model='eckart'` and the collector would tell it to supply `tunneling_application`, which is exactly the un-actionable warning Part 2 exists to avoid. Same shape as the `energy_level_of_theory` case, and the same reason it is reported rather than wired.

## Premises checked

Both of the stated field counts were correct on `main` (12 vs 18; thermo already 15 vs 14 after #151). The claim that `computed_reaction.py` does not reference `provenance_warnings` was correct. The one thing worth flagging is the framing that the collectors merely needed "wiring in": `collect_kinetics_provenance_warnings` could not be wired as-is on either bundle route — a quarter of what it asks for is un-carriable there — which is why the core was refactored to take explicit values with an explicit not-applicable sentinel rather than a request object.
