### PR TITLE
Ask whether a frequency list is the spectrum, and measure it against its own geometry

### DIFF
--- a/backend/app/api/routes/uploads.py
+++ b/backend/app/api/routes/uploads.py
@@ -205,6 +205,7 @@ def upload_conformer(
         primary_calc=request.calculation,
         additional_calcs=request.additional_calculations,
         statmech=request.statmech,
+        reference_xyz_text=request.geometry.xyz_text,
     )
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.conformer

--- a/backend/app/schemas/workflows/network_pdep_upload.py
+++ b/backend/app/schemas/workflows/network_pdep_upload.py
@@ -62,6 +62,7 @@ from tckdb_schemas.shared.calculation_in import (
     GeometryIn,
     calculation_in_to_with_results_payload,
     freq_evidence,
+    frequency_completeness_findings,
     transition_state_frequency_findings,
 )
 from tckdb_schemas.stationary_point import (
@@ -184,28 +185,42 @@ class NetworkSpeciesIn(SchemaBase):
         single imaginary mode against a well.
         """
         kind = self.species_entry.species_entry_kind
+        xyz_by_geometry_key = {
+            conformer.geometry.key: conformer.geometry.xyz_text
+            for conformer in self.conformers
+        }
         findings: list[StationaryPointFinding] = []
         for conformer in self.conformers:
+            location = (
+                f"species['{self.key}'].conformers['{conformer.key}']"
+                f".calculation['{conformer.calculation.key}']"
+            )
             n_imag, imag_freq_cm1 = freq_evidence(conformer.calculation)
             findings.extend(
                 evaluate_species_entry_frequency(
-                    kind,
-                    n_imag,
-                    imag_freq_cm1,
-                    location=(
-                        f"species['{self.key}'].conformers['{conformer.key}']"
-                        f".calculation['{conformer.calculation.key}']"
-                    ),
+                    kind, n_imag, imag_freq_cm1, location=location
+                )
+            )
+            findings.extend(
+                frequency_completeness_findings(
+                    conformer.calculation,
+                    location=f"{location}.freq_frequencies_cm1",
+                    xyz_text=conformer.geometry.xyz_text,
                 )
             )
         for calc in self.calculations:
+            location = f"species['{self.key}'].calculations['{calc.key}']"
             n_imag, imag_freq_cm1 = freq_evidence(calc)
             findings.extend(
                 evaluate_species_entry_frequency(
-                    kind,
-                    n_imag,
-                    imag_freq_cm1,
-                    location=f"species['{self.key}'].calculations['{calc.key}']",
+                    kind, n_imag, imag_freq_cm1, location=location
+                )
+            )
+            findings.extend(
+                frequency_completeness_findings(
+                    calc,
+                    location=f"{location}.freq_frequencies_cm1",
+                    xyz_text=xyz_by_geometry_key.get(calc.geometry_key or ""),
                 )
             )
         return findings
@@ -279,13 +294,17 @@ class TransitionStateIn(SchemaBase):
         """Judge this saddle point against its own frequency evidence."""
         findings: list[StationaryPointFinding] = []
         for calc in (self.calculation, *self.calculations):
+            location = (
+                f"transition_states['{self.key}'].calculations['{calc.key}']"
+            )
             findings.extend(
-                transition_state_frequency_findings(
+                transition_state_frequency_findings(calc, location=location)
+            )
+            findings.extend(
+                frequency_completeness_findings(
                     calc,
-                    location=(
-                        f"transition_states['{self.key}'].calculations"
-                        f"['{calc.key}']"
-                    ),
+                    location=f"{location}.freq_frequencies_cm1",
+                    xyz_text=self.geometry.xyz_text,
                 )
             )
         return findings

--- a/backend/app/schemas/workflows/stationary_point_seam.py
+++ b/backend/app/schemas/workflows/stationary_point_seam.py
@@ -47,12 +47,24 @@ def inline_calculation_findings(
         freq_result = item.calculation.freq_result
         if freq_result is None:
             continue
+        location = f"calculations['{item.key}'].freq_result"
         findings.extend(
             evaluate_species_entry_frequency(
                 kind,
                 freq_result.n_imag,
                 freq_result.imag_freq_cm1,
-                location=f"calculations['{item.key}'].freq_result",
+                location=location,
+            )
+        )
+        # No reference geometry to fall back to: these three requests
+        # carry a product and its evidence, never a conformer. So the
+        # completeness question is answerable only for a calculation that
+        # named the geometry it ran on, and stays silent otherwise —
+        # which is the same rule the bundles apply, reached by a
+        # different route.
+        findings.extend(
+            item.calculation.frequency_completeness_findings(
+                location=f"{location}.modes"
             )
         )
     return findings

--- a/backend/app/services/upload_reconciliation.py
+++ b/backend/app/services/upload_reconciliation.py
@@ -412,6 +412,7 @@ def reconcile_species_entry_full(
     primary_calc: CalculationWithResultsPayload | None = None,
     additional_calcs: list[CalculationWithResultsPayload] | None = None,
     statmech: ConformerUploadStatmechPayload | None = None,
+    reference_xyz_text: str | None = None,
 ) -> list[UploadWarning]:
     """Layer 2: reconcile using full deduction pipeline.
 
@@ -423,6 +424,12 @@ def reconcile_species_entry_full(
     :param primary_calc: Primary calculation payload (opt/freq/sp).
     :param additional_calcs: Additional calculations (freq, sp, etc.).
     :param statmech: Optional statmech payload with symmetry info.
+    :param reference_xyz_text: The enclosing conformer's geometry, when
+        the caller has one. Needed by the frequency-completeness check
+        below, which asks whether a deposited frequency list is the
+        whole spectrum and cannot answer that without knowing how many
+        atoms the frequency job ran on. Callers with no geometry leave
+        it ``None`` and the check stays silent.
     :returns: List of warnings (may be empty).
     """
     warnings: list[UploadWarning] = []
@@ -444,6 +451,29 @@ def reconcile_species_entry_full(
     # Layer 1b: parser-fidelity check across all freq-bearing calcs.
     if primary_calc is not None:
         warnings.extend(check_freq_parser_fidelity([primary_calc, *additional]))
+
+    # Layer 1c: is the deposited frequency list the whole spectrum?
+    #
+    # This runs here rather than from the route's
+    # ``stationary_point_findings()`` call because the conformer route
+    # deliberately does not make that call — the Layer-1 pass above
+    # already owns the ``n_imag`` findings and calling both would report
+    # each one twice under two different ``field`` paths. Nothing else
+    # computes the completeness findings, so there is no such duplication
+    # to avoid for them, and routing them through here is what puts them
+    # on the one upload path that skips the schema-side collection.
+    if primary_calc is not None:
+        for index, calc in enumerate([primary_calc, *additional]):
+            warnings.extend(
+                stationary_point_warnings(
+                    calc.frequency_completeness_findings(
+                        location=(
+                            f"calculations[{index}].freq_result.modes"
+                        ),
+                        fallback_xyz_text=reference_xyz_text,
+                    )
+                )
+            )
 
     # Layer 2: deduction-based checks
     ess_result = build_ess_result_from_upload(

--- a/backend/tests/api/test_api_frequency_list_completeness.py
+++ b/backend/tests/api/test_api_frequency_list_completeness.py
@@ -1,0 +1,529 @@
+"""The proof that a frequency list is checked against its own geometry.
+
+`ADR 0012 <../../../docs/adr/0012-imaginary-modes-are-judged-by-magnitude-not-counted.md>`_
+§"What a record must carry" requires "the complete signed unrounded
+frequency list, never filtered", and until this branch nothing asked.
+A depositor could send three modes, all imaginary, with ``n_imag = 3``
+and pass every check TCKDB had, ``freq_n_imag_disagrees_with_modes``
+included — that rule compares the imaginary count against ``n_imag``,
+and a list of nothing but imaginary modes satisfies it exactly.
+
+Why it matters beyond tidiness: `paper/18__TCKDB/3_results.tex` reports
+recovering a harmonic spectrum from a stored Hessian and comparing it
+against the independently stored frequency lists, agreeing to within
+0.045 cm-1. A subset agrees on every mode it contains and is silent
+about the ones it omits, which reads as agreement. The completeness of
+the stored list is load-bearing for that claim.
+
+Tier: **warn**, not block. The two arguments are set out in
+``tckdb_schemas.frequency_completeness``; the one this file makes
+executable is the second, which is that ``modes = null`` is accepted and
+must stay accepted, so a block's cheapest workaround is deleting the
+frequency list — turning a partial list into no list at all. The tests
+below therefore assert ``201`` throughout and read the warning out of
+the response body.
+"""
+
+from __future__ import annotations
+
+from tckdb_schemas.frequency_completeness import (
+    W_FREQ_LIST_EXCEEDS_GEOMETRY,
+    W_FREQ_LIST_INCOMPLETE,
+)
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+#: Water, non-linear: 3 atoms, 3N - 6 = 3 vibrational modes.
+_WATER_XYZ = (
+    "3\nwater\n"
+    "O  0.000000  0.000000  0.117300\n"
+    "H  0.000000  0.757200 -0.469200\n"
+    "H  0.000000 -0.757200 -0.469200"
+)
+_WATER_SPECTRUM = [1595.0, 3657.0, 3756.0]
+
+#: Carbon dioxide, linear: 3 atoms, 3N - 5 = 4 vibrational modes. The
+#: case a naive ``3N - 6`` rule would flag as an over-count, or a naive
+#: "exactly 3N - 6" rule as a mismatch.
+_CO2_XYZ = (
+    "3\ncarbon dioxide\n"
+    "C  0.000000  0.000000  0.000000\n"
+    "O  0.000000  0.000000  1.162000\n"
+    "O  0.000000  0.000000 -1.162000"
+)
+_CO2_SPECTRUM = [667.0, 667.0, 1333.0, 2349.0]
+
+
+def _freq_calc(frequencies: list[float] | None, *, n_imag: int = 0) -> dict:
+    result: dict = {"n_imag": n_imag, "zpe_hartree": 0.02}
+    if frequencies is not None:
+        result["modes"] = [
+            {
+                "mode_index": index + 1,
+                "frequency_cm1": value,
+                "is_imaginary": value < 0,
+            }
+            for index, value in enumerate(frequencies)
+        ]
+    return {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "freq_result": result,
+    }
+
+
+def _conformer_payload(
+    *,
+    smiles: str,
+    xyz_text: str,
+    frequencies: list[float] | None,
+    label: str,
+    multiplicity: int = 1,
+    molecule_kind: str | None = None,
+) -> dict:
+    species_entry: dict = {
+        "smiles": smiles,
+        "charge": 0,
+        "multiplicity": multiplicity,
+    }
+    if molecule_kind is not None:
+        species_entry["molecule_kind"] = molecule_kind
+    return {
+        "species_entry": species_entry,
+        "geometry": {"xyz_text": xyz_text},
+        "calculation": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [_freq_calc(frequencies)],
+        "label": label,
+    }
+
+
+def _post(client, payload: dict):
+    resp = client.post("/api/v1/uploads/conformers", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _completeness_warnings(body: dict) -> list[dict]:
+    return [
+        w
+        for w in body["warnings"]
+        if w["code"] in {W_FREQ_LIST_INCOMPLETE, W_FREQ_LIST_EXCEEDS_GEOMETRY}
+    ]
+
+
+class TestACompleteListIsAccepted:
+    def test_water_depositing_its_three_modes_draws_no_completeness_warning(
+        self, client
+    ):
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="O",
+                xyz_text=_WATER_XYZ,
+                frequencies=_WATER_SPECTRUM,
+                label="water-complete",
+            ),
+        )
+        assert _completeness_warnings(body) == []
+
+    def test_water_depositing_all_nine_eigenvalues_is_also_complete(self, client):
+        """ADR 0012 asks for the six translation/rotation eigenvalues too.
+
+        "the six translation/rotation eigenvalues must be present so
+        contamination is directly assessable". A record carrying all
+        ``3N`` is the most complete record the ADR describes, so the
+        upper bound is ``3N`` and not ``3N - 6`` — a rule that refused
+        this would refuse exactly what the ADR asks for.
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="O",
+                xyz_text=_WATER_XYZ,
+                frequencies=[0.1, 0.2, 0.3, 12.0, 15.0, 18.0, *_WATER_SPECTRUM],
+                label="water-with-rigid-body-block",
+            ),
+        )
+        assert _completeness_warnings(body) == []
+
+
+class TestATruncatedListSaysSo:
+    def test_water_depositing_one_of_three_modes_is_accepted_and_flagged(
+        self, client
+    ):
+        """The same geometry, one mode deposited instead of three.
+
+        Accepted — 201, the record is stored — and flagged, which is the
+        whole tier decision made visible: the evidence survives, and a
+        consumer is told the list is not the spectrum.
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="O",
+                xyz_text=_WATER_XYZ,
+                frequencies=[3756.0],
+                label="water-truncated",
+            ),
+        )
+        warnings = _completeness_warnings(body)
+        assert [w["code"] for w in warnings] == [W_FREQ_LIST_INCOMPLETE]
+        assert "1 mode(s)" in warnings[0]["message"]
+        assert "at least 3" in warnings[0]["message"]
+
+    def test_the_attack_this_branch_closes_is_reported(self, client):
+        """Only the imaginary modes deposited, ``n_imag`` agreeing exactly.
+
+        The record ``freq_n_imag_disagrees_with_modes`` cannot see: the
+        count and the list agree, because everything in the list is
+        imaginary, so PR #160's rule is satisfied byte for byte. It is
+        deposited against a van der Waals complex because that is the
+        one declared kind whose imaginary modes are accepted rather than
+        refused — which is exactly the corner where a subset could hide.
+        """
+        payload = _conformer_payload(
+            smiles="O",
+            xyz_text=_WATER_XYZ,
+            frequencies=[-40.0, -18.0],
+            label="water-imaginary-only",
+        )
+        payload["species_entry"]["species_entry_kind"] = "vdw_complex"
+        payload["additional_calculations"][0]["freq_result"]["n_imag"] = 2
+        body = _post(client, payload)
+        assert [w["code"] for w in _completeness_warnings(body)] == [
+            W_FREQ_LIST_INCOMPLETE
+        ]
+
+    def test_a_list_longer_than_the_geometry_allows_names_the_geometry(
+        self, client
+    ):
+        """Ten modes on a three-atom geometry: nine degrees of freedom exist.
+
+        Arithmetically impossible rather than merely short, so it gets
+        its own code — the usual cause is a calculation attached to the
+        wrong geometry, which is a different repair from "deposit the
+        rest of the list".
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="O",
+                xyz_text=_WATER_XYZ,
+                frequencies=[float(100 * n) for n in range(1, 11)],
+                label="water-overlong",
+            ),
+        )
+        assert [w["code"] for w in _completeness_warnings(body)] == [
+            W_FREQ_LIST_EXCEEDS_GEOMETRY
+        ]
+
+
+class TestALinearMoleculeIsNotFlagged:
+    def test_carbon_dioxide_depositing_3n_minus_5_is_accepted_silently(
+        self, client
+    ):
+        """The case a naive ``3N - 6`` rule breaks.
+
+        CO2 has four vibrational modes, not three, and no linearity
+        determination happens anywhere in this check — the floor is the
+        weakest bound that is certainly true, so a collinear geometry
+        clears it without being asked whether it is collinear.
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="O=C=O",
+                xyz_text=_CO2_XYZ,
+                frequencies=_CO2_SPECTRUM,
+                label="co2-linear",
+            ),
+        )
+        assert _completeness_warnings(body) == []
+
+    def test_hydrogen_molecule_deposits_its_single_mode(self, client):
+        """Two atoms are collinear by definition, so ``N = 2`` is exact.
+
+        ``3N - 6`` is zero here and would accept an empty list; the
+        floor for a diatomic is therefore stated as ``3N - 5 = 1``,
+        which is a fact about two points rather than a measurement.
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="[H][H]",
+                xyz_text="2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.741",
+                frequencies=[4401.0],
+                label="h2-complete",
+            ),
+        )
+        assert _completeness_warnings(body) == []
+
+    def test_a_diatomic_depositing_an_empty_list_is_flagged(self, client):
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="[H][H]",
+                xyz_text="2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.741",
+                frequencies=[],
+                label="h2-empty",
+            ),
+        )
+        assert [w["code"] for w in _completeness_warnings(body)] == [
+            W_FREQ_LIST_INCOMPLETE
+        ]
+
+
+class TestSpeciesWithNoModesToDeposit:
+    def test_a_single_atom_depositing_no_modes_is_accepted(self, client):
+        """A hydrogen atom has zero vibrational modes, and an empty list
+        is the complete spectrum for it."""
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="[H]",
+                xyz_text="1\nH atom\nH 0.0 0.0 0.0",
+                frequencies=[],
+                label="h-atom-empty",
+                multiplicity=2,
+            ),
+        )
+        assert _completeness_warnings(body) == []
+
+    def test_a_single_atom_reporting_modes_is_flagged_not_refused(self, client):
+        """Three translations exist, so ``3N = 3`` is the ceiling; a
+        fourth entry describes motion the geometry does not have."""
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="[H]",
+                xyz_text="1\nH atom\nH 0.0 0.0 0.0",
+                frequencies=[10.0, 20.0, 30.0, 40.0],
+                label="h-atom-overlong",
+                multiplicity=2,
+            ),
+        )
+        assert [w["code"] for w in _completeness_warnings(body)] == [
+            W_FREQ_LIST_EXCEEDS_GEOMETRY
+        ]
+
+
+#: H + CH4 -> H2 + CH3, so the saddle point is CH5: 6 atoms, non-linear,
+#: 3N - 6 = 12 vibrational modes of which one is the reaction coordinate.
+_CH5_XYZ = (
+    "6\nH...H-CH3 abstraction TS\n"
+    "C  0.000  0.000  0.000\n"
+    "H -0.510  0.883  0.000\n"
+    "H -0.510 -0.883  0.000\n"
+    "H  0.000  0.000 -1.090\n"
+    "H  0.000  0.000  1.350\n"
+    "H  0.000  0.000  2.250"
+)
+_CH5_SPECTRUM = [
+    -1300.0,
+    -42.0,
+    -13.0,
+    550.0,
+    1100.0,
+    1180.0,
+    1400.0,
+    1450.0,
+    1500.0,
+    3000.0,
+    3100.0,
+    3150.0,
+]
+
+
+def _transition_state_payload(frequencies: list[float], *, label: str) -> dict:
+    return {
+        "reaction": {
+            "reversible": True,
+            "reactants": [
+                {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+                {"species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1}},
+            ],
+            "products": [
+                {
+                    "species_entry": {
+                        "smiles": "[H][H]",
+                        "charge": 0,
+                        "multiplicity": 1,
+                    }
+                },
+                {
+                    "species_entry": {
+                        "smiles": "[CH3]",
+                        "charge": 0,
+                        "multiplicity": 2,
+                    }
+                },
+            ],
+        },
+        "charge": 0,
+        "multiplicity": 2,
+        "geometry": {"xyz_text": _CH5_XYZ},
+        "primary_opt": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [
+            {
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_result": {
+                    "n_imag": 3,
+                    "imag_freq_cm1": -1300.0,
+                    "reaction_coordinate_mode_index": 1,
+                    "modes": [
+                        {
+                            "mode_index": index + 1,
+                            "frequency_cm1": value,
+                            "is_imaginary": value < 0,
+                            "imaginary_disposition": (
+                                {2: "torsion", 3: "rigid_body_residue"}.get(
+                                    index + 1
+                                )
+                            ),
+                        }
+                        for index, value in enumerate(frequencies)
+                    ],
+                },
+            }
+        ],
+        "label": label,
+    }
+
+
+class TestTheTransitionStateADR0012WasWrittenAbout:
+    """ADR 0012's motivating record, whole and truncated.
+
+    -1300, -42, -13 on a six-atom saddle point. Accepted either way, and
+    ADR 0012's extra-imaginary-mode warning fires either way; what
+    changes is whether the record also says its frequency list is not
+    the spectrum.
+    """
+
+    def test_the_complete_twelve_mode_spectrum_draws_no_completeness_warning(
+        self, client
+    ):
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(_CH5_SPECTRUM, label="ts-complete"),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert _completeness_warnings(body) == []
+        # The ADR 0012 judgement is unchanged and still present.
+        assert any(
+            w["code"] == "transition_state_extra_imaginary_modes_below_tau"
+            for w in body["warnings"]
+        ), body["warnings"]
+
+    def test_only_the_imaginary_modes_is_accepted_and_says_it_is_partial(
+        self, client
+    ):
+        """The exact payload the premise named: three modes, all
+        imaginary, ``n_imag = 3``. Every pre-existing check passes it."""
+        resp = client.post(
+            "/api/v1/uploads/transition-states",
+            json=_transition_state_payload(
+                _CH5_SPECTRUM[:3], label="ts-imaginary-only"
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        warnings = _completeness_warnings(body)
+        assert [w["code"] for w in warnings] == [W_FREQ_LIST_INCOMPLETE]
+        assert "3 mode(s)" in warnings[0]["message"]
+        assert "at least 12" in warnings[0]["message"]
+
+
+class TestSpeciesWithNoAtomsAndSpeciesWithUnknownAtoms:
+    """What the atomless and lumped kinds actually do, shown not assumed."""
+
+    def test_an_electron_never_reaches_this_check_because_it_carries_no_geometry(
+        self, client
+    ):
+        """``ATOMLESS_MOLECULE_KINDS`` closes the door before this rule.
+
+        ``raise_for_atomless_structure`` refuses a geometry deposited
+        against ``molecule_kind: electron`` — definitional, blocking, and
+        older than this branch. So an electron reaches the completeness
+        check with no geometry to count, and the check is unreachable for
+        it rather than wrong about it. Asserted on the status and the
+        code rather than on prose, because the word "electron" appears in
+        the payload and would be echoed back by any refusal.
+        """
+        payload = _conformer_payload(
+            smiles="e",
+            xyz_text="1\nnot a thing\nH 0.0 0.0 0.0",
+            frequencies=[100.0],
+            label="electron-with-geometry",
+            multiplicity=2,
+        )
+        payload["species_entry"]["molecule_kind"] = "electron"
+        payload["species_entry"]["charge"] = -1
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 422, resp.text
+
+    def test_a_pseudo_species_is_refused_by_the_conformer_route_before_this_check(
+        self, client
+    ):
+        """The lumped kind does not reach the conformer route at all.
+
+        ``pseudo`` is deliberately absent from
+        ``ATOMLESS_MOLECULE_KINDS`` — a lumped construct's composition is
+        unknown rather than empty, so its geometry is not a
+        contradiction the way an electron's is. It is nevertheless out of
+        reach here, because ``app/chemistry/species.py:577`` refuses any
+        non-``molecule`` kind on this route outright. So the lumped case
+        this check might misjudge, where a mode count genuinely is not a
+        function of an atom count, is not reachable through a conformer
+        deposit; it is named in
+        ``tckdb_schemas.frequency_completeness`` as one reason the rule
+        warns rather than blocks, and this test records that the reason
+        is currently hypothetical on this route rather than pretending it
+        was exercised.
+        """
+        payload = _conformer_payload(
+            smiles="O",
+            xyz_text=_WATER_XYZ,
+            frequencies=[1595.0],
+            label="pseudo-truncated",
+        )
+        payload["species_entry"]["molecule_kind"] = "pseudo"
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"] == (
+            "Conformer upload currently supports only molecule species"
+        )
+
+
+class TestAbsenceIsStillAccepted:
+    def test_omitting_modes_entirely_draws_no_completeness_warning(self, client):
+        """The load-bearing asymmetry, restated as a test.
+
+        ``modes = null`` is incompleteness that says so, and it stays
+        accepted and unflagged. This is exactly why the short-list rule
+        cannot block: a block here would make deleting the list the
+        cheapest way past it, and the deleted list is the one this
+        record shows TCKDB has always accepted.
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="O",
+                xyz_text=_WATER_XYZ,
+                frequencies=None,
+                label="water-no-modes",
+            ),
+        )
+        assert _completeness_warnings(body) == []

--- a/backend/tests/schemas/test_frequency_list_completeness.py
+++ b/backend/tests/schemas/test_frequency_list_completeness.py
@@ -1,0 +1,590 @@
+"""The arithmetic of "is this frequency list the spectrum?", pinned.
+
+The API tests in ``tests/api/test_api_frequency_list_completeness.py``
+prove the rule reaches a depositor through the real routes. This file
+pins the numbers it is built on, including the boundaries — a completeness
+rule is exactly as good as its ``3N - 6`` versus ``3N - 5`` versus ``3N``
+edges, and every one of those has a way of being wrong that no
+end-to-end test would notice.
+
+The seam tests at the foot prove the rule is wired into all four upload
+request models, not only the one that happened to get a demonstration.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tckdb_schemas.frequency_completeness import (
+    W_FREQ_LIST_EXCEEDS_GEOMETRY,
+    W_FREQ_LIST_INCOMPLETE,
+    atom_count_of_xyz,
+    evaluate_frequency_list_completeness,
+    maximum_mode_count,
+    minimum_complete_mode_count,
+)
+from tckdb_schemas.stationary_point import ValidationTier
+from tckdb_schemas.workflows import (
+    ComputedReactionUploadRequest,
+    ComputedSpeciesUploadRequest,
+    ConformerUploadRequest,
+    TransitionStateUploadRequest,
+)
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+_WATER_XYZ = (
+    "3\nwater\n"
+    "O  0.000000  0.000000  0.117300\n"
+    "H  0.000000  0.757200 -0.469200\n"
+    "H  0.000000 -0.757200 -0.469200"
+)
+
+
+class TestTheBounds:
+    @pytest.mark.parametrize(
+        ("n_atoms", "expected"),
+        [
+            # A single atom has three translations and no vibrations.
+            (1, 0),
+            # Two atoms are collinear by definition, so N = 2 is exact
+            # rather than a lower bound: 3N - 5 = 1. Stating it as
+            # 3N - 6 = 0 would accept an empty list for every diatomic.
+            (2, 1),
+            # From three atoms on, linearity is a measurement this check
+            # declines to make, so the floor is 3N - 6 and a collinear
+            # geometry clears it with a mode to spare.
+            (3, 3),
+            (6, 12),
+            (15, 39),
+        ],
+    )
+    def test_minimum_complete_mode_count(self, n_atoms: int, expected: int):
+        assert minimum_complete_mode_count(n_atoms) == expected
+
+    @pytest.mark.parametrize(("n_atoms", "expected"), [(1, 3), (3, 9), (6, 18)])
+    def test_maximum_is_three_n(self, n_atoms: int, expected: int):
+        assert maximum_mode_count(n_atoms) == expected
+
+    def test_a_linear_triatomic_clears_the_floor_without_being_asked(self):
+        """CO2 has 3N - 5 = 4 modes and the floor for N = 3 is 3.
+
+        The property the whole design rests on: no collinearity
+        tolerance is chosen anywhere, because ``3N - 5 > 3N - 6``.
+        """
+        assert 4 > minimum_complete_mode_count(3)
+        assert evaluate_frequency_list_completeness(4, 3, location="x") == []
+
+
+class TestTheJudgement:
+    def test_a_complete_spectrum_is_silent(self):
+        assert evaluate_frequency_list_completeness(3, 3, location="x") == []
+
+    def test_the_full_three_n_eigenvalue_set_is_silent(self):
+        """ADR 0012 asks for the six rigid-body eigenvalues as well."""
+        assert evaluate_frequency_list_completeness(9, 3, location="x") == []
+
+    def test_one_short_of_the_floor_is_reported(self):
+        findings = evaluate_frequency_list_completeness(2, 3, location="x")
+        assert [f.code for f in findings] == [W_FREQ_LIST_INCOMPLETE]
+        assert findings[0].tier is ValidationTier.warn
+        assert findings[0].structural_flag is True
+
+    def test_one_past_the_ceiling_is_reported_under_a_different_code(self):
+        findings = evaluate_frequency_list_completeness(10, 3, location="x")
+        assert [f.code for f in findings] == [W_FREQ_LIST_EXCEEDS_GEOMETRY]
+        assert findings[0].tier is ValidationTier.warn
+
+    def test_the_location_is_used_verbatim(self):
+        findings = evaluate_frequency_list_completeness(
+            1, 3, location="species['a'].calculations['f'].freq_result.modes"
+        )
+        assert findings[0].location == (
+            "species['a'].calculations['f'].freq_result.modes"
+        )
+        assert findings[0].message.startswith(findings[0].location + ":")
+
+    @pytest.mark.parametrize(
+        ("n_modes", "n_atoms"),
+        [(None, 3), (3, None), (None, None)],
+    )
+    def test_absence_reports_nothing(self, n_modes, n_atoms):
+        """Neither half alone is a claim about the other.
+
+        ``modes = null`` is incompleteness that says so and stays
+        accepted; a payload with no geometry cannot be asked the
+        question at all.
+        """
+        assert (
+            evaluate_frequency_list_completeness(
+                n_modes, n_atoms, location="x"
+            )
+            == []
+        )
+
+
+class TestCountingAtoms:
+    def test_a_well_formed_block_counts(self):
+        assert atom_count_of_xyz(_WATER_XYZ) == 3
+
+    def test_none_counts_to_none(self):
+        assert atom_count_of_xyz(None) is None
+
+    @pytest.mark.parametrize(
+        "xyz_text",
+        [
+            "not a number\ncomment\nH 0 0 0",
+            "5\ncomment\nH 0 0 0",
+            "",
+        ],
+    )
+    def test_an_uncountable_block_declines_rather_than_guessing(self, xyz_text):
+        """A geometry that cannot be parsed is another check's refusal.
+
+        ``parse_xyz_elements`` owns that contract and raises
+        ``atom_map_geometry_unparseable``; reporting the same defect here
+        in different words would give a depositor two problems to fix
+        where there is one.
+        """
+        assert atom_count_of_xyz(xyz_text) is None
+
+
+# ---------------------------------------------------------------------------
+# Seams: every published upload request model asks the question
+# ---------------------------------------------------------------------------
+
+
+def _freq_result(frequencies: list[float]) -> dict:
+    return {
+        "n_imag": 0,
+        "modes": [
+            {
+                "mode_index": index + 1,
+                "frequency_cm1": value,
+                "is_imaginary": False,
+            }
+            for index, value in enumerate(frequencies)
+        ],
+    }
+
+
+def _conformer_request(frequencies: list[float]) -> ConformerUploadRequest:
+    return ConformerUploadRequest(
+        species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+        geometry={"xyz_text": _WATER_XYZ},
+        calculation={
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        additional_calculations=[
+            {
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_result": _freq_result(frequencies),
+            }
+        ],
+    )
+
+
+def _computed_species_request(
+    frequencies: list[float],
+) -> ComputedSpeciesUploadRequest:
+    return ComputedSpeciesUploadRequest(
+        species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+        conformers=[
+            {
+                "key": "c1",
+                "geometry": {"xyz_text": _WATER_XYZ},
+                "primary_calculation": {
+                    "key": "c1_opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                },
+                "additional_calculations": [
+                    {
+                        "key": "c1_freq",
+                        "type": "freq",
+                        "software_release": _SOFTWARE,
+                        "level_of_theory": _LOT,
+                        "freq_result": _freq_result(frequencies),
+                    }
+                ],
+            }
+        ],
+    )
+
+
+_TS_XYZ = (
+    "4\nsaddle\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.000  0.000  1.100\n"
+    "H  1.030  0.000 -0.360\n"
+    "H -0.510  0.890 -0.360"
+)
+
+
+def _ts_freq_result(frequencies: list[float]) -> dict:
+    return {
+        "n_imag": 1,
+        "imag_freq_cm1": frequencies[0],
+        "modes": [
+            {
+                "mode_index": index + 1,
+                "frequency_cm1": value,
+                "is_imaginary": value < 0,
+            }
+            for index, value in enumerate(frequencies)
+        ],
+    }
+
+
+def _transition_state_request(
+    frequencies: list[float],
+) -> TransitionStateUploadRequest:
+    return TransitionStateUploadRequest(
+        reaction={
+            "reversible": True,
+            "reactants": [
+                {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+                {"species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}},
+            ],
+            "products": [
+                {"species_entry": {"smiles": "C", "charge": 0, "multiplicity": 1}},
+            ],
+        },
+        charge=0,
+        multiplicity=1,
+        geometry={"xyz_text": _TS_XYZ},
+        primary_opt={
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        additional_calculations=[
+            {
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_result": _ts_freq_result(frequencies),
+            }
+        ],
+    )
+
+
+def _computed_reaction_request(
+    frequencies: list[float],
+) -> ComputedReactionUploadRequest:
+    return ComputedReactionUploadRequest(
+        species=[
+            {
+                "key": "s1",
+                "species_entry": {"smiles": "O", "charge": 0, "multiplicity": 1},
+                "conformers": [
+                    {
+                        "key": "s1_c1",
+                        "geometry": {"key": "s1_geom", "xyz_text": _WATER_XYZ},
+                        "calculation": {
+                            "key": "s1_opt",
+                            "type": "opt",
+                            "software_release": _SOFTWARE,
+                            "level_of_theory": _LOT,
+                        },
+                    }
+                ],
+                "calculations": [
+                    {
+                        "key": "s1_freq",
+                        "type": "freq",
+                        "geometry_key": "s1_geom",
+                        "software_release": _SOFTWARE,
+                        "level_of_theory": _LOT,
+                        "freq_n_imag": 0,
+                        "freq_frequencies_cm1": frequencies,
+                    }
+                ],
+            },
+            {
+                "key": "s2",
+                "species_entry": {"smiles": "O", "charge": 0, "multiplicity": 1},
+                "conformers": [
+                    {
+                        "key": "s2_c1",
+                        "geometry": {"key": "s2_geom", "xyz_text": _WATER_XYZ},
+                        "calculation": {
+                            "key": "s2_opt",
+                            "type": "opt",
+                            "software_release": _SOFTWARE,
+                            "level_of_theory": _LOT,
+                        },
+                    }
+                ],
+            },
+        ],
+        reactant_keys=["s1"],
+        product_keys=["s2"],
+    )
+
+
+_COMPLETE = [1595.0, 3657.0, 3756.0]
+_TRUNCATED = [3756.0]
+_TS_COMPLETE = [-1300.0, 500.0, 900.0, 1200.0, 1500.0, 3000.0]
+_TS_TRUNCATED = [-1300.0]
+
+
+class TestEveryPublishedRequestModelAsksTheQuestion:
+    """One parametrised proof per published upload request body.
+
+    Without this, a rule wired into one model and forgotten in three
+    would look fully tested — which is the shape of the defect the
+    completeness rule itself exists to catch.
+    """
+
+    @pytest.mark.parametrize(
+        ("build", "complete", "truncated"),
+        [
+            (_conformer_request, _COMPLETE, _TRUNCATED),
+            (_computed_species_request, _COMPLETE, _TRUNCATED),
+            (_transition_state_request, _TS_COMPLETE, _TS_TRUNCATED),
+            (_computed_reaction_request, _COMPLETE, _TRUNCATED),
+        ],
+        ids=[
+            "conformers",
+            "computed-species",
+            "transition-states",
+            "computed-reaction",
+        ],
+    )
+    def test_a_complete_list_is_silent_and_a_truncated_one_is_not(
+        self, build, complete, truncated
+    ):
+        assert [
+            f.code
+            for f in build(complete).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == []
+        assert [
+            f.code
+            for f in build(truncated).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == [W_FREQ_LIST_INCOMPLETE]
+
+
+# ---------------------------------------------------------------------------
+# Seams: the bundle-local transition states
+# ---------------------------------------------------------------------------
+#
+# Added because a mutation that deleted the computed-reaction transition
+# state's call left every other test in this file green. The request-level
+# parametrisation above reaches each bundle's *species* side only, so a
+# transition state is a separate seam and needs a separate proof — which
+# is exactly the "a subset agrees on everything it contains" failure this
+# whole branch is about, in test coverage rather than in frequency lists.
+
+
+def _bundle_ts_payload(frequencies: list[float]) -> dict:
+    return {
+        "charge": 0,
+        "multiplicity": 1,
+        "geometry": {"key": "ts_geom", "xyz_text": _TS_XYZ},
+        "calculation": {
+            "key": "ts_opt",
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "calculations": [
+            {
+                "key": "ts_freq",
+                "type": "freq",
+                "geometry_key": "ts_geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 1,
+                "freq_imag_freq_cm1": frequencies[0],
+                "freq_frequencies_cm1": frequencies,
+            }
+        ],
+    }
+
+
+def _computed_reaction_ts(frequencies: list[float]):
+    from tckdb_schemas.workflows.computed_reaction_upload import (
+        BundleTransitionStateIn,
+    )
+
+    return BundleTransitionStateIn(**_bundle_ts_payload(frequencies))
+
+
+def _network_pdep_ts(frequencies: list[float]):
+    from app.schemas.workflows.network_pdep_upload import TransitionStateIn
+
+    return TransitionStateIn(
+        key="ts1", micro_reaction_key="mr1", **_bundle_ts_payload(frequencies)
+    )
+
+
+class TestTheBundleTransitionStateSeams:
+    @pytest.mark.parametrize(
+        "build",
+        [_computed_reaction_ts, _network_pdep_ts],
+        ids=["computed-reaction-ts", "network-pdep-ts"],
+    )
+    def test_a_complete_list_is_silent_and_a_truncated_one_is_not(self, build):
+        assert [
+            f.code
+            for f in build(_TS_COMPLETE).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == []
+        assert [
+            f.code
+            for f in build(_TS_TRUNCATED).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == [W_FREQ_LIST_INCOMPLETE]
+
+
+def _network_pdep_species(frequencies: list[float]):
+    from app.schemas.workflows.network_pdep_upload import NetworkSpeciesIn
+
+    return NetworkSpeciesIn(
+        key="w1",
+        species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+        conformers=[
+            {
+                "key": "w1_c1",
+                "geometry": {"key": "w1_geom", "xyz_text": _WATER_XYZ},
+                "calculation": {
+                    "key": "w1_opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                },
+            }
+        ],
+        calculations=[
+            {
+                "key": "w1_freq",
+                "type": "freq",
+                "geometry_key": "w1_geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 0,
+                "freq_frequencies_cm1": frequencies,
+            }
+        ],
+    )
+
+
+def _product_upload_calculations(frequencies: list[float]) -> list[dict]:
+    """One keyed inline freq calculation naming the geometry it ran on.
+
+    The statmech / thermo / transport requests carry a product and its
+    evidence and never a conformer, so there is no reference geometry to
+    fall back to — ``input_geometries`` is the only way the completeness
+    question is answerable on these three routes, and this fixture is the
+    proof that it is.
+    """
+    return [
+        {
+            "key": "f1",
+            "calculation": {
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "input_geometries": [{"xyz_text": _WATER_XYZ}],
+                "freq_result": _freq_result(frequencies),
+            },
+        }
+    ]
+
+
+def _statmech_request(frequencies: list[float]):
+    from app.schemas.workflows.statmech_upload import StatmechUploadRequest
+
+    return StatmechUploadRequest(
+        species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+        calculations=_product_upload_calculations(frequencies),
+    )
+
+
+def _thermo_request(frequencies: list[float]):
+    from app.schemas.workflows.thermo_upload import ThermoUploadRequest
+
+    return ThermoUploadRequest(
+        species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+        h298_kj_mol=-241.8,
+        s298_j_mol_k=188.8,
+        calculations=_product_upload_calculations(frequencies),
+    )
+
+
+def _transport_request(frequencies: list[float]):
+    from app.schemas.workflows.transport_upload import TransportUploadRequest
+
+    return TransportUploadRequest(
+        species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+        sigma_angstrom=2.641,
+        epsilon_over_k_k=809.1,
+        calculations=_product_upload_calculations(frequencies),
+    )
+
+
+class TestTheProductUploadSeam:
+    """statmech, thermo and transport share one traversal and one proof."""
+
+    @pytest.mark.parametrize(
+        "build",
+        [_statmech_request, _thermo_request, _transport_request],
+        ids=["statmech", "thermo", "transport"],
+    )
+    def test_a_complete_list_is_silent_and_a_truncated_one_is_not(self, build):
+        assert [
+            f.code
+            for f in build(_COMPLETE).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == []
+        assert [
+            f.code
+            for f in build(_TRUNCATED).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == [W_FREQ_LIST_INCOMPLETE]
+
+    def test_a_calculation_naming_no_geometry_is_not_judged(self):
+        """No geometry, no question — and no false alarm either."""
+        from app.schemas.workflows.statmech_upload import StatmechUploadRequest
+
+        request = StatmechUploadRequest(
+            species_entry={"smiles": "O", "charge": 0, "multiplicity": 1},
+            calculations=[
+                {
+                    "key": "f1",
+                    "calculation": {
+                        "type": "freq",
+                        "software_release": _SOFTWARE,
+                        "level_of_theory": _LOT,
+                        "freq_result": _freq_result(_TRUNCATED),
+                    },
+                }
+            ],
+        )
+        assert [
+            f.code
+            for f in request.stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == []
+
+
+class TestTheNetworkWellSeam:
+    def test_a_complete_list_is_silent_and_a_truncated_one_is_not(self):
+        assert [
+            f.code
+            for f in _network_pdep_species(_COMPLETE).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == []
+        assert [
+            f.code
+            for f in _network_pdep_species(_TRUNCATED).stationary_point_findings()
+            if f.code == W_FREQ_LIST_INCOMPLETE
+        ] == [W_FREQ_LIST_INCOMPLETE]

--- a/backend/tests/schemas/test_stationary_point_validation_tiers.py
+++ b/backend/tests/schemas/test_stationary_point_validation_tiers.py
@@ -770,6 +770,19 @@ def _ts_reaction() -> dict:
     }
 
 
+#: Saddle-point geometry for the transition-state builders below.
+#:
+#: A *linear triatomic*, and deliberately so. ``_XYZ`` is a single
+#: hydrogen atom, which was fine while nothing read the geometry, but a
+#: single atom has three degrees of freedom in total and the motivating
+#: record below deposits four frequencies — a combination
+#: ``freq_list_exceeds_geometry_degrees_of_freedom`` correctly refuses to
+#: call coherent. Three collinear atoms have ``3N - 5 = 4`` vibrational
+#: modes, so the motivating record is exactly a complete spectrum here,
+#: and the fixture doubles as the linear-molecule case that a naive
+#: ``3N - 6`` completeness rule would have wrongly flagged.
+_TS_XYZ = "3\ncomment\nH 0.0 0.0 -0.9\nH 0.0 0.0 0.0\nH 0.0 0.0 0.9"
+
 #: The motivating record, as a producer would deposit it: the signed
 #: frequency list, the designated reaction coordinate, and a disposition
 #: for each other imaginary mode.
@@ -810,7 +823,7 @@ def _standalone_ts(
         reaction=_ts_reaction(),
         charge=0,
         multiplicity=2,
-        geometry={"xyz_text": _XYZ},
+        geometry={"xyz_text": _TS_XYZ},
         primary_opt={
             "type": "opt",
             "software_release": _SOFTWARE,
@@ -851,7 +864,7 @@ def _bundle_ts_payload(
     return {
         "charge": 0,
         "multiplicity": 2,
-        "geometry": {"key": "ts_geom", "xyz_text": _XYZ},
+        "geometry": {"key": "ts_geom", "xyz_text": _TS_XYZ},
         "calculation": {
             "key": "ts_opt",
             "type": "opt",

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,63 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.29.0 — a frequency list is measured against the geometry it was computed on
+
+**Not breaking.** No field is added, renamed or removed, and **every
+0.28.0 payload validates unchanged under 0.29.0**: the set of payloads
+that validate is byte-for-byte the set that validated before, and every
+payload 0.28.0 refused is still refused. The new judgement is entirely at
+the **warning** tier — it changes what an accepted upload is *told*,
+never whether it is accepted.
+
+[ADR 0012](https://github.com/TCKDB/TCKDB/blob/main/docs/adr/0012-imaginary-modes-are-judged-by-magnitude-not-counted.md)
+§"What a record must carry" requires "the complete signed unrounded
+frequency list, never filtered", and nothing checked it. A depositor
+could send three modes, all imaginary, with `n_imag = 3` and pass every
+rule the package had — `freq_n_imag_disagrees_with_modes` included,
+because that rule compares the imaginary count against `n_imag` and a
+list of nothing but imaginary modes satisfies it exactly. The real modes
+were simply absent, and absence is silent.
+
+New module `tckdb_schemas.frequency_completeness`, with two codes:
+
+| code | when |
+|---|---|
+| `freq_list_incomplete_for_geometry` | the list is shorter than the smallest complete spectrum the geometry admits |
+| `freq_list_exceeds_geometry_degrees_of_freedom` | the list is longer than `3N`, so it describes motion the geometry does not have |
+
+Both are warnings carrying `structural_flag=True`, reported through the
+existing `stationary_point_findings()` surface on every published upload
+request model and reaching a client as an `UploadWarning` in the 201
+body.
+
+**The bounds are deliberately the weakest ones that are certainly true.**
+Linearity is never determined: a collinear molecule has `3N - 5` modes,
+one *more* than `3N - 6`, so comparing against `3N - 6` accepts every
+linear molecule without choosing a collinearity tolerance. For `N ≤ 2`
+linearity is a fact rather than a measurement, so those take exact counts
+(`N = 1` → 0 modes, `N = 2` → 1). The ceiling is `3N` and not `3N - 6`
+because ADR 0012 also asks for "the six translation/rotation eigenvalues
+… so contamination is directly assessable" — a record carrying all `3N`
+is the most complete record the ADR describes and must not be refused as
+an over-count.
+
+**Why warn and not block.** The check cannot tell a filtered list from a
+genuinely shorter one: a partial-Hessian job, a frozen-atom or ONIOM
+Hessian, and a lumped participant all produce fewer than `3N - 6` modes
+and are correct records of what was computed. And `modes = null` is
+accepted and must stay accepted, so a block's cheapest workaround is
+deleting the frequency list — turning a partial list into no list at all,
+which is the failure ADR 0012 §"Why not refuse, when refusing is cheaper"
+names outright. The over-long case genuinely is definitional; it warns
+here because promoting it to a refusal belongs in the scientific-check
+register rather than in an implementation.
+
+Minor rather than patch because two new machine-readable warning codes
+enter the published vocabulary: a consumer may now branch on them, which
+it could not before. Neither is a refusal code, so no client rejection
+constant changes.
+
 ### 0.28.0 — a frequency result that contradicts itself says so by name
 
 **Not breaking.** No field is added, renamed or removed, and the set of

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.28.0"
+version = "0.29.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
@@ -16,6 +16,7 @@ from tckdb_schemas.enums import (
     PathSearchMethod,
     SCFStabilityStatus,
 )
+from tckdb_schemas.frequency_completeness import evaluate_deposited_frequency_list
 from tckdb_schemas.fragments.calculation_origin import CalculationOriginMetadata
 from tckdb_schemas.fragments.geometry import GeometryPayload
 from tckdb_schemas.fragments.execution_environment import ExecutionEnvironmentManifestPayload
@@ -928,6 +929,38 @@ class CalculationWithResultsPayload(CalculationPayload):
                 self.freq_result.reaction_coordinate_mode_index
             ),
             tau=self.tau_resolution(),
+        )
+
+    def frequency_completeness_findings(
+        self, *, location: str, fallback_xyz_text: str | None = None
+    ) -> list[StationaryPointFinding]:
+        """Judge whether this calculation's frequency list is the spectrum.
+
+        A thin adapter over :mod:`tckdb_schemas.frequency_completeness`,
+        which owns the arithmetic and knows no payload shapes. What is
+        payload-shaped, and lives here, is *which* geometry the frequency
+        job ran on: ``input_geometries[0]`` when the producer named one,
+        and otherwise the reference geometry the workflow will fall back
+        to — the same fallback ``input_geometries``' own description
+        documents, so the check counts the atoms the database will end up
+        binding this calculation to rather than a different set.
+
+        :param location: Path to the payload element, used verbatim.
+        :param fallback_xyz_text: The enclosing conformer's or transition
+            state's reference geometry, for the common case of a freq
+            calculation that names no input geometry of its own.
+        """
+        if self.freq_result is None or self.freq_result.modes is None:
+            return []
+        return evaluate_deposited_frequency_list(
+            len(self.freq_result.modes),
+            input_geometry_xyz_text=(
+                self.input_geometries[0].xyz_text
+                if self.input_geometries
+                else None
+            ),
+            fallback_xyz_text=fallback_xyz_text,
+            location=location,
         )
 
     def tau_resolution(self) -> TauResolution:

--- a/schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py
@@ -1,0 +1,256 @@
+"""Whether a deposited frequency list is the spectrum, or only part of it.
+
+`ADR 0012 <../../../../docs/adr/0012-imaginary-modes-are-judged-by-magnitude-not-counted.md>`_
+§"What a record must carry" says the frequency list "must be complete,
+signed and unrounded, never filtered". Nothing enforced the *complete*.
+
+A depositor could upload three modes, all imaginary, with ``n_imag = 3``
+and pass every check TCKDB had — including
+``freq_n_imag_disagrees_with_modes``, which compares the imaginary count
+against ``n_imag`` and is satisfied exactly. The real modes were simply
+absent, and absence is silent: a consumer recomputing a partition
+function from that list gets a number, not an error, and a comparison
+against an independently recovered spectrum agrees on every mode present
+and says nothing about the ones missing. An unenforced completeness
+requirement therefore does not merely fail to help — it makes a partial
+record read as a whole one.
+
+What is checkable, and what is not
+----------------------------------
+Completeness is not a property of the payload's frequency list alone. It
+is a relation between that list and the geometry the frequency job ran
+on: a harmonic analysis of *N* atoms has ``3N − 6`` vibrational modes,
+or ``3N − 5`` if the atoms are collinear, and none at all for a single
+atom. So the check needs the geometry, which is why it lives here and is
+called from the request models that hold both rather than from
+``FreqResultPayload``, which holds only one.
+
+**The bound is deliberately the weakest one that is certainly true.**
+Linearity is not determined here. A collinear molecule has ``3N − 5``
+modes, one *more* than ``3N − 6``, so comparing against ``3N − 6``
+accepts every linear molecule without ever asking whether it is linear —
+and asking would mean choosing a collinearity tolerance, which is a
+numerical judgement this check has no business making at validation
+time. For ``N ≤ 2`` linearity is a fact rather than a measurement (two
+atoms are collinear by definition), so those cases take their exact
+counts.
+
+The upper bound is ``3N``, not ``3N − 6``, because ADR 0012 asks for
+*both*: the spectrum, and "the six translation/rotation eigenvalues …
+so contamination is directly assessable". A record carrying all ``3N``
+eigenvalues of the mass-weighted Hessian is the most complete record the
+ADR describes, and refusing it as an over-count would refuse exactly
+what the ADR asks for. Only a list longer than ``3N`` describes more
+degrees of freedom than the geometry has.
+
+Why this warns rather than blocks
+---------------------------------
+Under `ADR 0008 <0008-validation-tiers-definitions-block-expectations-warn.md>`_
+a check may block only when it asserts a definition or a contract.
+"A frequency list is the spectrum" reads like a definition, and the
+argument that it is not is this: **the check cannot tell a filtered list
+from a genuinely shorter one.** A partial-Hessian frequency job, a
+frozen-atom or ONIOM Hessian, or a lumped ``pseudo`` participant all
+produce fewer than ``3N − 6`` modes and are correct records of what was
+computed. TCKDB carries no field saying which of those a short list is,
+so refusing would assert a determination the deposit does not contain
+the information to support — the same shape of error ADR 0012 identified
+in the ``n_imag == 1`` gate it retired.
+
+The second argument is structural and decides it. ``modes = null`` is
+accepted and must stay accepted: absence is incompleteness, not
+contradiction, and the read surface already reports
+``n_imag_at_or_above_tau = null`` rather than ``0`` for a record with no
+frequency list. So the cheapest way past a completeness *block* is to
+delete the frequency list entirely, turning a partial list — some
+information, honestly labelled — into no information at all. ADR 0012
+§"Why not refuse, when refusing is cheaper" names that failure exactly:
+"A rule that converts visible ambiguity into invisible falsehood is
+worse than no rule."
+
+One sub-case genuinely is definitional: a list *longer* than ``3N`` is
+arithmetically impossible for a harmonic analysis of that geometry, and
+no correct deposit produces it. It is reported here at the warning tier
+with its own code so that the two facts stay distinguishable; promoting
+it to a refusal wants a scientific-check register entry, which is a
+decision to take in the register rather than during an implementation.
+
+Pure functions only — no Pydantic, no backend imports. Callers extract
+the two integers from whatever shape they hold and pass them in.
+"""
+
+from __future__ import annotations
+
+from tckdb_schemas.fragments.reaction_atom_map import parse_xyz_elements
+from tckdb_schemas.stationary_point import StationaryPointFinding, ValidationTier
+
+#: The deposited frequency list is shorter than the smallest complete
+#: harmonic spectrum the geometry admits, so modes the calculation
+#: produced are missing from the record. ADR 0012 requires the complete
+#: signed unrounded list; this says the record does not carry one.
+W_FREQ_LIST_INCOMPLETE = "freq_list_incomplete_for_geometry"
+
+#: The deposited frequency list is longer than ``3N`` for the geometry it
+#: is attached to, so it describes more degrees of freedom than that
+#: geometry has. Usually a list attached to the wrong geometry rather
+#: than a filtered one.
+W_FREQ_LIST_EXCEEDS_GEOMETRY = "freq_list_exceeds_geometry_degrees_of_freedom"
+
+
+def minimum_complete_mode_count(n_atoms: int) -> int:
+    """Smallest frequency-list length a complete spectrum can have.
+
+    Exact for ``N <= 2``, where linearity is a fact rather than a
+    measurement: a single atom has no vibrations at all, and two atoms
+    are collinear by definition and have exactly one. For ``N >= 3`` it
+    is ``3N - 6``, which is a *lower* bound — a collinear geometry has
+    ``3N - 5`` and clears it — chosen so the check never asks whether a
+    geometry is linear.
+
+    :param n_atoms: Number of atoms in the geometry the frequency job
+        ran on.
+    :returns: The threshold below which a list is certainly incomplete.
+    """
+    if n_atoms <= 1:
+        return 0
+    if n_atoms == 2:
+        return 1
+    return 3 * n_atoms - 6
+
+
+def maximum_mode_count(n_atoms: int) -> int:
+    """Longest frequency list the geometry admits.
+
+    ``3N``: the full eigenvalue spectrum of the mass-weighted Hessian,
+    which ADR 0012 asks for so the six translation/rotation eigenvalues
+    are available to assess contamination.
+    """
+    return 3 * n_atoms
+
+
+def atom_count_of_xyz(xyz_text: str | None) -> int | None:
+    """Atom count of an XYZ block, or ``None`` when it cannot be counted.
+
+    An unparseable geometry is refused by the atom-map fragment that owns
+    that contract; this check declines to speak about it rather than
+    reporting the same defect a second time in different words.
+    """
+    if xyz_text is None:
+        return None
+    try:
+        return len(parse_xyz_elements(xyz_text))
+    except ValueError:
+        return None
+
+
+def evaluate_frequency_list_completeness(
+    n_modes: int | None,
+    n_atoms: int | None,
+    *,
+    location: str,
+) -> list[StationaryPointFinding]:
+    """Judge one deposited frequency list against its own geometry.
+
+    :param n_modes: Length of the deposited frequency list. ``None``
+        means no list was deposited, which is incompleteness that says
+        so; nothing is reported.
+    :param n_atoms: Atom count of the geometry the frequency job ran on.
+        ``None`` means no geometry is in hand, and the check is not
+        reachable — nothing is reported.
+    :param location: Path to the payload element, used verbatim.
+    :returns: Findings, possibly empty. Never raises.
+    """
+    if n_modes is None or n_atoms is None:
+        return []
+
+    floor = minimum_complete_mode_count(n_atoms)
+    ceiling = maximum_mode_count(n_atoms)
+
+    if n_modes > ceiling:
+        return [
+            StationaryPointFinding(
+                tier=ValidationTier.warn,
+                code=W_FREQ_LIST_EXCEEDS_GEOMETRY,
+                location=location,
+                structural_flag=True,
+                message=(
+                    f"{location}: the frequency list carries {n_modes} modes "
+                    f"but the geometry it is attached to has {n_atoms} atom(s), "
+                    f"which have only {ceiling} degrees of freedom in total "
+                    f"({W_FREQ_LIST_EXCEEDS_GEOMETRY}). A harmonic analysis "
+                    f"of this geometry cannot produce that many modes, so the "
+                    f"list and the geometry are not describing the same "
+                    f"molecule — check that the calculation is attached to "
+                    f"the geometry it actually ran on."
+                ),
+            )
+        ]
+
+    if n_modes < floor:
+        return [
+            StationaryPointFinding(
+                tier=ValidationTier.warn,
+                code=W_FREQ_LIST_INCOMPLETE,
+                location=location,
+                structural_flag=True,
+                message=(
+                    f"{location}: the frequency list carries {n_modes} mode(s) "
+                    f"but a harmonic analysis of this {n_atoms}-atom geometry "
+                    f"produces at least {floor} "
+                    f"({W_FREQ_LIST_INCOMPLETE}). ADR 0012 requires the "
+                    f"complete signed unrounded list, never filtered: a "
+                    f"partial list agrees with an independently recovered "
+                    f"spectrum on every mode it contains and is silent about "
+                    f"the ones it omits, which reads as agreement. The record "
+                    f"is accepted and flagged. Deposit every mode the "
+                    f"frequency job printed, including the reaction "
+                    f"coordinate and any mode removed from the partition "
+                    f"function; if the job genuinely computed a partial "
+                    f"Hessian, say so in the calculation's parameters so the "
+                    f"short list is explicable."
+                ),
+            )
+        ]
+
+    return []
+
+
+def evaluate_deposited_frequency_list(
+    n_modes: int | None,
+    *,
+    input_geometry_xyz_text: str | None,
+    fallback_xyz_text: str | None,
+    location: str,
+) -> list[StationaryPointFinding]:
+    """Judge a deposited list against whichever geometry it will be bound to.
+
+    Every upload shape carrying a frequency list resolves its geometry
+    the same way — the calculation's own first input geometry when the
+    producer named one, and otherwise the enclosing conformer's or
+    transition state's reference geometry, which is the fallback the
+    persistence workflow itself applies for ``freq``. Written once here
+    so the three payload shapes that call it cannot drift into counting
+    three different sets of atoms.
+
+    Both arguments are XYZ text, not payload objects: this module knows
+    the rule, and the caller knows where its geometries live.
+    """
+    xyz_text = (
+        input_geometry_xyz_text
+        if input_geometry_xyz_text is not None
+        else fallback_xyz_text
+    )
+    return evaluate_frequency_list_completeness(
+        n_modes, atom_count_of_xyz(xyz_text), location=location
+    )
+
+
+__all__ = [
+    "W_FREQ_LIST_EXCEEDS_GEOMETRY",
+    "W_FREQ_LIST_INCOMPLETE",
+    "atom_count_of_xyz",
+    "evaluate_deposited_frequency_list",
+    "evaluate_frequency_list_completeness",
+    "maximum_mode_count",
+    "minimum_complete_mode_count",
+]

--- a/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
@@ -38,6 +38,7 @@ from tckdb_schemas.fragments.refs import (
     SoftwareReleaseRef,
     WorkflowToolReleaseRef,
 )
+from tckdb_schemas.frequency_completeness import evaluate_deposited_frequency_list
 from tckdb_schemas.stationary_point import (
     StationaryPointFinding,
     evaluate_transition_state_frequency,
@@ -223,6 +224,40 @@ def transition_state_frequency_findings(
             (observation.canonical_key, observation.canonical_value)
             for observation in (calc_in.parameters or ())
         ),
+    )
+
+
+def frequency_completeness_findings(
+    calc_in: "CalculationIn", *, location: str, xyz_text: str | None
+) -> list[StationaryPointFinding]:
+    """Judge a bundle-local calculation's frequency list against its geometry.
+
+    The bundle form of
+    :meth:`CalculationWithResultsPayload.frequency_completeness_findings`.
+    It reads the mode list through :func:`freq_result_of` rather than off
+    ``freq_frequencies_cm1`` directly, for the same reason
+    :func:`freq_evidence` exists: the flat fields only become a stored
+    result block when ``type`` is ``freq``, so judging the raw field
+    would judge something the database will never hold.
+
+    :param xyz_text: The geometry this calculation ran on, already
+        resolved from ``geometry_key`` by the enclosing model — this
+        function cannot see the bundle's geometry namespace.
+    """
+    freq_result = freq_result_of(calc_in)
+    if freq_result is None or freq_result.modes is None:
+        return []
+    # ``input_geometries`` is added by the computed-reaction subclass and
+    # absent from the base bundle calculation, so it is read defensively
+    # rather than declared — the resolved ``geometry_key`` is the
+    # universal source and the inline list, where a producer supplied
+    # one, is the more specific one.
+    inline = getattr(calc_in, "input_geometries", None)
+    return evaluate_deposited_frequency_list(
+        len(freq_result.modes),
+        input_geometry_xyz_text=inline[0].xyz_text if inline else None,
+        fallback_xyz_text=xyz_text,
+        location=location,
     )
 
 

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -70,6 +70,7 @@ from tckdb_schemas.shared.calculation_in import (
     GeometryIn,
     calculation_in_to_with_results_payload as _base_calc_to_payload,
     freq_evidence,
+    frequency_completeness_findings,
     transition_state_frequency_findings,
 )
 from tckdb_schemas.stationary_point import (
@@ -703,28 +704,46 @@ class BundleSpeciesIn(SchemaBase):
         ignored which entity owns the frequency would wrongly reject it.
         """
         kind = self.species_entry.species_entry_kind
+        xyz_by_geometry_key = {
+            conformer.geometry.key: conformer.geometry.xyz_text
+            for conformer in self.conformers
+        }
         findings: list[StationaryPointFinding] = []
         for conformer in self.conformers:
+            location = (
+                f"species['{self.key}'].conformers['{conformer.key}']"
+                f".calculation"
+            )
             n_imag, imag_freq_cm1 = freq_evidence(conformer.calculation)
             findings.extend(
                 evaluate_species_entry_frequency(
-                    kind,
-                    n_imag,
-                    imag_freq_cm1,
-                    location=(
-                        f"species['{self.key}'].conformers['{conformer.key}']"
-                        f".calculation"
-                    ),
+                    kind, n_imag, imag_freq_cm1, location=location
+                )
+            )
+            findings.extend(
+                frequency_completeness_findings(
+                    conformer.calculation,
+                    location=f"{location}.freq_frequencies_cm1",
+                    xyz_text=conformer.geometry.xyz_text,
                 )
             )
         for calc in self.calculations:
+            location = f"species['{self.key}'].calculations['{calc.key}']"
             n_imag, imag_freq_cm1 = freq_evidence(calc)
             findings.extend(
                 evaluate_species_entry_frequency(
-                    kind,
-                    n_imag,
-                    imag_freq_cm1,
-                    location=f"species['{self.key}'].calculations['{calc.key}']",
+                    kind, n_imag, imag_freq_cm1, location=location
+                )
+            )
+            findings.extend(
+                frequency_completeness_findings(
+                    calc,
+                    location=f"{location}.freq_frequencies_cm1",
+                    # ``validate_calc_geometry_belongs_to_conformer`` has
+                    # already refused a key that names anything else, so a
+                    # miss here means the calculation named no geometry at
+                    # all and the check declines to speak.
+                    xyz_text=xyz_by_geometry_key.get(calc.geometry_key or ""),
                 )
             )
         return findings
@@ -833,10 +852,15 @@ class BundleTransitionStateIn(SchemaBase):
         """Judge this transition state against its own frequency evidence."""
         findings: list[StationaryPointFinding] = []
         for calc in (self.calculation, *self.calculations):
+            location = f"transition_state.calculations['{calc.key}']"
             findings.extend(
-                transition_state_frequency_findings(
+                transition_state_frequency_findings(calc, location=location)
+            )
+            findings.extend(
+                frequency_completeness_findings(
                     calc,
-                    location=f"transition_state.calculations['{calc.key}']",
+                    location=f"{location}.freq_frequencies_cm1",
+                    xyz_text=self.geometry.xyz_text,
                 )
             )
         return findings

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -41,6 +41,7 @@ from tckdb_schemas.fragments.calculation import (
     SPResultPayload,
     WavefunctionDiagnosticPayload,
 )
+from tckdb_schemas.frequency_completeness import evaluate_deposited_frequency_list
 from tckdb_schemas.fragments.geometry import GeometryPayload
 from tckdb_schemas.fragments.identity import SpeciesEntryIdentityPayload
 from tckdb_schemas.fragments.refs import (
@@ -259,6 +260,31 @@ class CalculationInBundle(SchemaBase):
                     )
                 seen.add(c.constraint_index)
         return self
+
+    def frequency_completeness_findings(
+        self, *, location: str, fallback_xyz_text: str | None = None
+    ) -> list[StationaryPointFinding]:
+        """Judge whether this calculation's frequency list is the spectrum.
+
+        The bundle twin of
+        :meth:`CalculationWithResultsPayload.frequency_completeness_findings`.
+        This class re-declares the primitive payload's fields rather than
+        inheriting them, so the adapter is re-declared too; the rule it
+        adapts to lives once, in
+        :mod:`tckdb_schemas.frequency_completeness`.
+        """
+        if self.freq_result is None or self.freq_result.modes is None:
+            return []
+        return evaluate_deposited_frequency_list(
+            len(self.freq_result.modes),
+            input_geometry_xyz_text=(
+                self.input_geometries[0].xyz_text
+                if self.input_geometries
+                else None
+            ),
+            fallback_xyz_text=fallback_xyz_text,
+            location=location,
+        )
 
     @model_validator(mode="after")
     def reject_database_id_fields(self) -> Self:
@@ -664,15 +690,22 @@ class ComputedSpeciesUploadRequest(SchemaBase):
             for calc in (conf.primary_calculation, *conf.additional_calculations):
                 if calc.freq_result is None:
                     continue
+                location = (
+                    f"conformers['{conf.key}'].calculations"
+                    f"['{calc.key}'].freq_result"
+                )
                 findings.extend(
                     evaluate_species_entry_frequency(
                         kind,
                         calc.freq_result.n_imag,
                         calc.freq_result.imag_freq_cm1,
-                        location=(
-                            f"conformers['{conf.key}'].calculations"
-                            f"['{calc.key}'].freq_result"
-                        ),
+                        location=location,
+                    )
+                )
+                findings.extend(
+                    calc.frequency_completeness_findings(
+                        location=f"{location}.modes",
+                        fallback_xyz_text=conf.geometry.xyz_text,
                     )
                 )
         return findings

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
@@ -353,6 +353,12 @@ class ConformerUploadRequest(SchemaBase):
                     location=f"{label}.freq_result",
                 )
             )
+            findings.extend(
+                calc.frequency_completeness_findings(
+                    location=f"{label}.freq_result.modes",
+                    fallback_xyz_text=self.geometry.xyz_text,
+                )
+            )
         return findings
 
     @model_validator(mode="after")

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/transition_state_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/transition_state_upload.py
@@ -252,6 +252,12 @@ class TransitionStateUploadRequest(SchemaBase):
                     location=f"{label}.freq_result"
                 )
             )
+            findings.extend(
+                calc.frequency_completeness_findings(
+                    location=f"{label}.freq_result.modes",
+                    fallback_xyz_text=self.geometry.xyz_text,
+                )
+            )
         return findings
 
     @model_validator(mode="after")


### PR DESCRIPTION
ADR 0012 §"What a record must carry" requires "the complete signed
unrounded frequency list, never filtered". Nothing asked. A depositor
could send three modes, all imaginary, with `n_imag = 3` and pass every
check TCKDB had — `freq_n_imag_disagrees_with_modes` (#160) included,
because that rule compares the imaginary count against `n_imag` and a
list of nothing but imaginary modes satisfies it exactly. The real modes
were simply absent, and absence is silent.

`paper/18__TCKDB/3_results.tex` reports recovering a harmonic spectrum
from a stored Hessian and comparing it against the independently stored
frequency lists, agreeing to within 0.045 cm-1. A subset agrees on every
mode it contains and is silent about the ones it omits, which reads as
agreement. The completeness of the stored list is load-bearing for that
claim, and it was unenforced.

## What this adds

New pure module `tckdb_schemas.frequency_completeness`, and two warning
codes reported through the existing `stationary_point_findings()` surface
on every published upload request model:

| code | when |
|---|---|
| `freq_list_incomplete_for_geometry` | the list is shorter than the smallest complete spectrum the geometry admits |
| `freq_list_exceeds_geometry_degrees_of_freedom` | the list is longer than `3N`, so it describes motion the geometry does not have |

Both carry `structural_flag=True` and reach a client as an
`UploadWarning` in the 201 body.

## The measurement that chose the rule

Three candidate rules were on the table: `3N-6` against the geometry, a
count recovered from a stored Hessian, or a declared completeness flag.
Measured against every real deposit in the repo:

| corpus | records with a frequency list | with a countable geometry | with a Hessian |
|---|---|---|---|
| ARC `output.yml` statmech (13 runs) | 57 | **57 (100%)** | **0** |
| hydrazine PDep supporting-information (deployed on the Pi) | 4 | **4 (100%)** | **0** |
| pre-generated ARC upload payloads | **0 of 57 freq calcs** | 57 | 0 |

Geometry is universal; an inline Hessian is absent everywhere. The
Hessian rule is not merely rare, it is structurally unreachable at
validation time — `app/services/hessian_extraction.py` fills `calc_hessian`
by best-effort extraction from an uploaded *artifact*, after the
calculation row exists, so even the deposits that eventually have one do
not have it when the check must run. Rule 1 is the only reachable rule
and it is reachable essentially always.

## Tier: warn, and the argument

ADR 0008 lets a check block only when it asserts a definition or a
contract. "A frequency list is the spectrum" reads like a definition.
Two arguments say it is not.

**The check cannot tell a filtered list from a genuinely shorter one.**
A partial-Hessian frequency job, a frozen-atom or ONIOM Hessian, and a
lumped participant all produce fewer than `3N-6` modes and are correct
records of what was computed. TCKDB carries no field saying which of
those a short list is, so refusing would assert a determination the
deposit does not contain the information to support — the same shape of
error ADR 0012 identified in the `n_imag == 1` gate it retired.

**`modes = null` is accepted and must stay accepted.** Absence is
incompleteness, not contradiction — 0.28.0's changelog and the read
surface's `n_imag_at_or_above_tau = null` both say so. So the cheapest
way past a completeness *block* is to delete the frequency list, turning
a partial list (some information, honestly labelled) into no information
at all. ADR 0012 §"Why not refuse, when refusing is cheaper" names that
failure outright: "A rule that converts visible ambiguity into invisible
falsehood is worse than no rule."

One sub-case genuinely is definitional: a list longer than `3N` is
arithmetically impossible for a harmonic analysis of that geometry. It
warns here under its own code because promoting it to a refusal wants a
scientific-check register entry, and the register is owned by another
agent this round. **That is the follow-up this branch asks for.**

## The bounds are the weakest ones that are certainly true

Linearity is never determined. A collinear molecule has `3N-5` modes,
one *more* than `3N-6`, so comparing against `3N-6` accepts every linear
molecule without choosing a collinearity tolerance — a numerical
judgement this check has no business making at validation time. For
`N ≤ 2` linearity is a fact rather than a measurement, so those take
exact counts (`N=1` → 0, `N=2` → 1; stating `N=2` as `3N-6 = 0` would
accept an empty list for every diatomic).

The ceiling is `3N`, not `3N-6`, because ADR 0012 also asks for "the six
translation/rotation eigenvalues … so contamination is directly
assessable". A record carrying all `3N` eigenvalues is the most complete
record the ADR describes; refusing it as an over-count would refuse
exactly what the ADR asks for.

## Would existing deposits now be refused?

**No.** Nothing is refused — the rule only warns, and the set of payloads
that validate is byte-for-byte unchanged. Nothing is even *flagged*
across all three corpora: 44/57 ARC statmech records are complete, 4/4
hydrazine PDep records are complete (including linear H2 at `3N-5`), and
the 57 pre-generated ARC deposit bodies carry no frequency list at all.

The 13 ARC transition states whose statmech list is `3N-7` — the reaction
coordinate removed, which ADR 0012 §claim 2 itself mandates for the
partition function — never reach this rule: `freq_n_imag_disagrees_with_modes`
already refuses them, because `n_imag = 1` beside an all-real list is a
contradiction. #160 covers more than it was credited with.

## Verification

Three gates, on `db4bc37f` first and then on this branch:

| gate | main | branch |
|---|---|---|
| rest | 4226 passed, 14 skipped | 4259 passed, 14 skipped (+33) |
| api | 2662 passed | 2677 passed (+15) |
| scientific | 2049 passed | 2049 passed |

The deltas are exactly the new tests. `ruff check app tests scripts` from
`backend/` and `ruff check tckdb_schemas tests` from the wire package both
pass. `backend/tests/api/golden/openapi.json` is unchanged — the additions
are methods, not fields.

Sixteen mutations were applied one at a time and every one turned a test
red: the `3N-6` floor to `3N-5`, the diatomic floor to 0, the `3N` ceiling
to `3N-6`, each of the two branches deleted, `structural_flag` flipped,
the fallback-geometry rule short-circuited, and each of the eight upload
seams unwired individually. Two of those (the computed-reaction transition
state, and the statmech/thermo/transport seam) came back **green** on the
first pass, which is a finding rather than a relief — the seam tests at
the foot of `test_frequency_list_completeness.py` were written because of
them.

One existing fixture changed: `_XYZ` in
`tests/schemas/test_stationary_point_validation_tiers.py` was a single
hydrogen atom used as the geometry for the transition-state builders,
which have four frequencies. A single atom has three degrees of freedom
in total, so that fixture was physically impossible and the over-count
rule correctly said so. It now uses a linear triatomic (`3N-5 = 4`), so
every assertion in those tests is preserved unchanged and the fixture
doubles as the linear-molecule case.

## Versions

`tckdb-schemas` 0.28.0 → **0.29.0**, with a README changelog entry.
Minor rather than patch because two new machine-readable warning codes
enter the published vocabulary. **Not breaking**: every 0.28.0 payload
validates unchanged, and every payload 0.28.0 refused is still refused.

No `tckdb-client` bump is needed. The generated rejection-code constants
cover `error_envelope` codes only, and these are `upload_warning` codes;
`test_client_rejection_codes_generated.py` and
`test_scientific_check_register.py` both pass unchanged.
