### PR TITLE
Refuse a frequency list that has more modes than the geometry has degrees of freedom

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -72,10 +72,15 @@ this file by four different routes, and no one of them is enough:
   and ``scientific_read.handles.reconcile_id_ref`` both take their code as
   a *parameter*, ``tckdb_schemas.stationary_point`` raises with whichever
   code its blocking finding carries, and the integrity handler looks its
-  code up by PostgreSQL constraint name. That is eighteen codes the scan
+  code up by PostgreSQL constraint name. That is nineteen codes the scan
   is blind to, and the ``*_handle_conflict`` family was found only by the
   observer below. For those the guard checks the *defining* module
-  instead, which is where the literal actually lives.
+  instead, which is where the literal actually lives. The nineteenth,
+  ``freq_list_exceeds_geometry_degrees_of_freedom``, shows why that is the
+  right key rather than a convenience: its literal lives in
+  ``tckdb_schemas.frequency_completeness`` while the ``raise`` that
+  carries it lives in ``stationary_point``, so no scan of raise sites
+  could attribute it to the module a reader needs to open.
 * **A handler, a middleware or a route writes the body itself** and names
   the code in a literal there — twenty-one of these, none of them at a
   ``raise``. They are found by reading the small number of places that
@@ -297,6 +302,17 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/export.py"),
     ApiCode("export_seed_unresolved", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/export.py"),
+    ApiCode("freq_list_exceeds_geometry_degrees_of_freedom", 422, Surface.coded_exception,
+            "schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py",
+            note=(
+                "One of two codes that module reports, and the only one that "
+                "refuses. Its sibling freq_list_incomplete_for_geometry is an "
+                "UploadWarning on an accepted 201 and is deliberately absent "
+                "from this catalogue, which enumerates error bodies only. "
+                "Minted from a variable: raise_for_blocking_findings reports "
+                "whichever code its blocking finding carries, so the scan "
+                "cannot see it and the origin is the defining module."
+            )),
     ApiCode("freq_n_imag_disagrees_with_modes", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py"),
     ApiCode("geometry_too_large", 422, Surface.message_prefix,

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -37,6 +37,10 @@ from tckdb_schemas.fragments.calculation import (
     W_FREQ_N_IMAG_DISAGREES_WITH_MODES,
     FreqResultPayload,
 )
+from tckdb_schemas.frequency_completeness import (
+    W_FREQ_LIST_EXCEEDS_GEOMETRY,
+    evaluate_frequency_list_completeness,
+)
 from tckdb_schemas.stationary_point import (
     TAU_ANALYTIC_DEFAULT_CM1,
     TAU_ANALYTIC_TIGHT_CM1,
@@ -57,6 +61,7 @@ from tckdb_schemas.stationary_point import (
     W_TS_REACTION_COORDINATE_NOT_DESIGNATED,
     evaluate_species_entry_frequency,
     evaluate_transition_state_frequency,
+    raise_for_blocking_findings,
     resolve_tau,
 )
 
@@ -532,6 +537,112 @@ CHECK_FREQ_N_IMAG_AGREES_WITH_ITS_MODES = ScientificCheck(
         "the complete signed frequency list, and asking is as far as this "
         "tier goes. What has no door is depositing both and letting them "
         "contradict each other."
+    ),
+)
+
+CHECK_FREQ_LIST_WITHIN_GEOMETRY_DEGREES_OF_FREEDOM = ScientificCheck(
+    group="Stationary points",
+    sort_key=8,
+    code=W_FREQ_LIST_EXCEEDS_GEOMETRY,
+    asserts=(
+        "A frequency list carries no more modes than the geometry it is "
+        "attached to has degrees of freedom: at most ``3N`` for ``N`` atoms, "
+        "the six rigid-body modes included."
+    ),
+    tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
+    tier_rationale=(
+        "Definitional, and — unusually in this group — arithmetically so. "
+        "``3N`` is the dimension of the nuclear coordinate space, so it is the "
+        "total number of eigenvalues the mass-weighted Hessian of an "
+        "``N``-atom geometry has: not the vibrational count, which is "
+        "``3N - 6`` or ``3N - 5``, but every Cartesian degree of freedom "
+        "including the six translations and rotations ADR 0012 asks a record "
+        "to carry. A longer list is therefore not a short spectrum — it is "
+        "not a spectrum of that geometry at all, under any harmonic "
+        "treatment, integration grid, coordinate system or level of theory. "
+        "That is what separates it from the ``n_imag == 1`` gate ADR 0012 "
+        "retired: there, two scientifically correct calculations of one "
+        "structure legitimately returned different answers and the tier was "
+        "an expectation about numerical quality wearing the costume of a "
+        "definition. Here no protocol takes part, so no correct deposit is "
+        "refused. "
+        "The contrast with the *floor* is the argument, and the floor is "
+        "correctly a warning for precisely the reasons this is not. First, "
+        "the ambiguity a short list carries is one-sided: a partial-Hessian "
+        "job, a frozen-atom or ONIOM Hessian and a lumped ``pseudo`` "
+        "participant all *remove* modes and are honest records of what was "
+        "computed, TCKDB carries no field saying which of them a short list "
+        "is, and nothing whatsoever filters modes *in*. Second, ``modes = "
+        "null`` is accepted and must stay accepted, so the cheapest way past "
+        "a completeness *block* on the floor would be deleting the frequency "
+        "list — converting visible ambiguity into invisible falsehood, which "
+        "ADR 0012 §\"Why not refuse, when refusing is cheaper\" names as worse "
+        "than no rule. Neither reaches the ceiling. Deleting an over-long "
+        "list loses a spectrum the check has already found is not this "
+        "geometry's, which is the repair rather than the evasion; and "
+        "accepting it is the destructive option, because stored it reads as "
+        "this geometry's spectrum and a consumer recomputing a partition "
+        "function from the pair gets a number rather than an error. "
+        "No threshold is declared because there is none to declare: ``3N`` is "
+        "counted from the deposited geometry, not tuned."
+    ),
+    adr="0012",
+    enforced_by=(
+        PythonCheck(
+            evaluate_frequency_list_completeness,
+            note=(
+                "Owns the arithmetic and knows no payload shapes; the "
+                "geometry each frequency list is measured against is resolved "
+                "by ``evaluate_deposited_frequency_list`` in the same module "
+                "— the calculation's own first input geometry where the "
+                "producer named one, and otherwise the enclosing conformer's "
+                "or transition state's reference geometry, which is the "
+                "fallback the persistence workflow itself applies for "
+                "``freq``. Written once so the payload shapes that call it "
+                "cannot drift into counting three different sets of atoms. "
+                "**The same function also reports the floor**, "
+                "``freq_list_incomplete_for_geometry``, at the warning tier "
+                "and with a structural flag; that finding has no entry here "
+                "because it is an expectation rather than a definition, for "
+                "the reasons set out above. This entry is deliberately about "
+                "one of the two codes the function emits."
+            ),
+        ),
+        PythonCheck(
+            raise_for_blocking_findings,
+            note=(
+                "Where the refusal actually happens, and named because the "
+                "deciding module cannot do it. "
+                "``tckdb_schemas.frequency_completeness`` returns findings "
+                "and never raises, so the code reaches the 422 envelope only "
+                "through this shared raiser, which every published upload "
+                "request model calls from a ``model_validator`` before any "
+                "route body opens a submission. It reports whichever code its "
+                "blocking findings agreed on — a payload carrying two "
+                "different contradictions falls back to the generic code and "
+                "names both in the message, because naming either one would "
+                "tell the client the other is not there."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "**None, and that absence is the argument for blocking rather than a "
+        "gap in it.** Every other entry in this group needs a door because a "
+        "correct record can trip it: a genuine higher-order saddle is "
+        "deposited by designating its reaction coordinate, a van der Waals "
+        "complex by declaring ``molecule_kind``, a contradictory ``n_imag`` "
+        "by omitting ``modes``. There is no counterpart here because there is "
+        "nothing to let through — no calculation, honest or otherwise, "
+        "produces more modes than the geometry has degrees of freedom, so a "
+        "hatch would exist only to admit a record whose own two halves "
+        "disagree. What looks like a hatch and is not: omitting ``modes`` "
+        "still avoids the refusal, but it is not a door onto legitimate "
+        "chemistry the check would have refused — it deposits a different, "
+        "weaker record, and the thing it drops is a frequency list this check "
+        "has already determined does not belong to the geometry beside it. "
+        "The repair is to attach the calculation to the geometry it ran on, "
+        "or to deposit that geometry."
     ),
 )
 

--- a/backend/tests/api/test_api_frequency_list_completeness.py
+++ b/backend/tests/api/test_api_frequency_list_completeness.py
@@ -15,13 +15,31 @@ against the independently stored frequency lists, agreeing to within
 about the ones it omits, which reads as agreement. The completeness of
 the stored list is load-bearing for that claim.
 
-Tier: **warn**, not block. The two arguments are set out in
+Two bounds, two tiers, and the split is the design rather than an
+accident of when each was written.
+
+The **floor** — fewer modes than the smallest complete spectrum the
+geometry admits — is **warn**. The two arguments are set out in
 ``tckdb_schemas.frequency_completeness``; the one this file makes
 executable is the second, which is that ``modes = null`` is accepted and
 must stay accepted, so a block's cheapest workaround is deleting the
-frequency list — turning a partial list into no list at all. The tests
-below therefore assert ``201`` throughout and read the warning out of
-the response body.
+frequency list — turning a partial list into no list at all.
+
+The **ceiling** — more modes than ``3N`` — is **block**. ``3N`` is the
+total number of Cartesian degrees of freedom, the six rigid-body modes
+included, so no harmonic analysis of that geometry produces more at any
+level of theory, on any grid, in any coordinate system: there is no
+correct deposit to refuse, and no filtering that produces *extra* modes,
+so neither of the floor's arguments reaches it. It warned in 0.29.0
+pending a scientific-check register entry and now has one
+(``CHECK_FREQ_LIST_WITHIN_GEOMETRY_DEGREES_OF_FREEDOM``).
+
+So the tests below assert ``201`` and read a warning out of the body for
+everything on the floor side, and ``422`` with a named ``code`` for
+everything past the ceiling. The end-to-end proof that the code reaches
+the ``code`` field of the response body — as opposed to appearing inside
+its prose — lives in ``test_api_scientific_rejection_codes.py``, which is
+where the register's guard requires it.
 """
 
 from __future__ import annotations
@@ -106,6 +124,18 @@ def _conformer_payload(
 def _post(client, payload: dict):
     resp = client.post("/api/v1/uploads/conformers", json=payload)
     assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _post_refused(client, payload: dict) -> dict:
+    """Post a payload the ceiling must refuse, and return the 422 body.
+
+    Separate from :func:`_post` rather than parameterised on status,
+    because a helper that accepts either would let a refusal quietly
+    become an acceptance and vice versa.
+    """
+    resp = client.post("/api/v1/uploads/conformers", json=payload)
+    assert resp.status_code == 422, resp.text
     return resp.json()
 
 
@@ -200,17 +230,25 @@ class TestATruncatedListSaysSo:
             W_FREQ_LIST_INCOMPLETE
         ]
 
-    def test_a_list_longer_than_the_geometry_allows_names_the_geometry(
-        self, client
-    ):
+
+class TestAnOverlongListIsRefused:
+    """The other bound, and the other tier.
+
+    Kept as its own class rather than sitting beside the truncation tests,
+    because the two are different judgements about different records and
+    reading them under one heading is how the tiers get conflated again.
+    """
+
+    def test_a_list_longer_than_the_geometry_allows_is_refused(self, client):
         """Ten modes on a three-atom geometry: nine degrees of freedom exist.
 
-        Arithmetically impossible rather than merely short, so it gets
-        its own code — the usual cause is a calculation attached to the
-        wrong geometry, which is a different repair from "deposit the
-        rest of the list".
+        Arithmetically impossible rather than merely short, so it gets its
+        own code *and* its own tier — the usual cause is a calculation
+        attached to the wrong geometry, which is a different repair from
+        "deposit the rest of the list" and a different judgement about
+        whether the record can be stored at all.
         """
-        body = _post(
+        body = _post_refused(
             client,
             _conformer_payload(
                 smiles="O",
@@ -219,9 +257,10 @@ class TestATruncatedListSaysSo:
                 label="water-overlong",
             ),
         )
-        assert [w["code"] for w in _completeness_warnings(body)] == [
-            W_FREQ_LIST_EXCEEDS_GEOMETRY
-        ]
+        assert body["code"] == W_FREQ_LIST_EXCEEDS_GEOMETRY
+        # Nothing was written, so there is no warning to carry either: the
+        # blocking tier owns the fact it refuses.
+        assert "warnings" not in body
 
 
 class TestALinearMoleculeIsNotFlagged:
@@ -295,10 +334,15 @@ class TestSpeciesWithNoModesToDeposit:
         )
         assert _completeness_warnings(body) == []
 
-    def test_a_single_atom_reporting_modes_is_flagged_not_refused(self, client):
-        """Three translations exist, so ``3N = 3`` is the ceiling; a
-        fourth entry describes motion the geometry does not have."""
-        body = _post(
+    def test_a_single_atom_reporting_four_modes_is_refused(self, client):
+        """Three translations exist, so ``3N = 3`` is the ceiling.
+
+        A fourth entry describes motion the geometry does not have, and a
+        one-atom geometry is the sharpest form of the case: there is no
+        vibrational mode to be partially reported, so a non-empty list of
+        length four cannot be a filtered anything.
+        """
+        body = _post_refused(
             client,
             _conformer_payload(
                 smiles="[H]",
@@ -308,9 +352,27 @@ class TestSpeciesWithNoModesToDeposit:
                 multiplicity=2,
             ),
         )
-        assert [w["code"] for w in _completeness_warnings(body)] == [
-            W_FREQ_LIST_EXCEEDS_GEOMETRY
-        ]
+        assert body["code"] == W_FREQ_LIST_EXCEEDS_GEOMETRY
+
+    def test_a_single_atom_reporting_its_three_translations_is_accepted(
+        self, client
+    ):
+        """``3N = 3`` exactly: on the ceiling, so accepted.
+
+        The boundary that keeps the refusal above from being an off-by-one
+        on the smallest geometry TCKDB accepts.
+        """
+        body = _post(
+            client,
+            _conformer_payload(
+                smiles="[H]",
+                xyz_text="1\nH atom\nH 0.0 0.0 0.0",
+                frequencies=[0.1, 0.2, 0.3],
+                label="h-atom-at-ceiling",
+                multiplicity=2,
+            ),
+        )
+        assert _completeness_warnings(body) == []
 
 
 #: H + CH4 -> H2 + CH3, so the saddle point is CH5: 6 atoms, non-linear,

--- a/backend/tests/api/test_api_scientific_rejection_codes.py
+++ b/backend/tests/api/test_api_scientific_rejection_codes.py
@@ -457,6 +457,147 @@ class TestAFrequencyResultAgainstItsOwnModes:
 
 
 # ---------------------------------------------------------------------------
+# A frequency list against the geometry it is attached to
+# ---------------------------------------------------------------------------
+#
+# The one bound in ``tckdb_schemas.frequency_completeness`` that refuses.
+# ``3N`` is the dimension of the nuclear coordinate space, so a list longer
+# than it is not a short spectrum -- it is not a spectrum of that geometry
+# under any harmonic treatment, grid, coordinate system or level of theory.
+# The *floor* (``freq_list_incomplete_for_geometry``) stays advisory, and
+# the last test here is what proves the promotion did not drag it along:
+# a filtered list has several honest explanations and ``modes = null`` is
+# accepted, so blocking on the floor would pay a depositor to delete the
+# list. Nothing filters modes *in*, so the ceiling has no such reading.
+
+
+def _water_conformer(frequencies: list[float] | None, *, label: str) -> dict:
+    """A water conformer depositing *frequencies* as its own spectrum.
+
+    Water because ``3N = 9`` and ``3N - 6 = 3`` are far enough apart that
+    the floor, the ceiling and the space between them are three visibly
+    different lists rather than three off-by-ones.
+    """
+    payload = _conformer_payload(
+        species_entry=_WATER,
+        xyz_text=(
+            "3\nwater\n"
+            "O  0.000000  0.000000  0.117300\n"
+            "H  0.000000  0.757200 -0.469200\n"
+            "H  0.000000 -0.757200 -0.469200"
+        ),
+        label=label,
+    )
+    payload["additional_calculations"] = [
+        _freq_calc(n_imag=0, frequencies=frequencies)
+    ]
+    return payload
+
+
+class TestAFrequencyListAgainstItsGeometry:
+    def test_ten_modes_on_a_nine_degree_of_freedom_geometry(self, client):
+        """The refusal, named in the ``code`` field.
+
+        Water has nine Cartesian degrees of freedom in total. A tenth
+        mode describes motion the geometry does not have, so the list and
+        the geometry are not records of the same molecule -- and no
+        re-run, tighter grid or different coordinate system changes that,
+        which is why this refuses where the floor warns.
+        """
+        response = client.post(
+            "/api/v1/uploads/conformers",
+            json=_water_conformer(
+                [float(100 * n) for n in range(1, 11)], label="water-overlong"
+            ),
+        )
+        body = _assert_code(
+            response, "freq_list_exceeds_geometry_degrees_of_freedom"
+        )
+        # The arithmetic a depositor needs, in the sentence rather than
+        # left for them to work out.
+        assert "carries 10 modes" in str(body["detail"])
+        assert "only 9 degrees of freedom" in str(body["detail"])
+        # Which element of the payload, without parsing the sentence.
+        assert body["context"] == {
+            "locations": ["additional_calculations[0].freq_result.modes"]
+        }
+
+    def test_exactly_three_n_is_accepted_because_the_ceiling_is_inclusive(
+        self, client
+    ):
+        """Nine modes on water: the whole mass-weighted Hessian spectrum.
+
+        ADR 0012 §"What a record must carry" asks for the six
+        translation/rotation eigenvalues *as well as* the spectrum, "so
+        contamination is directly assessable". That record sits exactly on
+        the ceiling, so a strict comparison would refuse the most complete
+        deposit the ADR describes. This is the assertion that keeps the
+        refusal above narrow.
+        """
+        response = client.post(
+            "/api/v1/uploads/conformers",
+            json=_water_conformer(
+                [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 1595.0, 3657.0, 3756.0],
+                label="water-all-nine",
+            ),
+        )
+        assert response.status_code == 201, response.text
+
+    def test_a_linear_molecule_at_its_ceiling_is_accepted(self, client):
+        """Carbon dioxide, nine modes, ``3N = 9``.
+
+        Linearity is never determined by this check -- doing so would mean
+        choosing a collinearity tolerance at validation time -- so the
+        molecule most likely to be mis-bounded by a rule written around
+        ``3N - 6`` is asserted directly. Its vibrational count is
+        ``3N - 5 = 4``, one *more* than ``3N - 6``, and its full
+        eigenvalue set is nine.
+        """
+        payload = _conformer_payload(
+            species_entry={"smiles": "O=C=O", "charge": 0, "multiplicity": 1},
+            xyz_text=(
+                "3\ncarbon dioxide\n"
+                "C  0.000000  0.000000  0.000000\n"
+                "O  0.000000  0.000000  1.162000\n"
+                "O  0.000000  0.000000 -1.162000"
+            ),
+            label="co2-all-nine",
+        )
+        payload["additional_calculations"] = [
+            _freq_calc(
+                n_imag=0,
+                frequencies=[
+                    0.1, 0.2, 0.3, 0.4, 0.5, 667.0, 667.0, 1333.0, 2349.0
+                ],
+            )
+        ]
+        response = client.post("/api/v1/uploads/conformers", json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_a_short_list_still_only_warns(self, client):
+        """The floor did not become a block by accident.
+
+        Two modes where water has three. Advisory on purpose: a
+        partial-Hessian job, a frozen-atom or ONIOM Hessian and a lumped
+        participant all produce fewer modes and are honest records of what
+        was computed, TCKDB carries no field saying which, and
+        ``modes = null`` is accepted -- so a block here would pay a
+        depositor to delete the list, which ADR 0012 §"Why not refuse,
+        when refusing is cheaper" calls worse than no rule. Asserted
+        beside the refusal above because a promotion applied one bound too
+        widely is invisible from the blocking side.
+        """
+        response = client.post(
+            "/api/v1/uploads/conformers",
+            json=_water_conformer([1595.0, 3756.0], label="water-short"),
+        )
+        assert response.status_code == 201, response.text
+        assert "freq_list_incomplete_for_geometry" in {
+            warning["code"] for warning in response.json()["warnings"]
+        }
+
+
+# ---------------------------------------------------------------------------
 # Conservation, against the saddle point
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/api/test_api_uploads.py
+++ b/backend/tests/api/test_api_uploads.py
@@ -290,9 +290,30 @@ class TestVdwComplexImaginaryModeWarns:
         ``test_vdw_complex_with_higher_order_saddle_is_accepted`` is
         accepted with its list attached too, and warns for the same
         reason it always did.
+
+        **The geometry is widened to two atoms here, and it has to be.**
+        Every other test in this class runs on the one-hydrogen-atom
+        fixture, which was fine while nothing read the geometry — but a
+        single atom has ``3N = 3`` degrees of freedom in total and this
+        test deposits *four* frequencies, a combination no harmonic
+        analysis produces and
+        ``freq_list_exceeds_geometry_degrees_of_freedom`` now refuses.
+        Two atoms have six, which hold the list. The same fixture defect
+        was found and fixed once already, on ``_TS_XYZ`` in
+        ``tests/schemas/test_stationary_point_validation_tiers.py``; this
+        copy survived because the bound was reported as a warning nobody
+        asserted on, and the promotion to a refusal is what surfaced it.
+        The property under test is untouched: three declared imaginary
+        modes, agreeing with ``n_imag``, on a kind for which several
+        imaginary modes are an expectation.
         """
         payload = _hydrogen_conformer_payload(label="vdw-saddle-listed")
+        payload["species_entry"]["smiles"] = "[H][H]"
+        payload["species_entry"]["multiplicity"] = 1
         payload["species_entry"]["species_entry_kind"] = "vdw_complex"
+        payload["geometry"]["xyz_text"] = (
+            "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.741"
+        )
         payload["additional_calculations"] = [
             _freq_calc(n_imag=3, frequencies=[-22.0, -14.0, -9.0, 1600.0])
         ]

--- a/backend/tests/schemas/test_frequency_list_completeness.py
+++ b/backend/tests/schemas/test_frequency_list_completeness.py
@@ -14,6 +14,7 @@ request models, not only the one that happened to get a demonstration.
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 from tckdb_schemas.frequency_completeness import (
     W_FREQ_LIST_EXCEEDS_GEOMETRY,
     W_FREQ_LIST_INCOMPLETE,
@@ -93,7 +94,52 @@ class TestTheJudgement:
     def test_one_past_the_ceiling_is_reported_under_a_different_code(self):
         findings = evaluate_frequency_list_completeness(10, 3, location="x")
         assert [f.code for f in findings] == [W_FREQ_LIST_EXCEEDS_GEOMETRY]
-        assert findings[0].tier is ValidationTier.warn
+
+    def test_one_past_the_ceiling_blocks_where_one_short_of_the_floor_warns(
+        self,
+    ):
+        """The asymmetry, asserted as one fact rather than two.
+
+        Written as a single test because the two tiers are only
+        defensible together: the floor cannot distinguish a filtered list
+        from a genuinely shorter one and ``modes = null`` is accepted, so
+        blocking it would pay a depositor to delete the list; nothing
+        filters modes *in*, so neither argument reaches the ceiling. A
+        change that promoted or demoted one of them alone should fail
+        here, which two separate assertions in two separate tests would
+        let through one at a time.
+        """
+        over = evaluate_frequency_list_completeness(10, 3, location="x")
+        under = evaluate_frequency_list_completeness(2, 3, location="x")
+        assert over[0].tier is ValidationTier.block
+        assert under[0].tier is ValidationTier.warn
+        # The structural flag keeps an *accepted* record out of default
+        # queries and bulk exports. A refused payload leaves no record to
+        # keep out of anything, so the blocking finding carries none --
+        # the same as every other blocking finding in ``stationary_point``.
+        assert over[0].structural_flag is False
+        assert under[0].structural_flag is True
+
+    def test_the_refusal_says_why_it_is_a_refusal(self):
+        """The message has to carry the argument, not only the arithmetic.
+
+        A depositor who reads "cannot produce that many modes" and
+        nothing else will look for the switch that turns the rule off.
+        The sentence names the reason there is none: filtering makes a
+        spectrum shorter, never longer.
+        """
+        message = evaluate_frequency_list_completeness(10, 3, location="x")[
+            0
+        ].message
+        assert "carries 10 modes" in message
+        assert "only 9 degrees of freedom" in message
+        assert "shorter, never longer" in message
+        assert message.isascii(), (
+            "a message that reaches a response body and a log must be "
+            "ASCII; an em dash in one rolled back a whole upload against a "
+            "SQL_ASCII database on 2026-08-04 (see "
+            "backend/scripts/check_runtime_ascii.py)"
+        )
 
     def test_the_location_is_used_verbatim(self):
         findings = evaluate_frequency_list_completeness(
@@ -333,6 +379,22 @@ _TRUNCATED = [3756.0]
 _TS_COMPLETE = [-1300.0, 500.0, 900.0, 1200.0, 1500.0, 3000.0]
 _TS_TRUNCATED = [-1300.0]
 
+#: Water, ``3N = 9``: the whole mass-weighted Hessian spectrum, the six
+#: near-zero rigid-body eigenvalues ADR 0012 asks for included. Sits
+#: exactly on the ceiling and must be accepted.
+_AT_CEILING = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 1595.0, 3657.0, 3756.0]
+#: One past it, which no harmonic analysis of three atoms can produce.
+_OVERLONG = [*_AT_CEILING, 4000.0]
+
+#: The same pair for the four-atom saddle point (``3N = 12``). The first
+#: entry stays imaginary so ``freq_n_imag_disagrees_with_modes`` and the
+#: reaction-coordinate contract are both satisfied and the completeness
+#: bound is the only rule in play.
+_TS_AT_CEILING = [
+    -1300.0, 0.1, 0.2, 0.3, 0.4, 0.5, 500.0, 900.0, 1200.0, 1500.0, 3000.0, 3100.0
+]
+_TS_OVERLONG = [*_TS_AT_CEILING, 3200.0]
+
 
 class TestEveryPublishedRequestModelAsksTheQuestion:
     """One parametrised proof per published upload request body.
@@ -370,6 +432,69 @@ class TestEveryPublishedRequestModelAsksTheQuestion:
             for f in build(truncated).stationary_point_findings()
             if f.code == W_FREQ_LIST_INCOMPLETE
         ] == [W_FREQ_LIST_INCOMPLETE]
+
+    @pytest.mark.parametrize(
+        ("build", "overlong"),
+        [
+            (_conformer_request, _OVERLONG),
+            (_computed_species_request, _OVERLONG),
+            (_transition_state_request, _TS_OVERLONG),
+            (_computed_reaction_request, _OVERLONG),
+        ],
+        ids=[
+            "conformers",
+            "computed-species",
+            "transition-states",
+            "computed-reaction",
+        ],
+    )
+    def test_a_list_past_the_ceiling_refuses_the_request(self, build, overlong):
+        """Every published model refuses, not merely reports.
+
+        The parametrisation above proves each model *collects* the
+        finding. That is not the same claim once the ceiling blocks: a
+        model could collect findings and never call
+        ``raise_for_blocking_findings``, in which case the ceiling would
+        be reported to the route as a warning-shaped finding that
+        ``stationary_point_warnings`` silently drops -- a refusal that
+        refuses nothing, and invisible from either side on its own. So
+        each seam is asserted at the raise.
+        """
+        with pytest.raises(ValidationError) as exc:
+            build(overlong)
+        assert W_FREQ_LIST_EXCEEDS_GEOMETRY in str(exc.value)
+
+    @pytest.mark.parametrize(
+        ("build", "at_ceiling"),
+        [
+            (_conformer_request, _AT_CEILING),
+            (_computed_species_request, _AT_CEILING),
+            (_transition_state_request, _TS_AT_CEILING),
+            (_computed_reaction_request, _AT_CEILING),
+        ],
+        ids=[
+            "conformers",
+            "computed-species",
+            "transition-states",
+            "computed-reaction",
+        ],
+    )
+    def test_a_list_exactly_at_the_ceiling_is_accepted_by_every_model(
+        self, build, at_ceiling
+    ):
+        """``3N`` exactly, through each seam, accepted and unflagged.
+
+        The complement of the test above, and it is what keeps the
+        refusal from being one mode too eager on any one seam. ADR 0012
+        asks for the six translation/rotation eigenvalues alongside the
+        spectrum, so this list -- the whole mass-weighted Hessian
+        spectrum -- is the most complete record it describes.
+        """
+        assert [
+            f.code
+            for f in build(at_ceiling).stationary_point_findings()
+            if f.code in {W_FREQ_LIST_EXCEEDS_GEOMETRY, W_FREQ_LIST_INCOMPLETE}
+        ] == []
 
 
 # ---------------------------------------------------------------------------
@@ -443,6 +568,21 @@ class TestTheBundleTransitionStateSeams:
             for f in build(_TS_TRUNCATED).stationary_point_findings()
             if f.code == W_FREQ_LIST_INCOMPLETE
         ] == [W_FREQ_LIST_INCOMPLETE]
+
+    @pytest.mark.parametrize(
+        "build",
+        [_computed_reaction_ts, _network_pdep_ts],
+        ids=["computed-reaction-ts", "network-pdep-ts"],
+    )
+    def test_the_ceiling_refuses_and_the_ceiling_itself_does_not(self, build):
+        with pytest.raises(ValidationError) as exc:
+            build(_TS_OVERLONG)
+        assert W_FREQ_LIST_EXCEEDS_GEOMETRY in str(exc.value)
+        assert [
+            f.code
+            for f in build(_TS_AT_CEILING).stationary_point_findings()
+            if f.code in {W_FREQ_LIST_EXCEEDS_GEOMETRY, W_FREQ_LIST_INCOMPLETE}
+        ] == []
 
 
 def _network_pdep_species(frequencies: list[float]):
@@ -551,6 +691,21 @@ class TestTheProductUploadSeam:
             if f.code == W_FREQ_LIST_INCOMPLETE
         ] == [W_FREQ_LIST_INCOMPLETE]
 
+    @pytest.mark.parametrize(
+        "build",
+        [_statmech_request, _thermo_request, _transport_request],
+        ids=["statmech", "thermo", "transport"],
+    )
+    def test_the_ceiling_refuses_and_the_ceiling_itself_does_not(self, build):
+        with pytest.raises(ValidationError) as exc:
+            build(_OVERLONG)
+        assert W_FREQ_LIST_EXCEEDS_GEOMETRY in str(exc.value)
+        assert [
+            f.code
+            for f in build(_AT_CEILING).stationary_point_findings()
+            if f.code in {W_FREQ_LIST_EXCEEDS_GEOMETRY, W_FREQ_LIST_INCOMPLETE}
+        ] == []
+
     def test_a_calculation_naming_no_geometry_is_not_judged(self):
         """No geometry, no question — and no false alarm either."""
         from app.schemas.workflows.statmech_upload import StatmechUploadRequest
@@ -588,3 +743,13 @@ class TestTheNetworkWellSeam:
             for f in _network_pdep_species(_TRUNCATED).stationary_point_findings()
             if f.code == W_FREQ_LIST_INCOMPLETE
         ] == [W_FREQ_LIST_INCOMPLETE]
+
+    def test_the_ceiling_refuses_and_the_ceiling_itself_does_not(self):
+        with pytest.raises(ValidationError) as exc:
+            _network_pdep_species(_OVERLONG)
+        assert W_FREQ_LIST_EXCEEDS_GEOMETRY in str(exc.value)
+        assert [
+            f.code
+            for f in _network_pdep_species(_AT_CEILING).stationary_point_findings()
+            if f.code in {W_FREQ_LIST_EXCEEDS_GEOMETRY, W_FREQ_LIST_INCOMPLETE}
+        ] == []

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.37.0"
+version = "0.38.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -99,6 +99,7 @@ class RejectionCode(str, Enum):
     EXPORT_ALL_CAP_EXCEEDED = "export_all_cap_exceeded"
     EXPORT_SEED_EMPTY = "export_seed_empty"
     EXPORT_SEED_UNRESOLVED = "export_seed_unresolved"
+    FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM = "freq_list_exceeds_geometry_degrees_of_freedom"
     FREQ_N_IMAG_DISAGREES_WITH_MODES = "freq_n_imag_disagrees_with_modes"
     GEOMETRY_TOO_LARGE = "geometry_too_large"
     HANDLE_NOT_FOUND = "handle_not_found"
@@ -233,6 +234,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.EXPORT_ALL_CAP_EXCEEDED,
         RejectionCode.EXPORT_SEED_EMPTY,
         RejectionCode.EXPORT_SEED_UNRESOLVED,
+        RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM,
         RejectionCode.FREQ_N_IMAG_DISAGREES_WITH_MODES,
         RejectionCode.GEOMETRY_TOO_LARGE,
         RejectionCode.HANDLE_TYPE_MISMATCH,
@@ -377,6 +379,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.EXPORT_ALL_CAP_EXCEEDED: frozenset({422}),
     RejectionCode.EXPORT_SEED_EMPTY: frozenset({422}),
     RejectionCode.EXPORT_SEED_UNRESOLVED: frozenset({422}),
+    RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM: frozenset({422}),
     RejectionCode.FREQ_N_IMAG_DISAGREES_WITH_MODES: frozenset({422}),
     RejectionCode.GEOMETRY_TOO_LARGE: frozenset({422}),
     RejectionCode.HANDLE_NOT_FOUND: frozenset({404}),

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -84,23 +84,23 @@ disagree, this one is right by construction.
 
 | Tier | Entries | Meaning |
 | --- | --- | --- |
-| `block` | 18 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
+| `block` | 19 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
 | `warn` | 8 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
 | `label` | 1 | Labels a stored record at read time without refusing anything — a `HardFailReason` in the trust evaluator. For facts TCKDB observes about a record after it was accepted, which no upload-time check could have refused because they did not exist yet. |
 | `review` | 0 | Referred to `machine_review` under a versioned rubric. ADR 0008 puts every cross-check against external reference data here. |
 | `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
-| **total** | **32** | |
+| **total** | **33** | |
 
 ## Where a check's code reaches a client
 
 | Channel | Entries | What a consumer can do with it |
 | --- | --- | --- |
-| `error_envelope` | 19 | the `code` field of the 422 error body — a client can branch on it |
+| `error_envelope` | 20 | the `code` field of the 422 error body — a client can branch on it |
 | `upload_warning` | 9 | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | `trust_label` | 1 | a read-time trust label (`HardFailReason`), not any refusal |
 | `database_constraint` | 1 | PostgreSQL only, so the refusal is a 409 rather than a 422 — named, where the constraint declares a rejection code |
 | `none` | 2 | *nothing carries a code* |
-| **total** | **32** | |
+| **total** | **33** | |
 
 ## Recorded divergences
 
@@ -109,7 +109,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - **[8]** The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
 - **[11]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
 - **[15]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
-- **[29]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+- **[30]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 ## Entries
 
@@ -484,9 +484,29 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Omit `modes`. A record that deposits only the scalar is incomplete, warns nowhere and is refused nowhere — ADR 0012 asks for the complete signed frequency list, and asking is as far as this tier goes. What has no door is depositing both and letting them contradict each other.
 
+### 19. A frequency list carries no more modes than the geometry it is attached to has degrees of freedom: at most `3N` for `N` atoms, the six rigid-body modes included.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `freq_list_exceeds_geometry_degrees_of_freedom` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
+| **Governing ADR** | 0012 |
+
+**Why this tier.** Definitional, and — unusually in this group — arithmetically so. `3N` is the dimension of the nuclear coordinate space, so it is the total number of eigenvalues the mass-weighted Hessian of an `N`-atom geometry has: not the vibrational count, which is `3N - 6` or `3N - 5`, but every Cartesian degree of freedom including the six translations and rotations ADR 0012 asks a record to carry. A longer list is therefore not a short spectrum — it is not a spectrum of that geometry at all, under any harmonic treatment, integration grid, coordinate system or level of theory. That is what separates it from the `n_imag == 1` gate ADR 0012 retired: there, two scientifically correct calculations of one structure legitimately returned different answers and the tier was an expectation about numerical quality wearing the costume of a definition. Here no protocol takes part, so no correct deposit is refused. The contrast with the *floor* is the argument, and the floor is correctly a warning for precisely the reasons this is not. First, the ambiguity a short list carries is one-sided: a partial-Hessian job, a frozen-atom or ONIOM Hessian and a lumped `pseudo` participant all *remove* modes and are honest records of what was computed, TCKDB carries no field saying which of them a short list is, and nothing whatsoever filters modes *in*. Second, `modes = null` is accepted and must stay accepted, so the cheapest way past a completeness *block* on the floor would be deleting the frequency list — converting visible ambiguity into invisible falsehood, which ADR 0012 §"Why not refuse, when refusing is cheaper" names as worse than no rule. Neither reaches the ceiling. Deleting an over-long list loses a spectrum the check has already found is not this geometry's, which is the repair rather than the evasion; and accepting it is the destructive option, because stored it reads as this geometry's spectrum and a consumer recomputing a partition function from the pair gets a number rather than an error. No threshold is declared because there is none to declare: `3N` is counted from the deposited geometry, not tuned.
+
+**Enforced at.**
+
+- `evaluate_frequency_list_completeness` — `schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py::evaluate_frequency_list_completeness`
+  *Owns the arithmetic and knows no payload shapes; the geometry each frequency list is measured against is resolved by `evaluate_deposited_frequency_list` in the same module — the calculation's own first input geometry where the producer named one, and otherwise the enclosing conformer's or transition state's reference geometry, which is the fallback the persistence workflow itself applies for `freq`. Written once so the payload shapes that call it cannot drift into counting three different sets of atoms. **The same function also reports the floor**, `freq_list_incomplete_for_geometry`, at the warning tier and with a structural flag; that finding has no entry here because it is an expectation rather than a definition, for the reasons set out above. This entry is deliberately about one of the two codes the function emits.*
+- `raise_for_blocking_findings` — `schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py::raise_for_blocking_findings`
+  *Where the refusal actually happens, and named because the deciding module cannot do it. `tckdb_schemas.frequency_completeness` returns findings and never raises, so the code reaches the 422 envelope only through this shared raiser, which every published upload request model calls from a `model_validator` before any route body opens a submission. It reports whichever code its blocking findings agreed on — a payload carrying two different contradictions falls back to the generic code and names both in the message, because naming either one would tell the client the other is not there.*
+
+**Escape hatch.** **None, and that absence is the argument for blocking rather than a gap in it.** Every other entry in this group needs a door because a correct record can trip it: a genuine higher-order saddle is deposited by designating its reaction coordinate, a van der Waals complex by declaring `molecule_kind`, a contradictory `n_imag` by omitting `modes`. There is no counterpart here because there is nothing to let through — no calculation, honest or otherwise, produces more modes than the geometry has degrees of freedom, so a hatch would exist only to admit a record whose own two halves disagree. What looks like a hatch and is not: omitting `modes` still avoids the refusal, but it is not a door onto legitimate chemistry the check would have refused — it deposits a different, weaker record, and the thing it drops is a frequency list this check has already determined does not belong to the geometry beside it. The repair is to attach the calculation to the geometry it ran on, or to deposit that geometry.
+
 ## Atom mapping across a reaction
 
-### 19. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
+### 20. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
 
 | Field | Value |
 | --- | --- |
@@ -507,7 +527,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Case is not load-bearing, and no longer needs a special provision to stop it becoming so. The comparison used to be case-insensitive on both sides, because the two ends quote two different geometries and nothing guaranteed they spelled an element the same way — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not, and refusing the second would have refused correct chemistry. `b4e7c1d20f83` canonicalised the symbol on the way into `geometry_atom.element` and `c5a1f8e3d074` made that a CHECK, so one element now has one spelling in every state the database can be in and both the constraint and the service compare the stored values directly. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
-### 20. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
+### 21. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 
 | Field | Value |
 | --- | --- |
@@ -531,7 +551,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Per leg, not globally: the reactant and product legs each claim the whole saddle point, which is the point of storing two maps both pointing at it. A `side` column exists on the pair row purely so this can be a unique constraint, because SQL cannot dereference the participant to find its role.
 
-### 21. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
+### 22. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
 
 | Field | Value |
 | --- | --- |
@@ -555,7 +575,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None, and the cost is stated in ADR 0011: the map is welded to the geometries it names, so depositing a second conformer or re-optimising at another level of theory does not carry it across. Canonical-order-relative indexing would be portable, and was rejected because its failure mode is a map that looks fine and refers to a different atom order than the depositor intended. Portability can be added later as a derived view; correctness cannot be retrofitted onto records nobody can verify.
 
-### 22. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
+### 23. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
 
 | Field | Value |
 | --- | --- |
@@ -573,7 +593,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Leave the map incomplete, or deposit an unbalanced reaction — either drops the rule to the warning tier by design rather than by accident.
 
-### 23. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
+### 24. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
 
 | Field | Value |
 | --- | --- |
@@ -591,7 +611,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction. A participant with no atoms is not an absence: both surfaces can say it has none -- an empty atom list -- so a reaction releasing a free electron carries a complete partition on both and is compared like any other, with the electron contributing no atoms to either side of the comparison.
 
-### 24. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
+### 25. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
 
 | Field | Value |
 | --- | --- |
@@ -609,7 +629,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
 
-### 25. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
+### 26. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
 
 | Field | Value |
 | --- | --- |
@@ -627,7 +647,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-### 26. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
+### 27. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
 
 | Field | Value |
 | --- | --- |
@@ -651,7 +671,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Rate coefficients
 
-### 27. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
+### 28. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
 
 | Field | Value |
 | --- | --- |
@@ -671,7 +691,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Statistical mechanics
 
-### 28. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
+### 29. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
 
 | Field | Value |
 | --- | --- |
@@ -692,7 +712,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Pressure-dependent networks
 
-### 29. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+### 30. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 | Field | Value |
 | --- | --- |
@@ -715,7 +735,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
 
-### 30. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
+### 31. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
 
 | Field | Value |
 | --- | --- |
@@ -736,7 +756,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Custody of the evidence
 
-### 31. The bytes TCKDB serves for a stored artifact are the bytes it stored, and a record whose evidence is known not to be is labelled as such at read time rather than graded as if it were intact.
+### 32. The bytes TCKDB serves for a stored artifact are the bytes it stored, and a record whose evidence is known not to be is labelled as such at read time rather than graded as if it were intact.
 
 | Field | Value |
 | --- | --- |
@@ -764,7 +784,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Reproducibility
 
-### 32. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
+### 33. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
 
 | Field | Value |
 | --- | --- |

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,57 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.30.0 — **BREAKING**: a frequency list longer than `3N` is refused, not flagged
+
+**This narrows the set of payloads that validate.** A payload accepted by
+0.29.0 with a `freq_list_exceeds_geometry_degrees_of_freedom` warning is
+refused by 0.30.0 with a 422 naming that same code. Nothing is added,
+renamed or removed, and every *other* 0.29.0 payload validates unchanged
+— but a rule that moves from warn to block is a breaking wire change and
+is labelled one, whatever the shape of the diff.
+
+| | 0.29.0 | 0.30.0 |
+|---|---|---|
+| `n_modes > 3N` | 201, `UploadWarning` with `structural_flag` | **422**, `code = freq_list_exceeds_geometry_degrees_of_freedom` |
+| `n_modes == 3N` | 201, silent | 201, silent (unchanged) |
+| `n_modes < 3N − 6` | 201, `UploadWarning` | 201, `UploadWarning` (unchanged) |
+| `modes` omitted | 201, silent | 201, silent (unchanged) |
+
+**Who is affected.** Only a deposit whose frequency list is longer than
+the total number of Cartesian degrees of freedom of the geometry it is
+attached to. The in-repo corpora were re-measured against this bound
+specifically — 57 ARC statmech records and the 4 conformers of the
+hydrazine pressure-dependent network — and **nothing is within six modes
+of the ceiling**: the closest record sits at `3N − 6`, and the 13 records
+that do violate a bound violate the *floor*, which still warns. No
+existing deposit changes verdict.
+
+**Why this one may block when its sibling may not.** `3N` is the
+dimension of the nuclear coordinate space, so it is the total number of
+eigenvalues the mass-weighted Hessian of an `N`-atom geometry has — every
+Cartesian degree of freedom, the six rigid-body modes
+[ADR 0012](https://github.com/TCKDB/TCKDB/blob/main/docs/adr/0012-imaginary-modes-are-judged-by-magnitude-not-counted.md)
+asks a record to carry included. A longer list is not a short spectrum;
+it is not a spectrum of that geometry under any harmonic treatment, grid,
+coordinate system or level of theory, so no protocol takes part and no
+correct deposit is refused. Both arguments that keep the *floor*
+advisory fail here: every mechanism that makes a short list honest — a
+partial Hessian, a frozen-atom or ONIOM region, a lumped participant —
+*removes* modes, and nothing filters modes in; and deleting an over-long
+list to evade the refusal loses a spectrum the check has already found is
+not this geometry's, which is the repair rather than the evasion.
+`freq_list_incomplete_for_geometry` is unchanged and stays a warning.
+
+The tier now follows a scientific-check register entry
+(`CHECK_FREQ_LIST_WITHIN_GEOMETRY_DEGREES_OF_FREEDOM`, ADR 0012) rather
+than an implementation, which is what 0.29.0 said the promotion was
+waiting for. `RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM`
+is exported by `tckdb-client` 0.38.0.
+
+**Migrating:** attach the calculation to the geometry it actually ran on,
+or deposit the geometry it ran on. If the payload was relying on the
+warning, the fix is the same fix it was advising.
+
 ### 0.29.0 — a frequency list is measured against the geometry it was computed on
 
 **Not breaking.** No field is added, renamed or removed, and **every

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.29.0"
+version = "0.30.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py
@@ -43,10 +43,22 @@ ADR describes, and refusing it as an over-count would refuse exactly
 what the ADR asks for. Only a list longer than ``3N`` describes more
 degrees of freedom than the geometry has.
 
-Why this warns rather than blocks
----------------------------------
+**The ceiling is inclusive, and that carries more weight than it used
+to.** Since a list longer than ``3N`` is now *refused* rather than
+flagged, ``n_modes == 3N`` being accepted is the property that keeps the
+refusal narrow: the most complete record ADR 0012 describes sits exactly
+on the line, and a strict comparison here would refuse the very deposit
+the ADR asks for.
+
+Why the floor warns and the ceiling blocks
+------------------------------------------
 Under `ADR 0008 <0008-validation-tiers-definitions-block-expectations-warn.md>`_
-a check may block only when it asserts a definition or a contract.
+a check may block only when it asserts a definition or a contract. The
+two bounds fall on opposite sides of that line, and the asymmetry is not
+an accident of implementation — it is the whole content of this module's
+judgement.
+
+**The floor warns.**
 "A frequency list is the spectrum" reads like a definition, and the
 argument that it is not is this: **the check cannot tell a filtered list
 from a genuinely shorter one.** A partial-Hessian frequency job, a
@@ -68,12 +80,39 @@ information, honestly labelled — into no information at all. ADR 0012
 "A rule that converts visible ambiguity into invisible falsehood is
 worse than no rule."
 
-One sub-case genuinely is definitional: a list *longer* than ``3N`` is
-arithmetically impossible for a harmonic analysis of that geometry, and
-no correct deposit produces it. It is reported here at the warning tier
-with its own code so that the two facts stay distinguishable; promoting
-it to a refusal wants a scientific-check register entry, which is a
-decision to take in the register rather than during an implementation.
+**The ceiling blocks**, and neither argument above reaches it.
+
+A list *longer* than ``3N`` is not a short spectrum. It is not a spectrum
+of that geometry under any reading. ``3N`` is the dimension of the
+nuclear coordinate space, so it is the *total* number of eigenvalues the
+mass-weighted Hessian of an ``N``-atom geometry has — not the vibrational
+count, which is ``3N − 6`` or ``3N − 5``, but every Cartesian degree of
+freedom including the six rigid-body modes ADR 0012 asks a record to
+carry. No harmonic treatment, integration grid, coordinate system or
+level of theory produces more, and two correct calculations of one
+structure cannot disagree about it: unlike the ``n_imag == 1`` gate ADR
+0012 retired, no protocol takes part in the arithmetic. So there is no
+correct deposit this refuses, which is exactly what ADR 0008 asks a
+blocking check to be able to say.
+
+The first argument does not transfer because the ambiguity it protects is
+one-sided: every mechanism that makes a short list honest — a partial
+Hessian, a frozen-atom or ONIOM region, a lumped participant — *removes*
+modes. Nothing filters modes in. The second does not transfer either.
+Deleting the frequency list to get past this refusal does not convert a
+partial truth into silence, because the check has already found that the
+list is not this geometry's: what is lost is a spectrum bound to the
+wrong structure, and losing that is the repair rather than the evasion.
+Accepting it is the destructive option — stored, it reads as a spectrum
+of the geometry beside it, and a consumer recomputing a partition
+function from the pair gets a number rather than an error.
+
+0.29.0 reported this at the warning tier and said so: "promoting it to a
+refusal wants a scientific-check register entry, which is a decision to
+take in the register rather than during an implementation". It now has
+one — ``CHECK_FREQ_LIST_WITHIN_GEOMETRY_DEGREES_OF_FREEDOM`` in
+``backend/app/scientific_checks/declarations.py`` — and the tier follows
+the register rather than the schedule.
 
 Pure functions only — no Pydantic, no backend imports. Callers extract
 the two integers from whatever shape they hold and pass them in.
@@ -94,6 +133,15 @@ W_FREQ_LIST_INCOMPLETE = "freq_list_incomplete_for_geometry"
 #: is attached to, so it describes more degrees of freedom than that
 #: geometry has. Usually a list attached to the wrong geometry rather
 #: than a filtered one.
+#:
+#: **Blocking**, unlike its sibling above, and the ``W_`` prefix is house
+#: style for "machine-readable code" rather than a tier — the same
+#: spelling ``W_TS_NO_IMAGINARY_MODE`` uses in
+#: :mod:`tckdb_schemas.stationary_point`. The refusal is raised by
+#: :func:`~tckdb_schemas.stationary_point.raise_for_blocking_findings`,
+#: which every published upload request model calls from a
+#: ``model_validator``, so the code arrives as the ``code`` field of a 422
+#: rather than as a warning on an accepted deposit.
 W_FREQ_LIST_EXCEEDS_GEOMETRY = "freq_list_exceeds_geometry_degrees_of_freedom"
 
 
@@ -158,7 +206,14 @@ def evaluate_frequency_list_completeness(
         ``None`` means no geometry is in hand, and the check is not
         reachable — nothing is reported.
     :param location: Path to the payload element, used verbatim.
-    :returns: Findings, possibly empty. Never raises.
+    :returns: Findings, possibly empty. A list past the ceiling yields a
+        **blocking** finding and a list below the floor a warning; see the
+        module docstring for why the two bounds differ. Never raises —
+        the refusal is raised by
+        :func:`~tckdb_schemas.stationary_point.raise_for_blocking_findings`,
+        which the request models call once for every finding they have
+        collected, so this function stays a pure judgement and one payload
+        with two contradictions still reports both.
     """
     if n_modes is None or n_atoms is None:
         return []
@@ -169,19 +224,29 @@ def evaluate_frequency_list_completeness(
     if n_modes > ceiling:
         return [
             StationaryPointFinding(
-                tier=ValidationTier.warn,
+                tier=ValidationTier.block,
                 code=W_FREQ_LIST_EXCEEDS_GEOMETRY,
                 location=location,
-                structural_flag=True,
+                # No structural flag, and not an oversight. The flag keeps
+                # an *accepted* record out of default query results and
+                # bulk exports; a refused payload leaves no record to keep
+                # out of anything. Every other blocking finding in
+                # ``stationary_point`` carries no flag for the same reason.
                 message=(
                     f"{location}: the frequency list carries {n_modes} modes "
                     f"but the geometry it is attached to has {n_atoms} atom(s), "
                     f"which have only {ceiling} degrees of freedom in total "
-                    f"({W_FREQ_LIST_EXCEEDS_GEOMETRY}). A harmonic analysis "
-                    f"of this geometry cannot produce that many modes, so the "
-                    f"list and the geometry are not describing the same "
-                    f"molecule — check that the calculation is attached to "
-                    f"the geometry it actually ran on."
+                    f"({W_FREQ_LIST_EXCEEDS_GEOMETRY}). 3N counts every "
+                    f"Cartesian degree of freedom, the six translations and "
+                    f"rotations included, so no harmonic analysis of this "
+                    f"geometry can produce that many modes at any level of "
+                    f"theory, on any grid, in any coordinate system. The list "
+                    f"and the geometry are not describing the same molecule. "
+                    f"This is refused rather than flagged because there is no "
+                    f"correct calculation it could be a record of: filtering "
+                    f"a spectrum makes it shorter, never longer. Attach the "
+                    f"calculation to the geometry it actually ran on, or "
+                    f"deposit that geometry."
                 ),
             )
         ]


### PR DESCRIPTION
PR #162 added two frequency-completeness findings measured against the deposit's own geometry, and warned on both. This promotes one of them to a refusal and leaves the other exactly where it was.

## The floor stays advisory, deliberately

`freq_list_incomplete_for_geometry` — fewer modes than `3N − 6` — is **unchanged**. A partial-Hessian job, a frozen-atom or ONIOM Hessian and a lumped `pseudo` participant all produce fewer modes and are honest records of what was computed; TCKDB carries no field saying which of them a short list is; and, decisively, `modes = null` is accepted and must stay accepted, so a block's cheapest workaround is deleting the frequency list. ADR 0012: *"A rule that converts visible ambiguity into invisible falsehood is worse than no rule."*

## The ceiling is a different kind of statement

`3N` is the dimension of the nuclear coordinate space, so it is the *total* number of eigenvalues the mass-weighted Hessian of an `N`-atom geometry has — every Cartesian degree of freedom, the six rigid-body modes ADR 0012 asks a record to carry included. A longer list is not a short spectrum. It is not a spectrum of that geometry under any harmonic treatment, integration grid, coordinate system or level of theory, so no protocol takes part and two correct calculations of one structure cannot disagree about it.

Neither of the floor's arguments reaches it:

- the ambiguity a short list carries is **one-sided** — every mechanism that makes a short list honest *removes* modes, and nothing filters modes in;
- deleting an over-long list loses a spectrum the check has already found is not this geometry's, which is the repair rather than the evasion. Accepting it is the destructive option: stored, it reads as this geometry's spectrum, and a consumer recomputing a partition function from the pair gets a number rather than an error.

So under ADR 0008 it may block, and does. It warned in 0.29.0 pending a scientific-check register entry — which is what that module's own docstring said the promotion was waiting for.

## What is in here

- **Register entry** `CHECK_FREQ_LIST_WITHIN_GEOMETRY_DEGREES_OF_FREEDOM` (ADR 0012, tier `block`, channel `error_envelope`), with two enforcement sites: the module that decides, and the shared raiser that turns a blocking finding into a coded 422 — because the deciding module never raises. Register 32 → 33 entries, inside the 10–40 bound.
- **`escape_hatch` records that there is none**, and why that absence is the argument for blocking rather than a gap in it. Every other entry in the group needs a door because a correct record can trip it; nothing correct trips this one.
- **Catalogue entry**, since the code moves from the `upload_warning` channel to `error_envelope`, plus the regenerated client enum member.
- **Per-seam coverage at the raise** for all eight upload shapes, with the matching `n_modes == 3N` acceptance for each. Collecting a finding and refusing on it are different claims once the tier is `block`: a model could collect and never call `raise_for_blocking_findings`, and `stationary_point_warnings` drops blocking findings, so the refusal would refuse nothing — and that is invisible from either side alone.

## Breaking, and measured

**This narrows the set of payloads that validate**, and the changelog says so in those words. Re-measured against *this* bound rather than trusting #162's floor measurement:

| corpus | records with a frequency list | ceiling violations |
|---|---|---|
| ARC `output.yml` statmech records | 57 | **0** |
| hydrazine PDep network conformers | 4 | **0** |
| ARC `tckdb_payloads/` deposit bodies | 0 | **0** |

Nothing is within six modes of the ceiling — the closest record sits at exactly `3N − 6`. The 13 records that do violate a bound violate the **floor**, which still warns. No existing deposit changes verdict.

The promotion did find one incoherent **test fixture**: `TestVdwComplexImaginaryModeWarns` deposited four vibrational modes on a one-atom geometry (`3N = 3`). That is the same defect #162 fixed on `_TS_XYZ`; this copy survived because the bound reported a warning nobody asserted on. Widened to two atoms in the second commit, property under test untouched.

## Versions

`tckdb-schemas` 0.29.0 → **0.30.0** (breaking). `tckdb-client` 0.37.0 → **0.38.0**.

No Alembic revision: nothing about the schema changes. Head stays `b7e4d1a9c026`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)