### PR TITLE
Let an optimisation serve the single-point role, and name thermo's refusal

### DIFF
--- a/backend/app/schemas/reads/scientific_statmech.py
+++ b/backend/app/schemas/reads/scientific_statmech.py
@@ -269,12 +269,24 @@ class StatmechEvidenceSummary(BaseModel):
     ``statmech_source_calculation`` and ``statmech_torsion``.
     ``has_rotor_scans`` is true iff at least one torsion row carries
     a ``source_scan_calculation_id``.
+
+    ``sp_from_optimization`` disambiguates ``has_sp_calculation``. The
+    upload layer accepts an ``opt`` calculation under the ``sp`` role —
+    an optimisation's final energy is the single-point value at the
+    optimisation's own level of theory — so ``has_sp_calculation`` alone
+    no longer says whether a dedicated single point was ever run. That is
+    a genuine provenance difference between two records, and the four-role
+    model says a difference like that belongs in the data rather than in
+    an inference a reader has to draw from
+    ``include=source_calculations``.
     """
 
     source_calculation_count: int
     has_opt_calculation: bool
     has_freq_calculation: bool
     has_sp_calculation: bool
+    #: At least one ``sp``-role source link points at an ``opt`` job.
+    sp_from_optimization: bool = False
     has_rotor_scans: bool
     torsion_count: int
     has_frequency_scale_factor: bool

--- a/backend/app/services/scientific_read/statmech.py
+++ b/backend/app/services/scientific_read/statmech.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session, selectinload
 from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
+    CalculationType,
     RecordReviewStatus,
     StatmechCalculationRole,
     SubmissionRecordType,
@@ -289,6 +290,7 @@ def build_statmech_record(
         torsion_rows=torsion_rows,
         has_frequency_scale_factor=fsf_summary is not None,
         has_conformer_context=has_conformer_context,
+        sp_from_optimization=_sp_role_is_an_optimization(session, source_rows),
     )
     available = AvailableStatmechSections(
         has_source_calculations=bool(source_rows),
@@ -960,12 +962,43 @@ def _build_conformer_context(
 # ---------------------------------------------------------------------------
 
 
+def _sp_role_is_an_optimization(
+    session: Session, source_rows: list[StatmechSourceCalculation]
+) -> bool:
+    """Did the single-point energy come from an optimisation's final step?
+
+    The upload layer accepts an ``opt`` calculation under the ``sp`` role,
+    because an optimisation's final energy *is* the single-point value at
+    the optimisation's own level of theory
+    (:func:`app.services.statmech_resolution.assert_statmech_role_compatible`).
+    That makes ``has_sp_calculation`` ambiguous on its own — true for a
+    dedicated single point and true for a borrowed one — and the
+    difference is a real provenance distinction a reader should not have
+    to infer from ``include=source_calculations``.
+
+    One bounded query, and none at all for the common case of a statmech
+    with no ``sp``-role link; ``sp``-role rows number 0 or 1 in practice.
+    """
+    sp_ids = [
+        r.calculation_id
+        for r in source_rows
+        if r.role is StatmechCalculationRole.sp
+    ]
+    if not sp_ids:
+        return False
+    types = session.scalars(
+        select(Calculation.type).where(Calculation.id.in_(sp_ids))
+    ).all()
+    return any(calc_type is CalculationType.opt for calc_type in types)
+
+
 def _build_evidence_summary(
     *,
     source_rows: list[StatmechSourceCalculation],
     torsion_rows: list[StatmechTorsion],
     has_frequency_scale_factor: bool,
     has_conformer_context: bool,
+    sp_from_optimization: bool = False,
 ) -> StatmechEvidenceSummary:
     roles = {r.role for r in source_rows}
     has_rotor_scans = any(
@@ -976,6 +1009,7 @@ def _build_evidence_summary(
         has_opt_calculation=StatmechCalculationRole.opt in roles,
         has_freq_calculation=StatmechCalculationRole.freq in roles,
         has_sp_calculation=StatmechCalculationRole.sp in roles,
+        sp_from_optimization=sp_from_optimization,
         has_rotor_scans=has_rotor_scans,
         torsion_count=len(torsion_rows),
         has_frequency_scale_factor=has_frequency_scale_factor,

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -42,17 +42,30 @@ W_STATMECH_CALCULATION_KEY_UNDECLARED = "statmech_calculation_key_undeclared"
 #: play, because its ``Calculation.type`` is a different kind of job.
 W_STATMECH_SOURCE_ROLE_TYPE_MISMATCH = "statmech_source_role_type_mismatch"
 
-#: Roles that name a specific kind of job, and the ``CalculationType`` each
-#: one requires. ``composite`` and ``imported`` are deliberately absent:
-#: they describe a scientific origin rather than a job type, so no single
-#: ``CalculationType`` is the right one for them (the same carve-out
-#: ``_THERMO_ROLE_TO_CALC_TYPE`` makes in :mod:`app.workflows.thermo`).
-_STATMECH_ROLE_TO_CALC_TYPE: dict[StatmechCalculationRole, CalculationType] = {
-    StatmechCalculationRole.opt: CalculationType.opt,
-    StatmechCalculationRole.freq: CalculationType.freq,
-    StatmechCalculationRole.sp: CalculationType.sp,
-    StatmechCalculationRole.scan: CalculationType.scan,
+#: Roles that name a specific kind of job, and the ``CalculationType``\ s
+#: each one accepts. The first entry is the canonical one — the type the
+#: role is named after — and is what the refusal reports as *expected*.
+#:
+#: ``composite`` and ``imported`` are deliberately absent: they describe a
+#: scientific origin rather than a job type, so no ``CalculationType`` is
+#: the right one for them (the same carve-out
+#: ``_THERMO_ROLE_TO_CALC_TYPES`` makes in :mod:`app.workflows.thermo`).
+#:
+#: ``sp`` is the one role with a second accepted type, and the asymmetry is
+#: deliberate — see :func:`assert_statmech_role_compatible`.
+_STATMECH_ROLE_TO_CALC_TYPES: dict[
+    StatmechCalculationRole, tuple[CalculationType, ...]
+] = {
+    StatmechCalculationRole.opt: (CalculationType.opt,),
+    StatmechCalculationRole.freq: (CalculationType.freq,),
+    StatmechCalculationRole.sp: (CalculationType.sp, CalculationType.opt),
+    StatmechCalculationRole.scan: (CalculationType.scan,),
 }
+
+
+def accepted_types_phrase(accepted: tuple[CalculationType, ...]) -> str:
+    """``"'sp' or 'opt'"`` — the accepted types, for a refusal message."""
+    return " or ".join(f"'{calc_type.value}'" for calc_type in accepted)
 
 
 def _resolve_calculation_key(
@@ -104,13 +117,33 @@ def assert_statmech_role_compatible(
 
     This is DR-0028 Requirement 1, applied to the path it was written for
     but never reached: thermo has enforced it since DR-0028
-    (``app.workflows.thermo._assert_calculation_role_compatible``) while
-    statmech accepted any pairing. Local string keys made the gap sharper
+    (:func:`app.workflows.thermo.assert_thermo_role_matches_calculation_type`)
+    while statmech accepted any pairing. Local string keys made the gap sharper
     than row ids did — a plausible-looking wrong key resolves silently
     where a wrong integer would more often have failed a foreign key.
 
     ``composite`` and ``imported`` accept any type, as they do for thermo:
     they name where a number came from, not which job produced it.
+
+    One named exception, and only one: **``role='sp'`` accepts an ``opt``
+    calculation.** A depositor who never ran a separate single point has
+    not lost the number — an optimisation's final energy *is* the
+    single-point value, at the optimisation's own level of theory, which
+    the calculation row already carries. Refusing that rejects a
+    legitimate and common deposit. The mixed-method case is not a
+    counter-example but the other branch: someone optimising at
+    wB97X-D/def2-TZVP and refining at DLPNO-CCSD(T)/def2-TZVP *has* a
+    separate ``sp`` calculation and links the ``sp`` role to it, so there
+    is never a second level of theory to reconcile here.
+
+    The exception does not run in reverse, and the asymmetry is the point:
+    an ``sp`` calculation cannot serve the ``opt`` role, because it
+    optimised nothing and there is no converged geometry to claim. Nor
+    does it generalise — ``role='freq'`` on an ``sp`` job is still a
+    record asserting vibrational evidence that was never produced.
+    ``backend/tests/api/test_api_upload_key_and_role_contracts.py`` pins
+    both directions so that "restoring symmetry" fails a test rather than
+    a deposit.
 
     :param calculation: The resolved source calculation row.
     :param role: The role the upload declared for it.
@@ -118,11 +151,12 @@ def assert_statmech_role_compatible(
         into the 422 body — so it must name the caller's own key, never a
         row id.
     :raises CodedValueError: if ``role`` names a job type and the
-        calculation is not of that type.
+        calculation is of none of the types that role accepts.
     """
