### PR TITLE
Point the non-ASCII gate at the package that writes the warnings

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -167,8 +167,16 @@ jobs:
         # Narrower than ruff's RUF001-003, which this repo disables on
         # purpose because scientific notation is legitimate prose. This one
         # looks only at strings that leave the process -- raises, log calls,
-        # message=/detail=/reason= -- and covers app/ and scripts/ but not
-        # tests/, where non-ASCII data is the point. See the script's header.
+        # message=/detail=/reason= -- and covers app/, scripts/ and the wire
+        # package, but not tests/, where non-ASCII data is the point. See the
+        # script's header.
+        #
+        # No arguments on purpose: the target list lives in the script, so a
+        # local run and this one scan the same tree. The wire package sits
+        # outside `working-directory: backend`, and the script resolves it
+        # relative to its own location rather than the current directory. It
+        # refuses a target that expands to no files, so a moved package
+        # fails the gate instead of silently emptying it.
         run: conda run -n tckdb_env python scripts/check_runtime_ascii.py
 
       - name: Type check (mypy, scoped)

--- a/backend/scripts/check_runtime_ascii.py
+++ b/backend/scripts/check_runtime_ascii.py
@@ -13,6 +13,14 @@ WHY
     rebuilt by someone in a hurry.
 
 WHAT IS IN SCOPE, AND WHY IT IS DRAWN THIS NARROWLY
+    Three trees: ``backend/app``, ``backend/scripts`` and the wire package
+    ``schemas/python/tckdb-schemas/tckdb_schemas``. The wire package was
+    added late and should have been there from the first commit: it raises
+    the validation errors a client reads and builds the ``message=``
+    strings that are written to ``upload_warning.message``. It had nine
+    violations on the day it was first scanned, all of them at emission
+    sites, in the one package this check had never been pointed at.
+
     Only string literals that are structurally *at an emission site*:
     the argument of a ``raise``, the argument of a logging call, or a
     ``message=`` / ``detail=`` / ``reason=`` / ``msg=`` keyword. Those
@@ -79,12 +87,29 @@ from pathlib import Path
 
 BACKEND_ROOT = Path(__file__).resolve().parent.parent
 
-#: Checked by default.
+#: The repository root. The wire package is a sibling of ``backend``, so the
+#: default targets are expressed relative to ``BACKEND_ROOT`` and resolved
+#: here rather than against the current directory: CI runs this script with
+#: ``working-directory: backend`` and a developer runs it from wherever they
+#: happen to be, and the two must scan the same tree.
+REPO_ROOT = BACKEND_ROOT.parent
+
+#: Where the wire package's sources live, relative to ``BACKEND_ROOT``.
+WIRE_PACKAGE_TARGET = "../schemas/python/tckdb-schemas/tckdb_schemas"
+
+#: Checked by default, as paths relative to ``BACKEND_ROOT``.
 #:
 #: ``app`` because it is the deployed code. ``scripts`` because several of
 #: them write to a real database (``bulk_load_arc.py``,
 #: ``seed_scientific_demo_data.py``) and one of them says in its own comment
 #: that the cluster it connects to is ``SQL_ASCII``.
+#:
+#: ``tckdb_schemas`` because it was left out and the omission was not a
+#: judgement, it was an oversight: the wire package raises validation errors
+#: and builds the ``message=`` strings that become ``UploadWarning.message``
+#: rows. A database column and a client-facing string are exactly what this
+#: check was written for, and until now it was the one package that produced
+#: them and was never looked at. Nine violations were sitting there.
 #:
 #: ``tests`` is deliberately NOT checked. Test data is the one place where
 #: non-ASCII is the point: ``tests/schemas/test_artifact_in_schema.py``
@@ -92,8 +117,15 @@ BACKEND_ROOT = Path(__file__).resolve().parent.parent
 #: ``haséaccent`` precisely to prove the system handles them. Linting those
 #: would mean annotating the tests that prove the encoding works, in order
 #: to protect against an encoding problem. And nothing under ``tests``
