### PR TITLE
Promote a leading token only where the catalogue calls it a code

### DIFF
--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -85,7 +85,8 @@ list is a second artifact to keep in step and that forgetting to register
 a new code would silently degrade it to ``validation_error`` — the same
 failure class the narrowing existed to fix. That objection was correct
 against a *bare* list. It is answered by a catalogued one, because
-forgetting is caught at test time by three independent nets:
+forgetting is caught at test time by two static scans that between them
+cover every shape a message-prefix code is written in:
 
 * ``backend/tests/api/test_api_code_catalogue.py::test_every_raise_site_code_is_catalogued``
   statically scans every ``raise`` in ``backend/app`` and
@@ -95,23 +96,36 @@ forgetting is caught at test time by three independent nets:
   *not* see two shapes — a code interpolated into the code position
   (``f"{PREFIX}: …"``) and a message bound to a local before being raised —
   which is why it is not the only net.
-* The runtime observer (``backend/tests/error_code_observer.py``) fails the
-  test that *emits* an uncatalogued code, and it is exactly those two
-  shapes it covers: the six ``*_handle_conflict`` codes are interpolated
-  from a ``conflict_code`` parameter, and they were found by the observer
-  and by nothing else.
 * ``backend/tests/api/test_error_contract_catalogue_gate.py`` pins this
   module's dependency on the catalogue, so the gate cannot be quietly
-  widened back to "any leading token" or narrowed to nothing.
+  widened back to "any leading token" or narrowed to nothing — and it
+  carries a second static scan for the first of those two shapes: find the
+  helpers that raise a *parameter* in the code position, then require every
+  literal handed to that parameter to be catalogued. ``reconcile_id_ref``
+  is the one such helper and the six ``*_handle_conflict`` codes are its
+  arguments.
 
-The residual exposure is therefore a code emitted only in production, never
-in any test, *and* written in a shape the static scan cannot read. A census
-of every string literal in both trees beginning with a ``token: `` prefix
-found 73 such tokens: 66 catalogued as ``message_prefix``, 5 logger format
+That second scan is not belt and braces; it replaces a net this change
+removes. The runtime observer in ``backend/tests/error_code_observer.py``
+fails the test that *emits* an uncatalogued code, and until now that was
+the only thing covering an interpolated code — it is how the six
+``*_handle_conflict`` codes were found. But a gated promotion never puts an
+unknown token in ``code`` at all, so the body the observer inspects is a
+clean ``validation_error`` and it has nothing to see. Measured, not
+reasoned about: renaming ``conflict_code="level_of_theory_handle_conflict"``
+leaves the observer green after this change and made it red before. The
+observer still covers every other surface; for this one, the scan above is
+the replacement.
+
+The residual exposure is therefore the one shape neither scan reads: a
+message bound to a local before being raised (``message = "code: …"; raise
+ValueError(message)``). No such site exists — a census of every string
+literal in both trees beginning with a ``token: `` prefix found 73 tokens,
+of which 66 are catalogued as ``message_prefix``, 5 are logger format
 strings that reach no response body (``geometry_validation``, ``manifest``,
-``readyz``, ``startup``, ``status``), and the 2 accidental prefixes above.
-So the set of error-reachable prefixes the catalogue does not cover is
-presently empty — measured, and re-measurable, rather than asserted.
+``readyz``, ``startup``, ``status``), and 2 are the accidental prefixes
+above. So the set of error-reachable prefixes the catalogue does not cover
+is presently empty — measured, and re-measurable, rather than asserted.
 """
 
 from __future__ import annotations

--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -19,6 +19,10 @@ Three ways a ``code`` can be found, in descending order of trust
    sentence (``"Value error, invalid_handle: …"``) or buried in a list of
    validation failures. Promoted by :func:`validation_detail_code`.
 
+(2) and (3) additionally require the token to be a code
+:mod:`app.api.code_catalogue` lists as arriving that way; see "Why position
+is necessary but not sufficient" below.
+
 (2) and (3) read English, and reading English is how a code silently stops
 being reported when somebody rewords a sentence — which is exactly what had
 happened to the parenthesised convention the scientific checks used to use
@@ -52,6 +56,62 @@ the *unfiltered* candidate set, so a message containing two tokens keeps
 falling back exactly as it did; the position test can only turn a promoted
 token into the generic fallback, never turn a fallback into a new code.
 No response gains a code it did not already have.
+
+Why position is necessary but not sufficient
+--------------------------------------------
+Position says *somebody meant this to be read as a code*. It cannot say
+whether the token **is** one, because a code and a function name are the
+same shape and both get written first. The house style is
+``raise ValueError(f"{context}: <prose>")``, and when ``context`` is the
+enclosing function rather than a field path — ``create_applied_group_additivity``,
+``keyset_predicate`` — the position test promotes a function name and the
+envelope publishes it as though a client could branch on it.
+
+So the token is now also checked against :mod:`app.api.code_catalogue`,
+which enumerates every code the API can emit and records, per code, *by
+which mechanism* it arrives. A token is promoted only where the catalogue
+declares that code as :data:`~app.api.code_catalogue.Surface.message_prefix`
+— that is, only where the catalogue agrees this is a code and agrees it
+legitimately arrives by being written in front of a colon. A function name
+that lands in the code position is catalogued as
+:data:`~app.api.code_catalogue.Surface.accidental_prefix` — the catalogue's
+own word for "not a code" — and is therefore not promoted. The honest
+record of a defect becomes the thing that stops it reaching a client.
+
+Why consulting a list is safe here, having been refused before
+--------------------------------------------------------------
+#159 declined to gate promotion on a hand-list, on the grounds that the
+list is a second artifact to keep in step and that forgetting to register
+a new code would silently degrade it to ``validation_error`` — the same
+failure class the narrowing existed to fix. That objection was correct
+against a *bare* list. It is answered by a catalogued one, because
+forgetting is caught at test time by three independent nets:
+
+* ``backend/tests/api/test_api_code_catalogue.py::test_every_raise_site_code_is_catalogued``
+  statically scans every ``raise`` in ``backend/app`` and
+  ``tckdb_schemas`` and demands an entry. Measured by mutation, not
+  assumed: a new ``raise ValueError("some_new_code: …")`` fails it as a
+  plain literal, as an f-string, and when raised inside a helper. It does
+  *not* see two shapes — a code interpolated into the code position
+  (``f"{PREFIX}: …"``) and a message bound to a local before being raised —
+  which is why it is not the only net.
+* The runtime observer (``backend/tests/error_code_observer.py``) fails the
+  test that *emits* an uncatalogued code, and it is exactly those two
+  shapes it covers: the six ``*_handle_conflict`` codes are interpolated
+  from a ``conflict_code`` parameter, and they were found by the observer
+  and by nothing else.
+* ``backend/tests/api/test_error_contract_catalogue_gate.py`` pins this
+  module's dependency on the catalogue, so the gate cannot be quietly
+  widened back to "any leading token" or narrowed to nothing.
+
+The residual exposure is therefore a code emitted only in production, never
+in any test, *and* written in a shape the static scan cannot read. A census
+of every string literal in both trees beginning with a ``token: `` prefix
+found 73 such tokens: 66 catalogued as ``message_prefix``, 5 logger format
+strings that reach no response body (``geometry_validation``, ``manifest``,
+``readyz``, ``startup``, ``status``), and the 2 accidental prefixes above.
+So the set of error-reachable prefixes the catalogue does not cover is
+presently empty — measured, and re-measurable, rather than asserted.
 """
 
 from __future__ import annotations
