### PR TITLE
Name the classes that exist, and check that they do

### DIFF
--- a/backend/app/schemas/entities/calculation.py
+++ b/backend/app/schemas/entities/calculation.py
@@ -555,8 +555,10 @@ class CalculationSCFStabilityRead(ORMBaseSchema):
     because the projected ``not_checked`` shape is all-nulls.
 
     No cross-field validators here — those guard producer input on
-    :class:`CalculationSCFStabilityCreate` and would mis-fire against
-    the projected ``not_checked`` shape.
+    ``tckdb_schemas.fragments.calculation.SCFStabilityContent`` (its
+    ``validate_status_consistency`` cross-checks ``status`` against
+    ``instability_count`` and the reoptimisation flag) and would
+    mis-fire against the projected ``not_checked`` shape.
     """
 
     calculation_id: int

--- a/backend/docs/specs/scientific_calculation_reads.md
+++ b/backend/docs/specs/scientific_calculation_reads.md
@@ -733,15 +733,16 @@ class CalculationResultSummary(BaseModel):
     """Single-result projection — exactly one of the per-type blocks set.
 
     Each per-type block is a thin wrapper around the existing
-    CalculationSPResultRead/OptResultRead/FreqResultRead etc., reduced to
+    CalculationSPResultRead, CalculationOptResultRead and
+    CalculationFreqResultRead, reduced to
     only the fields that are publicly meaningful for evidence purposes
     (energy, converged, basis-of-truth flags). Heavy arrays (frequency
     modes, scan/IRC point arrays) are NOT exposed here — the per-mode
     frequency array is available via `include=freq_modes`; scan/IRC/
     path-search summaries via `include=scan|irc|path_search`."""
-    sp: CalculationResultSPSummary | None = None
-    opt: CalculationResultOptSummary | None = None
-    freq: CalculationResultFreqSummary | None = None
+    sp: CalculationSPResultSummary | None = None
+    opt: CalculationOptResultSummary | None = None
+    freq: CalculationFreqResultSummary | None = None
 
 
 class CalculationDependencySummary(BaseModel):

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -7077,7 +7077,7 @@
         "type": "object"
       },
       "CalculationSCFStabilityRead": {
-        "description": "Read shape for SCF stability evidence.\n\nStatus widens the persisted enum with the projected ``\"not_checked\"``\nvalue the route handler emits when no row exists. All evidence\nfields are nullable because they are nullable on the row AND\nbecause the projected ``not_checked`` shape is all-nulls.\n\nNo cross-field validators here — those guard producer input on\n:class:`CalculationSCFStabilityCreate` and would mis-fire against\nthe projected ``not_checked`` shape.",
+        "description": "Read shape for SCF stability evidence.\n\nStatus widens the persisted enum with the projected ``\"not_checked\"``\nvalue the route handler emits when no row exists. All evidence\nfields are nullable because they are nullable on the row AND\nbecause the projected ``not_checked`` shape is all-nulls.\n\nNo cross-field validators here — those guard producer input on\n``tckdb_schemas.fragments.calculation.SCFStabilityContent`` (its\n``validate_status_consistency`` cross-checks ``status`` against\n``instability_count`` and the reoptimisation flag) and would\nmis-fire against the projected ``not_checked`` shape.",
         "properties": {
           "calculation_id": {
             "title": "Calculation Id",

--- a/backend/tests/scripts/test_read_spec_names_resolve.py
+++ b/backend/tests/scripts/test_read_spec_names_resolve.py
@@ -1,0 +1,102 @@
+"""A schema class named in the read spec must exist.
+
+``backend/docs/specs/scientific_calculation_reads.md`` is the document
+``CLAUDE.md`` routes people to for calculation reads, so a class name in it that
+no longer resolves costs the next reader a grep and can send them looking for a
+shape that was renamed years ago.
+
+Three had rotted before this file existed: the spec annotated fields as
+``CalculationResultSPSummary`` / ``…OptSummary`` / ``…FreqSummary`` while the
+real classes are ``CalculationSPResultSummary`` / ``CalculationOptResultSummary``
+/ ``CalculationFreqResultSummary`` — the words transposed, which is exactly the
+kind of drift a human eye slides over.
+
+**A spec both defines and references names, and only one of those is checkable.**
+This document is partly a design proposal: it declares shapes it is *asking for*
+(``class CalculationsSearchResponse(BaseModel):`` and friends) alongside
+references to shapes that already exist. Requiring every name to resolve would
+fail on the proposals, and exempting every unresolved name would check nothing.
+So the rule is: a name the spec **defines** in one of its own code blocks is
+exempt; a name it merely **references** must resolve to a real class.
+
+That is precisely the distinction that catches the failure — the three stale
+names appeared only as field annotations, never as definitions.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+SPEC = BACKEND_ROOT / "docs" / "specs" / "scientific_calculation_reads.md"
+
+#: Names shaped like a Pydantic schema class. Deliberately suffix-driven rather
+#: than "any CamelCase word": the spec's prose is full of capitalised ordinary
+#: words, and a scan that flagged those would be abandoned within a week.
+_NAME = re.compile(r"\b([A-Z][A-Za-z0-9]*(?:Summary|Read|Response|Payload|Block))\b")
+
+#: A class the spec declares for itself, in any of its fenced blocks.
+_DEFINED = re.compile(r"^\s*class\s+([A-Za-z0-9_]+)\s*[(:]", re.MULTILINE)
+
+
+def _spec_text() -> str:
+    return SPEC.read_text(encoding="utf-8")
+
+
+def _resolvable_names() -> set[str]:
+    """Every schema class importable from ``app.schemas``."""
+    import app.schemas as schemas_package
+
+    names: set[str] = set()
+    for module_info in pkgutil.walk_packages(
+        schemas_package.__path__, schemas_package.__name__ + "."
+    ):
+        try:
+            module = importlib.import_module(module_info.name)
+        except Exception:  # pragma: no cover - an unimportable module is its own bug
+            continue
+        names.update(vars(module))
+    return names
+
+
+def _referenced_but_not_defined() -> list[str]:
+    text = _spec_text()
+    defined = set(_DEFINED.findall(text))
+    return sorted({name for name in _NAME.findall(text)} - defined)
+
+
+def test_the_scan_finds_names_to_check() -> None:
+    """Guard the guard: an empty scan would pass the real test vacuously.
+
+    The assertion below is over whatever this returns, so a regex that stopped
+    matching — or a spec that moved — would report success having checked
+    nothing.
+    """
+    assert SPEC.is_file(), f"{SPEC} is missing; the spec moved and this guard did not"
+    referenced = _referenced_but_not_defined()
+    # 17 when this guard was written (33 schema-shaped names in the spec, minus
+    # the 16 it declares for itself). The floor is set below that rather than at
+    # it, so ordinary editing does not trip it, but a scan that broke — a moved
+    # spec, a regex that stopped matching, a change to how the spec fences its
+    # code — collapses well past it.
+    assert len(referenced) >= 12, (
+        f"Only {len(referenced)} referenced schema names found in the spec, against "
+        f"17 when this guard was written. The scan has probably broken rather than "
+        f"the spec having shrunk that far."
+    )
+
+
+@pytest.mark.parametrize("name", _referenced_but_not_defined())
+def test_a_referenced_schema_name_resolves(name: str) -> None:
+    """Every class the spec cites must exist somewhere under ``app.schemas``."""
+    assert name in _resolvable_names(), (
+        f"{SPEC.name} references '{name}', which is not a class anywhere under "
+        f"app.schemas. Either it was renamed and the spec was not updated, or the "
+        f"spec is proposing it — in which case declare it in a code block in the "
+        f"spec, which is how this guard tells a proposal from a stale reference."
+    )

