### PR TITLE
Refuse a deep page on the two release reads

### DIFF
--- a/backend/app/services/scientific_read/releases.py
+++ b/backend/app/services/scientific_read/releases.py
@@ -10,8 +10,8 @@ a superseded selection would defeat the point of publishing the audit trail.
 
 from __future__ import annotations
 
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy import and_, func, select
+from sqlalchemy.orm import Session, aliased
 
 from app.db.models.app_user import AppUser
 from app.db.models.common import DatasetReleaseStatus, ReleaseSelectionAction
@@ -45,6 +45,7 @@ from app.services.release.manifest import (
     verify_release,
 )
 from app.services.release.records import encode_scalar, public_refs_for
+from app.services.scientific_read.common import validate_pagination
 
 
 class UnknownReleaseError(ValueError):
@@ -169,12 +170,21 @@ def list_releases(
     offset: int = 0,
     limit: int = 50,
 ) -> ScientificReleaseListResponse:
-    """List releases, newest first. Withdrawn releases are listed, not hidden."""
+    """List releases, newest first. Withdrawn releases are listed, not hidden.
+
+    :raises ValueError: 422 when ``offset``/``limit`` are outside the hosted
+        pagination bounds.
+    """
+    offset, limit = validate_pagination(offset, limit)
     stmt = select(DatasetRelease)
     if status is not None:
         stmt = stmt.where(DatasetRelease.status == status)
