### PR TITLE
Point the non-ASCII gate at the Python that runs on a contributor's machine

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -167,17 +167,27 @@ jobs:
         # Narrower than ruff's RUF001-003, which this repo disables on
         # purpose because scientific notation is legitimate prose. This one
         # looks only at strings that leave the process -- raises, log calls,
-        # message=/detail=/reason= -- and covers app/, scripts/ and the wire
-        # package, but not tests/, where non-ASCII data is the point. See the
-        # script's header.
+        # message=/detail=/reason= -- and covers app/, scripts/, the wire
+        # package, the Python client, the CHEMKIN adapter and the MCP
+        # integration, but not tests/, where non-ASCII data is the point. See
+        # the script's header.
         #
         # No arguments on purpose: the target list lives in the script, so a
-        # local run and this one scan the same tree. The wire package sits
-        # outside `working-directory: backend`, and the script resolves it
-        # relative to its own location rather than the current directory. It
-        # refuses a target that expands to no files, so a moved package
-        # fails the gate instead of silently emptying it.
-        run: conda run -n tckdb_env python scripts/check_runtime_ascii.py
+        # local run and this one scan the same tree. Four of the six targets
+        # sit outside `working-directory: backend`, and the script resolves
+        # them relative to its own location rather than the current
+        # directory. It refuses a target that expands to no files, so a moved
+        # package fails the gate instead of silently emptying it.
+        #
+        # `--audit` runs first so the log opens with the coverage account:
+        # what is scanned, and what is deliberately not scanned and why. Five
+        # encoding misses in one week were all the same shape -- a correct
+        # check aimed at fewer places than it should have been -- and none of
+        # them was visible in a CI log until someone went looking. It fails
+        # on any source file that is in neither list.
+        run: |
+          conda run -n tckdb_env python scripts/check_runtime_ascii.py --audit
+          conda run -n tckdb_env python scripts/check_runtime_ascii.py
 
       - name: Type check (mypy, scoped)
         if: matrix.gate == 'api'

--- a/backend/scripts/check_runtime_ascii.py
+++ b/backend/scripts/check_runtime_ascii.py
@@ -13,13 +13,28 @@ WHY
     rebuilt by someone in a hurry.
 
 WHAT IS IN SCOPE, AND WHY IT IS DRAWN THIS NARROWLY
-    Three trees: ``backend/app``, ``backend/scripts`` and the wire package
-    ``schemas/python/tckdb-schemas/tckdb_schemas``. The wire package was
-    added late and should have been there from the first commit: it raises
-    the validation errors a client reads and builds the ``message=``
-    strings that are written to ``upload_warning.message``. It had nine
-    violations on the day it was first scanned, all of them at emission
-    sites, in the one package this check had never been pointed at.
+    Six trees; see ``DEFAULT_TARGETS``. Three of them are backend-side
+    (``backend/app``, ``backend/scripts``, and the wire package
+    ``schemas/python/tckdb-schemas/tckdb_schemas``); three are the
+    shipped Python that runs on a *contributor's* machine
+    (``clients/python/src/tckdb_client``, the CHEMKIN adapter
+    ``clients/python/adapters/chemkin/tckdb_chemkin``, and the MCP
+    integration ``integrations/mcp/src/tckdb_mcp``).
+
+    Each of those was added after a measurement, not before one. The
+    wire package had nine violations on the day it was first scanned.
+    The client builders had eight and the CHEMKIN adapter two, all of
+    them at emission sites, in packages this check had never been
+    pointed at. ``tckdb_mcp`` had none: it is here for coverage, so the
+    next string written into it is checked by the pull request that
+    writes it, and nothing in this file's history should be read as
+    having repaired anything there.
+
+    That is the recurring shape, and it is the reason for ``--audit``
+    below: every one of these was a correct check aimed at fewer places
+    than it should have been, and in each case the omission was found
+    by a person noticing, months late, rather than by the check saying
+    so.
 
     Only string literals that are structurally *at an emission site*:
     the argument of a ``raise``, the argument of a logging call, or a
@@ -70,11 +85,27 @@ ESCAPE HATCH
     need a non-ASCII character -- an error quoting a unit symbol, a
     parser reporting the token it failed on. Say so in place.
 
+SAYING WHAT IS *NOT* SCANNED
+    A target list is a list somebody forgets to extend, and this one was
+    forgotten five times. So the list is not the only record: every
+    ``*.py`` and ``*.sh`` in the repository is either under a target or
+    named in ``UNSCANNED_BY_DESIGN`` with a reason. ``--audit`` proves
+    it and prints the exclusions; ``tests/scripts/test_check_runtime_ascii.py``
+    runs the audit, so a *new* tree of Python that nothing scans fails a
+    pull request on the day it is added rather than being discovered by
+    an incident.
+
+    The audit deliberately does not decide whether a tree *should* be
+    scanned. It only refuses to let one be absent from both lists, which
+    is the state that made every previous miss invisible.
+
 USAGE
     python scripts/check_runtime_ascii.py [PATH ...]
+    python scripts/check_runtime_ascii.py --audit
 
     Defaults to the packaged sources. Exits 1 and prints one line per
