### PR TITLE
Scope a torsion's rotor scan to its own species

### DIFF
--- a/backend/app/services/calculation_ownership.py
+++ b/backend/app/services/calculation_ownership.py
@@ -62,19 +62,29 @@ W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH = (
 #: is a different field with a different repair — the depositor picked the
 #: wrong rotor scan, not the wrong supporting job.
 #:
-#: Reachable, and by exactly one route, which is worth writing down
-#: because it was read as unreachable once. ``_persist_statmech_block`` is
-#: shared by the species bundle and the PDep bundle. Under
-#: ``/uploads/computed-species`` the calc-key map is one species entry's
-#: own, so the comparison is against a value just assigned; under
-#: ``/uploads/networks/pdep`` the map handed to the same seam spans every
-#: species *and* every transition state. The PDep payload schema narrows
-#: a **species** torsion's scan key to that species's own calculations
-#: before the seam ever sees it — and does not do the same for a
-#: **transition state**'s. So a TS torsion naming a species scan
-#: calculation reaches this guard, and
+#: Reachable by two routes, which is worth writing down because it was
+#: read as unreachable once and then as reachable by exactly one.
+#:
+#: ``_persist_statmech_block`` is shared by the species bundle and the
+#: PDep bundle. Under ``/uploads/computed-species`` the calc-key map is
+#: one species entry's own, so the comparison is against a value just
+#: assigned; under ``/uploads/networks/pdep`` the map handed to the same
+#: seam spans every species *and* every transition state. The PDep
+#: payload schema narrows a **species** torsion's scan key to that
+#: species's own calculations before the seam ever sees it — and does not
+#: do the same for a **transition state**'s. So a TS torsion naming a
+#: species scan calculation reaches this guard, and
 #: ``tests/api/test_api_network_pdep_ownership.py`` provokes it on the
 #: wire.
+#:
+#: ``/uploads/computed-reaction`` is the second route (#193). It does not
+#: use the shared seam — it persists torsions inline — and resolved the
+#: scan key against the bundle-global map with no owner check at all, so
+#: one species' rotor could be parameterised by another's scan and the
+#: deposit succeeded. That call site now routes through this function;
+#: ``tests/api/test_api_bundle_torsion_scan_ownership.py`` provokes it.
+#: A transition state cannot reach the rule on that route at all —
+#: ``BundleTransitionStateIn`` carries no statmech, hence no torsions.
 W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH = (
     "statmech_torsion_scan_calculation_owner_mismatch"
 )

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -46,6 +46,7 @@ from app.schemas.workflows.computed_reaction_upload import (
 )
 from app.services.artifact_persistence import persist_artifact
 from app.services.calculation_ownership import (
+    W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH,
     W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
     assert_calculation_owned_by,
 )
@@ -1134,12 +1135,33 @@ def persist_computed_reaction_upload(
                     )
                 )
 
-            for torsion_in in s.torsions:
+            for ti, torsion_in in enumerate(s.torsions):
                 scan_calc_id: int | None = None
                 if torsion_in.source_scan_calculation_key is not None:
                     scan_calc_id = calculation_key_to_id[
                         torsion_in.source_scan_calculation_key
                     ]