-    rows = list(session.scalars(stmt.order_by(DatasetRelease.id.desc())))
-    page = rows[offset : offset + limit]
+    total = session.scalar(select(func.count()).select_from(stmt.subquery())) or 0
+    page = list(
+        session.scalars(
+            stmt.order_by(DatasetRelease.id.desc()).offset(offset).limit(limit)
+        )
+    )
     return ScientificReleaseListResponse(
         request=RequestEcho(
             filter={"status": status.value if status else None},
@@ -184,8 +194,8 @@ def list_releases(
             offset=offset,
             limit=limit,
             returned=len(page),
-            total=len(rows),
-            post_collapse_total=len(rows),
+            total=total,
+            post_collapse_total=total,
         ),
     )
 
@@ -336,15 +346,72 @@ def get_release_selections(
     recommendation was reasoned about and revised — filtering it down to only
     what currently stands would hand back the same opaque answer the selection
     layer exists to replace.
+
+    Paging happens in SQL. A mature release publishes thousands of selections,
+    and this endpoint exists precisely to be read a page at a time; reading the
+    whole ledger to hand back fifty rows made every page cost the same as the
+    largest one. ``stands`` is the reason that was ever tempting — it is a
+    property of the supersession chain, not of the row — but "nothing
+    supersedes me" is a correlated ``NOT EXISTS``, so the whole-set question
+    is answerable per row without the whole set in memory.
+
+    :raises ValueError: 422 when ``offset``/``limit`` are outside the hosted
+        pagination bounds.
     """
     release = resolve_release(session, handle)
-    state = load_selection_state(session, release)
-    standing = {row.id for row in state.active}
-    rows = state.all_selections
-    if not include_superseded:
-        rows = [row for row in rows if row.id in standing]
+    offset, limit = validate_pagination(offset, limit)
 
-    by_id = {row.id: row for row in state.all_selections}
+    superseder = aliased(ReleaseSelection)
+    stands = and_(
+        ~(
+            select(1)
+            .where(
+                superseder.dataset_release_id == release.id,
+                superseder.supersedes_selection_id == ReleaseSelection.id,
+            )
+            .exists()
+        ),
+        ReleaseSelection.action != ReleaseSelectionAction.withdraw,
+    )
+
+    stmt = select(ReleaseSelection).where(
+        ReleaseSelection.dataset_release_id == release.id
+    )
+    if not include_superseded:
+        stmt = stmt.where(stands)
+
+    total = session.scalar(select(func.count()).select_from(stmt.subquery())) or 0
+    page_rows = list(
+        session.execute(
+            stmt.add_columns(stands.label("stands"))
+            .order_by(ReleaseSelection.id)
+            .offset(offset)
+            .limit(limit)
+        ).all()
+    )
+    rows = [row for row, _stands in page_rows]
+    stands_by_id = {row.id: bool(flag) for row, flag in page_rows}
+
+    # The row a page row supersedes may live outside the page, so resolve those
+    # refs by id rather than assuming the page is self-contained.
+    parent_ids = {
+        row.supersedes_selection_id
+        for row in rows
+        if row.supersedes_selection_id is not None
+    }
+    by_id: dict[int, str] = (
+        dict(
+            session.execute(
+                select(ReleaseSelection.id, ReleaseSelection.public_ref).where(
+                    ReleaseSelection.dataset_release_id == release.id,
+                    ReleaseSelection.id.in_(parent_ids),
+                )
+            ).all()
+        )
+        if parent_ids
+        else {}
+    )
+
     policies = {
         policy.id: policy
         for policy in session.scalars(
@@ -360,28 +427,22 @@ def get_release_selections(
         )
     }
 
-    # Resolve refs one query per record type, not one per row: a mature
-    # release has thousands of selections and a per-row lookup would make the
-    # ledger endpoint quadratic in the thing it exists to publish.
+    # Resolve refs one query per record type, not one per row: a per-row lookup
+    # would make the ledger endpoint quadratic in the thing it exists to
+    # publish. Scoped to the page, because that is all this response renders.
     record_refs = _refs_by_type(session, [(r.record_type, r.record_id) for r in rows])
     subject_refs = _refs_by_type(session, [(r.subject_type, r.subject_id) for r in rows])
 
-    page = rows[offset : offset + limit]
     records = [
         ReleaseSelectionRecord(
             selection_ref=row.public_ref,
             action=row.action,
-            stands=row.id in standing
-            and row.action is not ReleaseSelectionAction.withdraw,
+            stands=stands_by_id[row.id],
             record_type=row.record_type.value,
             record_ref=record_refs.get((row.record_type, row.record_id)),
             subject_type=row.subject_type.value,
             subject_ref=subject_refs.get((row.subject_type, row.subject_id)),
-            supersedes_selection_ref=(
-                by_id[row.supersedes_selection_id].public_ref
-                if row.supersedes_selection_id in by_id
-                else None
-            ),
+            supersedes_selection_ref=by_id.get(row.supersedes_selection_id),
             rationale=row.rationale,
             created_at=encode_scalar(row.created_at),
             curator=(
@@ -400,7 +461,7 @@ def get_release_selections(
                 else None
             ),
         )
-        for row in page
+        for row in rows
     ]
 
     return ScientificReleaseSelectionsResponse(
@@ -413,9 +474,9 @@ def get_release_selections(
         pagination=Pagination(
             offset=offset,
             limit=limit,
-            returned=len(page),
-            total=len(rows),
-            post_collapse_total=len(rows),
+            returned=len(rows),
+            total=total,
+            post_collapse_total=total,
         ),
     )
 

--- a/backend/tests/api/test_api_dataset_releases.py
+++ b/backend/tests/api/test_api_dataset_releases.py
@@ -19,6 +19,7 @@ import json
 
 import pytest
 
+from app.api.config import settings
 from app.db.models.app_user import AppUser
 from app.db.models.common import RecordReviewStatus, SubmissionRecordType
 from app.services.record_review import set_record_review_status
@@ -855,3 +856,84 @@ def test_superseding_through_the_wrong_release_is_a_404(
         ]["total"]
         == 0
     )
+
+
+# ---------------------------------------------------------------------------
+# Abuse controls: the release reads page like every other read surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/api/v1/scientific/releases",
+        f"/api/v1/scientific/releases/{RELEASE['tag']}/selections",
+    ],
+)
+def test_release_reads_refuse_deep_offsets(
+    client, login_as, _api_curator_user, corpus, route
+):
+    """Deep paging is refused here with the same code as everywhere else.
+
+    These two reads used to materialise every row into Python and slice it,
+    so ``offset=10001`` returned a cheerful empty 200 while every other read
+    surface refused it. Nothing was ever incorrect -- ``limit`` is bounded by
+    the route, so no unbounded body was ever returned -- but one family of
+    reads answered a question the hosted abuse-control policy says is not
+    answerable, and the difference was invisible until somebody paged deeply.
+
+    Both sides of the boundary are asserted. An expected value derived from
+    the same setting the guard reads follows that setting wherever it moves;
+    pinning the cap itself as *accepted* is what stops this passing if the
+    comparison is widened. ``offset`` carries no ``le`` on either route, so
+    this is reachable against the configuration TCKDB actually runs.
+    """
+    _as_curator(client, login_as, _api_curator_user)
+    _publish(client, corpus)
+
+    allowed = client.get(f"{route}?offset={settings.public_max_offset}")
+    assert allowed.status_code == 200, allowed.text
+
+    refused = client.get(f"{route}?offset={settings.public_max_offset + 1}")
+    assert refused.status_code == 422, refused.text
+    assert refused.json()["code"] == "offset_too_large"
+
+
+def test_ledger_page_resolves_a_supersession_outside_the_page(
+    client, login_as, _api_curator_user, _api_admin_user, corpus
+):
+    """``supersedes_selection_ref`` still resolves when the parent is off-page.
+
+    A page is not self-contained: the row a selection supersedes is by
+    construction *older*, so on any page but the first it lives behind the
+    offset. The ledger used to have the whole release in memory and could not
+    get this wrong; paging in SQL is exactly what makes it possible to.
+    """
+    _entry, chosen, other = corpus
+    _as_curator(client, login_as, _api_curator_user)
+    assert client.post("/api/v1/releases/policies", json=POLICY).status_code == 201
+    assert client.post("/api/v1/releases", json=RELEASE).status_code == 201
+    first = client.post(
+        f"/api/v1/releases/{RELEASE['tag']}/selections",
+        json={"record_ref": chosen.public_ref, "rationale": "Initial pick."},
+    ).json()
+
+    login_as(_api_admin_user)
+    assert (
+        client.post(
+            f"/api/v1/releases/{RELEASE['tag']}/selections/{first['selection_ref']}/supersede",
+            json={"record_ref": other.public_ref, "rationale": "Rescaled."},
+        ).status_code
+        == 201
+    )
+
+    second_page = client.get(
+        f"/api/v1/scientific/releases/{RELEASE['tag']}/selections?offset=1&limit=1"
+    ).json()
+
+    assert second_page["pagination"]["total"] == 2
+    assert second_page["pagination"]["returned"] == 1
+    (row,) = second_page["records"]
+    assert row["action"] == "supersede"
+    assert row["stands"] is True
+    assert row["supersedes_selection_ref"] == first["selection_ref"]


### PR DESCRIPTION
## What

`GET /scientific/releases` and `GET /scientific/releases/{handle}/selections` were the only two paged read routes that never called `validate_pagination`. They read every matching row into Python and sliced it:

```python
rows = list(session.scalars(stmt.order_by(DatasetRelease.id.desc())))
page = rows[offset : offset + limit]
```

**This is not a correctness bug.** `limit` is bounded by the route (`le=200`), so no response was ever unbounded and nothing 500ed. It is an abuse-control and consistency gap: `?offset=10001` returned a cheerful empty 200 here, where the other 28 `validate_pagination` call sites refuse it with `offset_too_large`. The difference was invisible until somebody paged deeply, and these two routes had no pagination wire tests at all — which is why.

Before:

```
GET /api/v1/scientific/releases?offset=10001
  -> 200 {"records":[],"pagination":{"offset":10001,"limit":50,"returned":0,"total":1,...}}
GET /api/v1/scientific/releases/2026.07.0/selections?offset=10001
  -> 200 {"records":[],"pagination":{"offset":10001,"limit":50,"returned":0,"total":1,...}}
```

After:

```
GET /api/v1/scientific/releases?offset=10000  -> 200 (accepted at the cap)
GET /api/v1/scientific/releases?offset=10001
  -> 422 {"code":"offset_too_large","detail":"offset_too_large: offset must be <= 10000 (got 10001)","context":{}}
GET /api/v1/scientific/releases/2026.07.0/selections?offset=10001
  -> 422 {"code":"offset_too_large","detail":"offset_too_large: offset must be <= 10000 (got 10001)","context":{}}
```

No new error code — `offset_too_large` is the one PR #170 already added.

## Instance, not family

The `list(session.scalars(...))`-then-slice shape appears at 15 sites, so I checked all of them before fixing two. The other 13 slice **after** a Python-side review-visibility filter and sort, whose post-filter `total` SQL cannot produce without duplicating the review-floor logic — and all 13 already call `validate_pagination`, so they are bounded. Different shape, deliberate design, left alone. `releases.py` was the only paged read module on `main` with zero `validate_pagination` calls.

Two things I found and did **not** change, noted for triage rather than folded in:

- `/submissions/*` (4 routes) and `/admin/curator-tasks` page correctly in SQL but have no deep-offset cap either. They are authenticated, not the public read contract, and they are not the materialise-and-slice shape — a separate policy question about whether the hosted offset bound should cover authenticated surfaces.
- `ml_dataset.py` slices in Python (`ordered[offset:]`) with no cap, but it is the curator/admin-only NDJSON bulk export with its own export cap. Deliberately a different design.

## Also in this change

Paging the ledger in SQL required moving `stands` — "nothing supersedes me", a property of the supersession chain rather than of the row, and the reason materialising the whole release was ever tempting — into a correlated `NOT EXISTS`, scoped to the same release exactly as the old Python `superseded_ids` set was. While there, the public-ref batch resolution narrowed from the entire ledger to the page being rendered; it previously resolved refs for thousands of rows to render fifty.

Success-path response shapes are unchanged on both routes. Error details carry no database primary keys.

## Schema / migration impact

**None.** No model, schema, or migration change. `backend/alembic/versions/` untouched.

## New environment variables

**None.** Both caps are the existing `settings.public_max_limit` / `settings.public_max_offset`.

## Verification actually run

Env: `DB_TEST_NAME=tckdb_test_191`, `PYTHONPATH` pointed at the worktree's `schemas/python/tckdb-schemas`.

```
conda run -n tckdb_env python -m pytest tests/api/test_api_dataset_releases.py -k refuse_deep_offsets -v
    # before the fix: 2 failed, showing the 200 + empty page quoted above
conda run -n tckdb_env python -m pytest tests/api/test_api_dataset_releases.py tests/services/release -p no:randomly -q
    # 100 passed
conda run -n tckdb_env python -m pytest tests/services/release tests/api/test_api_dataset_releases.py \
    tests/api/test_api_query_caps.py tests/api/test_error_contract_catalogue_gate.py -p no:randomly -q
    # 127 passed
conda run -n tckdb_env python -m pytest tests/api tests/services -p no:randomly -q
    # 4767 passed in 2252.81s (0:37:32)
conda run -n tckdb_env ruff check app/services/scientific_read/releases.py tests/api/test_api_dataset_releases.py
    # All checks passed (run from backend/)
```

CI agrees: all three required gates pass on this branch — **Backend API gate**
(9m24s), **Backend complement gate** (7m29s), **Scientific read and service
gate** (11m54s), plus **Required gates** (12m20s).

A throwaway harness (deleted) confirmed `LIMIT`/`OFFSET` now reach PostgreSQL on both routes, via a `before_cursor_execute` listener:

```
FROM dataset_release ORDER BY dataset_release.id DESC LIMIT %(param_1)s::INTEGER OFFSET %(param_2)s::INTEGER
FROM release_selection WHERE ... ORDER BY release_selection.id LIMIT %(param_1)s::INTEGER OFFSET %(param_2)s::INTEGER
```

### Mutation checks

Each mutation was grepped back out of the file to confirm it applied before drawing any conclusion — one earlier attempt silently no-oped on a failed assert, and `common.py` turned out to have two `offset > settings.public_max_offset` lines, so the naive text substitution would have hit the wrong guard.

| Mutation | Expected red | Result |
|---|---|---|
| Drop `validate_pagination` from `list_releases` | list param only | 1 failed, 1 passed ✓ |
| Drop `validate_pagination` from `get_release_selections` | selections param only | 1 failed, 1 passed ✓ |
| Widen `offset >` to `offset >=` in `validate_pagination` | both params, on the *accepted-at-the-cap* assertion | 2 failed ✓ |
| Restrict superseded-parent lookup to the current page | the new cross-page ledger test only | 1 failed, 1 passed ✓ |

The third exists because a refusal test that only asserts the 422 is vacuous against a guard that refuses everything; asserting `settings.public_max_offset` itself is *accepted* is what makes the boundary real. The fourth covers the one genuinely new risk in this rewrite — a page is not self-contained, and the row a selection supersedes is by construction older, so on any page but the first it sits behind the offset. The pre-existing supersede test stays green under that mutation because both its rows land on page 0.