--- a/backend/tests/scripts/test_read_spec_names_resolve.py
+++ b/backend/tests/scripts/test_read_spec_names_resolve.py
@@ -67,7 +67,7 @@ def _resolvable_names() -> set[str]:
 def _referenced_but_not_defined() -> list[str]:
     text = _spec_text()
     defined = set(_DEFINED.findall(text))
-    return sorted({name for name in _NAME.findall(text)} - defined)
+    return sorted(set(_NAME.findall(text)) - defined)
 
 
 def test_the_scan_finds_names_to_check() -> None:


### PR DESCRIPTION
Closes #135 and #144.

## Two documents naming classes that do not exist

**`backend/docs/specs/scientific_calculation_reads.md`** annotated three fields as `CalculationResultSPSummary` / `…OptSummary` / `…FreqSummary`. The real classes transpose the words — `CalculationSPResultSummary`, `CalculationOptResultSummary`, `CalculationFreqResultSummary`. #135 reported only the `freq` one; **all three were wrong.** This is the spec `CLAUDE.md` routes people to for calculation reads.

**`backend/app/schemas/entities/calculation.py:558`** cited `CalculationSCFStabilityCreate`, which exists nowhere. The validators it means live on `SCFStabilityContent` in the wire package — `validate_status_consistency`, cross-checking `status` against `instability_count` and the reoptimisation flag. Worse than the first: it is a Pydantic docstring, so it renders into the OpenAPI description and is served. A client generator or an LLM agent reading the schema was told to use a class the API has never had.

## The guard, and why it needs a distinction

`backend/tests/scripts/test_read_spec_names_resolve.py`.

This spec does two things at once: it **declares** shapes it is asking for (`class CalculationsSearchResponse(BaseModel):` and fifteen others) and it **references** shapes that already exist. Requiring every name to resolve fails on the proposals; exempting every unresolved name checks nothing.

So: a name the spec **defines** in one of its own code blocks is exempt; a name it merely **references** must resolve to a class under `app.schemas`. That is precisely the distinction that catches this failure — all three stale names appeared only as field annotations, never as definitions.

Two prose fragments were **spelled in full rather than exempted**: `CalculationSPResultRead/OptResultRead/FreqResultRead` is shorthand for three real classes, and the slash-separated tails are not names. Writing them out removes an allowlist entry and makes the sentence clearer — the better trade than an exemption with a reason.

## Verification

| check | result |
|---|---|
| guard passes on the fixed tree | 18 passed |
| reintroduce `CalculationResultFreqSummary` | fails, naming it |
| scan-found-something floor | 12, against 17 measured |

The floor sits below the measured count rather than at it, so ordinary editing does not trip it while a broken scan — moved spec, regex that stopped matching, changed fencing — collapses well past it. Every other assertion is parametrised over that scan, so without this test an empty result would pass everything.

## Note

The scan is scoped to this one spec. Generalising it to every doc under `backend/docs/specs/` is a reasonable follow-up but a larger blast radius, and worth doing only once someone has looked at what it would flag.