### PR TITLE
Stop exporting three codes no request can produce, and test one that can

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,49 @@ wrapper over a contract that is itself still moving.
 
 ### Changed
 
+- **Three codes a client could import but never receive are no longer
+  exported.** `app/api/code_catalogue.py` gains a `Reach` field, so an entry
+  can now record that no request produces it — the middle case of a three-way
+  distinction that previously had no spelling: catalogued and client-facing (a
+  caller can provoke it), catalogued and not client-facing (a real guard no
+  request can trip), not catalogued at all (not a code). Before this, a guard
+  could only be recorded by telling clients they might receive it, or by
+  deleting the entry and leaving the next reader to rediscover the literal.
+  `Reach` governs the client enum and nothing else; promotion
+  (`MESSAGE_PREFIX_CODES`) deliberately does not consult it.
+
+  **`tckdb-client` 0.39.0 → 0.40.0**, and three `RejectionCode` members are
+  removed: `TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH`,
+  `APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH` and
+  `IDEMPOTENCY_IN_PROGRESS`. Removing a member is breaking for an importer
+  even when the code was unreachable, hence the minor bump. **No code changes
+  value**, and all three keep a catalogue entry stating why no request reaches
+  them. The two ownership guards stay in the code: against a bug five lines up
+  they are a cheap tripwire, and in a database where a mis-attached
+  calculation is a scientific error rather than a crash that is worth keeping.
+  `idempotency_in_progress` is a contingency, not a milestone —
+  `docs/specs/upload-idempotency-key-spec.md` lists it under *Optional* ("Only
+  implement `idempotency_in_progress` if needed by the chosen approach") and
+  the approach chosen does not need it; `app/api/idempotency.py` used to say
+  "for v0", which does not distinguish a deferral from a decision, and now
+  says which one it is.
+
+- **A refusal that was recorded as unreachable is reachable, and is now
+  tested.** `statmech_torsion_scan_calculation_owner_mismatch` was classified
+  alongside the two above on the rule "an ownership guard is reachable exactly
+  when the field it guards accepts a foreign row id". That rule is
+  incomplete: a guard is also reachable when its key resolves in a namespace
+  wider than the target's owner. `_persist_statmech_block` is shared by the
+  species bundle, where the calc-key map is one species entry's own, and the
+  PDep bundle, where it spans every species and transition state — and the
+  PDep schema narrows a *species* statmech's keys to that species's own
+  calculations but does not do the same for a *transition state*'s. A TS
+  torsion naming a species-owned rotor scan therefore reaches the guard.
+  Measured on the wire at `POST /api/v1/uploads/networks/pdep`; the code
+  stays exported and `tests/api/test_api_network_pdep_ownership.py` provokes
+  it, and the sibling `statmech_source_calculation_owner_mismatch`, through
+  the route.
+
 - **Two refusals stopped naming the function they were raised in.** The
   `detail` of the group-additivity missing-thermo guard and of the two keyset
   argument guards used to begin `create_applied_group_additivity: ` and

--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -183,6 +183,58 @@ class Surface(str, Enum):
     accidental_prefix = "accidental_prefix"
 
 
+class Reach(str, Enum):
+    """Whether a *request* can produce this code.
+
+    :class:`Surface` says how a code gets into a body. This says whether
+    anything a caller can send makes it get there at all, and the two are
+    independent. Keeping them apart is what lets the catalogue stay
+    complete while the client enum stays honest: this module enumerates
+    what exists, and ``RejectionCode`` answers "what might I get back".
+
+    Three-way, not two: catalogued and client-facing (a caller can
+    provoke it); catalogued and not client-facing (a real guard no
+    request can trip); not catalogued at all (not a code). The middle
+    case had no spelling before, so a guard could only be recorded by
+    telling clients they might receive it, or by deleting the entry and
+    leaving the next reader to rediscover the literal.
+
+    This governs the client enum and nothing else. It is deliberately
+    *not* consulted by :data:`app.api.error_contract.MESSAGE_PREFIX_CODES`
+    — promotion is a question about whether a message declared a code,
+    and gating that on reachability would degrade a refusal the day
+    somebody made it reachable and forgot to reclassify.
+    """
+
+    #: A caller can provoke it with a request. The default, because the
+    #: overwhelming majority of codes are refusals of something a
+    #: depositor did.
+    request = "request"
+
+    #: No request can produce it: the branch compares against a value the
+    #: request path established itself, or names a state nothing sets.
+    #: Catalogued, because the literal exists and a reader who greps it
+    #: deserves an answer; never exported, because an enum member a
+    #: client can import and branch on but never receive is a lie in the
+    #: contract.
+    #:
+    #: Not a defect to clean up. Several of these guard an ownership rule
+    #: that no current write path can break because the calculation was
+    #: scoped to the target three lines above the check — and in a
+    #: database where a mis-attached calculation is a scientific error
+    #: rather than a crash, a cheap tripwire against a bug five lines up
+    #: is worth keeping. What is not worth keeping is telling a client it
+    #: might receive one.
+    #:
+    #: Every entry carrying this value must state *why* in its
+    #: :attr:`ApiCode.note`, and the reason has to be a property of the
+    #: code rather than of the test suite. "No test provokes it" is not
+    #: one: three quarters of the codes no test reaches are ordinary
+    #: refusals nobody has got round to, and classifying those as guards
+    #: would hide them from clients for the wrong reason entirely.
+    guard = "guard"
+
+
 @dataclass(frozen=True)
 class ApiCode:
     """One code the API can report, and how it gets there.
@@ -200,15 +252,22 @@ class ApiCode:
         red gate; see :attr:`app.scientific_checks.PythonCheck.location`
         for the incident). Where a code is minted from a variable this is
         the module holding the constant, not the module that raises.
+    :param reach: Whether a request can produce it — see :class:`Reach`.
+        Defaults to :attr:`Reach.request`, so the classification costs
+        nothing to the entries where it is uninteresting and has to be
+        written down where it is not.
     :param note: A fact the site cannot state about itself. Deliberately
         rare — this is an enumeration, not a second copy of the refusal
-        messages.
+        messages. Required on every :attr:`Reach.guard` entry, because
+        "no request can produce this" is a claim and an unexplained claim
+        is the kind that rots.
     """
 
     code: str
     status: int
     surface: Surface
     origin: str
+    reach: Reach = Reach.request
     note: str | None = None
 
     @property
@@ -217,14 +276,23 @@ class ApiCode:
 
         Derived, never declared. A 5xx is not a refusal of anything the
         caller did; a generic fallback repeats the status; an accidental
-        prefix is not a contract at all. Everything else is a refusal a
-        caller can act on, and the point of this module is that acting on
-        it must not require hard-coding a string.
+        prefix is not a contract at all; and a guard no request can trip
+        is a code the caller will never see, so a branch written for it
+        is a branch that never runs — the same silent non-event a
+        hard-coded typo produces, which is what generating this enum
+        exists to remove. Everything else is a refusal a caller can act
+        on, and the point of this module is that acting on it must not
+        require hard-coding a string.
         """
-        return 400 <= self.status < 500 and self.surface not in {
-            Surface.generic_fallback,
-            Surface.accidental_prefix,
-        }
+        return (
+            400 <= self.status < 500
+            and self.reach is Reach.request
+            and self.surface
+            not in {
+                Surface.generic_fallback,
+                Surface.accidental_prefix,
+            }
+        )
 
 
 #: Every code the API can report, ordered by code so a diff is readable.
@@ -235,7 +303,23 @@ class ApiCode:
 #: referee could argue with and must stay expensive.
 CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("applied_energy_correction_source_calculation_owner_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/calculation_ownership.py"),
+            "backend/app/services/calculation_ownership.py",
+            reach=Reach.guard,
+            note=(
+                "No request produces this code. All three call sites "
+                "(workflows/thermo.py once, workflows/computed_species.py "
+                "twice) read the calculation out of a key map the enclosing "
+                "block built for the target's own owner, and no applied "
+                "correction anywhere carries an existing_calculation_id, so "
+                "nothing can name a foreign row. The condition itself is not "
+                "unreachable: the reaction bundle resolves the same key in a "
+                "namespace spanning every species and the transition state. "
+                "It checks ownership with an inline comparison that raises a "
+                "bare ValueError instead of calling this guard, so a "
+                "depositor who makes that mistake there receives "
+                "validation_error. Converting those two copies is what would "
+                "make this code reachable, and is why the guard stays."
+            )),
     ApiCode("applied_energy_correction_source_key_undeclared", 422, Surface.coded_exception,
             "backend/app/services/energy_correction_resolution.py"),
     ApiCode("arrhenius_a_units_molecularity_mismatch", 422, Surface.coded_exception,
@@ -357,7 +441,20 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("idempotency_conflict", 409, Surface.response_literal,
             "backend/app/api/errors.py"),
     ApiCode("idempotency_in_progress", 409, Surface.response_literal,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            reach=Reach.guard,
+            note=(
+                "The ternary that mints it has one live arm. "
+                "IdempotencyConflict.in_progress defaults to False and the "
+                "one construction site never passes it, so no response can "
+                "carry this code. Not a milestone that has not arrived: "
+                "docs/specs/upload-idempotency-key-spec.md lists it under "
+                "*Optional* -- 'Only implement idempotency_in_progress if "
+                "needed by the chosen approach' -- and the approach chosen, a "
+                "unique constraint plus the integrity handler, does not need "
+                "it. It is a contingency, and app/api/idempotency.py names "
+                "the change that would make it live."
+            )),
     ApiCode("include_not_implemented_yet", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/calculations.py"),
     ApiCode("integrity_conflict", 409, Surface.generic_fallback,
@@ -558,7 +655,21 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("transition_state_reaction_coordinate_not_designated", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
     ApiCode("transport_source_calculation_owner_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/calculation_ownership.py"),
+            "backend/app/services/calculation_ownership.py",
+            reach=Reach.guard,
+            note=(
+                "No request produces it, and unlike its four siblings no "
+                "write path anywhere can even produce the condition. "
+                "Transport has one guard, in workflows/transport.py, over a "
+                "calculation the same loop persisted two statements earlier "
+                "with the transport target's own species entry; "
+                "TransportSourceCalculationIn carries only calculation_key "
+                "and role, so no request can name a foreign row; and the two "
+                "other callers of resolve_and_create_transport (the conformer "
+                "upload, the PDep bundle) pass no source calculations at all. "
+                "The guard stays as the tripwire for the day one of them "
+                "does."
+            )),
     ApiCode("unique_conflict", 409, Surface.sqlstate_category,
             "backend/app/api/errors.py"),
     ApiCode("unknown_curation_policy", 404, Surface.message_prefix,
@@ -616,6 +727,7 @@ __all__ = [
     "CATALOGUE",
     "STATUS_FALLBACK_PATTERN",
     "ApiCode",
+    "Reach",
     "Surface",
     "catalogued_codes",
     "client_facing",

--- a/backend/app/api/idempotency.py
+++ b/backend/app/api/idempotency.py
@@ -10,13 +10,41 @@ Provides a route-level dependency (``idempotency_dependency``) that:
    existing response or (b) record a fresh response after the write.
 
 Concurrent in-flight duplicate requests are *not* protected by an
-explicit advisory lock or ``idempotency_in_progress`` placeholder for
-v0. The unique constraint
-``uq_idempotency_record_user_method_endpoint_key`` plus the integrity
-error handler in :mod:`app.api.errors` is what catches a race: the
-losing committer surfaces ``409 idempotency_conflict`` via constraint-
-name mapping. This is the explicitly-allowed v0 behavior in
-``docs/specs/upload-idempotency-key-spec.md``.
+explicit advisory lock or ``idempotency_in_progress`` placeholder. The
+unique constraint ``uq_idempotency_record_user_method_endpoint_key``
+plus the integrity error handler in :mod:`app.api.errors` is what
+catches a race: the losing committer surfaces ``409
+idempotency_conflict`` via constraint-name mapping.
+
+Whether that is a gap or a decision
+-----------------------------------
+This paragraph used to end "for v0", and "deliberate for v0" and
+"planned for v1" are not the same claim — a reader looking for which
+one this was could not tell, which is the only reason the distinction
+is spelled out here at all.
+
+It is a decision. ``docs/specs/upload-idempotency-key-spec.md`` lists
+``idempotency_in_progress`` under *Optional* and says "Only implement
+``idempotency_in_progress`` if needed by the chosen approach". It was
+never a milestone to reach; it was a code that some approaches need and
+others do not, and the approach chosen here — one unique constraint,
+one integrity handler — does not. Nothing scheduled sets the flag.
+
+The consequence, recorded because it is a published contract. The
+``in_progress`` ternary in
+:func:`app.api.errors._idempotency_conflict_handler` has one live arm:
+``IdempotencyConflict.in_progress`` defaults to ``False`` and the one
+construction site in :mod:`app.services.idempotency` never passes it,
+so ``idempotency_in_progress`` cannot reach a response body. It is
+catalogued as :attr:`app.api.code_catalogue.Reach.guard` and is not
+generated into the client's ``RejectionCode``, because an enum member a
+caller can import and branch on but never receive is a lie in the
+contract.
+
+The parameter and the ternary stay. They are the two lines that make
+the state sayable the day an advisory lock is added, and the catalogue
+entry is what tells whoever adds it that the code already exists rather
+than inventing a second spelling for it.
 """
 
 from __future__ import annotations

--- a/backend/app/services/calculation_ownership.py
+++ b/backend/app/services/calculation_ownership.py
@@ -61,17 +61,48 @@ W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH = (
 #: Separate from the statmech source-link code because the torsion's scan
 #: is a different field with a different repair — the depositor picked the
 #: wrong rotor scan, not the wrong supporting job.
+#:
+#: Reachable, and by exactly one route, which is worth writing down
+#: because it was read as unreachable once. ``_persist_statmech_block`` is
+#: shared by the species bundle and the PDep bundle. Under
+#: ``/uploads/computed-species`` the calc-key map is one species entry's
+#: own, so the comparison is against a value just assigned; under
+#: ``/uploads/networks/pdep`` the map handed to the same seam spans every
+#: species *and* every transition state. The PDep payload schema narrows
+#: a **species** torsion's scan key to that species's own calculations
+#: before the seam ever sees it — and does not do the same for a
+#: **transition state**'s. So a TS torsion naming a species scan
+#: calculation reaches this guard, and
+#: ``tests/api/test_api_network_pdep_ownership.py`` provokes it on the
+#: wire.
 W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH = (
     "statmech_torsion_scan_calculation_owner_mismatch"
 )
 
 #: A transport source link cites a calculation owned by another subject.
+#:
+#: The one code here that no write path can produce: transport's single
+#: guard reads a calculation the same loop persisted against the target's
+#: own species entry, its source-link payload carries no
+#: ``existing_calculation_id``, and the other two callers of
+#: ``resolve_and_create_transport`` pass no source calculations at all.
+#: Catalogued as ``Reach.guard`` and not exported to clients; kept as the
+#: tripwire for the path that changes any of those three facts.
 W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH = (
     "transport_source_calculation_owner_mismatch"
 )
 
 #: An applied energy correction names a source calculation owned by
 #: another subject.
+#:
+#: No request produces *this code*: all three call sites read from a key
+#: map built for the target's own owner. The rule is not unreachable,
+#: though — the reaction bundle resolves the same key in a bundle-wide
+#: namespace and enforces ownership with an inline comparison that raises
+#: a bare ``ValueError``, so the same mistake there answers
+#: ``validation_error``. Also catalogued as ``Reach.guard``, and the
+#: repair that would change that is converting those two copies to call
+#: this function.
 W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH = (
     "applied_energy_correction_source_calculation_owner_mismatch"
 )

--- a/backend/docs/reviews/error_code_coverage_triage.md
+++ b/backend/docs/reviews/error_code_coverage_triage.md
@@ -80,6 +80,38 @@ code (scan in "Method" below). The repair is a message reword
 
 ### 2. Three of the five ownership codes are guards that check a value they just set
 
+> **Two of three, corrected in #184.** The rule below is incomplete, and
+> `statmech_torsion_scan_calculation_owner_mismatch` is the code it gets
+> wrong. A guard is reachable when the field it guards can name a
+> calculation the enclosing block did not itself scope to the target —
+> which a foreign row id achieves, and so does a **key resolved in a
+> namespace wider than the target's owner**. The second clause is the one
+> missing here, and it is not hypothetical: this analysis read call
+> *sites* rather than the callers of the function containing them, and
+> `_persist_statmech_block` has two production callers in
+> `workflows/network_pdep.py` besides the one in `computed_species.py`.
+> Both hand it a map spanning every species and every transition state in
+> the bundle. The PDep payload schema narrows a *species* statmech's
+> source and torsion keys to that species's own calculations first; it
+> does not do the same for a *transition state*'s. So a TS torsion naming
+> a species-owned scan calculation reaches the guard, and
+> `POST /api/v1/uploads/networks/pdep` returns
+> `422 statmech_torsion_scan_calculation_owner_mismatch` — measured, and
+> pinned by `tests/api/test_api_network_pdep_ownership.py`. That code
+> stays in the client enum. The other two were removed from it in #184
+> and keep annotated catalogue entries.
+>
+> Two further consequences of applying the corrected rule, neither fixed
+> in #184 (both live in files that change hands elsewhere): the reaction
+> bundle enforces the same ownership rule with four inline comparisons
+> that raise a bare `ValueError`
+> (`workflows/computed_reaction.py:807`, `:847`, `:1095`) instead of
+> calling the shared guard, so the same mistake there answers
+> `validation_error`; and a species torsion's `source_scan_calculation_key`
+> in that bundle (`workflows/computed_reaction.py:1128`) is checked for
+> neither ownership nor anything else, so a torsion may cite a sibling
+> species's or the TS's scan calculation and be persisted silently.
+
 `assert_calculation_owned_by` takes its code as a parameter and has five.
 Two are emitted by the suite; three are not — and the three are unreachable by
 construction, for one reason:
@@ -115,6 +147,18 @@ not "checked but never routed", but "checked against a value the same function
 assigned".
 
 ### 3. `idempotency_in_progress` is a dead ternary branch, and the code says why
+
+> **Half-corrected in #186.** The branch is dead, as stated. But
+> `app/api/idempotency.py` did *not* say why in the sense that matters: it
+> said "for v0", which reads as a milestone not yet reached, and the
+> distinction between a deferral and a decision is the one a client author
+> needs. The spec settles it — `idempotency_in_progress` is listed under
+> *Optional*, "Only implement `idempotency_in_progress` if needed by the
+> chosen approach", and the approach chosen does not need it. It is a
+> contingency. The comment now says so, the catalogue entry is
+> `Reach.guard`, and the member is gone from the client enum; the ternary
+> and the `in_progress` parameter stay, because they are what make the
+> state sayable if an advisory lock is ever added.
 
 `app/api/errors.py:444` picks the code off `exc.in_progress`.
 `IdempotencyConflict.__init__` defaults it to `False`

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -31,6 +31,8 @@ from pathlib import Path
 from app.api.code_catalogue import (
     CATALOGUE,
     STATUS_FALLBACK_PATTERN,
+    ApiCode,
+    Reach,
     Surface,
     catalogued_codes,
     client_facing,
@@ -523,6 +525,13 @@ def test_client_facing_excludes_what_a_client_cannot_use() -> None:
                 "reach a client as an importable constant"
             )
             excluded += 1
+        if entry.reach is Reach.guard:
+            assert entry.code not in exported, (
+                f"{entry.code} is classified as a guard no request can trip, "
+                "so a client branch written for it would never run -- the "
+                "silent non-event this enum is generated to remove"
+            )
+            excluded += 1
         if entry.status >= 500:
             assert entry.code not in exported, (
                 f"{entry.code} is reported at {entry.status}; a 5xx refuses "
@@ -651,4 +660,123 @@ def test_a_refusal_that_is_not_science_is_importable_by_a_client() -> None:
             f"{code} has been added to the scientific check register. That is "
             "the decision #164 refused; if it has been revisited, this test "
             "should be changed deliberately and not merely to go green."
+        )
+
+
+#: The three codes #184 and #186 classified as guards. Named here rather
+#: than derived, because the value of the classification is that flipping
+#: one back is a deliberate act with a test to change, not a silent
+#: widening of the client contract.
+_GUARD_CODES = (
+    "applied_energy_correction_source_calculation_owner_mismatch",
+    "idempotency_in_progress",
+    "transport_source_calculation_owner_mismatch",
+)
+
+
+def test_the_reach_rule_can_say_no() -> None:
+    """``Reach`` must change an answer, or it is a comment with a type.
+
+    The same shape as ``test_the_origin_detector_can_say_no`` above, and
+    for the same reason: a field whose only evidence is that the codes
+    carrying it happen not to be exported proves nothing, because they
+    could be excluded by one of the three older rules instead. So it is
+    exercised on two entries that differ in nothing else.
+    """
+    origin = "backend/app/services/calculation_ownership.py"
+    reachable = ApiCode("probe_code", 422, Surface.coded_exception, origin)
+    guarded = ApiCode(
+        "probe_code", 422, Surface.coded_exception, origin,
+        reach=Reach.guard, note="probe",
+    )
+
+    assert reachable.reach is Reach.request, "Reach.request must be the default"
+    assert reachable.is_client_facing
+    assert not guarded.is_client_facing
+
+
+def test_every_guard_entry_is_catalogued_annotated_and_unexported() -> None:
+    """The three-way distinction, asserted as three separate properties.
+
+    Catalogued, because the literal exists and a reader who greps it
+    deserves an answer. Annotated, because "no request can produce this"
+    is a claim and an unexplained claim is the kind that rots -- the note
+    has to say which property of the code makes it true. Not exported,
+    because a caller cannot receive it.
+    """
+    guards = [entry for entry in CATALOGUE if entry.reach is Reach.guard]
+    assert guards, (
+        "no entry is classified as a guard, so every assertion below runs "
+        "over an empty set -- the failure this file exists to avoid"
+    )
+    assert len(guards) * 8 < len(CATALOGUE), (
+        f"{len(guards)} of {len(CATALOGUE)} entries are classified as guards. "
+        "The class is meant to be the rare case a caller can never reach; at "
+        "this proportion it has become a place to put codes nobody has "
+        "tested, which is a different thing and hides real refusals from "
+        "clients."
+    )
+
+    catalogued = catalogued_codes()
+    exported = {entry.code for entry in client_facing()}
+    for entry in guards:
+        assert entry.code in catalogued
+        assert entry.code not in exported
+        assert entry.note, (
+            f"{entry.code} is classified Reach.guard with no note. The note "
+            "is where the claim is justified; without it the classification "
+            "is unfalsifiable."
+        )
+
+    named = {entry.code for entry in guards}
+    for code in _GUARD_CODES:
+        assert code in named, (
+            f"{code} is no longer classified as a guard. If a write path now "
+            "reaches it, that is good news and this list should shrink "
+            "deliberately -- together with the client version bump that "
+            "re-exports it."
+        )
+
+
+def test_the_ownership_guards_are_guards_because_of_a_schema_shape() -> None:
+    """The classification rests on live schemas, so it is checked against them.
+
+    An ownership guard can fire only when the field it guards can name a
+    calculation the enclosing block did not itself scope to the target:
+    a foreign row id, or a key resolved in a namespace wider than the
+    target's owner. The two ownership codes classified ``Reach.guard``
+    are classified that way because their fields carry no
+    ``existing_*_id`` -- a property of these payload models, not of the
+    test suite. Asserting it here means the day somebody adds the field,
+    this fails and names the entry to reclassify, instead of the
+    catalogue telling clients the wrong thing for another year.
+
+    The third ownership code with the same *shape*,
+    ``statmech_torsion_scan_calculation_owner_mismatch``, is deliberately
+    absent: its key is resolved in a bundle-wide namespace on the PDep
+    path, so it is reachable and stays exported. See
+    ``tests/api/test_api_network_pdep_ownership.py``.
+    """
+    from tckdb_schemas.energy_correction import (
+        AppliedEnergyCorrectionUploadPayload,
+    )
+
+    from app.schemas.workflows.transport_upload import (
+        TransportSourceCalculationIn,
+    )
+
+    for model in (
+        TransportSourceCalculationIn,
+        AppliedEnergyCorrectionUploadPayload,
+    ):
+        foreign = sorted(
+            name
+            for name in model.model_fields
+            if name.endswith("_id") or name.startswith("existing_")
+        )
+        assert not foreign, (
+            f"{model.__name__} now carries {foreign}. A field that accepts a "
+            "row this request did not create is exactly what makes an "
+            "ownership guard reachable, so the matching catalogue entry is "
+            "no longer Reach.guard and the client enum must re-export it."
         )

--- a/backend/tests/api/test_api_network_pdep_ownership.py
+++ b/backend/tests/api/test_api_network_pdep_ownership.py
@@ -1,0 +1,167 @@
+"""A PDep bundle's transition state may only cite its own calculations.
+
+Why this file exists, and why it is about a *code* rather than a rule
+---------------------------------------------------------------------
+``app.services.calculation_ownership.assert_calculation_owned_by`` is one
+implementation with five codes, and two of them were read as unreachable
+by construction: every call site was said to read a calculation out of a
+key map the same block had just built for the target's own owner, so the
+comparison was against a value it had itself assigned. The rule that
+verdict rested on was "an ownership guard is reachable exactly when the
+field it guards accepts a foreign row id", and for
+``statmech_torsion_scan_calculation_owner_mismatch`` that rule gives the
+wrong answer.
+
+``_persist_statmech_block`` is shared. Under ``/uploads/computed-species``
+its calc-key map is one species entry's own, and the reading holds. Under
+``/uploads/networks/pdep`` the same seam is handed a map spanning every
+species *and* every transition state in the bundle
+(``app.workflows.network_pdep``), which is a namespace wider than the
+target's owner — the second way a guard becomes reachable, and the one
+the rule did not name. The PDep payload schema narrows a **species**
+statmech's source and torsion keys to that species's own calculations
+before the seam ever sees them
+(``NetworkPDepUploadRequest.validate_key_references``); it does not do
+the same for a **transition state**'s. So a TS statmech that cites a
+species-owned calculation, or a TS torsion that names a species-owned
+rotor scan, reaches the guard and is refused with a code.
+
+That is a real refusal a depositor can provoke and a client can branch
+on, and until this file existed nothing in the suite produced either one
+on the wire — which is why the runtime observer, whose whole job is to
+hold the catalogue to what a consumer receives, had never recorded them.
+Both are now provoked through the route, so the ``(status, code)`` pair
+is measured rather than declared.
+
+What these tests are *not*
+--------------------------
+They are not an endorsement of the asymmetry above. A TS-side key being
+narrowed at the schema layer the way a species-side key already is would
+be a better refusal — the same 422, one layer earlier, naming the keys
+that *are* in scope. If that lands, these tests should be rewritten to
+assert the new refusal deliberately, not deleted: the property being
+protected is "a transition state cannot borrow another subject's
+calculation", and it must keep costing a red test to break.
+
+The assertions are on ``code``, never on substrings of ``detail``:
+Pydantic echoes rejected input back into its error string, so a substring
+check passes even when the field was wrongly accepted.
+"""
+
+from __future__ import annotations
+
+from tests.workflows.test_network_pdep_upload import (
+    _LOT_DFT,
+    _SOFTWARE,
+    _full_payload,
+)
+
+_PDEP_URL = "/api/v1/uploads/networks/pdep"
+
+_SOURCE_OWNER_MISMATCH = "statmech_source_calculation_owner_mismatch"
+_TORSION_OWNER_MISMATCH = "statmech_torsion_scan_calculation_owner_mismatch"
+
+
+def _assert_code(response, expected: str) -> dict:
+    """The response is a 422 whose ``code`` field is *expected*."""
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body.get("code") == expected, (
+        f"expected code={expected!r}, got {body.get('code')!r}. "
+        f"detail={body.get('detail')!r}"
+    )
+    return body
+
+
+def _payload_with_ts_statmech_citing_a_species_calculation() -> dict:
+    """A TS statmech whose ``source_calculations`` names ethyl's freq job.
+
+    ``ethyl_freq`` is a real key in the bundle's global calc namespace and
+    a real ``freq`` calculation, so nothing but ownership is wrong with
+    it. That is deliberate: a payload that also had a bad role or a
+    missing key could be refused for the other reason and the test would
+    pass while proving nothing.
+    """
+    payload = _full_payload(include_solve=False)
+    payload["transition_states"][0]["statmech"] = {
+        "statmech_treatment": "rrho",
+        "source_calculations": [
+            {"calculation_key": "ethyl_freq", "role": "freq"}
+        ],
+    }
+    return payload
+
+
+def _payload_with_ts_torsion_citing_a_species_scan() -> dict:
+    """A TS torsion whose rotor scan belongs to ethyl.
+
+    The TS statmech's own source link stays correct (``ts_elim_freq``), so
+    the only thing left to refuse is the torsion's scan key. The scan is
+    added to ethyl rather than reused from somewhere, because the key must
+    resolve to a genuine ``scan`` calculation for the ownership check to
+    be what fires.
+    """
+    payload = _full_payload(include_solve=False)
+    ethyl = next(sp for sp in payload["species"] if sp["key"] == "ethyl")
+    ethyl["calculations"].append(
+        {
+            "key": "ethyl_scan",
+            "type": "scan",
+            "geometry_key": "ethyl_geom",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT_DFT,
+        }
+    )
+    payload["transition_states"][0]["statmech"] = {
+        "statmech_treatment": "rrho_1d",
+        "source_calculations": [
+            {"calculation_key": "ts_elim_freq", "role": "freq"}
+        ],
+        "torsions": [
+            {"torsion_index": 1, "source_scan_calculation_key": "ethyl_scan"}
+        ],
+    }
+    return payload
+
+
+def test_ts_statmech_citing_a_species_calculation_is_refused(client) -> None:
+    body = _assert_code(
+        client.post(_PDEP_URL, json=_payload_with_ts_statmech_citing_a_species_calculation()),
+        _SOURCE_OWNER_MISMATCH,
+    )
+    # The context names the field the way the depositor wrote it and the
+    # kind of owner that disagreed -- never a row id (DR-0028 Req. 2).
+    assert body["context"]["owner_kind"] == "transition_state_entry", body
+    assert "ethyl_freq" in body["context"]["field"], body
+    assert "id" not in body["context"], body
+
+
+def test_ts_torsion_citing_a_species_scan_is_refused(client) -> None:
+    """The code the triage recorded as unreachable, measured on the wire.
+
+    It carries its own code rather than the statmech source-link one
+    because the repair differs: the depositor picked the wrong rotor
+    scan, not the wrong supporting job (#158/#162).
+    """
+    body = _assert_code(
+        client.post(_PDEP_URL, json=_payload_with_ts_torsion_citing_a_species_scan()),
+        _TORSION_OWNER_MISMATCH,
+    )
+    assert body["context"]["target"] == "statmech torsion", body
+    assert "ethyl_scan" in body["context"]["field"], body
+
+
+def test_the_same_bundle_without_the_borrowed_keys_is_accepted(client) -> None:
+    """The negative half: the payload is refused for ownership and nothing else.
+
+    Without this, both tests above would still pass if the fixture had
+    drifted into being invalid for some unrelated reason and every PDep
+    upload were failing at 422.
+    """
+    payload = _payload_with_ts_torsion_citing_a_species_scan()
+    statmech = payload["transition_states"][0]["statmech"]
+    statmech["torsions"] = [
+        {"torsion_index": 1, "source_scan_calculation_key": None}
+    ]
+    resp = client.post(_PDEP_URL, json=payload)
+    assert resp.status_code == 201, resp.text

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -188,8 +188,12 @@ repairing and resending, while a reaction that does not balance means the
 deposit is wrong and should not be retried at all.
 
 `exc.code` names which one it was. `RejectionCode` is generated from the
-server's scientific check register, so a code that is renamed breaks the
-import rather than turning a branch into one that silently never matches:
+server's code catalogue, so a code that is renamed breaks the import rather
+than turning a branch into one that silently never matches. Every member is
+a refusal a caller can actually receive: codes the catalogue records as
+guards no request can trip are catalogued on the server and deliberately not
+exported, because a branch for a code that never arrives is the same silent
+non-event as a typo.
 
 ```python
 from tckdb_client import RejectionCode, TCKDBHTTPError, rejection_code

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.39.0"
+version = "0.40.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -71,7 +71,6 @@ class RejectionCode(str, Enum):
     can be used wherever the raw code was.
     """
 
-    APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH = "applied_energy_correction_source_calculation_owner_mismatch"
     APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED = "applied_energy_correction_source_key_undeclared"
     ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH = "arrhenius_a_units_molecularity_mismatch"
     ATOM_MAP_ATOMS_UNACCOUNTED_FOR = "atom_map_atoms_unaccounted_for"
@@ -105,7 +104,6 @@ class RejectionCode(str, Enum):
     HANDLE_NOT_FOUND = "handle_not_found"
     HANDLE_TYPE_MISMATCH = "handle_type_mismatch"
     IDEMPOTENCY_CONFLICT = "idempotency_conflict"
-    IDEMPOTENCY_IN_PROGRESS = "idempotency_in_progress"
     INCLUDE_NOT_IMPLEMENTED_YET = "include_not_implemented_yet"
     INVALID_CURSOR = "invalid_cursor"
     INVALID_HANDLE = "invalid_handle"
@@ -187,7 +185,6 @@ class RejectionCode(str, Enum):
     TRANSITION_STATE_NO_IMAGINARY_MODE = "transition_state_no_imaginary_mode"
     TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS = "transition_state_reaction_coordinate_ambiguous"
     TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED = "transition_state_reaction_coordinate_not_designated"
-    TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH = "transport_source_calculation_owner_mismatch"
     UNIQUE_CONFLICT = "unique_conflict"
     UNKNOWN_CURATION_POLICY = "unknown_curation_policy"
     UNKNOWN_INCLUDE_TOKEN = "unknown_include_token"
@@ -210,7 +207,6 @@ class RejectionCode(str, Enum):
 #: payload may be sent again under the same idempotency key.
 VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
     {
-        RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
         RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED,
         RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH,
         RejectionCode.ATOM_MAP_ATOMS_UNACCOUNTED_FOR,
@@ -305,7 +301,6 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.TRANSITION_STATE_NO_IMAGINARY_MODE,
         RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS,
         RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED,
-        RejectionCode.TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH,
         RejectionCode.UNKNOWN_INCLUDE_TOKEN,
         RejectionCode.UNKNOWN_RECORD,
         RejectionCode.UNKNOWN_RECORD_TYPE,
@@ -333,7 +328,6 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.CURATION_POLICY_VERSION_CONFLICT,
         RejectionCode.ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE,
         RejectionCode.IDEMPOTENCY_CONFLICT,
-        RejectionCode.IDEMPOTENCY_IN_PROGRESS,
         RejectionCode.NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE,
         RejectionCode.REFERENCE_CONFLICT,
         RejectionCode.RELEASE_TAG_TAKEN,
@@ -355,7 +349,6 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
 #: wire boundary and again in the schema reports the same code from
 #: both, at two different statuses.
 REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
-    RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH: frozenset({422}),
     RejectionCode.ATOM_MAP_ATOMS_UNACCOUNTED_FOR: frozenset({422}),
@@ -389,7 +382,6 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.HANDLE_NOT_FOUND: frozenset({404}),
     RejectionCode.HANDLE_TYPE_MISMATCH: frozenset({422}),
     RejectionCode.IDEMPOTENCY_CONFLICT: frozenset({409}),
-    RejectionCode.IDEMPOTENCY_IN_PROGRESS: frozenset({409}),
     RejectionCode.INCLUDE_NOT_IMPLEMENTED_YET: frozenset({422}),
     RejectionCode.INVALID_CURSOR: frozenset({422}),
     RejectionCode.INVALID_HANDLE: frozenset({422}),
@@ -471,7 +463,6 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.TRANSITION_STATE_NO_IMAGINARY_MODE: frozenset({422}),
     RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS: frozenset({422}),
     RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED: frozenset({422}),
-    RejectionCode.TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.UNIQUE_CONFLICT: frozenset({409}),
     RejectionCode.UNKNOWN_CURATION_POLICY: frozenset({404}),
     RejectionCode.UNKNOWN_INCLUDE_TOKEN: frozenset({422}),


### PR DESCRIPTION
Three codes a client could import and never receive are no longer exported;
a fourth, recorded as unreachable, turned out to be reachable and is now
provoked on the wire.

## What changed

`app/api/code_catalogue.py` gains a `Reach` field. The catalogue could
previously say *how* a code reaches a body (`Surface`) but not *whether* a
request makes it get there, so the three-way distinction had no spelling:

* catalogued and client-facing — a caller can provoke it;
* catalogued and **not** client-facing — a real guard no request can trip;
* not catalogued — not a code.

The middle case was unrepresentable, so a guard could only be recorded by
telling clients they might receive it, or by deleting the entry and leaving
the next reader to rediscover the literal. `Reach` governs the client enum
and nothing else — `MESSAGE_PREFIX_CODES` deliberately does not consult it,
because promotion is a question about whether a message declared a code, and
gating it on reachability would degrade a refusal the day somebody made it
reachable and forgot to reclassify.

Three entries are classified `Reach.guard`, each with a note stating the
property of the code that makes the claim true:

| code | why no request produces it |
|---|---|
| `transport_source_calculation_owner_mismatch` | one call site, over a calculation the same loop just persisted against the target's own species entry; `TransportSourceCalculationIn` carries only `calculation_key` and `role`; the two other callers of `resolve_and_create_transport` pass no source calculations at all |
| `applied_energy_correction_source_calculation_owner_mismatch` | all three call sites read from a key map built for the target's own owner, and no applied correction anywhere carries an `existing_calculation_id` |
| `idempotency_in_progress` | `IdempotencyConflict.in_progress` defaults to `False` and the one construction site never passes it |

**`tckdb-client` 0.39.0 → 0.40.0.** Three `RejectionCode` members are
removed. No code changes value. Removing a member is breaking for an
importer even when the code was unreachable, hence the minor bump.

The guards themselves stay. Against a bug five lines up they are a cheap
tripwire, and in a database where a mis-attached calculation is a scientific
error rather than a crash that is worth keeping.

## `in_progress`: a decision, not a gap

`app/api/idempotency.py` said the placeholder was not implemented "for v0",
which does not distinguish a deferral from a decision — and that ambiguity
was the finding. The spec settles it:

> Only implement `idempotency_in_progress` if needed by the chosen approach.

— `docs/specs/upload-idempotency-key-spec.md`, under **Optional**. It was
never a milestone to reach; it is a code some approaches need, and the
approach chosen here (one unique constraint, one integrity handler) does
not. The comment now says which one it is, and names the change that would
make the code live. The ternary and the `in_progress` parameter stay: they
are what make the state sayable if an advisory lock is ever added, and the
catalogue entry is what stops whoever adds it inventing a second spelling.

## The reachability rule was wrong, and it cost a code

The triage classified the three ownership guards on this rule:

> An ownership guard is reachable exactly when the field it guards accepts a
> foreign row id.

That is incomplete. A guard is reachable when the field it guards can name a
calculation the enclosing block did not itself scope to the target — which a
foreign row id achieves, **and so does a key resolved in a namespace wider
than the target's owner**.

`_persist_statmech_block` has three production callers, not one. Under
`/uploads/computed-species` its calc-key map is one species entry's own and
the original reading holds. `workflows/network_pdep.py` calls it twice more
with a map spanning every species *and* every transition state in the
bundle. The PDep payload schema narrows a **species** statmech's source and
torsion keys to that species's own calculations before the seam sees them;
it does not do the same for a **transition state**'s. So:

```
POST /api/v1/uploads/networks/pdep
  transition_states[0].statmech.torsions[0].source_scan_calculation_key = "ethyl_scan"

422 {"code": "statmech_torsion_scan_calculation_owner_mismatch", ...}
```

Measured, not read. `statmech_torsion_scan_calculation_owner_mismatch` stays
in the client enum, and `tests/api/test_api_network_pdep_ownership.py`
provokes it — and its sibling `statmech_source_calculation_owner_mismatch` —
through the route, so both `(status, code)` pairs are now observed rather
than merely catalogued. A third test uploads the same bundle with the
borrowed key removed and asserts 201, so the two refusals cannot pass by the
fixture having drifted into being invalid for an unrelated reason.

The triage document is corrected in place at both findings.

## Findings not fixed here

Both live in files another branch owns this round.

1. **The reaction bundle enforces the same ownership rule four times
   inline, with no code.** `workflows/computed_reaction.py:807`, `:847` and
   `:1095` compare `species_entry_id` / `transition_state_entry_id` by hand
   and raise a bare `ValueError`, so the same mistake that answers
   `applied_energy_correction_source_calculation_owner_mismatch` elsewhere
   answers `validation_error` there. Converting them to
   `assert_calculation_owned_by` is what would make that code reachable.

2. **A species torsion in that bundle has no ownership check at all.**
   `workflows/computed_reaction.py:1128` resolves
   `source_scan_calculation_key` out of the bundle-global namespace and
   persists it with nothing compared. The schema
   (`computed_reaction_upload.py:1490`) checks only that the key exists and
   is scan-typed, both against the *global* map. A species torsion may
   therefore cite a sibling species's or the transition state's rotor scan
   and be accepted. This is the one finding here that is a wrong number in
   the database rather than a wrong string on the wire.

3. **Four more reachable ownership guards carry no code**, all over
   `existing_statmech_id` / `statmech_ref` — a genuine foreign row
   reference: `workflows/thermo.py:203`, `workflows/kinetics.py:231`,
   `:235`, `:266`. Same shape as (1), different subject.

4. **`AppliedEnergyCorrectionUploadPayload`'s docstring overstates the
   contract** (`tckdb_schemas/energy_correction.py:169-183`): it says *both*
   keys are refused with `applied_energy_correction_source_key_undeclared`.
   That is true of `source_conformer_key` on all three roots and of
   `source_calculation_key` on `/uploads/conformers` only. On the two bundle
   roots the calculation key is a raw dict subscript.

## Verification

All three gates green. Client suite green (1348). `ruff check app tests
scripts` clean. Alembic head unchanged — no migration in this change.
