### PR TITLE
Tell a code apart from a function of the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,35 @@ wrapper over a contract that is itself still moving.
 
 ### Changed
 
+- **Two refusals stopped naming the function they were raised in.** The
+  `detail` of the group-additivity missing-thermo guard and of the two keyset
+  argument guards used to begin `create_applied_group_additivity: ` and
+  `keyset_predicate: ` — the enclosing function in the position a client reads
+  as a code. #164 stopped either being *promoted* into the `code` field; this
+  reworks the messages themselves, so what a caller reads says what went wrong.
+  Both entries are gone from `app/api/code_catalogue.py`, because a message
+  with no token in the code position is not a code by any spelling.
+  **No `RejectionCode` member is removed and `tckdb-client` is unchanged at
+  0.38.0**: an `accidental_prefix` entry was never client-facing, so neither
+  string was ever generated into the enum — checked with
+  `generate_client_rejection_codes.py --check`, which reports the committed
+  file up to date. Neither code was ever emitted, either: the runtime observer
+  recorded 101 distinct `(status, code)` pairs across all three gates and
+  neither appears. Both guards are reachable only by a direct programmatic
+  call — `persist_thermo_upload` passes a row it has just flushed, so
+  `session.get` cannot return `None` from any HTTP path — and the catalogue
+  said otherwise, which is corrected.
+- **The origin guard can now tell a code from a function of the same name.**
+  `test_every_origin_still_defines_its_code` matched the code anywhere a
+  double quote preceded it, so `"keyset_predicate"` in `__all__` satisfied the
+  entry for `keyset_predicate` — the guard was blindest exactly where that
+  class of defect lives, and #164 reworded that message with the guard staying
+  green. Matching is now by syntactic position, shared with the catalogue's
+  closure scan so the two cannot drift. That scan also reads `*_code=`
+  arguments at any call, not only at a `raise`, which brings the six
+  `*_handle_conflict` codes into static view (five of them are emitted by no
+  test) and revealed one uncatalogued code, `database_error` — a dead
+  `fallback_code` in the operational-error handler, now listed and annotated.
 - `backend/pyproject.toml` now declares the repository's actual MIT license
   instead of `TBD — see repository root`.
 

--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -74,8 +74,17 @@ this file by four different routes, and no one of them is enough:
   code its blocking finding carries, and the integrity handler looks its
   code up by PostgreSQL constraint name. That is nineteen codes the scan
   is blind to, and the ``*_handle_conflict`` family was found only by the
-  observer below. For those the guard checks the *defining* module
-  instead, which is where the literal actually lives. The nineteenth,
+  observer below. Six of the nineteen have since been brought back into
+  static view: #177 widened the scan to read a ``*_code=`` argument at
+  any call, not only at a ``raise``, so the codes handed to
+  ``reconcile_id_ref`` are seen where they are written. That matters
+  because five of those six are emitted by no test — the observer's
+  record across the three gates holds 101 distinct ``(status, code)``
+  pairs and only ``level_of_theory_handle_conflict`` among them — and a
+  runtime observer can only see what the suite provokes. For the rest the
+  guard
+  checks the *defining* module instead, which is where the literal
+  actually lives. The nineteenth,
   ``freq_list_exceeds_geometry_degrees_of_freedom``, shows why that is the
   right key rather than a convenience: its literal lives in
   ``tckdb_schemas.frequency_completeness`` while the ``raise`` that
@@ -161,6 +170,16 @@ class Surface(str, Enum):
     #: rather than hidden, and never exported to a client — a fabricated
     #: code that looks real is worse than an honestly generic one, which
     #: is the finding #159 was opened for.
+    #:
+    #: **No entry uses this today.** The two that did —
+    #: ``create_applied_group_additivity`` and ``keyset_predicate`` —
+    #: were reworded in #178 so that their refusals say what went wrong
+    #: instead of naming the function it went wrong in, and a message
+    #: with no token in the code position is not an accidental prefix at
+    #: all. Cataloguing one was always the second-best fix: it stopped
+    #: the token being *promoted* (#164) while leaving a depositor to
+    #: read a function name. The value stays because the classification
+    #: is what makes recording the next one cheaper than hiding it.
     accidental_prefix = "accidental_prefix"
 
 
