### PR TITLE
Let a statmech record cite a calculation an earlier request deposited

### DIFF
--- a/backend/app/schemas/workflows/statmech_upload.py
+++ b/backend/app/schemas/workflows/statmech_upload.py
@@ -13,7 +13,7 @@ the same key-based reference components from
 
 from __future__ import annotations
 
-from typing import Self, TypeAlias
+from typing import Self
 
 from pydantic import Field, model_validator
 from tckdb_schemas.stationary_point import (
@@ -59,12 +59,103 @@ class StatmechCalculationIn(SchemaBase):
     calculation: CalculationWithResultsPayload
 
 
-#: Statmech → calculation link by local key. Was a class of its own here;
-#: it is now the shared wire component, because the conformer, bundle and
-#: standalone paths all express this link identically. Spelled as an
-#: explicit ``TypeAlias``: a bare ``X = SomeClass`` assignment is a
-#: *variable* to mypy, and annotating with it is an error.
-StatmechSourceCalculationIn: TypeAlias = StatmechSourceCalcIn
+class StatmechSourceCalculationIn(StatmechSourceCalcIn):
+    """Statmech → calculation link, for the *standalone* statmech upload.
+
+    Exactly one of ``calculation_key`` (a calculation declared inline in
+    this same request) or ``existing_calculation_id`` (a calculation row
+    a *previous* request already deposited) must be given. It widens the
+    shared wire component :class:`~tckdb_schemas.statmech_bits.StatmechSourceCalcIn`,
+    which stays key-only, and the widening is deliberately scoped to this
+    one contract — see "Why only here" below.
+
+    Why chaining exists at all
+    --------------------------
+    Local keys resolve only within one payload. Without a way to name a
+    calculation deposited earlier, a statmech deposit has to re-send the
+    opt/freq/sp jobs it already stored. Calculations are append-only and
+    are **never deduplicated**, so a re-send mints a second row for the
+    same job. That is not merely wasted space: it destroys the meaning of
+    counting candidates. "Seven independent depositions, twenty-one
+    distinct calculations" is evidence of reproducibility only while a
+    calculation row means *a job someone ran*; once re-deposits mint
+    duplicates the count silently becomes "how many times someone
+    re-uploaded", and the store cannot tell the two apart.
+
+    The counter-argument — that a self-contained deposit is stronger for
+    provenance, because a record can then never cite something that was
+    not reviewed alongside it — was weighed and accepted as the smaller
+    loss.
+
+    Audience guidance
+    -----------------
+    * ``calculation_key`` is the **contributor-facing** path. Web uploads,
+      community contributors and general workflow tools use local string
+      keys so a depositor never needs to know a database id.
+    * ``existing_calculation_id`` is **programmatic chaining**: a client
+      threading ids back out of a prior TCKDB upload response (ARC's
+      adapter chaining from its conformer upload, or replay/admin/repair
+      tooling). It is *not* the primary public upload UX.
+
+    The ``existing_*_id`` convention is deliberately id-based, and it is
+    **not** a violation of the "no FK IDs in upload schemas" rule. That
+    rule governs contributor-facing *scientific content* — a depositor
+    describes a molecule, not a row. This field describes neither; it is
+    a client quoting back an id TCKDB itself just issued to it. Please do
+    not "fix" it into a key: there is no key namespace spanning two
+    requests, which is the entire problem it solves.
+
+    Nothing is skipped on this path. A chained citation is loaded, checked
+    for owner-consistency against the statmech target's species entry, and
+    put through the identical role/type contract
+    (:func:`app.services.statmech_resolution.assert_statmech_role_compatible`)
+    that a locally-keyed citation passes. If it were cheaper to validate,
+    it would become the route depositors use to get around validation.
+
+    Why only here (the bundle answer)
+    ---------------------------------
+    The contribution-bundle routes (``/uploads/computed-species``,
+    ``/uploads/computed-reaction``, and the PDep network path) do **not**
+    get this field, and their omission is a decision rather than an
+    oversight. A bundle is self-contained by construction: it carries one
+    global calc-key namespace covering every calculation the bundle
+    deposits, so every citation a bundle needs to make is expressible as a
+    key within the request it arrives in. There is nothing for chaining to
+    reach for. Those paths therefore keep the key-only
+    ``StatmechSourceCalcIn``, and because ``SchemaBase`` sets
+    ``extra="forbid"`` a bundle that sends ``existing_calculation_id``
+    is refused with ``extra_forbidden`` rather than silently ignored.
+
+    The mirror of this field is
+    :class:`app.schemas.workflows.thermo_upload.ThermoSourceCalculationIn`
+    ``.existing_calculation_id``, which does the same job for thermo. The
+    two are intended to stay symmetric; an asymmetry between them is a
+    bug, not a signal. (Statmech reached this contract later only because
+    PR #148 moved it to local keys without a chaining mechanism, and the
+    gap read as deliberate because nothing recorded that it was not.)
+
+    :param calculation_key: Local key of a calculation declared in this
+        request's ``calculations`` list.
+    :param existing_calculation_id: Database id of a calculation row a
+        previous request already deposited. Programmatic chaining only;
+        contributor-facing uploads should prefer ``calculation_key``. The
+        workflow validates existence, owner-consistency and role/type
+        compatibility before linking.
+    :param role: Scientific role the calculation plays for this statmech.
+    """
+
+    calculation_key: str | None = Field(default=None, min_length=1)
+    existing_calculation_id: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def validate_exactly_one_reference(self) -> Self:
+        """Require exactly one of calculation_key or existing_calculation_id."""
+        if (self.calculation_key is None) == (self.existing_calculation_id is None):
+            raise ValueError(
+                "source_calculations entry must specify exactly one of "
+                "calculation_key or existing_calculation_id."
+            )
+        return self
 
 
 class StatmechUploadRequest(SchemaBase):
@@ -171,8 +262,20 @@ class StatmechUploadRequest(SchemaBase):
 
     @model_validator(mode="after")
     def validate_source_calculation_keys_exist(self) -> Self:
+        """Every *local* citation must name a calculation this request declares.
+
+        Chained citations (``existing_calculation_id``) carry no key and
+        are skipped here on purpose: the row they name was deposited by an
+        earlier request, so this payload cannot possibly declare it. They
+        are not thereby unchecked — existence, owner-consistency and
+        role/type compatibility are all enforced against the database in
+        :func:`app.services.statmech_resolution.resolve_or_create_statmech`,
+        which is the only place that can check them.
+        """
         defined = {c.key for c in self.calculations}
         for sc in self.source_calculations:
+            if sc.calculation_key is None:
+                continue
             if sc.calculation_key not in defined:
                 raise ValueError(
                     f"source_calculations references undefined "
@@ -182,10 +285,28 @@ class StatmechUploadRequest(SchemaBase):
 
     @model_validator(mode="after")
     def validate_unique_source_calculation_pairs(self) -> Self:
-        pairs = [(sc.calculation_key, sc.role) for sc in self.source_calculations]
+        """Refuse a repeated link, whichever way the calculation is named.
+
+        ``statmech_source_calculation`` is keyed on ``(statmech_id,
+        calculation_id, role)``, so a duplicate is a primary-key violation
+        surfacing as a 500. The reference is now two-valued, so the
+        uniqueness tuple carries both halves — the same shape thermo's
+        ``ThermoSourceCalculationIn`` uniqueness check uses.
+
+        One duplicate this cannot see: the same calculation cited once by
+        inline key and once by id. That is impossible in practice, because
+        an inline calculation is minted by this request and so has no id an
+        earlier request could have handed out; the database's own primary
+        key remains the backstop either way.
+        """
+        pairs = [
+            (sc.calculation_key, sc.existing_calculation_id, sc.role)
+            for sc in self.source_calculations
+        ]
         if len(set(pairs)) != len(pairs):
             raise ValueError(
-                "source_calculations must be unique by (calculation_key, role)."
+                "source_calculations must be unique by (calculation_key, "
+                "existing_calculation_id, role)."
             )
         return self
 

--- a/backend/app/schemas/workflows/thermo_upload.py
+++ b/backend/app/schemas/workflows/thermo_upload.py
@@ -80,6 +80,29 @@ class ThermoSourceCalculationIn(SchemaBase):
       upload, or replay/admin/repair tooling). It is not intended as the
       primary public upload UX.
 
+    The ``existing_*_id`` convention is deliberately id-based and is
+    **not** a violation of the "no FK IDs in upload schemas" rule, which
+    governs contributor-facing *scientific content*. A depositor describes
+    a molecule, not a row; this field is a client quoting back an id TCKDB
+    itself issued to it, and there is no key namespace spanning two
+    requests for it to use instead. Please do not "fix" it into a key.
+
+    The mirror of this field is
+    :class:`app.schemas.workflows.statmech_upload.StatmechSourceCalculationIn`
+    ``.existing_calculation_id``, which does the same job for statmech and
+    carries the fuller argument for why chaining exists at all (calculations
+    are append-only and never deduplicated, so a deposit forced to re-send
+    them mints duplicate rows for the same job and destroys the meaning of
+    counting distinct calculations). The two are intended to stay
+    symmetric: an asymmetry between them is a bug, not a signal. Statmech
+    reached this contract later only because PR #148 moved it to local keys
+    without a chaining mechanism.
+
+    Neither field is offered by the contribution-bundle routes, and that
+    omission is deliberate on both: a bundle carries one global calc-key
+    namespace covering everything it deposits, so every citation it needs
+    to make is expressible as a key within the request it arrives in.
+
     :param calculation_key: Local key of a calculation declared in
         ``ThermoUploadRequest.calculations``.
     :param existing_calculation_id: Database id of a calculation row that

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -8,6 +8,18 @@ by row id. Turning a key into a real ``calculation.id`` happens here, from
 the ``calculations_by_key`` map the calling workflow builds after it has
 persisted the request's own calculations. That is the whole reason the
 schema layer never needs to know a primary key.
+
+The standalone statmech upload adds one second way to name a calculation:
+``existing_calculation_id``, citing a row an *earlier request* deposited.
+It exists because calculations are append-only and never deduplicated, so
+a deposit forced to re-send calculations it already stored would mint
+duplicate rows for the same job and turn "how many distinct calculations
+support this" into "how many times someone re-uploaded". It is handled
+here, next to the key path and not in the calling workflow, so that the
+two ways of naming a calculation cannot drift apart in what they check —
+a citation that is cheaper to validate is the route depositors use to get
+around validation. Bundle paths keep the key-only component; see
+``app.schemas.workflows.statmech_upload.StatmechSourceCalculationIn``.
 """
 
 from __future__ import annotations
@@ -18,6 +30,7 @@ from collections.abc import Mapping
 from sqlalchemy.orm import Session
 
 from app.api.error_contract import CodedValueError
+from app.api.errors import NotFoundError
 from app.db.models.calculation import Calculation
 from app.db.models.common import CalculationType, StatmechCalculationRole
 from app.db.models.statmech import (
@@ -97,6 +110,106 @@ def _resolve_calculation_key(
             message_prefix=False,
         )
     return calculation_id
+
+
+def _chained_calculation_id(source: object) -> int | None:
+    """Read the optional ``existing_calculation_id`` off a source-calc link.
+
+    Read reflectively, and the indirection is the point rather than
+    laziness. Only the standalone statmech upload's
+    ``StatmechSourceCalculationIn`` declares this field; the shared wire
+    component ``tckdb_schemas.statmech_bits.StatmechSourceCalcIn`` that
+    the conformer and bundle paths use stays key-only, so there is no
+    single static type this function could take that spans all three.
+    Widening the shared component instead would hand chaining to the
+    bundle routes, which do not need it and are deliberately denied it.
+
+    ``payload.source_calculations`` is annotated with the key-only base
+    class, so this also documents *why* an attribute the annotation does
+    not mention is nonetheless present at runtime: Pydantic v2 defaults to
+    ``revalidate_instances="never"``, so a subclass instance assigned to a
+    parent-typed field passes through intact rather than being narrowed to
+    the parent. ``test_statmech_upload_chained_id_survives_payload_handover``
+    pins that, because it is the kind of behaviour that would otherwise
+    change under us silently and drop the link with no error at all.
+    """
+    value = getattr(source, "existing_calculation_id", None)
+    return value if isinstance(value, int) else None
+
+
+def assert_statmech_calculation_owned_by(
+    calculation: Calculation,
+    *,
+    species_entry_id: int,
+    context: str,
+) -> None:
+    """Refuse a supporting calculation belonging to another species entry.
+
+    Supporting calculations attached to a statmech record must belong to
+    the same species entry as the statmech target; otherwise the
+    provenance link is scientifically meaningless — the record would cite
+    evidence about a different molecule.
+
+    Lives here rather than in ``app.workflows.statmech`` because the two
+    ways of naming a calculation must be judged by the same code. For an
+    inline calculation the check is defensive (the workflow persists it
+    against the target's own species entry, so it cannot fail); for an
+    ``existing_calculation_id`` it is the real thing, because a chained id
+    can name any row in the database.
+
+    :raises ValueError: if the calculation does not belong to
+        ``species_entry_id``. Surfaces as HTTP 422.
+    """
+    if calculation.species_entry_id == species_entry_id:
+        return
+    # ``context`` already names the calculation the way the depositor
+    # wrote it, which is the identifier they can act on. The row ids go to
+    # the log instead — a 422 body must not hand out primary keys.
+    logger.warning(
+        "%s: calculation id=%s owned by species_entry_id=%s, not %s",
+        context,
+        calculation.id,
+        calculation.species_entry_id,
+        species_entry_id,
+    )
+    raise ValueError(
+        f"{context}: this calculation belongs to another species entry, "
+        "not to the statmech target. A supporting calculation must be one "
+        "of the target species entry's own."
+    )
+
+
+def _resolve_existing_calculation(
+    session: Session,
+    calculation_id: int,
+    *,
+    species_entry_id: int,
+    context: str,
+) -> Calculation:
+    """Load a chained ``existing_calculation_id`` and check it may be cited.
+
+    The counterpart of :func:`_resolve_calculation_key` for the citation
+    that reaches outside this request. A row that is absent is a 404 (the
+    depositor named something that is not there); a row owned by another
+    species entry is a 422. Neither message discloses a row id the caller
+    did not supply — the id in ``existing_calculation_id`` is echoed back
+    only because they wrote it.
+
+    Returning the row rather than its id is deliberate: the caller needs
+    it for :func:`assert_statmech_role_compatible`, and re-fetching would
+    invite the two checks to run against different rows.
+    """
+    calculation = session.get(Calculation, calculation_id)
+    if calculation is None:
+        raise NotFoundError(
+            f"{context}: refers to a calculation that does not exist."
+        )
+    assert_statmech_calculation_owned_by(
+        calculation,
+        species_entry_id=species_entry_id,
+        context=context,
+    )
+    return calculation
 
 
 def assert_statmech_role_compatible(
@@ -327,17 +440,34 @@ def resolve_or_create_statmech(
 
     for index, source in enumerate(payload.source_calculations):
         context = f"statmech.source_calculations[{index}]"
-        calculation_id = _resolve_calculation_key(
-            source.calculation_key,
-            key_map,
-            context=context,
-        )
-        _assert_role_compatible_by_id(
-            session,
-            calculation_id,
-            role=source.role,
-            context=f"{context}.calculation_key='{source.calculation_key}'",
-        )
+        chained_id = _chained_calculation_id(source)
+        if chained_id is not None:
+            context = f"{context}.existing_calculation_id"
+            calculation = _resolve_existing_calculation(
+                session,
+                chained_id,
+                species_entry_id=species_entry_id,
+                context=context,
+            )
+            calculation_id = calculation.id
+            # Same function, same map, same refusal as the local path.
+            # Routing the chained citation around this check is exactly
+            # how it would become the way to deposit an unchecked link.
+            assert_statmech_role_compatible(
+                calculation, role=source.role, context=context
+            )
+        else:
+            calculation_id = _resolve_calculation_key(
+                source.calculation_key,
+                key_map,
+                context=context,
+            )
+            _assert_role_compatible_by_id(
+                session,
+                calculation_id,
+                role=source.role,
+                context=f"{context}.calculation_key='{source.calculation_key}'",
+            )
         session.add(
             StatmechSourceCalculation(
                 statmech_id=statmech.id,

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -158,7 +158,9 @@ def assert_statmech_calculation_owned_by(
     can name any row in the database.
 
     :raises ValueError: if the calculation does not belong to
-        ``species_entry_id``. Surfaces as HTTP 422.
+        ``species_entry_id``. Surfaces as HTTP 422 with the generic
+        ``validation_error`` code — the same envelope this violation
+        already produces on the inline path.
     """
     if calculation.species_entry_id == species_entry_id:
         return
@@ -172,10 +174,20 @@ def assert_statmech_calculation_owned_by(
         calculation.species_entry_id,
         species_entry_id,
     )
+    # Deliberately *not* "{context}: ...". An uncoded ValueError has its
+    # code scraped out of the message by ``validation_detail_code``, whose
+    # pattern matches any ``snake_case_token: `` — so a field path ending
+    # in ``existing_calculation_id`` followed by a colon is promoted to
+    # ``code="existing_calculation_id"``, which is not a code at all and
+    # is not in any register a client could branch on. Phrasing the field
+    # path as the sentence's subject keeps this on the honest generic
+    # ``validation_error``, which is what the inline path already returns.
+    # (Thermo's equivalent refusal still emits the scraped string; see
+    # ``app/workflows/thermo.py`` ``_assert_calculation_owned_by``.)
     raise ValueError(
-        f"{context}: this calculation belongs to another species entry, "
-        "not to the statmech target. A supporting calculation must be one "
-        "of the target species entry's own."
+        f"{context} refers to a calculation that belongs to another "
+        "species entry, not to the statmech target. A supporting "
+        "calculation must be one of the target species entry's own."
     )
 
 
@@ -202,7 +214,7 @@ def _resolve_existing_calculation(
     calculation = session.get(Calculation, calculation_id)
     if calculation is None:
         raise NotFoundError(
-            f"{context}: refers to a calculation that does not exist."
+            f"{context} refers to a calculation that does not exist."
         )
     assert_statmech_calculation_owned_by(
         calculation,
@@ -355,7 +367,13 @@ def resolve_or_create_statmech(
     :raises ValueError: If ``uploaded_calculation_role`` is set but
         ``uploaded_calculation_id`` is not supplied.
     :raises CodedValueError: If a local calculation key does not resolve,
-        or if a declared role contradicts the resolved calculation's type.
+        or if a declared role contradicts the resolved calculation's type
+        — whichever way the calculation was named.
+    :raises NotFoundError: If an ``existing_calculation_id`` names a row
+        that does not exist. Only the standalone statmech upload can
+        produce this; the conformer and bundle payloads carry the
+        key-only component and have no way to name a row outside their
+        own request.
     """
     key_map: Mapping[str, int] = calculations_by_key or {}
 

--- a/backend/app/workflows/statmech.py
+++ b/backend/app/workflows/statmech.py
@@ -27,43 +27,21 @@ from app.services.record_review import (
     apply_review_policy,
 )
 from app.services.species_resolution import resolve_species_entry
-from app.services.statmech_resolution import resolve_or_create_statmech
+from app.services.statmech_resolution import (
+    assert_statmech_calculation_owned_by,
+    resolve_or_create_statmech,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _assert_calculation_owned_by(
-    calculation: Calculation,
-    *,
-    species_entry_id: int,
-    context: str,
-) -> None:
-    """Defensive owner-consistency check for a resolved source calculation.
-
-    Supporting calculations attached to a statmech record must belong to
-    the same species entry as the statmech target; otherwise the
-    provenance link would be scientifically meaningless.
-
-    :raises ValueError: if the calculation does not belong to
-        ``species_entry_id``.
-    """
-    if calculation.species_entry_id != species_entry_id:
-        # ``context`` already names the calculation by the caller's own key,
-        # which is the identifier they can act on. The three row ids this
-        # message used to interpolate are internal handles that go to the
-        # log instead — a 422 body must not hand out primary keys.
-        logger.warning(
-            "%s: calculation id=%s owned by species_entry_id=%s, not %s",
-            context,
-            calculation.id,
-            calculation.species_entry_id,
-            species_entry_id,
-        )
-        raise ValueError(
-            f"{context}: this calculation belongs to another species entry, "
-            "not to the statmech target. A supporting calculation must be one "
-            "of the target species entry's own."
-        )
+#: Owner-consistency for a statmech supporting calculation. The body moved
+#: to :mod:`app.services.statmech_resolution` when the standalone upload
+#: gained ``existing_calculation_id``: a chained citation can name any row
+#: in the database, so this stopped being a purely defensive check and had
+#: to be judged by the same code that judges the inline path. Re-exported
+#: under the old name so the inline call site below reads unchanged.
+_assert_calculation_owned_by = assert_statmech_calculation_owned_by
 
 
 def persist_statmech_upload(
@@ -83,12 +61,21 @@ def persist_statmech_upload(
     Statmech is append-only: repeated uploads against the same species
     entry create independent rows.
 
+    A ``source_calculations`` entry may instead cite a calculation an
+    *earlier* request deposited, by ``existing_calculation_id``. Nothing
+    is persisted for it here — the row already exists, which is the point,
+    since re-sending it would mint a duplicate calculation for the same
+    job. Its existence, ownership and role/type compatibility are checked
+    inside the resolution service alongside the inline path.
+
     :param session: Active SQLAlchemy session.
     :param request: Workflow-facing standalone statmech upload payload.
     :param created_by: Optional application user id for newly created rows.
     :returns: Newly created ``Statmech`` row.
     :raises ValueError: If a resolved supporting calculation does not
         belong to the statmech target's species entry.
+    :raises NotFoundError: If an ``existing_calculation_id`` names a
+        calculation row that does not exist.
     """
     species_entry = resolve_species_entry(
         session, request.species_entry, created_by=created_by
@@ -114,8 +101,15 @@ def persist_statmech_upload(
 
     # Build the canonical statmech payload and route through the shared
     # resolution service. The source-calculation links and torsions travel
-    # as-is: both paths now speak the same key-based components, so there
-    # is nothing to translate here — only a key → id map to hand over.
+    # as-is — only a key → id map is handed over.
+    #
+    # ``source_calculations`` entries are ``StatmechSourceCalculationIn``,
+    # a subclass of the key-only component this payload's field is
+    # annotated with, because the standalone upload also accepts
+    # ``existing_calculation_id``. They survive the handover unnarrowed
+    # (Pydantic v2 revalidates model instances never by default), and the
+    # service reads the chained id back off them; nothing is translated
+    # here, so there is only one place that decides what a citation means.
     # No uploaded_calculation_id here — standalone uploads have no
     # implicit "freshly uploaded" anchor calculation.
     core_payload = ConformerUploadStatmechPayload(

--- a/backend/docs/specs/ingestion_submission_model.md
+++ b/backend/docs/specs/ingestion_submission_model.md
@@ -44,6 +44,56 @@ seam. Direct uploads additionally set `link_records=True` so the workflow's full
 review-target set is linked; the bundle path keeps its own curated, role-bearing
 `submission_record_link` rows.
 
+## Citing a calculation deposited by an earlier request
+
+A submission is normally self-contained: everything a record cites is declared
+in the same payload and addressed by **local string key**, so a depositor never
+needs to know a database id. Two product uploads make one bounded exception.
+
+`POST /uploads/thermo` and `POST /uploads/statmech` accept
+`source_calculations[*].existing_calculation_id` — a calculation row deposited
+by a *previous* request — as an alternative to `calculation_key`. Exactly one of
+the two must be given per entry.
+
+The exception exists because **calculations are append-only and are never
+deduplicated**. Without it, a client that deposits opt/freq/sp during its
+conformer step and then deposits statmech has to re-send those calculations,
+minting a second row for the same job. That does not merely waste space: it
+destroys the meaning of counting candidates. A count of distinct calculations
+supporting a species is evidence of reproducibility only while a calculation row
+means *a job someone ran*; once re-deposits mint duplicates, the count silently
+becomes "how many times someone re-uploaded", and the store cannot tell the two
+apart. The counter-argument — a self-contained deposit is stronger for
+provenance, because a record can then never cite something not reviewed
+alongside it — was weighed and accepted as the smaller loss.
+
+This is **programmatic chaining**, not the contributor UX: it is for clients
+threading ids back out of a prior TCKDB upload response (ARC's adapter, replay
+and repair tooling). It is not a violation of the "no FK IDs in upload schemas"
+rule, which governs contributor-facing scientific content — the depositor is
+quoting back an id TCKDB issued to them, not describing chemistry by row.
+
+A chained citation is not a cheaper citation. It passes the same checks a
+locally-keyed one does, in the same code, and the checks live in the resolution
+service rather than the calling workflow so the two cannot drift apart:
+
+| check | local key | `existing_calculation_id` |
+|---|---|---|
+| reference resolves | schema: key was declared in this payload | service: row exists, else **404** |
+| owner-consistency with the target species entry | by construction, plus a defensive guard | enforced against the row, **422** |
+| role/type compatibility | `assert_statmech_role_compatible` / `assert_thermo_role_matches_calculation_type` | the same function, same coded refusal |
+| link uniqueness | schema, per `(key, role)` | schema, per `(key, existing_id, role)` |
+| submission scoping, `record_review`, audit | applies to the statmech/thermo record created by this request | unchanged — the cited calculation is **not** re-reviewed or re-linked; it keeps the review state its own submission gave it |
+
+The **contribution-bundle routes do not offer this field, deliberately**. A
+bundle is self-contained by construction — it carries one global calc-key
+namespace covering every calculation it deposits — so every citation it needs to
+make is expressible as a key within the request it arrives in, and there is
+nothing for chaining to reach for. The bundle paths keep the key-only
+`StatmechSourceCalcIn`; because the wire base sets `extra="forbid"`, a bundle
+that sends `existing_calculation_id` is refused with `extra_forbidden` rather
+than silently ignored.
+
 ## Async upload jobs (`/jobs/*`)
 
 ### Support and retry contract

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -37615,6 +37615,44 @@
         "title": "StatmechSourceCalcIn",
         "type": "object"
       },
+      "StatmechSourceCalculationIn": {
+        "additionalProperties": false,
+        "description": "Statmech → calculation link, for the *standalone* statmech upload.\n\nExactly one of ``calculation_key`` (a calculation declared inline in\nthis same request) or ``existing_calculation_id`` (a calculation row\na *previous* request already deposited) must be given. It widens the\nshared wire component :class:`~tckdb_schemas.statmech_bits.StatmechSourceCalcIn`,\nwhich stays key-only, and the widening is deliberately scoped to this\none contract — see \"Why only here\" below.\n\nWhy chaining exists at all\n--------------------------\nLocal keys resolve only within one payload. Without a way to name a\ncalculation deposited earlier, a statmech deposit has to re-send the\nopt/freq/sp jobs it already stored. Calculations are append-only and\nare **never deduplicated**, so a re-send mints a second row for the\nsame job. That is not merely wasted space: it destroys the meaning of\ncounting candidates. \"Seven independent depositions, twenty-one\ndistinct calculations\" is evidence of reproducibility only while a\ncalculation row means *a job someone ran*; once re-deposits mint\nduplicates the count silently becomes \"how many times someone\nre-uploaded\", and the store cannot tell the two apart.\n\nThe counter-argument — that a self-contained deposit is stronger for\nprovenance, because a record can then never cite something that was\nnot reviewed alongside it — was weighed and accepted as the smaller\nloss.\n\nAudience guidance\n-----------------\n* ``calculation_key`` is the **contributor-facing** path. Web uploads,\n  community contributors and general workflow tools use local string\n  keys so a depositor never needs to know a database id.\n* ``existing_calculation_id`` is **programmatic chaining**: a client\n  threading ids back out of a prior TCKDB upload response (ARC's\n  adapter chaining from its conformer upload, or replay/admin/repair\n  tooling). It is *not* the primary public upload UX.\n\nThe ``existing_*_id`` convention is deliberately id-based, and it is\n**not** a violation of the \"no FK IDs in upload schemas\" rule. That\nrule governs contributor-facing *scientific content* — a depositor\ndescribes a molecule, not a row. This field describes neither; it is\na client quoting back an id TCKDB itself just issued to it. Please do\nnot \"fix\" it into a key: there is no key namespace spanning two\nrequests, which is the entire problem it solves.\n\nNothing is skipped on this path. A chained citation is loaded, checked\nfor owner-consistency against the statmech target's species entry, and\nput through the identical role/type contract\n(:func:`app.services.statmech_resolution.assert_statmech_role_compatible`)\nthat a locally-keyed citation passes. If it were cheaper to validate,\nit would become the route depositors use to get around validation.\n\nWhy only here (the bundle answer)\n---------------------------------\nThe contribution-bundle routes (``/uploads/computed-species``,\n``/uploads/computed-reaction``, and the PDep network path) do **not**\nget this field, and their omission is a decision rather than an\noversight. A bundle is self-contained by construction: it carries one\nglobal calc-key namespace covering every calculation the bundle\ndeposits, so every citation a bundle needs to make is expressible as a\nkey within the request it arrives in. There is nothing for chaining to\nreach for. Those paths therefore keep the key-only\n``StatmechSourceCalcIn``, and because ``SchemaBase`` sets\n``extra=\"forbid\"`` a bundle that sends ``existing_calculation_id``\nis refused with ``extra_forbidden`` rather than silently ignored.\n\nThe mirror of this field is\n:class:`app.schemas.workflows.thermo_upload.ThermoSourceCalculationIn`\n``.existing_calculation_id``, which does the same job for thermo. The\ntwo are intended to stay symmetric; an asymmetry between them is a\nbug, not a signal. (Statmech reached this contract later only because\nPR #148 moved it to local keys without a chaining mechanism, and the\ngap read as deliberate because nothing recorded that it was not.)\n\n:param calculation_key: Local key of a calculation declared in this\n    request's ``calculations`` list.\n:param existing_calculation_id: Database id of a calculation row a\n    previous request already deposited. Programmatic chaining only;\n    contributor-facing uploads should prefer ``calculation_key``. The\n    workflow validates existence, owner-consistency and role/type\n    compatibility before linking.\n:param role: Scientific role the calculation plays for this statmech.",
+        "properties": {
+          "calculation_key": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Calculation Key"
+          },
+          "existing_calculation_id": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Existing Calculation Id"
+          },
+          "role": {
+            "$ref": "#/components/schemas/StatmechCalculationRole"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "StatmechSourceCalculationIn",
+        "type": "object"
+      },
       "StatmechSourceCalculationRead": {
         "description": "Read schema for a statmech source-calculation link.",
         "properties": {
@@ -38598,7 +38636,7 @@
           },
           "source_calculations": {
             "items": {
-              "$ref": "#/components/schemas/StatmechSourceCalcIn"
+              "$ref": "#/components/schemas/StatmechSourceCalculationIn"
             },
             "title": "Source Calculations",
             "type": "array"
@@ -41885,7 +41923,7 @@
       },
       "ThermoSourceCalculationIn": {
         "additionalProperties": false,
-        "description": "Link between a thermo upload and a supporting calculation.\n\nExactly one of ``calculation_key`` (inline reference into the same\nupload's ``calculations`` list) or ``existing_calculation_id`` (FK\nreference to a row already persisted in the ``calculation`` table)\nmust be provided. See DR-0028 for the rationale: ARC's typical\npipeline uploads opt/freq/sp during conformer upload, so the thermo\nupload should reference those existing rows rather than re-declare\nduplicate calculations.\n\nAudience guidance:\n\n* ``calculation_key`` is the **contributor-facing** path. Web uploads,\n  community contributors, and general workflow tools should use local\n  string keys so users never need to know database IDs. The future\n  computed-species bundle endpoint will resolve calculations,\n  artifacts, thermo, and thermo source links together server-side\n  using these keys.\n* ``existing_calculation_id`` is an **advanced / programmatic**\n  mechanism for clients that are chaining from a prior TCKDB upload\n  response (e.g. ARC's adapter using IDs returned by the conformer\n  upload, or replay/admin/repair tooling). It is not intended as the\n  primary public upload UX.\n\n:param calculation_key: Local key of a calculation declared in\n    ``ThermoUploadRequest.calculations``.\n:param existing_calculation_id: Database id of a calculation row that\n    already exists. Intended for programmatic workflows that are\n    chaining from a prior TCKDB upload response; contributor-facing\n    bundle uploads should prefer ``calculation_key`` so users do not\n    need to know database IDs. The workflow validates\n    owner-consistency and role/type compatibility before linking.\n:param role: The scientific role the calculation plays for this thermo.",
+        "description": "Link between a thermo upload and a supporting calculation.\n\nExactly one of ``calculation_key`` (inline reference into the same\nupload's ``calculations`` list) or ``existing_calculation_id`` (FK\nreference to a row already persisted in the ``calculation`` table)\nmust be provided. See DR-0028 for the rationale: ARC's typical\npipeline uploads opt/freq/sp during conformer upload, so the thermo\nupload should reference those existing rows rather than re-declare\nduplicate calculations.\n\nAudience guidance:\n\n* ``calculation_key`` is the **contributor-facing** path. Web uploads,\n  community contributors, and general workflow tools should use local\n  string keys so users never need to know database IDs. The future\n  computed-species bundle endpoint will resolve calculations,\n  artifacts, thermo, and thermo source links together server-side\n  using these keys.\n* ``existing_calculation_id`` is an **advanced / programmatic**\n  mechanism for clients that are chaining from a prior TCKDB upload\n  response (e.g. ARC's adapter using IDs returned by the conformer\n  upload, or replay/admin/repair tooling). It is not intended as the\n  primary public upload UX.\n\nThe ``existing_*_id`` convention is deliberately id-based and is\n**not** a violation of the \"no FK IDs in upload schemas\" rule, which\ngoverns contributor-facing *scientific content*. A depositor describes\na molecule, not a row; this field is a client quoting back an id TCKDB\nitself issued to it, and there is no key namespace spanning two\nrequests for it to use instead. Please do not \"fix\" it into a key.\n\nThe mirror of this field is\n:class:`app.schemas.workflows.statmech_upload.StatmechSourceCalculationIn`\n``.existing_calculation_id``, which does the same job for statmech and\ncarries the fuller argument for why chaining exists at all (calculations\nare append-only and never deduplicated, so a deposit forced to re-send\nthem mints duplicate rows for the same job and destroys the meaning of\ncounting distinct calculations). The two are intended to stay\nsymmetric: an asymmetry between them is a bug, not a signal. Statmech\nreached this contract later only because PR #148 moved it to local keys\nwithout a chaining mechanism.\n\nNeither field is offered by the contribution-bundle routes, and that\nomission is deliberate on both: a bundle carries one global calc-key\nnamespace covering everything it deposits, so every citation it needs\nto make is expressible as a key within the request it arrives in.\n\n:param calculation_key: Local key of a calculation declared in\n    ``ThermoUploadRequest.calculations``.\n:param existing_calculation_id: Database id of a calculation row that\n    already exists. Intended for programmatic workflows that are\n    chaining from a prior TCKDB upload response; contributor-facing\n    bundle uploads should prefer ``calculation_key`` so users do not\n    need to know database IDs. The workflow validates\n    owner-consistency and role/type compatibility before linking.\n:param role: The scientific role the calculation plays for this thermo.",
         "properties": {
           "calculation_key": {
             "anyOf": [

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -795,12 +795,21 @@ class TestChainedCitationPassesEveryCheckALocalOneDoes:
         """A chained id can name *any* row, so owner-consistency stops
         being defensive here and becomes the real check.
 
-        The refusal is a bare ``ValueError`` → HTTP 422 with the generic
-        ``validation_error`` code, matching what the same violation
-        produces on the inline path and on thermo's chained path. That it
-        carries no specific code is tracked as #158; this test pins the
-        status and the absence of an id leak, not the generic code, so
-        giving it a code later is not a breaking change here.
+        The refusal is a bare ``ValueError`` → HTTP 422 carrying the
+        generic ``validation_error`` code, which is what the same
+        violation produces on the inline path. That it has no *specific*
+        code is tracked as #158.
+
+        ``code`` is asserted here for a reason that is easy to lose. An
+        uncoded ``ValueError`` has its code scraped out of the message by
+        ``validation_detail_code``, whose pattern promotes any
+        ``snake_case_token: ``. Phrase this refusal as ``f"{context}: …"``
+        with a field path ending in ``existing_calculation_id`` and the
+        response advertises ``code="existing_calculation_id"`` — a string
+        that is not a code, is in no register, and would invite a client
+        to branch on it. This test is what stops that phrasing coming
+        back. (Thermo's equivalent refusal still emits the scraped
+        string; ``app/workflows/thermo.py`` ``_assert_calculation_owned_by``.)
         """
         other = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
         a = _deposit_calculations(client, label="chain-owner", species=other)
@@ -815,7 +824,9 @@ class TestChainedCitationPassesEveryCheckALocalOneDoes:
             ),
         )
         assert resp.status_code == 422, resp.text
-        detail = resp.json()["detail"]
+        body = resp.json()
+        assert body["code"] == "validation_error", body
+        detail = body["detail"]
         assert "another species entry" in detail
         # No row id the depositor did not supply, and no id at all beyond
         # the one they wrote (which is not echoed into this message).

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -34,6 +34,10 @@ resp.text`` is true even when the field was wrongly *accepted*. Only
 
 from __future__ import annotations
 
+from sqlalchemy import select
+
+from app.db.models.calculation import Calculation
+
 _SOFTWARE = {"name": "Gaussian", "version": "16"}
 _LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
 
@@ -517,3 +521,407 @@ class TestTheExceptionDoesNotRunInReverse:
         resp = client.post("/api/v1/uploads/thermo", json=payload)
         body = _assert_code(resp, _THERMO_ROLE_TYPE_MISMATCH)
         assert body["context"]["accepted_calculation_types"] == ["sp", "opt"]
+
+
+# ---------------------------------------------------------------------------
+# Citing a calculation a *previous* request deposited
+# ---------------------------------------------------------------------------
+#
+# Everything above names a calculation by a local key, which resolves only
+# within one payload. ``existing_calculation_id`` is the one way to name a
+# calculation across requests, and it exists because calculations are
+# append-only and never deduplicated: a statmech deposit forced to re-send
+# the opt/freq/sp it already stored would mint a second row for the same
+# job, and the count of distinct calculations supporting a species would
+# quietly stop meaning "jobs someone ran" and start meaning "times someone
+# re-uploaded".
+#
+# The tests here exist mostly to prove the *other* half: a chained citation
+# is not a cheaper citation. If it skipped a check, it would immediately
+# become the route depositors use to skip that check.
+
+
+def _calculation_ids(client, species_entry_id: int) -> set[int]:
+    """Every calculation row currently owned by ``species_entry_id``.
+
+    Read through the request session the ``client`` fixture binds its
+    dependency overrides to, so this sees exactly what the requests wrote
+    and nothing committed by any other test.
+    """
+    return set(
+        client._db_session.scalars(
+            select(Calculation.id).where(
+                Calculation.species_entry_id == species_entry_id
+            )
+        ).all()
+    )
+
+
+def _deposit_calculations(client, *, label: str, species: dict) -> dict:
+    """Request A: deposit opt/freq/sp via the conformer route.
+
+    This is the real chaining source rather than a contrived one — the
+    conformer upload response is the only place TCKDB hands a client the
+    calculation ids it later chains from, and depositing conformers then
+    statmech is exactly ARC's pipeline.
+
+    :returns: ``{"species_entry_id": …, "opt": id, "freq": id, "sp": id}``.
+    """
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_conformer_payload(
+            label,
+            species_entry=species,
+            calculation=dict(_opt_calc(), key="opt_job"),
+            additional_calculations=[
+                dict(_freq_calc(), key="freq_job"),
+                dict(_sp_calc(), key="sp_job"),
+            ],
+        ),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    deposited = {
+        "species_entry_id": body["species_entry_id"],
+        body["primary_calculation"]["type"]: body["primary_calculation"][
+            "calculation_id"
+        ],
+    }
+    for ref in body["additional_calculations"]:
+        deposited[ref["type"]] = ref["calculation_id"]
+    assert {"opt", "freq", "sp"} <= set(deposited), deposited
+    return deposited
+
+
+class TestChainedCitationAcrossRequests:
+    def test_statmech_cites_a_prior_calculation_and_mints_no_duplicate(
+        self, client
+    ):
+        """The whole point of the feature, in two requests.
+
+        Request A deposits opt/freq/sp. Request B deposits statmech citing
+        all three by ``existing_calculation_id``. The links must point at
+        those exact rows, and the set of calculations owned by the species
+        entry must be **unchanged** — if it grew, the deposit re-minted a
+        job that was already stored, which is the failure this field was
+        added to prevent.
+        """
+        species = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+        a = _deposit_calculations(client, label="chain-a", species=species)
+        entry_id = a["species_entry_id"]
+
+        before = _calculation_ids(client, entry_id)
+        assert before == {a["opt"], a["freq"], a["sp"]}, before
+
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry=species,
+                source_calculations=[
+                    {"existing_calculation_id": a["opt"], "role": "opt"},
+                    {"existing_calculation_id": a["freq"], "role": "freq"},
+                    {"existing_calculation_id": a["sp"], "role": "sp"},
+                ],
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        statmech_id = resp.json()["id"]
+
+        read = client.get(f"/api/v1/statmech/{statmech_id}")
+        assert read.status_code == 200, read.text
+        links = {
+            sc["role"]: sc["calculation_id"]
+            for sc in read.json()["source_calculations"]
+        }
+        assert links == {
+            "opt": a["opt"],
+            "freq": a["freq"],
+            "sp": a["sp"],
+        }, links
+
+        after = _calculation_ids(client, entry_id)
+        assert after == before, (
+            "the chained deposit minted calculation rows: "
+            f"{sorted(after - before)}"
+        )
+
+    def test_chained_and_inline_citations_may_be_mixed(self, client):
+        """One list may name some calcs by id and mint others inline.
+
+        The inline calc *is* a new row — that is not the duplication the
+        feature prevents, because nothing had deposited it before.
+        """
+        species = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+        a = _deposit_calculations(client, label="chain-mixed", species=species)
+        entry_id = a["species_entry_id"]
+        before = _calculation_ids(client, entry_id)
+
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry=species,
+                calculations=[
+                    {"key": "fresh_freq", "calculation": _freq_calc()}
+                ],
+                source_calculations=[
+                    {"existing_calculation_id": a["opt"], "role": "opt"},
+                    {"calculation_key": "fresh_freq", "role": "freq"},
+                ],
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+
+        after = _calculation_ids(client, entry_id)
+        assert len(after) == len(before) + 1, (before, after)
+        assert before <= after
+
+        read = client.get(f"/api/v1/statmech/{resp.json()['id']}")
+        links = {
+            sc["role"]: sc["calculation_id"]
+            for sc in read.json()["source_calculations"]
+        }
+        assert links["opt"] == a["opt"]
+        assert links["freq"] in (after - before)
+
+
+class TestChainedCitationPassesEveryCheckALocalOneDoes:
+    """A citation that reaches outside the request is not a cheaper one."""
+
+    def test_role_contradicting_the_type_is_refused_with_the_same_code(
+        self, client
+    ):
+        """Chained and local refusals are the same coded error, not merely
+        both-refusals — a client branching on ``code`` must not have to
+        know which way the calculation was named."""
+        species = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+        a = _deposit_calculations(client, label="chain-role", species=species)
+
+        chained = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry=species,
+                source_calculations=[
+                    {"existing_calculation_id": a["sp"], "role": "freq"},
+                ],
+            ),
+        )
+        chained_body = _assert_code(chained, _ROLE_TYPE_MISMATCH)
+
+        local = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry={"smiles": "CCCCC", "charge": 0, "multiplicity": 1},
+                calculations=[{"key": "my_sp_job", "calculation": _sp_calc()}],
+                source_calculations=[
+                    {"calculation_key": "my_sp_job", "role": "freq"}
+                ],
+            ),
+        )
+        local_body = _assert_code(local, _ROLE_TYPE_MISMATCH)
+
+        for key in (
+            "declared_role",
+            "expected_calculation_type",
+            "accepted_calculation_types",
+            "actual_calculation_type",
+        ):
+            assert chained_body["context"][key] == local_body["context"][key]
+
+        # The field path names the reference the depositor wrote, and the
+        # cited row id appears nowhere except where they supplied it.
+        assert chained_body["context"]["field"] == (
+            "statmech.source_calculations[0].existing_calculation_id"
+        )
+
+    def test_the_opt_serves_sp_exception_reaches_the_chained_path(
+        self, client
+    ):
+        """PR #156 made ``sp`` accept a tuple of types. A chained citation
+        must inherit that, not a stale single-type copy of the rule."""
+        species = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+        a = _deposit_calculations(client, label="chain-optsp", species=species)
+
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry=species,
+                source_calculations=[
+                    {"existing_calculation_id": a["opt"], "role": "sp"},
+                ],
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+
+    def test_the_exception_still_does_not_run_in_reverse_when_chained(
+        self, client
+    ):
+        species = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+        a = _deposit_calculations(client, label="chain-spopt", species=species)
+
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry=species,
+                source_calculations=[
+                    {"existing_calculation_id": a["sp"], "role": "opt"},
+                ],
+            ),
+        )
+        body = _assert_code(resp, _ROLE_TYPE_MISMATCH)
+        assert body["context"]["accepted_calculation_types"] == ["opt"]
+
+    def test_an_id_that_does_not_exist_is_a_clean_404(self, client):
+        """Not a 500, and not a foreign-key error leaking out of psycopg."""
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry={"smiles": "CCCCCC", "charge": 0, "multiplicity": 1},
+                source_calculations=[
+                    {"existing_calculation_id": 999_999_999, "role": "sp"},
+                ],
+            ),
+        )
+        assert resp.status_code == 404, resp.text
+        body = resp.json()
+        assert set(body) >= {"code", "detail"}, body
+        assert body["code"] == "resource_not_found", body
+        assert "does not exist" in body["detail"]
+        # The field the depositor wrote is named; nothing else is.
+        assert "existing_calculation_id" in body["detail"]
+
+    def test_a_calculation_owned_by_another_species_entry_is_refused(
+        self, client
+    ):
+        """A chained id can name *any* row, so owner-consistency stops
+        being defensive here and becomes the real check.
+
+        The refusal is a bare ``ValueError`` → HTTP 422 with the generic
+        ``validation_error`` code, matching what the same violation
+        produces on the inline path and on thermo's chained path. That it
+        carries no specific code is tracked as #158; this test pins the
+        status and the absence of an id leak, not the generic code, so
+        giving it a code later is not a breaking change here.
+        """
+        other = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
+        a = _deposit_calculations(client, label="chain-owner", species=other)
+
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                species_entry={"smiles": "CCCCCCC", "charge": 0, "multiplicity": 1},
+                source_calculations=[
+                    {"existing_calculation_id": a["sp"], "role": "sp"},
+                ],
+            ),
+        )
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        assert "another species entry" in detail
+        # No row id the depositor did not supply, and no id at all beyond
+        # the one they wrote (which is not echoed into this message).
+        assert "species_entry_id=" not in detail
+        assert "id=" not in detail
+
+    def test_neither_reference_is_refused_at_the_schema(self, client):
+        """Assert on error type and location, never substring presence:
+        Pydantic echoes rejected input into its message, so
+        ``"existing_calculation_id" in resp.text`` is true even when the
+        field was wrongly *accepted*."""
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(source_calculations=[{"role": "sp"}]),
+        )
+        assert resp.status_code == 422, resp.text
+        details = resp.json()["detail"]
+        assert any(
+            d["type"] == "value_error"
+            and tuple(d["loc"])[-2:] == ("source_calculations", 0)
+            for d in details
+        ), details
+
+    def test_both_references_at_once_are_refused_at_the_schema(self, client):
+        resp = client.post(
+            "/api/v1/uploads/statmech",
+            json=_standalone_statmech_payload(
+                calculations=[{"key": "k", "calculation": _sp_calc()}],
+                source_calculations=[
+                    {
+                        "calculation_key": "k",
+                        "existing_calculation_id": 1,
+                        "role": "sp",
+                    }
+                ],
+            ),
+        )
+        assert resp.status_code == 422, resp.text
+        details = resp.json()["detail"]
+        assert any(d["type"] == "value_error" for d in details), details
+
+
+class TestBundleRoutesDoNotOfferChaining:
+    """The answer to "should bundles get this too" is no, and it is
+    enforced rather than merely documented.
+
+    A bundle is self-contained by construction: one global calc-key
+    namespace covers every calculation it deposits, so every citation it
+    needs to make is already expressible as a key within the request it
+    arrives in. There is nothing for chaining to reach for. Because the
+    shared wire component sets ``extra="forbid"``, a bundle that sends the
+    field is refused rather than silently ignored — which is the failure
+    mode that matters, since a silently dropped provenance link looks
+    exactly like a successful deposit.
+    """
+
+    def test_computed_species_bundle_refuses_existing_calculation_id(
+        self, client
+    ):
+        payload = _bundle_payload(
+            statmech={
+                "external_symmetry": 1,
+                "source_calculations": [
+                    {"existing_calculation_id": 1, "role": "sp"}
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 422, resp.text
+        details = resp.json()["detail"]
+        assert any(
+            d["type"] == "extra_forbidden"
+            and tuple(d["loc"])[-1] == "existing_calculation_id"
+            for d in details
+        ), details
+
+    def test_conformer_nested_statmech_refuses_existing_calculation_id(
+        self, client
+    ):
+        payload = _conformer_payload(
+            "conf-no-chaining",
+            statmech={
+                "source_calculations": [
+                    {"existing_calculation_id": 1, "role": "sp"}
+                ]
+            },
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 422, resp.text
+        details = resp.json()["detail"]
+        assert any(
+            d["type"] == "extra_forbidden"
+            and tuple(d["loc"])[-1] == "existing_calculation_id"
+            for d in details
+        ), details
+
+    def test_the_bundle_still_accepts_the_key_it_does_offer(self, client):
+        """The refusals above are about the chaining field only — the
+        bundle's own key-based citation is untouched."""
+        payload = _bundle_payload(
+            statmech={
+                "external_symmetry": 1,
+                "source_calculations": [
+                    {"calculation_key": "opt0", "role": "opt"}
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text

--- a/backend/tests/workflows/test_statmech_upload.py
+++ b/backend/tests/workflows/test_statmech_upload.py
@@ -13,7 +13,13 @@ import pytest
 from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
+from tckdb_schemas.statmech_bits import StatmechSourceCalcIn
+from tckdb_schemas.workflows.conformer_upload import (
+    ConformerUploadStatmechPayload,
+)
 
+from app.api.error_contract import CodedValueError
+from app.api.errors import NotFoundError
 from app.db.models.app_user import AppUser
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
@@ -35,7 +41,11 @@ from app.db.models.statmech import (
     StatmechTorsionDefinition,
 )
 from app.db.models.workflow import WorkflowToolRelease
-from app.schemas.workflows.statmech_upload import StatmechUploadRequest
+from app.schemas.workflows.statmech_upload import (
+    StatmechSourceCalculationIn,
+    StatmechUploadRequest,
+)
+from app.services.statmech_resolution import _chained_calculation_id
 from app.workflows.statmech import persist_statmech_upload
 
 # ---------------------------------------------------------------------------
@@ -846,3 +856,225 @@ def test_rotational_constant_positive_check(db_conn) -> None:
             savepoint.rollback()
     finally:
         session.close()
+
+
+# ---------------------------------------------------------------------------
+# Citing a calculation deposited by an earlier request
+# ---------------------------------------------------------------------------
+
+
+def test_statmech_upload_chained_id_survives_payload_handover() -> None:
+    """The chained id must survive the workflow's payload handover.
+
+    ``persist_statmech_upload`` copies ``source_calculations`` into a
+    ``ConformerUploadStatmechPayload``, whose field is annotated with the
+    key-only wire component that the standalone entry subclasses. Pydantic
+    v2 defaults to ``revalidate_instances="never"``, so the subclass
+    instance passes through intact — but if that default ever changed, or
+    if someone set ``revalidate_instances`` on the shared base config, the
+    entry would be narrowed to the parent and the chained id would vanish
+    **silently**: no error, no link row, a deposit that looks successful
+    and cites nothing.
+
+    That is why this is pinned separately from the end-to-end route tests.
+    A dropped link is the one failure this feature can produce that does
+    not announce itself.
+    """
+    entry = StatmechSourceCalculationIn(existing_calculation_id=4321, role="sp")
+    payload = ConformerUploadStatmechPayload(source_calculations=[entry])
+
+    carried = payload.source_calculations[0]
+    assert isinstance(carried, StatmechSourceCalculationIn), type(carried)
+    assert _chained_calculation_id(carried) == 4321
+    assert carried.calculation_key is None
+
+
+def test_statmech_key_only_entries_report_no_chained_id() -> None:
+    """The reader must not confuse "no chained id" with "some id".
+
+    Paired with the test above so neither can pass vacuously: the bundle
+    and conformer paths hand the service key-only entries, and those must
+    take the key branch.
+    """
+    key_entry = StatmechSourceCalcIn(calculation_key="freq0", role="freq")
+    assert _chained_calculation_id(key_entry) is None
+
+    local = StatmechSourceCalculationIn(calculation_key="freq0", role="freq")
+    assert _chained_calculation_id(local) is None
+
+
+def test_statmech_upload_links_existing_calculation_without_duplicating_it(
+    db_conn,
+) -> None:
+    """Workflow-level counterpart of the two-request API test: the link
+    points at the pre-existing row and no calculation row is added."""
+    identity = {"smiles": "CCOCC", "charge": 0, "multiplicity": 1}
+    session = Session(db_conn)
+    try:
+        with session.begin():
+            first = persist_statmech_upload(
+                session, _basic_request(species_entry=dict(identity))
+            )
+            entry_id = first.species_entry_id
+            existing = session.scalars(
+                select(Calculation).where(
+                    Calculation.species_entry_id == entry_id
+                )
+            ).all()
+            assert len(existing) == 1
+            existing_id = existing[0].id
+
+            second = persist_statmech_upload(
+                session,
+                StatmechUploadRequest(
+                    species_entry=dict(identity),
+                    scientific_origin="computed",
+                    statmech_treatment="rrho",
+                    external_symmetry=2,
+                    source_calculations=[
+                        {
+                            "existing_calculation_id": existing_id,
+                            "role": "freq",
+                        }
+                    ],
+                ),
+            )
+
+            assert second.id != first.id
+            links = session.scalars(
+                select(StatmechSourceCalculation).where(
+                    StatmechSourceCalculation.statmech_id == second.id
+                )
+            ).all()
+            assert [(lk.calculation_id, lk.role) for lk in links] == [
+                (existing_id, StatmechCalculationRole.freq)
+            ]
+
+            after = session.scalars(
+                select(Calculation).where(
+                    Calculation.species_entry_id == entry_id
+                )
+            ).all()
+            assert [row.id for row in after] == [existing_id]
+    finally:
+        session.close()
+
+
+def test_statmech_upload_chained_id_that_does_not_exist_raises_not_found(
+    db_conn,
+) -> None:
+    """A missing row is a named 404, never a ``KeyError`` or a raw FK error."""
+    request = StatmechUploadRequest(
+        species_entry={"smiles": "CCOCCC", "charge": 0, "multiplicity": 1},
+        scientific_origin="computed",
+        statmech_treatment="rrho",
+        source_calculations=[
+            {"existing_calculation_id": 999_999_999, "role": "sp"}
+        ],
+    )
+    with pytest.raises(NotFoundError, match="does not exist"):
+        with Session(db_conn) as session, session.begin():
+            persist_statmech_upload(session, request)
+
+
+def test_statmech_upload_chained_id_from_another_species_entry_raises(
+    db_conn,
+) -> None:
+    """Owner-consistency is enforced against the row, and the message
+    discloses no id the depositor did not supply."""
+    with pytest.raises(ValueError, match="another species entry") as excinfo:
+        with Session(db_conn) as session, session.begin():
+            owner = persist_statmech_upload(
+                session,
+                _basic_request(
+                    species_entry={
+                        "smiles": "CCOCCCC",
+                        "charge": 0,
+                        "multiplicity": 1,
+                    }
+                ),
+            )
+            foreign_calc = session.scalars(
+                select(Calculation).where(
+                    Calculation.species_entry_id == owner.species_entry_id
+                )
+            ).all()[0]
+
+            persist_statmech_upload(
+                session,
+                StatmechUploadRequest(
+                    species_entry={
+                        "smiles": "CCOCCCCC",
+                        "charge": 0,
+                        "multiplicity": 1,
+                    },
+                    scientific_origin="computed",
+                    statmech_treatment="rrho",
+                    source_calculations=[
+                        {
+                            "existing_calculation_id": foreign_calc.id,
+                            "role": "freq",
+                        }
+                    ],
+                ),
+            )
+
+    detail = str(excinfo.value)
+    assert "species_entry_id=" not in detail
+    assert "id=" not in detail
+
+
+def test_statmech_upload_chained_role_type_mismatch_is_coded(db_conn) -> None:
+    """A chained citation gets the same coded refusal a local one gets."""
+    identity = {"smiles": "CCOCCCCCC", "charge": 0, "multiplicity": 1}
+    with pytest.raises(CodedValueError) as excinfo:
+        with Session(db_conn) as session, session.begin():
+            owner = persist_statmech_upload(
+                session, _basic_request(species_entry=dict(identity))
+            )
+            freq_calc = session.scalars(
+                select(Calculation).where(
+                    Calculation.species_entry_id == owner.species_entry_id
+                )
+            ).all()[0]
+            assert freq_calc.type == CalculationType.freq
+
+            persist_statmech_upload(
+                session,
+                StatmechUploadRequest(
+                    species_entry=dict(identity),
+                    scientific_origin="computed",
+                    statmech_treatment="rrho",
+                    source_calculations=[
+                        {
+                            "existing_calculation_id": freq_calc.id,
+                            "role": "sp",
+                        }
+                    ],
+                ),
+            )
+
+    assert excinfo.value.code == "statmech_source_role_type_mismatch"
+    context = excinfo.value.context
+    assert context["field"] == (
+        "statmech.source_calculations[0].existing_calculation_id"
+    )
+    assert context["accepted_calculation_types"] == ["sp", "opt"]
+
+
+def test_statmech_upload_rejects_duplicate_chained_links() -> None:
+    """``(existing_calculation_id, role)`` must be unique, the way
+    ``(calculation_key, role)`` already is — the underlying table is keyed
+    on ``(statmech_id, calculation_id, role)``, so a repeat is a 500."""
+    with pytest.raises(ValidationError) as excinfo:
+        StatmechUploadRequest(
+            species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+            scientific_origin="computed",
+            source_calculations=[
+                {"existing_calculation_id": 7, "role": "sp"},
+                {"existing_calculation_id": 7, "role": "sp"},
+            ],
+        )
+    assert any(
+        d["type"] == "value_error" for d in excinfo.value.errors()
+    ), excinfo.value.errors()

--- a/backend/tests/workflows/test_statmech_upload.py
+++ b/backend/tests/workflows/test_statmech_upload.py
@@ -1062,6 +1062,80 @@ def test_statmech_upload_chained_role_type_mismatch_is_coded(db_conn) -> None:
     assert context["accepted_calculation_types"] == ["sp", "opt"]
 
 
+def test_statmech_upload_accepts_two_different_chained_calcs_in_one_role(
+    db_conn,
+) -> None:
+    """Two *different* chained calculations may share a role.
+
+    The link table is keyed on ``(statmech_id, calculation_id, role)``, so
+    one rotor scan per torsion — every one of them ``role='scan'`` — is a
+    legitimate record, and the key-based validator has always allowed it
+    (two distinct keys, same role).
+
+    This is the case that makes the uniqueness tuple's second element
+    load-bearing. Narrowing it back to ``(calculation_key, role)`` still
+    catches a repeated *identical* link, because every chained entry has
+    ``calculation_key=None`` and the pair collides — so a test using the
+    same id twice passes either way and proves nothing. What the narrow
+    tuple actually breaks is this: two different ids collapse to
+    ``(None, 'scan')`` and a valid deposit is refused.
+    """
+    identity = {"smiles": "CCOCCCCCCC", "charge": 0, "multiplicity": 1}
+    session = Session(db_conn)
+    try:
+        with session.begin():
+            seeded = persist_statmech_upload(
+                session,
+                _basic_request(
+                    species_entry=dict(identity),
+                    calculations=[
+                        {"key": "scan_a", "calculation": _scan_calc_payload()},
+                        {"key": "scan_b", "calculation": _scan_calc_payload()},
+                    ],
+                    source_calculations=[
+                        {"calculation_key": "scan_a", "role": "scan"},
+                        {"calculation_key": "scan_b", "role": "scan"},
+                    ],
+                ),
+            )
+            # The key-based path already allows it — the premise this test
+            # extends to the chained path rather than assumes.
+            assert len(seeded.source_calculations) == 2
+
+            scan_ids = sorted(
+                row.id
+                for row in session.scalars(
+                    select(Calculation).where(
+                        Calculation.species_entry_id == seeded.species_entry_id,
+                        Calculation.type == CalculationType.scan,
+                    )
+                ).all()
+            )
+            assert len(scan_ids) == 2, scan_ids
+
+            chained = persist_statmech_upload(
+                session,
+                StatmechUploadRequest(
+                    species_entry=dict(identity),
+                    scientific_origin="computed",
+                    source_calculations=[
+                        {"existing_calculation_id": scan_ids[0], "role": "scan"},
+                        {"existing_calculation_id": scan_ids[1], "role": "scan"},
+                    ],
+                ),
+            )
+
+            links = session.scalars(
+                select(StatmechSourceCalculation).where(
+                    StatmechSourceCalculation.statmech_id == chained.id
+                )
+            ).all()
+            assert sorted(lk.calculation_id for lk in links) == scan_ids
+            assert {lk.role for lk in links} == {StatmechCalculationRole.scan}
+    finally:
+        session.close()
+
+
 def test_statmech_upload_rejects_duplicate_chained_links() -> None:
     """``(existing_calculation_id, role)`` must be unique, the way
     ``(calculation_key, role)`` already is — the underlying table is keyed

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,36 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.27.0 — a statmech source link may be unique on something other than its key
+
+Additive, and a **relaxation**: nothing is renamed, removed or newly
+refused, so **every 0.26.0 payload validates unchanged under 0.27.0**.
+Minor rather than patch because the accepted set genuinely grows.
+
+`ConformerUploadStatmechPayload.validate_unique_source_calculation_pairs`
+now keys uniqueness on `(calculation_key, existing_calculation_id, role)`
+rather than `(calculation_key, role)`, reading the second element
+reflectively.
+
+For a payload built from this package there is no behaviour change at
+all: `StatmechSourceCalcIn` has no `existing_calculation_id`, so the
+second element is always `None` and the rule is the pair it always was.
+The widening exists because this class is also the payload the backend
+hands its statmech resolution service, and the standalone statmech upload
+(`POST /api/v1/uploads/statmech`, a backend-side contract) passes a
+subclass whose entries may name a calculation by row id — citing one a
+*previous* request deposited — instead of by key. Under the old tuple
+every such entry collapsed to `(None, role)`, so two genuinely different
+calculations sharing a role, which is one rotor scan per torsion with all
+of them `role='scan'`, were refused as a duplicate.
+
+`existing_calculation_id` itself is deliberately **not** added to
+`StatmechSourceCalcIn`. It is shared with the conformer and bundle paths,
+which are self-contained by construction — one calc-key namespace covers
+everything they deposit — so they have nothing to chain to, and
+`extra="forbid"` keeps them refusing the field outright rather than
+silently dropping the link.
+
 ### 0.26.0 — the reaction bundle's statmech gains the six fields the species bundle already had
 
 Purely additive. Nothing is renamed, removed, narrowed or newly refused,

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.26.0"
+version = "0.27.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
@@ -110,8 +110,27 @@ class ConformerUploadStatmechPayload(SchemaBase):
         primary-key violation surfacing as a 500. The bundle and
         standalone statmech uploads validate this; the conformer path
         did not.
+
+        The tuple carries a second discriminator alongside the key, read
+        reflectively because this class is also the payload the *backend*
+        hands the statmech resolution service — and the standalone
+        statmech upload's entries are a subclass that may name a
+        calculation by ``existing_calculation_id`` instead of by key.
+        Without it, every such entry collapses to ``(None, role)`` and two
+        genuinely different calculations sharing a role — one rotor scan
+        per torsion, all of them ``role='scan'`` — are refused as a
+        duplicate. Nothing changes for a payload built from this package:
+        ``StatmechSourceCalcIn`` has no such attribute, so the second
+        element is always ``None`` and the rule is the pair it always was.
         """
-        pairs = [(sc.calculation_key, sc.role) for sc in self.source_calculations]
+        pairs = [
+            (
+                sc.calculation_key,
+                getattr(sc, "existing_calculation_id", None),
+                sc.role,
+            )
+            for sc in self.source_calculations
+        ]
         if len(set(pairs)) != len(pairs):
             raise ValueError(
                 "statmech.source_calculations must be unique by "


### PR DESCRIPTION
## What

`POST /api/v1/uploads/statmech` accepts `source_calculations[*].existing_calculation_id` — a calculation row a **previous** request deposited — as an alternative to `calculation_key`. Exactly one of the two per entry. Modelled on thermo's field, which has had this since DR-0028.

## Why

PR #148 moved the statmech path from raw calculation ids to local keys. Local keys resolve only within one payload, so a statmech deposit had no way to name a calculation it had already stored — it had to re-send it.

**Calculations are append-only and are never deduplicated**, so re-sending mints a second row for the same job. That is not merely wasted space: it destroys the meaning of counting candidates. "Seven independent depositions, twenty-one distinct calculations" — the project's own ethylene walkthrough — is evidence of reproducibility only while a calculation row means *a job someone ran*. Once re-deposits mint duplicates, the count silently becomes "how many times someone re-uploaded", and the store cannot tell the two apart.

The counter-argument — a self-contained deposit is stronger for provenance, since a record can then never cite something not reviewed alongside it — was weighed and accepted as the smaller loss.

This is **programmatic chaining** (ARC's adapter threading ids out of its conformer-upload response; replay/repair tooling), not the contributor UX, which stays local-keys-via-bundles. It is *not* a violation of the "no FK IDs in upload schemas" rule, which governs contributor-facing scientific content — the depositor is quoting back an id TCKDB issued to them. Both fields' docstrings say so, so nobody "fixes" it later.

## A chained citation is not a cheaper citation

The point that mattered most. If `existing_calculation_id` bypassed validation, it would become the route depositors use to get around validation. Resolution therefore lives in `statmech_resolution.py` — the service that already owns statmech source-link semantics for all three write paths — rather than in the calling workflow, so the two ways of naming a calculation cannot drift apart.

| check | local key | `existing_calculation_id` |
|---|---|---|
| reference resolves | schema: key was declared in this payload | service: row exists, else **404** |
| owner-consistency with the target species entry | by construction + defensive guard | enforced against the row, **422** |
| role/type compatibility | `assert_statmech_role_compatible` | **the same function**, same coded refusal — including PR #156's tuple, so `role='sp'` on an `opt` is accepted here too |
| link uniqueness | schema, `(key, role)` | schema, `(key, existing_id, role)` |
| submission scoping / `record_review` / audit | applies to the statmech record this request creates | unchanged — the cited calculation is **not** re-reviewed or re-linked; it keeps the review state its own submission gave it (same as thermo) |

`assert_statmech_role_compatible` is *called*, never reimplemented.

## Bundles: no, and it is enforced

The contribution-bundle routes (`/uploads/computed-species`, `/uploads/computed-reaction`, PDep) and the nested conformer statmech do **not** get this field. A bundle is self-contained by construction — one global calc-key namespace covers every calculation it deposits — so every citation it needs to make is already expressible as a key within the request it arrives in. There is nothing for chaining to reach for.

That is why the field lives on a backend-side subclass rather than on the shared wire component `tckdb_schemas.statmech_bits.StatmechSourceCalcIn`: widening the shared component would hand chaining to the routes that must not have it. Because the wire base sets `extra="forbid"`, a bundle that sends the field is **refused with `extra_forbidden`** rather than having the link silently dropped — the failure mode that actually matters, since a dropped provenance link looks exactly like a successful deposit.

Written down in three places rather than left to inference (that inference gap is what caused this task): both `existing_calculation_id` docstrings name each other, and `backend/docs/specs/ingestion_submission_model.md` gains a section with the rule and the table above.

## Notes

- **No migration.** Contract change only; Alembic head stays `b7e4d1a9c026`.
- **`tckdb-schemas` 0.26.0 → 0.27.0** (minor). The *field* is not in the wire package — like thermo's, it lives on a backend-side schema, deliberately (see above). The bump is for one validator relaxation the chained path forced; see "A false duplicate" below.
- **No `tckdb-client` bump** — the client has no support for `existing_calculation_id` on any path, and its `Statmech` builder targets the *bundle* endpoints, which are unaffected.
- `backend/tests/api/golden/openapi.json`: +40/-2 — one new component `StatmechSourceCalculationIn`, `StatmechUploadRequest.source_calculations` re-pointed at it, and `ThermoSourceCalculationIn`'s description text. `StatmechSourceCalcIn` remains, still used by the bundle and conformer paths.

## Two defects the verification turned up

Recorded because both were invisible in the tests as first written.

**A scraped error code.** An uncoded `ValueError` has its `code` lifted out of the message by `validation_detail_code`, whose pattern promotes any `snake_case_token: `. Written in house style as `f"{context}: …"` with a field path ending in `existing_calculation_id`, the owner-consistency refusal advertised `code="existing_calculation_id"` — a string that is not a code, is in no register, and would invite a client to branch on it. Rewording the field path into the sentence's subject puts it back on the generic `validation_error`, which is what the same violation already returns on the inline path; the test now asserts `code` so the phrasing cannot return.

**Thermo has emitted the same scraped string since DR-0028** (`backend/app/workflows/thermo.py:82`, `_assert_calculation_owned_by`). Deliberately left alone here — changing it alters a published error contract and deserves its own decision. Worth a tracked task.

**A false duplicate.** `ConformerUploadStatmechPayload` — the payload the workflow hands the resolution service — checked link uniqueness on `(calculation_key, role)`. Every chained entry has no key, so two of them collapsed to `(None, role)` and two genuinely *different* calculations sharing a role were refused as a repeat. That is not a corner case: one rotor scan per torsion, each `role='scan'`, is the ordinary shape of a statmech record. The tuple now carries the second discriminator.

That last one is why the version note above changed: it is a wire-package edit, so **`tckdb-schemas` 0.26.0 → 0.27.0** (minor — the accepted set grows; every 0.26.0 payload still validates unchanged, since `StatmechSourceCalcIn` has no such attribute and the second element is always `None`). Changelog entry included. `tckdb-client` still needs no bump.

The test that catches the false duplicate had to be written twice. The first used the same id twice — which the narrow tuple also rejects, so it passed under the mutation and proved nothing. Only two *different* ids distinguish the rules.

## Verification

Gates measured on `main` @ `e14209a3` first, then on the branch:

| gate | main | branch |
|---|---|---|
| complement (`test-rest.sh`) | 4192 passed, 14 skipped | 4200 passed, 14 skipped (+8) |
| api (`test-api.sh`) | 2639 passed | 2651 passed (+12) |
| scientific (`test-scientific.sh`) | 2048 passed | 2048 passed (+0) |
| `tckdb-schemas` package tests | 38 passed | 38 passed |

Every part was mutation-checked — reverted individually, with the newly-red set recorded. All eight turn something red, and only the expected tests.
