### PR TITLE
Name every record the reaction bundle wrote, and let a depositor cite a paper

### DIFF
--- a/backend/app/api/routes/uploads.py
+++ b/backend/app/api/routes/uploads.py
@@ -7,7 +7,7 @@ the ``get_write_db`` dependency (commit on success, rollback on exception).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_write_db
@@ -155,13 +155,38 @@ class TransportUploadResult(BaseModel):
 
 
 class ComputedReactionUploadResult(BaseModel):
+    """What the reaction bundle wrote, named back to the depositor.
+
+    ``extra="forbid"`` is load-bearing rather than tidy. This model is
+    built as ``ComputedReactionUploadResult(**result_dict)`` from the
+    workflow's return value, so under pydantic's default ``extra="ignore"``
+    a key the workflow computes but the model does not declare is dropped
+    in silence — with a 201 that looks complete. That is exactly how
+    ``statmech_ids`` and ``atom_map_id`` went missing: both were collected
+    by the workflow, both were discarded here, and no test could fail
+    because the seam had no failure mode. Forbidding extras turns the next
+    such omission into an error at construction time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     type: str = "computed_reaction"
     submission_id: int | None = None
     reaction_entry_id: int
     reaction_id: int
     transition_state_entry_id: int | None = None
+    #: The ``reaction_atom_map`` row this bundle wrote, if it carried an
+    #: ``atom_map`` block. Previously computed and dropped, which is why
+    #: every atom-map test in the tree reads it back through
+    #: ``/reactions/{id}/full`` instead of taking it from the 201.
+    atom_map_id: int | None = None
     kinetics_ids: list[int]
     thermo_ids: list[int]
+    #: One id per ``statmech`` row written for a species in this bundle.
+    #: A bundle depositing all three product types now gets all three
+    #: named; before, statmech had to be found by querying back through
+    #: ``species_entry_ids``.
+    statmech_ids: list[int] = Field(default_factory=list)
     species_entry_ids: list[int]
     species_count: int
     # Bundle-local calc key → assigned ``calculation.id`` for every

--- a/backend/app/services/provenance_warnings.py
+++ b/backend/app/services/provenance_warnings.py
@@ -372,6 +372,28 @@ def collect_kinetics_provenance_warnings(
 def collect_kinetics_content_warnings(
     request: KineticsUploadRequest,
 ) -> list[UploadWarning]:
+    """Adapter for the standalone ``/uploads/kinetics`` request shape.
+
+    Kept so the standalone route reads unchanged. All three inputs exist on
+    ``KineticsUploadRequest``, so all three are judged.
+    """
+    return collect_kinetics_content_warnings_for(
+        scientific_origin=request.scientific_origin,
+        interpretation_assignments=request.interpretation_assignments,
+        network_kinetics_ref=request.network_kinetics_ref,
+        tunneling_model=request.tunneling_model,
+        tunneling_application=request.tunneling_application,
+    )
+
+
+def collect_kinetics_content_warnings_for(
+    *,
+    scientific_origin: ScientificOriginKind,
+    interpretation_assignments: object | None = NOT_APPLICABLE,
+    network_kinetics_ref: object | None = NOT_APPLICABLE,
+    tunneling_model: object | None = None,
+    tunneling_application: object | None = NOT_APPLICABLE,
+) -> list[UploadWarning]:
     """Report scientific evidence a rate could carry but does not.
 
     Separate from the provenance collector because these describe *scientific