-#: executes in a deployment.
-DEFAULT_TARGETS = ("app", "scripts")
+#: executes in a deployment. The same reasoning excludes the wire package's
+#: own ``tests/``, which is why the target is the package directory and not
+#: the distribution directory above it.
+DEFAULT_TARGETS = ("app", "scripts", WIRE_PACKAGE_TARGET)
+
+
+def default_target_paths() -> list[Path]:
+    """The default targets as absolute paths."""
+    return [(BACKEND_ROOT / name).resolve() for name in DEFAULT_TARGETS]
 
 ALLOW_MARKER = "# tckdb: allow-non-ascii"
 
@@ -135,10 +167,13 @@ class Finding:
     characters: str
 
     def render(self, root: Path) -> str:
-        try:
-            shown = self.path.relative_to(root)
-        except ValueError:
-            shown = self.path
+        shown: Path = self.path
+        for base in (root, REPO_ROOT):
+            try:
+                shown = self.path.relative_to(base)
+            except ValueError:
+                continue
+            break
         snippet = self.text if len(self.text) <= 80 else self.text[:77] + "..."
         return (
             f"{shown}:{self.line}: non-ASCII {self.characters!r} in a "
@@ -318,13 +353,16 @@ def check_file(path: Path) -> list[Finding]:
     return check_source(source, path)
 
 
+def walk(path: Path) -> list[Path]:
+    """The files *path* expands to: every ``*.py`` and ``*.sh`` beneath it."""
+    if path.is_dir():
+        return sorted({*path.rglob("*.py"), *path.rglob("*.sh")})
+    return [path]
+
+
 def check_path(path: Path) -> list[Finding]:
     findings: list[Finding] = []
-    if path.is_dir():
-        files = sorted({*path.rglob("*.py"), *path.rglob("*.sh")})
-    else:
-        files = [path]
-    for file in files:
+    for file in walk(path):
         findings.extend(check_file(file))
     return findings
 
@@ -334,20 +372,33 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "targets",
         nargs="*",
-        help="files or directories to check (default: app, scripts)",
+        help=(
+            "files or directories to check "
+            f"(default: {', '.join(DEFAULT_TARGETS)})"
+        ),
     )
     args = parser.parse_args(argv)
 
-    targets = [Path(t) for t in args.targets] or [
-        BACKEND_ROOT / name for name in DEFAULT_TARGETS
-    ]
+    targets = [Path(t) for t in args.targets] or default_target_paths()
 
     findings: list[Finding] = []
     for target in targets:
         if not target.exists():
             print(f"error: no such path: {target}", file=sys.stderr)
             return 2
-        findings.extend(check_path(target))
+        walked = walk(target)
+        if target.is_dir() and not walked:
+            # Guard the guard. A target that expands to nothing makes this
+            # check pass without reading a line, which is indistinguishable
+            # from a clean tree in the CI log. A mistyped or moved directory
+            # is the way a check quietly stops checking.
+            print(
+                f"error: {target} contains no *.py or *.sh to check",
+                file=sys.stderr,
+            )
+            return 2
+        for file in walked:
+            findings.extend(check_file(file))
 
     if not findings:
         return 0

--- a/backend/scripts/check_runtime_ascii.py
+++ b/backend/scripts/check_runtime_ascii.py
@@ -167,13 +167,7 @@ class Finding:
     characters: str
 
     def render(self, root: Path) -> str:
-        shown: Path = self.path
-        for base in (root, REPO_ROOT):
-            try:
-                shown = self.path.relative_to(base)
-            except ValueError:
-                continue
-            break
+        shown = _relative(self.path)
         snippet = self.text if len(self.text) <= 80 else self.text[:77] + "..."
         return (
             f"{shown}:{self.line}: non-ASCII {self.characters!r} in a "
@@ -353,6 +347,16 @@ def check_file(path: Path) -> list[Finding]:
     return check_source(source, path)
 
 
+def _relative(path: Path) -> Path:
+    """*path* against the nearest of the roots, for readable output."""
+    for base in (BACKEND_ROOT, REPO_ROOT):
+        try:
+            return path.relative_to(base)
+        except ValueError:
+            continue
+    return path
+
+
 def walk(path: Path) -> list[Path]:
     """The files *path* expands to: every ``*.py`` and ``*.sh`` beneath it."""
     if path.is_dir():
@@ -399,6 +403,11 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         for file in walked:
             findings.extend(check_file(file))
+        # Say what was read. A silent success cannot be told apart from a
+        # success over nothing, and "the gate is green" is worth exactly as
+        # much as the tree it looked at -- which is the defect this target
+        # list had for as long as it existed.
+        print(f"checked {len(walked)} file(s) under {_relative(target)}")
 
     if not findings:
         return 0

--- a/backend/tests/scripts/test_check_runtime_ascii.py
+++ b/backend/tests/scripts/test_check_runtime_ascii.py
@@ -289,7 +289,7 @@ def test_shell_scripts_are_actually_collected():
 
 
 def test_the_packaged_sources_are_clean():
-    """Runs the real check over app/ and scripts/, as CI does."""
+    """Runs the real check over every default target, as CI does."""
     assert checker.main([]) == 0
 
 
@@ -304,3 +304,176 @@ def test_tests_are_out_of_scope_by_construction():
     in a deployment.
     """
     assert "tests" not in checker.DEFAULT_TARGETS
+
+
+# ---------------------------------------------------------------------------
+# What it is pointed at
+#
+# The rule above is only worth what its target list covers, and for a long
+# time that list was two directories chosen when the script was written. The
+# wire package -- which raises the validation errors a client reads and builds
+# the ``message=`` strings written to ``upload_warning.message`` -- was never
+# on it, and had nine violations at emission sites the day it was first
+# scanned. Nothing asserted the coverage, so nothing noticed.
+#
+# Everything below fails if the target list shrinks, if the wire package stops
+# resolving, or if CI stops scanning what a local run scans.
+# ---------------------------------------------------------------------------
+
+#: The trees that must stay covered. Each entry is here because losing it
+#: would lose a real emission site, not because it happens to be listed
+#: today: ``app`` is the deployed code, ``scripts`` writes to real databases,
+#: and the wire package produces the persisted warning text.
+REQUIRED_TARGETS = frozenset({"app", "scripts", checker.WIRE_PACKAGE_TARGET})
+
+WIRE_PACKAGE = (checker.BACKEND_ROOT / checker.WIRE_PACKAGE_TARGET).resolve()
+
+
+def test_the_target_list_does_not_shrink():
+    """A deleted target is a silent loss of coverage.
+
+    This is the assertion that did not exist. Removing the wire package
+    from ``DEFAULT_TARGETS`` would leave every other test in this file
+    green while the check stopped reading the package that caused
+    2026-08-04's class of failure.
+    """
+    assert REQUIRED_TARGETS <= set(checker.DEFAULT_TARGETS)
+
+
+def test_every_default_target_resolves_to_real_files():
+    """Guard the guard: a target that expands to nothing passes vacuously.
+
+    ``main`` reports zero findings for a directory it cannot read and for
+    a directory that is empty, and the two are indistinguishable in a CI
+    log. Assert the expansion instead of the exit code.
+    """
+    for target in checker.default_target_paths():
+        assert target.exists(), target
+        walked = checker.walk(target)
+        assert walked, target
+        assert any(p.suffix == ".py" for p in walked), target
+
+
+def test_the_wire_package_target_reaches_the_modules_that_emit():
+    """Named modules, not a count.
+
+    A path that resolved one directory too high (the distribution root)
+    or one too low would still expand to files and still satisfy the test
+    above. These two modules are where the nine violations were.
+    """
+    walked = set(checker.walk(WIRE_PACKAGE))
+    assert WIRE_PACKAGE / "stationary_point.py" in walked
+    assert WIRE_PACKAGE / "fragments" / "calculation.py" in walked
+
+
+def test_the_wire_package_is_covered_by_the_defaults():
+    """The modules above are reached by ``main([])``, not only directly."""
+    covered: set[Path] = set()
+    for target in checker.default_target_paths():
+        covered.update(checker.walk(target))
+    assert WIRE_PACKAGE / "stationary_point.py" in covered
+
+
+def test_the_wire_packages_own_tests_stay_out_of_scope():
+    """Same reasoning as ``backend/tests``: test data is where non-ASCII lives.
+
+    The target is the package directory, so ``tckdb-schemas/tests`` sits
+    outside it. If the target ever moved up to the distribution root this
+    would fail, which is the point.
+    """
+    wire_tests = WIRE_PACKAGE.parent / "tests"
+    assert wire_tests.is_dir(), "expected the wire package to ship tests"
+    covered: set[Path] = set()
+    for target in checker.default_target_paths():
+        covered.update(checker.walk(target))
+    assert not any(wire_tests in p.parents for p in covered)
+
+
+def test_the_wire_package_is_clean():
+    assert checker.check_path(WIRE_PACKAGE) == []
+
+
+def test_a_reintroduced_em_dash_in_a_wire_message_is_caught():
+    """The live rule against the live file, not a hand-written sample.
+
+    Reads the real ``stationary_point.py``, puts an em dash back into a
+    ``message=`` literal that had one, and checks the modified source.
+    Proves the checker fires on this package's actual shape -- deeply
+    nested ``message=(...)`` f-string concatenations inside a
+    ``StationaryPointFinding(...)`` call -- rather than on the flat
+    one-liners the parametrized cases above use.
+    """
+    path = WIRE_PACKAGE / "stationary_point.py"
+    source = path.read_text(encoding="utf-8")
+    clean = "correct chemistry -- a transition "
+    assert clean in source, "the message this mutation targets has moved"
+    assert checker.check_source(source, path) == []
+
+    mutated = source.replace(clean, "correct chemistry — a transition ")
+    found = checker.check_source(mutated, path)
+    assert len(found) == 1
+    assert found[0].characters == "—"
+
+
+def test_the_defaults_do_not_depend_on_the_current_directory(tmp_path, monkeypatch):
+    """CI runs from ``backend/``; a developer runs from anywhere.
+
+    The wire package is outside ``backend``, so it is reached by a
+    ``..`` segment. Resolved against the current directory instead of the
+    script's own location, that would point somewhere else -- or nowhere
+    -- depending on who ran it.
+    """
+    from_here = checker.default_target_paths()
+    monkeypatch.chdir(tmp_path)
+    assert checker.default_target_paths() == from_here
+    monkeypatch.chdir(checker.REPO_ROOT)
+    assert checker.default_target_paths() == from_here
+    assert all(p.is_absolute() for p in from_here)
+
+
+def test_an_empty_target_is_an_error_not_a_pass(tmp_path, capsys):
+    """A moved or mistyped directory must fail loudly.
+
+    Exit 0 on a directory with nothing in it is how a check stops
+    checking without anyone finding out.
+    """
+    (tmp_path / "notes.txt").write_text("no sources here", encoding="utf-8")
+    assert checker.main([str(tmp_path)]) == 2
+    assert "no *.py or *.sh" in capsys.readouterr().err
+
+
+def test_a_missing_target_is_an_error_not_a_pass(tmp_path, capsys):
+    assert checker.main([str(tmp_path / "gone")]) == 2
+    assert "no such path" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# CI parity
+# ---------------------------------------------------------------------------
+
+WORKFLOW = checker.REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+STEP_NAME = "Lint (non-ASCII in runtime strings)"
+
+
+def _ascii_lint_step() -> dict:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for job in workflow["jobs"].values():
+        for step in job.get("steps", []):
+            if step.get("name") == STEP_NAME:
+                return step
+    raise AssertionError(f"no step named {STEP_NAME!r} in {WORKFLOW}")
+
+
+def test_ci_invokes_the_check_with_no_arguments():
+    """The target list has to live in one place.
+
+    If CI passed its own paths, a local run and a CI run would scan
+    different trees and the divergence would only show up as a green PR
+    followed by a red merge -- or, worse, the other way round.
+    """
+    step = _ascii_lint_step()
+    command = step["run"].strip()
+    assert command.endswith("scripts/check_runtime_ascii.py"), command
+    assert step["working-directory"] == "backend"

--- a/backend/tests/scripts/test_check_runtime_ascii.py
+++ b/backend/tests/scripts/test_check_runtime_ascii.py
@@ -447,6 +447,25 @@ def test_a_missing_target_is_an_error_not_a_pass(tmp_path, capsys):
     assert "no such path" in capsys.readouterr().err
 
 
+def test_a_green_run_says_what_it_read(capsys):
+    """The CI log has to show the coverage, not just the verdict.
+
+    "The gate is green" is worth exactly as much as the tree it looked
+    at, and for as long as this check existed the tree silently excluded
+    the package that produces the strings it protects. A success that
+    prints nothing cannot be told apart from a success over nothing.
+    """
+    assert checker.main([]) == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert len(lines) == len(checker.DEFAULT_TARGETS)
+    assert any(
+        line.startswith("checked ")
+        and checker.WIRE_PACKAGE_TARGET.removeprefix("../") in line
+        and " 0 file(s) " not in line
+        for line in lines
+    ), lines
+
+
 # ---------------------------------------------------------------------------
 # CI parity
 # ---------------------------------------------------------------------------

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
@@ -261,7 +261,7 @@ class FreqResultPayload(SchemaBase):
                     f"from one reading the evidence "
                     f"({W_FREQ_N_IMAG_DISAGREES_WITH_MODES}). Deposit the "
                     f"complete signed frequency list, or omit modes entirely "
-                    f"— absence is incompleteness, which is accepted, and only "
+                    f"-- absence is incompleteness, which is accepted, and only "
                     f"contradiction is refused.",
                     context={
                         "n_imag": self.n_imag,

--- a/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py
@@ -669,8 +669,8 @@ def _vdw_complex_findings(
                 location=location,
                 message=(
                     f"{location}: the imaginary mode is "
-                    f"{abs(imag_freq_cm1):.1f} cm⁻¹, at or above "
-                    f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm⁻¹. That is far "
+                    f"{abs(imag_freq_cm1):.1f} cm-1, at or above "
+                    f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm-1. That is far "
                     f"too stiff to be an intermolecular mode of a van der "
                     f"Waals complex, so it is unlikely to be Hessian grid "
                     f"noise and looks instead like a genuine reaction "
@@ -739,8 +739,8 @@ def evaluate_transition_state_frequency(
                 location=location,
                 message=(
                     f"{location}: a transition state has at least one "
-                    f"imaginary mode by definition — it is the reaction "
-                    f"coordinate — but the frequency analysis reports none "
+                    f"imaginary mode by definition -- it is the reaction "
+                    f"coordinate -- but the frequency analysis reports none "
                     f"({W_TS_NO_IMAGINARY_MODE}). Zero imaginary modes is a "
                     f"minimum: the geometry did not converge onto a barrier "
                     f"top. Re-run the saddle-point search, or deposit the "
@@ -771,9 +771,9 @@ def evaluate_transition_state_frequency(
                     f"imaginary modes and the payload does not say which one "
                     f"is the reaction coordinate "
                     f"({W_TS_REACTION_COORDINATE_NOT_DESIGNATED}). Extra "
-                    f"imaginary modes are accepted — a torsional maximum or a "
+                    f"imaginary modes are accepted -- a torsional maximum or a "
                     f"loose intermolecular mode is real chemistry, not a "
-                    f"defect — but exactly one mode must be designated and "
+                    f"defect -- but exactly one mode must be designated and "
                     f"removed from the partition function, which is the "
                     f"contract every transition-state-theory code enforces. "
                     f"Set freq_result.reaction_coordinate_mode_index, and give "
@@ -866,9 +866,9 @@ def evaluate_transition_state_frequency(
                     f"numerical noise "
                     f"({W_TS_EXTRA_IMAGINARY_MODE_ABOVE_TAU}). The structure "
                     f"is a genuine higher-order saddle. It is accepted "
-                    f"because that can be correct chemistry — a transition "
+                    f"because that can be correct chemistry -- a transition "
                     f"state may sit at a torsional maximum and still be the "
-                    f"right reactive bottleneck — and flagged because a "
+                    f"right reactive bottleneck -- and flagged because a "
                     f"consumer treating it as a plain first-order saddle "
                     f"would be wrong. {resolved_tau.reason} {_REMEDIATION}"
                 ),
@@ -946,12 +946,12 @@ def _soft_reaction_coordinate_findings(
             tau=tau,
             message=(
                 f"{location}: the transition state's reaction coordinate is "
-                f"{magnitude_cm1:.1f} cm⁻¹, below "
-                f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm⁻¹ "
+                f"{magnitude_cm1:.1f} cm-1, below "
+                f"{TS_IMAGINARY_FREQUENCY_MIN_CM1:.0f} cm-1 "
                 f"({W_TS_IMAG_FREQ_TOO_SMALL}). A reaction coordinate this "
                 f"soft is often an under-converged geometry or a coarse "
-                f"integration grid. It can also be real — flat and "
-                f"variational barriers genuinely produce one — which is why "
+                f"integration grid. It can also be real -- flat and "
+                f"variational barriers genuinely produce one -- which is why "
                 f"this is a quality expectation and not a refusal. For "
                 f"reference, the noise floor for this calculation's extra "
                 f"modes is {tau.reason}"


### PR DESCRIPTION
## The defect

`backend/scripts/check_runtime_ascii.py` exists because an em dash in an upload-warning
message rolled back a whole upload on 2026-08-04. It was pointed at `backend/app` and
`backend/scripts`. The wire package -- which raises the validation errors a client reads
and builds the `message=` strings written to `upload_warning.message` -- was never on the
list. It is the one package whose entire job is producing the strings this check protects,
and it had nine violations, all at emission sites.

Same class as #81 and #109/#124/#153: a working protection pointed at less than it should be.

## Re-measured, on `cf993460`

The list I was handed was stale in one place. `frequency_completeness.py:180` no longer
has an em dash -- #163 rewrote that message and made it ASCII, and
`tests/schemas/test_frequency_list_completeness.py:137` now asserts `message.isascii()`.
Nine violations, not ten:

```
fragments/calculation.py:262   '—'  raised message
stationary_point.py:672        'cm⁻¹' message=
stationary_point.py:673        'cm⁻¹' message=
stationary_point.py:741        '—'  message=
stationary_point.py:773        '—'  message=
stationary_point.py:867        '—'  message=
stationary_point.py:949        'cm⁻¹' message=
stationary_point.py:950        'cm⁻¹' message=
stationary_point.py:951        '—'  message=
```

After: zero. `--` for the em dashes, `cm-1` for the superscripts. No escape hatch --
nothing here is load-bearing typography, and `stationary_point.py:864` already wrote
`cm-1` four lines from one of the offenders.

## How CI reaches a sibling directory

CI runs the script with `working-directory: backend`, and the wire package is a sibling
of `backend/`. Two choices followed:

- The target goes in `DEFAULT_TARGETS`, not in the CI command line, so a local
  `python scripts/check_runtime_ascii.py` and the CI run scan the same tree. A test
  asserts CI passes no arguments.
- The defaults resolve against the script's own location, not the current directory:
  `(BACKEND_ROOT / "../schemas/python/tckdb-schemas/tckdb_schemas").resolve()`. Run from
  `backend/`, from the repo root, or from `/tmp`, the target set is identical.

The target is the **package** directory, not the distribution root, so
`tckdb-schemas/tests/` stays out of scope for the same reason `backend/tests/` does.

## Ruling out the vacuous pass

A path that resolves to nothing makes the gate exit 0 having read no lines, which reads
in a CI log exactly like a clean tree. Two things prevent it:

- `main()` now exits 2 on a directory target that expands to no `*.py` or `*.sh`.
- The gate now prints one line per target naming the tree and the file count, so the CI
  log is evidence of coverage and not only a verdict:

  ```
  checked 435 file(s) under app
  checked 63 file(s) under scripts
  checked 33 file(s) under schemas/python/tckdb-schemas/tckdb_schemas
  ```

- `test_every_default_target_resolves_to_real_files` asserts the expansion, and
  `test_the_wire_package_target_reaches_the_modules_that_emit` asserts it reaches
  `stationary_point.py` and `fragments/calculation.py` **by name** -- a target one
  directory too high still expands to files, so a count would not have caught it.

And the gate is demonstrably doing work rather than passing on an empty scan: run against
the pre-fix sources (`git show cf993460:...` into a scratch tree) it prints all nine and
exits 1.

Confirmed from CI's own log for this branch, not inferred -- `Lint (non-ASCII in runtime
strings)` in the Backend API gate
([job 94780725385](https://github.com/TCKDB/TCKDB/actions/runs/31804710689/job/94780725385)):

```
2026-08-14T13:27:52.2927577Z checked 435 file(s) under app
2026-08-14T13:27:52.2928060Z checked 63 file(s) under scripts
2026-08-14T13:27:52.2928619Z checked 33 file(s) under schemas/python/tckdb-schemas/tckdb_schemas
```

## Mutation check

Nine mutations, all red. The coverage test is the one this task exists to add, so it was
worth checking that it cannot pass by accident:

| mutation | red | first tests that caught it |
|---|---|---|
| M1 wire package dropped from `DEFAULT_TARGETS` | yes | `test_the_target_list_does_not_shrink` |
| M2 target aimed at the distribution root | yes | `..._reaches_the_modules_that_emit`, `..._own_tests_stay_out_of_scope` |
| M3 target aimed at a moved/renamed package | yes | `..._resolves_to_real_files` (+5) |
| M4 defaults resolved against the cwd | yes | `..._do_not_depend_on_the_current_directory` |
| M5 empty-target guard removed | yes | `test_an_empty_target_is_an_error_not_a_pass` |
| M6 one em dash put back in a wire `message=` | yes | `..._reintroduced_em_dash_in_a_wire_message_is_caught` |
| M7 CI passes its own target list | yes | `test_ci_invokes_the_check_with_no_arguments` |
| M8 `walk` stops recursing (`rglob` -> `glob`) | yes | `..._reaches_the_modules_that_emit` |
| M9 the coverage summary stops being printed | yes | `test_a_green_run_says_what_it_read` |

One honest gap: M2 does not turn `test_a_green_run_says_what_it_read` red, because that
test's expected substring is derived from `WIRE_PACKAGE_TARGET` and moves with the
mutation. Three other tests catch M2.

## Reported, not fixed

`clients/python/src/tckdb_client` has the same gap -- it is not scanned either, and it
emits client-facing strings. Eight violations. Another task owns that package, so this PR
does not touch it and does not add it to the target list:

`clients/python/adapters/chemkin/tckdb_chemkin/normalizer.py` has two more, same owner:

```
adapters/chemkin/tckdb_chemkin/normalizer.py:272  '§'   accumulated warning
adapters/chemkin/tckdb_chemkin/normalizer.py:279  '§—'  accumulated warning

src/tckdb_client/builders/calculation.py:547   '→'  raised message
src/tckdb_client/builders/sources.py:108       '…'  raised message
src/tckdb_client/builders/uploads.py:271       '—'  message=
src/tckdb_client/builders/uploads.py:495       '—'  message=
src/tckdb_client/builders/uploads.py:564       '…'  raised message
src/tckdb_client/builders/uploads.py:575       '→'  raised message
src/tckdb_client/builders/uploads.py:1456      '—'  message=
src/tckdb_client/builders/uploads.py:1478      '—'  message=
```

`integrations/mcp` is a third uncovered tree, but it scans clean today (31 files, zero
findings), so adding it would be a deliberate zero-violation change rather than a fix.
Left out of this PR's target list to keep the change to the tree that was actually
dirty.

## No wire version bump

No code value moves, no field changes, no payload that validated stops validating. A
message string is not the wire contract.

## Verification

Three gates green with `PYTHONPATH` pointed at this worktree's wire package (without it
the editable install resolves to the main checkout and none of these edits are exercised
-- gate-skill hazard 3): rest 4287 passed / 14 skipped, api 2709 passed, scientific 2049
passed. `ruff check app tests scripts` clean, `mypy` clean over 149 files, wire package's
own 38 tests pass. Alembic head unchanged at `b7e4d1a9c026`.
