### PR TITLE
Point the no-FK-ids gate at every upload root, not one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,37 @@ wrapper over a contract that is itself still moving.
 
 ### Changed
 
+- **A calculation's citation is a paper on every upload root, not a row id on
+  five of them.** `CalculationPayload.literature_id` is replaced by an inline
+  `literature` fragment, resolved to a `literature` row by the workflow layer.
+  The field was the calculation block of `/uploads/conformers`,
+  `/uploads/transition-states`, `/uploads/statmech`, `/uploads/thermo` and
+  `/uploads/transport` (and their `/jobs/*` twins). A depositor has a DOI, not
+  our primary key: supplying one required having already queried this database.
+  Resolution moves to `resolve_and_persist_calculation_with_results`, the one
+  seam every upload root reaches, instead of being repeated in three
+  workflows.
+
+  **`tckdb-schemas` 0.32.0 → 0.33.0.** Breaking: `literature_id` no longer
+  validates on those roots. `SchemaBase` is `extra="forbid"`, so an old payload
+  gets a 422 naming the field rather than a 201 with the citation silently
+  dropped. **No stored value changes** — `calculation.literature_id` is
+  unaffected and no migration is involved.
+
+  The same field had already been removed from the reaction bundle, the
+  network-PDep route and `CalculationIn`, each time by hand, each time on one
+  root. The reason it kept surviving is that the no-FK-ids invariant was
+  asserted by exactly one test over exactly one upload root. That walker now
+  runs over **every** upload root, discovered from the live route table so a
+  new route is covered the moment it is registered
+  (`backend/tests/schemas/test_upload_roots_expose_no_fk_ids.py`). Generalising
+  it surfaced four further FK-shaped fields on depositor-facing surfaces
+  (`SCFStabilityPayload.source_calculation_id` / `source_artifact_id`,
+  `CalculationScanPointCreate.geometry_id`,
+  `ReactionParticipantUpload.species_entry_id`); each is read by the server
+  today, so each is frozen in a documented inventory with its reason rather
+  than removed unreviewed.
+
 - **Three codes a client could import but never receive are no longer
   exported.** `app/api/code_catalogue.py` gains a `Reach` field, so an entry
   can now record that no request produces it — the middle case of a three-way

--- a/backend/app/services/calculation_resolution.py
+++ b/backend/app/services/calculation_resolution.py
@@ -62,6 +62,7 @@ from app.schemas.fragments.refs import (
 )
 from app.services.execution_environment_integrity import manifest_integrity_evidence
 from app.services.geometry_resolution import resolve_geometry_payload