@@ -61,6 +121,8 @@ import re
 from typing import Any
 
 from tckdb_schemas.coded_error import CodedValidationError
+
+from app.api.code_catalogue import CATALOGUE, Surface
 
 _NESTED_CODE_PATTERN = re.compile(r"(?<![a-z0-9_])([a-z][a-z0-9_]*_[a-z0-9_]+): ")
 
@@ -76,13 +138,27 @@ _CODE_POSITION_PATTERN = re.compile(r"^([a-z][a-z0-9_]*_[a-z0-9_]+): ")
 #: down without turning the test back into "somewhere in the sentence".
 _FRAMEWORK_MESSAGE_PREFIXES = ("Value error, ", "Assertion failed, ")
 
+#: The codes the catalogue says arrive by being written in front of a colon.
+#: Derived from :data:`app.api.code_catalogue.CATALOGUE` rather than listed
+#: again here: a second spelling of the same set is the drift this whole
+#: mechanism is trying to avoid. Built once — the catalogue is a module
+#: constant — and read on every promotion.
+#:
+#: Membership, not observation, is the test. Fifty-odd catalogued codes have
+#: never been seen in a test run (tracked as #174); they are codes all the
+#: same, and gating on "has the observer seen it?" would degrade exactly the
+#: refusals nobody has exercised yet.
+MESSAGE_PREFIX_CODES: frozenset[str] = frozenset(
+    entry.code for entry in CATALOGUE if entry.surface is Surface.message_prefix
+)
+
 
 def _code_position_token(text: str) -> str | None:
-    """The code *text* declares as its own, or ``None``.
+    """The token *text* wrote where a code goes, or ``None``.
 