-    finding, in ``path:line: text`` form.
+    finding, in ``path:line: text`` form. ``--audit`` exits 1 naming any
+    source file that is neither scanned nor declared out of scope.
 """
 
 from __future__ import annotations
@@ -96,6 +127,16 @@ REPO_ROOT = BACKEND_ROOT.parent
 
 #: Where the wire package's sources live, relative to ``BACKEND_ROOT``.
 WIRE_PACKAGE_TARGET = "../schemas/python/tckdb-schemas/tckdb_schemas"
+
+#: The Python client a contributor installs, relative to ``BACKEND_ROOT``.
+CLIENT_PACKAGE_TARGET = "../clients/python/src/tckdb_client"
+
+#: The CHEMKIN importer adapter, which ships and versions separately from
+#: the client (``clients/python/adapters/chemkin/pyproject.toml``).
+CHEMKIN_ADAPTER_TARGET = "../clients/python/adapters/chemkin/tckdb_chemkin"
+
+#: The MCP integration. Added at zero violations -- coverage, not repair.
+MCP_INTEGRATION_TARGET = "../integrations/mcp/src/tckdb_mcp"
 
 #: Checked by default, as paths relative to ``BACKEND_ROOT``.
 #:
@@ -120,12 +161,186 @@ WIRE_PACKAGE_TARGET = "../schemas/python/tckdb-schemas/tckdb_schemas"
 #: executes in a deployment. The same reasoning excludes the wire package's
 #: own ``tests/``, which is why the target is the package directory and not
 #: the distribution directory above it.
-DEFAULT_TARGETS = ("app", "scripts", WIRE_PACKAGE_TARGET)
+#:
+#: ``tckdb_client`` and ``tckdb_chemkin`` for the same reason the wire
+#: package was added, one layer further out: their strings are the ones a
+#: contributor reads in a terminal, and the adapter's are accumulated into
+#: ``NormalizedReaction.warnings`` and carried up through an import run.
+#: Eight and two violations respectively when first scanned.
+#:
+#: ``tckdb_mcp`` scanned clean when it was added. It is on the list so that
+#: the *next* string written there is checked; nothing was repaired in it.
+DEFAULT_TARGETS = (
+    "app",
+    "scripts",
+    WIRE_PACKAGE_TARGET,
+    CLIENT_PACKAGE_TARGET,
+    CHEMKIN_ADAPTER_TARGET,
+    MCP_INTEGRATION_TARGET,
+)
 
 
 def default_target_paths() -> list[Path]:
     """The default targets as absolute paths."""
     return [(BACKEND_ROOT / name).resolve() for name in DEFAULT_TARGETS]
+
+
+#: Source suffixes the audit accounts for. Exactly what :func:`walk` reads,
+#: so "scanned" and "audited" cannot drift apart.
+SOURCE_SUFFIXES = (".py", ".sh")
+
+#: Never walked: version control, virtualenvs, caches, build output, and
+#: anything under a dot-directory (which is how ``.git``, ``.venv`` and
+#: ``.claude/worktrees`` are excluded without naming each one).
+_AUDIT_SKIP_DIRS = frozenset({"node_modules", "__pycache__", "build", "dist"})
+
+#: Why the audit passes over a tests tree. Stated once because it is the
+#: same reason every time, and it is the reason given in this file's header
+#: for scanning the wire *package* rather than its distribution directory.
+TEST_TREE_REASON = (
+    "test data is the one place non-ASCII is the point, and nothing under "
+    "tests/ runs in a deployment"
+)
+
+#: Source files no target covers, and why. Keys are repository-relative
+#: POSIX paths; a file is declared if it equals a key or lies under one.
+#:
+#: This exists so that "not scanned" is a decision on the record rather than
+#: an absence nobody can see. ``--audit`` fails on any source file that is in
+#: neither this table nor a target, which is the state every one of the five
+#: 2026-08 encoding misses was in.
+UNSCANNED_BY_DESIGN: tuple[tuple[str, str], ...] = (
+    (
+        "backend/alembic",
+        "migration revisions. Four raise-site em dashes are sitting here "
+        "(b6e1d3a9c740:144, c4d8f1b2a9e6:183, d3a7f1c9b284:352, "
+        "e3f4a5b6c7d8:628), printed to an operator's terminal by a "
+        "downgrade guard. They are recorded rather than fixed because "
+        ".claude/rules/migration-rules.md forbids mutating a revision that "
+        "has been applied to a deployed database. Scanning this tree means "
+        "settling that question first",
+    ),
+    (
+        "backend/main.py",
+        "the ASGI entry point: three statements and no string literal at "
+        "all. Everything it serves is emitted from backend/app, which is "
+        "scanned",
+    ),
+    (
+        "clients/python/examples",
+        "demo programs that print to a terminal. Out of charter for the "
+        "same reason a docstring is: nothing here reaches a database "
+        "column, a response body or a log",
+    ),
+    (
+        "clients/python/scripts",
+        "one generator that rewrites a checked-in Markdown document; its "
+        "output is prose in a document, not an emitted string",
+    ),
+    (
+        "examples/clients",
+        "demo programs, as clients/python/examples",
+    ),
+)
+
+
+def _is_test_path(relative: str) -> bool:
+    """Whether *relative* is test scaffolding rather than shipped code."""
+    parts = relative.split("/")
+    return "tests" in parts or parts[-1] == "conftest.py"
+
+
+def audit_reason(relative: str) -> str | None:
+    """Why *relative* is not scanned, or ``None`` if nothing says."""
+    if _is_test_path(relative):
+        return TEST_TREE_REASON
+    for prefix, reason in UNSCANNED_BY_DESIGN:
+        if relative == prefix or relative.startswith(prefix + "/"):
+            return reason
+    return None
+
+
+def repository_sources() -> list[str]:
+    """Every source file in the repository, repository-relative."""
+    out: list[str] = []
+    for path in REPO_ROOT.rglob("*"):
+        if path.suffix not in SOURCE_SUFFIXES or path.is_dir():
+            continue
+        parts = path.relative_to(REPO_ROOT).parts
+        if any(
+            part.startswith(".") or part in _AUDIT_SKIP_DIRS or part.endswith(".egg-info")
+            for part in parts[:-1]
+        ):
+            continue
+        out.append("/".join(parts))
+    return sorted(out)
+
+
+def audit() -> tuple[list[str], dict[str, int]]:
+    """Split the repository's sources into undeclared and declared-by-reason.
+
+    Returns the source files that are neither scanned nor declared, and a
+    count of declared files per ``UNSCANNED_BY_DESIGN`` prefix (plus the
+    test trees under their shared reason). A declaration matching nothing
+    is reported as a count of zero: a stale exclusion is the same failure
+    as a target that expands to no files, one list drifting away from the
+    tree it describes.
+    """
+    scanned = default_target_paths()
+    undeclared: list[str] = []
+    counts: dict[str, int] = {"tests/ trees": 0}
+    for prefix, _ in UNSCANNED_BY_DESIGN:
+        counts[prefix] = 0
+
+    for relative in repository_sources():
+        absolute = REPO_ROOT / relative
+        if any(target in absolute.parents or target == absolute for target in scanned):
+            continue
+        if _is_test_path(relative):
+            counts["tests/ trees"] += 1
+            continue
+        for prefix, _ in UNSCANNED_BY_DESIGN:
+            if relative == prefix or relative.startswith(prefix + "/"):
+                counts[prefix] += 1
+                break
+        else:
+            undeclared.append(relative)
+    return undeclared, counts
+
+
+def run_audit() -> int:
+    """Print the coverage account and fail on anything undeclared."""
+    undeclared, counts = audit()
+    for target in DEFAULT_TARGETS:
+        resolved = (BACKEND_ROOT / target).resolve()
+        print(f"scanned    {len(walk(resolved)):>4}  {_relative(resolved)}")
+    for label, count in counts.items():
+        print(f"declared   {count:>4}  {label}")
+
+    empty = [label for label, count in counts.items() if count == 0]
+    if empty:
+        print(
+            "error: declared out of scope but matching no file: "
+            + ", ".join(empty)
+            + "\n       A stale exclusion hides the tree it used to name.",
+            file=sys.stderr,
+        )
+        return 1
+    if undeclared:
+        for relative in undeclared:
+            print(f"undeclared {'':>4}  {relative}")
+        print(
+            f"\n{len(undeclared)} source file(s) are neither scanned by "
+            f"{Path(__file__).name} nor named in UNSCANNED_BY_DESIGN.\n"
+            "Add the tree to DEFAULT_TARGETS, or say in UNSCANNED_BY_DESIGN "
+            "why it is not scanned. Silence is what let five encoding misses "
+            "through.",
+            file=sys.stderr,
+        )
+        return 1
+    print("audit: every source file is scanned or declared out of scope")
+    return 0
+
 
 ALLOW_MARKER = "# tckdb: allow-non-ascii"
 
@@ -381,7 +596,20 @@ def main(argv: list[str] | None = None) -> int:
             f"(default: {', '.join(DEFAULT_TARGETS)})"
         ),
     )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help=(
+            "check no source file in the repository is missing from both "
+            "the target list and UNSCANNED_BY_DESIGN, and print the account"
+        ),
+    )
     args = parser.parse_args(argv)
+
+    if args.audit:
+        if args.targets:
+            parser.error("--audit takes no paths: it looks at the whole repository")
+        return run_audit()
 
     targets = [Path(t) for t in args.targets] or default_target_paths()
 

--- a/backend/tests/scripts/test_check_runtime_ascii.py
+++ b/backend/tests/scripts/test_check_runtime_ascii.py
@@ -457,7 +457,11 @@ def test_a_green_run_says_what_it_read(capsys):
     """
     assert checker.main([]) == 0
     lines = capsys.readouterr().out.splitlines()
