### PR TITLE
Make three fields that did nothing either do it or say no

### DIFF
--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -68,6 +68,7 @@ from app.services.charge_multiplicity_extraction import (
 from app.services.conformer_resolution import resolve_conformer_group
 from app.services.energy_correction_resolution import (
     create_applied_energy_correction,
+    resolve_applied_correction_source_key,
     resolve_or_create_freq_scale_factor_ref,
 )
 from app.services.geometry_resolution import resolve_geometry_payload
@@ -407,6 +408,15 @@ def persist_computed_reaction_upload(
     geometry_key_to_id: dict[str, int] = {}
     calculation_key_to_id: dict[str, int] = {}
     observation_id_by_geometry_key: dict[str, int] = {}
+    # Conformer keys are scoped to the species that declared them, unlike
+    # calc and geometry keys which are globally unique across the bundle.
+    # That scoping is what makes an applied correction's
+    # ``source_conformer_key`` owner-correct by construction: a species's
+    # correction can only name that species's own conformers, so there is
+    # no sibling-species conformer to borrow and no separate owner check
+    # to write. Uniqueness within a species is enforced by the request
+    # model, so this map loses nothing.
+    observation_id_by_conformer_key: dict[str, dict[str, int]] = {}
     # Review-row targets accumulated as records are written so the
     # caller's ReviewPolicy can be applied at end-of-workflow.
     review_targets: list[RecordRef] = []
@@ -435,6 +445,7 @@ def persist_computed_reaction_upload(
         )
 
         # Conformers
+        conformers_by_key = observation_id_by_conformer_key.setdefault(sp.key, {})
         for conf in sp.conformers:
             geom_payload = conf.geometry.to_payload()
             geometry = resolve_geometry_payload(session, geom_payload)
@@ -472,6 +483,7 @@ def persist_computed_reaction_upload(
             session.add(observation)
             session.flush()
             observation_id_by_geometry_key[conf.geometry.key] = observation.id
+            conformers_by_key[conf.key] = observation.id
             review_targets.append(
                 RecordRef(SubmissionRecordType.conformer_group, conformer_group.id)
             )
@@ -799,10 +811,26 @@ def persist_computed_reaction_upload(
                         f"refers to a calculation that is not owned by this "
                         f"species entry."
                     )
+            source_conf_id = resolve_applied_correction_source_key(
+                ac.source_conformer_key,
+                observation_id_by_conformer_key.get(sp.key, {}),
+                field=(
+                    f"species['{sp.key}'].applied_energy_corrections[{i}]."
+                    f"source_conformer_key"
+                ),
+                declares=(
+                    "Every conformer under this species carries a required "
+                    "'key'; 'source_conformer_key' must match one of them. "
+                    "A sibling species's conformer is not in scope -- a "
+                    "correction targeting one species entry cannot cite "
+                    "another's structure."
+                ),
+            )
             applied = create_applied_energy_correction(
                 session,
                 ac,
                 target_species_entry_id=species_entry.id,
+                source_conformer_observation_id=source_conf_id,
                 source_calculation_id=source_calc_id,
                 created_by=created_by,
             )
@@ -823,10 +851,32 @@ def persist_computed_reaction_upload(
                         f"refers to a calculation that is not owned by this "
                         f"transition state entry."
                     )
+            # A transition state in this bundle declares no conformers at
+            # all -- it carries one geometry and its calculations, and no
+            # ``ConformerObservation`` is written for it. So the namespace
+            # is empty by construction, and any key names nothing. It is
+            # refused rather than ignored for the same reason every other
+            # source key is: a link the depositor believes they recorded
+            # and did not is worse than a link they were told they cannot
+            # make.
+            source_conf_id = resolve_applied_correction_source_key(
+                ac.source_conformer_key,
+                {},
+                field=(
+                    f"transition_state.applied_energy_corrections[{i}]."
+                    f"source_conformer_key"
+                ),
+                declares=(
+                    "A computed-reaction bundle declares conformers only "
+                    "under a species; its transition state has none, so a "
+                    "TS-side correction cannot name one."
+                ),
+            )
             applied = create_applied_energy_correction(
                 session,
                 ac,
                 target_transition_state_entry_id=ts_entry.id,
+                source_conformer_observation_id=source_conf_id,
                 source_calculation_id=source_calc_id,
                 created_by=created_by,
             )

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -34,6 +34,7 @@ from app.schemas.fragments.calculation import (
     SCFStabilityPayload,
 )
 from app.schemas.fragments.geometry import GeometryPayload
+from app.schemas.fragments.refs import WorkflowToolReleaseRef
 from app.schemas.workflows.computed_species_upload import (
     CalculationInBundle,
     ComputedSpeciesUploadRequest,
@@ -75,6 +76,7 @@ from app.services.charge_multiplicity_extraction import (
 from app.services.conformer_resolution import resolve_conformer_group
 from app.services.energy_correction_resolution import (
     create_applied_energy_correction,
+    resolve_applied_correction_source_key,
     resolve_or_create_freq_scale_factor_ref,
 )
 from app.services.geometry_resolution import resolve_geometry_payload
@@ -100,6 +102,15 @@ from app.services.species_resolution import resolve_species_entry
 from app.services.statmech_resolution import assert_statmech_role_compatible
 from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
 from app.workflows.thermo import assert_thermo_role_matches_calculation_type
+
+#: How a computed-species bundle declares a name in the conformer
+#: namespace, phrased as the object of the remedy sentence in
+#: ``resolve_applied_correction_source_key``.
+_BUNDLE_CONFORMER_KEY_REMEDY = (
+    "Every conformer in this bundle carries a required 'key'; "
+    "'source_conformer_key' must match one of them."
+)
+
 
 # ---------------------------------------------------------------------------
 # Outcome dataclasses
@@ -188,6 +199,7 @@ def _build_synthetic_thermo_upload_request(
     thermo_in: ThermoInBundle,
     *,
     species_entry_payload,
+    default_workflow_tool_release: WorkflowToolReleaseRef | None = None,
 ) -> ThermoUploadRequest:
     """Construct a ``ThermoUploadRequest`` from the bundle's thermo block.
 
@@ -196,13 +208,18 @@ def _build_synthetic_thermo_upload_request(
     ``source_calculations``) — those resolve from the bundle's calc-key
     namespace separately. The synthetic request is fed to
     ``resolve_thermo_upload`` to pick up provenance resolution for free.
+
+    ``default_workflow_tool_release`` is the bundle root's value, applied
+    only where the thermo block itself names none.
     """
     return ThermoUploadRequest(
         species_entry=species_entry_payload,
         scientific_origin=thermo_in.scientific_origin,
         literature=thermo_in.literature,
         software_release=thermo_in.software_release,
-        workflow_tool_release=thermo_in.workflow_tool_release,
+        workflow_tool_release=(
+            thermo_in.workflow_tool_release or default_workflow_tool_release
+        ),
         h298_kj_mol=thermo_in.h298_kj_mol,
         s298_j_mol_k=thermo_in.s298_j_mol_k,
         h298_uncertainty_kj_mol=thermo_in.h298_uncertainty_kj_mol,
@@ -474,7 +491,14 @@ def persist_computed_species_upload(
             )
         )
 
-    # Build the local-key → Calculation map for cross-references.
+    # Build the local-key → row maps for cross-references. Conformer keys
+    # are required and unique across the bundle
+    # (``validate_unique_conformer_keys``), so this is a total namespace:
+    # every conformer a depositor can name is in it, and nothing else is.
+    conformer_keys_to_observation_id: dict[str, int] = {
+        outcome.conformer_in_bundle.key: outcome.observation.id
+        for outcome in conformer_outcomes
+    }
     calc_keys_to_id: dict[str, Calculation] = {}
     for outcome in conformer_outcomes:
         calc_keys_to_id[outcome.conformer_in_bundle.primary_calculation.key] = (
@@ -541,12 +565,21 @@ def persist_computed_species_upload(
     # names its subject unambiguously and matches the real payload path.
     # The reaction bundle, which carries many species, prefixes with the
     # species key instead.
+    #
+    # ``collect_provenance_warnings`` documents that callers pass the
+    # *effective* value rather than the raw field, which is now the
+    # bundle-level fallback where the block itself is silent — warning
+    # about provenance that was in fact recorded is the same lie in the
+    # other direction.
     if request.thermo is not None:
         upload_warnings.extend(
             collect_provenance_warnings(
                 scientific_origin=request.thermo.scientific_origin,
                 software_release=request.thermo.software_release,
-                workflow_tool_release=request.thermo.workflow_tool_release,
+                workflow_tool_release=(
+                    request.thermo.workflow_tool_release
+                    or request.workflow_tool_release
+                ),
                 literature=request.thermo.literature,
                 field_prefix="thermo.",
             )
@@ -556,7 +589,10 @@ def persist_computed_species_upload(
             collect_provenance_warnings(
                 scientific_origin=request.statmech.scientific_origin,
                 software_release=request.statmech.software_release,
-                workflow_tool_release=request.statmech.workflow_tool_release,
+                workflow_tool_release=(
+                    request.statmech.workflow_tool_release
+                    or request.workflow_tool_release
+                ),
                 literature=request.statmech.literature,
                 freq_scale_factor=request.statmech.freq_scale_factor,
                 field_prefix="statmech.",
@@ -617,6 +653,8 @@ def persist_computed_species_upload(
             request,
             species_entry_id=species_entry.id,
             calc_keys_to_id=calc_keys_to_id,
+            conformer_keys_to_observation_id=conformer_keys_to_observation_id,
+            default_workflow_tool_release=request.workflow_tool_release,
             created_by=created_by,
         )
 
@@ -625,6 +663,7 @@ def persist_computed_species_upload(
             request.statmech,
             species_entry_id=species_entry.id,
             calc_keys_to_id=calc_keys_to_id,
+            default_workflow_tool_release=request.workflow_tool_release,
             created_by=created_by,
             warnings=upload_warnings,
         )
@@ -648,6 +687,7 @@ def persist_computed_species_upload(
             request,
             species_entry_id=species_entry.id,
             calc_keys_to_id=calc_keys_to_id,
+            conformer_keys_to_observation_id=conformer_keys_to_observation_id,
             created_by=created_by,
         )
 
@@ -716,12 +756,17 @@ def _persist_thermo_block(
     *,
     species_entry_id: int,
     calc_keys_to_id: dict[str, Calculation],
+    conformer_keys_to_observation_id: dict[str, int],
+    default_workflow_tool_release: WorkflowToolReleaseRef | None = None,
     created_by: int | None,
 ) -> tuple[Thermo | None, list[int]]:
     """Persist optional thermo + nested AECs.
 
     Returns ``(thermo_row | None, applied_correction_ids)`` so the caller
     can record review state for both the thermo row and each AEC row.
+
+    ``default_workflow_tool_release`` is the bundle-level fallback used
+    when the thermo block names no workflow tool of its own.
     """
     if request.thermo is None:
         return None, []
@@ -758,7 +803,9 @@ def _persist_thermo_block(
         )
 
     synthetic = _build_synthetic_thermo_upload_request(
-        thermo_in, species_entry_payload=request.species_entry
+        thermo_in,
+        species_entry_payload=request.species_entry,
+        default_workflow_tool_release=default_workflow_tool_release,
     )
     thermo_create = resolve_thermo_upload(
         session, synthetic, species_entry_id=species_entry_id
@@ -788,10 +835,21 @@ def _persist_thermo_block(
             )
             source_calc_id = calc_row.id
 
+        source_conf_id = resolve_applied_correction_source_key(
+            ac.source_conformer_key,
+            conformer_keys_to_observation_id,
+            field=(
+                f"thermo.applied_energy_corrections[{i}]."
+                f"source_conformer_key"
+            ),
+            declares=_BUNDLE_CONFORMER_KEY_REMEDY,
+        )
+
         applied = create_applied_energy_correction(
             session,
             ac,
             target_species_entry_id=species_entry_id,
+            source_conformer_observation_id=source_conf_id,
             source_calculation_id=source_calc_id,
             created_by=created_by,
         )
@@ -806,6 +864,7 @@ def _persist_top_level_applied_corrections(
     *,
     species_entry_id: int,
     calc_keys_to_id: dict[str, Calculation],
+    conformer_keys_to_observation_id: dict[str, int],
     created_by: int | None,
 ) -> list[int]:
     """Persist bundle-level applied energy corrections (AEC/BAC).
@@ -813,8 +872,9 @@ def _persist_top_level_applied_corrections(
     Top-level applied corrections target the bundle's species entry.
     Each ``source_calculation_key`` is resolved against the bundle's
     global calc-key namespace and verified to belong to the same
-    species entry; the row + optional component breakdown are written
-    via the shared ``create_applied_energy_correction`` service.
+    species entry; each ``source_conformer_key`` is resolved against the
+    bundle's conformer keys. The row + optional component breakdown are
+    written via the shared ``create_applied_energy_correction`` service.
 
     Returns the list of created AEC ids so the caller can record review
     state for each one.
@@ -839,10 +899,18 @@ def _persist_top_level_applied_corrections(
             )
             source_calc_id = calc_row.id
 
+        source_conf_id = resolve_applied_correction_source_key(
+            ac.source_conformer_key,
+            conformer_keys_to_observation_id,
+            field=f"applied_energy_corrections[{i}].source_conformer_key",
+            declares=_BUNDLE_CONFORMER_KEY_REMEDY,
+        )
+
         applied = create_applied_energy_correction(
             session,
             ac,
             target_species_entry_id=species_entry_id,
+            source_conformer_observation_id=source_conf_id,
             source_calculation_id=source_calc_id,
             created_by=created_by,
         )
@@ -857,6 +925,7 @@ def _persist_statmech_block(
     species_entry_id: int | None = None,
     transition_state_entry_id: int | None = None,
     calc_keys_to_id: dict[str, Calculation],
+    default_workflow_tool_release: WorkflowToolReleaseRef | None = None,
     created_by: int | None,
     warnings: list[UploadWarning] | None = None,
 ) -> Statmech | None:
@@ -887,9 +956,14 @@ def _persist_statmech_block(
         if s.software_release is not None
         else None
     )
+    # The statmech block's own value wins; the caller's bundle-level
+    # default fills in only where the block stays silent.
+    statmech_workflow_tool_ref = (
+        s.workflow_tool_release or default_workflow_tool_release
+    )
     workflow_tool_release = (
-        resolve_workflow_tool_release_ref(session, s.workflow_tool_release)
-        if s.workflow_tool_release is not None
+        resolve_workflow_tool_release_ref(session, statmech_workflow_tool_ref)
+        if statmech_workflow_tool_ref is not None
         else None
     )
 

--- a/backend/app/workflows/conformer.py
+++ b/backend/app/workflows/conformer.py
@@ -206,13 +206,23 @@ def persist_conformer_upload(
             created_by=created_by,
         )
 
-    # The one name this request gives the conformer it is depositing. A
-    # conformer upload creates exactly one observation, and ``label`` is
-    # the only string the depositor attaches to it, so it is the whole
-    # conformer namespace here -- unlike the bundle, where every
-    # ``ConformerInBundle`` carries a required ``key``.
+    # The name this request gives the conformer it is depositing, which
+    # is now a name chosen to be one: ``conformer_key``, the conformer
+    # namespace's counterpart to the ``key`` this request already puts on
+    # its calculations, and to the required ``key`` every
+    # ``ConformerInBundle`` carries.
+    #
+    # It used to be ``label``, because a label was the only string a
+    # conformer upload attached to its conformer. That conflated two
+    # different things. A label is a human tag that also feeds
+    # conformer-group matching, so renaming it for grouping reasons
+    # silently broke a correction reference; and a depositor with no
+    # label could not point at their own conformer at all. A reference
+    # key answers only to references.
     conformers_by_key: dict[str, int] = (
-        {request.label: observation.id} if request.label is not None else {}
+        {request.conformer_key: observation.id}
+        if request.conformer_key is not None
+        else {}
     )
 
     applied_corrections: list = []
@@ -230,8 +240,10 @@ def persist_conformer_upload(
                 f"applied_energy_corrections[{index}].source_conformer_key"
             ),
             declares=(
-                "A conformer upload names its conformer with the "
-                "request's 'label'."
+                "Put a matching 'conformer_key' on the request. It is "
+                "deliberately not 'label' -- a label also drives "
+                "conformer-group matching, so a reference to it breaks "
+                "when the label is changed for grouping reasons."
             ),
         )
         source_calc_id = resolve_applied_correction_source_key(

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -978,7 +978,7 @@
       },
       "AppliedEnergyCorrectionUploadPayload": {
         "additionalProperties": false,
-        "description": "Upload-facing payload for one applied energy correction.\n\nExactly one of ``scheme`` or ``frequency_scale_factor`` must be provided.\nThe ``source_conformer_key`` and ``source_calculation_key`` are local\nstring keys that reference other objects in the same upload bundle;\nthey are resolved to integer IDs by the workflow orchestrator.",
+        "description": "Upload-facing payload for one applied energy correction.\n\nExactly one of ``scheme`` or ``frequency_scale_factor`` must be provided.\nThe ``source_conformer_key`` and ``source_calculation_key`` are local\nstring keys that reference other objects in the same upload bundle;\nthey are resolved to integer IDs by the workflow orchestrator.\n\nBoth keys resolve against a namespace the *enclosing* request\ndeclared, and a key naming nothing in it is refused with\n``applied_energy_correction_source_key_undeclared`` rather than\ndropped. ``source_conformer_key`` names the request's\n``conformer_key`` on ``/uploads/conformers``; ``conformers[*].key``\non ``/uploads/computed-species``; and, on\n``/uploads/computed-reaction``, ``conformers[*].key`` of the species\nthe correction sits under — a transition state declares no\nconformers there, so a TS-side correction can never name one.\nScoping the reaction bundle's conformer namespace to one species is\nwhat makes ownership true by construction: a correction targeting\none species entry cannot borrow another's conformer.",
         "properties": {
           "application_role": {
             "$ref": "#/components/schemas/tckdb_schemas__enums__EnergyCorrectionApplicationRole"
@@ -2604,7 +2604,7 @@
         "description": "A species defined within this kinetics bundle.\n\n:param key: Local key for referencing this species in the reaction.\n:param species_entry: Species identity (SMILES, charge, multiplicity).\n:param conformers: Conformer observations (geometry + opt calculation). Each\n    list item creates a distinct observation row, even when multiple items\n    land in the same conformer group.\n:param calculations: Additional calculations (freq, sp at higher LOT). Their\n    ``geometry_key`` must reference one of this species's conformer\n    geometries so the backend can anchor them to the correct observation.\n:param thermo: Optional thermochemistry data.",
         "properties": {
           "applied_energy_corrections": {
-            "description": "Applied energy corrections targeting this species's resolved species_entry. Use for scheme-backed corrections such as AEC totals (application_role=aec_total) and BAC totals (application_role=bac_total). ``source_calculation_key`` resolves against the bundle's global calculation namespace; the workflow rejects 422 when the referenced calc is not owned by this species.",
+            "description": "Applied energy corrections targeting this species's resolved species_entry. Use for scheme-backed corrections such as AEC totals (application_role=aec_total) and BAC totals (application_role=bac_total). ``source_calculation_key`` resolves against the bundle's global calculation namespace; the workflow rejects 422 when the referenced calc is not owned by this species. ``source_conformer_key`` resolves against this species's own ``conformers[*].key`` — a sibling species's conformer is not in scope and is refused.",
             "items": {
               "$ref": "#/components/schemas/AppliedEnergyCorrectionInBundle"
             },
@@ -3110,7 +3110,7 @@
         "description": "Transition state for the reaction in this bundle.\n\n:param charge: Net charge of the TS structure.\n:param multiplicity: Spin multiplicity.\n:param unmapped_smiles: Optional SMILES for the TS.\n:param geometry: Saddle-point geometry.\n:param calculation: Primary opt calculation.\n:param calculations: Additional calculations (freq, sp, irc).\n:param label: Optional label.\n:param note: Optional note.",
         "properties": {
           "applied_energy_corrections": {
-            "description": "Applied energy corrections targeting the resolved transition_state_entry directly. TS-side corrections are never stored as reaction-entry corrections. ``source_calculation_key`` resolves against the bundle's global calculation namespace; the workflow rejects 422 when the referenced calc is not owned by this transition state.",
+            "description": "Applied energy corrections targeting the resolved transition_state_entry directly. TS-side corrections are never stored as reaction-entry corrections. ``source_calculation_key`` resolves against the bundle's global calculation namespace; the workflow rejects 422 when the referenced calc is not owned by this transition state. ``source_conformer_key`` has nothing to resolve against here — a transition state in this bundle declares no conformers — so setting it is refused rather than ignored.",
             "items": {
               "$ref": "#/components/schemas/AppliedEnergyCorrectionInBundle"
             },
@@ -10093,10 +10093,10 @@
       },
       "ComputedSpeciesUploadRequest": {
         "additionalProperties": false,
-        "description": "Bundle upload payload for one computed species result.",
+        "description": "Bundle upload payload for one computed species result.\n\n``workflow_tool_release`` is the bundle-level default: the thermo and\nstatmech blocks fall back to it when they name no workflow tool of\ntheir own, and a block that names one overrides it. That is the same\nprecedence ``ComputedReactionUploadRequest`` has always applied to\nits ``literature`` / ``analysis_software_release`` /\n``workflow_tool_release`` trio.\n\n``note`` is **not** persisted by this route. It is recorded here so\nthe omission is stated rather than discovered: the bundle has no row\nof its own to carry a bundle-level note, and choosing one is a\nseparate decision from wiring a field that already has a home.",
         "properties": {
           "applied_energy_corrections": {
-            "description": "Applied energy corrections targeting the bundle's species entry (one bundle = one species entry). Use this for scheme-backed corrections such as AEC totals (application_role=aec_total) and BAC totals (application_role=bac_total). Frequency-scale-factor corrections still belong on thermo/statmech blocks where their source calc lives.",
+            "description": "Applied energy corrections targeting the bundle's species entry (one bundle = one species entry). Use this for scheme-backed corrections such as AEC totals (application_role=aec_total) and BAC totals (application_role=bac_total). Frequency-scale-factor corrections still belong on thermo/statmech blocks where their source calc lives. ``source_conformer_key`` resolves against this bundle's conformer keys.",
             "items": {
               "$ref": "#/components/schemas/AppliedEnergyCorrectionInBundle"
             },
@@ -10120,6 +10120,7 @@
                 "type": "null"
               }
             ],
+            "description": "Free-text note about the bundle. Accepted and validated but not persisted: there is no bundle-level row to carry it.",
             "title": "Note"
           },
           "species_entry": {
@@ -10153,7 +10154,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Bundle-level workflow-tool provenance. Used as the default for the thermo and statmech blocks; a value on either of those overrides it."
           }
         },
         "required": [
@@ -11745,6 +11747,19 @@
           },
           "calculation": {
             "$ref": "#/components/schemas/ConformerCalculationIn"
+          },
+          "conformer_key": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional local name for the single conformer observation this upload creates, referenced from ``applied_energy_corrections[*].source_conformer_key``. It is the conformer namespace's counterpart to ``ConformerCalculationIn.key``, and it is deliberately not ``label``: a label is a human tag that also participates in conformer-group matching, so renaming it for grouping reasons would silently break a correction reference, and a depositor who has no label has no way to point at their own conformer. Optional by design — a payload with no conformer cross-reference never needs one.",
+            "title": "Conformer Key"
           },
           "geometry": {
             "$ref": "#/components/schemas/GeometryPayload"

--- a/backend/tests/api/test_api_bundle_thermo_and_scf_provenance.py
+++ b/backend/tests/api/test_api_bundle_thermo_and_scf_provenance.py
@@ -28,7 +28,9 @@ from sqlalchemy import select
 
 from app.db.models.calculation import Calculation, CalculationSCFStability
 from app.db.models.common import SCFStabilityStatus, ThermoCalculationRole
+from app.db.models.statmech import Statmech
 from app.db.models.thermo import Thermo, ThermoSourceCalculation
+from app.db.models.workflow import WorkflowToolRelease
 
 _SOFTWARE = {"name": "Gaussian", "version": "16"}
 _LOT = {"method": "wb97xd", "basis": "def2tzvp"}
@@ -426,3 +428,127 @@ def test_calculation_rows_are_shared_not_duplicated_by_thermo_links(
         )
     ).one()
     assert link.calculation_id == total
+
+
+# ---------------------------------------------------------------------------
+# A bundle-level workflow tool, on the root that never read it
+# ---------------------------------------------------------------------------
+
+
+_ARC = {"name": "ARC", "version": "1.1.0"}
+
+
+class TestSpeciesBundleLevelWorkflowTool:
+    """``ComputedSpeciesUploadRequest.workflow_tool_release`` did nothing.
+
+    The reaction root declared its ``workflow_tool_release`` and read it
+    in the same commit (2026-03-22); the species root declared the same
+    field five weeks later and no commit ever wired it. That is drift,
+    not design — so it is now the bundle-level default the thermo and
+    statmech blocks inherit, the precedence the reaction root already
+    applies to this field and its two siblings.
+
+    The sharpest symptom was not the missing link. A depositor who filled
+    the field in was *also* told, in the 201 body, that their record was
+    missing workflow-tool provenance.
+    """
+
+    def test_thermo_inherits_the_bundle_level_tool(self, client, db_session):
+        bundle = _species_bundle(
+            workflow_tool_release=dict(_ARC),
+            thermo={"scientific_origin": "computed", "h298_kj_mol": 218.0},
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        thermo = db_session.get(Thermo, resp.json()["thermo"]["thermo_id"])
+        assert thermo.workflow_tool_release_id is not None
+
+    def test_statmech_inherits_the_bundle_level_tool(self, client, db_session):
+        bundle = _species_bundle(
+            workflow_tool_release=dict(_ARC),
+            statmech={"external_symmetry": 1, "statmech_treatment": "rrho"},
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        statmech = db_session.get(
+            Statmech, resp.json()["statmech"]["statmech_id"]
+        )
+        assert statmech.workflow_tool_release_id is not None
+
+    def test_a_block_level_tool_overrides_the_bundle_default(
+        self, client, db_session
+    ):
+        """Fallback, not replacement — the block that speaks wins."""
+        bundle = _species_bundle(
+            workflow_tool_release=dict(_ARC),
+            thermo={
+                "scientific_origin": "computed",
+                "h298_kj_mol": 218.0,
+                "workflow_tool_release": {"name": "Arkane", "version": "3.2"},
+            },
+            statmech={"external_symmetry": 1, "statmech_treatment": "rrho"},
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        thermo = db_session.get(Thermo, resp.json()["thermo"]["thermo_id"])
+        statmech = db_session.get(
+            Statmech, resp.json()["statmech"]["statmech_id"]
+        )
+        thermo_release = db_session.get(
+            WorkflowToolRelease, thermo.workflow_tool_release_id
+        )
+        statmech_release = db_session.get(
+            WorkflowToolRelease, statmech.workflow_tool_release_id
+        )
+        assert thermo_release.version == "3.2"
+        # The silent block still inherits, so the override is scoped.
+        assert statmech_release.version == "1.1.0"
+        assert thermo.workflow_tool_release_id != (
+            statmech.workflow_tool_release_id
+        )
+
+    def test_the_bundle_no_longer_warns_about_what_it_was_given(
+        self, client
+    ):
+        """The 201 body used to report the filled-in field as missing."""
+        bundle = _species_bundle(
+            workflow_tool_release=dict(_ARC),
+            thermo={"scientific_origin": "computed", "h298_kj_mol": 218.0},
+            statmech={"external_symmetry": 1, "statmech_treatment": "rrho"},
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "missing_workflow_tool_provenance" not in codes
+        # The other gaps this bundle really does have are still reported,
+        # so the assertion above is not passing over an empty set.
+        assert "missing_software_release_provenance" in codes
+
+    def test_a_bundle_that_names_no_tool_still_warns(self, client):
+        """The red half: silence is still reported as silence."""
+        bundle = _species_bundle(
+            thermo={"scientific_origin": "computed", "h298_kj_mol": 218.0},
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        codes = {w["code"] for w in resp.json()["warnings"]}
+        assert "missing_workflow_tool_provenance" in codes
+
+    def test_the_root_note_is_still_not_persisted(self, client, db_session):
+        """Stated, not discovered.
+
+        ``note`` is the species root's other unread field. It is left
+        unwired deliberately: unlike ``workflow_tool_release`` it has no
+        row to go to — the bundle owns no record of its own — so giving
+        it one is a decision about what a bundle-level note *is*, not the
+        wiring omission this change fixes. The field now says so in its
+        own description, and this test pins that the claim is true.
+        """
+        bundle = _species_bundle(
+            note="this note goes nowhere",
+            thermo={"scientific_origin": "computed", "h298_kj_mol": 218.0},
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        thermo = db_session.get(Thermo, resp.json()["thermo"]["thermo_id"])
+        assert thermo.note is None

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 from sqlalchemy import select
 
 from app.db.models.calculation import Calculation
+from app.db.models.energy_correction import AppliedEnergyCorrection
+from app.db.models.species import ConformerObservation
 
 _SOFTWARE = {"name": "Gaussian", "version": "16"}
 _LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
@@ -298,26 +300,104 @@ class TestConformerCorrectionSourceKeys:
         resp = client.post("/api/v1/uploads/conformers", json=payload)
         assert resp.status_code == 201, resp.text
 
-    def test_conformer_key_that_is_not_the_label_is_refused(self, client):
+    def test_conformer_key_that_names_nothing_is_refused(self, client):
         payload = _conformer_payload(
             "conf-aec-label",
+            conformer_key="the-conformer",
             applied_energy_corrections=[
                 _zpe_correction(source_conformer_key="some-other-conformer")
             ],
         )
         resp = client.post("/api/v1/uploads/conformers", json=payload)
         body = _assert_code(resp, _KEY_UNDECLARED)
-        assert body["context"]["declared_keys"] == ["conf-aec-label"]
+        assert body["context"]["declared_keys"] == ["the-conformer"]
 
-    def test_conformer_key_matching_the_label_is_accepted(self, client):
+    def test_the_declared_conformer_key_is_accepted_and_persisted(
+        self, client, db_session
+    ):
         payload = _conformer_payload(
-            "conf-aec-good-label",
+            "conf-aec-good-key",
+            conformer_key="the-conformer",
             applied_energy_corrections=[
-                _zpe_correction(source_conformer_key="conf-aec-good-label")
+                _zpe_correction(source_conformer_key="the-conformer")
             ],
         )
         resp = client.post("/api/v1/uploads/conformers", json=payload)
         assert resp.status_code == 201, resp.text
+        # ``id`` on this route is the conformer observation the upload
+        # created -- the row a source_conformer_key must point at.
+        observation_id = resp.json()["id"]
+        row = db_session.scalars(
+            select(AppliedEnergyCorrection).order_by(
+                AppliedEnergyCorrection.id.desc()
+            )
+        ).first()
+        # A 201 proves the payload was accepted, not that the link exists.
+        assert row.source_conformer_observation_id == observation_id
+
+
+class TestTheConformerNamespaceIsNotTheLabel:
+    """A reference key answers to references; a label does not.
+
+    ``source_conformer_key`` used to resolve against ``request.label``,
+    because a label was the only string a conformer upload attached to
+    its conformer. That conflated two jobs. ``label`` is a human tag that
+    also feeds conformer-group matching, so renaming it for grouping
+    reasons silently broke a correction reference; and a depositor who
+    set no label could not name their own conformer at all — the exact
+    shape of "a field that cannot be right".
+
+    ``conformer_key`` is the conformer namespace's counterpart to the
+    ``key`` this same request already puts on its calculations.
+    """
+
+    def test_a_label_is_no_longer_a_reference(self, client):
+        """The old spelling now refuses instead of resolving."""
+        payload = _conformer_payload(
+            "conf-label-not-key",
+            applied_energy_corrections=[
+                _zpe_correction(source_conformer_key="conf-label-not-key")
+            ],
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        # Nothing at all is declared: the label is not in the namespace.
+        assert body["context"]["declared_keys"] == []
+        assert body["context"]["key"] == "conf-label-not-key"
+
+    def test_a_label_does_not_shadow_a_different_conformer_key(self, client):
+        """Setting both, the key is the one that resolves — not the label."""
+        payload = _conformer_payload(
+            "a-human-label",
+            conformer_key="a-machine-key",
+            applied_energy_corrections=[
+                _zpe_correction(source_conformer_key="a-human-label")
+            ],
+        )
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert body["context"]["declared_keys"] == ["a-machine-key"]
+
+    def test_a_conformer_with_no_label_can_still_be_named(
+        self, client, db_session
+    ):
+        """The case that was previously impossible to express."""
+        payload = _conformer_payload(
+            None,
+            conformer_key="unlabelled-conformer",
+            applied_energy_corrections=[
+                _zpe_correction(source_conformer_key="unlabelled-conformer")
+            ],
+        )
+        payload.pop("label")
+        resp = client.post("/api/v1/uploads/conformers", json=payload)
+        assert resp.status_code == 201, resp.text
+        row = db_session.scalars(
+            select(AppliedEnergyCorrection).order_by(
+                AppliedEnergyCorrection.id.desc()
+            )
+        ).first()
+        assert row.source_conformer_observation_id == resp.json()["id"]
 
 
 # ---------------------------------------------------------------------------
@@ -933,3 +1013,299 @@ class TestBundleRoutesDoNotOfferChaining:
         )
         resp = client.post("/api/v1/uploads/computed-species", json=payload)
         assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# The same rule on the two bundle routes — the ones ARC deposits through
+# ---------------------------------------------------------------------------
+
+
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2 = "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+_XYZ_TS = "2\nH...H\nH 0.0 0.0 0.0\nH 0.0 0.0 1.40"
+
+
+def _aec_total(**overrides) -> dict:
+    """One scheme-backed AEC total, naming no source key by default."""
+    base: dict = {
+        "scheme": {"name": "AEC-key-contract", "kind": "atom_energy"},
+        "application_role": "aec_total",
+        "value": -0.0012,
+        "value_unit": "hartree",
+    }
+    base.update(overrides)
+    return base
+
+
+def _latest_correction(db_session) -> AppliedEnergyCorrection:
+    """The row the request under test just wrote.
+
+    Asserted against the database rather than the response body: a 201
+    proves the payload was accepted, not that the link was stored — which
+    is precisely the distinction this whole file exists to make.
+    """
+    row = db_session.scalars(
+        select(AppliedEnergyCorrection).order_by(
+            AppliedEnergyCorrection.id.desc()
+        )
+    ).first()
+    assert row is not None, "no applied_energy_correction row was written"
+    return row
+
+
+def _rxn_opt(key: str) -> dict:
+    return {
+        "key": key,
+        "type": "opt",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "opt_converged": True,
+    }
+
+
+def _rxn_species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": _rxn_opt(f"{key}-opt"),
+            }
+        ],
+    }
+
+
+def _rxn_bundle() -> dict:
+    """``H + H -> H2``. Two species, so a sibling conformer key exists."""
+    return {
+        "species": [
+            _rxn_species("h", "[H]", 2, _XYZ_H),
+            _rxn_species("h2", "[H][H]", 1, _XYZ_H2),
+        ],
+        "reversible": True,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+    }
+
+
+def _rxn_bundle_with_ts() -> dict:
+    bundle = _rxn_bundle()
+    bundle["transition_state"] = {
+        "charge": 0,
+        "multiplicity": 3,
+        "geometry": {"key": "ts-geom", "xyz_text": _XYZ_TS},
+        "calculation": _rxn_opt("ts-opt"),
+        "calculations": [
+            {
+                "key": "ts-freq",
+                "type": "freq",
+                "geometry_key": "ts-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 1,
+                "freq_imag_freq_cm1": -1500.0,
+                "freq_frequencies_cm1": [-1500.0],
+            }
+        ],
+    }
+    return bundle
+
+
+class TestSpeciesBundleConformerSourceKeys:
+    """``source_conformer_key`` was inert on both bundle roots.
+
+    ``/uploads/conformers`` got this rule; the bundles never did. Both
+    bundle workflows passed only ``source_calculation_id`` to
+    ``create_applied_energy_correction`` and never read
+    ``source_conformer_key`` at all — so a depositor naming a real
+    conformer got a 201 with ``source_conformer_observation_id`` NULL,
+    and a depositor naming one that does not exist got the identical
+    201. By deposit volume this was the larger half: these are the two
+    routes the ARC adapter uses.
+    """
+
+    def test_a_declared_conformer_key_is_persisted(self, client, db_session):
+        payload = _bundle_payload(
+            applied_energy_corrections=[_aec_total(source_conformer_key="c0")]
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text
+        observation_id = resp.json()["conformers"][0][
+            "conformer_observation_id"
+        ]
+        assert (
+            _latest_correction(db_session).source_conformer_observation_id
+            == observation_id
+        )
+
+    def test_an_undeclared_conformer_key_is_refused(self, client):
+        payload = _bundle_payload(
+            applied_energy_corrections=[_aec_total(source_conformer_key="c1")]
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert body["context"]["key"] == "c1"
+        assert body["context"]["declared_keys"] == ["c0"]
+        assert (
+            body["context"]["field"]
+            == "applied_energy_corrections[0].source_conformer_key"
+        )
+
+    def test_the_rule_reaches_thermos_nested_corrections_too(self, client):
+        """Two lists of corrections in this bundle, one rule."""
+        payload = _bundle_payload(
+            thermo={
+                "h298_kj_mol": 217.998,
+                "applied_energy_corrections": [
+                    _aec_total(source_conformer_key="not-a-conformer")
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert (
+            body["context"]["field"]
+            == "thermo.applied_energy_corrections[0].source_conformer_key"
+        )
+
+    def test_a_declared_key_under_thermo_is_persisted(
+        self, client, db_session
+    ):
+        payload = _bundle_payload(
+            thermo={
+                "h298_kj_mol": 217.998,
+                "applied_energy_corrections": [
+                    _aec_total(source_conformer_key="c0")
+                ],
+            }
+        )
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text
+        observation_id = resp.json()["conformers"][0][
+            "conformer_observation_id"
+        ]
+        assert (
+            _latest_correction(db_session).source_conformer_observation_id
+            == observation_id
+        )
+
+    def test_omitting_the_key_still_leaves_the_link_unset(
+        self, client, db_session
+    ):
+        """The green half: silence stays silence, and is not a refusal."""
+        payload = _bundle_payload(applied_energy_corrections=[_aec_total()])
+        resp = client.post("/api/v1/uploads/computed-species", json=payload)
+        assert resp.status_code == 201, resp.text
+        assert (
+            _latest_correction(db_session).source_conformer_observation_id
+            is None
+        )
+
+
+class TestReactionBundleConformerSourceKeys:
+    """The reaction bundle scopes the conformer namespace to one species.
+
+    Calculation keys are global across that bundle, with ownership
+    checked separately afterwards. Conformer keys are not: a correction
+    targeting one species entry resolves only against that species's own
+    ``conformers[*].key``, which makes ownership true by construction
+    rather than by a second check that can be forgotten — and it is why
+    the request model now requires those keys to be unique within a
+    species, which nothing enforced before.
+    """
+
+    def test_a_declared_conformer_key_is_persisted(self, client, db_session):
+        bundle = _rxn_bundle()
+        bundle["species"][0]["applied_energy_corrections"] = [
+            _aec_total(source_conformer_key="h-conf")
+        ]
+        resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        row = _latest_correction(db_session)
+        assert row.source_conformer_observation_id is not None
+        observation = db_session.get(
+            ConformerObservation, row.source_conformer_observation_id
+        )
+        assert observation is not None
+
+    def test_an_undeclared_conformer_key_is_refused(self, client):
+        bundle = _rxn_bundle()
+        bundle["species"][0]["applied_energy_corrections"] = [
+            _aec_total(source_conformer_key="h-confomer")
+        ]
+        resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert body["context"]["declared_keys"] == ["h-conf"]
+        assert body["context"]["field"] == (
+            "species['h'].applied_energy_corrections[0].source_conformer_key"
+        )
+
+    def test_a_sibling_species_conformer_is_out_of_scope(self, client):
+        """The ownership rule, expressed as a namespace rather than a check."""
+        bundle = _rxn_bundle()
+        bundle["species"][0]["applied_energy_corrections"] = [
+            _aec_total(source_conformer_key="h2-conf")
+        ]
+        resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        # The sibling's key is really present in this payload and is
+        # still refused; the message names only what is in scope.
+        assert body["context"]["key"] == "h2-conf"
+        assert body["context"]["declared_keys"] == ["h-conf"]
+
+    def test_duplicate_conformer_keys_within_a_species_are_refused(
+        self, client
+    ):
+        """An ambiguous key is the defect that keys exist to remove."""
+        bundle = _rxn_bundle()
+        species = bundle["species"][0]
+        species["conformers"] = [
+            species["conformers"][0],
+            {
+                "key": "h-conf",
+                "geometry": {"key": "h-geom-2", "xyz_text": _XYZ_H},
+                "calculation": _rxn_opt("h-opt-2"),
+            },
+        ]
+        resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        assert resp.status_code == 422, resp.text[:400]
+        assert resp.json()["code"] == "request_validation_error"
+
+    def test_a_transition_state_correction_cannot_name_a_conformer(
+        self, client
+    ):
+        """A TS in this bundle declares no conformers, so no key can be right.
+
+        Refusing beats ignoring for the reason it does everywhere else:
+        the depositor believes they recorded a link and did not.
+        """
+        bundle = _rxn_bundle_with_ts()
+        bundle["transition_state"]["applied_energy_corrections"] = [
+            _aec_total(source_conformer_key="ts-conf")
+        ]
+        resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        body = _assert_code(resp, _KEY_UNDECLARED)
+        assert body["context"]["declared_keys"] == []
+        assert body["context"]["field"] == (
+            "transition_state.applied_energy_corrections[0]."
+            "source_conformer_key"
+        )
+
+    def test_a_transition_state_correction_without_a_key_still_uploads(
+        self, client, db_session
+    ):
+        bundle = _rxn_bundle_with_ts()
+        bundle["transition_state"]["applied_energy_corrections"] = [
+            _aec_total()
+        ]
+        resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+        assert resp.status_code == 201, resp.text[:800]
+        row = _latest_correction(db_session)
+        assert row.source_conformer_observation_id is None
+        assert row.target_transition_state_entry_id is not None

--- a/backend/tests/workflows/test_conformer_upload.py
+++ b/backend/tests/workflows/test_conformer_upload.py
@@ -685,12 +685,20 @@ def test_conformer_upload_rejects_irc_additional() -> None:
 # resolved to the primary observation/calculation. The test that matters is
 # therefore not the rejection but the acceptance: a correction naming the
 # additional freq calculation must land on that row, not on the primary.
+#
+# The conformer half then resolved against ``label`` for a while, because a
+# label was the only name this request gave its single conformer. That was
+# still a conflation -- a label is a human tag that also feeds
+# conformer-group matching -- so the namespace is now the request's own
+# ``conformer_key``, the counterpart to the ``key`` it already puts on its
+# calculations.
 # ---------------------------------------------------------------------------
 
 
 def _correction_request(
     *,
     label: str,
+    conformer_key: str | None = None,
     source_calculation_key: str | None = "primary_sp",
     source_conformer_key: str | None = None,
 ) -> ConformerUploadRequest:
@@ -735,6 +743,7 @@ def _correction_request(
             },
         ],
         label=label,
+        conformer_key=conformer_key,
         applied_energy_corrections=[correction],
     )
 
@@ -775,9 +784,52 @@ def test_correction_conformer_key_links_the_observation_it_names(
         outcome = persist_conformer_upload(
             session,
             _correction_request(
-                label="aec-names-label", source_conformer_key="aec-names-label"
+                label="aec-names-key",
+                conformer_key="the-conformer",
+                source_conformer_key="the-conformer",
             ),
         )
+        applied = session.scalars(
+            select(AppliedEnergyCorrection).where(
+                AppliedEnergyCorrection.source_conformer_observation_id
+                == outcome.observation.id
+            )
+        ).all()
+        assert len(applied) == 1
+
+
+def test_correction_conformer_key_is_not_the_label(db_conn) -> None:
+    """``label`` was the namespace and is not one any more.
+
+    A label is a human tag that also drives conformer-group matching, so
+    a reference resolving through it broke whenever the label was changed
+    for grouping reasons -- and a depositor with no label could not name
+    their conformer at all. ``conformer_key`` answers only to references,
+    which is the whole of its job.
+    """
+    with Session(db_conn) as session, session.begin():
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_conformer_upload(
+                session,
+                _correction_request(
+                    label="a-human-label",
+                    conformer_key="a-machine-key",
+                    source_conformer_key="a-human-label",
+                ),
+            )
+    assert excinfo.value.context["declared_keys"] == ["a-machine-key"]
+
+
+def test_correction_conformer_key_works_without_any_label(db_conn) -> None:
+    """The deposit that could not previously be expressed at all."""
+    with Session(db_conn) as session, session.begin():
+        request = _correction_request(
+            label="unused",
+            conformer_key="unlabelled",
+            source_conformer_key="unlabelled",
+        )
+        request.label = None
+        outcome = persist_conformer_upload(session, request)
         applied = session.scalars(
             select(AppliedEnergyCorrection).where(
                 AppliedEnergyCorrection.source_conformer_observation_id
@@ -814,22 +866,24 @@ def test_correction_with_undeclared_conformer_key_is_refused(db_conn) -> None:
                 session,
                 _correction_request(
                     label="aec-ghost-conf",
+                    conformer_key="aec-ghost-conf-key",
                     source_conformer_key="a-different-conformer",
                 ),
             )
     assert (
         excinfo.value.code == "applied_energy_correction_source_key_undeclared"
     )
-    assert excinfo.value.context["declared_keys"] == ["aec-ghost-conf"]
+    assert excinfo.value.context["declared_keys"] == ["aec-ghost-conf-key"]
 
 
-def test_correction_conformer_key_with_no_label_is_refused(db_conn) -> None:
-    """No label means the request named no conformer at all."""
+def test_correction_conformer_key_with_no_conformer_key_is_refused(
+    db_conn,
+) -> None:
+    """No ``conformer_key`` means the request named no conformer at all."""
     with Session(db_conn) as session, session.begin():
         request = _correction_request(
-            label="aec-no-label", source_conformer_key="anything"
+            label="aec-no-key", source_conformer_key="anything"
         )
-        request.label = None
         with pytest.raises(CodedValueError) as excinfo:
             persist_conformer_upload(session, request)
     assert excinfo.value.context["declared_keys"] == []

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,60 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.31.0 — **BREAKING**: `source_conformer_key` now points at something, on every route that accepts it
+
+**A field that cannot be wrong is not a field.** Three upload paths
+accepted a value, returned 201, and did nothing with it. All three are
+now either persisted or refused, and the set of payloads that validate
+narrows in three places — hence the major-ish bump on a pre-1.0 line.
+
+| payload | 0.30.0 | 0.31.0 |
+|---|---|---|
+| species/reaction bundle, `source_conformer_key` naming a declared conformer | 201, link **not** stored | 201, link stored |
+| species/reaction bundle, `source_conformer_key` naming nothing | 201, silently ignored | **422** `applied_energy_correction_source_key_undeclared` |
+| `/uploads/conformers`, `source_conformer_key` equal to `label` | 201, resolved via the label | **422**, same code |
+| `/uploads/conformers`, `source_conformer_key` equal to a new `conformer_key` | field did not exist | 201, link stored |
+| reaction bundle, two conformers of one species sharing a `key` | 201 | **422** |
+| species bundle root `workflow_tool_release` | accepted, dropped, *and* warned about as missing | persisted as the thermo/statmech default |
+
+**New field: `ConformerUploadRequest.conformer_key`** (optional). It is
+the conformer namespace's counterpart to `ConformerCalculationIn.key`.
+`source_conformer_key` previously resolved against `label`, because a
+label was the only string a conformer upload attached to its conformer.
+That conflated two jobs: a label is a human tag that also feeds
+conformer-group matching, so renaming it for grouping reasons silently
+broke a correction reference, and a depositor with no label could not
+name their own conformer at all.
+
+**Migrating a conformer upload.** If you set `source_conformer_key` to
+your own `label`, add `conformer_key` with that same string; `label` is
+free to keep meaning what it means. If you set neither, nothing changes.
+
+**Migrating a bundle.** A `source_conformer_key` that names a real
+`conformers[*].key` needs no change — it now does what it always looked
+like it did. One that names anything else was never recording a link and
+now says so. On the reaction bundle the namespace is scoped to the
+species the correction sits under: a sibling species's conformer is out
+of scope, which is what makes ownership true by construction rather than
+by a second check. A transition state in that bundle declares no
+conformers at all, so a TS-side `source_conformer_key` can never resolve
+and is refused rather than ignored.
+
+**`ComputedSpeciesUploadRequest.workflow_tool_release` is now read.** It
+is the bundle-level default the `thermo` and `statmech` blocks inherit
+when they name no workflow tool of their own — the precedence
+`ComputedReactionUploadRequest` has applied to `literature` /
+`analysis_software_release` / `workflow_tool_release` since those fields
+and their reader landed in one commit (2026-03-22). The species root
+declared the same field five weeks later and no commit ever wired it, so
+this is drift, not design. Nothing that omitted the field changes.
+
+**`ComputedSpeciesUploadRequest.note` is still not persisted**, and now
+says so in its own description. Unlike `workflow_tool_release` it has no
+row to go to — the bundle owns no record of its own — so giving it one
+is a decision about what a bundle-level note *is*, not a wiring
+omission.
+
 ### 0.30.0 — **BREAKING**: a frequency list longer than `3N` is refused, not flagged
 
 **This narrows the set of payloads that validate.** A payload accepted by

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.30.0"
+version = "0.31.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/energy_correction.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/energy_correction.py
@@ -169,6 +169,19 @@ class AppliedEnergyCorrectionUploadPayload(SchemaBase):
     The ``source_conformer_key`` and ``source_calculation_key`` are local
     string keys that reference other objects in the same upload bundle;
     they are resolved to integer IDs by the workflow orchestrator.
+
+    Both keys resolve against a namespace the *enclosing* request
+    declared, and a key naming nothing in it is refused with
+    ``applied_energy_correction_source_key_undeclared`` rather than
+    dropped. ``source_conformer_key`` names the request's
+    ``conformer_key`` on ``/uploads/conformers``; ``conformers[*].key``
+    on ``/uploads/computed-species``; and, on
+    ``/uploads/computed-reaction``, ``conformers[*].key`` of the species
+    the correction sits under — a transition state declares no
+    conformers there, so a TS-side correction can never name one.
+    Scoping the reaction bundle's conformer namespace to one species is
+    what makes ownership true by construction: a correction targeting
+    one species entry cannot borrow another's conformer.
     """
 
     # Provenance source — exactly one required

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -609,7 +609,9 @@ class BundleSpeciesIn(SchemaBase):
             "(application_role=bac_total). ``source_calculation_key`` "
             "resolves against the bundle's global calculation namespace; "
             "the workflow rejects 422 when the referenced calc is not "
-            "owned by this species."
+            "owned by this species. ``source_conformer_key`` resolves "
+            "against this species's own ``conformers[*].key`` — a "
+            "sibling species's conformer is not in scope and is refused."
         ),
     )
 
@@ -815,7 +817,10 @@ class BundleTransitionStateIn(SchemaBase):
             "``source_calculation_key`` resolves against the bundle's "
             "global calculation namespace; the workflow rejects 422 "
             "when the referenced calc is not owned by this transition "
-            "state."
+            "state. ``source_conformer_key`` has nothing to resolve "
+            "against here — a transition state in this bundle declares "
+            "no conformers — so setting it is refused rather than "
+            "ignored."
         ),
     )
     validation_evidence: list[TransitionStateValidationEvidenceIn] = Field(
@@ -1340,6 +1345,23 @@ class ComputedReactionUploadRequest(SchemaBase):
             raise ValueError("Calculation keys must be globally unique.")
         if len(set(all_geom_keys)) != len(all_geom_keys):
             raise ValueError("Geometry keys must be globally unique.")
+
+        # Conformer keys are unique *within* a species, not globally.
+        # They are the namespace ``applied_energy_corrections[*].
+        # source_conformer_key`` resolves against, and that namespace is
+        # scoped to one species precisely so a correction cannot borrow a
+        # sibling species's conformer. Per-species is therefore the whole
+        # scope in which a duplicate could make a reference ambiguous —
+        # and an ambiguous reference is the defect these keys exist to
+        # remove, so it is refused rather than resolved to whichever
+        # conformer happened to be written last.
+        for sp in self.species:
+            conformer_keys = [conf.key for conf in sp.conformers]
+            if len(set(conformer_keys)) != len(conformer_keys):
+                raise ValueError(
+                    f"Conformer keys must be unique within species "
+                    f"'{sp.key}'."
+                )
 
         return self
 

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py
@@ -617,7 +617,20 @@ class StatmechInBundle(SchemaBase):
 
 
 class ComputedSpeciesUploadRequest(SchemaBase):
-    """Bundle upload payload for one computed species result."""
+    """Bundle upload payload for one computed species result.
+
+    ``workflow_tool_release`` is the bundle-level default: the thermo and
+    statmech blocks fall back to it when they name no workflow tool of
+    their own, and a block that names one overrides it. That is the same
+    precedence ``ComputedReactionUploadRequest`` has always applied to
+    its ``literature`` / ``analysis_software_release`` /
+    ``workflow_tool_release`` trio.
+
+    ``note`` is **not** persisted by this route. It is recorded here so
+    the omission is stated rather than discovered: the bundle has no row
+    of its own to carry a bundle-level note, and choosing one is a
+    separate decision from wiring a field that already has a home.
+    """
 
     species_entry: SpeciesEntryIdentityPayload
 
@@ -634,12 +647,26 @@ class ComputedSpeciesUploadRequest(SchemaBase):
             "(application_role=aec_total) and BAC totals "
             "(application_role=bac_total). Frequency-scale-factor "
             "corrections still belong on thermo/statmech blocks where "
-            "their source calc lives."
+            "their source calc lives. ``source_conformer_key`` resolves "
+            "against this bundle's conformer keys."
         ),
     )
 
-    workflow_tool_release: WorkflowToolReleaseRef | None = None
-    note: str | None = None
+    workflow_tool_release: WorkflowToolReleaseRef | None = Field(
+        default=None,
+        description=(
+            "Bundle-level workflow-tool provenance. Used as the default "
+            "for the thermo and statmech blocks; a value on either of "
+            "those overrides it."
+        ),
+    )
+    note: str | None = Field(
+        default=None,
+        description=(
+            "Free-text note about the bundle. Accepted and validated but "
+            "not persisted: there is no bundle-level row to carry it."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_unique_conformer_keys(self) -> Self:

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/conformer_upload.py
@@ -236,11 +236,29 @@ class ConformerUploadRequest(SchemaBase):
     scientific_origin: ScientificOriginKind = ScientificOriginKind.computed
     note: str | None = None
     label: str | None = Field(default=None, max_length=64)
+    conformer_key: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Optional local name for the single conformer observation this "
+            "upload creates, referenced from "
+            "``applied_energy_corrections[*].source_conformer_key``. It is "
+            "the conformer namespace's counterpart to "
+            "``ConformerCalculationIn.key``, and it is deliberately not "
+            "``label``: a label is a human tag that also participates in "
+            "conformer-group matching, so renaming it for grouping reasons "
+            "would silently break a correction reference, and a depositor "
+            "who has no label has no way to point at their own conformer. "
+            "Optional by design — a payload with no conformer "
+            "cross-reference never needs one."
+        ),
+    )
 
     @model_validator(mode="after")
     def normalize_optional_text_fields(self) -> Self:
         self.note = normalize_optional_text(self.note)
         self.label = normalize_optional_text(self.label)
+        self.conformer_key = normalize_optional_text(self.conformer_key)
         return self
 
     def declared_calculation_keys(self) -> list[str]:


### PR DESCRIPTION
Closes #148. Closes #149. Closes #152.

Three tickets, one defect wearing three hats: **a depositor fills in a field, gets a 201, and nothing happens.** A field that cannot be wrong is not a field — the depositor believes they recorded something and did not. Same shape as #127 (a key that resolved to the primary record whatever it said) and #176 (a code destroyed before promotion).

All three are wire-contract changes to the upload paths, so one version bump rather than three.

## Before, on `main`

Real responses, through the real routes.

| | request | `main` | this branch |
|---|---|---|---|
| #148 | species bundle, `source_conformer_key: "c0"` (a declared conformer) | `201`, stored `source_conformer_observation_id = None` | `201`, stored `= 1` |
| #148 | species bundle, `source_conformer_key: "no-such-conformer"` | `201`, silently ignored | `422 applied_energy_correction_source_key_undeclared` |
| #148 | reaction bundle, `source_conformer_key: "rc0"` | `201`, stored `= None` | `201`, stored `= 3` |
| #148 | reaction bundle, `source_conformer_key: "totally-made-up"` | `201`, silently ignored | `422`, naming `'rc0'` as what *is* declared |
| #149 | `/uploads/conformers` with `conformer_key` | `422 extra_forbidden` — the field did not exist | `201`, link stored |
| #149 | `/uploads/conformers`, no `label`, `source_conformer_key` set | `422` telling the depositor to use `label` | `422` telling them to use `conformer_key` |
| #152 | species bundle root `workflow_tool_release` | `201`; `thermo.workflow_tool_release_id = None`, `statmech.workflow_tool_release_id = None`, **and** a `missing_workflow_tool_provenance` warning about the field they had just filled in | `201`; both linked, warning gone |

The last row is the one worth reading twice. The depositor supplied the provenance and was told in the 201 body that it was missing.

## #148 — `source_conformer_key` was inert on both bundle roots

`computed_species.py` and `computed_reaction.py` passed only `source_calculation_id` to `create_applied_energy_correction` and never read `source_conformer_key` at all. #127 fixed the standalone conformer route; these are the two routes the ARC adapter actually deposits through, so by volume this was the larger half.

Both roots now resolve through the same `resolve_applied_correction_source_key` #127 introduced, so an undeclared key is refused with the existing code and no new one is minted.

**The reaction bundle scopes its conformer namespace to one species**, rather than making it global and checking ownership afterwards as calculation keys do. That makes ownership true by construction: a correction targeting one species entry has no sibling-species conformer in scope to borrow, so there is no second check to forget. It also exposed that **nothing enforced conformer-key uniqueness** in that bundle — `validate_unique_keys` covered species, calculation and geometry keys and not conformers — so a duplicate key resolved to whichever conformer happened to be written last. Now unique within a species, which is exactly the scope in which a duplicate could make a reference ambiguous.

A transition state in the reaction bundle **declares no conformers at all** (it carries one geometry and its calculations; no `ConformerObservation` is written for it). So a TS-side `source_conformer_key` can never resolve, and is refused rather than ignored.

## #149 — the conformer upload had no key namespace for its conformer

`source_conformer_key` resolved against `request.label`, because a label was the only name a conformer upload gave its single conformer. That conflated two things. `label` is a human tag that also participates in conformer-group matching, so renaming it for grouping reasons silently broke a correction reference; and a depositor with no label could not reference their conformer at all.

New optional `ConformerUploadRequest.conformer_key` — the conformer namespace's counterpart to `ConformerCalculationIn.key`, which #148 (the earlier one) established for calculations. `label` no longer resolves.

## #152 — persist it, and the git history says why

**Decision: (a), persist it.** The evidence:

| | field first declared | first read | same commit? |
|---|---|---|---|
| `ComputedReactionUploadRequest.workflow_tool_release` | `4e514ecc`, 2026-03-22 | `4e514ecc`, same commit — `resolve_workflow_tool_release_ref(session, request.workflow_tool_release)` into `Kinetics.workflow_tool_release_id` | yes |
| `ComputedSpeciesUploadRequest.workflow_tool_release` | `fd631ddd`, 2026-04-29 | never | — |

`git log --all -p -- backend/app/workflows/computed_species.py | grep "request\.workflow_tool_release"` returns nothing across the entire history. The species root's file was created five weeks after the reaction root's, with the field declared by convention alongside the nested `CalculationInBundle` / `ThermoInBundle` fields that *were* wired, and never connected. Had it been copied from the working reaction pattern it would have brought the reader with it. Drift, not design — the same shape as #114 and #142. The reaction root's fallback pattern has since been extended twice more (`61f4b256` / `e08abb61`, 2026-08-13), so it is the live convention, not a fossil.

It is now the bundle-level default the `thermo` and `statmech` blocks inherit, with a block-level value overriding it — identical precedence to the reaction root. `collect_provenance_warnings` is fed the *effective* value, which its own docstring already required of callers.

### Sibling check

**Yes, there is one: `ComputedSpeciesUploadRequest.note`.** It is the species root's other unread field (`schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_species_upload.py:660`; `request.note` appears nowhere in `backend/app/workflows/computed_species.py`).

It is **deliberately not wired here**, and now says so in its own field description with a test pinning the claim. Unlike `workflow_tool_release` it has no row to go to — the bundle owns no record of its own, and the only plausible destination is `Submission.summary`, which is a curation surface. Giving a bundle-level note a home is a decision about what such a note *is*, not the wiring omission this change fixes. Stated rather than discovered is the point; if the answer is "put it on the submission", that is a small follow-up.

The reaction root has no `note` field at all, so there is no precedent to copy.

## Breaking

**Yes — `tckdb-schemas` 0.30.0 → 0.31.0, BREAKING.** Three narrowings of the accepted-payload set:

1. Bundle `source_conformer_key` naming nothing: `201` → `422`.
2. `/uploads/conformers` `source_conformer_key` equal to `label`: `201` → `422`.
3. Reaction bundle, two conformers of one species sharing a `key`: `201` → `422`.

**A depositor relying on `label` resolution adds `conformer_key` with that same string.** `label` keeps meaning what it means, and is now free to change for grouping reasons without breaking the reference. A depositor who set neither is unaffected. A bundle whose `source_conformer_key` already named a real `conformers[*].key` needs no change — it now does what it always looked like it did.

**No new error codes.** Every refusal reuses `applied_energy_correction_source_key_undeclared`, already in the catalogue.

**No migration.** Alembic head unchanged at `b7e4d1a9c026`.

## Verification

- Three gates green. Measured on `9f7a7dab` first, then on the branch: rest `4293 -> 4295 passed, 14 skipped`; api `2731 passed`; scientific `2049 passed`. Re-run after rebasing onto `2d63789f` (#169): rest `4323 passed, 14 skipped`.
- The api baseline was contaminated by an overlapping run and is inferred at `2711` rather than measured, so the number to trust is the structural one: **25 test functions added, 3 removed, and all 3 of those are renames** (`git diff origin/main -- backend/tests | grep -cE '^[-+] *def test_'`). Nothing was weakened, skipped, xfailed or deleted.
- `tckdb-schemas` package tests `38 passed`, including `test_import_boundaries.py` unchanged.
- OpenAPI golden regenerated. Components changed: `AppliedEnergyCorrectionUploadPayload` (description), `BundleSpeciesIn` and `BundleTransitionStateIn` (AEC field descriptions), `ComputedSpeciesUploadRequest` (class description + `applied_energy_corrections` / `workflow_tool_release` / `note` descriptions), `ConformerUploadRequest` (new `conformer_key` property). No shape removals.
- `ruff check app tests scripts` clean.
- **11 mutations, 11 red**, each turning exactly one intended test red and nothing else: dropping the persisted link on each of the four AEC write paths; making the species namespace non-total; making the reaction namespace global instead of per-species; ignoring the TS key; restoring `label` as the conformer namespace; dropping the bundle-level default on thermo and on statmech; feeding the warning collector the raw field instead of the effective one; and removing the conformer-key uniqueness rule.

## Not fixed

- `ComputedSpeciesUploadRequest.note` — above; now documented and tested as unpersisted.
- A species bundle carrying `workflow_tool_release` with **no** `thermo` and no `statmech` block still has nothing to attach it to. This matches the reaction root, which also confines the bundle default to its analysis products and does not apply it to calculations. The field description now states the scope rather than implying a wider one.
- **The same mistake gets two different response shapes depending on which key it is.** On both bundle roots an undeclared `source_calculation_key` is caught by a schema-level validator that raises a bare `ValueError` (`computed_species_upload.py:760`, `:813`; `computed_reaction_upload.py:1514`, `:1525`), so a client sees `request_validation_error` with no branchable code. The conformer key added here is refused at the workflow with `applied_energy_correction_source_key_undeclared`, as `/uploads/conformers` already does for both keys. Routing the bundle calc-key refusal through the same coded seam means deleting those validators and is a change with its own blast radius; the catalogue is also owned by another branch this round. Reported, not fixed.
- `clients/python` needs no change to be correct: it never emits `source_conformer_key`, and no new rejection code was added. It may want to expose `conformer_key` on its conformer-upload builder — reported, not made, per the file ownership split.