-    A code is declared by being written where a code goes: first, followed
-    by ``": "``. Anything else in the sentence is prose that happens to
-    contain an underscore.
+    Purely syntactic: first in the message, followed by ``": "``. Says that
+    somebody meant it to be read as a code, not that it is one — see
+    :func:`_promotable_code` for the second half of the test.
     """
 
     for prefix in _FRAMEWORK_MESSAGE_PREFIXES:
@@ -91,6 +167,26 @@ def _code_position_token(text: str) -> str | None:
             break
     match = _CODE_POSITION_PATTERN.match(text)
     return match.group(1) if match else None
+
+
+def _promotable_code(text: str) -> str | None:
+    """The code *text* declares, or ``None`` if it declares no code.
+
+    Both halves must hold. The token has to be in the **code position**,
+    because that is how a raiser declares a code; and the catalogue has to
+    list it as a ``message_prefix`` code, because position alone cannot tell
+    a code from the function name the house style puts in the same place.
+
+    Keeping the two halves separate is deliberate: the position test says
+    what the message *claims*, and the catalogue says whether the claim is
+    one the API actually makes. See the module docstring for why gating on a
+    list is safe here and was not before.
+    """
+
+    token = _code_position_token(text)
+    if token is None or token not in MESSAGE_PREFIX_CODES:
+        return None
+    return token
 
 
 def _json_safe(obj: Any) -> Any:
@@ -125,7 +221,19 @@ class CodedValueError(CodedValidationError):
 
 
 def detail_code(detail: object, *, fallback: str) -> str:
-    """Extract a legacy ``code: message`` prefix or return *fallback*."""
+    """Extract a legacy ``code: message`` prefix or return *fallback*.
+
+    A ``dict`` detail carrying its own ``code`` key is a *declaration* — the
+    raiser named the code rather than spelling it in a sentence — so it is
+    passed through unchecked, the same way a
+    :class:`CodedValidationError`'s ``.code`` is.
+
+    A string prefix is read English, so it must clear the same catalogue
+    test the code position clears in :func:`validation_detail_code`. Without
+    it this path had the wider hole of the two: its character test does not
+    even require an underscore, so ``raise HTTPException(422, "manifest: …")``
+    would publish ``code="manifest"``.
+    """
 
     if isinstance(detail, dict):
         nested = detail.get("code")
@@ -133,7 +241,12 @@ def detail_code(detail: object, *, fallback: str) -> str:
             return nested
     if isinstance(detail, str):
         prefix, separator, _tail = detail.partition(": ")
-        if separator and prefix and all(ch.islower() or ch.isdigit() or ch == "_" for ch in prefix):
+        if (
+            separator
+            and prefix
+            and all(ch.islower() or ch.isdigit() or ch == "_" for ch in prefix)
+            and prefix in MESSAGE_PREFIX_CODES
+        ):
             return prefix
     return fallback
 
@@ -197,10 +310,11 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
 
     Prefers a code the raising exception *declared* (see
     :func:`_declared_errors`) over one spelled inside a message. A code
-    spelled inside a message counts only where it is spelled in the **code
-    position** (see :func:`_code_position_token` and the module docstring);
-    a ``snake_case`` token found mid-sentence is a field path or a
-    quantity, not a contract.
+    spelled inside a message counts only where it is in the **code
+    position** *and* the catalogue lists it as arriving that way (see
+    :func:`_promotable_code` and the module docstring); a ``snake_case``
+    token found mid-sentence is a field path or a quantity, and one in the
+    code position that no catalogue entry claims is a function name.
     """
 
     # Pydantic/FastAPI expose the independent validation failures as the
@@ -227,7 +341,7 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
             value = str(value)
         if isinstance(value, str):
             candidates.update(_NESTED_CODE_PATTERN.findall(value))
-            declared = _code_position_token(value)
+            declared = _promotable_code(value)
             if declared is not None:
                 in_code_position.add(declared)
 