-    expected = _STATMECH_ROLE_TO_CALC_TYPE.get(role)
-    if expected is None or calculation.type == expected:
+    accepted = _STATMECH_ROLE_TO_CALC_TYPES.get(role)
+    if accepted is None or calculation.type in accepted:
         return
+    expected = accepted[0]
     # The row id is the operator's handle, not the depositor's: it goes to
     # the log, while the 422 names only the key the depositor wrote.
     logger.info(
@@ -137,13 +171,16 @@ def assert_statmech_role_compatible(
         f"{context}: role='{role.value}' claims a "
         f"'{expected.value}' calculation, but the calculation it names has "
         f"type '{calculation.type.value}'. A statmech record must not claim "
-        f"evidence it does not have. Point the link at the "
-        f"'{expected.value}' calculation, or declare the role the named "
-        f"calculation actually played.",
+        f"evidence it does not have. Point the link at a "
+        f"{accepted_types_phrase(accepted)} calculation, or declare the role "
+        f"the named calculation actually played.",
         context={
             "field": context,
             "declared_role": role.value,
             "expected_calculation_type": expected.value,
+            "accepted_calculation_types": [
+                calc_type.value for calc_type in accepted
+            ],
             "actual_calculation_type": calculation.type.value,
         },
         message_prefix=False,

--- a/backend/app/workflows/thermo.py
+++ b/backend/app/workflows/thermo.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.api.errors import NotFoundError
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
@@ -29,12 +32,33 @@ from app.services.record_review import (
     apply_review_policy,
 )
 from app.services.species_resolution import resolve_species_entry
+from app.services.statmech_resolution import accepted_types_phrase
 from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
 
-_THERMO_ROLE_TO_CALC_TYPE: dict[ThermoCalculationRole, CalculationType] = {
-    ThermoCalculationRole.opt: CalculationType.opt,
-    ThermoCalculationRole.freq: CalculationType.freq,
-    ThermoCalculationRole.sp: CalculationType.sp,
+logger = logging.getLogger(__name__)
+
+#: A thermo source link declares a role the resolved calculation cannot
+#: play, because its ``Calculation.type`` is a different kind of job.
+#:
+#: Deliberately *not* the statmech code
+#: (``statmech_source_role_type_mismatch``): the two refusals are about
+#: different subjects — which supporting calculations a partition function
+#: was built from, versus which ones an enthalpy was — and a client that
+#: repairs one may have nothing to say about the other. Same rule, same
+#: shape of context, two codes a client can tell apart.
+W_THERMO_SOURCE_ROLE_TYPE_MISMATCH = "thermo_source_role_type_mismatch"
+
+#: Roles that name a specific kind of job, and the ``CalculationType``\ s
+#: each accepts; the first entry is the canonical one the role is named
+#: after. Mirrors ``_STATMECH_ROLE_TO_CALC_TYPES`` including the ``sp``
+#: exception — there is no reason for the two products to disagree about
+#: what a role means, and making them agree was the whole point of #126.
+_THERMO_ROLE_TO_CALC_TYPES: dict[
+    ThermoCalculationRole, tuple[CalculationType, ...]
+] = {
+    ThermoCalculationRole.opt: (CalculationType.opt,),
+    ThermoCalculationRole.freq: (CalculationType.freq,),
+    ThermoCalculationRole.sp: (CalculationType.sp, CalculationType.opt),
 }
 
 
@@ -79,23 +103,54 @@ def assert_thermo_role_matches_calculation_type(
 
     DR-0028 Requirement 1: a single typo in ``existing_calculation_id`` (or
     a mis-keyed inline calc) would otherwise silently link thermo to the
-    wrong supporting calc within the same species. ``opt``/``freq``/``sp``
+    wrong supporting calc within the same species. ``opt``/``freq``
     require exact ``CalculationType`` match. ``composite`` and ``imported``
     accept any type for v0 — those roles describe a scientific origin
     rather than a specific job type, and the existing test/usage corpus
     has no precedent constraining them.
 
-    :raises ValueError: if ``role`` is one of opt/freq/sp and the
-        calculation's type does not match.
+    ``sp`` additionally accepts an ``opt``: a depositor who ran no separate
+    single point still has the number, because the optimisation's final
+    energy *is* the single-point value at the optimisation's own level of
+    theory. The reverse is refused — an ``sp`` job optimised nothing, so it
+    cannot serve the ``opt`` role — and the exception generalises no
+    further. :func:`app.services.statmech_resolution.assert_statmech_role_compatible`
+    carries the full argument and holds the identical map; the two products
+    must not disagree about what a role means.
+
+    :raises CodedValueError: if ``role`` is one of opt/freq/sp and the
+        calculation's type is none of the ones that role accepts. The
+        detail names the offending field but never a row id (DR-0028
+        Req 2); the id goes to the log instead.
     """
-    expected = _THERMO_ROLE_TO_CALC_TYPE.get(role)
-    if expected is None:
+    accepted = _THERMO_ROLE_TO_CALC_TYPES.get(role)
+    if accepted is None or calculation.type in accepted:
         return
-    if calculation.type != expected:
-        raise ValueError(
-            f"{context}: role='{role.value}' is incompatible with the "
-            f"resolved calculation type."
-        )
+    logger.info(
+        "thermo role/type mismatch at %s: calculation id=%s type=%s, role=%s",
+        context,
+        calculation.id,
+        calculation.type.value,
+        role.value,
+    )
+    raise CodedValueError(
+        W_THERMO_SOURCE_ROLE_TYPE_MISMATCH,
+        f"{context}: role='{role.value}' is incompatible with the "
+        f"resolved calculation type '{calculation.type.value}'. A thermo "
+        f"record must not claim evidence it does not have. Point the link "
+        f"at a {accepted_types_phrase(accepted)} calculation, or declare "
+        f"the role the named calculation actually played.",
+        context={
+            "field": context,
+            "declared_role": role.value,
+            "expected_calculation_type": accepted[0].value,
+            "accepted_calculation_types": [
+                calc_type.value for calc_type in accepted
+            ],
+            "actual_calculation_type": calculation.type.value,
+        },
+        message_prefix=False,
+    )
 
 
 def _resolve_source_calculation(

--- a/backend/docs/specs/scientific_statmech_reads.md
+++ b/backend/docs/specs/scientific_statmech_reads.md
@@ -65,7 +65,12 @@ Defined in [scientific_statmech.py](../../app/schemas/reads/scientific_statmech.
   calc detail endpoint).
 - **`StatmechConformerContextItem`** — `conformer_group_ref` for
   groups reachable via the statmech's `species_entry`.
-- **`StatmechEvidenceSummary`** — bounded counts/booleans.
+- **`StatmechEvidenceSummary`** — bounded counts/booleans, including
+  `sp_from_optimization`: the upload layer accepts an `opt` calculation
+  under the `sp` role (an optimisation's final energy *is* the
+  single-point value, at the optimisation's own level of theory), so
+  `has_sp_calculation` alone does not say whether a dedicated single
+  point was run. This flag does.
 - **`AvailableStatmechSections`** — `has_*` boolean map.
 
 `statmech` rows do **not** carry frequencies inline — frequencies

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -36753,7 +36753,7 @@
         "type": "object"
       },
       "StatmechEvidenceSummary": {
-        "description": "Compact statmech-evidence projection.\n\nCounts come from cheap aggregates over\n``statmech_source_calculation`` and ``statmech_torsion``.\n``has_rotor_scans`` is true iff at least one torsion row carries\na ``source_scan_calculation_id``.",
+        "description": "Compact statmech-evidence projection.\n\nCounts come from cheap aggregates over\n``statmech_source_calculation`` and ``statmech_torsion``.\n``has_rotor_scans`` is true iff at least one torsion row carries\na ``source_scan_calculation_id``.\n\n``sp_from_optimization`` disambiguates ``has_sp_calculation``. The\nupload layer accepts an ``opt`` calculation under the ``sp`` role —\nan optimisation's final energy is the single-point value at the\noptimisation's own level of theory — so ``has_sp_calculation`` alone\nno longer says whether a dedicated single point was ever run. That is\na genuine provenance difference between two records, and the four-role\nmodel says a difference like that belongs in the data rather than in\nan inference a reader has to draw from\n``include=source_calculations``.",
         "properties": {
           "has_conformer_context": {
             "title": "Has Conformer Context",
@@ -36782,6 +36782,11 @@
           "source_calculation_count": {
             "title": "Source Calculation Count",
             "type": "integer"
+          },
+          "sp_from_optimization": {
+            "default": false,
+            "title": "Sp From Optimization",
+            "type": "boolean"
           },
           "torsion_count": {
             "title": "Torsion Count",

--- a/backend/tests/api/scientific/test_api_scientific_statmech.py
+++ b/backend/tests/api/scientific/test_api_scientific_statmech.py
@@ -261,6 +261,75 @@ def test_detail_evidence_summary_with_freq_and_torsion(client, db_session):
     assert ev["source_calculation_count"] == 1
 
 
+def _attach_sp_source(db_session, sm, *, species_entry, calc_type):
+    """Link one ``sp``-role source calculation of the given job type."""
+    calc = make_calculation(
+        db_session, type=calc_type, species_entry_id=species_entry.id
+    )
+    attach_statmech_source_calculation(
+        db_session,
+        statmech=sm,
+        calculation=calc,
+        role=StatmechCalculationRole.sp,
+    )
+    return calc
+
+
+def test_detail_sp_from_a_dedicated_single_point_is_not_flagged(
+    client, db_session
+):
+    """``has_sp_calculation`` on its own stopped being a complete answer.
+
+    The upload layer accepts an ``opt`` under the ``sp`` role, so a reader
+    seeing ``has_sp_calculation: true`` can no longer tell whether a
+    dedicated single point was ever run. These two tests are the pair that
+    makes the distinction visible without asking for
+    ``include=source_calculations``.
+    """
+    _, entry, sm = _make_statmech(db_session)
+    _attach_sp_source(db_session, sm, species_entry=entry, calc_type=CalculationType.sp)
+    ev = client.get(_detail_url(sm.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["has_sp_calculation"] is True
+    assert ev["sp_from_optimization"] is False
+
+
+def test_detail_sp_borrowed_from_an_optimization_is_flagged(
+    client, db_session
+):
+    _, entry, sm = _make_statmech(db_session)
+    _attach_sp_source(
+        db_session, sm, species_entry=entry, calc_type=CalculationType.opt
+    )
+    ev = client.get(_detail_url(sm.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["has_sp_calculation"] is True
+    assert ev["sp_from_optimization"] is True
+
+
+def test_detail_sp_from_optimization_is_false_without_an_sp_role(
+    client, db_session
+):
+    """An ``opt``-role link to an ``opt`` job says nothing about the energy."""
+    species, entry, sm = _make_statmech(db_session)
+    calc = make_calculation(
+        db_session, type=CalculationType.opt, species_entry_id=entry.id
+    )
+    attach_statmech_source_calculation(
+        db_session,
+        statmech=sm,
+        calculation=calc,
+        role=StatmechCalculationRole.opt,
+    )
+    ev = client.get(_detail_url(sm.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["has_sp_calculation"] is False
+    assert ev["sp_from_optimization"] is False
+
+
 def test_detail_available_sections_present(client, db_session):
     species, entry, sm = _make_statmech(db_session)
     body = client.get(_detail_url(sm.public_ref)).json()

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -5,11 +5,19 @@ provenance it does not have, and getting away with it.
 
 * **A declared role must match the calculation's type.** Thermo has
   enforced this since DR-0028 Requirement 1
-  (``app.workflows.thermo._assert_calculation_role_compatible``). Statmech
-  did not, on any of its three write paths, so
+  (``app.workflows.thermo.assert_thermo_role_matches_calculation_type``).
+  Statmech did not, on any of its three write paths, so
   ``{"calculation_key": "my_sp_job", "role": "freq"}`` persisted happily
   and the statmech record then claimed a frequency calculation it never
   had.
+
+* **With exactly one exception: an ``opt`` may serve the ``sp`` role.**
+  A depositor who ran no separate single point has not lost the number —
+  the optimisation's final energy *is* the single-point value, at the
+  optimisation's own level of theory. The exception does not run in
+  reverse and does not generalise; the last section here pins both
+  halves of that, because "restoring symmetry" should cost a red test
+  rather than a rejected deposit.
 
 * **A declared key must name something declared.** The conformer upload's
   applied energy corrections tested both of their source keys for
@@ -30,6 +38,7 @@ _SOFTWARE = {"name": "Gaussian", "version": "16"}
 _LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
 
 _ROLE_TYPE_MISMATCH = "statmech_source_role_type_mismatch"
+_THERMO_ROLE_TYPE_MISMATCH = "thermo_source_role_type_mismatch"
 _KEY_UNDECLARED = "applied_energy_correction_source_key_undeclared"
 
 
@@ -60,6 +69,15 @@ def _freq_calc() -> dict:
         "software_release": _SOFTWARE,
         "level_of_theory": _LOT,
         "freq_result": {"n_imag": 0, "zpe_hartree": 0.021},
+    }
+
+
+def _opt_calc() -> dict:
+    return {
+        "type": "opt",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "opt_result": {"converged": True},
     }
 
 
@@ -296,3 +314,206 @@ class TestConformerCorrectionSourceKeys:
         )
         resp = client.post("/api/v1/uploads/conformers", json=payload)
         assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Thermo's copy of the rule, and the code it now carries
+# ---------------------------------------------------------------------------
+
+
+def _thermo_payload(smiles: str, **overrides) -> dict:
+    base: dict = {
+        "species_entry": {"smiles": smiles, "charge": 0, "multiplicity": 1},
+        "scientific_origin": "computed",
+        "h298_kj_mol": -83.7,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestThermoRoleMismatchIsMachineReadable:
+    """The same claim, refused by thermo, must name itself to a client.
+
+    Statmech's refusal has carried a code since #152; thermo's raised a
+    bare ``ValueError``, so the identical depositor mistake arrived as
+    ``validation_error`` — a code no client can branch on and one that
+    never appears in the generated ``RejectionCode`` constants. The two
+    codes are deliberately different strings: same rule, different
+    subject, and a client may want to tell a broken partition function
+    from a broken enthalpy.
+    """
+
+    def test_freq_role_on_an_sp_calculation_is_refused_with_a_code(
+        self, client
+    ):
+        payload = _thermo_payload(
+            "CCCCO",
+            calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "freq"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/thermo", json=payload)
+        body = _assert_code(resp, _THERMO_ROLE_TYPE_MISMATCH)
+        assert body["context"]["declared_role"] == "freq"
+        assert body["context"]["expected_calculation_type"] == "freq"
+        assert body["context"]["actual_calculation_type"] == "sp"
+        # The offending link is named by the depositor's own key, and no
+        # row id is disclosed anywhere in the body (DR-0028 Req 2).
+        assert "my_sp_job" in body["context"]["field"]
+        assert "calculation_id" not in resp.text
+
+    def test_the_code_is_not_statmechs(self, client):
+        """Two subjects, two codes — a client must be able to tell them apart."""
+        payload = _thermo_payload(
+            "CCCCCO",
+            calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "freq"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/thermo", json=payload)
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["code"] != _ROLE_TYPE_MISMATCH
+
+    def test_matching_roles_still_upload(self, client):
+        payload = _thermo_payload(
+            "CCCCCCO",
+            calculations=[
+                {"key": "my_sp_job", "calculation": _sp_calc()},
+                {"key": "my_freq_job", "calculation": _freq_calc()},
+            ],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "sp"},
+                {"calculation_key": "my_freq_job", "role": "freq"},
+            ],
+        )
+        resp = client.post("/api/v1/uploads/thermo", json=payload)
+        assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# The one exception: an ``opt`` may serve the ``sp`` role — one way only
+# ---------------------------------------------------------------------------
+
+
+class TestOptimisationMayServeTheSinglePointRole:
+    """A depositor who ran no separate single point still has the energy.
+
+    The optimisation's final energy *is* the single-point value, at the
+    optimisation's own level of theory — which the calculation row it
+    points at already carries, so nothing is left unstated. The
+    mixed-method depositor is the other branch entirely: they have a real
+    ``sp`` calculation and link the ``sp`` role to that.
+    """
+
+    def test_statmech_sp_role_accepts_an_opt_calculation(self, client):
+        payload = _standalone_statmech_payload(
+            species_entry={"smiles": "CCCCC", "charge": 0, "multiplicity": 1},
+            calculations=[{"key": "my_opt_job", "calculation": _opt_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_opt_job", "role": "sp"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/statmech", json=payload)
+        assert resp.status_code == 201, resp.text
+
+    def test_thermo_sp_role_accepts_an_opt_calculation(self, client):
+        payload = _thermo_payload(
+            "CCCCCC",
+            calculations=[{"key": "my_opt_job", "calculation": _opt_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_opt_job", "role": "sp"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/thermo", json=payload)
+        assert resp.status_code == 201, resp.text
+
+    def test_bundle_statmech_sp_role_accepts_an_opt_calculation(self, client):
+        payload = _bundle_payload(
+            statmech={
+                "external_symmetry": 1,
+                "source_calculations": [
+                    {"calculation_key": "opt0", "role": "sp"}
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text
+
+    def test_bundle_thermo_sp_role_accepts_an_opt_calculation(self, client):
+        payload = _bundle_payload(
+            thermo={
+                "h298_kj_mol": 217.998,
+                "source_calculations": [
+                    {"calculation_key": "opt0", "role": "sp"}
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text
+
+
+class TestTheExceptionDoesNotRunInReverse:
+    """An ``sp`` calculation optimised nothing, so it cannot be the ``opt``.
+
+    This asymmetry is the part a later reader is most likely to "tidy up".
+    It is not an oversight: ``role='opt'`` is the claim that the linked job
+    produced the converged geometry the record stands on, and a
+    single-point job produced no geometry at all. The accepted-type list in
+    the refusal's ``context`` is asserted here so the one-sidedness is
+    visible in the response, not only in the source.
+    """
+
+    def test_statmech_opt_role_refuses_an_sp_calculation(self, client):
+        payload = _standalone_statmech_payload(
+            species_entry={"smiles": "CCCCCC", "charge": 0, "multiplicity": 1},
+            calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "opt"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/statmech", json=payload)
+        body = _assert_code(resp, _ROLE_TYPE_MISMATCH)
+        assert body["context"]["declared_role"] == "opt"
+        assert body["context"]["actual_calculation_type"] == "sp"
+        assert body["context"]["accepted_calculation_types"] == ["opt"]
+
+    def test_thermo_opt_role_refuses_an_sp_calculation(self, client):
+        payload = _thermo_payload(
+            "CCCCCCC",
+            calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_sp_job", "role": "opt"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/thermo", json=payload)
+        body = _assert_code(resp, _THERMO_ROLE_TYPE_MISMATCH)
+        assert body["context"]["declared_role"] == "opt"
+        assert body["context"]["actual_calculation_type"] == "sp"
+        assert body["context"]["accepted_calculation_types"] == ["opt"]
+
+    def test_sp_role_still_refuses_a_freq_calculation(self, client):
+        """The exception is one named type, not "anything with an energy"."""
+        payload = _standalone_statmech_payload(
+            species_entry={"smiles": "CCCCCCC", "charge": 0, "multiplicity": 1},
+            calculations=[{"key": "my_freq_job", "calculation": _freq_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_freq_job", "role": "sp"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/statmech", json=payload)
+        body = _assert_code(resp, _ROLE_TYPE_MISMATCH)
+        assert body["context"]["accepted_calculation_types"] == ["sp", "opt"]
+
+    def test_thermo_sp_role_still_refuses_a_freq_calculation(self, client):
+        payload = _thermo_payload(
+            "CCCCCCCC",
+            calculations=[{"key": "my_freq_job", "calculation": _freq_calc()}],
+            source_calculations=[
+                {"calculation_key": "my_freq_job", "role": "sp"}
+            ],
+        )
+        resp = client.post("/api/v1/uploads/thermo", json=payload)
+        body = _assert_code(resp, _THERMO_ROLE_TYPE_MISMATCH)
+        assert body["context"]["accepted_calculation_types"] == ["sp", "opt"]


### PR DESCRIPTION
Closes #151. Closes #147.

Two changes to the same two role/type validators, plus the read-side
consequence of the first.

## #151 — an optimisation may serve the single-point role

`role: "sp"` may now name a `type: "opt"` calculation, in statmech and in
thermo alike.

A depositor who never ran a separate single point has not lost the number.
The optimisation's final energy **is** the single-point value, at the
optimisation's own level of theory — which the calculation row it points at
already carries, so nothing about the record is left unstated. Refusing that
rejected a legitimate and common deposit.

The mixed-method case is not a counter-example, it is the other branch:
someone optimising at wB97X-D/def2-TZVP and refining at
DLPNO-CCSD(T)/def2-TZVP *has* a separate `sp` calculation and links the `sp`
role to it. They were never going to point the `sp` role at the `opt`, so
there is no second level of theory to reconcile here.

**One named exception, not a loosening.**

* `role='freq'` on an `sp` job is still a record claiming evidence it does
  not have, and is still refused.
* The exception does **not** run in reverse. An `sp` calculation optimised
  nothing, so it cannot serve the `opt` role.
  `TestTheExceptionDoesNotRunInReverse` pins that asymmetry through the real
  routes, and asserts the accepted-type list in the refusal's `context`, so
  "restoring symmetry" costs a red test rather than a rejected deposit.

Mechanically, `_STATMECH_ROLE_TO_CALC_TYPE` and `_THERMO_ROLE_TO_CALC_TYPE`
become `…_TYPES`, mapping a role to the tuple of types it accepts; the first
entry stays the canonical one the role is named after, and is what the
refusal keeps reporting as `expected_calculation_type`. A new
`accepted_calculation_types` list is additive. Every statmech write path
inherits this from the shared service, and both bundle roots inherit thermo's
from `app.workflows.thermo` — neither workflow needed touching.

## #147 — thermo's refusal now names itself

`app.workflows.thermo.assert_thermo_role_matches_calculation_type` raised a
bare `ValueError`, so the identical depositor mistake arrived as
`code: "validation_error"` from thermo and as
`statmech_source_role_type_mismatch` from statmech. A client could branch on
one and not the other.

It now raises `CodedValueError` with `thermo_source_role_type_mismatch` and
the same shape of structured `context` statmech uses. Deliberately **not**
statmech's code: same rule, different subject — which supporting calculations
a partition function was built from versus which ones an enthalpy was — and a
client repairing one may have nothing to say about the other.

The published `detail` sentence is extended, not replaced; the substring the
existing bundle test matches is intact. The calculation's row id goes to the
log, never to the 422 (DR-0028 Req 2).

## Read-side consequence

Because an `sp`-role link may now point at an `opt` job,
`StatmechEvidenceSummary.has_sp_calculation` stopped being a complete answer
on its own — it reads identically whether the single point was dedicated or
borrowed. That is a real provenance difference, and the four-role model says
it belongs in the data. The evidence summary gains `sp_from_optimization`,
computed from one bounded query that runs only when an `sp`-role link exists.

## Verification

Baselines measured on the base commit, not quoted from memory.

| gate | base | this branch |
|---|---|---|
| rest | 4192 passed, 14 skipped | 4192 passed, 14 skipped |
| api | 2625 passed | 2639 passed (+14) |
| scientific | 2045 passed | 2048 passed (+3) |

Each of the four changes was mutation-checked separately: reverting it turns
exactly its own new tests red and moves nothing else.

No Alembic revision — head stays `b7e4d1a9c026`. No wire-schema or client
change, so no version bump; `generate_client_rejection_codes.py --check`
reports the generated constants already up to date (see the note below).