+from app.services.literature_resolution import resolve_or_create_literature
 from app.services.software_reconciliation import (
     SoftwareReconciliationResult,
     reconcile_software_provenance,
@@ -1377,6 +1378,18 @@ def resolve_and_persist_calculation_with_results(
     :returns: Persisted ``Calculation`` row.
     """
 
+    # The citation arrives as an inline fragment, never as a row id: a
+    # depositor knows their paper's DOI, not our ``literature.id`` (#194,
+    # .claude/rules/schema-rules.md). This is the single place it is
+    # resolved — every upload root that persists a calculation comes
+    # through here, so putting the resolution at any earlier seam would
+    # mean doing it once per caller and getting it wrong in one of them,
+    # which is how the raw id survived on five routes in the first place.
+    literature_id = (
+        resolve_or_create_literature(session, calc_upload.literature).id
+        if calc_upload.literature is not None
+        else None
+    )
     request = CalculationCreateRequest(
         type=calc_upload.type,
         quality=calc_upload.quality,
@@ -1385,7 +1398,7 @@ def resolve_and_persist_calculation_with_results(
         software_release=calc_upload.software_release,
         workflow_tool_release=calc_upload.workflow_tool_release,
         level_of_theory=calc_upload.level_of_theory,
-        literature_id=calc_upload.literature_id,
+        literature_id=literature_id,
         execution_environment=calc_upload.execution_environment,
     )
     resolved = resolve_calculation_create_request(session, request)

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -149,17 +149,11 @@ def _persist_calculation(
 
     # The calculation's citation arrives as an inline literature fragment
     # (it used to arrive as a raw ``literature_id``, which only a client
-    # that had already queried this database could supply). Resolve it to a
-    # row here — the wire package has no session — and hand the id to the
-    # adapter, which refuses the pair "fragment present, id absent".
-    literature_id = (
-        resolve_or_create_literature(session, calc_in.literature).id
-        if calc_in.literature is not None
-        else None
-    )
-    shared_payload = calculation_in_to_with_results_payload(
-        calc_in, literature_id=literature_id
-    )
+    # that had already queried this database could supply). It is carried
+    # through unresolved: the shared payload now takes the fragment too, so
+    # ``resolve_and_persist_calculation_with_results`` resolves it once,
+    # rather than each workflow resolving it for itself (#194).
+    shared_payload = calculation_in_to_with_results_payload(calc_in)
     calculation = resolve_and_persist_calculation_with_results(
         session,
         shared_payload,

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -145,15 +145,15 @@ class ComputedSpeciesUploadOutcome:
 
 def _to_calc_with_results_payload(
     calc_in: CalculationInBundle,
-    *,
-    literature_id: int | None,
 ) -> CalculationWithResultsPayload:
     """Build the existing primitive payload from a bundle calc block.
 
-    Drops bundle-only fields (``key``, ``depends_on``, ``artifacts``,
-    inline ``literature``) and substitutes the resolved ``literature_id``
-    so the existing ``resolve_and_persist_calculation_with_results``
-    service can be reused unchanged.
+    Drops bundle-only fields (``key``, ``depends_on``, ``artifacts``) and
+    forwards everything else — including the inline ``literature``
+    fragment, which the shared payload now carries in place of a raw
+    ``literature_id`` (#194) — so the existing
+    ``resolve_and_persist_calculation_with_results`` service can be reused
+    unchanged. The citation is resolved there, once, rather than here.
     """
     return CalculationWithResultsPayload(
         type=calc_in.type,
@@ -161,7 +161,7 @@ def _to_calc_with_results_payload(
         software_release=calc_in.software_release,
         workflow_tool_release=calc_in.workflow_tool_release,
         level_of_theory=calc_in.level_of_theory,
-        literature_id=literature_id,
+        literature=calc_in.literature,
         execution_environment=calc_in.execution_environment,
         opt_result=calc_in.opt_result,
         freq_result=calc_in.freq_result,
@@ -184,15 +184,6 @@ def _to_calc_with_results_payload(
         parameters_extracted_at=calc_in.parameters_extracted_at,
         constraints=calc_in.constraints,
     )
-
-
-def _resolve_inline_literature_id(
-    session: Session, calc_in: CalculationInBundle
-) -> int | None:
-    if calc_in.literature is None:
-        return None
-    lit = resolve_or_create_literature(session, calc_in.literature)
-    return lit.id
 
 
 def _build_synthetic_thermo_upload_request(
@@ -320,14 +311,9 @@ def persist_computed_species_upload(
         # Step 4: primary opt + additionals. We replicate the
         # /uploads/conformers anchor-and-link logic here because the
         # bundle wraps multiple conformers in one transaction.
-        primary_lit_id = _resolve_inline_literature_id(
-            session, conf_in.primary_calculation
-        )
         primary_calc = resolve_and_persist_calculation_with_results(
             session,
-            _to_calc_with_results_payload(
-                conf_in.primary_calculation, literature_id=primary_lit_id
-            ),
+            _to_calc_with_results_payload(conf_in.primary_calculation),
             species_entry_id=species_entry.id,
             created_by=created_by,
         )
@@ -378,12 +364,9 @@ def persist_computed_species_upload(
         # acceptable as v0 inline duplication.
         additional_calcs: list[Calculation] = []
         for additional_in in conf_in.additional_calculations:
-            child_lit_id = _resolve_inline_literature_id(session, additional_in)
             child_calc = resolve_and_persist_calculation_with_results(
                 session,
-                _to_calc_with_results_payload(
-                    additional_in, literature_id=child_lit_id
-                ),
+                _to_calc_with_results_payload(additional_in),
                 species_entry_id=species_entry.id,
                 created_by=created_by,
             )

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -145,19 +145,11 @@ def _persist_calculation(
     if calc_in.geometry_key is not None:
         effective_geometry_id = geometry_key_map[calc_in.geometry_key]
 
-    # Same inline-literature resolution the computed-reaction workflow
-    # does: the shared ``CalculationIn`` no longer accepts a raw
-    # ``literature_id``, so the citation is resolved here and the id handed
-    # to the adapter. This route reaches the same shared model, so the FK
-    # leak the network-PDep no-FK gate used to exempt is gone with it.
-    literature_id = (
-        resolve_or_create_literature(session, calc_in.literature).id
-        if calc_in.literature is not None
-        else None
-    )
-    shared_payload = calculation_in_to_with_results_payload(
-        calc_in, literature_id=literature_id
-    )
+    # The inline literature fragment is forwarded unresolved; the shared
+    # persistence seam resolves it (#194). This route reaches the same
+    # shared model as every other upload root, so the FK leak the
+    # network-PDep no-FK gate used to exempt is gone with it.
+    shared_payload = calculation_in_to_with_results_payload(calc_in)
     calculation = resolve_and_persist_calculation_with_results(
         session,
         shared_payload,

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -8554,16 +8554,15 @@
           "level_of_theory": {
             "$ref": "#/components/schemas/LevelOfTheoryRef"
           },
-          "literature_id": {
+          "literature": {
             "anyOf": [
               {
-                "type": "integer"
+                "$ref": "#/components/schemas/LiteratureUploadRequest"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Literature Id"
+            ]
           },
           "opt_result": {
             "anyOf": [
@@ -10476,16 +10475,15 @@
           "level_of_theory": {
             "$ref": "#/components/schemas/LevelOfTheoryRef"
           },
-          "literature_id": {
+          "literature": {
             "anyOf": [
               {
-                "type": "integer"
+                "$ref": "#/components/schemas/LiteratureUploadRequest"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Literature Id"
+            ]
           },
           "opt_result": {
             "anyOf": [

--- a/backend/tests/api/test_api_bundle_calculation_literature.py
+++ b/backend/tests/api/test_api_bundle_calculation_literature.py
@@ -23,7 +23,6 @@ citation.
 
 from __future__ import annotations
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
@@ -209,13 +208,23 @@ def test_the_shared_calculation_model_no_longer_declares_literature_id():
         assert "literature" in model.model_fields, model.__name__
 
 
-def test_the_adapter_refuses_to_drop_a_citation_it_was_not_given_an_id_for():
-    """The guard on the seam that could otherwise lose a citation silently.
+def test_the_adapter_carries_the_citation_through_without_resolving_it():
+    """The seam that could otherwise lose a citation silently.
 
-    ``calculation_in_to_with_results_payload`` cannot resolve literature —
-    the wire package has no database. If it defaulted the id to ``None``,
-    a workflow that forgot to resolve would produce a valid payload with
-    the citation missing and nothing would fail. It raises instead.
+    This test used to assert a *guard*: the adapter took a resolved
+    ``literature_id`` keyword and raised if handed a fragment without one,
+    because the shared payload it produced carried a raw ``literature_id``
+    and only the caller had a session to resolve with. Three workflows
+    each did that resolution, and the shared payload's raw id was itself
+    reachable from five other upload roots — which is how #194 found the
+    same FK leak on ``/uploads/conformers`` and friends.
+
+    The shared payload now carries the inline fragment too, so the adapter
+    forwards it untouched and one seam
+    (``resolve_and_persist_calculation_with_results``) resolves it. The
+    assertion is correspondingly stronger: not "it refuses to lose the
+    citation", but "the citation is still here, unresolved and intact, and
+    there is no id-shaped field left for anyone to forget to populate".
     """
     from tckdb_schemas.shared.calculation_in import (
         CalculationIn,
@@ -229,9 +238,14 @@ def test_the_adapter_refuses_to_drop_a_citation_it_was_not_given_an_id_for():
         level_of_theory=_LOT,
         literature=_LITERATURE,
     )
-    with pytest.raises(ValueError, match="literature_id"):
-        calculation_in_to_with_results_payload(calc)
+    payload = calculation_in_to_with_results_payload(calc)
 
-    # With the id supplied it converts, and carries the id through.
-    payload = calculation_in_to_with_results_payload(calc, literature_id=7)
-    assert payload.literature_id == 7
+    assert payload.literature == calc.literature
+    assert payload.literature is not None
+    assert "literature_id" not in type(payload).model_fields
+
+    # And a calculation citing nothing still cites nothing.
+    uncited = CalculationIn(
+        key="c2", type="sp", software_release=_SOFTWARE, level_of_theory=_LOT
+    )
+    assert calculation_in_to_with_results_payload(uncited).literature is None

--- a/backend/tests/schemas/test_upload_roots_expose_no_fk_ids.py
+++ b/backend/tests/schemas/test_upload_roots_expose_no_fk_ids.py
@@ -59,8 +59,11 @@ from app.api.app import create_app
 #: Path prefixes whose POST bodies are depositor-facing upload payloads.
 #: ``/uploads`` is the synchronous surface; ``/jobs`` is the async twin and
 #: takes the same models, so it is included for the case where the two ever
-#: diverge.
-_UPLOAD_PREFIXES = ("/api/v1/uploads/", "/api/v1/jobs/")
+#: diverge. ``/bundles`` is the contribution-bundle root — the surface a
+#: contributor is actually pointed at — and it reaches many of the same
+#: nested models, so leaving it out would have reproduced this issue's own
+#: mistake at the level of the guard.
+_UPLOAD_PREFIXES = ("/api/v1/uploads/", "/api/v1/jobs/", "/api/v1/bundles/")
 
 
 def _upload_root_models() -> dict[str, type]:
@@ -199,13 +202,18 @@ def test_upload_roots_were_actually_discovered() -> None:
     every parametrised case below into a vacuous pass. Assert the surface is
     non-trivial and that the roots #194 was about are in it.
     """
-    assert len(UPLOAD_ROOTS) >= 11, sorted(UPLOAD_ROOTS)
+    assert len(UPLOAD_ROOTS) >= 12, sorted(UPLOAD_ROOTS)
     for expected in (
         "ConformerUploadRequest",
         "TransitionStateUploadRequest",
         "ComputedSpeciesUploadRequest",
         "ComputedReactionUploadRequest",
         "NetworkPDepUploadRequest",
+        # The contribution-bundle root. Named explicitly because it is the
+        # surface contributors are documented towards, and because it lives
+        # under a different prefix from the rest — the exact way a root gets
+        # left out of a check that looks complete.
+        "ContributionBundleV0",
     ):
         assert expected in UPLOAD_ROOTS, sorted(UPLOAD_ROOTS)
 

--- a/backend/tests/schemas/test_upload_roots_expose_no_fk_ids.py
+++ b/backend/tests/schemas/test_upload_roots_expose_no_fk_ids.py
@@ -1,0 +1,266 @@
+"""No upload root may ask a depositor for a database primary key.
+
+A depositor has a molecule, a log file and a citation. They do not have
+our row ids, and they cannot get one without first querying this
+database — which is exactly the client we are not designing for. So an
+upload payload names things with local keys and scientific content, and
+the workflow layer resolves them (``.claude/rules/schema-rules.md``,
+DR-0029 Requirement 1).
+
+That rule was already asserted — on **one** root. A walker over
+``NetworkPDepUploadRequest`` lived in ``tests/workflows/`` and checked the
+pressure-dependent tree only, while ten other upload roots were checked
+by nobody. The consequence is on the record: ``literature_id`` was found
+by hand on the reaction bundle (#118), by hand again on the PDep route
+(#154), and by hand a third time on the conformer and transition-state
+routes (#194) — three separate discoveries of one field, over three
+weeks, because a guard pointed at one root out of eleven is not a guard.
+
+This module points it at all of them, and derives the root set from the
+**live route table** rather than a hand-written list: a new upload route
+is covered the moment it is registered, without anyone remembering to
+add it here. That is the part that makes the rule enforceable rather
+than merely stated.
+
+Two escape hatches exist, and both cost prose:
+
+:data:`SANCTIONED_CHAINING`
+    ``existing_*_id`` is the one sanctioned exception in
+    ``.claude/rules/schema-rules.md`` — programmatic chaining, where a
+    client cites a record *it deposited itself* in an earlier request
+    and no local key can reach backwards across the request boundary.
+    Entries are listed by exact ``Model.field``, not matched by pattern,
+    so inventing a new one is a visible decision rather than a silent
+    match.
+
+:data:`DEFERRED_LEAKS`
+    Genuine leaks this guard found that predate it and are actively read
+    by the server, so removing them is a behaviour change with its own
+    design and its own review. They are frozen here with a reason and a
+    tracked follow-up. Freezing them is what lets the guard go green
+    over every root *today* instead of after a multi-root breaking
+    change — a regression anywhere else fails immediately.
+
+Do not add to either list to make a red run go away. A new FK id on an
+upload surface is the defect this file exists to catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.routing import APIRoute
+
+from app.api.app import create_app
+
+# ---------------------------------------------------------------------------
+# The roots, discovered from the live surface
+# ---------------------------------------------------------------------------
+
+#: Path prefixes whose POST bodies are depositor-facing upload payloads.
+#: ``/uploads`` is the synchronous surface; ``/jobs`` is the async twin and
+#: takes the same models, so it is included for the case where the two ever
+#: diverge.
+_UPLOAD_PREFIXES = ("/api/v1/uploads/", "/api/v1/jobs/")
+
+
+def _upload_root_models() -> dict[str, type]:
+    """Return ``{model_name: model_cls}`` for every upload request body."""
+    app = create_app()
+    roots: dict[str, type] = {}
+    for route in app.routes:
+        if not isinstance(route, APIRoute) or "POST" not in route.methods:
+            continue
+        if not route.path.startswith(_UPLOAD_PREFIXES):
+            continue
+        for body_param in route.dependant.body_params:
+            annotation = body_param.field_info.annotation
+            if isinstance(annotation, type) and hasattr(annotation, "model_fields"):
+                roots[annotation.__name__] = annotation
+    return roots
+
+
+UPLOAD_ROOTS = _upload_root_models()
+
+
+# ---------------------------------------------------------------------------
+# The two escape hatches
+# ---------------------------------------------------------------------------
+
+#: ``Model.field`` -> why this id is a sanctioned citation, not a leak.
+SANCTIONED_CHAINING: dict[str, str] = {
+    "StatmechSourceCalculationIn.existing_calculation_id": (
+        "A statmech record may be built from calculations deposited by an "
+        "earlier request. Those rows exist and are the client's own, but no "
+        "local key survives across the request boundary, so the id it was "
+        "handed back is the only way to name them. Sanctioned in #129."
+    ),
+    "ThermoSourceCalculationIn.existing_calculation_id": (
+        "Same case as the statmech spelling: thermo cites the calculations "
+        "its numbers came from, and those may predate this request."
+    ),
+    "ThermoUploadRequest.existing_statmech_id": (
+        "Thermo derived from a statmech record deposited earlier. The "
+        "alternative — re-uploading the statmech block to get a local key — "
+        "would create a duplicate record to express a reference."
+    ),
+}
+
+#: ``Model.field`` -> why it is still here and what has to happen to remove it.
+#:
+#: Every entry below was found by this walker on the run that generalised it.
+#: None is defensible as a permanent shape; each is deferred because the
+#: server reads the value today, so removing the field is a behaviour change
+#: needing its own design rather than a schema edit.
+DEFERRED_LEAKS: dict[str, str] = {
+    "SCFStabilityPayload.source_calculation_id": (
+        "Cites the calculation whose log carries the SCF stability evidence. "
+        "Read at app/services/calculation_resolution.py:784. The class "
+        "docstring justifies these ids by saying 'the primitive upload routes "
+        "take this shape' — but no primitive route takes SCFStabilityPayload "
+        "at all; it is reached ONLY from /uploads/{conformers,transition-"
+        "states,statmech,thermo,transport}, which are the depositor-facing "
+        "roots the docstring says take SCFStabilityContent instead. The "
+        "stated rationale does not describe the code. Removing the ids needs "
+        "a local-key spelling for the citation; tracked separately."
+    ),
+    "SCFStabilityPayload.source_artifact_id": (
+        "Same class, same five roots, same stale rationale — cites a "
+        "calculation_artifact row instead of a calculation. Read at "
+        "app/services/calculation_resolution.py:785."
+    ),
+    "CalculationScanPointCreate.geometry_id": (
+        "Mutually exclusive alternative to the inline 'geometry' fragment, "
+        "and the fragment is the shape a depositor can actually produce. "
+        "Read at app/services/calculation_scan_resolution.py:84. Documented "
+        "as being 'for primitive/internal callers', but it is reachable from "
+        "the computed-species and computed-reaction bundle roots, where by "
+        "that same reasoning it does not belong."
+    ),
+    "ReactionParticipantUpload.species_entry_id": (
+        "Programmatic chaining in substance — 'exactly one of "
+        "species_entry_id or species_entry' — but not in name: without the "
+        "'existing_' prefix nothing distinguishes it from a plain FK, and it "
+        "does not carry the ownership/role checks schema-rules.md requires "
+        "of a sanctioned chaining field. Renaming it is a breaking change to "
+        "a published route and needs those checks added at the same time."
+    ),
+}
+
+_ALLOWED = {**SANCTIONED_CHAINING, **DEFERRED_LEAKS}
+
+
+# ---------------------------------------------------------------------------
+# The walker
+# ---------------------------------------------------------------------------
+
+
+def _nested_models(annotation) -> list[type]:
+    """Every Pydantic model reachable through a field annotation."""
+    found: list[type] = []
+    stack = [annotation]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, type) and hasattr(current, "model_fields"):
+            found.append(current)
+            continue
+        stack.extend(getattr(current, "__args__", ()) or ())
+    return found
+
+
+def fk_shaped_fields(model_cls: type) -> list[str]:
+    """Return ``Model.field`` for every FK- or hash-shaped field in the tree.
+
+    Walks the whole nested model tree rooted at ``model_cls``. Ignores the
+    allowlists — callers filter — so a caller can always see the raw truth.
+    """
+
+    def _walk(cls: type, seen: set[type]) -> list[str]:
+        if cls in seen:
+            return []
+        seen.add(cls)
+        offenders: list[str] = []
+        for name, field in cls.model_fields.items():
+            if name.endswith("_hash") or name in {"id", "public_ref"}:
+                offenders.append(f"{cls.__name__}.{name}")
+            elif name.endswith("_id") and not name.endswith("_uuid"):
+                offenders.append(f"{cls.__name__}.{name}")
+            for sub in _nested_models(field.annotation):
+                offenders.extend(_walk(sub, seen))
+        return offenders
+
+    return sorted(set(_walk(model_cls, set())))
+
+
+def test_upload_roots_were_actually_discovered() -> None:
+    """The walker is worthless if the route scan silently finds nothing.
+
+    A refactor that moves the upload routers, renames the prefix, or stops
+    declaring bodies as Pydantic models would empty ``UPLOAD_ROOTS`` and turn
+    every parametrised case below into a vacuous pass. Assert the surface is
+    non-trivial and that the roots #194 was about are in it.
+    """
+    assert len(UPLOAD_ROOTS) >= 11, sorted(UPLOAD_ROOTS)
+    for expected in (
+        "ConformerUploadRequest",
+        "TransitionStateUploadRequest",
+        "ComputedSpeciesUploadRequest",
+        "ComputedReactionUploadRequest",
+        "NetworkPDepUploadRequest",
+    ):
+        assert expected in UPLOAD_ROOTS, sorted(UPLOAD_ROOTS)
+
+
+@pytest.mark.parametrize("root_name", sorted(UPLOAD_ROOTS))
+def test_upload_root_exposes_no_fk_ids_or_hashes(root_name: str) -> None:
+    """No FK id or derived hash anywhere in this root's request tree."""
+    offenders = [
+        field
+        for field in fk_shaped_fields(UPLOAD_ROOTS[root_name])
+        if field not in _ALLOWED
+    ]
+    assert offenders == [], (
+        f"{root_name} exposes database ids a depositor cannot know: "
+        f"{offenders}. Take scientific content or a local key instead and "
+        f"resolve it in the workflow layer (.claude/rules/schema-rules.md)."
+    )
+
+
+def test_allowlists_are_not_carrying_dead_entries() -> None:
+    """Every allowlisted field must still be reachable from some root.
+
+    An entry that no longer matches anything is a fix nobody noticed — and
+    it leaves a name in the file that would silence a *future* field of the
+    same name. Removing it is the point at which the prose gets re-read.
+    """
+    reachable: set[str] = set()
+    for model in UPLOAD_ROOTS.values():
+        reachable.update(fk_shaped_fields(model))
+    stale = sorted(set(_ALLOWED) - reachable)
+    assert stale == [], (
+        f"These allowlist entries match nothing on any upload root: {stale}. "
+        "Delete them."
+    )
+
+
+def test_sanctioned_and_deferred_lists_do_not_overlap() -> None:
+    """A field is either a sanctioned citation or a leak awaiting removal."""
+    both = sorted(set(SANCTIONED_CHAINING) & set(DEFERRED_LEAKS))
+    assert both == [], both
+
+
+def test_sanctioned_chaining_entries_are_all_existing_prefixed() -> None:
+    """The sanctioned exception is ``existing_*_id`` and nothing else.
+
+    Guards the list against being used as a general-purpose muzzle: a field
+    that is not spelled ``existing_*_id`` has not met the naming half of the
+    rule, whatever its intent, and belongs in ``DEFERRED_LEAKS`` until it is.
+    """
+    for entry in SANCTIONED_CHAINING:
+        field = entry.split(".", 1)[1]
+        assert field.startswith("existing_") and field.endswith("_id"), entry
+
+
+def test_every_allowlist_entry_states_a_reason() -> None:
+    """A bare name would let the next person silence a real regression."""
+    for entry, reason in _ALLOWED.items():
+        assert len(reason.split()) >= 12, f"{entry}: reason too thin"

--- a/backend/tests/workflows/test_network_pdep_upload.py
+++ b/backend/tests/workflows/test_network_pdep_upload.py
@@ -2520,41 +2520,23 @@ def test_upload_schema_exposes_no_fk_ids_or_hashes() -> None:
     local keys and the workflow resolves them, so a database id or a derived
     hash appearing in an upload schema means someone has to know our primary
     keys to contribute.
+
+    The walker itself no longer lives here. It was the *only* copy of this
+    check in the tree and it pointed at this one root, which is why the
+    same ``literature_id`` leak was found by hand on three other roots over
+    three weeks (#118, #154, #194). It now lives in
+    ``tests/schemas/test_upload_roots_expose_no_fk_ids.py`` and runs over
+    every upload root discovered from the live route table.
+
+    This case stays because it is the strictest one: PDep is checked with
+    **no allowlist at all**, where the shared module tolerates a frozen
+    inventory of pre-existing leaks on other roots. This root has none and
+    must keep having none — do not add an exemption here; widen the schema
+    or fix it.
     """
+    from tests.schemas.test_upload_roots_expose_no_fk_ids import fk_shaped_fields
 
-    def _nested_models(annotation) -> list:
-        found = []
-        stack = [annotation]
-        while stack:
-            current = stack.pop()
-            if isinstance(current, type) and hasattr(current, "model_fields"):
-                found.append(current)
-                continue
-            stack.extend(getattr(current, "__args__", ()) or ())
-        return found
-
-    def _walk(model_cls, seen: set) -> list[str]:
-        if model_cls in seen:
-            return []
-        seen.add(model_cls)
-        offenders: list[str] = []
-        for name, field in model_cls.model_fields.items():
-            if name.endswith("_hash") or name in {"id", "public_ref"}:
-                offenders.append(f"{model_cls.__name__}.{name}")
-            elif name.endswith("_id") and not name.endswith("_uuid"):
-                offenders.append(f"{model_cls.__name__}.{name}")
-            for sub in _nested_models(field.annotation):
-                offenders.extend(_walk(sub, seen))
-        return offenders
-
-    offenders = _walk(NetworkPDepUploadRequest, set())
-    # This assertion used to carry one exemption: ``CalculationIn.literature_id``,
-    # an FK leak inherited from the shared calculation fragment rather than
-    # introduced here. That field is gone — the shared ``CalculationIn`` now
-    # takes an inline ``literature`` fragment, which the workflow resolves —
-    # so the gate is unconditional again. Do not re-add an exemption; widen
-    # the schema or fix it.
-    assert offenders == []
+    assert fk_shaped_fields(NetworkPDepUploadRequest) == []
 
 
 def test_chebyshev_grid_dimensions_must_match_declared_orders() -> None:

--- a/backend/tests/workflows/test_upload_calculation_literature.py
+++ b/backend/tests/workflows/test_upload_calculation_literature.py
@@ -1,0 +1,227 @@
+"""A calculation's citation is a paper, not a row id — on every root.
+
+``CalculationWithResultsPayload`` is the calculation block of five upload
+roots (``/uploads/`` conformers, transition-states, statmech, thermo,
+transport) *and*, until #194, the internal shape three bundle workflows
+built after resolving literature themselves. Because it was both, it kept
+a raw ``literature_id``: correct for the internal use, a database primary
+key on a depositor-facing surface for the other five.
+
+#118 removed that field from the reaction bundle. #154 removed it from
+the network-PDep route. #172 removed it from ``CalculationIn``. It
+survived all three on the shared payload, and was found by hand a fourth
+time. These tests pin both halves of the correction — the raw id is
+refused, and the inline fragment it was replaced by actually reaches a
+``literature`` row — on the two roots #194 named.
+
+The general statement lives in
+``tests/schemas/test_upload_roots_expose_no_fk_ids.py``, which asserts it
+over every upload root discovered from the live route table. This file is
+the behavioural half: that the replacement works, not merely that the
+field is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from tckdb_schemas.workflows.conformer_upload import ConformerCalculationIn
+
+from app.db.models.calculation import Calculation
+from app.db.models.literature import Literature
+from app.schemas.fragments.calculation import CalculationWithResultsPayload
+from app.schemas.workflows.conformer_upload import ConformerUploadRequest
+from app.schemas.workflows.transition_state_upload import (
+    TransitionStateUploadRequest,
+)
+from app.workflows.conformer import persist_conformer_upload
+from app.workflows.transition_state import persist_transition_state_upload
+
+_SOFTWARE = {"name": "gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+_XYZ_TS = "3\nH transfer TS\nH 0.0 0.0 0.0\nH 0.0 0.0 0.9\nH 0.0 0.0 1.8\n"
+_REACTION = {
+    "reversible": True,
+    "reactants": [
+        {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+        {"species_entry": {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}},
+    ],
+    "products": [
+        {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+        {"species_entry": {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}},
+    ],
+}
+
+
+@pytest.fixture
+def stub_doi(monkeypatch):
+    """Resolve DOIs without reaching Crossref."""
+    monkeypatch.setattr(
+        "app.services.literature_resolution.fetch_doi_metadata",
+        lambda doi: {
+            "title": "A paper the depositor has and the row id they do not",
+            "container-title": ["J. Chem. Phys."],
+            "issued": 2010,
+            "URL": f"https://doi.org/{doi}",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# The removed field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model", [CalculationWithResultsPayload, ConformerCalculationIn]
+)
+def test_the_shared_calculation_payload_no_longer_declares_literature_id(model):
+    """Pinned on the model, not just on one route's rejection.
+
+    ``ConformerCalculationIn`` subclasses the shared payload, so it is
+    checked separately: a subclass could re-add the field and every
+    route-level test that posts the base shape would still pass.
+    """
+    assert "literature_id" not in model.model_fields, model.__name__
+    assert "literature" in model.model_fields, model.__name__
+
+
+def test_conformer_upload_refuses_a_raw_literature_id():
+    """Refused at the boundary, naming the field.
+
+    ``SchemaBase`` sets ``extra="forbid"``, so an old client's payload is a
+    422 that says ``literature_id`` rather than a 201 with the citation
+    silently dropped. Asserting the field name matters: a 422 for an
+    unrelated reason would satisfy a bare status check.
+    """
+    with pytest.raises(ValidationError, match="literature_id"):
+        ConformerUploadRequest(
+            species_entry={"smiles": "[H]", "charge": 0, "multiplicity": 2},
+            geometry={"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+            calculation={
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_result": {"n_imag": 0},
+                "literature_id": 42,
+            },
+        )
+
+
+def test_transition_state_upload_refuses_a_raw_literature_id():
+    with pytest.raises(ValidationError, match="literature_id"):
+        TransitionStateUploadRequest(
+            reaction=_REACTION,
+            charge=0,
+            multiplicity=2,
+            geometry={"xyz_text": _XYZ_TS},
+            primary_opt={
+                "type": "opt",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "literature_id": 42,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# The replacement, end to end
+# ---------------------------------------------------------------------------
+
+
+def test_conformer_upload_resolves_an_inline_calculation_citation(
+    db_conn, stub_doi
+) -> None:
+    """The fragment a depositor can actually produce reaches a row.
+
+    Removing the id is only half a fix: if nothing resolved the fragment,
+    the citation would be accepted and dropped, which is worse than
+    refusing it. Assert the ``calculation.literature_id`` column is
+    populated and points at the paper that was cited.
+    """
+    request = ConformerUploadRequest(
+        species_entry={"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        geometry={"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+        calculation={
+            "type": "freq",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "freq_result": {"n_imag": 0},
+            "literature": {
+                "doi": "10.1063/conformer-calc-citation",
+                "title": "fallback if DOI lookup fails",
+            },
+        },
+        note="inline calculation citation",
+    )
+
+    with Session(db_conn) as session, session.begin():
+        outcome = persist_conformer_upload(session, request)
+        calc = session.get(
+            Calculation, outcome.primary_calculation.calculation_id
+        )
+        assert calc.literature_id is not None
+        lit = session.get(Literature, calc.literature_id)
+        assert lit.doi == "10.1063/conformer-calc-citation"
+        assert lit.title == "A paper the depositor has and the row id they do not"
+
+
+def test_transition_state_upload_resolves_an_inline_calculation_citation(
+    db_conn, stub_doi
+) -> None:
+    request = TransitionStateUploadRequest(
+        reaction=_REACTION,
+        charge=0,
+        multiplicity=2,
+        geometry={"xyz_text": _XYZ_TS},
+        primary_opt={
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "literature": {
+                "doi": "10.1063/ts-calc-citation",
+                "title": "fallback if DOI lookup fails",
+            },
+        },
+        label="TS with an inline citation",
+    )
+
+    with Session(db_conn) as session, session.begin():
+        ts_entry = persist_transition_state_upload(session, request)
+        calc = session.scalars(
+            select(Calculation).where(
+                Calculation.transition_state_entry_id == ts_entry.id
+            )
+        ).one()
+        assert calc.literature_id is not None
+        lit = session.get(Literature, calc.literature_id)
+        assert lit.doi == "10.1063/ts-calc-citation"
+
+
+def test_an_uncited_calculation_stays_uncited(db_conn) -> None:
+    """Absence must survive the new resolution step.
+
+    The seam now calls literature resolution on every calculation. A
+    resolver that created an empty row for a payload that cited nothing
+    would attach a meaningless provenance record to most of the database,
+    so the ``None`` path is asserted rather than assumed.
+    """
+    request = ConformerUploadRequest(
+        species_entry={"smiles": "[H]", "charge": 0, "multiplicity": 2},
+        geometry={"xyz_text": "1\nH atom\nH 0.0 0.0 0.0"},
+        calculation={
+            "type": "freq",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "freq_result": {"n_imag": 0},
+        },
+        note="no citation",
+    )
+    with Session(db_conn) as session, session.begin():
+        outcome = persist_conformer_upload(session, request)
+        calc = session.get(
+            Calculation, outcome.primary_calculation.calculation_id
+        )
+        assert calc.literature_id is None

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.32.0"
+version = "0.33.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
@@ -25,6 +25,7 @@ from tckdb_schemas.fragments.refs import (
     SoftwareReleaseRef,
     WorkflowToolReleaseRef,
 )
+from tckdb_schemas.literature import LiteratureUploadRequest
 from tckdb_schemas.stationary_point import (
     ImaginaryMode,
     StationaryPointFinding,
@@ -104,7 +105,8 @@ class CalculationPayload(SchemaBase):
     :param software_release: Required software release reference.
     :param workflow_tool_release: Optional workflow tool provenance reference.
     :param level_of_theory: Required level-of-theory reference.
-    :param literature_id: Optional literature provenance id.
+    :param literature: Optional inline literature provenance, resolved (or
+        created) by the workflow.
     """
 
     type: CalculationType
@@ -114,7 +116,15 @@ class CalculationPayload(SchemaBase):
     workflow_tool_release: WorkflowToolReleaseRef | None = None
     level_of_theory: LevelOfTheoryRef
 
-    literature_id: int | None = None
+    #: Replaces the former ``literature_id``, a raw database primary key on
+    #: a depositor-facing surface. Only a client that had already queried
+    #: this database could supply one, which is the client we do not design
+    #: for (``.claude/rules/schema-rules.md``, DR-0029 Req 1). The species
+    #: bundle took the inline fragment from the start and ``CalculationIn``
+    #: was converted in #172; this is the same conversion for the five
+    #: routes that reach the shared payload directly — conformers,
+    #: transition-states, statmech, thermo and transport.
+    literature: LiteratureUploadRequest | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/shared/calculation_in.py
@@ -269,8 +269,6 @@ def frequency_completeness_findings(
 
 def calculation_in_to_with_results_payload(
     calc_in: "CalculationIn",
-    *,
-    literature_id: int | None = None,
 ) -> CalculationWithResultsPayload:
     """Adapt a bundle-local ``CalculationIn`` to the shared upload shape.
 
@@ -281,29 +279,16 @@ def calculation_in_to_with_results_payload(
     ``geometry_key``, ``artifacts``) are consumed by the workflow directly and
     are not part of the shared payload.
 
-    ``literature_id`` is passed *in* rather than read off ``calc_in``: the
-    upload now carries an inline ``literature`` fragment, and resolving it
-    to a row needs a database session, which this package deliberately
-    cannot reach. The caller resolves and hands the id down — the same
-    split ``computed_species._to_calc_with_results_payload`` has always
-    used.
-
-    A caller that supplies a ``literature`` fragment but no resolved id is
-    refused rather than quietly losing the citation. Defaulting to ``None``
-    would make "this upload cited nothing" and "the workflow forgot to
-    resolve the citation" the same value, which is the class of silent drop
-    this change exists to remove.
-
-    :raises ValueError: if ``calc_in.literature`` is set and
-        ``literature_id`` is not.
+    The citation is forwarded as the inline ``literature`` fragment, not as
+    a resolved id. This function used to take a ``literature_id`` keyword
+    and refuse the pair "fragment present, id absent", because the shared
+    payload carried a raw ``literature_id`` and only the caller had a
+    database session to produce one. The shared payload now carries the
+    fragment too (#194), so there is no id to lose here and no seam at
+    which to lose it: resolution happens once, in
+    ``resolve_and_persist_calculation_with_results``, which has the
+    session. The guard is gone because the failure mode it guarded is.
     """
-    if calc_in.literature is not None and literature_id is None:
-        raise ValueError(
-            "calculation_in_to_with_results_payload was given a calculation "
-            "carrying an inline 'literature' fragment but no resolved "
-            "literature_id. Resolve it in the workflow and pass it in; "
-            "dropping it here would discard a depositor's citation."
-        )
 
     opt_result: OptResultPayload | None = None
     freq_result: FreqResultPayload | None = None
@@ -340,7 +325,7 @@ def calculation_in_to_with_results_payload(
         software_release=calc_in.software_release,
         workflow_tool_release=calc_in.workflow_tool_release,
         level_of_theory=calc_in.level_of_theory,
-        literature_id=literature_id,
+        literature=calc_in.literature,
         execution_environment=calc_in.execution_environment,
         opt_result=opt_result,
         freq_result=freq_result,

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -221,8 +221,6 @@ class ComputedReactionCalculationIn(_BaseCalculationIn):
 
 def calculation_in_to_with_results_payload(
     calc_in: ComputedReactionCalculationIn,
-    *,
-    literature_id: int | None = None,
 ) -> CalculationWithResultsPayload:
     """Adapt a computed-reaction ``ComputedReactionCalculationIn`` to the
     shared upload shape.
@@ -230,13 +228,11 @@ def calculation_in_to_with_results_payload(
     Forwards the three producer-declared provenance fields onto the
     shared ``CalculationWithResultsPayload`` so the existing calculation
     persistence seam writes the corresponding rows. The base converter
-    handles type/result/parameter mapping unchanged.
-
-    ``literature_id`` is the workflow-resolved id for the calculation's
-    inline ``literature`` fragment; see the base converter for why it
-    cannot be resolved inside this package.
+    handles type/result/parameter mapping unchanged — including the
+    calculation's inline ``literature`` fragment, which is carried through
+    unresolved and resolved once at the persistence seam.
     """
-    base = _base_calc_to_payload(calc_in, literature_id=literature_id)
+    base = _base_calc_to_payload(calc_in)
     return base.model_copy(
         update={
             "input_geometries": list(calc_in.input_geometries),


### PR DESCRIPTION
Closes #194.

## The premise, and where it was wrong

The brief said `literature_id` survived on `CalculationPayload`, reachable by `/uploads/conformers` and `/uploads/transition-states`, and that the FK-leak walker covered one root out of four.

**Both halves confirmed, both understated.**

- The field leaked on **five** roots, not two: `/uploads/conformers`, `/uploads/transition-states`, `/uploads/statmech`, `/uploads/thermo`, `/uploads/transport` (plus their `/jobs/*` twins).
- The walker covered one root out of **eleven**, not four.

## Reproduction, before

Against a real DB, `/uploads/conformers` and `/uploads/transition-states` accepted a raw `literature_id` and wrote it straight to `calculation.literature_id`:

```
REPRO /uploads/conformers: request VALIDATED, calculation.literature_id=1
REPRO /uploads/conformers: persisted calculation.literature_id=1
PASSED
REPRO /uploads/transition-states: request VALIDATED, primary_opt.literature_id=2
REPRO /uploads/transition-states: persisted calculation.literature_id=2
PASSED
```

## Reproduction, after

```
E  pydantic_core._pydantic_core.ValidationError: 1 validation error for ConformerUploadRequest
E  calculation.literature_id
E    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden

E  pydantic_core._pydantic_core.ValidationError: 1 validation error for TransitionStateUploadRequest
E  primary_opt.literature_id
E    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
```

Both cases are now kept as permanent tests in `backend/tests/workflows/test_upload_calculation_literature.py`, together with the positive half — that the inline fragment that replaces the id actually reaches a `literature` row, and that an uncited calculation stays uncited.

## The walker, generalised first

`backend/tests/schemas/test_upload_roots_expose_no_fk_ids.py` discovers every upload request body **from the live route table** (`create_app()` → `APIRoute.dependant.body_params` under `/api/v1/uploads/` and `/api/v1/jobs/`), rather than from a hand-written list. A new upload route is covered the moment it is registered — which is the structural half of this issue, and the reason the same field was found by hand three times.

### Complete failure list on first run

11 roots discovered, 8 red, 9 distinct offending fields:

```
[FAIL] ComputedReactionUploadRequest: 1
          CalculationScanPointCreate.geometry_id
[FAIL] ComputedSpeciesUploadRequest: 1
          CalculationScanPointCreate.geometry_id
[FAIL] ConformerUploadRequest: 3
          ConformerCalculationIn.literature_id
          SCFStabilityPayload.source_artifact_id
          SCFStabilityPayload.source_calculation_id
[ok  ] KineticsUploadRequest: 0
[ok  ] NetworkPDepUploadRequest: 0
[ok  ] NetworkUploadRequest: 0
[FAIL] ReactionUploadRequest: 1
          ReactionParticipantUpload.species_entry_id
[FAIL] StatmechUploadRequest: 4
          CalculationWithResultsPayload.literature_id
          SCFStabilityPayload.source_artifact_id
          SCFStabilityPayload.source_calculation_id
          StatmechSourceCalculationIn.existing_calculation_id
[FAIL] ThermoUploadRequest: 5
          CalculationWithResultsPayload.literature_id
          SCFStabilityPayload.source_artifact_id
          SCFStabilityPayload.source_calculation_id
          ThermoSourceCalculationIn.existing_calculation_id
          ThermoUploadRequest.existing_statmech_id
[FAIL] TransitionStateUploadRequest: 3
          CalculationWithResultsPayload.literature_id
          SCFStabilityPayload.source_artifact_id
          SCFStabilityPayload.source_calculation_id
[FAIL] TransportUploadRequest: 3
          CalculationWithResultsPayload.literature_id
          SCFStabilityPayload.source_artifact_id
          SCFStabilityPayload.source_calculation_id
```

## What was fixed

`CalculationPayload.literature_id: int | None` → `literature: LiteratureUploadRequest | None`.

The root cause is that `CalculationWithResultsPayload` was doing two jobs: the **public request body** of five upload roots, and the **internal resolved shape** three bundle workflows built after resolving literature themselves. The raw id was correct for the second job and a leak in the first. #172 fixed `CalculationIn` (the depositor-facing bundle shape) but the shared payload underneath it kept the id, which is precisely why the leak survived.

Resolution moves into `resolve_and_persist_calculation_with_results` — the one seam every upload root that persists a calculation passes through. It has a `Session`; the wire package deliberately does not. Three workflows (`computed_reaction`, `computed_species`, `network_pdep`) stop doing the resolution for themselves, so there is one place to get it right instead of four.

## What was deliberately **not** fixed

Four genuine leaks predate this guard and are **read by the server today**, so removing them is a behaviour change needing its own design. They are frozen in a documented `DEFERRED_LEAKS` inventory — named individually, each with a reason, so a regression anywhere else still fails immediately. Each deserves its own issue:

1. **`SCFStabilityPayload.source_calculation_id` / `source_artifact_id`** (5 roots). Read at `app/services/calculation_resolution.py:784-785`. **The class docstring's justification is factually wrong**: it says "the primitive upload routes take this shape" and that "bundle roots take `SCFStabilityContent` instead" — but *no* primitive route takes `SCFStabilityPayload` at all. It is reachable **only** from `/uploads/{conformers,transition-states,statmech,thermo,transport}`, i.e. exactly the depositor-facing roots the docstring says are excluded. Worth its own task, including correcting that comment.
2. **`CalculationScanPointCreate.geometry_id`** (2 bundle roots). Read at `app/services/calculation_scan_resolution.py:84`. Documented as "for primitive/internal callers", but reachable from the computed-species and computed-reaction **bundle** roots, where by its own reasoning it does not belong.
3. **`ReactionParticipantUpload.species_entry_id`** (`/uploads/reactions`). Programmatic chaining in substance ("exactly one of `species_entry_id` or `species_entry`") but not in name. Renaming to `existing_species_entry_id` is a breaking change to a published route and, per `.claude/rules/schema-rules.md`, must add the ownership/role checks a sanctioned chaining field is required to carry — so the rename cannot be done alone.

Three `existing_*_id` fields are **allowlisted**, not deferred: that is the one sanctioned exception in `.claude/rules/schema-rules.md` (decided in #129). The allowlist is keyed by exact `Model.field` rather than by pattern, and a separate test asserts every entry is genuinely `existing_*`-prefixed, so it cannot be used as a general-purpose muzzle. Two more tests assert every entry states a reason and that no entry has gone stale.

## Test changed (not weakened)

`test_the_adapter_refuses_to_drop_a_citation_it_was_not_given_an_id_for` asserted that `calculation_in_to_with_results_payload` **raises** when handed a `literature` fragment without a pre-resolved `literature_id`. That guard existed only because the payload carried a raw id the caller had to populate. The payload now carries the fragment, so there is no id to forget and the failure mode is gone.

The test is **replaced by a stronger assertion**, not deleted: `test_the_adapter_carries_the_citation_through_without_resolving_it` asserts the citation survives the adapter intact, that an uncited calculation stays uncited, and that `literature_id` is absent from the model entirely — the last of which the old test could not check.

`test_upload_schema_exposes_no_fk_ids_or_hashes` in `test_network_pdep_upload.py` keeps its name and its unconditional (**no allowlist**) assertion, but now calls the shared walker instead of carrying a private copy. One implementation, so the two cannot drift.

## Mutation check

Re-introduced a fake FK field on two roots the walker **newly** covers. Both were confirmed present in the file before the run, and both restored to a clean `git status` afterwards with `__pycache__` cleared:

```
E  AssertionError: ConformerUploadRequest exposes database ids a depositor cannot know:
   ['ConformerCalculationIn.mutation_probe_species_id']
FAILED ...[ConformerUploadRequest]                             1 failed, 15 passed

E  AssertionError: TransportUploadRequest exposes database ids a depositor cannot know:
   ['TransportUploadRequest.mutation_probe_conformer_id']
FAILED ...[TransportUploadRequest]                             1 failed, 15 passed
```

A third guard (`test_upload_roots_were_actually_discovered`) exists because the parametrised cases would pass **vacuously** if a refactor emptied the route scan.

## Schema / migration impact

- **Database schema: none.** No migration, no ORM change. `calculation.literature_id` the *column* is untouched; only the upload-facing field is removed.
- **Wire contract: breaking.** `tckdb-schemas` **0.32.0 → 0.33.0**. `literature_id` no longer validates on the five affected roots. `SchemaBase` is `extra="forbid"`, so an old payload gets a 422 naming the field rather than a 201 with the citation silently dropped.
- **OpenAPI golden regenerated** (`backend/tests/api/golden/openapi.json`): 6 insertions, 8 deletions, entirely the `literature_id` → `literature` swap on two components.
- **`tckdb-client`: no bump needed.** It references only `GET /api/v1/literature/{literature_id}`, an unrelated read route.

## New environment variables

**None.**

## Verification actually run

All with `PYTHONPATH="$PWD/schemas/python/tckdb-schemas"` from the worktree root, confirmed resolving to the worktree's own wire package (`has literature_id: False`, `has literature: True`) — not the main checkout's editable install.

```bash
# the three required CI gates, run the way CI runs them
conda run -n tckdb_env bash backend/scripts/test-rest.sh        # 4350 passed, 14 skipped (4:32)
conda run -n tckdb_env bash backend/scripts/test-api.sh         # 2765 passed          (5:09)
conda run -n tckdb_env bash backend/scripts/test-scientific.sh  # 2055 passed          (3:21)

# confirmed the two new files are inside the required gate's selection
bash backend/scripts/test-rest.sh --collect-only -q
#   tests/schemas/test_upload_roots_expose_no_fk_ids.py: 16
#   tests/workflows/test_upload_calculation_literature.py: 7

# OpenAPI golden
UPDATE_OPENAPI_GOLDEN=1 pytest tests/api/test_openapi_snapshot.py   # 3 passed

# lint, from backend/ (not the repo root)
conda run -n tckdb_env ruff check <changed backend files>       # All checks passed!
```

Pre-existing `I001` findings in `schemas/python/tckdb-schemas/` are untouched and are not linted by CI (`backend-ci.yml` runs `ruff check app tests scripts` from `backend/`); the new import was placed in sorted position so this change does not add to them.

## References

- `.claude/rules/schema-rules.md` — "No FK IDs in upload schemas", and `existing_*_id` as the one sanctioned exception.
- DR-0029 Requirement 1 — a depositor names things with local keys. (Note: `docs/decisions/` is gitignored and so is not present in a `git worktree`; cited from the issue.)
- Prior removals of this same field: #118 (reaction bundle), #154 (network-PDep), #172 (`CalculationIn`).