@@ -299,6 +413,7 @@ def reject_unsupported_filters(
 
 
 __all__ = [
+    "MESSAGE_PREFIX_CODES",
     "CodedValidationError",
     "CodedValueError",
     "detail_code",

--- a/backend/tests/api/test_error_contract_catalogue_gate.py
+++ b/backend/tests/api/test_error_contract_catalogue_gate.py
@@ -46,9 +46,13 @@ while proving nothing.
 
 from __future__ import annotations
 
+import ast
+import re
+from pathlib import Path
+
 import pytest
 
-from app.api.code_catalogue import CATALOGUE, Surface
+from app.api.code_catalogue import CATALOGUE, Surface, catalogued_codes
 from app.api.error_contract import (
     MESSAGE_PREFIX_CODES,
     detail_code,
@@ -56,9 +60,94 @@ from app.api.error_contract import (
 )
 from app.services.scientific_read.keyset import keyset_predicate
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCANNED_ROOTS = (
+    REPO_ROOT / "backend" / "app",
+    REPO_ROOT / "schemas" / "python" / "tckdb-schemas" / "tckdb_schemas",
+)
+SKIPPED = ("/tests/", "/importers/")
+_BARE_CODE = re.compile(r"^[a-z][a-z0-9_]*_[a-z0-9_]+$")
+
 
 def _promoted(message: str) -> str:
     return validation_detail_code(message, fallback="validation_error")
+
+
+def _sources() -> list[tuple[str, ast.Module]]:
+    parsed: list[tuple[str, ast.Module]] = []
+    for root in SCANNED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            if any(skip in str(path) for skip in SKIPPED):
+                continue
+            parsed.append(
+                (str(path.relative_to(REPO_ROOT)), ast.parse(path.read_text()))
+            )
+    return parsed
+
+
+def _helpers_that_raise_a_parameter_as_the_code(
+    sources: list[tuple[str, ast.Module]],
+) -> dict[str, str]:
+    """``function name -> parameter`` for ``raise X(f"{param}: ...")``.
+
+    The shape the catalogue's raise-site scan cannot read, because the code
+    is not a literal anywhere near the ``raise``.
+    """
+    helpers: dict[str, str] = {}
+    for _path, tree in sources:
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            parameters = {
+                argument.arg
+                for argument in [
+                    *node.args.args,
+                    *node.args.kwonlyargs,
+                    *node.args.posonlyargs,
+                ]
+            }
+            for inner in ast.walk(node):
+                if not isinstance(inner, ast.Raise) or not isinstance(
+                    inner.exc, ast.Call
+                ):
+                    continue
+                for argument in inner.exc.args:
+                    if not isinstance(argument, ast.JoinedStr) or len(
+                        argument.values
+                    ) < 2:
+                        continue
+                    head, following = argument.values[0], argument.values[1]
+                    if (
+                        isinstance(head, ast.FormattedValue)
+                        and isinstance(head.value, ast.Name)
+                        and head.value.id in parameters
+                        and isinstance(following, ast.Constant)
+                        and isinstance(following.value, str)
+                        and following.value.startswith(": ")
+                    ):
+                        helpers[node.name] = head.value.id
+    return helpers
+
+
+def _codes_passed_to(helpers: dict[str, str]) -> dict[str, str]:
+    """``code -> call site`` for every literal handed to such a parameter."""
+    found: dict[str, str] = {}
+    for path, tree in _sources():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            parameter = helpers.get(name or "")
+            if parameter is None:
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != parameter:
+                    continue
+                value = keyword.value
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    if _BARE_CODE.fullmatch(value.value):
+                        found.setdefault(value.value, path)
+    return found
 
 
 class TestTheGateIsTheCatalogue:
@@ -95,15 +184,30 @@ class TestTheGateIsTheCatalogue:
 class TestNoCataloguedCodeIsLost:
     """The regression that matters: promotion must keep every real code."""
 
-    @pytest.mark.parametrize("code", sorted(MESSAGE_PREFIX_CODES))
-    def test_every_catalogued_message_prefix_code_is_still_promoted(self, code):
-        """One case per code, so a loss names the code that was lost.
+    def test_every_catalogued_message_prefix_code_is_still_promoted(self):
+        """Written as a loop, not a ``parametrize``, and that is a finding.
 
-        The prose deliberately contains no second ``token: ``, because a
-        message carrying two tokens has always fallen back and this is not
-        the test for that.
+        Parametrising over ``MESSAGE_PREFIX_CODES`` reads better and names
+        the lost code in the test id -- but pytest turns an empty parameter
+        set into a *skip*, so the mutation that empties the derivation
+        (measured: ``frozenset()``) made the one test that checks nothing is
+        lost report ``1 skipped`` instead of failing. A vacuous pass dressed
+        as a skip is the exact shape this repository keeps finding, so the
+        loop form is used and the count is asserted.
+
+        The prose deliberately carries no second ``token: ``: a message with
+        two tokens has always fallen back, and that is a different test.
         """
-        assert _promoted(f"{code}: the request was refused.") == code
+        lost = [
+            code
+            for code in sorted(MESSAGE_PREFIX_CODES)
+            if _promoted(f"{code}: the request was refused.") != code
+        ]
+        assert not lost, f"these codes stopped being promoted: {lost}"
+        assert len(MESSAGE_PREFIX_CODES) > 50, (
+            f"only {len(MESSAGE_PREFIX_CODES)} codes were checked, so this "
+            "test passed without exercising the read API's code surface"
+        )
 
     def test_a_code_still_survives_pydantic_wrapping_its_sentence(self):
         """The framework-wrapper path is gated the same way, not bypassed."""
@@ -160,6 +264,71 @@ class TestAFunctionNameIsNotACode:
                 "calculation owned by a different species entry."
             )
             == "validation_error"
+        )
+
+
+class TestTheShapeTheRaiseSiteScanCannotRead:
+    """The net this change would otherwise have removed.
+
+    Before this change, an uncatalogued code in the code position was
+    *promoted*, so the runtime observer saw it in the body and failed the
+    test that produced it. That was the only net covering a code
+    interpolated into the code position from a parameter, because the
+    catalogue's static scan reads literals at ``raise`` sites and this shape
+    has no literal there.
+
+    Gating promotion closes that net: the token now degrades to
+    ``validation_error``, the body carries no unknown code, and the observer
+    has nothing to see. Measured, not reasoned about -- renaming
+    ``conflict_code="level_of_theory_handle_conflict"`` to ``..._clash``
+    leaves both the raise-site scan and the observer green, where before
+    this change the observer failed the test that emitted it.
+
+    So the net is restored here, statically and in the same shape: find the
+    helpers that raise a *parameter* as the code, then require every literal
+    handed to that parameter to be catalogued. ``reconcile_id_ref`` is the
+    one such helper today and the six ``*_handle_conflict`` codes are its
+    arguments; five of the six are never emitted by any test, so the
+    observer could not have covered them either.
+    """
+
+    def test_the_scan_finds_the_helper_it_is_written_for(self):
+        """An empty scan would make the next assertion prove nothing."""
+        helpers = _helpers_that_raise_a_parameter_as_the_code(_sources())
+        assert "reconcile_id_ref" in helpers, sorted(helpers)
+        assert helpers["reconcile_id_ref"] == "conflict_code"
+
+    def test_every_code_minted_from_a_parameter_is_catalogued(self):
+        """Otherwise the gate would silently degrade a real code.
+
+        This is the failure #159 refused to risk. It is checked rather than
+        argued about, and the check names what it saw.
+        """
+        helpers = _helpers_that_raise_a_parameter_as_the_code(_sources())
+        codes = _codes_passed_to(helpers)
+        assert len(codes) >= 6, f"the scan found only {sorted(codes)}"
+        known = catalogued_codes()
+        missing = {code: where for code, where in codes.items() if code not in known}
+        assert not missing, (
+            "these codes reach the code position but no catalogue entry "
+            f"claims them, so promotion will drop them: {missing}"
+        )
+
+    def test_they_are_catalogued_as_arriving_by_this_mechanism(self):
+        """Catalogued is not enough -- the surface has to be right too.
+
+        A code listed under any other surface would still be dropped by the
+        gate, so the containment that matters is against the promotable set,
+        not against the catalogue as a whole.
+        """
+        helpers = _helpers_that_raise_a_parameter_as_the_code(_sources())
+        codes = _codes_passed_to(helpers)
+        assert len(codes) >= 6, f"the scan found only {sorted(codes)}"
+        not_promotable = sorted(set(codes) - MESSAGE_PREFIX_CODES)
+        assert not not_promotable, (
+            "these codes are written in the code position but are not "
+            f"catalogued as message_prefix, so they will not be promoted: "
+            f"{not_promotable}"
         )
 
 

--- a/backend/tests/api/test_error_contract_catalogue_gate.py
+++ b/backend/tests/api/test_error_contract_catalogue_gate.py
@@ -1,0 +1,206 @@
+"""Position says a token *means* to be a code; the catalogue says it is one.
+
+#159 narrowed code promotion to the code position -- the start of a
+message, optionally behind a framework wrapper -- because position is how a
+raiser declares a code. That killed the ``existing_calculation_id``
+fabrication, where a field path ended a sentence. It could not kill the
+other half of the problem, because a code and a function name are the same
+shape and both get written first:
+
+    raise ValueError("create_applied_group_additivity: thermo_id does not ...")
+    raise ValueError("keyset_predicate: at least one sort key is required.")
+
+Both are the house style ``f"{context}: <prose>"`` with the enclosing
+function as ``context``, and both were published as though a client could
+branch on them.
+
+So promotion now also consults :mod:`app.api.code_catalogue`, which records
+per code *by which mechanism* it reaches the body. A leading token is
+promoted only where the catalogue lists that code as
+:data:`~app.api.code_catalogue.Surface.message_prefix`. The two above are
+catalogued as :data:`~app.api.code_catalogue.Surface.accidental_prefix` --
+the catalogue's own word for "not a code" -- so the honest record of the
+defect is what stops it reaching a client.
+
+What this file exists to prevent
+--------------------------------
+#159 refused to gate promotion on a list, because forgetting to register a
+new code would silently degrade it to ``validation_error``. Three things
+answer that, and only the third lives here:
+
+* ``test_api_code_catalogue.py::test_every_raise_site_code_is_catalogued``
+  statically scans every ``raise`` and demands an entry (verified by
+  mutation: a new ``raise ValueError("some_new_code: ...")`` fails it as a
+  plain literal, as an f-string, and when raised inside a helper);
+* the runtime observer fails the test that *emits* an uncatalogued code,
+  which is what catches a code interpolated into the code position from a
+  variable -- the six ``*_handle_conflict`` codes are exactly that shape and
+  were found by the observer and by nothing else;
+* and these tests pin the dependency itself, so the gate cannot be widened
+  back to "any leading token" or narrowed to nothing without a red test.
+
+Every assertion below runs over something non-empty and is stated in both
+directions, because a gate that can only say yes -- or only say no -- passes
+while proving nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.code_catalogue import CATALOGUE, Surface
+from app.api.error_contract import (
+    MESSAGE_PREFIX_CODES,
+    detail_code,
+    validation_detail_code,
+)
+from app.services.scientific_read.keyset import keyset_predicate
+
+
+def _promoted(message: str) -> str:
+    return validation_detail_code(message, fallback="validation_error")
+
+
+class TestTheGateIsTheCatalogue:
+    """The set consulted is derived, not a second hand-written list."""
+
+    def test_it_is_exactly_the_catalogue_message_prefix_codes(self):
+        assert MESSAGE_PREFIX_CODES == {
+            entry.code
+            for entry in CATALOGUE
+            if entry.surface is Surface.message_prefix
+        }
+
+    def test_it_is_large_enough_to_be_the_read_api(self):
+        """A gate over a nearly-empty set would degrade the whole read API.
+
+        Most read-API refusals declare their code the legacy way, as the
+        leading ``"code: "`` of their own message, so this set has to stay
+        the size of that surface. If it collapsed, every one of those codes
+        would arrive as ``validation_error`` -- the failure #159 named.
+        """
+        assert len(MESSAGE_PREFIX_CODES) > 50, sorted(MESSAGE_PREFIX_CODES)
+
+    def test_it_excludes_what_the_catalogue_calls_not_a_code(self):
+        accidental = {
+            entry.code
+            for entry in CATALOGUE
+            if entry.surface is Surface.accidental_prefix
+        }
+        assert not (accidental & MESSAGE_PREFIX_CODES), sorted(
+            accidental & MESSAGE_PREFIX_CODES
+        )
+
+
+class TestNoCataloguedCodeIsLost:
+    """The regression that matters: promotion must keep every real code."""
+
+    @pytest.mark.parametrize("code", sorted(MESSAGE_PREFIX_CODES))
+    def test_every_catalogued_message_prefix_code_is_still_promoted(self, code):
+        """One case per code, so a loss names the code that was lost.
+
+        The prose deliberately contains no second ``token: ``, because a
+        message carrying two tokens has always fallen back and this is not
+        the test for that.
+        """
+        assert _promoted(f"{code}: the request was refused.") == code
+
+    def test_a_code_still_survives_pydantic_wrapping_its_sentence(self):
+        """The framework-wrapper path is gated the same way, not bypassed."""
+        assert (
+            validation_detail_code(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ["body"],
+                        "msg": (
+                            "Value error, pressure_alias_conflict: pressure and "
+                            "the deprecated alias must agree."
+                        ),
+                    }
+                ],
+                fallback="request_validation_error",
+            )
+            == "pressure_alias_conflict"
+        )
+
+
+class TestAFunctionNameIsNotACode:
+    """The defect, provoked from the real refusals rather than a copy."""
+
+    def test_the_keyset_guard_no_longer_advertises_its_own_name(self):
+        """``keyset_predicate`` guards an argument invariant, so it fires
+        only on a backend bug -- and used to answer with a ``code`` naming
+        the function that had the bug.
+
+        Provoked from the real function so that rewording its message
+        cannot make this test pass for the wrong reason.
+        """
+        with pytest.raises(ValueError) as raised:
+            keyset_predicate([], [])
+        message = str(raised.value)
+        assert _promoted(message) == "validation_error"
+
+    def test_the_length_guard_is_the_same_shape(self):
+        with pytest.raises(ValueError) as raised:
+            keyset_predicate([(object(), "asc")], [1, 2])
+        assert _promoted(str(raised.value)) == "validation_error"
+
+    def test_an_uncatalogued_token_in_the_code_position_is_not_promoted(self):
+        """The general rule, on a token no catalogue entry can ever claim."""
+        token = "zzz_uncatalogued_token"
+        assert token not in MESSAGE_PREFIX_CODES
+        assert _promoted(f"{token}: something went wrong.") == "validation_error"
+
+    def test_a_field_path_is_still_not_promoted(self):
+        """#159's case, still refused -- by position, before the catalogue."""
+        assert (
+            _promoted(
+                "source_calculations[0].existing_calculation_id: refers to a "
+                "calculation owned by a different species entry."
+            )
+            == "validation_error"
+        )
+
+
+class TestTheLegacyDetailPathIsGatedToo:
+    """``detail_code`` reads English as well, and read it more loosely.
+
+    Its character test does not even require an underscore, so before this
+    change ``raise HTTPException(422, "manifest: ...")`` would have
+    published ``code="manifest"``. Two of the five bare prefixes written in
+    the tree (``manifest``, ``readyz``, ``startup``, ``status``,
+    ``geometry_validation``) are one refactor away from an error body.
+    """
+
+    def test_a_catalogued_prefix_is_still_lifted(self):
+        assert (
+            detail_code("unknown_release: no such release.", fallback="http_404")
+            == "unknown_release"
+        )
+
+    def test_an_uncatalogued_prefix_falls_back_to_the_status(self):
+        assert (
+            detail_code(
+                "manifest: stored document hashes differently.",
+                fallback="http_500",
+            )
+            == "http_500"
+        )
+
+    def test_a_declared_code_in_a_dict_detail_is_not_second_guessed(self):
+        """A dict's ``code`` key is a declaration, not English.
+
+        The client-version handshake names its code that way, and it is
+        catalogued as ``detail_object`` rather than ``message_prefix``.
+        Passing the dict branch through the same gate would drop it, which
+        is why only the string branch is gated.
+        """
+        assert (
+            detail_code(
+                {"code": "tckdb_client_version_unsupported", "detail": "too old"},
+                fallback="http_426",
+            )
+            == "tckdb_client_version_unsupported"
+        )
+        assert "tckdb_client_version_unsupported" not in MESSAGE_PREFIX_CODES

--- a/backend/tests/workflows/test_group_additivity_upload.py
+++ b/backend/tests/workflows/test_group_additivity_upload.py
@@ -8,6 +8,7 @@ persists to ``group_additivity_scheme`` / ``applied_group_additivity`` /
 
 from __future__ import annotations
 
+import json
 import logging
 
 import pytest
@@ -246,6 +247,39 @@ def test_service_guard_rejects_ga_on_non_estimated_thermo(db_session):
         create_applied_group_additivity(
             db_session, payload, thermo_id=computed.id
         )
+
+
+def test_the_missing_thermo_guard_does_not_answer_with_its_own_name(db_session):
+    """The refusal must not advertise the function it was raised in.
+
+    The message is written in the house style, ``f"{context}: <prose>"``,
+    with the enclosing function as ``context`` -- so the token lands in the
+    code position and the envelope used to publish
+    ``code="create_applied_group_additivity"``: a function name presented to
+    a client as a branchable contract. It is in no register, in no generated
+    client constant, and it moves the day somebody renames the function.
+
+    The envelope is built here by the *real* handler rather than asserted
+    about in the abstract, because what a depositor receives is the thing
+    under test. ``validation_error`` is the right answer: honestly generic
+    beats convincingly fake.
+
+    This guard protects programmatic callers -- ``persist_thermo_upload``
+    passes the row it has just created, so no HTTP request can reach it --
+    which is why the case is provoked directly.
+    """
+    from app.api.errors import _value_error_handler
+
+    payload = AppliedGroupAdditivityUploadPayload.model_validate(_ga_payload())
+    with pytest.raises(ValueError) as raised:
+        create_applied_group_additivity(db_session, payload, thermo_id=-1)
+
+    response = _value_error_handler(None, raised.value)  # type: ignore[arg-type]
+    body = json.loads(response.body)
+    assert response.status_code == 422
+    assert body["code"] == "validation_error"
+    assert body["detail"] == str(raised.value)
+    assert body["context"] == {}
 
 
 def test_ga_requires_at_least_one_component():


### PR DESCRIPTION
## The defect

`POST`-time refusals written in the house style `f"{context}: <prose>"` put the
enclosing **function name** in the code position, and #159's positional rule
promoted it. Two exist:

| site | published `code` |
|---|---|
| `backend/app/services/group_additivity_resolution.py:129` | `create_applied_group_additivity` |
| `backend/app/services/scientific_read/keyset.py:214,218` | `keyset_predicate` |

#159 was right that position is how a raiser declares a code. Position simply
cannot tell a code from a function name — both are snake_case tokens someone
deliberately wrote first.

## The change

Promotion now also consults `app/api/code_catalogue.py`, which records per code
*by which mechanism* it reaches the body, and promotes only what that module
lists as `Surface.message_prefix`. Both defects are catalogued as
`Surface.accidental_prefix` — the catalogue's own word for "not a code" — so the
honest record of the defect is what stops it reaching a client.

`detail_code`'s string branch is gated the same way; it had the wider hole,
since its character test does not even require an underscore. Its dict branch is
untouched — a `code` key is a declaration, not English.

**Note the structural shift**: nothing in `backend/app/` imported the catalogue
before. It described behaviour; now it drives it.

**"The catalogue contains it" would not have fixed either defect.** Both codes
are *in* the catalogue. Mutating the gate to plain membership (M3 below) leaves
both defects live. It is the declared *surface*, not membership, that does the
work.

## The decisive question: does the drift guard catch an uncatalogued code?

**Yes for a literal at a raise site; no for two other shapes — and one of those
two mattered enough to need a replacement net.** Five probes inserted at a real
raise site, run against
`test_api_code_catalogue.py::test_every_raise_site_code_is_catalogued`:

| shape | caught |
|---|---|
| `raise ValueError("zzz_a: ...")` | **red** |
| `raise ValueError(f"zzz_b: got {n}")` | **red** |
| `raise ValueError(f"{_PROBE_C}: ...")` (code interpolated) | green — blind |
| `msg = "zzz_d: ..."; raise ValueError(msg)` | green — blind |
| `_helper()` that raises `"zzz_e: ..."` itself | **red** |

Shape C is not hypothetical: the six `*_handle_conflict` codes are exactly it,
via `reconcile_id_ref(conflict_code=...)`. #161 says they were found by the
runtime observer and by nothing else.

### The interaction that nearly shipped as a hole

Gating promotion **disables the observer for this surface**. The observer fails
the test that *emits* an uncatalogued code — but a gated promotion never puts an
unknown token in `code`, so the body is a clean `validation_error` and there is
nothing to see. Renaming `conflict_code="level_of_theory_handle_conflict"` to
`..._clash`:

* before this branch — observer fails the test that emitted it;
* after the first commit — raise-site scan green, observer green, **nothing**;
* after the second commit — the new scan fails, naming the code.

So the branch carries a second static scan in the shape of the gap: find helpers
that raise a *parameter* in the code position, then require every literal handed
to that parameter to be catalogued, and catalogued as `message_prefix`.

That leaves one shape unread (shape D). A census of every string literal in
`backend/app` and `tckdb_schemas` beginning with a `token: ` prefix finds 73:
66 catalogued `message_prefix`, 5 logger format strings that reach no response
body (`geometry_validation`, `manifest`, `readyz`, `startup`, `status`), and the
2 accidental prefixes. Zero uncatalogued error-reachable prefixes.

## Membership, not observation

143 catalogued codes; 53 never observed by any gate; **38 of those 53 are
`message_prefix`** — the population at risk. All 38 still promote, because the
gate reads catalogue membership, not the observer's record.

## Regression proof — all three gates, before and after

Every 4xx/5xx JSON body recorded as it is built, normalised (ids, refs, uuids,
temp paths), deduped, compared:

|  | before | after |
|---|---|---|
| distinct normalised error bodies | 398 | 399 |
| distinct `(status, code)` pairs | **100** | **100** |
| distinct codes | **98** | **98** |

* **lost: none** — no body, no code, no pair.
* **gained: one** — `{"code": "validation_error", "detail": "create_applied_group_additivity: thermo_id does not reference an existing thermo record.", "status": 422}`. That is the fix, showing up in the census exactly once.

Gate counts: rest 4259→4260 passed / 14 skipped; api 2689→2772 passed;
scientific 2049→2049 passed. `ruff check app tests scripts` clean.

## The fixed response

```
BEFORE (main, cb38bfc2)          AFTER (this branch)
422                              422
{                                {
  "code": "create_applied_         "code": "validation_error",
           group_additivity",      "detail": "create_applied_group_additivity:
  "detail": "create_applied_                   thermo_id does not reference an
    group_additivity: thermo_id                existing thermo record.",
    does not reference an          "context": {}
    existing thermo record.",    }
  "context": {}
}
```

The detail does not move by a byte. Only the fabricated `code` goes.

## Mutations

| # | mutation | result |
|---|---|---|
| M1 | gate removed (back to #159's rule) | 4 red — both defect tests, the uncatalogued-token test, the GA envelope test |
| M2 | gate over `frozenset()` | 7 red |
| M3 | gate on plain catalogue membership | 6 red — **both defects live again** |
| M4 | `detail_code` string branch ungated | 1 red |
| M5 | `accidental_prefix` readmitted | 5 red |
| M6 | new scan finds no helpers | 2 red |
| M7 | new scan finds no call sites | 1 red |

M2 was itself a finding: the per-code "nothing was lost" check had been a
`parametrize`, and pytest turns an empty parameter set into a **skip** — so the
one test guarding against loss reported `1 skipped`. Rewritten as a loop with a
floor.

## What I did not do

**The reword is not cheap.** Removing the leading token from
`group_additivity_resolution.py` turns
`test_api_code_catalogue.py::test_every_origin_still_defines_its_code` red: the
catalogue entry says the literal lives in that module, and after a reword it
does not. Fixing it means deleting two catalogue entries and the
`accidental_prefix`-must-exist assertion at `test_api_code_catalogue.py:320` —
both owned by the concurrent agent. Reverted and reported instead of shipped.

The same reword on `keyset.py` stays **green**, and for the wrong reason:
`_defines_code` is satisfied by `"keyset_predicate"` in `__all__`. The origin
guard cannot tell "defines this code" from "exports a function of this name".

## Alembic

Head unchanged at `b7e4d1a9c026`. No revision.
