### PR TITLE
Refuse to invent an error code, and name the refusals that had none

### DIFF
--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -14,8 +14,10 @@ Three ways a ``code`` can be found, in descending order of trust
    ``.code`` as an attribute. Nothing is parsed. This is the mechanism
    every scientific refusal uses, and the only one a new one should.
 2. **A legacy ``"code: message"`` detail**, promoted by :func:`detail_code`.
-3. **A nested ``code:`` inside a framework-generated validation message**,
-   promoted by :func:`validation_detail_code`.
+3. **The same legacy convention, one layer down** — a message that
+   *begins* with ``"code: "`` but which a framework has wrapped in its own
+   sentence (``"Value error, invalid_handle: …"``) or buried in a list of
+   validation failures. Promoted by :func:`validation_detail_code`.
 
 (2) and (3) read English, and reading English is how a code silently stops
 being reported when somebody rewords a sentence — which is exactly what had
@@ -24,6 +26,32 @@ happened to the parenthesised convention the scientific checks used to use
 colon, so those codes matched nothing and every chemistry refusal reached
 its client as the generic ``validation_error``. They are kept because
 existing details are a published surface, not because they are a good idea.
+
+What "declared" means for (3), and why it had to be narrowed
+------------------------------------------------------------
+(3) used to promote *any* ``snake_case_token: `` appearing anywhere in a
+message. The house style for a workflow refusal is
+``raise ValueError(f"{context}: <prose>")`` where ``context`` is a **field
+path**, so a path ending in a field name — ``source_calculations[0].
+existing_calculation_id`` — put that field name in front of a colon and
+the envelope advertised ``code="existing_calculation_id"``. That is worse
+than no code: ``validation_error`` is honestly generic, whereas a
+fabricated code looks real, so a client branches on a string that was
+never a contract and that moves the moment somebody renames a field or
+rewords a sentence.
+
+The rule is now positional, because *position is the declaration*. A code
+is a token the raiser wrote in the **code position** — the very start of
+its own message, which is exactly what convention (2) means by
+``"code: message"`` — and (3) is that same test applied underneath a
+framework wrapper. A token that merely occurs mid-sentence is prose, and
+prose is not promoted.
+
+The narrowing is deliberately one-way. The ambiguity check still runs on
+the *unfiltered* candidate set, so a message containing two tokens keeps
+falling back exactly as it did; the position test can only turn a promoted
+token into the generic fallback, never turn a fallback into a new code.
+No response gains a code it did not already have.
 """
 
 from __future__ import annotations
@@ -35,6 +63,34 @@ from typing import Any
 from tckdb_schemas.coded_error import CodedValidationError
 
 _NESTED_CODE_PATTERN = re.compile(r"(?<![a-z0-9_])([a-z][a-z0-9_]*_[a-z0-9_]+): ")
+
+#: The same token, but only where the message *starts* with it -- the code
+#: position of the ``"code: message"`` convention.
+_CODE_POSITION_PATTERN = re.compile(r"^([a-z][a-z0-9_]*_[a-z0-9_]+): ")
+
+#: Sentences a framework puts in front of an exception's own message.
+#: Pydantic v2 renders a ``ValueError`` raised inside a validator as
+#: ``"Value error, <str(exc)>"`` and an ``AssertionError`` as
+#: ``"Assertion failed, <str(exc)>"``. Stripping exactly these -- not "any
+#: leading words" -- is what lets the code position be recognised one layer
+#: down without turning the test back into "somewhere in the sentence".
+_FRAMEWORK_MESSAGE_PREFIXES = ("Value error, ", "Assertion failed, ")
+
+
+def _code_position_token(text: str) -> str | None:
+    """The code *text* declares as its own, or ``None``.
+
+    A code is declared by being written where a code goes: first, followed
+    by ``": "``. Anything else in the sentence is prose that happens to
+    contain an underscore.
+    """
+
+    for prefix in _FRAMEWORK_MESSAGE_PREFIXES:
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+            break
+    match = _CODE_POSITION_PATTERN.match(text)
+    return match.group(1) if match else None
 
 
 def _json_safe(obj: Any) -> Any:
@@ -140,7 +196,11 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
     """Promote one unambiguous validation code.
 
     Prefers a code the raising exception *declared* (see
-    :func:`_declared_errors`) over one spelled inside a message.
+    :func:`_declared_errors`) over one spelled inside a message. A code
+    spelled inside a message counts only where it is spelled in the **code
+    position** (see :func:`_code_position_token` and the module docstring);
+    a ``snake_case`` token found mid-sentence is a field path or a
+    quantity, not a contract.
     """
 
     # Pydantic/FastAPI expose the independent validation failures as the
@@ -160,12 +220,16 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
         return fallback
 
     candidates: set[str] = set()
+    in_code_position: set[str] = set()
 
     def collect_message(value: object) -> None:
         if isinstance(value, BaseException):
             value = str(value)
         if isinstance(value, str):
             candidates.update(_NESTED_CODE_PATTERN.findall(value))
+            declared = _code_position_token(value)
+            if declared is not None:
+                in_code_position.add(declared)
 
     def collect(value: object) -> None:
         if isinstance(value, dict):
@@ -184,8 +248,14 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
             collect_message(value)
 
     collect(detail)
+    # Ambiguity is judged on everything the pattern found, before the
+    # position test narrows it: a message carrying two tokens fell back
+    # before this rule existed and must keep falling back, so that
+    # tightening the rule can never *add* a code to a published response.
     if len(candidates) == 1:
-        return candidates.pop()
+        token = candidates.pop()
+        if token in in_code_position:
+            return token
     return fallback
 
 

--- a/backend/app/services/calculation_ownership.py
+++ b/backend/app/services/calculation_ownership.py
@@ -1,0 +1,164 @@
+"""One owner-consistency rule, for every product that cites a calculation.
+
+What the rule is
+----------------
+A scientific product — a thermo record, a statmech record, a transport
+record, an applied energy correction — cites the calculations that produced
+its numbers. Those calculations must belong to the *same subject* the
+product is about. A thermo record for propane citing a calculation of
+water is not a weaker link; it is a meaningless one, and no correct deposit
+can produce it, so ADR 0008 puts the refusal in the ``block`` tier.
+
+Why it lives here
+-----------------
+The rule was written five times: once in ``app.workflows.thermo``, once in
+``app.workflows.transport``, once in ``app.services.statmech_resolution``
+(moved there by #157) and twice more inline in the two bundle workflows,
+each spelling the same comparison and each phrasing the refusal
+differently. Only the thermo copy was pinned by a test, so the other four
+could drift without anything going red — and they had already drifted:
+thermo's copy logged nothing, so the row ids an operator needs to diagnose
+a cross-owner link existed for statmech and transport and not for thermo.
+
+One implementation cannot drift. What varies between the products is what
+they *call* the offence, and that stays a parameter: a client repairing a
+thermo link and a client repairing a torsion's scan link are doing
+different things, so they get different codes (#158).
+
+What never appears in the refusal
+---------------------------------
+Row ids. ``context`` names the offending field the way the depositor wrote
+it, which is the identifier they can act on; the ids of the rows that
+disagreed go to the log, where the operator is (DR-0028 Requirement 2).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.api.error_contract import CodedValueError
+from app.db.models.calculation import Calculation
+
+logger = logging.getLogger(__name__)
+
+#: A thermo source link cites a calculation owned by another subject.
+#:
+#: Deliberately distinct from the statmech and transport codes, and from
+#: ``thermo_source_role_type_mismatch``: "you cited someone else's
+#: calculation" and "you gave this calculation the wrong role" are
+#: different repairs, and so are the same mistake made about an enthalpy
+#: and about a partition function.
+W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH = (
+    "thermo_source_calculation_owner_mismatch"
+)
+
+#: A statmech source link cites a calculation owned by another subject.
+W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH = (
+    "statmech_source_calculation_owner_mismatch"
+)
+
+#: A statmech torsion names a scan calculation owned by another subject.
+#: Separate from the statmech source-link code because the torsion's scan
+#: is a different field with a different repair — the depositor picked the
+#: wrong rotor scan, not the wrong supporting job.
+W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH = (
+    "statmech_torsion_scan_calculation_owner_mismatch"
+)
+
+#: A transport source link cites a calculation owned by another subject.
+W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH = (
+    "transport_source_calculation_owner_mismatch"
+)
+
+#: An applied energy correction names a source calculation owned by
+#: another subject.
+W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH = (
+    "applied_energy_correction_source_calculation_owner_mismatch"
+)
+
+
+def assert_calculation_owned_by(
+    calculation: Calculation,
+    *,
+    code: str,
+    target: str,
+    context: str,
+    species_entry_id: int | None = None,
+    transition_state_entry_id: int | None = None,
+) -> None:
+    """Refuse a supporting calculation that belongs to another subject.
+
+    :param calculation: The resolved calculation row the deposit cites.
+    :param code: The machine-readable code this refusal reports; one of
+        the ``W_*`` constants in this module. Passed rather than derived
+        because the subject is what a client tells apart.
+    :param target: The record the calculation was cited by, named the way
+        a depositor would say it (``"thermo"``, ``"statmech torsion"``).
+        Appears in the sentence, never in the code.
+    :param context: Field path naming the offending link, echoed verbatim.
+    :param species_entry_id: The species entry the target belongs to, or
+        ``None`` when the target is not a species record.
+    :param transition_state_entry_id: The transition-state entry the
+        target belongs to, or ``None``.
+    :raises CodedValueError: if the calculation belongs to a different
+        subject than the one(s) supplied.
+    :raises ValueError: if neither owner id is supplied. A check with
+        nothing to compare against would pass for every input, which is
+        the one failure mode a defensive guard must not have.
+    """
+    if species_entry_id is None and transition_state_entry_id is None:
+        raise ValueError(
+            "assert_calculation_owned_by was given neither a species entry "
+            "nor a transition state entry to check against; such a call "
+            "would accept every calculation and guard nothing."
+        )
+
+    if species_entry_id is not None and (
+        calculation.species_entry_id != species_entry_id
+    ):
+        owner_noun = "species entry"
+        expected: int = species_entry_id
+        actual = calculation.species_entry_id
+    elif transition_state_entry_id is not None and (
+        calculation.transition_state_entry_id != transition_state_entry_id
+    ):
+        owner_noun = "transition state entry"
+        expected = transition_state_entry_id
+        actual = calculation.transition_state_entry_id
+    else:
+        return
+
+    # ``context`` already names the calculation the way the depositor wrote
+    # it, which is the identifier they can act on. The row ids go to the
+    # log instead -- a 422 body must not hand out primary keys.
+    logger.warning(
+        "%s: calculation id=%s is owned by %s=%s, not %s (target=%s)",
+        context,
+        calculation.id,
+        owner_noun.replace(" ", "_") + "_id",
+        actual,
+        expected,
+        target,
+    )
+    raise CodedValueError(
+        code,
+        f"{context}: this calculation belongs to another {owner_noun}, not "
+        f"to the {target} target. A supporting calculation must be one of "
+        f"the target {owner_noun}'s own.",
+        context={
+            "field": context,
+            "target": target,
+            "owner_kind": owner_noun.replace(" ", "_"),
+        },
+        message_prefix=False,
+    )
+
+
+__all__ = [
+    "W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH",
+    "W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH",
+    "W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH",
+    "W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH",
+    "W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH",
+    "assert_calculation_owned_by",
+]

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -41,6 +41,10 @@ from app.db.models.statmech import (
     StatmechTorsionDefinition,
 )
 from app.schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
+from app.services.calculation_ownership import (
+    W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.calculation_resolution import resolve_workflow_tool_release_ref
 from app.services.energy_correction_resolution import resolve_or_create_freq_scale_factor_ref
 from app.services.literature_resolution import resolve_or_create_literature
@@ -137,60 +141,6 @@ def _chained_calculation_id(source: object) -> int | None:
     return value if isinstance(value, int) else None
 
 
-def assert_statmech_calculation_owned_by(
-    calculation: Calculation,
-    *,
-    species_entry_id: int,
-    context: str,
-) -> None:
-    """Refuse a supporting calculation belonging to another species entry.
-
-    Supporting calculations attached to a statmech record must belong to
-    the same species entry as the statmech target; otherwise the
-    provenance link is scientifically meaningless — the record would cite
-    evidence about a different molecule.
-
-    Lives here rather than in ``app.workflows.statmech`` because the two
-    ways of naming a calculation must be judged by the same code. For an
-    inline calculation the check is defensive (the workflow persists it
-    against the target's own species entry, so it cannot fail); for an
-    ``existing_calculation_id`` it is the real thing, because a chained id
-    can name any row in the database.
-
-    :raises ValueError: if the calculation does not belong to
-        ``species_entry_id``. Surfaces as HTTP 422 with the generic
-        ``validation_error`` code — the same envelope this violation
-        already produces on the inline path.
-    """
-    if calculation.species_entry_id == species_entry_id:
-        return
-    # ``context`` already names the calculation the way the depositor
-    # wrote it, which is the identifier they can act on. The row ids go to
-    # the log instead — a 422 body must not hand out primary keys.
-    logger.warning(
-        "%s: calculation id=%s owned by species_entry_id=%s, not %s",
-        context,
-        calculation.id,
-        calculation.species_entry_id,
-        species_entry_id,
-    )
-    # Deliberately *not* "{context}: ...". An uncoded ValueError has its
-    # code scraped out of the message by ``validation_detail_code``, whose
-    # pattern matches any ``snake_case_token: `` — so a field path ending
-    # in ``existing_calculation_id`` followed by a colon is promoted to
-    # ``code="existing_calculation_id"``, which is not a code at all and
-    # is not in any register a client could branch on. Phrasing the field
-    # path as the sentence's subject keeps this on the honest generic
-    # ``validation_error``, which is what the inline path already returns.
-    # (Thermo's equivalent refusal still emits the scraped string; see
-    # ``app/workflows/thermo.py`` ``_assert_calculation_owned_by``.)
-    raise ValueError(
-        f"{context} refers to a calculation that belongs to another "
-        "species entry, not to the statmech target. A supporting "
-        "calculation must be one of the target species entry's own."
-    )
-
-
 def _resolve_existing_calculation(
     session: Session,
     calculation_id: int,
@@ -216,10 +166,12 @@ def _resolve_existing_calculation(
         raise NotFoundError(
             f"{context} refers to a calculation that does not exist."
         )
-    assert_statmech_calculation_owned_by(
+    assert_calculation_owned_by(
         calculation,
-        species_entry_id=species_entry_id,
+        code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+        target="statmech",
         context=context,
+        species_entry_id=species_entry_id,
     )
     return calculation
 

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -45,6 +45,10 @@ from app.schemas.workflows.computed_reaction_upload import (
     calculation_in_to_with_results_payload,
 )
 from app.services.artifact_persistence import persist_artifact
+from app.services.calculation_ownership import (
+    W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.calculation_parameter_extraction import (
     try_extract_parameters_from_input_upload,
 )
@@ -915,13 +919,16 @@ def persist_computed_reaction_upload(
             for index, sc in enumerate(t.source_calculations):
                 source_calc_id = calculation_key_to_id[sc.calculation_key]
                 source_calc = session.get(Calculation, source_calc_id)
-                if source_calc.species_entry_id != species_entry.id:
-                    raise ValueError(
+                assert_calculation_owned_by(
+                    source_calc,
+                    code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+                    target="thermo",
+                    context=(
                         f"species[{sp.key!r}].thermo.source_calculations"
-                        f"[{index}].calculation_key="
-                        f"'{sc.calculation_key}': refers to a calculation "
-                        f"that is not owned by this species entry."
-                    )
+                        f"[{index}].calculation_key='{sc.calculation_key}'"
+                    ),
+                    species_entry_id=species_entry.id,
+                )
                 assert_thermo_role_matches_calculation_type(
                     source_calc,
                     role=sc.role,

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -47,6 +47,13 @@ from app.services.artifact_persistence import (
     persist_artifact_batch,
     validate_and_decode_all_artifacts,
 )
+from app.services.calculation_ownership import (
+    W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH,
+    W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.calculation_parameter_extraction import (
     try_extract_parameters_from_input_upload,
 )
@@ -725,12 +732,16 @@ def _persist_thermo_block(
     resolved_sources: list[ThermoSourceCalculationCreate] = []
     for sc in thermo_in.source_calculations:
         calc_row = calc_keys_to_id[sc.calculation_key]
-        if calc_row.species_entry_id != species_entry_id:
-            raise ValueError(
+        assert_calculation_owned_by(
+            calc_row,
+            code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="thermo",
+            context=(
                 f"thermo.source_calculations calculation_key="
-                f"'{sc.calculation_key}': refers to a calculation owned "
-                f"by a different species entry."
-            )
+                f"'{sc.calculation_key}'"
+            ),
+            species_entry_id=species_entry_id,
+        )
         assert_thermo_role_matches_calculation_type(
             calc_row,
             role=sc.role,
@@ -765,12 +776,16 @@ def _persist_thermo_block(
         source_calc_id: int | None = None
         if ac.source_calculation_key is not None:
             calc_row = calc_keys_to_id[ac.source_calculation_key]
-            if calc_row.species_entry_id != species_entry_id:
-                raise ValueError(
+            assert_calculation_owned_by(
+                calc_row,
+                code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+                target="applied energy correction",
+                context=(
                     f"thermo.applied_energy_corrections[{i}]."
-                    f"source_calculation_key='{ac.source_calculation_key}': "
-                    f"refers to a calculation owned by a different species entry."
-                )
+                    f"source_calculation_key='{ac.source_calculation_key}'"
+                ),
+                species_entry_id=species_entry_id,
+            )
             source_calc_id = calc_row.id
 
         applied = create_applied_energy_correction(
@@ -812,12 +827,16 @@ def _persist_top_level_applied_corrections(
         source_calc_id: int | None = None
         if ac.source_calculation_key is not None:
             calc_row = calc_keys_to_id[ac.source_calculation_key]
-            if calc_row.species_entry_id != species_entry_id:
-                raise ValueError(
+            assert_calculation_owned_by(
+                calc_row,
+                code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+                target="applied energy correction",
+                context=(
                     f"applied_energy_corrections[{i}]."
-                    f"source_calculation_key='{ac.source_calculation_key}': "
-                    f"refers to a calculation owned by a different species entry."
-                )
+                    f"source_calculation_key='{ac.source_calculation_key}'"
+                ),
+                species_entry_id=species_entry_id,
+            )
             source_calc_id = calc_row.id
 
         applied = create_applied_energy_correction(
@@ -920,14 +939,17 @@ def _persist_statmech_block(
 
     for sc in s.source_calculations:
         calc_row = calc_keys_to_id[sc.calculation_key]
-        if (
-            (species_entry_id is not None and calc_row.species_entry_id != species_entry_id)
-            or (transition_state_entry_id is not None and calc_row.transition_state_entry_id != transition_state_entry_id)
-        ):
-            raise ValueError(
+        assert_calculation_owned_by(
+            calc_row,
+            code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="statmech",
+            context=(
                 f"statmech.source_calculations calculation_key="
-                f"'{sc.calculation_key}': refers to a calculation owned by a different subject."
-            )
+                f"'{sc.calculation_key}'"
+            ),
+            species_entry_id=species_entry_id,
+            transition_state_entry_id=transition_state_entry_id,
+        )
         # The third statmech write path, and the third to need DR-0028
         # Requirement 1: a declared role must match the type of the job it
         # names. Shared with the conformer and standalone paths through
@@ -952,15 +974,17 @@ def _persist_statmech_block(
         scan_calc_id: int | None = None
         if torsion_in.source_scan_calculation_key is not None:
             scan_calc_row = calc_keys_to_id[torsion_in.source_scan_calculation_key]
-            if (
-                (species_entry_id is not None and scan_calc_row.species_entry_id != species_entry_id)
-                or (transition_state_entry_id is not None and scan_calc_row.transition_state_entry_id != transition_state_entry_id)
-            ):
-                raise ValueError(
+            assert_calculation_owned_by(
+                scan_calc_row,
+                code=W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH,
+                target="statmech torsion",
+                context=(
                     f"statmech.torsions source_scan_calculation_key="
-                    f"'{torsion_in.source_scan_calculation_key}': refers to a "
-                    f"calculation owned by a different subject."
-                )
+                    f"'{torsion_in.source_scan_calculation_key}'"
+                ),
+                species_entry_id=species_entry_id,
+                transition_state_entry_id=transition_state_entry_id,
+            )
             scan_calc_id = scan_calc_row.id
 
         torsion = StatmechTorsion(

--- a/backend/app/workflows/statmech.py
+++ b/backend/app/workflows/statmech.py
@@ -18,6 +18,10 @@ from app.db.models.common import SubmissionRecordType
 from app.db.models.statmech import Statmech
 from app.schemas.workflows.conformer_upload import ConformerUploadStatmechPayload
 from app.schemas.workflows.statmech_upload import StatmechUploadRequest
+from app.services.calculation_ownership import (
+    W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
 )
@@ -27,21 +31,9 @@ from app.services.record_review import (
     apply_review_policy,
 )
 from app.services.species_resolution import resolve_species_entry
-from app.services.statmech_resolution import (
-    assert_statmech_calculation_owned_by,
-    resolve_or_create_statmech,
-)
+from app.services.statmech_resolution import resolve_or_create_statmech
 
 logger = logging.getLogger(__name__)
-
-
-#: Owner-consistency for a statmech supporting calculation. The body moved
-#: to :mod:`app.services.statmech_resolution` when the standalone upload
-#: gained ``existing_calculation_id``: a chained citation can name any row
-#: in the database, so this stopped being a purely defensive check and had
-#: to be judged by the same code that judges the inline path. Re-exported
-#: under the old name so the inline call site below reads unchanged.
-_assert_calculation_owned_by = assert_statmech_calculation_owned_by
 
 
 def persist_statmech_upload(
@@ -92,10 +84,12 @@ def persist_statmech_upload(
             species_entry_id=species_entry.id,
             created_by=created_by,
         )
-        _assert_calculation_owned_by(
+        assert_calculation_owned_by(
             calc_row,
-            species_entry_id=species_entry.id,
+            code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="statmech",
             context=f"statmech calculation '{calc_in.key}'",
+            species_entry_id=species_entry.id,
         )
         calculations_by_key[calc_in.key] = calc_row
 

--- a/backend/app/workflows/thermo.py
+++ b/backend/app/workflows/thermo.py
@@ -21,6 +21,11 @@ from app.schemas.workflows.thermo_upload import (
     ThermoSourceCalculationIn,
     ThermoUploadRequest,
 )
+from app.services.calculation_ownership import (
+    W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
 )
@@ -60,29 +65,6 @@ _THERMO_ROLE_TO_CALC_TYPES: dict[
     ThermoCalculationRole.freq: (CalculationType.freq,),
     ThermoCalculationRole.sp: (CalculationType.sp, CalculationType.opt),
 }
-
-
-def _assert_calculation_owned_by(
-    calculation: Calculation,
-    *,
-    species_entry_id: int,
-    context: str,
-) -> None:
-    """Defensive owner-consistency check for a resolved source calculation.
-
-    Supporting calculations attached to a thermo record must belong to the
-    same species entry as the thermo target; otherwise the provenance link
-    would be scientifically meaningless.
-
-    :raises ValueError: if the calculation does not belong to
-        ``species_entry_id``. The error detail names the field that was
-        wrong but does not leak internal row identifiers (DR-0028 Req 2).
-    """
-    if calculation.species_entry_id != species_entry_id:
-        raise ValueError(
-            f"{context}: refers to a calculation owned by a different "
-            f"species entry."
-        )
 
 
 def assert_thermo_role_matches_calculation_type(
@@ -181,10 +163,12 @@ def _resolve_source_calculation(
                 f"calculation that does not exist."
             )
         context = f"{field_path}.existing_calculation_id"
-        _assert_calculation_owned_by(
+        assert_calculation_owned_by(
             calc_row,
-            species_entry_id=species_entry_id,
+            code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="thermo",
             context=context,
+            species_entry_id=species_entry_id,
         )
 
     assert_thermo_role_matches_calculation_type(
@@ -263,10 +247,12 @@ def persist_thermo_upload(
             species_entry_id=species_entry.id,
             created_by=created_by,
         )
-        _assert_calculation_owned_by(
+        assert_calculation_owned_by(
             calc_row,
-            species_entry_id=species_entry.id,
+            code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="thermo",
             context=f"thermo calculation '{calc_in.key}'",
+            species_entry_id=species_entry.id,
         )
         calculations_by_key[calc_in.key] = calc_row
 
@@ -332,13 +318,15 @@ def persist_thermo_upload(
                     f"'{correction_payload.source_calculation_key}' did not "
                     f"resolve to a declared calculation."
                 )
-            _assert_calculation_owned_by(
+            assert_calculation_owned_by(
                 calc_row,
-                species_entry_id=species_entry.id,
+                code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+                target="applied energy correction",
                 context=(
                     "applied_energy_correction "
                     f"source_calculation_key='{correction_payload.source_calculation_key}'"
                 ),
+                species_entry_id=species_entry.id,
             )
             source_calc_id = calc_row.id
 

--- a/backend/app/workflows/transport.py
+++ b/backend/app/workflows/transport.py
@@ -11,6 +11,10 @@ from app.db.models.common import SubmissionRecordType
 from app.db.models.transport import Transport
 from app.schemas.entities.transport import TransportSourceCalculationCreate
 from app.schemas.workflows.transport_upload import TransportUploadRequest
+from app.services.calculation_ownership import (
+    W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
 )
@@ -23,40 +27,6 @@ from app.services.species_resolution import resolve_species_entry
 from app.services.transport_resolution import resolve_and_create_transport
 
 logger = logging.getLogger(__name__)
-
-
-def _assert_calculation_owned_by(
-    calculation: Calculation,
-    *,
-    species_entry_id: int,
-    context: str,
-) -> None:
-    """Defensive owner-consistency check for a resolved source calculation.
-
-    Supporting calculations attached to a transport record must belong to
-    the same species entry as the transport target; otherwise the
-    provenance link would be scientifically meaningless.
-
-    :raises ValueError: if the calculation does not belong to
-        ``species_entry_id``.
-    """
-    if calculation.species_entry_id != species_entry_id:
-        # ``context`` already names the calculation by the caller's own key,
-        # which is the identifier they can act on. The three row ids this
-        # message used to interpolate are internal handles that go to the
-        # log instead — a 422 body must not hand out primary keys.
-        logger.warning(
-            "%s: calculation id=%s owned by species_entry_id=%s, not %s",
-            context,
-            calculation.id,
-            calculation.species_entry_id,
-            species_entry_id,
-        )
-        raise ValueError(
-            f"{context}: this calculation belongs to another species entry, "
-            "not to the transport target. A supporting calculation must be one "
-            "of the target species entry's own."
-        )
 
 
 def persist_transport_upload(
@@ -100,10 +70,12 @@ def persist_transport_upload(
             species_entry_id=species_entry.id,
             created_by=created_by,
         )
-        _assert_calculation_owned_by(
+        assert_calculation_owned_by(
             calc_row,
-            species_entry_id=species_entry.id,
+            code=W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="transport",
             context=f"transport calculation '{calc_in.key}'",
+            species_entry_id=species_entry.id,
         )
         calculations_by_key[calc_in.key] = calc_row
 

--- a/backend/tests/api/test_api_bundle_thermo_and_scf_provenance.py
+++ b/backend/tests/api/test_api_bundle_thermo_and_scf_provenance.py
@@ -296,8 +296,12 @@ def test_reaction_bundle_thermo_source_must_belong_to_its_own_species(client):
     }
 
     resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
-    assert resp.status_code != 201, resp.text[:800]
-    assert "not owned by this species entry" in resp.text
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    # #158: the same rule the standalone thermo route enforces, reported
+    # under the same code -- the reaction bundle is not a second contract.
+    assert body["code"] == "thermo_source_calculation_owner_mismatch", body
+    assert "another species entry" in body["detail"]
 
 
 def test_reaction_bundle_thermo_source_key_must_exist(client):

--- a/backend/tests/api/test_api_upload_computed_species.py
+++ b/backend/tests/api/test_api_upload_computed_species.py
@@ -230,12 +230,36 @@ class TestValidationRejections:
         assert resp.status_code == 422
 
     def test_existing_calculation_id_in_parameters_json_rejected(self, client):
+        """The second site #161 was really about.
+
+        The refusal names the offending key at the end of a dotted path, so
+        the envelope's message scraper used to promote *that key* as the
+        response's ``code``: this route advertised
+        ``code="existing_calculation_id"``, a string in no register and in
+        no generated client constant. The refusal is legitimate; the code
+        was invented. It is now the honest generic one.
+
+        The substring assertion below is deliberately not the load-bearing
+        one -- Pydantic echoes rejected input into its own message, so
+        ``"existing_calculation_id" in resp.text`` would also be true if
+        the field had been wrongly *accepted*. Type and location are what
+        prove the refusal happened.
+        """
         payload = _hydrogen_bundle_payload()
         payload["conformers"][0]["primary_calculation"]["parameters_json"] = {
             "tckdb_origin": {"existing_calculation_id": 99}
         }
         resp = client.post("/api/v1/uploads/computed-species", json=payload)
         assert resp.status_code == 422
+        body = resp.json()
+        assert body["code"] == "request_validation_error", body
+        assert body["code"] != "existing_calculation_id", body
+        assert any(
+            d["type"] == "value_error"
+            and tuple(d["loc"])[:4]
+            == ("body", "conformers", 0, "primary_calculation")
+            for d in body["detail"]
+        ), body["detail"]
         assert "existing_calculation_id" in resp.text
 
     def test_empty_conformers_returns_422(self, client):

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -795,21 +795,16 @@ class TestChainedCitationPassesEveryCheckALocalOneDoes:
         """A chained id can name *any* row, so owner-consistency stops
         being defensive here and becomes the real check.
 
-        The refusal is a bare ``ValueError`` → HTTP 422 carrying the
-        generic ``validation_error`` code, which is what the same
-        violation produces on the inline path. That it has no *specific*
-        code is tracked as #158.
-
-        ``code`` is asserted here for a reason that is easy to lose. An
-        uncoded ``ValueError`` has its code scraped out of the message by
-        ``validation_detail_code``, whose pattern promotes any
-        ``snake_case_token: ``. Phrase this refusal as ``f"{context}: …"``
-        with a field path ending in ``existing_calculation_id`` and the
-        response advertises ``code="existing_calculation_id"`` — a string
-        that is not a code, is in no register, and would invite a client
-        to branch on it. This test is what stops that phrasing coming
-        back. (Thermo's equivalent refusal still emits the scraped
-        string; ``app/workflows/thermo.py`` ``_assert_calculation_owned_by``.)
+        The refusal declares ``statmech_source_calculation_owner_mismatch``
+        (#158). It used to be a bare ``ValueError``, and it was phrased
+        without the house-style colon on purpose: an uncoded ``ValueError``
+        had its code scraped out of the message by
+        ``validation_detail_code``, which promoted any ``snake_case_token:
+        `` — so ``f"{context}: …"`` with a field path ending in
+        ``existing_calculation_id`` made *that field name* the advertised
+        code. #161 fixed the envelope (only a token in the code position is
+        promoted) and #158 gave this refusal a real code, so the sentence
+        no longer has to be written around the parser.
         """
         other = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
         a = _deposit_calculations(client, label="chain-owner", species=other)
@@ -825,7 +820,9 @@ class TestChainedCitationPassesEveryCheckALocalOneDoes:
         )
         assert resp.status_code == 422, resp.text
         body = resp.json()
-        assert body["code"] == "validation_error", body
+        assert body["code"] == "statmech_source_calculation_owner_mismatch", body
+        # Never the field name the old scraper would have promoted.
+        assert body["code"] != "existing_calculation_id", body
         detail = body["detail"]
         assert "another species entry" in detail
         # No row id the depositor did not supply, and no id at all beyond

--- a/backend/tests/api/test_api_uploads.py
+++ b/backend/tests/api/test_api_uploads.py
@@ -487,6 +487,15 @@ class TestThermoUpload:
         assert "does not exist" in resp.json()["detail"]
 
     def test_existing_calc_wrong_species_entry_returns_422(self, client):
+        """A cross-owner chained citation is refused, under a real code.
+
+        This is the response #161 was about. The refusal used to be a bare
+        ``ValueError`` phrased ``f"{context}: …"`` where ``context`` ended
+        in ``existing_calculation_id``, and the envelope scraped that field
+        name out of the sentence and advertised it as ``code``. A client
+        could branch on a string that was never a contract and that moved
+        with any rewording. The code is now declared by the refusal.
+        """
         # Seed a calc owned by a CC species, then upload thermo for a
         # different species (H) that references it.
         _, calc_id = self._seed_calc(client, calc_type="sp")
@@ -500,8 +509,15 @@ class TestThermoUpload:
         }
         resp = client.post("/api/v1/uploads/thermo", json=payload)
         assert resp.status_code == 422, resp.text
-        detail = resp.json()["detail"]
-        assert "different species entry" in detail
+        body = resp.json()
+        assert body["code"] == "thermo_source_calculation_owner_mismatch", body
+        # The fabricated code must never come back: a field name is not a
+        # code, and no register or generated client constant holds it.
+        assert body["code"] != "existing_calculation_id", body
+        detail = body["detail"]
+        assert "another species entry" in detail
+        # The field the depositor wrote is still named, in context.
+        assert body["context"]["field"].endswith("existing_calculation_id")
         # No internal id values leaked.
         assert str(calc_id) not in detail
         assert "species_entry_id=" not in detail

--- a/backend/tests/api/test_error_contract_coded_promotion.py
+++ b/backend/tests/api/test_error_contract_coded_promotion.py
@@ -108,6 +108,95 @@ class TestPromotionIsTypedNotTextual:
         assert validation_detail_context(details) == {}
 
 
+class TestOnlyTheCodePositionDeclaresACode:
+    """#161: a field path that ends in a field name is not a code.
+
+    The house style for a workflow refusal is
+    ``raise ValueError(f"{context}: <prose>")`` with ``context`` a field
+    path. Before this rule, a path ending in ``existing_calculation_id``
+    put that field name in front of a colon and the envelope advertised it
+    as ``code`` — a string in no register, in no generated client
+    constant, that changes when somebody renames a field. That is worse
+    than an uncoded error: ``validation_error`` is honestly generic, a
+    fabricated code looks real.
+    """
+
+    def test_a_field_path_is_not_promoted(self):
+        message = (
+            "source_calculations[0].existing_calculation_id: refers to a "
+            "calculation owned by a different species entry."
+        )
+        assert (
+            validation_detail_code(message, fallback="validation_error")
+            == "validation_error"
+        )
+
+    def test_a_token_the_sentence_merely_mentions_is_not_promoted(self):
+        """The same defect, elsewhere: prose that names a column.
+
+        ``app/services/reaction_resolution.py`` refuses a reaction whose
+        family disagrees with the resolved one, and the sentence names the
+        column. That is prose about a field, not a declaration of a code.
+        """
+        message = (
+            "Resolved reaction already has a different reaction_family: "
+            "H_Abstraction != Disproportionation."
+        )
+        assert (
+            validation_detail_code(message, fallback="validation_error")
+            == "validation_error"
+        )
+
+    def test_a_code_written_in_the_code_position_is_still_promoted(self):
+        """The regression guard for the narrowing.
+
+        Every read-API refusal declares its code the legacy way, as the
+        leading ``"code: "`` of its own message. Twenty-four distinct codes
+        reach clients only through this path; tightening the rule must not
+        cost a single one of them.
+        """
+        message = "invalid_handle: 'not-a-handle' is not a <prefix>_<body> public ref"
+        assert (
+            validation_detail_code(message, fallback="validation_error")
+            == "invalid_handle"
+        )
+
+    def test_a_code_survives_pydantic_wrapping_its_sentence(self):
+        """A validator's ``ValueError`` reaches ``errors()`` as
+        ``"Value error, <message>"``. The code is still the first thing
+        the *raiser* wrote, so it is still in the code position."""
+        details = [
+            {
+                "type": "value_error",
+                "loc": ["body"],
+                "msg": (
+                    "Value error, pressure_alias_conflict: pressure_bar and "
+                    "deprecated pressure must agree."
+                ),
+            }
+        ]
+        assert (
+            validation_detail_code(details, fallback="request_validation_error")
+            == "pressure_alias_conflict"
+        )
+
+    def test_two_tokens_still_fall_back_exactly_as_before(self):
+        """The narrowing is one-way, and this is what pins that.
+
+        ``invalid_pagination: limit_too_large: …`` carries two tokens and
+        has always fallen back. Judging ambiguity *after* the position
+        filter would leave one survivor and promote it — turning a
+        published ``validation_error`` into a new code. Ambiguity is
+        therefore judged on the unfiltered set: the rule can only remove a
+        code, never add one.
+        """
+        message = "invalid_pagination: limit_too_large: limit must be <= 200 (got 500)"
+        assert (
+            validation_detail_code(message, fallback="validation_error")
+            == "validation_error"
+        )
+
+
 def _failure(code: str, field: str) -> dict:
     """One entry of a Pydantic ``errors()`` list, carrying a coded cause."""
     return {

--- a/backend/tests/api/test_error_contract_coded_promotion.py
+++ b/backend/tests/api/test_error_contract_coded_promotion.py
@@ -164,7 +164,18 @@ class TestOnlyTheCodePositionDeclaresACode:
     def test_a_code_survives_pydantic_wrapping_its_sentence(self):
         """A validator's ``ValueError`` reaches ``errors()`` as
         ``"Value error, <message>"``. The code is still the first thing
-        the *raiser* wrote, so it is still in the code position."""
+        the *raiser* wrote, so it is still in the code position.
+
+        Deliberately built without ``ctx``, and that is the whole point of
+        the case. Pydantic v2 *also* preserves the raw exception in
+        ``ctx["error"]``, whose ``str()`` carries no wrapper, so every live
+        route recovers its code from there and would keep working if the
+        prefix list were emptied — measured, not assumed (mutation M2b).
+        The prefix stripping is what stops the whole read API's twenty-four
+        codes depending on Pydantic continuing to hand over an exception
+        object: strip the context anywhere in front of this function and
+        ``msg`` is all that is left.
+        """
         details = [
             {
                 "type": "value_error",

--- a/backend/tests/invariants/test_structure_invariants.py
+++ b/backend/tests/invariants/test_structure_invariants.py
@@ -9,6 +9,8 @@ quietly.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -24,9 +26,13 @@ from app.schemas.fragments.geometry import GeometryPayload
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.workflows.reaction_upload import ReactionUploadRequest
 from app.schemas.workflows.thermo_upload import ThermoUploadRequest
+from app.services.calculation_ownership import (
+    W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.geometry_validation import validate_calculation_geometry
 from app.workflows.reaction import persist_reaction_upload
-from app.workflows.thermo import _assert_calculation_owned_by
 
 # ---------------------------------------------------------------------------
 # Invariant 1: geometry atom-count consistency
@@ -170,20 +176,27 @@ def test_reaction_upload_requires_at_least_one_participant_per_side() -> None:
 class _FakeCalc:
     """Minimal stand-in for a ``Calculation`` row for the guard test.
 
-    The workflow's owner-consistency check only reads ``id`` and
-    ``species_entry_id``; a full ORM row requires DB setup that adds no
-    signal to this invariant.
+    The owner-consistency check only reads ``id``, ``species_entry_id``
+    and ``transition_state_entry_id``; a full ORM row requires DB setup
+    that adds no signal to this invariant.
     """
 
-    def __init__(self, *, id: int, species_entry_id: int) -> None:
+    def __init__(
+        self,
+        *,
+        id: int,
+        species_entry_id: int | None = None,
+        transition_state_entry_id: int | None = None,
+    ) -> None:
         self.id = id
         self.species_entry_id = species_entry_id
+        self.transition_state_entry_id = transition_state_entry_id
 
 
-def test_thermo_workflow_rejects_calculation_owned_by_other_species() -> None:
-    """``_assert_calculation_owned_by`` is the defensive guard that
-    prevents a thermo upload from attaching a calculation belonging to
-    a different ``species_entry``.
+def test_owner_guard_rejects_calculation_owned_by_other_species() -> None:
+    """``assert_calculation_owned_by`` is the guard that prevents a
+    product from attaching a calculation belonging to a different
+    ``species_entry``.
 
     A silent regression here (e.g. flipped equality, or the guard being
     dropped during refactor) would let scientifically meaningless
@@ -192,17 +205,96 @@ def test_thermo_workflow_rejects_calculation_owned_by_other_species() -> None:
     calc = _FakeCalc(id=42, species_entry_id=7)
 
     # Same owner → no error.
-    _assert_calculation_owned_by(
-        calc, species_entry_id=7, context="same owner",  # type: ignore[arg-type]
+    assert_calculation_owned_by(
+        calc,  # type: ignore[arg-type]
+        code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+        target="thermo",
+        context="same owner",
+        species_entry_id=7,
     )
 
-    # Different owner → raise.
-    with pytest.raises(ValueError, match="different species entry"):
-        _assert_calculation_owned_by(
-            calc,
-            species_entry_id=8,  # type: ignore[arg-type]
+    # Different owner → raise, with the code and not a scraped field name.
+    with pytest.raises(ValueError, match="another species entry") as excinfo:
+        assert_calculation_owned_by(
+            calc,  # type: ignore[arg-type]
+            code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="thermo",
             context="cross-owner",
+            species_entry_id=8,
         )
+    assert excinfo.value.code == "thermo_source_calculation_owner_mismatch"
+
+
+def test_owner_guard_rejects_calculation_owned_by_other_ts_entry() -> None:
+    """The same guard, for the transition-state half of the relationship.
+
+    The bundle statmech path checks a transition-state entry rather than a
+    species entry, and before #162 that branch lived in its own inline
+    copy of the comparison. It is the same claim and now the same code.
+    """
+    calc = _FakeCalc(id=42, transition_state_entry_id=3)
+
+    assert_calculation_owned_by(
+        calc,  # type: ignore[arg-type]
+        code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+        target="statmech",
+        context="same owner",
+        transition_state_entry_id=3,
+    )
+
+    with pytest.raises(ValueError, match="another transition state entry"):
+        assert_calculation_owned_by(
+            calc,  # type: ignore[arg-type]
+            code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="statmech",
+            context="cross-owner",
+            transition_state_entry_id=4,
+        )
+
+
+def test_owner_guard_refuses_to_run_with_nothing_to_compare() -> None:
+    """A guard given no owner would accept every calculation.
+
+    The recurring defect in this area is a check that cannot fail. If both
+    owner ids are ``None`` the comparison is vacuous, so the call is a
+    programming error and says so, rather than silently passing.
+    """
+    calc = _FakeCalc(id=42, species_entry_id=7)
+
+    with pytest.raises(ValueError, match="guard nothing"):
+        assert_calculation_owned_by(
+            calc,  # type: ignore[arg-type]
+            code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+            target="thermo",
+            context="no owner supplied",
+        )
+
+
+def test_every_product_routes_its_owner_check_through_one_implementation() -> None:
+    """#162: the rule was written five times and pinned once.
+
+    Two of those copies had already drifted -- thermo's logged nothing
+    where statmech's and transport's logged the row ids an operator needs
+    -- and nothing went red, because only thermo's copy was covered. The
+    invariant is now the consolidation itself: no workflow may hold a
+    private owner-consistency comparison, and every module that needs one
+    must reach the shared implementation.
+    """
+    modules = [
+        "app/workflows/thermo.py",
+        "app/workflows/statmech.py",
+        "app/workflows/transport.py",
+        "app/workflows/computed_species.py",
+        "app/workflows/computed_reaction.py",
+        "app/services/statmech_resolution.py",
+    ]
+    root = Path(__file__).resolve().parents[2]
+    for relative in modules:
+        source = (root / relative).read_text()
+        assert "assert_calculation_owned_by" in source, relative
+        # The private per-product copies this consolidated (#162).
+        assert "def _assert_calculation_owned_by" not in source, relative
+        assert "def assert_statmech_calculation_owned_by" not in source, relative
 
 
 def test_thermo_upload_schema_rejects_source_calc_key_with_no_declared_calc() -> None:

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -2138,7 +2138,12 @@ def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_conn) -> Non
         )
         # Feed the seam a calc-key map pointing at O2's scan calc while
         # claiming a different species entry owns the statmech.
-        with pytest.raises(ValueError, match="different subject"):
+        # #158/#162: the seam's torsion scan link carries its own code,
+        # distinct from the statmech source-link code, because the repair
+        # is a different one -- the wrong rotor scan, not the wrong job.
+        with pytest.raises(
+            ValueError, match="another species entry"
+        ) as torsion_exc:
             _persist_statmech_block(
                 session,
                 statmech,
@@ -2146,6 +2151,10 @@ def test_seam_torsion_ownership_check_rejects_cross_species_scan(db_conn) -> Non
                 calc_keys_to_id={"O2_scan": o2_scan, "foreign_freq": foreign_freq},
                 created_by=None,
             )
+        assert (
+            torsion_exc.value.code
+            == "statmech_torsion_scan_calculation_owner_mismatch"
+        )
         # No torsion row was persisted for a foreign scan link.
         leaked = session.scalars(
             select(StatmechTorsion).where(

--- a/backend/tests/workflows/test_statmech_upload.py
+++ b/backend/tests/workflows/test_statmech_upload.py
@@ -1022,6 +1022,9 @@ def test_statmech_upload_chained_id_from_another_species_entry_raises(
     detail = str(excinfo.value)
     assert "species_entry_id=" not in detail
     assert "id=" not in detail
+    # #158: the refusal declares a code of its own rather than relying on
+    # the envelope's generic ``validation_error``.
+    assert excinfo.value.code == "statmech_source_calculation_owner_mismatch"
 
 
 def test_statmech_upload_chained_role_type_mismatch_is_coded(db_conn) -> None:

--- a/backend/tests/workflows/test_thermo_upload.py
+++ b/backend/tests/workflows/test_thermo_upload.py
@@ -55,9 +55,13 @@ from app.schemas.entities.thermo import (
 )
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.workflows.thermo_upload import ThermoUploadRequest
+from app.services.calculation_ownership import (
+    W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
+)
 from app.services.species_resolution import resolve_species_entry
 from app.services.thermo_resolution import persist_thermo
-from app.workflows.thermo import _assert_calculation_owned_by, persist_thermo_upload
+from app.workflows.thermo import persist_thermo_upload
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -889,12 +893,17 @@ def test_wrong_owner_source_calc_rejected_by_workflow_check(db_conn) -> None:
         )
         calc_a = _make_calculation(session, species_entry_id=species_a.id)
         # Guard runs on the still-attached ORM instance inside the session.
-        with pytest.raises(ValueError, match="different species entry"):
-            _assert_calculation_owned_by(
+        with pytest.raises(ValueError, match="another species entry") as excinfo:
+            assert_calculation_owned_by(
                 calc_a,
-                species_entry_id=calc_a.species_entry_id + 1,
+                code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+                target="thermo",
                 context="test wrong-owner guard",
+                species_entry_id=calc_a.species_entry_id + 1,
             )
+    # The code, not the sentence, is what a client branches on (#158).
+    assert excinfo.value.code == "thermo_source_calculation_owner_mismatch"
+    assert excinfo.value.context["field"] == "test wrong-owner guard"
 
 
 def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
@@ -905,7 +914,7 @@ def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
     half-written applied correction, no dangling source link.
 
     We simulate the cross-owner scenario by monkeypatching
-    ``_assert_calculation_owned_by`` to raise only when the workflow
+    ``assert_calculation_owned_by`` to raise only when the workflow
     reaches the applied-correction check (after the thermo row + source
     calc are already flushed in-session).
     """
@@ -935,30 +944,28 @@ def test_applied_correction_with_wrong_owner_source_calc_leaves_no_partial(
         ],
     )
 
-    real_check = thermo_module._assert_calculation_owned_by
+    real_check = thermo_module.assert_calculation_owned_by
     calls = {"n": 0}
 
-    def _fail_on_second_call(calculation, *, species_entry_id, context):
+    def _fail_on_second_call(calculation, **kwargs):
         calls["n"] += 1
         # First call = inline calc resolution (pass). Second call = applied
         # correction owner check (fail to simulate cross-owner).
         if calls["n"] == 1:
-            return real_check(
-                calculation, species_entry_id=species_entry_id, context=context,
-            )
+            return real_check(calculation, **kwargs)
         raise ValueError(
-            f"{context}: calculation id={calculation.id} belongs to a "
-            f"different species entry (simulated cross-owner)."
+            f"{kwargs['context']}: calculation id={calculation.id} belongs "
+            f"to a different species entry (simulated cross-owner)."
         )
 
     with pytest.raises(ValueError, match="simulated cross-owner"):
         with Session(db_conn) as session, session.begin():
-            original = thermo_module._assert_calculation_owned_by
-            thermo_module._assert_calculation_owned_by = _fail_on_second_call
+            original = thermo_module.assert_calculation_owned_by
+            thermo_module.assert_calculation_owned_by = _fail_on_second_call
             try:
                 persist_thermo_upload(session, request)
             finally:
-                thermo_module._assert_calculation_owned_by = original
+                thermo_module.assert_calculation_owned_by = original
 
     # Verify no partial persistence.
     with Session(db_conn) as verify:
@@ -1235,7 +1242,7 @@ def test_thermo_upload_existing_calc_id_wrong_species_entry_raises_422(
     species_a = {"smiles": "[OH]", "charge": 0, "multiplicity": 2}
     species_b = {"smiles": "[H]", "charge": 0, "multiplicity": 2}
 
-    with pytest.raises(ValueError, match="different species entry") as exc_info:
+    with pytest.raises(ValueError, match="another species entry") as exc_info:
         with Session(db_conn) as session, session.begin():
             entry_a = resolve_species_entry(
                 session, SpeciesEntryIdentityPayload(**species_a),
@@ -1259,6 +1266,9 @@ def test_thermo_upload_existing_calc_id_wrong_species_entry_raises_422(
     detail = str(exc_info.value)
     assert "species_entry_id=" not in detail
     assert "id=" not in detail
+    # #158: the refusal declares its own code rather than leaving the
+    # envelope to guess one out of the field path.
+    assert exc_info.value.code == "thermo_source_calculation_owner_mismatch"
 
 
 def test_thermo_upload_role_freq_with_opt_calc_raises_422(db_conn) -> None:

--- a/backend/tests/workflows/test_transport_upload.py
+++ b/backend/tests/workflows/test_transport_upload.py
@@ -26,11 +26,12 @@ from app.db.models.transport import Transport, TransportSourceCalculation
 from app.db.models.workflow import WorkflowToolRelease
 from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.workflows.transport_upload import TransportUploadRequest
-from app.services.species_resolution import resolve_species_entry
-from app.workflows.transport import (
-    _assert_calculation_owned_by,
-    persist_transport_upload,
+from app.services.calculation_ownership import (
+    W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH,
+    assert_calculation_owned_by,
 )
+from app.services.species_resolution import resolve_species_entry
+from app.workflows.transport import persist_transport_upload
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -365,9 +366,16 @@ def test_wrong_owner_source_calc_rejected_by_workflow_check(db_conn) -> None:
         session.add(calc)
         session.flush()
 
-        with pytest.raises(ValueError, match="not to the transport target"):
-            _assert_calculation_owned_by(
+        with pytest.raises(
+            ValueError, match="not to the transport target"
+        ) as excinfo:
+            assert_calculation_owned_by(
                 calc,
-                species_entry_id=calc.species_entry_id + 1,
+                code=W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH,
+                target="transport",
                 context="test wrong-owner guard",
+                species_entry_id=calc.species_entry_id + 1,
             )
+        # #158: transport's refusal carries its own code, distinct from
+        # thermo's and statmech's -- same rule, different subject.
+        assert excinfo.value.code == "transport_source_calculation_owner_mismatch"


### PR DESCRIPTION
Closes #161, #158, #162.

Three defects that are one story: refusals carrying no declared code, a
mechanism that invents one for them, and a rule written five times.

## The measurement came first

The scraper could not be touched safely without knowing what it recovers.
Removing or tightening it blindly would have downgraded *legitimate* codes
to `validation_error` — a regression dressed as a fix. So every promotion
decision the API's error handlers make was instrumented and recorded
across all three gates on `main` (`7089c466`).

**719 decisions. 530 by scraping, 25 distinct tokens, 24 legitimate and
one fabricated.**

| token | n | position | verdict |
|---|---|---|---|
| `missing_filter` | 88 | leading | legitimate |
| `unknown_include_token` | 80 | leading | legitimate |
| `handle_type_mismatch` | 67 | leading | legitimate |
| `missing_reaction_search_filter` | 65 | leading | legitimate |
| `client_sort_not_supported` | 62 | leading | legitimate |
| `invalid_handle` | 44 | leading | legitimate |
| `export_seed_empty` | 24 | leading | legitimate |
| `missing_structure_query`, `ml_export_seed_empty` | 12 each | leading | legitimate |
| `invalid_structure_query`, `invalid_temperature_range`, `missing_identifier`, `pressure_alias_conflict` | 10 each | leading | legitimate |
| `invalid_cursor` | 8 | leading | legitimate |
| `query_too_expensive` | 6 | leading | legitimate |
| `cursor_query_mismatch`, `multiple_structure_queries` | 4 each | leading | legitimate |
| `canonical_parameter_value_requires_key`, `level_of_theory_handle_conflict`, `parameter_value_requires_key`, `unknown_record_type`, `unsupported_ranking_for_calculation_type` | 2 each | leading | legitimate |
| `geometry_too_large`, `smiles_too_long` | 1 each | leading | legitimate |
| **`existing_calculation_id`** | **2** | **mid-sentence** | **FABRICATED** |

Every legitimate code is written where a code goes: first in its own
message, which is exactly what convention (2) of `error_contract` has
always meant by `"code: message"`. The read API has 24 codes that reach a
client *only* through this path. Direction (b) — stop scraping — would
have deleted all 24.

**The brief's premise was incomplete: there are two live fabrication
sites, not one.** `app/workflows/thermo.py:82` is the one it named. The
other is the computed-species bundle route, whose forbidden-FK walk in
`tckdb_schemas/workflows/computed_species_upload.py:96` names the
offending key at the end of a dotted path — so `POST
/uploads/computed-species` also advertised `code:
"existing_calculation_id"`. That file is off-limits for this branch and
did not need touching: the envelope fix cures it.

Two further sites would fabricate the moment they were reached by a route
test, and are cured the same way:
`app/services/reaction_resolution.py:1018,1028` (`reaction_family`) and
`app/schemas/workflows/network_pdep_upload.py:1007` (`state_energies`).

## #161 — direction (a), positionally

The rule is now positional, because **position is the declaration**. A
code is a token in the *code position* — the very start of its own
message, optionally behind Pydantic's `"Value error, "` wrapper. A token
found mid-sentence is prose.

This is direction (a) with "a declared code" defined by the convention the
codebase already uses, rather than by a registry. A hand-listed registry
of the 61 leading-prefix tokens would have been a new artifact to keep in
step, and the day somebody adds a read-API code and forgets to register it
their code silently degrades to `validation_error` — the same class of
failure this task exists to fix. It is also, per the brief, deliberately
*not* coupled to the scientific check register, whose membership is an
open decision (#156).

**The narrowing is one-way.** Ambiguity is still judged on the *unfiltered*
candidate set, so `invalid_pagination: limit_too_large: …` keeps falling
back exactly as it did. A response can lose a fabricated code; no response
gains one. Replayed against all 719 recorded decisions, exactly one
outcome class changes: `existing_calculation_id` → the generic fallback.

## #158 — five codes, one per subject

Six ownership refusals raised bare `ValueError`, so "you pointed at
something you do not own" — a real, actionable depositor mistake — arrived
indistinguishable from a Pydantic type error.

| code | subject |
|---|---|
| `thermo_source_calculation_owner_mismatch` | a thermo source link |
| `statmech_source_calculation_owner_mismatch` | a statmech source link |
| `statmech_torsion_scan_calculation_owner_mismatch` | a torsion's rotor scan |
| `transport_source_calculation_owner_mismatch` | a transport source link |
| `applied_energy_correction_source_calculation_owner_mismatch` | a correction's source |

A code per subject, not one shared code: a client repairing a thermo link,
a torsion's scan and an energy correction's source are doing different
things. Distinct, too, from the `*_source_role_type_mismatch` codes — wrong
owner and wrong role are different repairs.

Nothing depended on the old values: all six returned `validation_error` or
the fabricated field name, and no client constant, register entry or
generated file names either.

## #162 — the three copies were not three, and were not identical

| site | before |
|---|---|
| `app/workflows/statmech.py:35` | already an alias to the service (#157) |
| `app/services/statmech_resolution.py:140` | the real body; phrased **without** the house-style colon *on purpose*, to dodge the scraper; logged the row ids |
| `app/workflows/thermo.py:65` | kept the colon, so it fabricated a code; **logged nothing** |
| `app/workflows/transport.py:28` | own message; logged the row ids |
| `app/workflows/computed_species.py` ×4, `computed_reaction.py` ×1 | inline, uncoded, two of them also covering transition-state entries |

So: five implementations, three different sentences, two different
logging behaviours, one of them fabricating a code — and only thermo's was
pinned by a test, which is why the drift survived. All five now call one
implementation in `app/services/calculation_ownership.py`.

The consolidated guard also **refuses to run when given no owner to
compare against**. A guard with nothing to compare passes for every input,
which is the one failure mode a defensive check must not have.

Consolidating is what lets the sentence go back to the house style: with a
declared code, the message no longer has to be written around the parser.

## Proof through real routes

- `POST /uploads/thermo` cross-owner → `code:
  "thermo_source_calculation_owner_mismatch"`, and the test asserts it is
  **not** `existing_calculation_id`.
- `POST /uploads/statmech` chained cross-owner →
  `statmech_source_calculation_owner_mismatch`.
- `POST /uploads/computed-reaction` → the same thermo code as the
  standalone route; the bundle is not a second contract.
- `POST /uploads/computed-species` forbidden-FK walk → the honest generic
  `request_validation_error`, no longer the field name.
- Regression guard: the read API's legitimate scraped codes still arrive,
  pinned both as a unit rule and end-to-end.

## Mutation checks

| # | mutation | result |
|---|---|---|
| M1 | revert the positional narrowing | **killed** — both fabrication tests |
| M2 | empty the Pydantic prefix list | **killed** by the unit rule; **survived** the e2e pressure-alias test (see below) |
| M3 | flip the ownership comparison | **killed** — 63 tests |
| M4 | collapse the five codes into one shared code | **killed** — 4 tests, one per subject |
| M5 | drop the "nothing to compare against" guard | **killed** |
| M6 | drop the transition-state half of the comparison | **killed** (unit only — see findings) |
| M7 | take the declared code away again | **killed**, and the response fell back to `validation_error` rather than to `existing_calculation_id` — which is what proves #161 and #158 are independently doing their jobs |

## Findings not fixed

- **M2 survived end-to-end.** Pydantic v2 also preserves the raw exception
  in `ctx["error"]`, whose `str()` carries no wrapper, so every live route
  recovers its code from there and would keep working with the prefix list
  emptied. The stripping is kept as the thing that stops all 24 read-API
  codes depending on Pydantic continuing to hand over an exception object,
  and the test now says so rather than implying an e2e dependency it does
  not have.
- **The transition-state half of the ownership rule has no end-to-end
  coverage** — M6 was killed by the new unit invariant only. Anchor:
  `backend/app/workflows/computed_species.py:938`.
- **`app/workflows/thermo.py:204`** — `existing_statmech_id` pointing at a
  statmech owned by another species entry is still an uncoded
  `ValueError`. Same shape as #158's six but a different subject (a
  statmech record, not a calculation), so it is out of this branch's
  scope. It does not fabricate: its message has no `token: `.

## Not needed

No Alembic revision (head stays `b7e4d1a9c026`), no wire-schema change, no
scientific-check-register entry — the register's membership test is
chemistry positions, and provenance codes staying out of it follows the
precedent set by `statmech_source_role_type_mismatch` (#152) and
`thermo_source_role_type_mismatch` (#156), neither of which is registered
either.
