### PR TITLE
Keep the code when a wrapper adds the field it failed on

### DIFF
--- a/backend/app/schemas/workflows/kinetics_upload.py
+++ b/backend/app/schemas/workflows/kinetics_upload.py
@@ -2,6 +2,7 @@ import math
 from typing import Self
 
 from pydantic import Field, field_validator, model_validator
+from tckdb_schemas.coded_error import CodedValidationError
 
 from app.chemistry.units import validate_a_units_for_molecularity
 from app.db.models.common import (
@@ -34,10 +35,48 @@ def _validate_a_units_named(field: str, a_units: ArrheniusAUnits, molecularity: 
     Wraps :func:`validate_a_units_for_molecularity` so a rejected sibling
     A-factor (a ``multi_arrhenius`` term, PLOG entry, or falloff k0) reports
     which term failed without leaking database ids.
+
+    Adding the field name must not cost the code
+    -------------------------------------------
+    The wrapped check raises :class:`~tckdb_schemas.coded_error.CodedValidationError`,
+    which is a ``ValueError``, so the obvious ``except ValueError: raise
+    ValueError(f"{field}: {exc}")`` re-raised a *plain* ``ValueError`` and
+    the declared code was gone before any promotion rule could see it.
+    order-2 ``a_units`` on a unimolecular ``plog_entries[1]`` reached the
+    client as the generic ``request_validation_error`` -- these validators
+    run while the request body is being parsed, so the fallback is the
+    request one -- while the identical mistake on the main-line ``a_units``,
+    which calls the check directly, arrived as
+    ``arrhenius_a_units_molecularity_mismatch``. Same refusal, two contracts,
+    decided by whether a wrapper happened to be in the way.
+
+    So the coded case is caught first and re-raised *as itself*: same code,
+    same context (plus the field, which is the machine-readable form of what
+    the prefix says in prose), and ``str(exc)`` byte-identical to what the
+    lossy version produced. ``message_prefix=False`` is what keeps it
+    identical -- the default would insert the code ahead of the field and
+    move a published message.
+
+    Note what the prefix does *not* become. The message now starts with
+    ``"plog_entries[1].a_units: "``, and #159 promotes a leading token only
+    where :mod:`app.api.code_catalogue` calls it a code. A field path is not
+    catalogued, so it cannot be mistaken for one; the code arrives because
+    the exception declares it, never because of where it sits in a sentence.
     """
     try:
         validate_a_units_for_molecularity(a_units, molecularity)
+    except CodedValidationError as exc:
+        raise CodedValidationError(
+            exc.code,
+            f"{field}: {exc}",
+            context={**exc.context, "field": field},
+            message_prefix=False,
+        ) from exc
     except ValueError as exc:
+        # Defensive, and currently unreachable: every raise in
+        # ``validate_a_units_for_molecularity`` is coded. Kept so that a
+        # future uncoded ValueError still gets its field named rather than
+        # silently losing the context this helper exists to add.
         raise ValueError(f"{field}: {exc}") from exc
 
 

--- a/backend/tests/api/test_api_scientific_rejection_codes.py
+++ b/backend/tests/api/test_api_scientific_rejection_codes.py
@@ -654,6 +654,65 @@ class TestRateCoefficients:
         body = _assert_code(response, "arrhenius_a_units_molecularity_mismatch")
         assert "is incompatible with" in str(body["detail"])
 
+    def test_the_same_mistake_on_a_sibling_a_factor_reports_the_same_code(
+        self, client
+    ):
+        """A PLOG term's A-units are the same refusal as the main line's.
+
+        The main-line check calls ``validate_a_units_for_molecularity``
+        directly; every sibling A-factor (a ``multi_arrhenius`` term, a PLOG
+        entry, a falloff k0) goes through ``_validate_a_units_named``, which
+        prefixes the field so the client learns *which* term failed. That
+        wrapper used to re-raise a plain ``ValueError``, and because
+        ``CodedValueError`` is a ``ValueError`` the declared code was
+        destroyed at the raise site -- before any promotion rule could see
+        it. The same chemistry error therefore arrived under two different
+        contracts depending on where in the payload it was written.
+
+        The main line here is deliberately *correct* (``per_s`` for one
+        reactant), so the only failure is the PLOG entry's: with more than
+        one validation failure the envelope falls back by design, and this
+        would then pass for the wrong reason.
+        """
+        response = client.post(
+            "/api/v1/uploads/kinetics",
+            json={
+                "reaction": _reaction_payload([_METHANE], [_METHANE]),
+                "scientific_origin": "experimental",
+                "model_kind": "plog",
+                "a": 2.16e8,
+                "a_units": "per_s",
+                "n": 0.0,
+                "reported_ea": 14.35,
+                "reported_ea_units": "kj_mol",
+                "plog_entries": [
+                    {
+                        "entry_index": 1,
+                        "pressure_bar": 1.0,
+                        "a": 1.0e10,
+                        # Order-2 units on a unimolecular reaction.
+                        "a_units": "cm3_mol_s",
+                        "n": 0.0,
+                        "ea_kj_mol": 0.0,
+                    }
+                ],
+            },
+        )
+        body = _assert_code(response, "arrhenius_a_units_molecularity_mismatch")
+        detail = str(body["detail"])
+        # The prose is unchanged: the field prefix the wrapper has always
+        # added, then the check's own sentence, verbatim.
+        assert "plog_entries[1].a_units: " in detail
+        assert "is incompatible with" in detail
+        # And the field name did not become the code. That would be the
+        # #159 fabrication -- a leading token published as though a client
+        # could branch on it -- reintroduced by the fix for this one.
+        assert body["code"] != "plog_entries[1].a_units"
+        assert body["code"] != "a_units"
+        # The structured facts survive the re-raise, and name the term.
+        assert body["context"]["field"] == "plog_entries[1].a_units"
+        assert body["context"]["molecularity"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Atom mapping across a reaction

--- a/backend/tests/workflows/test_kinetics_upload.py
+++ b/backend/tests/workflows/test_kinetics_upload.py
@@ -930,6 +930,185 @@ def test_plog_entry_wrong_order_units_rejected():
         KineticsUploadRequest.model_validate(payload)
 
 
+# ---------------------------------------------------------------------------
+# Naming the offending term must not cost the term's code
+# ---------------------------------------------------------------------------
+#
+# ``_validate_a_units_named`` prefixes the field path onto the check's own
+# sentence. ``CodedValidationError`` is a ``ValueError``, so re-raising a
+# plain ``ValueError`` to add that prefix destroyed the declared code at the
+# raise site -- upstream of every promotion rule #159/#161/#164 built. These
+# pin both halves of the repair: the code survives, and the sentence does not
+# move by a byte.
+
+#: What the check itself says for order-3 units on a bimolecular reaction.
+#: Written out rather than derived so that rewording the check fails here
+#: instead of silently agreeing with itself.
+_ORDER_3_ON_BIMOLECULAR = (
+    "a_units 'cm6_mol2_s' is incompatible with bimolecular reaction "
+    "(molecularity=2). Expected one of: "
+    "['cm3_mol_s', 'cm3_molecule_s', 'm3_mol_s']."
+)
+
+
+def _sole_error(payload: dict) -> dict:
+    """The single Pydantic error the payload produces.
+
+    More than one and the envelope falls back by design, which would make
+    every assertion below pass for the wrong reason.
+    """
+    with pytest.raises(ValidationError) as caught:
+        KineticsUploadRequest.model_validate(payload)
+    errors = caught.value.errors()
+    assert len(errors) == 1, errors
+    return errors[0]
+
+
+def _multi_arrhenius_order_3_payload() -> dict:
+    return _multi_arrhenius_payload([
+        {"entry_index": 1, "a": 1.0e12, "a_units": "cm3_mol_s"},
+        {"entry_index": 2, "a": 3.0e11, "a_units": "cm6_mol2_s"},
+    ])
+
+
+def _plog_order_3_payload() -> dict:
+    payload = _kinetics_request().model_dump()
+    payload["model_kind"] = "plog"
+    payload["plog_entries"] = [
+        {"entry_index": 1, "pressure_bar": 0.1, "a": 1.0e10, "a_units": "cm3_mol_s"},
+        {"entry_index": 2, "pressure_bar": 1.0, "a": 2.0e10, "a_units": "cm6_mol2_s"},
+    ]
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("field", "build"),
+    [
+        ("arrhenius_entries[2].a_units", _multi_arrhenius_order_3_payload),
+        ("plog_entries[2].a_units", _plog_order_3_payload),
+    ],
+)
+def test_a_named_sibling_a_factor_keeps_its_code_and_its_sentence(field, build):
+    """Every call site of the wrapper, not just the one that was reported.
+
+    ``entry_index`` is 2 in both cases so a fix that hard-coded index 1 --
+    or that named the wrong term -- is visible here rather than plausible.
+    """
+    error = _sole_error(build())
+    declared = error["ctx"]["error"]
+
+    # The code the check declared reaches the envelope's reader as an
+    # attribute of the exception. Nothing is parsed out of the sentence.
+    assert declared.code == "arrhenius_a_units_molecularity_mismatch"
+    # Byte-for-byte what the lossy ``raise ValueError(f"{field}: {exc}")``
+    # produced: field path, ": ", then the check's own prose unchanged.
+    assert str(declared) == f"{field}: {_ORDER_3_ON_BIMOLECULAR}"
+    # The field is also machine-readable, alongside the facts the check
+    # already attached.
+    assert declared.context["field"] == field
+    assert declared.context["molecularity"] == 2
+    assert declared.context["a_units"] == "cm6_mol2_s"
+
+
+def test_the_falloff_k0_call_site_keeps_its_code_too():
+    """The third call site, whose molecularity is k∞'s plus one.
+
+    Kept separate from the parametrized pair because its expected sentence
+    is a different one -- order-2 units judged against order 3 -- and
+    folding it in would have meant asserting a sentence neither case
+    actually produces.
+    """
+    payload = _kinetics_request().model_dump()
+    payload["model_kind"] = "troe"
+    payload["a_units"] = "cm3_mol_s"
+    payload["falloff"] = {
+        "low_a": 1.0e30,
+        "low_a_units": "cm3_mol_s",  # order-2, but k0 must be order-3
+        "low_n": -3.0,
+        "low_ea_kj_mol": 0.0,
+        "troe_alpha": 0.5,
+        "troe_t3": 100.0,
+        "troe_t1": 1000.0,
+        "troe_t2": 5000.0,
+    }
+    declared = _sole_error(payload)["ctx"]["error"]
+    assert declared.code == "arrhenius_a_units_molecularity_mismatch"
+    assert str(declared) == (
+        "falloff.low_a_units: a_units 'cm3_mol_s' is incompatible with "
+        "termolecular reaction (molecularity=3). Expected one of: "
+        "['cm6_mol2_s', 'cm6_molecule2_s', 'm6_mol2_s']."
+    )
+    assert declared.context["field"] == "falloff.low_a_units"
+
+
+def test_the_second_code_the_wrapper_can_carry_also_survives():
+    """``validate_a_units_for_molecularity`` declares two codes, not one.
+
+    The falloff call site asks for ``len(reactants) + 1``, so a termolecular
+    reaction asks about molecularity 4 -- which the units table does not
+    define, and which the check refuses with
+    ``unsupported_reaction_molecularity`` rather than with the mismatch
+    code. It travelled through the same lossy wrapper, so it was lost the
+    same way and is repaired by the same change. Pinned separately because
+    a fix that special-cased the one code in the bug report would still
+    pass every other test here.
+    """
+    payload = _kinetics_request().model_dump()
+    payload["reaction"]["reactants"] = payload["reaction"]["reactants"] + [
+        payload["reaction"]["reactants"][0]
+    ]
+    payload["model_kind"] = "troe"
+    payload["a_units"] = "cm6_mol2_s"  # order 3, correct for three reactants
+    payload["falloff"] = {
+        "low_a": 1.0e30,
+        "low_a_units": "cm6_mol2_s",  # k0 would need order 4, which does not exist
+        "low_n": -3.0,
+        "low_ea_kj_mol": 0.0,
+        "troe_alpha": 0.5,
+        "troe_t3": 100.0,
+        "troe_t1": 1000.0,
+        "troe_t2": 5000.0,
+    }
+    declared = _sole_error(payload)["ctx"]["error"]
+    assert declared.code == "unsupported_reaction_molecularity"
+    assert str(declared) == (
+        "falloff.low_a_units: Unsupported reaction molecularity: 4. "
+        "Expected 1 (unimolecular), 2 (bimolecular), or 3 (termolecular)."
+    )
+    assert declared.context["field"] == "falloff.low_a_units"
+    assert declared.context["molecularity"] == 4
+
+
+def test_the_field_path_is_not_itself_promotable_as_a_code():
+    """The #159 trap, checked rather than assumed.
+
+    The repaired message still *starts* with a snake_case token followed by
+    a colon -- ``a_units``, inside ``plog_entries[2].a_units`` -- which is
+    exactly the shape #159 narrowed promotion to. Promotion is gated on the
+    catalogue, so a field path cannot be published as a code; if that gate
+    ever loosened, this fix would be the thing that fabricated one.
+    """
+    from app.api.error_contract import MESSAGE_PREFIX_CODES, validation_detail_code
+
+    for field in (
+        "arrhenius_entries[2].a_units",
+        "plog_entries[2].a_units",
+        "falloff.low_a_units",
+        "a_units",
+    ):
+        assert field not in MESSAGE_PREFIX_CODES
+
+    payload = _kinetics_request().model_dump()
+    payload["model_kind"] = "plog"
+    payload["plog_entries"] = [
+        {"entry_index": 2, "pressure_bar": 1.0, "a": 2.0e10, "a_units": "cm6_mol2_s"},
+    ]
+    with pytest.raises(ValidationError) as caught:
+        KineticsUploadRequest.model_validate(payload)
+    promoted = validation_detail_code(caught.value.errors(), fallback="validation_error")
+    assert promoted == "arrhenius_a_units_molecularity_mismatch"
+
+
 def test_falloff_low_a_units_wrong_order_rejected():
     """k0 is one order higher than k∞; a bimolecular reaction's low-pressure
     limit must be order-3, so order-2 low_a_units is rejected and named."""


### PR DESCRIPTION
## The defect

`_validate_a_units_named` in `backend/app/schemas/workflows/kinetics_upload.py`
prefixes the offending field path onto the A-units check's own sentence, so a
rejected *sibling* A-factor says which term failed. It did that with the house
idiom:

```python
except ValueError as exc:
    raise ValueError(f"{field}: {exc}") from exc
```

`CodedValidationError` is a `ValueError`. The declared code was therefore
destroyed at the raise site — upstream of every promotion rule #159, #161 and
#164 built. The same chemistry mistake arrived under two different contracts
depending only on where in the payload it was written:

| where the bad `a_units` is | code before | code after |
|---|---|---|
| `a_units` (main line — calls the check directly) | `arrhenius_a_units_molecularity_mismatch` | unchanged |
| `arrhenius_entries[i].a_units` | `request_validation_error` | `arrhenius_a_units_molecularity_mismatch` |
| `plog_entries[i].a_units` | `request_validation_error` | `arrhenius_a_units_molecularity_mismatch` |
| `falloff.low_a_units` | `request_validation_error` | `arrhenius_a_units_molecularity_mismatch` |
| `falloff.low_a_units`, 3 reactants (k0 asks for molecularity 4) | `request_validation_error` | `unsupported_reaction_molecularity` |

The fallback is `request_validation_error`, not `validation_error`: these are
`model_validator`s on the request body, so the failure is a
`RequestValidationError` and takes that handler's fallback.

Both routes that accept `KineticsUploadRequest` are affected —
`POST /api/v1/uploads/kinetics` and `POST /api/v1/jobs/kinetics`.

## The census

19 raise-sites across 18 handlers in `backend/app/**` and
`schemas/python/tckdb-schemas/**` match "an `except` of a `ValueError`-family
exception whose handler raises something that is not the original".

**Exactly one loses a code.** Verdicts were established by static
callee-reachability from each try-body (positive and negative controls run on
the analyser) and confirmed empirically: a `sys.monitoring`
`EXCEPTION_HANDLED` probe over all three gates records every `except` that
absorbs a `CodedValidationError`.

Because the census found one site and not a dozen, the fix is shape **(a)** —
catch the coded case separately and re-raise it as itself — not shape (b), a
`.with_field()` method. Shape (b) also could not have been written as a method
this round: `CodedValidationError` lives in `schemas/python/tckdb-schemas/`,
which another agent owns.

## The fix

```python
except CodedValidationError as exc:
    raise CodedValidationError(
        exc.code,
        f"{field}: {exc}",
        context={**exc.context, "field": field},
        message_prefix=False,
    ) from exc
```

`str(exc)` is byte-identical to what the lossy version produced — pinned
against written-out literals in `tests/workflows/test_kinetics_upload.py`, not
derived from the check, so rewording the check fails the test rather than
silently agreeing with itself. `message_prefix=False` is what keeps it
identical; the default would insert the code ahead of the field and move a
published message.

**No `#159` regression.** The message still *starts* with a snake_case token
followed by a colon — `a_units`, inside `plog_entries[2].a_units` — which is
exactly the shape #159 narrowed promotion to. Promotion is gated on the
catalogue, so a field path cannot be published as a code; that is asserted
directly rather than assumed.

## Catalogue and client

Neither needed a change. `arrhenius_a_units_molecularity_mismatch` and
`unsupported_reaction_molecularity` are both already in
`app/api/code_catalogue.py` and in the client's `RejectionCode` enum with
retry advice and status sets. `tckdb-client` stays at 0.38.0 because it has no
diff.

## Measured

Baselines re-measured on pristine `main` content in this worktree, after an
earlier attempt was found contaminated — edits had landed mid-run, which is
exactly the stale-baseline failure `tckdb-gates` warns about.

| gate | baseline | with the fix |
|---|---|---|
| rest | 4276 passed, 14 skipped | 4281 passed, 14 skipped (+5 new tests) |
| api | 2709 passed | 2710 passed (+1 new test) |
| scientific | 2049 passed | 2049 passed |

`backend/tests/error_code_observer.py`'s mechanism, extended to record every
error body across all three gates:

* **(status, code) pairs: 101 before, 101 after — 0 lost, 0 gained.** The code
  is not new to the route; it already arrived from the main-line `a_units`.
  What changed is the *payload positions* that reach it.
* **Distinct normalised bodies: 0 lost, exactly 1 gained** (after collapsing
  per-run public refs, which otherwise appear as 8 losses and 9 gains of the
  same shapes). The single gain is the intended one:

  ```
  422 {"code": "arrhenius_a_units_molecularity_mismatch",
       "context": {"a_units": "cmN_mol_s", "expected": ["per_s"],
                   "field": "plog_entries[N].a_units", "molecularity": N}, ...}
  ```

  `code` is the declared code, not `plog_entries[2].a_units` and not
  `a_units` — the #159 fabrication, checked against a real response body.

### Mutation check

| mutation | result |
|---|---|
| M1 revert to plain `ValueError` | RED |
| M2 `field` dropped from `context` | RED |
| M3 `message_prefix` left at its `True` default | RED |
| M4 code changed to a different catalogued code | RED |
| M5 field prefix dropped from the message | RED |
| M6 original `context` dropped, only `field` kept | RED |
| M7 the defensive plain-`ValueError` clause removed | **GREEN, expected** |

M7 is declared in the code comment: every raise in the wrapped check is coded,
so that clause cannot be entered. Run as a mutation so the claim is measured
rather than asserted.