@@ -270,14 +289,6 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/common.py"),
     ApiCode("composed_search_pagination_stalled", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py"),
-    ApiCode("create_applied_group_additivity", 422, Surface.accidental_prefix,
-            "backend/app/services/group_additivity_resolution.py",
-            note=(
-                "The function name, not a code. The refusal is written in "
-                "the house style, with the enclosing function as the "
-                "context prefix, so it lands in the code position and the "
-                "envelope reports it. Reachable from POST /uploads/thermo."
-            )),
     ApiCode("curation_policy_version_conflict", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
     ApiCode("curator_task_not_found", 404, Surface.coded_exception,
@@ -288,6 +299,19 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/keyset.py"),
     ApiCode("data_integrity_error", 500, Surface.generic_fallback,
             "backend/app/api/errors.py"),
+    ApiCode("database_error", 503, Surface.generic_fallback,
+            "backend/app/api/errors.py",
+            note=(
+                "The operational-error handler's fallback_code, and it is "
+                "dead: that handler always passes an explicit code "
+                "(database_unavailable, or query_timeout on SQLSTATE "
+                "57014), and error_envelope reads the fallback only when "
+                "code is falsy. Listed because the argument is written "
+                "and a future edit that stops setting code would emit it "
+                "-- an enumeration that omits a fallback nobody has "
+                "reached yet is one that goes stale silently. Found by "
+                "widening the closure scan to *_code keywords."
+            )),
     ApiCode("database_unavailable", 503, Surface.response_literal,
             "backend/app/api/errors.py"),
     ApiCode("doi_already_recorded", 422, Surface.message_prefix,
@@ -345,14 +369,6 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/common.py"),
     ApiCode("irc_result_not_found", 404, Surface.coded_exception,
             "backend/app/services/scientific_read/calculation_paths.py"),
-    ApiCode("keyset_predicate", 422, Surface.accidental_prefix,
-            "backend/app/services/scientific_read/keyset.py",
-            note=(
-                "The function name, not a code, in the code position -- the "
-                "same shape as create_applied_group_additivity. Guards an "
-                "internal argument invariant, so it fires only on a backend "
-                "bug."
-            )),
     ApiCode("level_of_theory_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py"),
     ApiCode("lowest_energy_unavailable", 422, Surface.coded_exception,

--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -64,8 +64,8 @@ whether the token **is** one, because a code and a function name are the
 same shape and both get written first. The house style is
 ``raise ValueError(f"{context}: <prose>")``, and when ``context`` is the
 enclosing function rather than a field path — ``create_applied_group_additivity``,
-``keyset_predicate`` — the position test promotes a function name and the
-envelope publishes it as though a client could branch on it.
+``keyset_predicate`` were the two — the position test promotes a function
+name and the envelope publishes it as though a client could branch on it.
 
 So the token is now also checked against :mod:`app.api.code_catalogue`,
 which enumerates every code the API can emit and records, per code, *by
@@ -77,6 +77,14 @@ that lands in the code position is catalogued as
 :data:`~app.api.code_catalogue.Surface.accidental_prefix` — the catalogue's
 own word for "not a code" — and is therefore not promoted. The honest
 record of a defect becomes the thing that stops it reaching a client.
+
+That record was always the second-best fix, and #178 applied the first:
+both messages now say what went wrong rather than naming the function they
+went wrong in, so neither token is in the code position and neither is
+catalogued under any surface. The gate below is unchanged and is what
+covers the next one written the same way — an allow-list of
+``message_prefix`` codes refuses an unknown token whether or not anyone
+thought to record it.
 
 Why consulting a list is safe here, having been refused before
 --------------------------------------------------------------
@@ -120,12 +128,14 @@ the replacement.
 The residual exposure is therefore the one shape neither scan reads: a
 message bound to a local before being raised (``message = "code: …"; raise
 ValueError(message)``). No such site exists — a census of every string
-literal in both trees beginning with a ``token: `` prefix found 73 tokens,
-of which 66 are catalogued as ``message_prefix``, 5 are logger format
-strings that reach no response body (``geometry_validation``, ``manifest``,
-``readyz``, ``startup``, ``status``), and 2 are the accidental prefixes
-above. So the set of error-reachable prefixes the catalogue does not cover
-is presently empty — measured, and re-measurable, rather than asserted.
+literal in both trees beginning with a ``token: `` prefix found 71 tokens
+(re-measured after #178), of which 66 are catalogued as ``message_prefix``
+and 5 are logger format strings that reach no response body
+(``geometry_validation``, ``manifest``, ``readyz``, ``startup``,
+``status``). The two accidental prefixes that made the count 73 are gone:
+they were reworded, not reclassified. So the set of error-reachable
+prefixes the catalogue does not cover is presently empty — measured, and
+re-measurable, rather than asserted.
 """
 
 from __future__ import annotations

--- a/backend/app/services/group_additivity_resolution.py
+++ b/backend/app/services/group_additivity_resolution.py
@@ -126,8 +126,8 @@ def create_applied_group_additivity(
     thermo = session.get(Thermo, thermo_id)
     if thermo is None:
         raise ValueError(
-            "create_applied_group_additivity: thermo_id does not reference an "
-            "existing thermo record."
+            "The thermo record this group-additivity breakdown explains does "
+            "not exist."
         )
     if thermo.scientific_origin != ScientificOriginKind.estimated:
         raise ValueError(

--- a/backend/app/services/group_additivity_resolution.py
+++ b/backend/app/services/group_additivity_resolution.py
@@ -120,8 +120,9 @@ def create_applied_group_additivity(
     :raises ValueError: if ``thermo_id`` does not reference a thermo record
         whose ``scientific_origin`` is ``estimated``. The upload schema
         already enforces this, but the guard also protects future
-        programmatic (non-upload) callers. The message names the field, not
-        the row id (no DB id leakage).
+        programmatic (non-upload) callers. Neither message carries a row id
+        (no DB id leakage), and neither opens with this function's name --
+        a refusal says what went wrong, not where.
     """
     thermo = session.get(Thermo, thermo_id)
     if thermo is None:

--- a/backend/app/services/scientific_read/keyset.py
+++ b/backend/app/services/scientific_read/keyset.py
@@ -211,11 +211,13 @@ def keyset_predicate(
     """
     if len(keys) != len(last_values):
         raise ValueError(
-            "keyset_predicate: keys and last_values must be the same length; "
-            f"got {len(keys)} keys and {len(last_values)} values."
+            "The sort keys and the previous page's final row must be the "
+            f"same length; got {len(keys)} keys and {len(last_values)} values."
         )
     if not keys:
-        raise ValueError("keyset_predicate: at least one sort key is required.")
+        raise ValueError(
+            "Keyset pagination needs at least one sort key to page from."
+        )
 
     branches = []
     for index, (column, direction) in enumerate(keys):

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -228,10 +228,10 @@ def _code_positions(
             # ``code=`` at a raise was already visible. ``conflict_code=``
             # was not, because ``reconcile_id_ref`` is *called*, not
             # raised -- so the six ``*_handle_conflict`` codes were
-            # invisible to every static check and were found by the
-            # runtime observer alone. Only one of the six is emitted by
-            # the suite, so being seen here is the only coverage the
-            # other five will ever get.
+            # invisible to this scan and were found by the runtime
+            # observer alone. Only one of the six is emitted anywhere in
+            # the three gates, so the observer cannot be what covers the
+            # other five.
             #
             # A *qualified* ``*_code=`` only, away from a raise. Bare
             # ``code=`` is also how ``UploadWarning``, the dry run's
@@ -368,7 +368,8 @@ def test_every_raise_site_code_is_catalogued() -> None:
     """
     scanned = _scan_code_sites()
     assert len(scanned) > 80, (
-        f"the scan found only {len(scanned)} codes at raise sites, which is "
+        f"the scan found only {len(scanned)} codes at raise sites and code "
+        "arguments, which is "
         "far fewer than this backend has. The scan is broken, and a broken "
         "scan passes this test by finding nothing."
     )
@@ -390,7 +391,7 @@ def test_the_origin_detector_can_say_no() -> None:
     exercised directly, on the spellings it must accept and the
     near-misses it must reject.
 
-    The fourth rejection is the one this test was reopened for. The
+    The ``__all__`` rejection is the one this test was reopened for. The
     regex this detector replaced answered *yes* for a module that merely
     exports a function of that name, so ``keyset_predicate`` was
     "defined" by ``__all__`` -- and #164 reworded its refusal with the

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -53,6 +53,21 @@ _CODE_POSITION = re.compile(r"^([a-z][a-z0-9_]*_[a-z0-9_]+): ")
 _BARE_CODE = re.compile(r"^[a-z][a-z0-9_]*$")
 _CODED_EXCEPTIONS = {"CodedValueError", "CodedValidationError"}
 
+#: The positions :func:`_code_positions` distinguishes. A *position* is
+#: where a literal sits in the syntax, not what it looks like -- which is
+#: the whole point: ``"keyset_predicate"`` looks identical in ``__all__``
+#: and in a ``raise``, and only one of them writes a code.
+_AT_A_REFUSAL = "at_a_refusal"      #: leading ``"code: "`` among a raise's arguments
+_CODED_FIRST_ARG = "coded_first_arg"  #: first argument of a ``Coded*Error`` raise
+_CODE_KEYWORD = "code_keyword"      #: a ``code=`` / ``*_code=`` argument
+_CODE_VALUE = "code_value"          #: a bare code used as a value
+_MESSAGE_TEXT = "message_text"      #: a ``"code: "`` message written anywhere
+
+#: The positions that mean *this module refuses with this code*. The
+#: closure scan uses only these, because a module that stores a code in a
+#: mapping is not thereby a raise site.
+_WRITTEN_AS_A_REFUSAL = frozenset({_AT_A_REFUSAL, _CODED_FIRST_ARG, _CODE_KEYWORD})
+
 
 def _module_constants(trees: list[ast.Module]) -> dict[str, str]:
     """``NAME = "literal"`` across the scanned tree.
@@ -97,8 +112,178 @@ def _leading_literal(node: ast.AST, constants: dict[str, str]) -> str | None:
     return None
 
 
-def _scan_raise_sites() -> dict[str, str]:
-    """Every code written as a literal where a refusal is raised.
+def _whole_literal(node: ast.AST, constants: dict[str, str]) -> str | None:
+    """The *entire* string an expression is, or ``None``.
+
+    A bare code is a whole string. ``_leading_literal`` would answer
+    ``"http_"`` for ``f"http_{exc.status_code}"`` -- a prefix of a token,
+    not a token -- and reading that as a code invented one.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    return None
+
+
+def _is_code_name(name: str) -> bool:
+    """Does *name* name a code? ``code``, ``conflict_code``, ``fallback_code``."""
+    lowered = name.lower()
+    return lowered == "code" or lowered.endswith("_code")
+
+
+def _held_strings(node: ast.AST):
+    """Every string a *value* expression holds, through the containers used.
+
+    ``{"23505": ("unique_conflict", "...")}`` and
+    ``"idempotency_in_progress" if exc.in_progress else "idempotency_conflict"``
+    are both a code written as a value; the literal is simply nested.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        yield node.value
+    elif isinstance(node, (ast.Tuple, ast.List)):
+        for element in node.elts:
+            yield from _held_strings(element)
+    elif isinstance(node, ast.Dict):
+        for value in node.values:
+            yield from _held_strings(value)
+    elif isinstance(node, ast.IfExp):
+        yield from _held_strings(node.body)
+        yield from _held_strings(node.orelse)
+
+
+def _documentation_strings(tree: ast.Module) -> set[int]:
+    """Node ids of every string that is a *statement* -- a docstring.
+
+    Prose is where a code gets *mentioned*, and mentioning is what this
+    module must not accept. A string that is its own statement does
+    nothing but document, so it is excluded before anything else looks at
+    it. This is why a docstring quoting ``"missing_filter: ..."`` cannot
+    stand in for the refusal that writes it.
+    """
+    return {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+
+
+def _code_positions(
+    tree: ast.Module, constants: dict[str, str]
+) -> dict[str, set[str]]:
+    """Every code written as a code in one module, and *how* it is written.
+
+    One walker, two callers -- :func:`_scan_code_sites` filters it to the
+    positions that raise and :func:`_defines_code` accepts all of them --
+    because two matchers drift apart, and the drift is invisible: both
+    stay green.
+
+    The distinction it exists to make is between a code and a *token that
+    happens to look like one*. ``keyset_predicate`` is written in
+    ``keyset.py`` twice over: once as the name of the function in
+    ``__all__``, and once (until #178) as the leading token of a refusal.
+    The regex this replaced could not tell those apart, because both are
+    a double quote followed by the token. So it accepted the export --
+    which meant rewording the refusal, the thing the guard exists to
+    catch, left it green. The guard was blindest exactly where the defect
+    was, and #164 reworded a message under it without noticing.
+
+    Positions are therefore about *syntax*, not spelling. A bare code
+    counts where it is used as a value -- passed to a call, stored in a
+    mapping, assigned to ``code`` or to an upper-case module constant --
+    and nowhere else. A name list, an import and a docstring all mention
+    the token without writing a code, and none of them is a value.
+
+    :returns: code -> the set of positions it was written in.
+    """
+    found: dict[str, set[str]] = {}
+    documentation = _documentation_strings(tree)
+
+    def record(code: str, position: str) -> None:
+        found.setdefault(code, set()).add(position)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+            call = node.exc
+            name = getattr(call.func, "id", None) or getattr(call.func, "attr", None)
+            if name in _CODED_EXCEPTIONS and call.args:
+                text = _whole_literal(call.args[0], constants)
+                if text and _BARE_CODE.fullmatch(text):
+                    record(text, _CODED_FIRST_ARG)
+            for keyword in call.keywords:
+                if keyword.arg == "code":
+                    text = _whole_literal(keyword.value, constants)
+                    if text and _BARE_CODE.fullmatch(text):
+                        record(text, _CODE_KEYWORD)
+            for argument in [*call.args, *(k.value for k in call.keywords)]:
+                text = _leading_literal(argument, constants)
+                if text:
+                    match = _CODE_POSITION.match(text)
+                    if match:
+                        record(match.group(1), _AT_A_REFUSAL)
+
+        if isinstance(node, ast.Call):
+            # ``code=`` at a raise was already visible. ``conflict_code=``
+            # was not, because ``reconcile_id_ref`` is *called*, not
+            # raised -- so the six ``*_handle_conflict`` codes were
+            # invisible to every static check and were found by the
+            # runtime observer alone. Only one of the six is emitted by
+            # the suite, so being seen here is the only coverage the
+            # other five will ever get.
+            #
+            # A *qualified* ``*_code=`` only, away from a raise. Bare
+            # ``code=`` is also how ``UploadWarning``, the dry run's
+            # messages and the rubric's findings are built, and those
+            # arrive with an *accepted* deposit -- 33 of them, none of
+            # which belongs in a catalogue of what refused a request. A
+            # name like ``conflict_code`` or ``fallback_code`` says which
+            # contract the string is for; a bare ``code`` does not.
+            for keyword in node.keywords:
+                if keyword.arg and keyword.arg != "code" and _is_code_name(keyword.arg):
+                    text = _whole_literal(keyword.value, constants)
+                    if text and _BARE_CODE.fullmatch(text):
+                        record(text, _CODE_KEYWORD)
+            for argument in node.args:
+                for text in _held_strings(argument):
+                    if _BARE_CODE.fullmatch(text):
+                        record(text, _CODE_VALUE)
+
+        if isinstance(node, ast.Dict):
+            for value in node.values:
+                for text in _held_strings(value):
+                    if _BARE_CODE.fullmatch(text):
+                        record(text, _CODE_VALUE)
+
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and (
+                target.id.isupper() or _is_code_name(target.id)
+            ):
+                for text in _held_strings(node.value):
+                    if _BARE_CODE.fullmatch(text):
+                        record(text, _CODE_VALUE)
+
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and id(node) not in documentation
+        ):
+            match = _CODE_POSITION.match(node.value)
+            if match:
+                record(match.group(1), _MESSAGE_TEXT)
+
+    for value in constants.values():
+        match = _CODE_POSITION.match(value)
+        if match:
+            record(match.group(1), _MESSAGE_TEXT)
+
+    return found
+
+
+def _scan_code_sites() -> dict[str, str]:
+    """Every code written as a literal where a refusal is raised or named.
 
     :returns: code -> ``path`` of the first site that writes it.
     """
@@ -114,42 +299,30 @@ def _scan_raise_sites() -> dict[str, str]:
 
     for path, tree in sources:
         rel = str(path.relative_to(REPO_ROOT))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
-                continue
-            call = node.exc
-            name = getattr(call.func, "id", None) or getattr(call.func, "attr", None)
-            if name in _CODED_EXCEPTIONS and call.args:
-                text = _leading_literal(call.args[0], constants)
-                if text and _BARE_CODE.fullmatch(text):
-                    found.setdefault(text, rel)
-            for keyword in call.keywords:
-                if keyword.arg == "code":
-                    text = _leading_literal(keyword.value, constants)
-                    if text and _BARE_CODE.fullmatch(text):
-                        found.setdefault(text, rel)
-            for argument in [*call.args, *(k.value for k in call.keywords)]:
-                text = _leading_literal(argument, constants)
-                if not text:
-                    continue
-                match = _CODE_POSITION.match(text)
-                if match:
-                    found.setdefault(match.group(1), rel)
+        for code, positions in _code_positions(tree, constants).items():
+            if positions & _WRITTEN_AS_A_REFUSAL:
+                found.setdefault(code, rel)
     return found
 
 
 def _defines_code(source: str, code: str) -> bool:
     """Is *code* written as a code in *source*?
 
-    Two spellings, because the backend has two conventions and the guard
-    must not quietly accept a substring of a longer identifier. A declared
-    code is a whole string literal, ``code="handle_not_found"``. A
-    message-prefix code opens one, ``"missing_filter: at least one of "``.
-    Requiring the opening quote is what stops ``invalid_handle`` from
-    being satisfied by a module that only mentions
-    ``invalid_handle_prefix``.
+    Delegates to :func:`_code_positions`, so "written as a code" means
+    the same thing here as it does to the closure scan. Any position
+    counts, because an origin is the module that *holds the literal* --
+    ``app/api/errors.py`` writes several of its codes into a response
+    body rather than raising them, and the ownership guard names its
+    codes as module constants for callers to pass in.
+
+    Source that does not parse defines nothing: a matcher that cannot
+    read the module must not report success for it.
     """
-    return bool(re.search(rf'"{re.escape(code)}(?:"|:)', source))
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    return bool(_code_positions(tree, _module_constants([tree])).get(code))
 
 
 def test_a_code_is_listed_once_per_status_it_arrives_at() -> None:
@@ -179,8 +352,21 @@ def test_every_raise_site_code_is_catalogued() -> None:
     This is the closure guard, and it is the reason the catalogue can
     claim completeness for the literal-written majority rather than
     hoping for it.
+
+    It reads ``*_code=`` arguments at every call and not only at a
+    ``raise``, which is what makes the six ``*_handle_conflict`` codes
+    visible: ``reconcile_id_ref`` is *called* with ``conflict_code=`` and
+    raises inside, so a scan of raise sites saw nothing.
+
+    Only one of the six -- ``level_of_theory_handle_conflict`` -- is
+    emitted anywhere in the three gates (measured against the runtime
+    observer's record of 101 distinct ``(status, code)`` pairs), so the
+    other five have no runtime coverage at all. ``test_error_contract_
+    catalogue_gate.py`` reaches them by a second static route, following
+    the parameter rather than the keyword; this makes the catalogue's own
+    closure guard see them directly, which is where a reader looks first.
     """
-    scanned = _scan_raise_sites()
+    scanned = _scan_code_sites()
     assert len(scanned) > 80, (
         f"the scan found only {len(scanned)} codes at raise sites, which is "
         "far fewer than this backend has. The scan is broken, and a broken "
@@ -201,13 +387,30 @@ def test_the_origin_detector_can_say_no() -> None:
     True`` leaves ``test_every_origin_still_defines_its_code`` green, and
     its ``checked > 50`` floor does not help -- that floor counts entries
     whose *path* resolved, which is a different thing. So the detector is
-    exercised directly, on the two spellings it must accept and the two
+    exercised directly, on the spellings it must accept and the
     near-misses it must reject.
+
+    The fourth rejection is the one this test was reopened for. The
+    regex this detector replaced answered *yes* for a module that merely
+    exports a function of that name, so ``keyset_predicate`` was
+    "defined" by ``__all__`` -- and #164 reworded its refusal with the
+    guard staying green. A code and an identifier are the same shape;
+    only position tells them apart.
     """
     assert _defines_code('raise ValueError("missing_filter: at least one")', "missing_filter")
-    assert _defines_code('not_found(code="handle_not_found")', "handle_not_found")
-    assert not _defines_code("a sentence mentioning missing_filter", "missing_filter")
+    assert _defines_code('raise NotFoundError(code="handle_not_found")', "handle_not_found")
+    assert _defines_code('reconcile(conflict_code="species_handle_conflict")', "species_handle_conflict")
+    assert _defines_code('JSONResponse(content={"code": "query_timeout"})', "query_timeout")
+    assert _defines_code('W_OWNER_MISMATCH = "thermo_source_calculation_owner_mismatch"',
+                         "thermo_source_calculation_owner_mismatch")
+    assert not _defines_code('"""a docstring mentioning missing_filter: prose."""',
+                             "missing_filter")
     assert not _defines_code('"invalid_handle_prefix"', "invalid_handle")
+    assert not _defines_code(
+        'def keyset_predicate(keys, values): ...\n__all__ = ["keyset_predicate"]',
+        "keyset_predicate",
+    )
+    assert not _defines_code("this is not python(", "some_code")
 
 
 def test_every_origin_still_defines_its_code() -> None:
@@ -301,30 +504,43 @@ def test_client_facing_excludes_what_a_client_cannot_use() -> None:
     in the code position would publish a fabricated code as though it were
     real, which is worse than an honestly generic one -- the finding #159
     was opened for.
+
+    No entry carries ``accidental_prefix`` since #178 reworded the last
+    two messages, so that half of the rule is now held by the count below
+    and by the two names pinned out of the catalogue: an exclusion loop
+    over an empty set is the failure this file exists to avoid, and a
+    surface with no members would have made it one silently.
     """
     exported = {entry.code for entry in client_facing()}
     assert exported, "nothing is exported -- the client enum would be empty"
 
+    excluded = 0
     for entry in CATALOGUE:
         if entry.surface in {Surface.generic_fallback, Surface.accidental_prefix}:
             assert entry.code not in exported, (
                 f"{entry.code} has surface {entry.surface.value} and must not "
                 "reach a client as an importable constant"
             )
+            excluded += 1
         if entry.status >= 500:
             assert entry.code not in exported, (
                 f"{entry.code} is reported at {entry.status}; a 5xx refuses "
                 "nothing the caller did"
             )
+            excluded += 1
 
-    assert any(
-        entry.surface is Surface.accidental_prefix for entry in CATALOGUE
-    ), (
-        "no accidental prefix is catalogued. Two are known to exist "
-        "(create_applied_group_additivity, keyset_predicate); if they have "
-        "been fixed, delete this assertion deliberately rather than letting "
-        "the exclusion guard above run over an empty set."
+    assert excluded > 5, (
+        f"only {excluded} entries were excluded, so the loop above proved "
+        "almost nothing about the exclusion rule"
     )
+
+    for gone in ("create_applied_group_additivity", "keyset_predicate"):
+        assert gone not in {entry.code for entry in CATALOGUE}, (
+            f"{gone} is catalogued again. It is a function name, not a code: "
+            "#178 reworded both refusals so neither token reaches the code "
+            "position, and an entry for one means a message has regressed to "
+            "the house style with the enclosing function as its context."
+        )
 
 
 def test_the_status_fallback_family_is_not_exported() -> None:

--- a/backend/tests/api/test_error_contract_catalogue_gate.py
+++ b/backend/tests/api/test_error_contract_catalogue_gate.py
@@ -17,10 +17,19 @@ branch on them.
 So promotion now also consults :mod:`app.api.code_catalogue`, which records
 per code *by which mechanism* it reaches the body. A leading token is
 promoted only where the catalogue lists that code as
-:data:`~app.api.code_catalogue.Surface.message_prefix`. The two above are
+:data:`~app.api.code_catalogue.Surface.message_prefix`. The two above were
 catalogued as :data:`~app.api.code_catalogue.Surface.accidental_prefix` --
 the catalogue's own word for "not a code" -- so the honest record of the
-defect is what stops it reaching a client.
+defect is what stopped it reaching a client.
+
+#178 then fixed the messages themselves. Both now say what went wrong
+instead of naming the function it went wrong in, so neither token occupies
+the code position any more and neither is catalogued at all: a message with
+no leading token is not an accidental prefix, it is just a message. The two
+raises above are kept in this docstring as the shape to recognise, and the
+tests below are still provoked from the real functions -- because the gate
+is what stops the *next* one, and the next one will be written the same
+way.
 
 What this file exists to prevent
 --------------------------------
@@ -67,10 +76,29 @@ SCANNED_ROOTS = (
 )
 SKIPPED = ("/tests/", "/importers/")
 _BARE_CODE = re.compile(r"^[a-z][a-z0-9_]*_[a-z0-9_]+$")
+_CODE_POSITION = re.compile(r"^[a-z][a-z0-9_]*_[a-z0-9_]+: ")
 
 
 def _promoted(message: str) -> str:
     return validation_detail_code(message, fallback="validation_error")
+
+
+def _assert_no_token_in_the_code_position(message: str) -> None:
+    """The message must not open with ``some_token: ``.
+
+    Asserting only that a message *falls back* would be satisfied by the
+    gate alone: re-adding ``keyset_predicate: `` in front of the prose
+    would still degrade to ``validation_error``, because the token is
+    uncatalogued, and the test that was meant to hold the wording would
+    stay green. #177 is the same lesson one layer down -- a guard that
+    passes for a second reason stops guarding the first.
+    """
+    assert not _CODE_POSITION.match(message), (
+        f"the refusal opens with a token in the code position: {message!r}. "
+        "A message says what went wrong; it does not name the function it "
+        "went wrong in, and a leading token is read as a code by anyone "
+        "who has seen the read API's convention."
+    )
 
 
 def _sources() -> list[tuple[str, ast.Module]]:
@@ -170,15 +198,37 @@ class TestTheGateIsTheCatalogue:
         """
         assert len(MESSAGE_PREFIX_CODES) > 50, sorted(MESSAGE_PREFIX_CODES)
 
-    def test_it_excludes_what_the_catalogue_calls_not_a_code(self):
-        accidental = {
+    def test_it_excludes_every_code_that_arrives_some_other_way(self):
+        """Promotion is for the message-prefix surface and no other.
+
+        Written over *every* other surface rather than over
+        ``accidental_prefix`` alone, which is what it used to say. #178
+        reworded the two accidental prefixes out of existence, so that
+        set is now empty and the assertion it satisfied would have gone
+        on passing while checking nothing -- the failure shape this file
+        is otherwise careful about. The surfaces below hold 70-odd
+        entries between them, and the count says so.
+        """
+        other = {
             entry.code
             for entry in CATALOGUE
-            if entry.surface is Surface.accidental_prefix
+            if entry.surface is not Surface.message_prefix
         }
-        assert not (accidental & MESSAGE_PREFIX_CODES), sorted(
-            accidental & MESSAGE_PREFIX_CODES
-        )
+        assert len(other) > 50, sorted(other)
+        assert not (other & MESSAGE_PREFIX_CODES), sorted(other & MESSAGE_PREFIX_CODES)
+
+    def test_a_function_name_is_in_no_surface_at_all(self):
+        """The two #178 reworded are not catalogued under any surface.
+
+        Not ``accidental_prefix`` either: a message that no longer leads
+        with the token has no token in the code position, so there is
+        nothing to classify. An entry reappearing means a refusal has
+        gone back to naming the function it was raised in.
+        """
+        catalogued = {entry.code for entry in CATALOGUE}
+        for name in ("create_applied_group_additivity", "keyset_predicate"):
+            assert name not in catalogued
+            assert name not in MESSAGE_PREFIX_CODES
 
 
 class TestNoCataloguedCodeIsLost:
@@ -238,17 +288,24 @@ class TestAFunctionNameIsNotACode:
         the function that had the bug.
 
         Provoked from the real function so that rewording its message
-        cannot make this test pass for the wrong reason.
+        cannot make this test pass for the wrong reason. Two things have
+        to be true for it now: the message no longer leads with the
+        function's name (#178), *and* a leading token would not be
+        promoted even if it did (#164). Either alone would leave the
+        other free to regress.
         """
         with pytest.raises(ValueError) as raised:
             keyset_predicate([], [])
         message = str(raised.value)
         assert _promoted(message) == "validation_error"
+        _assert_no_token_in_the_code_position(message)
 
     def test_the_length_guard_is_the_same_shape(self):
         with pytest.raises(ValueError) as raised:
             keyset_predicate([(object(), "asc")], [1, 2])
-        assert _promoted(str(raised.value)) == "validation_error"
+        message = str(raised.value)
+        assert _promoted(message) == "validation_error"
+        _assert_no_token_in_the_code_position(message)
 
     def test_an_uncatalogued_token_in_the_code_position_is_not_promoted(self):
         """The general rule, on a token no catalogue entry can ever claim."""

--- a/backend/tests/workflows/test_group_additivity_upload.py
+++ b/backend/tests/workflows/test_group_additivity_upload.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 import pytest
 from pydantic import ValidationError
@@ -252,12 +253,15 @@ def test_service_guard_rejects_ga_on_non_estimated_thermo(db_session):
 def test_the_missing_thermo_guard_does_not_answer_with_its_own_name(db_session):
     """The refusal must not advertise the function it was raised in.
 
-    The message is written in the house style, ``f"{context}: <prose>"``,
-    with the enclosing function as ``context`` -- so the token lands in the
-    code position and the envelope used to publish
+    The message used to be written in the house style,
+    ``f"{context}: <prose>"``, with the enclosing function as ``context`` --
+    so the token landed in the code position and the envelope published
     ``code="create_applied_group_additivity"``: a function name presented to
-    a client as a branchable contract. It is in no register, in no generated
-    client constant, and it moves the day somebody renames the function.
+    a client as a branchable contract. It was in no register, in no generated
+    client constant, and it moved the day somebody renamed the function.
+    #164 stopped it being promoted; #178 reworded it, which is the actual
+    fix, and dropped its catalogue entry because a message with no leading
+    token is not a code by any spelling.
 
     The envelope is built here by the *real* handler rather than asserted
     about in the abstract, because what a depositor receives is the thing
@@ -280,6 +284,13 @@ def test_the_missing_thermo_guard_does_not_answer_with_its_own_name(db_session):
     assert body["code"] == "validation_error"
     assert body["detail"] == str(raised.value)
     assert body["context"] == {}
+    assert not re.match(r"^[a-z][a-z0-9_]*_[a-z0-9_]+: ", str(raised.value)), (
+        f"the refusal opens with a token in the code position: "
+        f"{str(raised.value)!r}. Asserting only that the body falls back to "
+        "validation_error would not have caught this: the gate added in #164 "
+        "degrades an uncatalogued token anyway, so the wording needs its own "
+        "assertion or nothing holds it."
+    )
 
 
 def test_ga_requires_at_least_one_component():


### PR DESCRIPTION
Closes #177. Closes #178.

`#178` was blocked on `#177`: the assertion standing in its way is the one
`#177` fixes.

## #177 — the origin guard was satisfied by a name in `__all__`

`_defines_code` matched `"<code>"` or `"<code>:` anywhere in the origin
module. `backend/app/services/scientific_read/keyset.py` exports
`"keyset_predicate"` in `__all__`, so the entry for `keyset_predicate` was
satisfied by *the module exporting a function of that name* rather than by
the module defining the code. That can only happen where a code's value
coincides with an identifier — which is exactly the class of defect the
guard exists to catch. It was blindest where the defect lives, and #164
reworded the `keyset_predicate` message with
`test_every_origin_still_defines_its_code` staying green.

**Proof, measured on this tree.** With both messages reworded and both
catalogue entries still present:

| matcher | `test_every_origin_still_defines_its_code` |
|---|---|
| pre-#177 (`2ea4eeb8`, run verbatim against the reworded sources) | **green on `keyset_predicate`** — it names only `create_applied_group_additivity` |
| this branch | **red on both** |

The old regex catches the group-additivity rename (nothing quotes that name
in its module any more) and misses the keyset one (`__all__` quotes it).
That asymmetry is the bug, exactly.

Matching is now by *syntactic position*, and by one walker
(`_code_positions`) that the closure scan and the origin guard share — two
matchers drift, and the drift is invisible because both stay green. A bare
code counts where it is used as a value (a call argument, a mapping value,
an assignment to `code`/`*_code`/an upper-case constant) and a `"code: "`
message counts wherever it is written but not in a docstring. A name list
is none of those.

Positions were derived from the 146 entries rather than assumed: a rule of
"raise site or `code=` keyword" alone — the shape the issue proposed —
turns **20 of them red**, because `app/api/errors.py` writes several codes
into a response body, `calculation_ownership.py` names its codes as module
constants, and `client_version.py` passes them positionally to a helper.
All 146 pass under the rule as written.

**The scan is widened too**: `*_code=` is read at any call, not only at a
`raise`. `reconcile_id_ref` is *called* with `conflict_code=` and raises
inside, so a raise-site scan saw none of the six `*_handle_conflict` codes.
The observer sees only one of the six (`level_of_theory_handle_conflict`),
so the other five had no runtime coverage at all.

Widening it revealed one uncatalogued code — `database_error`, the
operational-error handler's `fallback_code`. It is dead (`error_envelope`
reads the fallback only when `code` is falsy, and that handler always sets
`code`), and it is now listed and annotated as such rather than left as a
hole in a catalogue that claims completeness. Bare `code=` is deliberately
*not* read away from a `raise`: that is also how `UploadWarning`, the dry
run's messages and the rubric's findings are built, and those arrive with
an accepted deposit.

## #178 — two messages still led with a function name

Reworded, both entries removed from the catalogue, and the assertions that
depended on them existing adjusted:

- `test_client_facing_excludes_what_a_client_cannot_use` counted the
  entries its exclusion loop actually excluded (>5) instead of asserting an
  accidental prefix exists, and pins both names *out* of the catalogue.
- `test_it_excludes_what_the_catalogue_calls_not_a_code` ran over what is
  now an empty set; it is rewritten over every non-`message_prefix` surface
  (70-odd entries) and joined by an explicit "in no surface at all" test.
- The two "does not advertise its own name" tests asserted only that the
  body falls back to `validation_error` — which #164's gate delivers
  whether or not the wording regresses. They now assert the message has no
  token in the code position, so the reword has a guard of its own. That is
  #177's lesson one layer down: a guard that passes for a second reason has
  stopped guarding the first.

`Surface.accidental_prefix` is kept with no members and says so; the
classification is what makes recording the next one cheaper than hiding it.

**A wrong note is corrected.** The catalogue said
`create_applied_group_additivity` was "Reachable from POST /uploads/thermo".
It is not, verified three ways: it has exactly one caller in `app/`
(`backend/app/workflows/thermo.py:347`); that caller passes `thermo.id`
from `persist_thermo`, which does `session.add(thermo); session.flush();
return thermo` (`backend/app/services/thermo_resolution.py:160-161,254`),
so `session.get(Thermo, thermo_id)` returns the identity-mapped row and
cannot be `None`; and the only test that provokes the branch does so by
passing `thermo_id=-1` directly. Both guards are backend-bug-only, and both
notes now say so.

## Client

**No enum member is removed.** An `accidental_prefix` entry was never
client-facing, so neither string was ever generated into `RejectionCode`;
`database_error` is a 503 and is not either.
`generate_client_rejection_codes.py --check` reports the committed file up
to date, `clients/python/**` is untouched and `tckdb-client` stays at
0.38.0 — a version bump with no diff would be a fiction.

## Verification

- Three gates on `main` (`2ea4eeb8`) and on this branch, `conda run`, with
  `DB_TEST_NAME=tckdb_test_177`.
- `ruff check app tests scripts` clean; `check_runtime_ascii.py` clean;
  `clients/python/tests/` — 1348 passed.
- Runtime observer, all three gates: 101 distinct `(status, code)` pairs,
  1183 error bodies. **Neither removed code appears in either run.**
- Seven mutations, each turning something red — including
  `_defines_code -> return True`, re-adding either message prefix, renaming
  a `conflict_code`, deleting the `database_error` entry, re-cataloguing
  `keyset_predicate`, and reverting the value-position restriction so a bare
  literal counts anywhere (the `__all__` hole).

### Measured

| gate | `main` @ `2ea4eeb8` | this branch |
|---|---|---|
| complement (`test-rest.sh`) | 4293 passed, 14 skipped | 4293 passed, 14 skipped |
| API (`test-api.sh`) | 2710 passed | 2711 passed (+1: the new "in no surface at all" test) |
| scientific (`test-scientific.sh`) | 2049 passed | 2049 passed |

Observer, all three gates both times: **101 distinct `(status, code)` pairs
before and after, none gained, none lost**, 1183 → 1184 bodies (the extra
test). `keyset_predicate`, `create_applied_group_additivity` and
`database_error` appear in neither run.

Catalogue: 146 entries → 145 (two removed, `database_error` added).
Client-facing: 132 → 132, and the generated file is byte-identical.