@@ -384,11 +406,44 @@ def collect_kinetics_content_warnings(
       deposited without its statmech legitimately carries no assignments.
     * ``tunneling_model`` is a reported label. A paper stating "Eckart
       tunneling was applied" ships no imaginary frequency and no barriers.
+
+    **Why the parameters, and why they default to** :data:`NOT_APPLICABLE`.
+
+    This collector used to read ``interpretation_assignments``,
+    ``network_kinetics_ref`` and ``tunneling_application`` straight off a
+    ``KineticsUploadRequest``. ``BundleKineticsIn`` — the reaction bundle's
+    kinetics block, and the model the ARC adapter actually deposits through
+    — carries none of the three, but *does* carry ``tunneling_model``. So a
+    bundle could declare ``tunneling_model='eckart'`` and, the moment this
+    collector was wired to that route, be told to supply
+    ``tunneling_application``: a field that does not exist on that model,
+    on a payload whose ``SchemaBase`` is ``extra="forbid"``. A depositor
+    following the advice would get a 422.
+
+    :data:`NOT_APPLICABLE` is how a caller says *there is no field here to
+    fill*, as distinct from ``None``/empty meaning *there is one and it was
+    left empty*. Judging is opt-in: a caller that does not pass an argument
+    is not asked about it, so a new caller cannot accidentally emit advice
+    it has no field to act on.
+
+    That the bundle must pass all three sentinels is a statement about the
+    bundle's schema, not an endorsement of it — see ``BundleKineticsIn``'s
+    docstring for the drift this records.
+
+    :param interpretation_assignments: The assignment list, or
+        :data:`NOT_APPLICABLE` where the payload has no such field.
+    :param network_kinetics_ref: The master-equation handle, or
+        :data:`NOT_APPLICABLE`. Only consulted to *suppress* the
+        missing-TS-interpretation warning, never to raise one.
+    :param tunneling_model: The reported label. Always available.
+    :param tunneling_application: The typed evidence, or
+        :data:`NOT_APPLICABLE`.
     """
     warnings: list[UploadWarning] = []
     if (
-        request.scientific_origin in _COMPUTATIONAL_ORIGINS
-        and not request.interpretation_assignments
+        scientific_origin in _COMPUTATIONAL_ORIGINS
+        and interpretation_assignments is not NOT_APPLICABLE
+        and not interpretation_assignments
     ):
         warnings.append(
             UploadWarning(
@@ -408,14 +463,24 @@ def collect_kinetics_content_warnings(
     # exactly what ``network_kinetics_ref`` declares — but for everything else
     # (including variational TST, which still evaluates Q at the variational
     # dividing surface) the omission is a real gap worth naming.
-    subjects = {
-        "transition_state" if item.role == "transition_state" else item.role
-        for item in request.interpretation_assignments
-    }
+    #
+    # ``network_kinetics_ref`` is only ever read to *suppress* this warning,
+    # so a caller with no such field is not silently accused of omitting one:
+    # NOT_APPLICABLE is not ``None``, and only ``None`` lets the warning
+    # through. The guard is unreachable anyway when
+    # ``interpretation_assignments`` is NOT_APPLICABLE, since the sentinel is
+    # not iterable — hence the explicit check before the comprehension.
+    subjects: set[object] = set()
+    if interpretation_assignments is not NOT_APPLICABLE:
+        subjects = {
+            "transition_state" if item.role == "transition_state" else item.role
+            for item in interpretation_assignments
+        }
     if (
-        request.interpretation_assignments
+        interpretation_assignments is not NOT_APPLICABLE
+        and interpretation_assignments
         and "transition_state" not in subjects
-        and request.network_kinetics_ref is None
+        and network_kinetics_ref is None
     ):
         warnings.append(
             UploadWarning(
@@ -430,16 +495,22 @@ def collect_kinetics_content_warnings(
                 ),
             )
         )
+    # The case #155 exists for. A caller that *has* a tunneling_application
+    # field and left it empty gets told so; a caller that has no such field
+    # gets nothing, because "attach the typed evidence" is not something it
+    # can do. Note the condition is on the *evidence* being NOT_APPLICABLE,
+    # not on the label: a bundle can and does declare ``tunneling_model``.
     if (
-        request.tunneling_model not in (None, TunnelingModel.none)
-        and request.tunneling_application is None
+        tunneling_application is not NOT_APPLICABLE
+        and tunneling_model not in (None, TunnelingModel.none)
+        and tunneling_application is None
     ):
         warnings.append(
             UploadWarning(
                 field="tunneling_application",
                 code=W_MISSING_TUNNELING_APPLICATION,
                 message=(
-                    f"tunneling_model='{request.tunneling_model.value}' is declared "
+                    f"tunneling_model='{tunneling_model.value}' is declared "
                     "with no typed tunneling_application evidence, so the correction "
                     "is recorded as a reported attribute and cannot be replayed."
                 ),

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -146,7 +146,19 @@ def _persist_calculation(
     is not yet in the key map).
     """
 
-    shared_payload = calculation_in_to_with_results_payload(calc_in)
+    # The calculation's citation arrives as an inline literature fragment
+    # (it used to arrive as a raw ``literature_id``, which only a client
+    # that had already queried this database could supply). Resolve it to a
+    # row here — the wire package has no session — and hand the id to the
+    # adapter, which refuses the pair "fragment present, id absent".
+    literature_id = (
+        resolve_or_create_literature(session, calc_in.literature).id
+        if calc_in.literature is not None
+        else None
+    )
+    shared_payload = calculation_in_to_with_results_payload(
+        calc_in, literature_id=literature_id
+    )
     calculation = resolve_and_persist_calculation_with_results(
         session,
         shared_payload,

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -145,7 +145,19 @@ def _persist_calculation(
     if calc_in.geometry_key is not None:
         effective_geometry_id = geometry_key_map[calc_in.geometry_key]
 
-    shared_payload = calculation_in_to_with_results_payload(calc_in)
+    # Same inline-literature resolution the computed-reaction workflow
+    # does: the shared ``CalculationIn`` no longer accepts a raw
+    # ``literature_id``, so the citation is resolved here and the id handed
+    # to the adapter. This route reaches the same shared model, so the FK
+    # leak the network-PDep no-FK gate used to exempt is gone with it.
+    literature_id = (
+        resolve_or_create_literature(session, calc_in.literature).id
+        if calc_in.literature is not None
+        else None
+    )
+    shared_payload = calculation_in_to_with_results_payload(
+        calc_in, literature_id=literature_id
+    )
     calculation = resolve_and_persist_calculation_with_results(
         session,
         shared_payload,

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -2128,7 +2128,7 @@
       },
       "BundleKineticsIn": {
         "additionalProperties": false,
-        "description": "One kinetics fit (Arrhenius parameters) within the bundle.\n\nThe reaction direction is determined by ``reactant_keys`` / ``product_keys``\nwhich reference species keys. For the forward direction, these match the\nbundle's reaction; for the reverse, they are swapped.\n\n:param reactant_keys: Species keys on the reactant side of this fit.\n:param product_keys: Species keys on the product side of this fit.\n:param scientific_origin: Scientific origin category.\n:param model_kind: Kinetics functional form.\n:param is_third_body: True for a simple ``+M`` third-body reaction (no falloff).\n:param a: Arrhenius pre-exponential factor.\n:param a_units: Units for A.\n:param n: Temperature exponent.\n:param reported_ea: Activation energy in reported units.\n:param reported_ea_units: Units for Ea.\n:param tmin_k: Minimum valid temperature.\n:param tmax_k: Maximum valid temperature.\n:param tunneling_model: Optional tunneling model label.\n:param degeneracy: Optional finite, strictly positive multiplicative\n    reaction-path degeneracy associated with the reported kinetics\n    expression. ``None`` means no claim is made; do not interpret it as\n    ``1.0``.\n:param degeneracy_convention: Whether degeneracy is already included in\n    the reported rate. Defaults to ``unknown`` for legacy producers.\n:param note: Optional note.",
+        "description": "One kinetics fit (Arrhenius parameters) within the bundle.\n\nThe reaction direction is determined by ``reactant_keys`` / ``product_keys``\nwhich reference species keys. For the forward direction, these match the\nbundle's reaction; for the reverse, they are swapped.\n\n:param reactant_keys: Species keys on the reactant side of this fit.\n:param product_keys: Species keys on the product side of this fit.\n:param scientific_origin: Scientific origin category.\n:param model_kind: Kinetics functional form.\n:param is_third_body: True for a simple ``+M`` third-body reaction (no falloff).\n:param a: Arrhenius pre-exponential factor.\n:param a_units: Units for A.\n:param n: Temperature exponent.\n:param reported_ea: Activation energy in reported units.\n:param reported_ea_units: Units for Ea.\n:param tmin_k: Minimum valid temperature.\n:param tmax_k: Maximum valid temperature.\n:param tunneling_model: Optional tunneling model label.\n:param degeneracy: Optional finite, strictly positive multiplicative\n    reaction-path degeneracy associated with the reported kinetics\n    expression. ``None`` means no claim is made; do not interpret it as\n    ``1.0``.\n:param degeneracy_convention: Whether degeneracy is already included in\n    the reported rate. Defaults to ``unknown`` for legacy producers.\n:param note: Optional note.\n\n**Three fields the standalone route has and this model does not.**\nRecorded here because the gap was invisible: nothing in the tree\ncompared this model against ``KineticsUploadRequest``, and\n``test_bundle_root_model_symmetry`` explicitly excludes kinetics on the\ngrounds that it has no second spelling — true of the *species bundle*,\nfalse of the standalone route.\n\n* ``interpretation_assignments`` — which statmech records the rate's\n  partition functions came from.\n* ``tunneling_application`` — the typed, replayable tunneling evidence.\n* ``network_kinetics_ref`` — the master-equation solve a fitted rate\n  delegates its pressure dependence to.\n\nThe first two are **drift, not design**. Both were added to\n``KineticsUploadRequest`` by ``ee7377f5`` (#66), a commit that edited\n*this file* in the same diff to close the analogous transition-state\nevidence gap on parity grounds — and left kinetics one-sided with no\nrecorded reason. No commit message, comment or doc anywhere claims a\ndeliberately reduced kinetics shape. The consequence is concrete: this\nmodel carries ``tunneling_model``, the *label*, so a bundle depositor\ncan claim Eckart tunneling was applied and has no way to attach the\nevidence for it. The standalone route cross-checks the two\n(``validate_tunneling_declaration_agrees``); here there is nothing to\ncheck against.\n\n``network_kinetics_ref`` is **unaddressed rather than decided**.\n``2fb5c25b`` (#29) established that this model \"carries only scalar\nArrhenius fields … and its workflow writes no kinetics child tables\",\ndirecting the pressure-dependent forms to the single-reaction endpoint.\nThat covers PLOG and Chebyshev child rows; ``network_kinetics_ref``\nresolves to a nullable scalar column on ``kinetics`` itself, and this\nmodel accepts ``pressure_context='pressure_dependent'`` — precisely the\nstate that handle exists to name — with no way to name it.\n\nClosing any of the three means new bundle-local-key schemas plus\npersistence in ``app.workflows.computed_reaction``, which is a feature\nrather than a contract change and is deliberately not attempted here.\nUntil then ``collect_kinetics_content_warnings_for`` is passed\n``NOT_APPLICABLE`` for all three, so no depositor is advised to fill a\nfield this model does not have.",
         "properties": {
           "a": {
             "anyOf": [
@@ -5200,7 +5200,7 @@
       },
       "CalculationIn": {
         "additionalProperties": false,
-        "description": "A calculation defined within this upload.\n\n:param key: Globally unique local key for this calculation.\n:param type: Calculation type (opt, freq, sp, irc, scan).\n:param quality: Curation quality flag.\n:param geometry_key: Local key referencing a geometry defined elsewhere\n    in the payload. For species calculations, typically points to a\n    conformer's geometry. For TS calculations, defaults to the TS geometry.\n:param software_release: Required software provenance reference.\n:param level_of_theory: Required level-of-theory reference.\n:param workflow_tool_release: Optional workflow-tool provenance reference.\n:param literature_id: Optional literature provenance id.\n:param sp_electronic_energy_hartree: SP result (if type=sp).\n:param opt_converged: Opt result (if type=opt).\n:param opt_n_steps: Opt result (if type=opt).\n:param opt_final_energy_hartree: Opt result (if type=opt).\n:param freq_n_imag: Freq result (if type=freq).\n:param freq_imag_freq_cm1: Freq result (if type=freq).\n:param freq_zpe_hartree: Freq result (if type=freq).\n:param parameters: Optional parsed execution-control parameter observations,\n    routed through the shared calculation persistence seam.\n:param parameters_json: Optional JSON snapshot from the parser.\n:param parameters_parser_version: Optional parser version tag.\n:param parameters_extracted_at: Optional extraction timestamp.\n:param wavefunction_diagnostic: Optional inline T1/D1 wavefunction\n    diagnostic, forwarded to the shared calculation persistence seam.\n:param spin_diagnostic: Optional inline spin-contamination ``<S^2>``\n    diagnostic, forwarded to the shared calculation persistence seam.\n:param artifacts: Optional list of file artifacts (logs, inputs, etc.).",
+        "description": "A calculation defined within this upload.\n\n:param key: Globally unique local key for this calculation.\n:param type: Calculation type (opt, freq, sp, irc, scan).\n:param quality: Curation quality flag.\n:param geometry_key: Local key referencing a geometry defined elsewhere\n    in the payload. For species calculations, typically points to a\n    conformer's geometry. For TS calculations, defaults to the TS geometry.\n:param software_release: Required software provenance reference.\n:param level_of_theory: Required level-of-theory reference.\n:param workflow_tool_release: Optional workflow-tool provenance reference.\n:param literature: Optional inline literature provenance, resolved (or\n    created) by the workflow. Replaces the former ``literature_id``,\n    which was a database primary key on an upload surface — usable only\n    by a client that had already queried this database, which a\n    depositor has not. Matches ``CalculationInBundle.literature`` on the\n    species bundle, which took the inline fragment from the start.\n:param sp_electronic_energy_hartree: SP result (if type=sp).\n:param opt_converged: Opt result (if type=opt).\n:param opt_n_steps: Opt result (if type=opt).\n:param opt_final_energy_hartree: Opt result (if type=opt).\n:param freq_n_imag: Freq result (if type=freq).\n:param freq_imag_freq_cm1: Freq result (if type=freq).\n:param freq_zpe_hartree: Freq result (if type=freq).\n:param parameters: Optional parsed execution-control parameter observations,\n    routed through the shared calculation persistence seam.\n:param parameters_json: Optional JSON snapshot from the parser.\n:param parameters_parser_version: Optional parser version tag.\n:param parameters_extracted_at: Optional extraction timestamp.\n:param wavefunction_diagnostic: Optional inline T1/D1 wavefunction\n    diagnostic, forwarded to the shared calculation persistence seam.\n:param spin_diagnostic: Optional inline spin-contamination ``<S^2>``\n    diagnostic, forwarded to the shared calculation persistence seam.\n:param artifacts: Optional list of file artifacts (logs, inputs, etc.).",
         "properties": {
           "artifacts": {
             "items": {
@@ -5322,16 +5322,15 @@
           "level_of_theory": {
             "$ref": "#/components/schemas/LevelOfTheoryRef"
           },
-          "literature_id": {
+          "literature": {
             "anyOf": [
               {
-                "type": "integer"
+                "$ref": "#/components/schemas/LiteratureUploadRequest"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Literature Id"
+            ]
           },
           "opt_converged": {
             "anyOf": [
@@ -9678,16 +9677,15 @@
           "level_of_theory": {
             "$ref": "#/components/schemas/LevelOfTheoryRef"
           },
-          "literature_id": {
+          "literature": {
             "anyOf": [
               {
-                "type": "integer"
+                "$ref": "#/components/schemas/LiteratureUploadRequest"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Literature Id"
+            ]
           },
           "opt_converged": {
             "anyOf": [
@@ -10003,7 +10001,20 @@
         "type": "object"
       },
       "ComputedReactionUploadResult": {
+        "additionalProperties": false,
+        "description": "What the reaction bundle wrote, named back to the depositor.\n\n``extra=\"forbid\"`` is load-bearing rather than tidy. This model is\nbuilt as ``ComputedReactionUploadResult(**result_dict)`` from the\nworkflow's return value, so under pydantic's default ``extra=\"ignore\"``\na key the workflow computes but the model does not declare is dropped\nin silence — with a 201 that looks complete. That is exactly how\n``statmech_ids`` and ``atom_map_id`` went missing: both were collected\nby the workflow, both were discarded here, and no test could fail\nbecause the seam had no failure mode. Forbidding extras turns the next\nsuch omission into an error at construction time.",
         "properties": {
+          "atom_map_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atom Map Id"
+          },
           "calculation_keys": {
             "additionalProperties": {
               "type": "integer"
@@ -10035,6 +10046,13 @@
               "type": "integer"
             },
             "title": "Species Entry Ids",
+            "type": "array"
+          },
+          "statmech_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Statmech Ids",
             "type": "array"
           },
           "submission_id": {

--- a/backend/tests/api/test_api_bundle_calculation_literature.py
+++ b/backend/tests/api/test_api_bundle_calculation_literature.py
@@ -1,0 +1,237 @@
+"""A calculation's citation is content, not a primary key.
+
+``CalculationIn`` — the shared calculation block behind the
+computed-reaction bundle and the network-PDep upload — accepted
+``literature_id: int``. A depositor cannot know that number. Supplying it
+requires having already queried this database for the row, which is the
+definition of a field only an insider can use, and it is the exact defect
+#118 removed from the standalone statmech route
+(``tests/workflows/test_statmech_upload.TestStatmechUploadRejectsRawFKs``).
+
+The species bundle never had it: ``CalculationInBundle.literature`` has
+always taken an inline ``LiteratureUploadRequest`` that the workflow
+resolves. The reaction bundle now takes the same fragment, so the two
+roots agree and ``.claude/rules/schema-rules.md``'s "No FK IDs in upload
+schemas" holds without an exemption.
+
+This is a **breaking** wire change: ``literature_id`` no longer
+validates. ``SchemaBase`` is ``extra="forbid"``, so an old payload gets a
+422 naming the field rather than being accepted and silently ignored —
+the failure mode worth having, since silently ignoring it would drop the
+citation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.db.models.calculation import Calculation
+from app.db.models.literature import Literature
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2 = "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+
+_LITERATURE = {
+    "kind": "article",
+    "title": "A barrier height for H + H",
+    "journal": "J. Test",
+    "year": 2026,
+    "doi": "10.1000/tckdb.calc.literature.inline",
+}
+
+
+def _species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [
+            {
+                "key": f"{key}-sp",
+                "type": "sp",
+                "geometry_key": f"{key}-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "sp_electronic_energy_hartree": -0.5,
+            },
+        ],
+    }
+
+
+def _bundle(**overrides) -> dict:
+    base: dict = {
+        "species": [
+            _species("h", "[H]", 2, _XYZ_H),
+            _species("h2", "[H][H]", 1, _XYZ_H2),
+        ],
+        "reversible": True,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# The new contract
+# ---------------------------------------------------------------------------
+
+
+def test_a_bundle_calculation_cites_literature_inline(
+    client: TestClient, db_session
+):
+    """The citation a depositor can actually supply, end to end.
+
+    Asserts the resolved row is attached to *the calculation named in the
+    payload* rather than merely that some literature row was created —
+    a workflow that resolved the fragment and then forgot to bind it
+    would pass the weaker check.
+    """
+    bundle = _bundle()
+    bundle["species"][0]["calculations"][0]["literature"] = dict(_LITERATURE)
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:1200]
+    body = resp.json()
+
+    calc_id = body["calculation_keys"]["h-sp"]
+    calc = db_session.get(Calculation, calc_id)
+    assert calc.literature_id is not None, (
+        "the bundle cited literature on this calculation and the workflow "
+        "did not attach it"
+    )
+    lit = db_session.get(Literature, calc.literature_id)
+    assert lit.doi == _LITERATURE["doi"]
+
+    # And only the calculation that cited it got it.
+    sibling = db_session.get(Calculation, body["calculation_keys"]["h2-sp"])
+    assert sibling.literature_id is None
+
+
+def test_two_calculations_citing_the_same_paper_share_one_row(
+    client: TestClient, db_session
+):
+    """Resolution deduplicates, so the inline fragment is not a row-per-mention.
+
+    The reason ``literature_id`` felt necessary was the fear of
+    duplicating a paper on every calculation. It is not: the workflow
+    routes through ``resolve_or_create_literature`` exactly as the species
+    bundle and every thermo/statmech block already do.
+    """
+    bundle = _bundle()
+    bundle["species"][0]["calculations"][0]["literature"] = dict(_LITERATURE)
+    bundle["species"][1]["calculations"][0]["literature"] = dict(_LITERATURE)
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:1200]
+    body = resp.json()
+
+    ids = {
+        db_session.get(Calculation, body["calculation_keys"][key]).literature_id
+        for key in ("h-sp", "h2-sp")
+    }
+    assert None not in ids
+    assert len(ids) == 1, f"the same DOI produced {len(ids)} literature rows"
+
+    rows = db_session.scalars(
+        select(Literature).where(Literature.doi == _LITERATURE["doi"])
+    ).all()
+    assert len(rows) == 1
+
+
+def test_a_calculation_may_still_cite_nothing(client: TestClient, db_session):
+    """Omission stays legal — this is provenance, not a required field."""
+    resp = client.post("/api/v1/uploads/computed-reaction", json=_bundle())
+    assert resp.status_code == 201, resp.text[:1200]
+    body = resp.json()
+    calc = db_session.get(Calculation, body["calculation_keys"]["h-sp"])
+    assert calc.literature_id is None
+
+
+# ---------------------------------------------------------------------------
+# The removed contract
+# ---------------------------------------------------------------------------
+
+
+def test_a_raw_literature_id_is_refused_by_the_route(client: TestClient):
+    """Refused loudly, at the boundary, naming the field.
+
+    ``extra="forbid"`` is what makes this a 422 rather than a 201 with the
+    citation quietly dropped. Asserting on the field name (not just the
+    status) is deliberate: a 422 for some unrelated reason would satisfy a
+    bare status check.
+    """
+    bundle = _bundle()
+    bundle["species"][0]["calculations"][0]["literature_id"] = 42
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 422, resp.text[:600]
+    assert "literature_id" in resp.text
+
+
+def test_the_shared_calculation_model_no_longer_declares_literature_id():
+    """The field is gone from the model, not merely unreachable by one route.
+
+    ``CalculationIn`` is shared with the network-PDep upload, whose no-FK
+    gate carried a standing exemption for this exact field
+    (``tests/workflows/test_network_pdep_upload``). Pinning the model
+    directly is what stops the field reappearing on a route this file does
+    not post to.
+    """
+    from tckdb_schemas.shared.calculation_in import CalculationIn
+    from tckdb_schemas.workflows.computed_reaction_upload import (
+        ComputedReactionCalculationIn,
+    )
+
+    for model in (CalculationIn, ComputedReactionCalculationIn):
+        assert "literature_id" not in model.model_fields, model.__name__
+        assert "literature" in model.model_fields, model.__name__
+
+
+def test_the_adapter_refuses_to_drop_a_citation_it_was_not_given_an_id_for():
+    """The guard on the seam that could otherwise lose a citation silently.
+
+    ``calculation_in_to_with_results_payload`` cannot resolve literature —
+    the wire package has no database. If it defaulted the id to ``None``,
+    a workflow that forgot to resolve would produce a valid payload with
+    the citation missing and nothing would fail. It raises instead.
+    """
+    from tckdb_schemas.shared.calculation_in import (
+        CalculationIn,
+        calculation_in_to_with_results_payload,
+    )
+
+    calc = CalculationIn(
+        key="c1",
+        type="sp",
+        software_release=_SOFTWARE,
+        level_of_theory=_LOT,
+        literature=_LITERATURE,
+    )
+    with pytest.raises(ValueError, match="literature_id"):
+        calculation_in_to_with_results_payload(calc)
+
+    # With the id supplied it converts, and carries the id through.
+    payload = calculation_in_to_with_results_payload(calc, literature_id=7)
+    assert payload.literature_id == 7

--- a/backend/tests/api/test_api_bundle_kinetics_content_applicability.py
+++ b/backend/tests/api/test_api_bundle_kinetics_content_applicability.py
@@ -1,0 +1,239 @@
+"""A warning must name a field the depositor can actually fill.
+
+``collect_kinetics_content_warnings`` reads ``interpretation_assignments``,
+``network_kinetics_ref`` and ``tunneling_application``.
+``BundleKineticsIn`` — the reaction bundle's kinetics block, and the model
+the ARC adapter deposits through — has none of the three, but *does* have
+``tunneling_model``. Wired naively to the bundle route, it would answer a
+bundle declaring ``tunneling_model='eckart'`` with "supply
+``tunneling_application``": a field that does not exist on that model, on
+a payload whose ``SchemaBase`` is ``extra="forbid"``. Following the advice
+yields a 422.
+
+The fix is the sentinel ``provenance_warnings.NOT_APPLICABLE``, the same
+device PR #155 used for ``energy_level_of_theory``: ``None`` means *there
+is a field and it is empty*, ``NOT_APPLICABLE`` means *there is no field
+here*, and only the first is judged.
+
+Two levels of test, because they are different claims:
+
+* The route level asserts what a depositor **receives** — the only thing
+  that matters to them, and the thing a unit test on the collector cannot
+  establish.
+* The unit level asserts the sentinel is **doing the work**. Without it,
+  the route test would also pass on ``main`` (where the collector is
+  simply never called on this route), so it would prove nothing about
+  this change.
+
+Whether the three fields *should* exist on ``BundleKineticsIn`` is a
+separate question with a separate answer: two of them are recorded drift.
+See ``BundleKineticsIn``'s docstring and
+``tests/schemas/test_bundle_root_model_symmetry.KNOWN_BUNDLE_KINETICS_GAPS``.
+This file is about not giving un-actionable advice in the meantime.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.services.provenance_warnings import (
+    NOT_APPLICABLE,
+    W_MISSING_KINETICS_INTERPRETATIONS,
+    W_MISSING_TS_INTERPRETATION,
+    W_MISSING_TUNNELING_APPLICATION,
+    collect_kinetics_content_warnings_for,
+)
+
+#: The codes that name a field ``BundleKineticsIn`` does not have.
+UNACTIONABLE_ON_THE_BUNDLE = frozenset(
+    {
+        W_MISSING_KINETICS_INTERPRETATIONS,
+        W_MISSING_TS_INTERPRETATION,
+        W_MISSING_TUNNELING_APPLICATION,
+    }
+)
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2 = "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+
+
+def _species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [],
+    }
+
+
+def _bundle_with_tunnelling_label() -> dict:
+    return {
+        "species": [
+            _species("h", "[H]", 2, _XYZ_H),
+            _species("h2", "[H][H]", 1, _XYZ_H2),
+        ],
+        "reversible": True,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+        "kinetics": [
+            {
+                "scientific_origin": "computed",
+                "model_kind": "arrhenius",
+                "a": 1.0e13,
+                "a_units": "cm3_mol_s",
+                "n": 0.0,
+                "reported_ea": 10.0,
+                "reported_ea_units": "kj_mol",
+                "tmin_k": 300.0,
+                "tmax_k": 2000.0,
+                "reactant_keys": ["h", "h"],
+                "product_keys": ["h2"],
+                # The claim the bundle can make and cannot evidence.
+                "tunneling_model": "eckart",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# What a depositor receives
+# ---------------------------------------------------------------------------
+
+
+def test_a_bundle_declaring_tunneling_is_not_told_to_fill_a_missing_field(
+    client: TestClient,
+):
+    """The end-to-end claim: no un-actionable code on the 201.
+
+    Asserted as "none of these three codes appear" rather than "the
+    warning list is empty", because the bundle route legitimately returns
+    other warnings (provenance) and this must not become a test that
+    passes only while the response happens to be quiet.
+    """
+    resp = client.post(
+        "/api/v1/uploads/computed-reaction", json=_bundle_with_tunnelling_label()
+    )
+    assert resp.status_code == 201, resp.text[:800]
+
+    codes = {w["code"] for w in resp.json()["warnings"]}
+    offending = codes & UNACTIONABLE_ON_THE_BUNDLE
+    assert not offending, (
+        f"the reaction bundle told a depositor to supply {sorted(offending)}, "
+        "which name fields BundleKineticsIn does not have; SchemaBase is "
+        "extra='forbid', so acting on that advice is a 422"
+    )
+
+
+def test_the_advice_would_in_fact_be_a_422(client: TestClient):
+    """Proves the premise the sentinel exists to defend.
+
+    Without this, "do not advise ``tunneling_application``" is an
+    assertion about a hypothetical. Here the field really is rejected, so
+    the warning really would be advice a depositor cannot follow.
+    """
+    bundle = _bundle_with_tunnelling_label()
+    bundle["kinetics"][0]["tunneling_application"] = {
+        "model": "eckart",
+        "transition_state_entry_ref": "ts-1",
+    }
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 422, resp.text[:600]
+    assert "tunneling_application" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# That the sentinel is what is doing it
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_suppresses_exactly_what_none_would_raise():
+    """The sentinel must differ from ``None``, or it is decoration.
+
+    Same origin, same declared ``tunneling_model``, same everything —
+    only the three inputs change from "absent field" to "empty field".
+    The ``None`` call is the control: it shows the collector *would* have
+    produced the un-actionable advice, so the empty result above is the
+    sentinel working rather than the collector having nothing to say.
+    """
+    as_bundle = collect_kinetics_content_warnings_for(
+        scientific_origin="computed",
+        interpretation_assignments=NOT_APPLICABLE,
+        network_kinetics_ref=NOT_APPLICABLE,
+        tunneling_model=_eckart(),
+        tunneling_application=NOT_APPLICABLE,
+    )
+    assert [w.code for w in as_bundle] == []
+
+    as_standalone = collect_kinetics_content_warnings_for(
+        scientific_origin="computed",
+        interpretation_assignments=[],
+        network_kinetics_ref=None,
+        tunneling_model=_eckart(),
+        tunneling_application=None,
+    )
+    assert {w.code for w in as_standalone} == {
+        W_MISSING_KINETICS_INTERPRETATIONS,
+        W_MISSING_TUNNELING_APPLICATION,
+    }
+
+
+def test_judging_is_opt_in_so_a_new_caller_cannot_leak_advice():
+    """The defaults are the safe direction.
+
+    A caller that passes only what it has must not be judged on what it
+    does not — otherwise the next route wired to this collector
+    reintroduces the defect by omission, which is exactly how it arrived.
+    """
+    warnings = collect_kinetics_content_warnings_for(
+        scientific_origin="computed",
+        tunneling_model=_eckart(),
+    )
+    assert [w.code for w in warnings] == []
+
+
+def test_a_caller_that_has_the_fields_is_still_fully_judged():
+    """The standalone route must be unchanged by the refactor.
+
+    The risk in making judging opt-in is that a real gap stops being
+    reported. This pins the standalone adapter's behaviour against the
+    parameterised core.
+    """
+    from app.services.provenance_warnings import collect_kinetics_content_warnings
+
+    class _Req:
+        scientific_origin = "computed"
+        interpretation_assignments: list = []
+        network_kinetics_ref = None
+        tunneling_model = _eckart()
+        tunneling_application = None
+
+    codes = {w.code for w in collect_kinetics_content_warnings(_Req())}
+    assert codes == {
+        W_MISSING_KINETICS_INTERPRETATIONS,
+        W_MISSING_TUNNELING_APPLICATION,
+    }
+
+
+def _eckart():
+    from app.db.models.common import TunnelingModel
+
+    return TunnelingModel.eckart

--- a/backend/tests/api/test_api_bundle_result_completeness.py
+++ b/backend/tests/api/test_api_bundle_result_completeness.py
@@ -1,0 +1,353 @@
+"""An upload's 201 must name every record it wrote, not most of them.
+
+``persist_computed_reaction_upload`` builds a result dict with eleven
+keys. ``ComputedReactionUploadResult`` declared nine fields, and
+``pydantic.BaseModel`` ignores extras by default — so
+``ComputedReactionUploadResult(**result_dict)`` silently discarded
+``statmech_ids`` and ``atom_map_id`` on every reaction-bundle upload.
+
+Nothing was lost in the database; the rows were written. What was lost
+was any way for the depositor to *name* them. A bundle carrying kinetics,
+thermo and statmech got a 201 that listed the first two, which reads as a
+deliberate contract rather than an omission. The cost was already being
+paid in this repo:
+``tests/api/test_api_bundle_provenance_warnings._statmech_rows`` reads
+statmech back through ``species_entry_ids`` and says in its docstring
+that it does so only because the response has no ``statmech_ids``.
+
+Two kinds of test live here:
+
+* **Per-field** — post a real bundle through the real route and assert
+  the response names the rows the database actually holds. These would
+  have gone red on ``main``.
+* **Structural** — ``extra="forbid"`` turns the *next* such omission from
+  a silent drop into a loud failure at construction time, and
+  :func:`test_an_unknown_workflow_key_cannot_be_silently_dropped` proves
+  that guard is live rather than merely declared.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.api.routes.uploads import ComputedReactionUploadResult
+from app.db.models.reaction_atom_map import ReactionAtomMap
+from app.db.models.statmech import Statmech
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+
+_XYZ_H = "1\nH atom\nH 0.0 0.0 0.0"
+_XYZ_H2 = "2\nH2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+
+
+def _species(key: str, smiles: str, multiplicity: int, xyz: str) -> dict:
+    return {
+        "key": key,
+        "species_entry": {
+            "smiles": smiles,
+            "charge": 0,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": f"{key}-conf",
+                "geometry": {"key": f"{key}-geom", "xyz_text": xyz},
+                "calculation": {
+                    "key": f"{key}-opt",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_converged": True,
+                },
+            }
+        ],
+        "calculations": [
+            {
+                "key": f"{key}-freq",
+                "type": "freq",
+                "geometry_key": f"{key}-geom",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_n_imag": 0,
+                "freq_zpe_hartree": 0.01,
+            },
+        ],
+    }
+
+
+def _bundle(**overrides) -> dict:
+    """``H + H -> H2``. Balanced, no transition state."""
+    base: dict = {
+        "species": [
+            _species("h", "[H]", 2, _XYZ_H),
+            _species("h2", "[H][H]", 1, _XYZ_H2),
+        ],
+        "reversible": True,
+        "reactant_keys": ["h", "h"],
+        "product_keys": ["h2"],
+    }
+    base.update(overrides)
+    return base
+
+
+_STATMECH = {
+    "scientific_origin": "computed",
+    "statmech_treatment": "rrho",
+    "external_symmetry": 1,
+}
+
+
+# ---------------------------------------------------------------------------
+# statmech_ids
+# ---------------------------------------------------------------------------
+
+
+def test_reaction_bundle_result_names_the_statmech_it_wrote(
+    client: TestClient, db_session
+):
+    """The response must list the statmech rows, not just kinetics/thermo.
+
+    Both species carry statmech so the assertion is on a *set of two*:
+    a response that named only one, or that collapsed the two into a
+    single id, fails here where a truthy ``statmech_ids`` check would
+    not.
+    """
+    bundle = _bundle()
+    bundle["species"][0]["statmech"] = dict(_STATMECH)
+    bundle["species"][1]["statmech"] = dict(_STATMECH)
+
+    resp = client.post("/api/v1/uploads/computed-reaction", json=bundle)
+    assert resp.status_code == 201, resp.text[:800]
+    body = resp.json()
+
+    assert "statmech_ids" in body, (
+        "the reaction bundle wrote statmech rows and the 201 does not name "
+        f"them; body keys were {sorted(body)}"
+    )
+
+    persisted = set(
+        db_session.scalars(
+            select(Statmech.id).where(
+                Statmech.species_entry_id.in_(body["species_entry_ids"])
+            )
+        ).all()
+    )
+    assert len(persisted) == 2, persisted
+    assert set(body["statmech_ids"]) == persisted
+
+
+def test_a_bundle_without_statmech_reports_an_empty_list_not_a_missing_key(
+    client: TestClient,
+):
+    """Absence is spelled ``[]``, the same way ``thermo_ids`` spells it.
+
+    A depositor reading ``body["statmech_ids"]`` must not have to guess
+    whether a missing key means "none written" or "this server is too old
+    to say".
+    """
+    resp = client.post("/api/v1/uploads/computed-reaction", json=_bundle())
+    assert resp.status_code == 201, resp.text[:800]
+    assert resp.json()["statmech_ids"] == []
+
+
+# ---------------------------------------------------------------------------
+# atom_map_id
+# ---------------------------------------------------------------------------
+
+
+_XYZ_CH3 = (
+    "4\nmethyl\n"
+    "C  0.000  0.000  0.000\n"
+    "H  1.080  0.000  0.000\n"
+    "H -0.540  0.935  0.000\n"
+    "H -0.540 -0.935  0.000"
+)
+_XYZ_CH4 = (
+    "5\nmethane\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
+)
+_XYZ_TS = (
+    "5\nTS for CH3 + H -> CH4\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.000  0.000  1.400"
+)
+
+
+def _mapped_bundle(with_map: bool) -> dict:
+    """``CH3 + H -> CH4`` with a transition state, the shape an atom map needs.
+
+    Mirrors ``tests/api/scientific/test_api_reaction_atom_map`` rather
+    than inventing a payload, so this test exercises the same write path
+    the atom-map suite does — only reading the id from the 201 instead of
+    querying it back.
+    """
+    bundle: dict = {
+        "species": [
+            _species("ch3", "[CH3]", 2, _XYZ_CH3),
+            _species("h", "[H]", 2, _XYZ_H),
+            _species("ch4", "C", 1, _XYZ_CH4),
+        ],
+        "reversible": True,
+        "reactant_keys": ["ch3", "h"],
+        "product_keys": ["ch4"],
+        "transition_state": {
+            "charge": 0,
+            "multiplicity": 2,
+            "geometry": {"key": "ts-geom", "xyz_text": _XYZ_TS},
+            "calculation": {
+                "key": "ts-opt",
+                "type": "opt",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "opt_converged": True,
+            },
+            "calculations": [
+                {
+                    "key": "ts-freq",
+                    "type": "freq",
+                    "geometry_key": "ts-geom",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "freq_n_imag": 1,
+                    "freq_imag_freq_cm1": -1500.0,
+                }
+            ],
+        },
+    }
+    if with_map:
+        bundle["atom_map"] = {
+            "source": "declared",
+            "ts_geometry_key": "ts-geom",
+            "participants": [
+                {
+                    "side": "reactant",
+                    "species_key": "ch3",
+                    "participant_index": 1,
+                    "geometry_key": "ch3-geom",
+                    "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4},
+                },
+                {
+                    "side": "reactant",
+                    "species_key": "h",
+                    "participant_index": 2,
+                    "geometry_key": "h-geom",
+                    "atom_to_ts": {1: 5},
+                },
+                {
+                    "side": "product",
+                    "species_key": "ch4",
+                    "participant_index": 1,
+                    "geometry_key": "ch4-geom",
+                    "atom_to_ts": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
+                },
+            ],
+        }
+    return bundle
+
+
+def test_reaction_bundle_result_names_the_atom_map_it_wrote(
+    client: TestClient, db_session
+):
+    """``atom_map_id`` was computed by the workflow and then dropped.
+
+    Found while fixing ``statmech_ids``: the same ``extra="ignore"``
+    default discarded it. Every atom-map test in the tree reads the map
+    back through ``/scientific/reaction-entries/{id}/full`` instead,
+    which is why nothing noticed.
+    """
+    resp = client.post(
+        "/api/v1/uploads/computed-reaction", json=_mapped_bundle(with_map=True)
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    body = resp.json()
+
+    assert "atom_map_id" in body, (
+        "the bundle wrote a reaction_atom_map row and the 201 does not name "
+        f"it; body keys were {sorted(body)}"
+    )
+    assert body["atom_map_id"] is not None
+    row = db_session.get(ReactionAtomMap, body["atom_map_id"])
+    assert row is not None, "the 201 named an atom_map_id that does not exist"
+    assert row.reaction_entry_id == body["reaction_entry_id"]
+
+
+def test_a_bundle_without_an_atom_map_reports_none(client: TestClient):
+    """``None`` means "no map was written", and must not mean "not said".
+
+    Paired with the test above so the field cannot be satisfied by
+    hard-coding either answer.
+    """
+    resp = client.post(
+        "/api/v1/uploads/computed-reaction", json=_mapped_bundle(with_map=False)
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert resp.json()["atom_map_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# The structural guard
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_workflow_key_cannot_be_silently_dropped():
+    """The guard that makes the *next* omission of this kind impossible.
+
+    ``ComputedReactionUploadResult(**result_dict)`` is the seam where
+    ``statmech_ids`` and ``atom_map_id`` were lost. Under pydantic's
+    default ``extra="ignore"`` that seam cannot fail, so no test anywhere
+    could have caught either. With ``extra="forbid"`` a workflow key with
+    no matching response field raises at construction, in every existing
+    reaction-bundle test at once.
+
+    This test exists because a config flag that is set but never
+    exercised is indistinguishable from one that was reverted.
+    """
+    with pytest.raises(Exception) as excinfo:
+        ComputedReactionUploadResult(
+            reaction_entry_id=1,
+            reaction_id=1,
+            transition_state_entry_id=None,
+            atom_map_id=None,
+            kinetics_ids=[],
+            thermo_ids=[],
+            statmech_ids=[],
+            species_entry_ids=[],
+            species_count=0,
+            a_product_type_invented_tomorrow=[7],
+        )
+    assert "a_product_type_invented_tomorrow" in str(excinfo.value)
+
+
+def test_the_result_model_declares_every_key_the_workflow_returns():
+    """Names the contract in one place a reader can check by eye.
+
+    The ``extra="forbid"`` test above proves the seam is loud; this one
+    states which keys are expected to cross it, so removing a field from
+    the response model fails with a message that says what is missing
+    rather than a KeyError somewhere downstream.
+    """
+    expected = {
+        "reaction_entry_id",
+        "reaction_id",
+        "transition_state_entry_id",
+        "atom_map_id",
+        "kinetics_ids",
+        "thermo_ids",
+        "statmech_ids",
+        "species_entry_ids",
+        "species_count",
+        "calculation_keys",
+        "warnings",
+    }
+    declared = set(ComputedReactionUploadResult.model_fields)
+    assert expected <= declared, f"response model is missing {expected - declared}"

--- a/backend/tests/schemas/test_bundle_root_model_symmetry.py
+++ b/backend/tests/schemas/test_bundle_root_model_symmetry.py
@@ -191,26 +191,12 @@ ALLOWED_ASYMMETRIES: dict[tuple[str, str], str] = {
         "species by key; the species bundle has one species and attaches "
         "geometries to conformers directly."
     ),
-    (
-        "calculation",
-        "literature",
-    ): (
-        "Species-root only: an inline literature fragment resolved by the "
-        "workflow. The reaction root takes a literature_id instead, which "
-        "is a different contract rather than the same one spelled twice — "
-        "see the literature_id entry immediately below."
-    ),
-    (
-        "calculation",
-        "literature_id",
-    ): (
-        "Reaction-root only, and flagged rather than endorsed. This is a "
-        "database FK on an upload surface; the species root's inline "
-        "'literature' fragment is the pattern the repo's no-FK-in-uploads "
-        "rule asks for. Tracked separately — this entry records the "
-        "asymmetry so the symmetry gate does not fire on it, and does not "
-        "claim it is right."
-    ),
+    # ``literature`` / ``literature_id`` were both listed here until the
+    # reaction root's raw FK was replaced by the same inline fragment the
+    # species root always took. Both roots now spell the citation
+    # ``literature``, so there is no asymmetry left to exempt — and
+    # ``test_the_allowlist_describes_asymmetries_that_still_exist`` would
+    # fail if these entries were left behind.
 }
 
 

--- a/backend/tests/schemas/test_bundle_root_model_symmetry.py
+++ b/backend/tests/schemas/test_bundle_root_model_symmetry.py
@@ -40,6 +40,20 @@ import pytest
 from tckdb_schemas.workflows import computed_reaction_upload as rx
 from tckdb_schemas.workflows import computed_species_upload as sp
 
+
+def _standalone_kinetics_model():
+    """``KineticsUploadRequest``, the standalone route's kinetics shape.
+
+    Imported inside a function because it lives backend-side, not in the
+    wire package: the standalone kinetics schema was never extracted when
+    the bundle roots were (``9fde2742``). That split is itself part of why
+    the two drifted — the models do not sit next to each other, and
+    nothing imported both until this file did.
+    """
+    from app.schemas.workflows.kinetics_upload import KineticsUploadRequest
+
+    return KineticsUploadRequest
+
 # ---------------------------------------------------------------------------
 # The pairs
 # ---------------------------------------------------------------------------
@@ -307,15 +321,19 @@ def test_the_statmech_pair_needs_no_exemptions():
         )
 
 
-def test_kinetics_and_transport_have_no_second_spelling():
+def test_kinetics_and_transport_have_no_second_spelling_across_the_two_roots():
     """Recorded because "cover those too" needs an answer either way.
 
     Kinetics exists only on the reaction root — a species bundle has no
     reaction to have a rate for — and transport has no bundle model on
-    either root; it is a standalone route only. Neither is a pair, so
-    neither can drift. This asserts that rather than leaving the reader
-    to infer it from MODEL_PAIRS, and it will fail the day a second
-    spelling is introduced, which is the day it would need adding above.
+    either root; it is a standalone route only.
+
+    This used to conclude "neither is a pair, so neither can drift". The
+    first half is right and the second half was wrong, and the error was
+    load-bearing: kinetics has no second spelling *across the two bundle
+    roots*, but it does have one across the **bundle and the standalone
+    route**, and that is where it drifted. See
+    :func:`test_bundle_kinetics_records_the_same_science_as_the_standalone_route`.
     """
     assert not hasattr(sp, "KineticsInBundle"), (
         "A species-root kinetics model now exists and should be added to "
@@ -329,3 +347,155 @@ def test_kinetics_and_transport_have_no_second_spelling():
             f"the {label} bundle root gained transport model(s) {transport}; "
             "if both roots now have one, add the pair to MODEL_PAIRS."
         )
+
+
+#: Scientific-content fields ``BundleKineticsIn`` lacks that
+#: ``KineticsUploadRequest`` has, each with the evidence for whether the
+#: asymmetry is deliberate. Unlike :data:`ALLOWED_ASYMMETRIES`, an entry
+#: here is **not** a claim that the gap is correct — two of the three are
+#: recorded drift. It is a claim that the gap is *known*, so that a fourth
+#: appearing is visible on the day it lands rather than months later.
+KNOWN_BUNDLE_KINETICS_GAPS: dict[str, str] = {
+    "interpretation_assignments": (
+        "DRIFT, not design. Added to KineticsUploadRequest by ee7377f5 (#66), "
+        "a commit that edited computed_reaction_upload.py in the same diff to "
+        "close the analogous transition-state evidence gap on parity grounds, "
+        "and left kinetics one-sided with no recorded reason. Closing it needs "
+        "a bundle-local-key assignment model plus persistence in "
+        "app.workflows.computed_reaction — a feature, not a contract change."
+    ),
+    "tunneling_application": (
+        "DRIFT, not design. Same commit, same omission, and the sharper half: "
+        "BundleKineticsIn carries tunneling_model, the label, so a bundle can "
+        "claim Eckart tunneling and never attach the evidence. The standalone "
+        "route cross-checks label against evidence "
+        "(validate_tunneling_declaration_agrees); the bundle has nothing to "
+        "check against."
+    ),
+    "network_kinetics_ref": (
+        "UNADDRESSED rather than decided. 2fb5c25b (#29) established that this "
+        "model carries only scalar Arrhenius fields and its workflow writes no "
+        "kinetics child tables, directing PLOG/Chebyshev to the single-reaction "
+        "endpoint. That reasoning covers child rows; network_kinetics_ref is a "
+        "nullable scalar column on kinetics itself, and BundleKineticsIn "
+        "accepts pressure_context='pressure_dependent' — the exact state the "
+        "handle names — with no way to name it."
+    ),
+}
+
+#: Fields on ``KineticsUploadRequest`` the bundle deliberately spells
+#: elsewhere or deliberately refuses. Excluded from the comparison rather
+#: than listed as gaps, because for each of these the reason is on record.
+_STANDALONE_ONLY_BY_DESIGN = frozenset(
+    {
+        # Identity. The bundle declares one reaction at its root and names
+        # participants by local key; ``direction`` is expressed by which
+        # keys land in ``reactant_keys`` vs ``product_keys``, which
+        # BundleKineticsIn's own docstring states.
+        "reaction",
+        "direction",
+        # Provenance. The reaction workflow writes ``request.literature``,
+        # ``request.analysis_software_release`` and
+        # ``request.workflow_tool_release`` onto every kinetics row it
+        # creates, so these are supplied once at the bundle root.
+        "software_release",
+        "workflow_tool_release",
+        "literature",
+        # A resolution hint for auto-resolving source SP calculations. The
+        # bundle names its source calculations by key instead, which is why
+        # ``_collect_bundle_provenance_warnings`` already passes it as
+        # NOT_APPLICABLE.
+        "energy_level_of_theory",
+        # Kinetics child tables. 2fb5c25b (#29) decided this explicitly:
+        # BundleKineticsIn "carries only scalar Arrhenius fields … and its
+        # workflow writes no kinetics child tables", and its
+        # ``validate_model_kind`` refuses the forms that would need them,
+        # directing those deposits to the single-reaction endpoint. This is
+        # the one asymmetry here that is genuinely on record as a decision.
+        "arrhenius_entries",
+        "chebyshev",
+        "falloff",
+        "plog_entries",
+        "third_body_efficiencies",
+    }
+)
+
+
+def test_bundle_kinetics_records_the_same_science_as_the_standalone_route():
+    """The comparison nothing in the tree was making.
+
+    ``BundleKineticsIn`` and ``KineticsUploadRequest`` describe the same
+    ``kinetics`` row. The bundle is the route the ARC adapter deposits
+    through, so a field the bundle lacks is missing from the *majority* of
+    deposits, not a minority.
+
+    The gate is deliberately shaped like ``ALLOWED_ASYMMETRIES`` but reads
+    the opposite way: entries in :data:`KNOWN_BUNDLE_KINETICS_GAPS` are
+    recorded gaps, most of them drift. Closing one means deleting its entry;
+    a *new* one means this test names it and someone has to decide.
+    """
+    standalone = _standalone_kinetics_model()
+    bundle_fields = set(rx.BundleKineticsIn.model_fields)
+    standalone_fields = set(standalone.model_fields)
+
+    missing = standalone_fields - bundle_fields - _STANDALONE_ONLY_BY_DESIGN
+    unexplained = sorted(missing - set(KNOWN_BUNDLE_KINETICS_GAPS))
+
+    assert not unexplained, (
+        f"{standalone.__name__} carries {len(unexplained)} scientific-content "
+        f"field(s) BundleKineticsIn does not: {unexplained}.\n"
+        "A reaction-bundle deposit therefore records less than the identical "
+        "standalone deposit, and nothing tells the depositor. Either widen "
+        "BundleKineticsIn (and persist it in app.workflows.computed_reaction), "
+        "or add the field to KNOWN_BUNDLE_KINETICS_GAPS with the git evidence "
+        "for why it belongs on only one route."
+    )
+
+
+def test_the_by_design_exclusions_still_name_real_fields():
+    """A stale exclusion is a hole that silently swallows the next gap.
+
+    ``_STANDALONE_ONLY_BY_DESIGN`` subtracts names before anything is
+    judged, so a name that no longer exists on either model — a rename, a
+    removal — would sit there forever excusing nothing, and a *new* field
+    that happened to reuse the name would be excused without anyone
+    deciding. Checked against the union so a field legitimately added to
+    the bundle later does not fail this.
+    """
+    known = set(_standalone_kinetics_model().model_fields) | set(
+        rx.BundleKineticsIn.model_fields
+    )
+    stale = sorted(_STANDALONE_ONLY_BY_DESIGN - known)
+    assert not stale, (
+        f"_STANDALONE_ONLY_BY_DESIGN excludes {stale}, which exists on neither "
+        "kinetics model. Drop the entries."
+    )
+
+
+def test_the_known_gap_list_describes_gaps_that_still_exist():
+    """A stale entry would hide a closed gap behind a "known" label."""
+    standalone = _standalone_kinetics_model()
+    bundle_fields = set(rx.BundleKineticsIn.model_fields)
+    stale = sorted(
+        name
+        for name in KNOWN_BUNDLE_KINETICS_GAPS
+        if name in bundle_fields or name not in standalone.model_fields
+    )
+    assert not stale, (
+        f"KNOWN_BUNDLE_KINETICS_GAPS still lists {stale}, which BundleKineticsIn "
+        "now has (or the standalone route no longer does). Delete the entries — "
+        "leaving them turns a closed gap into a permanent excuse."
+    )
+
+
+def test_the_bundle_can_claim_tunneling_it_cannot_evidence():
+    """Pins the concrete consequence, not just the field list.
+
+    The field-set tests above would still pass if ``tunneling_model`` were
+    also dropped from the bundle — a *consistent* model that simply says
+    less. This one asserts the specific inconsistency that makes the gap
+    worth fixing rather than worth tolerating: the label is accepted and
+    the evidence has nowhere to go.
+    """
+    assert "tunneling_model" in rx.BundleKineticsIn.model_fields
+    assert "tunneling_application" not in rx.BundleKineticsIn.model_fields

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -2548,9 +2548,13 @@ def test_upload_schema_exposes_no_fk_ids_or_hashes() -> None:
         return offenders
 
     offenders = _walk(NetworkPDepUploadRequest, set())
-    # ``CalculationIn.literature_id`` is a pre-existing FK leak inherited from
-    # the shared calculation fragment; it is not introduced by this schema.
-    assert [o for o in offenders if o != "CalculationIn.literature_id"] == []
+    # This assertion used to carry one exemption: ``CalculationIn.literature_id``,
+    # an FK leak inherited from the shared calculation fragment rather than
+    # introduced here. That field is gone — the shared ``CalculationIn`` now
+    # takes an inline ``literature`` fragment, which the workflow resolves —
+    # so the gate is unconditional again. Do not re-add an exemption; widen
+    # the schema or fix it.
+    assert offenders == []
 
 
 def test_chebyshev_grid_dimensions_must_match_declared_orders() -> None:

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,55 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.32.0 — **BREAKING**: a calculation cites literature inline, and the reaction bundle's 201 names its statmech
+
+**Breaking:** `CalculationIn.literature_id` is **removed**. It was a
+database primary key on an upload surface — supplying it required having
+already queried this database, which a depositor has not — contradicting
+"no FK IDs in upload schemas". It is replaced by `literature`, the same
+inline `LiteratureUploadRequest` fragment
+`CalculationInBundle.literature` has always taken on the species bundle,
+resolved (and deduplicated) by the workflow.
+
+`CalculationIn` is shared, so this lands on **two** routes:
+
+| payload | 0.31.0 | 0.32.0 |
+|---|---|---|
+| `computed-reaction`, calculation with `literature_id: 7` | 201, FK stored | **422** — `extra="forbid"` names the field |
+| `network-pdep`, calculation with `literature_id: 7` | 201, FK stored | **422** |
+| either route, calculation with inline `literature: {...}` | field did not exist | 201, row resolved-or-created and attached |
+| two calculations citing the same DOI | n/a | one `literature` row, shared |
+
+**Migrating.** Replace `"literature_id": <n>` with the citation itself:
+`"literature": {"kind": "article", "title": …, "doi": …}`. The workflow
+resolves an existing row by DOI/ISBN or creates one, so repeating the
+same fragment across calculations does not duplicate it. A calculation
+that cited nothing needs no change. The failure is a 422 naming
+`literature_id`, not a silent drop — deliberately, since silently
+ignoring it would discard the citation.
+
+`calculation_in_to_with_results_payload` gains a keyword-only
+`literature_id` and **raises** if handed a calculation carrying a
+`literature` fragment without one. The package cannot resolve literature
+(it has no database), so the caller resolves and passes the id down;
+defaulting to `None` would make "cited nothing" and "the workflow forgot"
+the same value.
+
+**Additive:** `ComputedReactionUploadResult` gains `statmech_ids` and
+`atom_map_id`. Both were already computed by the workflow and discarded
+by pydantic's default `extra="ignore"`, so a bundle depositing kinetics,
+thermo *and* statmech got a 201 naming two of the three, and the atom map
+it wrote had to be fetched back through the read API. The result model is
+now `extra="forbid"` so the next such omission fails loudly.
+
+**Documentation only, no shape change:** `BundleKineticsIn`'s docstring
+now records the three scientific-content fields the standalone
+`/uploads/kinetics` route has and it does not
+(`interpretation_assignments`, `tunneling_application`,
+`network_kinetics_ref`), with the git evidence that two of the three are
+drift rather than design. No field was added or removed; closing those
+gaps needs bundle-local-key schemas plus workflow persistence.
+
 ### 0.31.0 — **BREAKING**: `source_conformer_key` now points at something, on every route that accepts it
 
 **A field that cannot be wrong is not a field.** Three upload paths

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.31.0"
+version = "0.32.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
@@ -39,6 +39,7 @@ from tckdb_schemas.fragments.refs import (
     WorkflowToolReleaseRef,
 )
 from tckdb_schemas.frequency_completeness import evaluate_deposited_frequency_list
+from tckdb_schemas.literature import LiteratureUploadRequest
 from tckdb_schemas.stationary_point import (
     StationaryPointFinding,
     evaluate_transition_state_frequency,
@@ -58,7 +59,12 @@ class CalculationIn(SchemaBase):
     :param software_release: Required software provenance reference.
     :param level_of_theory: Required level-of-theory reference.
     :param workflow_tool_release: Optional workflow-tool provenance reference.
-    :param literature_id: Optional literature provenance id.
+    :param literature: Optional inline literature provenance, resolved (or
+        created) by the workflow. Replaces the former ``literature_id``,
+        which was a database primary key on an upload surface — usable only
+        by a client that had already queried this database, which a
+        depositor has not. Matches ``CalculationInBundle.literature`` on the
+        species bundle, which took the inline fragment from the start.
     :param sp_electronic_energy_hartree: SP result (if type=sp).
     :param opt_converged: Opt result (if type=opt).
     :param opt_n_steps: Opt result (if type=opt).
@@ -87,7 +93,7 @@ class CalculationIn(SchemaBase):
     software_release: SoftwareReleaseRef
     level_of_theory: LevelOfTheoryRef
     workflow_tool_release: WorkflowToolReleaseRef | None = None
-    literature_id: int | None = None
+    literature: LiteratureUploadRequest | None = None
     execution_environment: ExecutionEnvironmentManifestPayload | None = None
 
     # Optional inline results (avoids separate result upload)
@@ -263,6 +269,8 @@ def frequency_completeness_findings(
 
 def calculation_in_to_with_results_payload(
     calc_in: "CalculationIn",
+    *,
+    literature_id: int | None = None,
 ) -> CalculationWithResultsPayload:
     """Adapt a bundle-local ``CalculationIn`` to the shared upload shape.
 
@@ -272,7 +280,30 @@ def calculation_in_to_with_results_payload(
     parameter-snapshot metadata unchanged. Bundle-only fields (``key``,
     ``geometry_key``, ``artifacts``) are consumed by the workflow directly and
     are not part of the shared payload.
+
+    ``literature_id`` is passed *in* rather than read off ``calc_in``: the
+    upload now carries an inline ``literature`` fragment, and resolving it
+    to a row needs a database session, which this package deliberately
+    cannot reach. The caller resolves and hands the id down — the same
+    split ``computed_species._to_calc_with_results_payload`` has always
+    used.
+
+    A caller that supplies a ``literature`` fragment but no resolved id is
+    refused rather than quietly losing the citation. Defaulting to ``None``
+    would make "this upload cited nothing" and "the workflow forgot to
+    resolve the citation" the same value, which is the class of silent drop
+    this change exists to remove.
+
+    :raises ValueError: if ``calc_in.literature`` is set and
+        ``literature_id`` is not.
     """
+    if calc_in.literature is not None and literature_id is None:
+        raise ValueError(
+            "calculation_in_to_with_results_payload was given a calculation "
+            "carrying an inline 'literature' fragment but no resolved "
+            "literature_id. Resolve it in the workflow and pass it in; "
+            "dropping it here would discard a depositor's citation."
+        )
 
     opt_result: OptResultPayload | None = None
     freq_result: FreqResultPayload | None = None
@@ -309,7 +340,7 @@ def calculation_in_to_with_results_payload(
         software_release=calc_in.software_release,
         workflow_tool_release=calc_in.workflow_tool_release,
         level_of_theory=calc_in.level_of_theory,
-        literature_id=calc_in.literature_id,
+        literature_id=literature_id,
         execution_environment=calc_in.execution_environment,
         opt_result=opt_result,
         freq_result=freq_result,

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -221,6 +221,8 @@ class ComputedReactionCalculationIn(_BaseCalculationIn):
 
 def calculation_in_to_with_results_payload(
     calc_in: ComputedReactionCalculationIn,
+    *,
+    literature_id: int | None = None,
 ) -> CalculationWithResultsPayload:
     """Adapt a computed-reaction ``ComputedReactionCalculationIn`` to the
     shared upload shape.
@@ -229,8 +231,12 @@ def calculation_in_to_with_results_payload(
     shared ``CalculationWithResultsPayload`` so the existing calculation
     persistence seam writes the corresponding rows. The base converter
     handles type/result/parameter mapping unchanged.
+
+    ``literature_id`` is the workflow-resolved id for the calculation's
+    inline ``literature`` fragment; see the base converter for why it
+    cannot be resolved inside this package.
     """
-    base = _base_calc_to_payload(calc_in)
+    base = _base_calc_to_payload(calc_in, literature_id=literature_id)
     return base.model_copy(
         update={
             "input_geometries": list(calc_in.input_geometries),

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -973,6 +973,47 @@ class BundleKineticsIn(SchemaBase):
     :param degeneracy_convention: Whether degeneracy is already included in
         the reported rate. Defaults to ``unknown`` for legacy producers.
     :param note: Optional note.
+
+    **Three fields the standalone route has and this model does not.**
+    Recorded here because the gap was invisible: nothing in the tree
+    compared this model against ``KineticsUploadRequest``, and
+    ``test_bundle_root_model_symmetry`` explicitly excludes kinetics on the
+    grounds that it has no second spelling — true of the *species bundle*,
+    false of the standalone route.
+
+    * ``interpretation_assignments`` — which statmech records the rate's
+      partition functions came from.
+    * ``tunneling_application`` — the typed, replayable tunneling evidence.
+    * ``network_kinetics_ref`` — the master-equation solve a fitted rate
+      delegates its pressure dependence to.
+
+    The first two are **drift, not design**. Both were added to
+    ``KineticsUploadRequest`` by ``ee7377f5`` (#66), a commit that edited
+    *this file* in the same diff to close the analogous transition-state
+    evidence gap on parity grounds — and left kinetics one-sided with no
+    recorded reason. No commit message, comment or doc anywhere claims a
+    deliberately reduced kinetics shape. The consequence is concrete: this
+    model carries ``tunneling_model``, the *label*, so a bundle depositor
+    can claim Eckart tunneling was applied and has no way to attach the
+    evidence for it. The standalone route cross-checks the two
+    (``validate_tunneling_declaration_agrees``); here there is nothing to
+    check against.
+
+    ``network_kinetics_ref`` is **unaddressed rather than decided**.
+    ``2fb5c25b`` (#29) established that this model "carries only scalar
+    Arrhenius fields … and its workflow writes no kinetics child tables",
+    directing the pressure-dependent forms to the single-reaction endpoint.
+    That covers PLOG and Chebyshev child rows; ``network_kinetics_ref``
+    resolves to a nullable scalar column on ``kinetics`` itself, and this
+    model accepts ``pressure_context='pressure_dependent'`` — precisely the
+    state that handle exists to name — with no way to name it.
+
+    Closing any of the three means new bundle-local-key schemas plus
+    persistence in ``app.workflows.computed_reaction``, which is a feature
+    rather than a contract change and is deliberately not attempted here.
+    Until then ``collect_kinetics_content_warnings_for`` is passed
+    ``NOT_APPLICABLE`` for all three, so no depositor is advised to fill a
+    field this model does not have.
     """
 
     reactant_keys: list[str] = Field(min_length=1)


### PR DESCRIPTION
Closes #153, #154, #155. Grouped because all three are wire-package contract changes on the reaction bundle and one version bump beats three.

`tckdb-schemas` **0.31.0 → 0.32.0**. **#154 is breaking**: `CalculationIn.literature_id` is removed, so a payload that used to validate now 422s.

---

## #153 — the response could not say what statmech it wrote

`persist_computed_reaction_upload` returns eleven keys. `ComputedReactionUploadResult` declared nine, and the route builds it as `ComputedReactionUploadResult(**result_dict)`. Under pydantic's default `extra="ignore"` the two undeclared keys were dropped in silence.

**Before** — a bundle depositing statmech for both species:

```json
{"calculation_keys": {...}, "kinetics_ids": [], "reaction_entry_id": 1,
 "reaction_id": 1, "species_count": 2, "species_entry_ids": [1, 2],
 "submission_id": 1, "thermo_ids": [], "transition_state_entry_id": null,
 "type": "computed_reaction"}
```

Two `statmech` rows were written. The 201 does not mention them.

**After**:

```json
{"atom_map_id": null, "calculation_keys": {...}, "kinetics_ids": [],
 "reaction_entry_id": 1, "reaction_id": 1, "species_count": 2,
 "species_entry_ids": [1, 2], "statmech_ids": [1, 2], "submission_id": 1,
 "thermo_ids": [], "transition_state_entry_id": null, "type": "computed_reaction"}
```

**`atom_map_id` was dropped the same way** — computed by the workflow, discarded here, and not covered by anything. Every atom-map test in the tree reads the map back through `/scientific/reaction-entries/{id}/full` instead, which is why nothing noticed.

The result model is now `extra="forbid"`, so the *next* workflow key with no response field fails at construction rather than vanishing. That guard is exercised by a test, not merely declared.

The cost was already visible in the tree: `tests/api/test_api_bundle_provenance_warnings._statmech_rows` reads statmech back through `species_entry_ids` and says in its docstring that it does so only because the response has no `statmech_ids`.

## #154 — a calculation took a literature row id

`literature_id` was on the **shared** `CalculationIn`, not on `ComputedReactionCalculationIn` — so it leaked onto **two** upload surfaces, the reaction bundle and network-PDep. It is replaced by `literature`, the same inline `LiteratureUploadRequest` fragment `CalculationInBundle.literature` has always taken on the species bundle.

```
# was: 201, FK stored
"literature_id": 42
# now:
422 {"type": "extra_forbidden",
     "loc": ["body","species",0,"calculations",0,"literature_id"],
     "msg": "Extra inputs are not permitted", "input": 42}

# and inline works, deduplicated by resolve_or_create_literature:
"literature": {"kind": "article", "title": ..., "doi": ...}   -> 201
```

Two removals of standing exemptions fall out of this, and neither is a relaxation:

* Both `literature` and `literature_id` entries leave `ALLOWED_ASYMMETRIES` in `test_bundle_root_model_symmetry` — the roots now agree, and that file's stale-exemption test would fail if the entries were left behind.
* `test_network_pdep_upload.test_upload_schema_exposes_no_fk_ids_or_hashes` had a standing exemption for exactly this field. The gate is unconditional again.

`calculation_in_to_with_results_payload` gains a keyword-only `literature_id` and **raises** if handed a calculation carrying a `literature` fragment without one. The wire package has no database, so it cannot resolve the citation itself; defaulting to `None` would make "cited nothing" and "the workflow forgot to resolve it" the same value.

## #155 — the kinetics content collector, and what it revealed

**The premise as stated does not reproduce.** `collect_kinetics_content_warnings` is called from exactly one place, `uploads.py:310`, inside the standalone `/uploads/kinetics` route. It has never been wired to the bundle path, so no depositor can receive the un-actionable warning today. The defect is latent, not live — it would appear the moment anyone wired it.

**Verdict: drift for two of three.**

| field | verdict | evidence |
|---|---|---|
| `interpretation_assignments` | **drift** | added standalone-only by `ee7377f5` (#66) |
| `tunneling_application` | **drift** | same commit, same omission |
| `network_kinetics_ref` | **unaddressed, not decided** | `aa44a1c0` (#28) then `ee7377f5`; `2fb5c25b` (#29) covers it only by implication |

`ee7377f5` is decisive: it edited `computed_reaction_upload.py` **in the same diff** to close the analogous transition-state evidence gap on parity grounds, and left kinetics one-sided with no recorded reason. `git log -S` on the bundle file returns zero commits for all three names — they were never added and never removed there. No commit message, comment, docstring or doc anywhere claims a deliberately reduced kinetics shape.

The sharp end is `tunneling_application`: the bundle carries `tunneling_model`, the *label*, so a depositor can claim Eckart tunneling was applied and has no way to attach the evidence. The standalone route cross-checks the two; the bundle has nothing to check against.

`network_kinetics_ref` is weaker. `2fb5c25b` (#29) established that `BundleKineticsIn` "carries only scalar Arrhenius fields … and its workflow writes no kinetics child tables". That covers PLOG and Chebyshev child rows — but `network_kinetics_ref` is a nullable scalar column on `kinetics` itself, and the bundle accepts `pressure_context='pressure_dependent'`, precisely the state that handle exists to name.

**What this PR does and does not do.** Closing the drift means new bundle-local-key schemas plus persistence in `app.workflows.computed_reaction` — a feature, not a contract change, and accepting the fields without persisting them would be the silent drop this repo's own comments warn against. So:

1. `collect_kinetics_content_warnings_for` is request-agnostic with `NOT_APPLICABLE` defaults — the same sentinel PR #155 used for `energy_level_of_theory`. Judging is **opt-in**, so a future caller cannot leak advice by omission, which is exactly how this arrived.
2. Tests assert the un-actionable codes never reach a bundle depositor, that the advice really *would* be a 422 (so the premise is not hypothetical), and — the control — that passing `None` instead of the sentinel *does* raise them. Without that control the first assertion would pass on `main` too and prove nothing.
3. The drift is recorded where the next person will look: `BundleKineticsIn`'s docstring, and `KNOWN_BUNDLE_KINETICS_GAPS` with the git evidence per field.

**And a test that asserted something false.** `test_kinetics_and_transport_have_no_second_spelling` concluded "neither is a pair, so neither can drift". True across the two *bundle roots*; false across bundle and *standalone*, which is where kinetics actually drifted. That false claim is why this stayed invisible — the one guard that could have caught it had been told not to look. It is now a real bundle-vs-standalone comparison with a recorded-gap list and a stale-entry check on both the gap list and the by-design exclusions.

---

## Verification

Baselines measured on this branch's merge-base, not quoted.

| gate | before | after |
|---|---|---|
| rest | 4323 passed, 14 skipped | 4327 passed, 14 skipped (+4 schema-gate tests) |
| api | 2731 passed | 2748 passed (+17, all in three new files) |
| scientific | 2049 passed | 2049 passed (nothing added there) |

`ruff check app tests scripts` clean. Wire-package tests 38 passed, including `test_import_boundaries` (widened by one intra-package import, never relaxed).

**OpenAPI golden** regenerated deliberately. Four components changed, no additions or removals:

* `CalculationIn` — `+literature`, `−literature_id`
* `ComputedReactionCalculationIn` — `+literature`, `−literature_id`
* `ComputedReactionUploadResult` — `+atom_map_id`, `+statmech_ids`
* `BundleKineticsIn` — description only, same properties

**Mutation check — 9/9 killed.** The harness itself was wrong on the first run (it read bash's exit code, which the wrapper's trailing `echo` always makes 0, so every mutation reported green). Fixed to parse pytest's own code and to report `NO-SIGNAL` rather than guess.

| mutation | result |
|---|---|
| drop `statmech_ids` from the response model | RED |
| drop `atom_map_id` from the response model | RED |
| revert `extra="forbid"` to pydantic's default | RED |
| workflow resolves literature but forgets to pass the id | RED |
| adapter silently defaults instead of refusing | RED |
| put `literature_id` back on the shared model | RED |
| treat `NOT_APPLICABLE` as if it were `None` | RED |
| silently forget a recorded drift gap | RED |
| leave a stale by-design exclusion behind | RED |

No Alembic revision; head stays `b7e4d1a9c026`. These are contract and projection changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