-    assert len(lines) == len(checker.DEFAULT_TARGETS)
+    # One line per target, and never fewer lines than there are trees that
+    # must stay covered. The first half alone would track a shrinking target
+    # list instead of catching it: delete a target and both sides move
+    # together. ``REQUIRED_TREES`` is a list of literals, so it cannot move.
+    assert len(lines) == len(checker.DEFAULT_TARGETS) >= len(REQUIRED_TREES)
     assert any(
         line.startswith("checked ")
         and checker.WIRE_PACKAGE_TARGET.removeprefix("../") in line
@@ -496,3 +500,342 @@ def test_ci_invokes_the_check_with_no_arguments():
     command = step["run"].strip()
     assert command.endswith("scripts/check_runtime_ascii.py"), command
     assert step["working-directory"] == "backend"
+    lines = [line.strip() for line in command.splitlines() if line.strip()]
+    for line in lines:
+        assert line.endswith(
+            ("check_runtime_ascii.py", "check_runtime_ascii.py --audit")
+        ), line
+
+
+def test_ci_prints_the_coverage_account():
+    """The gate has to say what it is *not* scanning, in the log.
+
+    The summary line added in #166 made an empty scan visible. ``--audit``
+    is the same idea one level up: it makes an unscanned *tree* visible,
+    which is the state all five of the 2026-08 encoding misses were in.
+    A gate that only runs the scan reports coverage it already has.
+    """
+    command = _ascii_lint_step()["run"]
+    assert "check_runtime_ascii.py --audit" in command, command
+
+
+# ---------------------------------------------------------------------------
+# The trees that ship to a contributor
+#
+# Same defect as the wire package, one layer further out: the Python a
+# contributor installs -- ``tckdb_client``, the CHEMKIN adapter, the MCP
+# integration -- was never on the target list, and the client builders and the
+# adapter had ten violations between them the day they were first scanned.
+#
+# Every path below is written out as a literal on purpose. Asserting
+# ``checker.CLIENT_PACKAGE_TARGET in checker.DEFAULT_TARGETS`` would pass
+# unchanged if that constant were repointed at the wrong directory: the test
+# would follow the mutation instead of catching it. A literal cannot follow
+# anything.
+# ---------------------------------------------------------------------------
+
+#: Repository-relative, and deliberately not imported from the checker.
+REQUIRED_TREES = (
+    "backend/app",
+    "backend/scripts",
+    "schemas/python/tckdb-schemas/tckdb_schemas",
+    "clients/python/src/tckdb_client",
+    "clients/python/adapters/chemkin/tckdb_chemkin",
+    "integrations/mcp/src/tckdb_mcp",
+)
+
+CLIENT_PACKAGE = checker.REPO_ROOT / "clients/python/src/tckdb_client"
+CHEMKIN_ADAPTER = checker.REPO_ROOT / "clients/python/adapters/chemkin/tckdb_chemkin"
+MCP_INTEGRATION = checker.REPO_ROOT / "integrations/mcp/src/tckdb_mcp"
+
+
+def test_every_required_tree_is_a_default_target():
+    """Written as literals so the assertion cannot track a repointing."""
+    targets = {p.resolve() for p in checker.default_target_paths()}
+    for tree in REQUIRED_TREES:
+        assert (checker.REPO_ROOT / tree).resolve() in targets, tree
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        CLIENT_PACKAGE / "builders" / "uploads.py",
+        CLIENT_PACKAGE / "builders" / "calculation.py",
+        CLIENT_PACKAGE / "builders" / "sources.py",
+        CHEMKIN_ADAPTER / "normalizer.py",
+        MCP_INTEGRATION / "config.py",
+        MCP_INTEGRATION / "tools" / "reaction_kinetics.py",
+    ],
+)
+def test_the_new_targets_reach_the_modules_that_emit(module: Path):
+    """Named modules, not a count.
+
+    A target resolved one directory too high (``clients/python``) or one
+    too low (``.../builders``) still expands to files, and a test that
+    only counted them would stay green. These six modules are where the
+    ten violations were, or -- for ``tckdb_mcp`` -- where the next one
+    would be.
+    """
+    covered: set[Path] = set()
+    for target in checker.default_target_paths():
+        covered.update(checker.walk(target))
+    assert module in covered, module
+
+
+@pytest.mark.parametrize(
+    "tests_dir",
+    [
+        checker.REPO_ROOT / "clients/python/tests",
+        checker.REPO_ROOT / "clients/python/adapters/chemkin/tests",
+        checker.REPO_ROOT / "integrations/mcp/tests",
+    ],
+)
+def test_the_new_trees_own_tests_stay_out_of_scope(tests_dir: Path):
+    """Each target is a package directory, so its sibling tests sit outside."""
+    assert tests_dir.is_dir(), tests_dir
+    covered: set[Path] = set()
+    for target in checker.default_target_paths():
+        covered.update(checker.walk(target))
+    assert not any(tests_dir in p.parents for p in covered)
+
+
+@pytest.mark.parametrize(
+    "tree", [CLIENT_PACKAGE, CHEMKIN_ADAPTER, MCP_INTEGRATION]
+)
+def test_the_shipped_client_trees_are_clean(tree: Path):
+    assert checker.check_path(tree) == []
+
+
+def test_the_mcp_integration_was_clean_before_it_was_covered():
+    """Coverage, not repair -- said here so the diff is not misread.
+
+    ``tckdb_mcp`` had no violations on the day it was added to the target
+    list. Nothing in it was changed. It is on the list so the *next*
+    string written there is checked by the pull request that writes it,
+    which is precisely what did not happen for the wire package or for
+    the client builders.
+    """
+    walked = checker.walk(MCP_INTEGRATION)
+    assert walked, "the MCP target must not be empty"
+    assert any(p.suffix == ".py" for p in walked)
+    assert checker.check_path(MCP_INTEGRATION) == []
+
+
+def test_a_reintroduced_em_dash_in_a_client_diagnostic_is_caught():
+    """The live rule against the live file.
+
+    Puts the em dash back into the ``message=`` literal it was removed
+    from, in the real ``uploads.py``, and checks the modified source.
+    The literal is a multi-line implicit concatenation nested inside a
+    ``Diagnostic(...)`` call inside an ``out.append(...)`` -- the shape
+    the flat samples earlier in this file do not exercise.
+    """
+    path = CLIENT_PACKAGE / "builders" / "uploads.py"
+    source = path.read_text(encoding="utf-8")
+    clean = "carry a transport field -- the block will not be "
+    assert clean in source, "the message this mutation targets has moved"
+    assert checker.check_source(source, path) == []
+
+    mutated = source.replace(clean, "carry a transport field — the block will not be ")
+    found = checker.check_source(mutated, path)
+    assert len(found) == 1
+    assert found[0].characters == "—"
+
+
+def test_a_reintroduced_section_sign_in_a_chemkin_warning_is_caught():
+    """The adapter's accumulated warnings, which reach a user another way.
+
+    ``out.warnings.append(...)`` is an accumulator, not a raise and not a
+    ``message=`` keyword, so this also pins that the accumulator rule
+    covers the adapter and not only the backend's cccbdb builders.
+    """
+    path = CHEMKIN_ADAPTER / "normalizer.py"
+    source = path.read_text(encoding="utf-8")
+    clean = "(spec section 6.7)."
+    assert clean in source, "the warning this mutation targets has moved"
+    assert checker.check_source(source, path) == []
+
+    mutated = source.replace(clean, "(spec §6.7).")
+    found = checker.check_source(mutated, path)
+    assert len(found) == 1
+    assert found[0].kind == "accumulated warning"
+    assert found[0].characters == "§"
+
+
+def test_a_reintroduced_em_dash_in_the_mcp_integration_is_caught():
+    """The zero-violation tree still has to be a tree the rule fires on.
+
+    Adding a clean directory to the target list proves nothing on its
+    own: the same green result comes from a target that resolves nowhere.
+    This mutates a real ``raise`` in ``config.py`` and requires a finding.
+    """
+    path = MCP_INTEGRATION / "config.py"
+    source = path.read_text(encoding="utf-8")
+    clean = '"TCKDB_MCP_DEFAULT_LIMIT must be >= 1"'
+    assert clean in source, "the raise this mutation targets has moved"
+    assert checker.check_source(source, path) == []
+
+    mutated = source.replace(clean, '"TCKDB_MCP_DEFAULT_LIMIT must be — >= 1"')
+    found = checker.check_source(mutated, path)
+    assert len(found) == 1
+    assert found[0].kind == "raised message"
+    assert found[0].characters == "—"
+
+
+def test_the_summary_names_every_tree_with_a_non_empty_count(capsys):
+    """The failure mode this whole file exists to rule out.
+
+    A target that silently resolves to nothing produces the same green
+    exit as a clean tree. The summary is the only place the difference is
+    visible, so assert against the printed count, per named tree, using
+    literals rather than the checker's own target list.
+    """
+    assert checker.main([]) == 0
+    lines = capsys.readouterr().out.splitlines()
+    for tree in REQUIRED_TREES:
+        shown = tree.removeprefix("backend/")
+        matching = [
+            line
+            for line in lines
+            if line.startswith("checked ") and line.endswith(f" under {shown}")
+        ]
+        assert len(matching) == 1, (tree, lines)
+        count = int(matching[0].split()[1])
+        assert count > 0, matching[0]
+
+
+# ---------------------------------------------------------------------------
+# Saying what is NOT scanned
+#
+# Five encoding misses in one week, every one of them the same shape: a
+# correct check aimed at fewer places than it should have been, and nothing
+# anywhere that said so. The target list records what is scanned;
+# ``UNSCANNED_BY_DESIGN`` records what is not and why, and ``--audit`` refuses
+# to let a source file be absent from both.
+# ---------------------------------------------------------------------------
+
+
+def test_the_audit_accounts_for_every_source_file():
+    """The assertion that makes the *next* missing tree fail a pull request."""
+    undeclared, _ = checker.audit()
+    assert undeclared == [], undeclared
+
+
+def test_the_audit_run_reports_and_passes(capsys):
+    assert checker.main(["--audit"]) == 0
+    out = capsys.readouterr().out
+    assert "audit: every source file is scanned or declared" in out
+    assert "declared" in out
+
+
+def test_the_audit_covers_the_repository_not_just_the_backend():
+    """A repository-wide sweep is the point; a backend-only one would have
+    missed every tree this change adds."""
+    sources = checker.repository_sources()
+    for expected in (
+        "backend/app/api/app.py",
+        "clients/python/src/tckdb_client/builders/uploads.py",
+        "integrations/mcp/src/tckdb_mcp/config.py",
+        "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py",
+    ):
+        assert expected in sources, expected
+
+
+def test_an_undeclared_source_file_fails_the_audit(monkeypatch, capsys):
+    """Mutation: drop a declaration and the audit must go red.
+
+    ``backend/alembic`` is 69 files that no target covers. Removing its
+    entry has to surface all of them rather than quietly reclassifying
+    them, otherwise the table is decoration.
+    """
+    kept = tuple(
+        entry for entry in checker.UNSCANNED_BY_DESIGN if entry[0] != "backend/alembic"
+    )
+    assert len(kept) == len(checker.UNSCANNED_BY_DESIGN) - 1
+    monkeypatch.setattr(checker, "UNSCANNED_BY_DESIGN", kept)
+
+    undeclared, _ = checker.audit()
+    assert any(p.startswith("backend/alembic/") for p in undeclared)
+    assert checker.main(["--audit"]) == 1
+    assert "neither scanned" in capsys.readouterr().err
+
+
+def test_a_stale_declaration_fails_the_audit(monkeypatch, capsys):
+    """The other half: an exclusion that matches nothing.
+
+    A declaration left behind after its directory moves is the same
+    failure as a target that expands to no files -- one list drifting
+    away from the tree it claims to describe, while both stay green.
+    """
+    monkeypatch.setattr(
+        checker,
+        "UNSCANNED_BY_DESIGN",
+        (*checker.UNSCANNED_BY_DESIGN, ("backend/nowhere", "moved away")),
+    )
+    assert checker.main(["--audit"]) == 1
+    assert "matching no file" in capsys.readouterr().err
+
+
+def test_the_audit_does_not_silently_reclassify_a_scanned_tree(monkeypatch):
+    """Mutation: point a target at nothing and the audit must notice.
+
+    If ``tckdb_client`` were repointed at a directory that does not
+    exist, the gate itself exits 2 -- but only if it is run. The audit is
+    the second reader of the same list, and it has to see the package's
+    28 files become undeclared rather than vanish from both accounts.
+    """
+    monkeypatch.setattr(
+        checker,
+        "DEFAULT_TARGETS",
+        tuple(
+            "../clients/python/src/gone" if t == checker.CLIENT_PACKAGE_TARGET else t
+            for t in checker.DEFAULT_TARGETS
+        ),
+    )
+    undeclared, _ = checker.audit()
+    assert any(
+        p.startswith("clients/python/src/tckdb_client/") for p in undeclared
+    ), undeclared
+
+
+def test_test_trees_are_declared_rather_than_forgotten():
+    """``tests/`` is out of scope on purpose, and the audit says so.
+
+    The reason is the same one that keeps ``backend/tests`` off the
+    target list, and stating it once in the script is what stops a future
+    reader from reading the omission as an oversight.
+    """
+    _, counts = checker.audit()
+    assert counts["tests/ trees"] > 0
+    assert checker.audit_reason("clients/python/tests/test_client.py") == (
+        checker.TEST_TREE_REASON
+    )
+    assert checker.audit_reason("clients/python/conftest.py") == checker.TEST_TREE_REASON
+    assert checker.audit_reason("clients/python/src/tckdb_client/client.py") is None
+
+
+def test_the_declared_trees_name_the_alembic_violations_rather_than_hide_them():
+    """``backend/alembic`` is excluded, and the exclusion is not a shrug.
+
+    Four raise-site em dashes live there, printed by downgrade guards.
+    They are unfixed because applied revisions are immutable under
+    ``.claude/rules/migration-rules.md``, so the reason has to carry the
+    anchors -- an exclusion whose text is "not scanned" is how a known
+    defect becomes an unknown one.
+    """
+    reasons = dict(checker.UNSCANNED_BY_DESIGN)
+    alembic = reasons["backend/alembic"]
+    for revision in (
+        "b6e1d3a9c740",
+        "c4d8f1b2a9e6",
+        "d3a7f1c9b284",
+        "e3f4a5b6c7d8",
+    ):
+        assert revision in alembic, revision
+    still_there = checker.check_path(checker.REPO_ROOT / "backend" / "alembic")
+    assert len(still_there) == 4, [f.render(checker.BACKEND_ROOT) for f in still_there]
+
+
+def test_audit_rejects_paths():
+    with pytest.raises(SystemExit):
+        checker.main(["--audit", "app"])