+                    # ``calculation_key_to_id`` spans the whole bundle --
+                    # every species and the transition state -- so a key
+                    # resolving here says nothing about who owns what it
+                    # resolved to. Without this, one species' hindered
+                    # rotor can be parameterised by another species' scan
+                    # and the record looks entirely well-formed. A torsion
+                    # is a result and its scan is that result's
+                    # provenance; a rotor potential borrowed from a
+                    # different molecule is not weaker evidence, it is
+                    # evidence about something else.
+                    assert_calculation_owned_by(
+                        session.get(Calculation, scan_calc_id),
+                        code=W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH,
+                        target="statmech torsion",
+                        context=(
+                            f"species[{sp.key!r}].statmech.torsions[{ti}]."
+                            f"source_scan_calculation_key="
+                            f"'{torsion_in.source_scan_calculation_key}'"
+                        ),
+                        species_entry_id=species_entry.id,
+                    )
 
                 torsion = StatmechTorsion(
                     statmech_id=statmech.id,

--- a/backend/tests/api/test_api_bundle_torsion_scan_ownership.py
+++ b/backend/tests/api/test_api_bundle_torsion_scan_ownership.py
@@ -1,0 +1,138 @@
+"""A reaction bundle's torsion may only cite its own species' rotor scan.
+
+What was wrong
+--------------
+``app.workflows.computed_reaction`` resolved a torsion's
+``source_scan_calculation_key`` out of ``calculation_key_to_id`` -- the
+bundle-global namespace, spanning every species and the transition state
+-- and wrote the result to ``statmech_torsion.source_scan_calculation_id``
+without asking who owned it. The key resolving proves only that some
+subject in the bundle declared that calculation, not that the citing
+species did.
+
+So a bundle could give species A's hindered rotor species B's rotor
+scan. Both the schema checks passed: the key existed, and the target was
+a genuine ``scan``-type calculation. The row that came out looked
+entirely well-formed, and a partition function computed from it is wrong
+with nothing in the record saying so.
+
+This is the failure the four-role split exists to catch. A torsion is a
+*result*; its scan is that result's *provenance*. A rotor potential taken
+from a different molecule is not weaker evidence for this one -- it is
+evidence about something else, and ADR 0008 puts that in the ``block``
+tier because no correct deposit can produce it.
+
+Why these tests are on the wire
+-------------------------------
+The guard lives in the workflow, but what a depositor can act on is the
+``(status, code)`` pair their client receives. Asserting it here measures
+that pair instead of declaring it; ``statmech_torsion_scan_calculation_owner_mismatch``
+was catalogued long before anything on this route could produce it.
+
+Scope, stated rather than left to inference
+-------------------------------------------
+A **transition state** cannot reach this rule on this route:
+``BundleTransitionStateIn`` has no ``statmech`` field, so it carries no
+torsions. The TS case is reachable only through
+``/uploads/networks/pdep``, where it is enforced at the same seam and
+provoked by ``tests/api/test_api_network_pdep_ownership.py``. The rule in
+both places is the same one, and it is the strict one: a torsion's scan
+must belong to the torsion's own subject. Decided 2026-08-15 -- a
+depositor who genuinely approximated one rotor with another molecule's
+scan has no way to record that today, and gaining one is a schema change
+that says so explicitly, not a silently accepted link.
+
+Assertions are on ``code`` and ``context``, never on substrings of
+``detail``: Pydantic echoes rejected input back into its error string, so
+a substring check can pass even when the field was wrongly accepted.
+"""
+
+from __future__ import annotations
+
+from tests.workflows.test_computed_reaction_upload import _payload_with_ch4_scan
+
+_URL = "/api/v1/uploads/computed-reaction"
+_TORSION_OWNER_MISMATCH = "statmech_torsion_scan_calculation_owner_mismatch"
+
+
+def _payload_with_ch3_torsion_citing_ch4s_scan() -> dict:
+    """ch3's rotor is parameterised by ch4's scan.
+
+    ``ch4-scan`` is a real key in the bundle's global namespace and a real
+    ``scan`` calculation, so the schema's two existing checks both pass
+    and ownership is the only thing left wrong. That is deliberate: a
+    payload that also had a bad key or a non-scan target could be refused
+    for the other reason, and the test would pass while proving nothing.
+
+    ch3's own ``source_calculations`` link stays correct so the statmech
+    itself is not what is being refused.
+    """
+    payload = _payload_with_ch4_scan()  # scan belongs to species[2], ch4
+    payload["species"][0]["statmech"] = {  # ch3
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
+        "torsions": [
+            {
+                "torsion_index": 1,
+                "symmetry_number": 3,
+                "treatment_kind": "hindered_rotor",
+                "dimension": 1,
+                "source_scan_calculation_key": "ch4-scan",
+            }
+        ],
+    }
+    return payload
+
+
+def test_a_torsion_citing_another_species_scan_is_refused(client) -> None:
+    resp = client.post(_URL, json=_payload_with_ch3_torsion_citing_ch4s_scan())
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _TORSION_OWNER_MISMATCH, body
+    # The context names the field the depositor wrote and the kind of
+    # owner that disagreed -- never a row id (DR-0028 Requirement 2).
+    assert body["context"]["target"] == "statmech torsion", body
+    assert "ch4-scan" in body["context"]["field"], body
+    assert body["context"]["owner_kind"] == "species_entry", body
+
+
+def test_the_refusal_discloses_no_row_ids(client) -> None:
+    """The offending ids go to the log; the 422 body names only keys.
+
+    Separated from the test above because "refused with the right code"
+    and "refused without leaking primary keys" are different properties,
+    and a regression in the second is silent.
+
+    The status assertion is load-bearing, not decoration. Without it a
+    mutation that stops the guard firing altogether leaves a 201 whose
+    body contains no ids either, and this test passes while checking
+    nothing -- caught by running exactly that mutation (#192's class).
+    """
+    resp = client.post(_URL, json=_payload_with_ch3_torsion_citing_ch4s_scan())
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _TORSION_OWNER_MISMATCH, body
+    for value in (body.get("detail", ""), str(body.get("context", {}))):
+        assert "species_entry_id=" not in value, body
+        assert "calculation id" not in value, body
+
+
+def test_the_same_torsion_on_its_own_species_is_accepted(client) -> None:
+    """The negative half: the payload is refused for ownership, nothing else.
+
+    Without this, the tests above would still pass if the fixture had
+    drifted into being invalid for some unrelated reason and every
+    reaction bundle were answering 422.
+    """
+    payload = _payload_with_ch3_torsion_citing_ch4s_scan()
+    # Move the identical torsion onto ch4, which owns the scan.
+    torsions = payload["species"][0]["statmech"].pop("torsions")
+    payload["species"][2]["statmech"] = {
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [{"calculation_key": "ch4-freq", "role": "freq"}],
+        "torsions": torsions,
+    }
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 201, resp.text[:800]

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -753,9 +753,13 @@ def test_the_ownership_guards_are_guards_because_of_a_schema_shape() -> None:
 
     The third ownership code with the same *shape*,
     ``statmech_torsion_scan_calculation_owner_mismatch``, is deliberately
-    absent: its key is resolved in a bundle-wide namespace on the PDep
-    path, so it is reachable and stays exported. See
-    ``tests/api/test_api_network_pdep_ownership.py``.
+    absent: its key is resolved in a bundle-wide namespace on two paths,
+    so it is reachable and stays exported. See
+    ``tests/api/test_api_network_pdep_ownership.py`` for the PDep route
+    and ``tests/api/test_api_bundle_torsion_scan_ownership.py`` for
+    ``/uploads/computed-reaction`` (#193), where the same wide namespace
+    had no owner check at all until the call site was routed through the
+    shared guard.
     """
     from tckdb_schemas.energy_correction import (
         AppliedEnergyCorrectionUploadPayload,


### PR DESCRIPTION
Closes #193.

## What was wrong

`backend/app/workflows/computed_reaction.py` resolved a torsion's
`source_scan_calculation_key` out of `calculation_key_to_id` — the
bundle-global namespace, spanning every species and the transition state —
and wrote the result to `statmech_torsion.source_scan_calculation_id`
without asking who owned it.

A key resolving there proves only that *some* subject in the bundle declared
that calculation, not that the citing species did. So a bundle could give
species A's hindered rotor species B's rotor scan. Both existing schema
checks passed: the key existed, and the target was a genuine `scan`-type
calculation. The row came out looking entirely well-formed, and a partition
function computed from it is wrong with nothing in the record saying so.

This is the class the four-role split exists to prevent — the torsion is a
*result*, its scan is that result's *provenance*, and a rotor potential
borrowed from a different molecule is not weaker evidence for this one, it
is evidence about something else.

## Measurement, before the change

Run read-only against the live database:

| | |
|---|---|
| `statmech_torsion` rows carrying a scan | 50 |
| scan owned by a different species entry | **0** |
| scan owned by a different transition-state entry | **0** |
| reactions carrying statmech for 2+ species | **41** |

The vulnerable shape has been deposited 41 times and nothing has fallen in.
**No data repair is needed**; the change is purely preventative.

## The fix

The ownership rule already existed twenty lines above, for the same
statmech's `source_calculations`. This routes the torsion's scan key through
the shared guard in `app/services/calculation_ownership.py` (#162) rather
than adding a fifth inline copy. The refusal now:

- carries `statmech_torsion_scan_calculation_owner_mismatch` instead of a
  bare `ValueError` promoted to a generic `validation_error`;
- names the field the way the depositor wrote it;
- logs the disagreeing row ids rather than disclosing them (DR-0028 Req. 2).

## Decision recorded

**A torsion's scan must belong to the torsion's own subject.** A depositor
who genuinely approximated one rotor with another molecule's scan has no way
to record that today; gaining one is a schema change that says so
explicitly, not a silently accepted link. The strict rule is also the
reversible one — a rule can be relaxed later, data accepted under a loose
one cannot be un-accepted.

A transition state cannot reach this rule on this route at all:
`BundleTransitionStateIn` carries no `statmech`, hence no torsions. The TS
case stays reachable only through `/uploads/networks/pdep`, where it is
already enforced at the shared seam. Stated in the code rather than left to
inference.

## Schema / migration impact

**None.** No model, schema or migration change; the wire contract gains no
field and no package needs a version bump. The only behavioural change is a
refusal that did not previously fire.

## New environment variables

None.

## Verification actually run

- **Reproduced first.** ch3's torsion bound to ch4's scan was accepted:
  statmech owner `species_entry_id=1`, scan owner `species_entry_id=3`,
  scan type `scan`. After the fix the same payload is refused 422 with the
  code.
- **Mutation check.** Neutering the guard (comparing the scan against its
  own owner) turns both refusal tests red. The *first* run of that mutation
  left one test green — it asserted only the absence of row ids, which a 201
  also satisfies — so status and code assertions were added to make it
  non-vacuous. That vacuity is #192's class, caught in new code.
- `ruff check` from `backend/` on all four changed files: clean.
- `pytest tests/api/test_api_bundle_torsion_scan_ownership.py
  tests/api/test_api_network_pdep_ownership.py
  tests/api/test_api_code_catalogue.py
  tests/workflows/test_computed_reaction_upload.py` — **118 passed**.
- Full `pytest tests/` was still running locally when this was opened; CI is
  the authoritative gate.

## Also in this PR

Two pieces of prose the fix falsified:

- `calculation_ownership.py` said this code was reachable "by exactly one
  route". It is now two, and the docstring says which and why.
- `test_api_code_catalogue.py` named only the PDep path as the reason the
  code stays exported.

Related, not fixed here: #195 (three inline ownership copies in this same
file still raise bare `ValueError`, including the one immediately above this
change — deliberately left to its own single pass) and #146, whose stale
headline I corrected in the ledger while verifying anchors.