--- a/clients/python/adapters/chemkin/pyproject.toml
+++ b/clients/python/adapters/chemkin/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-chemkin"
-version = "0.2.0"
+version = "0.2.1"
 description = "CHEMKIN mechanism importer adapter for TCKDB (parser + identity + payload builder + uploader)."
 requires-python = ">=3.11"
 dependencies = [

--- a/clients/python/adapters/chemkin/tckdb_chemkin/__init__.py
+++ b/clients/python/adapters/chemkin/tckdb_chemkin/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
     "build_kinetics_payload",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/clients/python/adapters/chemkin/tckdb_chemkin/normalizer.py
+++ b/clients/python/adapters/chemkin/tckdb_chemkin/normalizer.py
@@ -270,13 +270,14 @@ def normalize_reaction(
         out.has_explicit_reverse = True
         out.warnings.append(
             f"Explicit REV/ reverse-rate on reaction (line {rxn.line_no}) "
-            "dropped; TCKDB has no reverse-linkage field yet (spec §6.7)."
+            "dropped; TCKDB has no reverse-linkage field yet "
+            "(spec section 6.7)."
         )
 
     for aux in rxn.unsupported_aux:
         out.warnings.append(
             f"Unsupported aux construct on reaction (line {rxn.line_no}): "
-            f"{aux!r} — skipped (spec §2 out-of-scope)."
+            f"{aux!r} -- skipped (spec section 2 out-of-scope)."
         )
 
     return out

--- a/clients/python/adapters/chemkin/tests/test_package_version.py
+++ b/clients/python/adapters/chemkin/tests/test_package_version.py
@@ -1,0 +1,47 @@
+"""The adapter's version is written down twice, so it can disagree.
+
+``tckdb-chemkin`` ships and versions separately from ``tckdb-client``:
+it has its own ``pyproject.toml`` and its own ``__version__``. Nothing
+derives one from the other -- unlike ``tckdb_client.__version__``, which
+reads installed distribution metadata and therefore cannot drift -- so a
+release that bumps the packaging metadata and forgets the module (or the
+other way round) ships a package that misreports itself to anyone who
+prints ``tckdb_chemkin.__version__``.
+
+Noticed while bumping both for an unrelated change. One assertion is
+cheaper than finding out from a bug report which of the two numbers was
+the real one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tckdb_chemkin
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _declared_version() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    assert match is not None, f"no version in {PYPROJECT}"
+    return match.group(1)
+
+
+def test_module_version_matches_the_packaging_metadata():
+    assert tckdb_chemkin.__version__ == _declared_version()
+
+
+def test_the_adapter_versions_separately_from_the_client():
+    """Its own distribution, so its own number.
+
+    If this file is ever moved under ``clients/python/pyproject.toml``'s
+    packaging, this assertion is the reminder that the two version
+    numbers stopped being independent.
+    """
+    client_pyproject = PYPROJECT.parents[2] / "pyproject.toml"
+    assert client_pyproject.is_file(), client_pyproject
+    assert 'name = "tckdb-client"' in client_pyproject.read_text(encoding="utf-8")
+    assert 'name = "tckdb-chemkin"' in PYPROJECT.read_text(encoding="utf-8")

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.38.0"
+version = "0.38.1"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/builders/calculation.py
+++ b/clients/python/src/tckdb_client/builders/calculation.py
@@ -545,7 +545,7 @@ class Calculation:
         raise TCKDBBuilderValidationError(
             "cannot infer dependency role for "
             f"{self.type!r} depending on {parent.type!r}; supported "
-            "phase-1 shapes are freq→opt, sp→opt, opt→<any>."
+            "phase-1 shapes are freq->opt, sp->opt, opt-><any>."
         )
 
 

--- a/clients/python/src/tckdb_client/builders/sources.py
+++ b/clients/python/src/tckdb_client/builders/sources.py
@@ -105,7 +105,7 @@ class SourceCalculations:
 
         if not isinstance(calc, _Calculation):
             raise TCKDBBuilderValidationError(
-                f"SourceCalculations.add({role!r}, …) expected a "
+                f"SourceCalculations.add({role!r}, ...) expected a "
                 f"Calculation, got {type(calc).__name__}."
             )
         self._entries.append((role, calc))

--- a/clients/python/src/tckdb_client/builders/uploads.py
+++ b/clients/python/src/tckdb_client/builders/uploads.py
@@ -270,7 +270,7 @@ class ComputedSpeciesUpload:
                     message=(
                         "Transport is accepted for forward compatibility but "
                         "the computed-species bundle schema does not yet "
-                        "carry a transport field — the block will not be "
+                        "carry a transport field -- the block will not be "
                         "emitted on the wire. Use the standalone "
                         "/uploads/transport endpoint to ship transport data "
                         "today."
@@ -493,7 +493,7 @@ def _artifact_second_phase_diag(calc: Calculation) -> Diagnostic:
         message=(
             f"Calculation {label!r} has "
             f"{len(calc.artifacts)} attached artifact(s). Artifacts are "
-            "not included in the scientific upload payload — call "
+            "not included in the scientific upload payload -- call "
             "upload.artifact_plan(result) on the upload response and "
             "pass the plan to client.upload_artifacts(plan)."
         ),
@@ -565,7 +565,7 @@ def _extract_computed_reaction_calc_keys(
             "missing the 'calculation_keys' mapping. The server is "
             "older than the tckdb-client artifact-planning feature; "
             "upload artifacts directly via "
-            "client.upload_artifact(calculation_id, …) once you know "
+            "client.upload_artifact(calculation_id, ...) once you know "
             "each calculation's server id."
         )
     out: dict[str, int] = {}
@@ -573,7 +573,7 @@ def _extract_computed_reaction_calc_keys(
         if not isinstance(key, str) or not isinstance(value, int):
             raise TCKDBBuilderValidationError(
                 "artifact_plan: calculation_keys entries must be "
-                f"str → int, got {key!r} -> {type(value).__name__}."
+                f"str -> int, got {key!r} -> {type(value).__name__}."
             )
         out[key] = value
     return out
@@ -1455,7 +1455,7 @@ class ComputedReactionUpload:
                     message=(
                         "Transport is accepted for forward compatibility but "
                         "the computed-reaction bundle schema does not yet "
-                        "carry a per-species transport field — the block "
+                        "carry a per-species transport field -- the block "
                         "will not be emitted on the wire. Use the "
                         "standalone /uploads/transport endpoint to ship "
                         "transport data today."
@@ -1477,7 +1477,7 @@ class ComputedReactionUpload:
                     message=(
                         "Thermo source_calculations were validated locally "
                         "but the computed-reaction BundleThermoIn schema "
-                        "does not carry that field — the references will "
+                        "does not carry that field -- the references will "
                         "not be emitted on the wire. The computed-species "
                         "endpoint does emit them; if provenance is "
                         "load-bearing, upload via /uploads/computed-species."


### PR DESCRIPTION
## What was wrong

`check_runtime_ascii.py` covered `backend/app`, `backend/scripts` and the wire package. It did not cover the Python that runs on a **contributor's** machine: the client they `pip install`, the CHEMKIN adapter, or the MCP integration. Ten violations were sitting in the first two, all at emission sites.

Re-measured on `74705725` (the #175 scan was a day old; it reproduced exactly):

```
clients/python/src/tckdb_client/builders/calculation.py:547  '→'  raised message
clients/python/src/tckdb_client/builders/sources.py:108      '…'  raised message
clients/python/src/tckdb_client/builders/uploads.py:271      '—'  message= argument
clients/python/src/tckdb_client/builders/uploads.py:495      '—'  message= argument
clients/python/src/tckdb_client/builders/uploads.py:564      '…'  raised message
clients/python/src/tckdb_client/builders/uploads.py:575      '→'  raised message
clients/python/src/tckdb_client/builders/uploads.py:1456     '—'  message= argument
clients/python/src/tckdb_client/builders/uploads.py:1478     '—'  message= argument
clients/python/adapters/chemkin/tckdb_chemkin/normalizer.py:272  '§'   accumulated warning
clients/python/adapters/chemkin/tckdb_chemkin/normalizer.py:279  '§—'  accumulated warning
```

After: **0**, both trees. No `# tckdb: allow-non-ascii` used — every one was decoration (`--`, `...`, `->`, `section`), which is not what the escape hatch is for. `uploads.py:575` already read `str → int, got ... -> ...`; the ASCII half of that string was already the convention.

`integrations/mcp/src/tckdb_mcp` (17 files) is added at **zero violations**. **That is coverage, not repair** — nothing in the MCP tree was changed, and this diff must not be read as having fixed anything there. It is on the list so the next string written there is checked by the PR that writes it.

## The part that is not about ten characters

This is the fifth encoding item in a week and all five were the same shape: a correct protection aimed at fewer places than it should have been, with nothing anywhere that said so. #166's per-target summary line made an *empty scan* visible. This adds `--audit`, which makes an *unscanned tree* visible:

```
$ python scripts/check_runtime_ascii.py --audit
scanned     435  app
scanned      63  scripts
scanned      33  schemas/python/tckdb-schemas/tckdb_schemas
scanned      28  clients/python/src/tckdb_client
scanned      10  clients/python/adapters/chemkin/tckdb_chemkin
scanned      17  integrations/mcp/src/tckdb_mcp
declared    512  tests/ trees
declared     69  backend/alembic
declared      1  backend/main.py
declared      8  clients/python/examples
declared      1  clients/python/scripts
declared      3  examples/clients
audit: every source file is scanned or declared out of scope
```

Every `*.py` and `*.sh` in the repository is either under a target or named in `UNSCANNED_BY_DESIGN` **with a reason**. Anything in neither fails. It also fails on a *stale* declaration matching no file — same failure as a target expanding to nothing, one list drifting from the tree it describes while both stay green. CI runs `--audit` before the scan, so the log opens with the account rather than a bare verdict.

The audit deliberately does not decide whether a tree *should* be scanned. It refuses to let one be absent from both lists, which is the state all five misses were in.

## The audit's first finding, unfixed

`backend/alembic` holds four raise-site em dashes in downgrade guards, printed to an operator's terminal during a migration:

```
backend/alembic/versions/b6e1d3a9c740_energy_transfer_declaration_scope.py:144
backend/alembic/versions/c4d8f1b2a9e6_network_solve_kind.py:183
backend/alembic/versions/d3a7f1c9b284_reaction_atom_map.py:352
backend/alembic/versions/e3f4a5b6c7d8_stage3_curated_release_semantics.py:628
```

Not fixed here: `.claude/rules/migration-rules.md` forbids mutating a revision that has been applied to a deployed DB, and settling that is a separate decision from this PR. The exclusion's reason text carries all four anchors and a test asserts the count is still exactly 4 — so the exclusion records a known defect instead of converting it into an unknown one.

## Proof the gate does work rather than passes over nothing

- Gate green on the fixed tree, 586 files across six targets.
- **Gate red on the pre-fix tree**: `git archive HEAD` into scratch, exit 1, all ten findings above.
- Em dash reintroduced on disk in each newly-covered tree: caught (`uploads.py:271`, `config.py:56`, `normalizer.py:272`), gate exit 1.
- Every new target resolves non-empty; #166's exit-2-on-empty-directory still holds — repointing `MCP_INTEGRATION_TARGET` at a missing directory exits **2**, not 0.

## Mutation checks

| mutation | result |
|---|---|
| drop `CLIENT_PACKAGE_TARGET` from `DEFAULT_TARGETS` | 7 tests red |
| repoint it at `clients/python/src` (exists, wrong level) | 2 tests red — **only the literal-based ones** |
| repoint `MCP_INTEGRATION_TARGET` at a missing dir | gate exit 2; 9 tests red |
| reintroduce `§` in `normalizer.py` | 5 tests red |
| reintroduce `—` in `uploads.py` / `config.py` | gate exit 1 |
| drop the `backend/alembic` declaration | audit red, 69 files named |
| add a declaration matching nothing | audit red |
| make `repository_sources()` walk nothing | 5 tests red |
| make `audit()` never append to `undeclared` | 2 tests red |
| remove `--audit` from the CI step | 1 test red |

**One mutation tracked rather than caught, and it is pre-existing.** `test_a_green_run_says_what_it_read` asserts `len(lines) == len(checker.DEFAULT_TARGETS)`: delete a target and both sides move together, so it stayed green through mutation 1. That is exactly the shape to watch for. Every new coverage assertion in this PR is written against **path literals**, never against the checker's own constants — mutation 2 is the demonstration: the count-based and constant-derived assertions all stayed green, and only the literals caught it. The old assertion is now floored by `len(REQUIRED_TREES)`.

## Versions

| package | before | after |
|---|---|---|
| `tckdb-client` | 0.38.0 | 0.38.1 |
| `tckdb-chemkin` | 0.2.0 | 0.2.1 |
| `tckdb-schemas` | 0.30.0 | 0.30.0 (unchanged) |

`adapters/chemkin` **does** version separately — its own `pyproject.toml` and its own `__version__`, in two places that nothing reconciles. Both bumped, and `adapters/chemkin/tests/test_package_version.py` now pins them against each other.

No `tckdb-schemas` bump: only message text changed. No code value moved, no payload that validated stops validating, no field added or removed.

## Alembic

Head stays single at `b7e4d1a9c026`. No revision.

## Verification

- `test-rest.sh` 4321 passed / 14 skipped; `test-api.sh` 2711 passed; `test-scientific.sh` 2049 passed
- `clients/python` 1348 passed; `adapters/chemkin/tests` 55 passed / 1 skipped; `integrations/mcp` 578 passed; wire-contract 38 passed
- `ruff check app tests scripts` clean; `mypy` clean (149 files)
