### PR TITLE
Name the seven ownership refusals that arrived uncoded

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -68,13 +68,17 @@ this file by four different routes, and no one of them is enough:
   where the refusal is raised. It is the bulk of the catalogue and it is
   closed under inspection.
 * **A scan cannot see a code minted from a variable.** Four mechanisms do
-  exactly that: :func:`app.services.calculation_ownership.assert_calculation_owned_by`
+  exactly that: the :mod:`app.services.calculation_ownership` guards
+  (:func:`~app.services.calculation_ownership.assert_owned_by` and its two
+  typed wrappers)
   and ``scientific_read.handles.reconcile_id_ref`` both take their code as
   a *parameter*, ``tckdb_schemas.stationary_point`` raises with whichever
   code its blocking finding carries, and the integrity handler looks its
-  code up by PostgreSQL constraint name. That is nineteen codes the scan
-  is blind to, and the ``*_handle_conflict`` family was found only by the
-  observer below. Six of the nineteen have since been brought back into
+  code up by PostgreSQL constraint name. That is twenty-two codes the scan
+  is blind to — nineteen until #195 gave the ownership family its three
+  statmech-and-selection codes — and the ``*_handle_conflict`` family was
+  found only by the
+  observer below. Six of them have since been brought back into
   static view: #177 widened the scan to read a ``*_code=`` argument at
   any call, not only at a ``raise``, so the codes handed to
   ``reconcile_id_ref`` are seen where they are written. That matters
@@ -304,21 +308,18 @@ class ApiCode:
 CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("applied_energy_correction_source_calculation_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
-            reach=Reach.guard,
             note=(
-                "No request produces this code. All three call sites "
-                "(workflows/thermo.py once, workflows/computed_species.py "
-                "twice) read the calculation out of a key map the enclosing "
-                "block built for the target's own owner, and no applied "
-                "correction anywhere carries an existing_calculation_id, so "
-                "nothing can name a foreign row. The condition itself is not "
-                "unreachable: the reaction bundle resolves the same key in a "
-                "namespace spanning every species and the transition state. "
-                "It checks ownership with an inline comparison that raises a "
-                "bare ValueError instead of calling this guard, so a "
-                "depositor who makes that mistake there receives "
-                "validation_error. Converting those two copies is what would "
-                "make this code reachable, and is why the guard stays."
+                "Reach.guard until #195, and the note it carried named the "
+                "repair that ended it: /uploads/computed-reaction resolves "
+                "source_calculation_key in a namespace spanning every "
+                "species and the transition state, then attaches the "
+                "correction to one of them. Both of its ownership "
+                "comparisons were inline and raised a bare ValueError, so "
+                "the mistake answered validation_error; both now call the "
+                "shared guard. The three older call sites still cannot "
+                "produce it -- they read from a key map built for the "
+                "target's own owner -- but reachability is a property of "
+                "the code, not of every site that raises it."
             )),
     ApiCode("applied_energy_correction_source_key_undeclared", 422, Surface.coded_exception,
             "backend/app/services/energy_correction_resolution.py"),
@@ -475,6 +476,18 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/common.py"),
     ApiCode("irc_result_not_found", 404, Surface.coded_exception,
             "backend/app/services/scientific_read/calculation_paths.py"),
+    ApiCode("kinetics_interpretation_conformer_selection_owner_mismatch", 422, Surface.coded_exception,
+            "backend/app/services/calculation_ownership.py"),
+    ApiCode("kinetics_interpretation_statmech_owner_mismatch", 422, Surface.coded_exception,
+            "backend/app/services/calculation_ownership.py",
+            note=(
+                "One code, two comparisons: a reactant/product assignment "
+                "is held to the participant's species entry and a "
+                "transition-state one to the declared TS entry. Not two "
+                "entries, because the field and the repair are the same "
+                "-- name the statmech belonging to this subject -- and "
+                "which owner disagreed is already in context['owner_kind']."
+            )),
     ApiCode("level_of_theory_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py"),
     ApiCode("limit_too_large", 422, Surface.message_prefix,
@@ -642,6 +655,16 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/calculation_ownership.py"),
     ApiCode("thermo_source_role_type_mismatch", 422, Surface.coded_exception,
             "backend/app/workflows/thermo.py"),
+    ApiCode("thermo_statmech_owner_mismatch", 422, Surface.coded_exception,
+            "backend/app/services/calculation_ownership.py",
+            note=(
+                "The ownership family's first code over a cited row that "
+                "is not a calculation. Distinct from "
+                "thermo_source_calculation_owner_mismatch because the "
+                "field is: existing_statmech_id names a partition "
+                "function, source_calculations name jobs, and a depositor "
+                "repairs them in different places."
+            )),
     ApiCode("transition_state_charge_mismatch", 422, Surface.coded_exception,
             "backend/app/services/reaction_resolution.py"),
     ApiCode("transition_state_composition_mismatch", 422, Surface.coded_exception,

--- a/backend/app/services/calculation_ownership.py
+++ b/backend/app/services/calculation_ownership.py
@@ -1,13 +1,14 @@
-"""One owner-consistency rule, for every product that cites a calculation.
+"""One owner-consistency rule, for every record that cites another.
 
 What the rule is
 ----------------
 A scientific product — a thermo record, a statmech record, a transport
-record, an applied energy correction — cites the calculations that produced
-its numbers. Those calculations must belong to the *same subject* the
-product is about. A thermo record for propane citing a calculation of
-water is not a weaker link; it is a meaningless one, and no correct deposit
-can produce it, so ADR 0008 puts the refusal in the ``block`` tier.
+record, an applied energy correction, a rate coefficient's interpretation
+— cites the records that produced or explain its numbers. Those records
+must belong to the *same subject* the citing record is about. A thermo
+record for propane citing a calculation of water is not a weaker link; it
+is a meaningless one, and no correct deposit can produce it, so ADR 0008
+puts the refusal in the ``block`` tier.
 
 Why it lives here
 -----------------
@@ -25,6 +26,21 @@ they *call* the offence, and that stays a parameter: a client repairing a
 thermo link and a client repairing a torsion's scan link are doing
 different things, so they get different codes (#158).
 
+Why the module is still named for calculations
+----------------------------------------------
+It was written for them, and five catalogue entries name this path as the
+origin of their code. #195 widened it: a thermo record cites a **statmech**
+row by ``existing_statmech_id``, and a kinetics interpretation cites one by
+``statmech_ref`` and a **conformer selection** by content — three more
+citations of a record owned by a subject, refused by three more inline
+copies of this comparison, each raising a bare ``ValueError``. The
+comparison is identical; only the noun changes. Splitting it across two
+modules by the type of the cited row would recreate exactly the drift the
+consolidation removed, so the noun became a parameter
+(:func:`assert_owned_by`) and the filename stayed put. Renaming it is a
+mechanical change to five ``origin`` strings whenever someone wants it;
+duplicating the rule is not recoverable.
+
 What never appears in the refusal
 ---------------------------------
 Row ids. ``context`` names the offending field the way the depositor wrote
@@ -38,6 +54,7 @@ import logging
 
 from app.api.error_contract import CodedValueError
 from app.db.models.calculation import Calculation
+from app.db.models.statmech import Statmech
 
 logger = logging.getLogger(__name__)
 
@@ -105,17 +122,159 @@ W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH = (
 #: An applied energy correction names a source calculation owned by
 #: another subject.
 #:
-#: No request produces *this code*: all three call sites read from a key
-#: map built for the target's own owner. The rule is not unreachable,
-#: though — the reaction bundle resolves the same key in a bundle-wide
-#: namespace and enforces ownership with an inline comparison that raises
-#: a bare ``ValueError``, so the same mistake there answers
-#: ``validation_error``. Also catalogued as ``Reach.guard``, and the
-#: repair that would change that is converting those two copies to call
-#: this function.
+#: Reachable since #195, and the route is the one the previous note named:
+#: ``/uploads/computed-reaction`` resolves ``source_calculation_key`` in a
+#: namespace spanning every species in the bundle *and* the transition
+#: state, then attaches the correction to one species entry or to the TS
+#: entry. Both of those comparisons used to be spelled inline and raised a
+#: bare ``ValueError``, so a depositor who cited a sibling species' job
+#: received ``validation_error``; both now call this function.
+#:
+#: The three older call sites — ``workflows/thermo.py`` once,
+#: ``workflows/computed_species.py`` twice — still cannot produce it, for
+#: the reason they never could: they read the calculation out of a key map
+#: the enclosing block built for the target's own owner, and
+#: ``AppliedEnergyCorrectionUploadPayload`` carries no
+#: ``existing_calculation_id``. A code is reachable when *some* path can
+#: produce it, so the entry is no longer ``Reach.guard`` and clients can
+#: branch on it. ``tests/api/test_api_bundle_ownership_codes.py`` provokes
+#: both bundle routes on the wire.
 W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH = (
     "applied_energy_correction_source_calculation_owner_mismatch"
 )
+
+#: A thermo record's ``existing_statmech_id`` names a statmech record
+#: owned by another species entry.
+#:
+#: The first code here over a cited row that is not a calculation, and it
+#: is a separate code from ``thermo_source_calculation_owner_mismatch``
+#: for the reason the whole family is separate: "you cited another
+#: species' partition function" and "you cited another species' job" are
+#: different repairs reaching different fields.
+#:
+#: Reachable by the first clause of the reachability rule and the
+#: plainest instance of it — ``existing_statmech_id`` is a literal row id
+#: the depositor supplies, so the enclosing block scopes nothing.
+W_THERMO_STATMECH_OWNER_MISMATCH = "thermo_statmech_owner_mismatch"
+
+#: A kinetics interpretation assignment names a statmech record that does
+#: not belong to the subject it was assigned to.
+#:
+#: One code across both subject kinds, deliberately. The reactant/product
+#: case compares against the participant's species entry and the
+#: transition-state case against the declared TS entry, but the field is
+#: the same ``statmech_ref`` and the repair is the same sentence: name the
+#: statmech that belongs to this subject. Which owner disagreed is a fact
+#: about the request, not a different contract, and it is already carried
+#: in ``context["owner_kind"]``.
+W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH = (
+    "kinetics_interpretation_statmech_owner_mismatch"
+)
+
+#: A kinetics interpretation's conformer selection belongs to a different
+#: species entry than the statmech it accompanies.
+#:
+#: Separate from the code above because the offending field is a different
+#: one: the depositor's ``statmech_ref`` may be entirely correct and the
+#: ``conformer_selection`` locator the thing to fix. Both are resolved in
+#: a database-wide namespace — a public ref and a content locator — so
+#: neither is scoped by the enclosing block.
+W_KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH = (
+    "kinetics_interpretation_conformer_selection_owner_mismatch"
+)
+
+
+def assert_owned_by(
+    *,
+    subject_noun: str,
+    row_id: int | None,
+    row_species_entry_id: int | None,
+    row_transition_state_entry_id: int | None,
+    code: str,
+    target: str,
+    context: str,
+    species_entry_id: int | None = None,
+    transition_state_entry_id: int | None = None,
+) -> None:
+    """Refuse a cited record that belongs to another subject.
+
+    The one implementation. :func:`assert_calculation_owned_by` and
+    :func:`assert_statmech_owned_by` are typed spellings of it for the two
+    ORM rows that carry both owner columns; a caller holding neither row —
+    a conformer selection, whose species is reached through its group —
+    calls this directly with the two ids it resolved.
+
+    :param subject_noun: What the cited record is, as a depositor would
+        say it (``"calculation"``, ``"statmech record"``, ``"conformer
+        selection"``). Appears in the sentence, never in the code.
+    :param row_id: Primary key of the cited row, for the log only. Never
+        reaches the response body.
+    :param row_species_entry_id: The species entry the cited record
+        belongs to, or ``None``.
+    :param row_transition_state_entry_id: The transition-state entry the
+        cited record belongs to, or ``None``.
+    :param code: The machine-readable code this refusal reports; one of
+        the ``W_*`` constants in this module. Passed rather than derived
+        because the subject is what a client tells apart.
+    :param target: The record that cited it, named the way a depositor
+        would say it (``"thermo"``, ``"statmech torsion"``). Appears in
+        the sentence, never in the code.
+    :param context: Field path naming the offending link, echoed verbatim.
+    :param species_entry_id: The species entry the target belongs to, or
+        ``None`` when the target is not a species record.
+    :param transition_state_entry_id: The transition-state entry the
+        target belongs to, or ``None``.
+    :raises CodedValueError: if the cited record belongs to a different
+        subject than the one(s) supplied.
+    :raises ValueError: if neither owner id is supplied. A check with
+        nothing to compare against would pass for every input, which is
+        the one failure mode a defensive guard must not have.
+    """
+    if species_entry_id is None and transition_state_entry_id is None:
+        raise ValueError(
+            "assert_owned_by was given neither a species entry nor a "
+            "transition state entry to check against; such a call would "
+            f"accept every {subject_noun} and guard nothing."
+        )
+
+    if species_entry_id is not None and row_species_entry_id != species_entry_id:
+        owner_noun = "species entry"
+        expected: int = species_entry_id
+        actual = row_species_entry_id
+    elif transition_state_entry_id is not None and (
+        row_transition_state_entry_id != transition_state_entry_id
+    ):
+        owner_noun = "transition state entry"
+        expected = transition_state_entry_id
+        actual = row_transition_state_entry_id
+    else:
+        return
+
+    # ``context`` already names the record the way the depositor wrote it,
+    # which is the identifier they can act on. The row ids go to the log
+    # instead -- a 422 body must not hand out primary keys.
+    logger.warning(
+        "%s: %s id=%s is owned by %s=%s, not %s (target=%s)",
+        context,
+        subject_noun,
+        row_id,
+        owner_noun.replace(" ", "_") + "_id",
+        actual,
+        expected,
+        target,
+    )
+    raise CodedValueError(
+        code,
+        f"{context}: this {subject_noun} belongs to another {owner_noun}, "
+        f"not to the {target} target. A supporting {subject_noun} must be "
+        f"one of the target {owner_noun}'s own.",
+        context={
+            "field": context,
+            "target": target,
+            "owner_kind": owner_noun.replace(" ", "_"),
+        },
+        message_prefix=False,
+    )
 
 
 def assert_calculation_owned_by(
@@ -129,77 +288,61 @@ def assert_calculation_owned_by(
 ) -> None:
     """Refuse a supporting calculation that belongs to another subject.
 
-    :param calculation: The resolved calculation row the deposit cites.
-    :param code: The machine-readable code this refusal reports; one of
-        the ``W_*`` constants in this module. Passed rather than derived
-        because the subject is what a client tells apart.
-    :param target: The record the calculation was cited by, named the way
-        a depositor would say it (``"thermo"``, ``"statmech torsion"``).
-        Appears in the sentence, never in the code.
-    :param context: Field path naming the offending link, echoed verbatim.
-    :param species_entry_id: The species entry the target belongs to, or
-        ``None`` when the target is not a species record.
-    :param transition_state_entry_id: The transition-state entry the
-        target belongs to, or ``None``.
-    :raises CodedValueError: if the calculation belongs to a different
-        subject than the one(s) supplied.
-    :raises ValueError: if neither owner id is supplied. A check with
-        nothing to compare against would pass for every input, which is
-        the one failure mode a defensive guard must not have.
+    See :func:`assert_owned_by` for every parameter; this reads the two
+    owner columns off the row so a caller cannot pass the wrong pair.
     """
-    if species_entry_id is None and transition_state_entry_id is None:
-        raise ValueError(
-            "assert_calculation_owned_by was given neither a species entry "
-            "nor a transition state entry to check against; such a call "
-            "would accept every calculation and guard nothing."
-        )
-
-    if species_entry_id is not None and (
-        calculation.species_entry_id != species_entry_id
-    ):
-        owner_noun = "species entry"
-        expected: int = species_entry_id
-        actual = calculation.species_entry_id
-    elif transition_state_entry_id is not None and (
-        calculation.transition_state_entry_id != transition_state_entry_id
-    ):
-        owner_noun = "transition state entry"
-        expected = transition_state_entry_id
-        actual = calculation.transition_state_entry_id
-    else:
-        return
-
-    # ``context`` already names the calculation the way the depositor wrote
-    # it, which is the identifier they can act on. The row ids go to the
-    # log instead -- a 422 body must not hand out primary keys.
-    logger.warning(
-        "%s: calculation id=%s is owned by %s=%s, not %s (target=%s)",
-        context,
-        calculation.id,
-        owner_noun.replace(" ", "_") + "_id",
-        actual,
-        expected,
-        target,
+    assert_owned_by(
+        subject_noun="calculation",
+        row_id=calculation.id,
+        row_species_entry_id=calculation.species_entry_id,
+        row_transition_state_entry_id=calculation.transition_state_entry_id,
+        code=code,
+        target=target,
+        context=context,
+        species_entry_id=species_entry_id,
+        transition_state_entry_id=transition_state_entry_id,
     )
-    raise CodedValueError(
-        code,
-        f"{context}: this calculation belongs to another {owner_noun}, not "
-        f"to the {target} target. A supporting calculation must be one of "
-        f"the target {owner_noun}'s own.",
-        context={
-            "field": context,
-            "target": target,
-            "owner_kind": owner_noun.replace(" ", "_"),
-        },
-        message_prefix=False,
+
+
+def assert_statmech_owned_by(
+    statmech: Statmech,
+    *,
+    code: str,
+    target: str,
+    context: str,
+    species_entry_id: int | None = None,
+    transition_state_entry_id: int | None = None,
+) -> None:
+    """Refuse a cited statmech record that belongs to another subject.
+
+    ``statmech`` carries the same two nullable owner columns a calculation
+    does — exactly one of them is non-null, by check constraint — so the
+    comparison is the calculation one with a different noun. See
+    :func:`assert_owned_by`.
+    """
+    assert_owned_by(
+        subject_noun="statmech record",
+        row_id=statmech.id,
+        row_species_entry_id=statmech.species_entry_id,
+        row_transition_state_entry_id=statmech.transition_state_entry_id,
+        code=code,
+        target=target,
+        context=context,
+        species_entry_id=species_entry_id,
+        transition_state_entry_id=transition_state_entry_id,
     )
 
 
 __all__ = [
     "W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH",
+    "W_KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH",
+    "W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH",
     "W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH",
     "W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH",
     "W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH",
+    "W_THERMO_STATMECH_OWNER_MISMATCH",
     "W_TRANSPORT_SOURCE_CALCULATION_OWNER_MISMATCH",
     "assert_calculation_owned_by",
+    "assert_owned_by",
+    "assert_statmech_owned_by",
 ]

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -46,6 +46,8 @@ from app.schemas.workflows.computed_reaction_upload import (
 )
 from app.services.artifact_persistence import persist_artifact
 from app.services.calculation_ownership import (
+    W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
     W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH,
     W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
     assert_calculation_owned_by,
@@ -811,13 +813,16 @@ def persist_computed_reaction_upload(
             if ac.source_calculation_key is not None:
                 source_calc_id = calculation_key_to_id[ac.source_calculation_key]
                 source_calc = session.get(Calculation, source_calc_id)
-                if source_calc.species_entry_id != species_entry.id:
-                    raise ValueError(
+                assert_calculation_owned_by(
+                    source_calc,
+                    code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+                    target="applied energy correction",
+                    context=(
                         f"species[{sp.key!r}].applied_energy_corrections[{i}]."
-                        f"source_calculation_key='{ac.source_calculation_key}': "
-                        f"refers to a calculation that is not owned by this "
-                        f"species entry."
-                    )
+                        f"source_calculation_key='{ac.source_calculation_key}'"
+                    ),
+                    species_entry_id=species_entry.id,
+                )
             source_conf_id = resolve_applied_correction_source_key(
                 ac.source_conformer_key,
                 observation_id_by_conformer_key.get(sp.key, {}),
@@ -851,13 +856,16 @@ def persist_computed_reaction_upload(
             if ac.source_calculation_key is not None:
                 source_calc_id = calculation_key_to_id[ac.source_calculation_key]
                 source_calc = session.get(Calculation, source_calc_id)
-                if source_calc.transition_state_entry_id != ts_entry.id:
-                    raise ValueError(
+                assert_calculation_owned_by(
+                    source_calc,
+                    code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
+                    target="applied energy correction",
+                    context=(
                         f"transition_state.applied_energy_corrections[{i}]."
-                        f"source_calculation_key='{ac.source_calculation_key}': "
-                        f"refers to a calculation that is not owned by this "
-                        f"transition state entry."
-                    )
+                        f"source_calculation_key='{ac.source_calculation_key}'"
+                    ),
+                    transition_state_entry_id=ts_entry.id,
+                )
             # A transition state in this bundle declares no conformers at
             # all -- it carries one geometry and its calculations, and no
             # ``ConformerObservation`` is written for it. So the namespace
@@ -1099,17 +1107,16 @@ def persist_computed_reaction_upload(
             for i, sc in enumerate(s.source_calculations):
                 calc_id = calculation_key_to_id[sc.calculation_key]
                 calc_row = session.get(Calculation, calc_id)
-                if calc_row.species_entry_id != species_entry.id:
-                    flavor = (
-                        "owned by a transition state"
-                        if calc_row.transition_state_entry_id is not None
-                        else "owned by a different species entry"
-                    )
-                    raise ValueError(
+                assert_calculation_owned_by(
+                    calc_row,
+                    code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
+                    target="statmech",
+                    context=(
                         f"species[{sp.key!r}].statmech.source_calculations[{i}]."
-                        f"calculation_key='{sc.calculation_key}': "
-                        f"refers to a calculation {flavor}."
-                    )
+                        f"calculation_key='{sc.calculation_key}'"
+                    ),
+                    species_entry_id=species_entry.id,
+                )
                 # The fourth statmech write path, and the one ARC actually
                 # deposits through. Same DR-0028 Requirement 1 as the other
                 # three, from the same shared service.

--- a/backend/app/workflows/kinetics.py
+++ b/backend/app/workflows/kinetics.py
@@ -41,6 +41,12 @@ from app.schemas.workflows.kinetics_upload import (
     KineticsUploadRequest,
 )
 from app.schemas.workflows.reaction_upload import ReactionUploadRequest
+from app.services.calculation_ownership import (
+    W_KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH,
+    W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH,
+    assert_owned_by,
+    assert_statmech_owned_by,
+)
 from app.services.calculation_resolution import resolve_level_of_theory_ref
 from app.services.kinetics_resolution import persist_kinetics, resolve_kinetics_upload
 from app.services.record_review import (
@@ -179,7 +185,8 @@ def _resolve_interpretation_assignments(
     """
 
     resolved: list[_ResolvedInterpretation] = []
-    for assignment in request.interpretation_assignments:
+    for index, assignment in enumerate(request.interpretation_assignments):
+        field = f"interpretation_assignments[{index}]"
         statmech = session.scalar(
             select(Statmech).where(Statmech.public_ref == assignment.statmech_ref)
         )
@@ -228,12 +235,26 @@ def _resolve_interpretation_assignments(
                 created_by=created_by,
             )
             species_entry_id = participant_entry.id
-            if statmech.species_entry_id != species_entry_id:
-                raise ValueError("interpretation statmech_ref must belong to its declared reaction participant.")
+            assert_statmech_owned_by(
+                statmech,
+                code=W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH,
+                target=f"{assignment.role} {assignment.participant_index}",
+                context=f"{field}.statmech_ref",
+                species_entry_id=species_entry_id,
+            )
             subject_key = f"{assignment.role}:{assignment.participant_index}"
         else:
-            if statmech.transition_state_entry_id != ts_entry_id:
-                raise ValueError("transition-state interpretation statmech_ref must belong to its declared TS entry.")
+            # ``ts_entry_id`` cannot be None here: the schema requires
+            # ``transition_state_entry_ref`` for this role and the lookup
+            # above refuses a ref that names nothing, so the guard always
+            # has an owner to compare against.
+            assert_statmech_owned_by(
+                statmech,
+                code=W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH,
+                target="transition state",
+                context=f"{field}.statmech_ref",
+                transition_state_entry_id=ts_entry_id,
+            )
             subject_key = "transition_state"
 
         selection_id: int | None = None
@@ -261,11 +282,35 @@ def _resolve_interpretation_assignments(
             if len(selection_ids) != 1:
                 raise ValueError("conformer_selection content locator must resolve exactly one selection.")
             selection_id = selection_ids[0]
-            if (
-                assignment.role != "transition_state"
-                and statmech.species_entry_id != selection_species_entry.id
-            ):
-                raise ValueError("conformer selection subject must match the interpretation statmech species.")
+            # The role test is defence in depth, not a live branch:
+            # ``validate_role_shape`` already refuses a conformer_selection
+            # on a transition-state assignment, so nothing reaching here
+            # can carry one. Kept because the guard below reads
+            # ``statmech.species_entry_id``, which a TS statmech has as
+            # NULL -- the comparison would be against nothing.
+            if assignment.role != "transition_state":
+                # The cited row is the *selection*; the subject it must
+                # agree with is the statmech this assignment names. So the
+                # selection's species entry is the row's owner and the
+                # statmech's is the target's -- the reverse of the reading
+                # the sentence invites, and the reason this calls the core
+                # helper rather than a statmech-shaped wrapper.
+                #
+                # ``statmech.species_entry_id`` is non-null here: the
+                # branch above has just held it equal to the participant's
+                # species entry.
+                assert_owned_by(
+                    subject_noun="conformer selection",
+                    row_id=selection_id,
+                    row_species_entry_id=selection_species_entry.id,
+                    row_transition_state_entry_id=None,
+                    code=(
+                        W_KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH
+                    ),
+                    target=f"{assignment.role} {assignment.participant_index}",
+                    context=f"{field}.conformer_selection",
+                    species_entry_id=statmech.species_entry_id,
+                )
 
         resolved.append(
             _ResolvedInterpretation(

--- a/backend/app/workflows/thermo.py
+++ b/backend/app/workflows/thermo.py
@@ -24,7 +24,9 @@ from app.schemas.workflows.thermo_upload import (
 from app.services.calculation_ownership import (
     W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
     W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_THERMO_STATMECH_OWNER_MISMATCH,
     assert_calculation_owned_by,
+    assert_statmech_owned_by,
 )
 from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
@@ -189,8 +191,16 @@ def _resolve_statmech_id(
 
     Mirrors the ``existing_calculation_id`` handling for source
     calculations (DR-0028): a missing row produces 404, a row owned by a
-    different species entry produces 422 (ValueError). The error detail
-    names the field but does not leak internal identifiers.
+    different species entry produces 422. The error detail names the field
+    but does not leak internal identifiers.
+
+    The 422 goes through the shared ownership guard rather than an inline
+    comparison, which is what gives it
+    ``thermo_statmech_owner_mismatch`` instead of the generic
+    ``validation_error`` a client cannot branch on (#195). This is the
+    plainest reachable case of the rule: ``existing_statmech_id`` is a row
+    id the depositor supplies, so nothing in the enclosing request scoped
+    it to this species entry.
     """
     if existing_statmech_id is None:
         return None
@@ -200,11 +210,19 @@ def _resolve_statmech_id(
             "existing_statmech_id refers to a statmech record that does "
             "not exist."
         )
-    if statmech.species_entry_id != species_entry_id:
-        raise ValueError(
-            "existing_statmech_id refers to a statmech record owned by a "
-            "different species entry."
-        )
+    assert_statmech_owned_by(
+        statmech,
+        code=W_THERMO_STATMECH_OWNER_MISMATCH,
+        target="thermo",
+        # Named the way its two neighbours in this module are, and not as
+        # the bare field: a message opening ``existing_statmech_id: `` puts
+        # a snake_case token in the code position, which is the shape #159
+        # and #164 spent two changes teaching the envelope to distrust. The
+        # code is declared on the exception; the sentence must not look like
+        # it is declaring a second one.
+        context="thermo existing_statmech_id",
+        species_entry_id=species_entry_id,
+    )
     return statmech.id
 
 

--- a/backend/docs/reviews/error_code_coverage_triage.md
+++ b/backend/docs/reviews/error_code_coverage_triage.md
@@ -111,6 +111,17 @@ code (scan in "Method" below). The repair is a message reword
 > in that bundle (`workflows/computed_reaction.py:1128`) is checked for
 > neither ownership nor anything else, so a torsion may cite a sibling
 > species's or the TS's scan calculation and be persisted silently.
+>
+> **Both resolved.** #193 routed the torsion's scan key through the shared
+> guard; #195 did the same for the inline comparisons (three, not four —
+> the count above was measured before #174 and #177 moved the file, and
+> re-deriving the anchors on `main` found three). Two of the three now
+> report `applied_energy_correction_source_calculation_owner_mismatch`,
+> which is what took that entry out of `Reach.guard` and back into the
+> client enum, and the third reports the
+> `statmech_source_calculation_owner_mismatch` its three sibling write
+> paths already did. Provoked on the wire in
+> `tests/api/test_api_bundle_ownership_codes.py`.
 
 `assert_calculation_owned_by` takes its code as a parameter and has five.
 Two are emitted by the suite; three are not — and the three are unreachable by
@@ -460,6 +471,18 @@ The last three are the finding-2 cluster. They are deliberate forward guards,
 so the recommendation is **not** deletion — it is that they stop being
 exported to the client enum as branchable refusals while the API cannot
 produce them.
+
+> **Two of the three have since become reachable, and the row above is
+> right about why it could not see it.** Both rows list only the call
+> sites that *use the shared guard*, because that is what a scan of
+> `assert_calculation_owned_by` finds. The reaction bundle enforced the
+> same rule with its own inline comparison, so its call sites are absent
+> from both rows and the "why it cannot fire" column was reasoning over
+> an incomplete list. #193 (`statmech_torsion_scan_...`) and #195
+> (`applied_energy_correction_source_...`) routed those sites through the
+> guard; both codes are now `Reach.request` and exported.
+> `transport_source_calculation_owner_mismatch` is the one that stands:
+> no write path anywhere produces the condition.
 
 ---
 

--- a/backend/tests/api/test_api_bundle_ownership_codes.py
+++ b/backend/tests/api/test_api_bundle_ownership_codes.py
@@ -1,0 +1,212 @@
+"""Three reaction-bundle ownership refusals, measured on the wire.
+
+What was wrong
+--------------
+``app.workflows.computed_reaction`` held three inline copies of the
+owner-consistency comparison the rest of the backend routes through
+``app.services.calculation_ownership``. Each raised a bare ``ValueError``,
+so each arrived at a depositor as ``code="validation_error"`` -- the same
+answer a missing required field gets. A client could not branch on them,
+and a depositor could not tell "you cited the transition state's job for a
+species correction" from "your enthalpy is the wrong type".
+
+All three resolve ``calculation_key`` through ``calculation_key_to_id``,
+the bundle-global namespace spanning every species *and* the transition
+state, and then attach the result to one specific entry. That is the
+second clause of the reachability rule (#173): a key resolved in a
+namespace wider than the target's owner makes the guard reachable even
+though no payload here carries an ``existing_*_id``. Two of the three
+produce ``applied_energy_correction_source_calculation_owner_mismatch``,
+which was catalogued ``Reach.guard`` on exactly that misreading until
+these tests measured it.
+
+Why these tests are on the wire
+-------------------------------
+The guards live in the workflow and are covered there
+(``tests/workflows/test_computed_reaction_upload.py``), but what a
+depositor can act on is the ``(status, code)`` pair their client receives,
+and the workflow tests cannot see whether the envelope preserved it.
+
+Assertions are on ``code`` and ``context``, never on substrings of
+``detail``: Pydantic echoes rejected input back into its error string, so
+a substring check can pass even when the field was wrongly accepted. Each
+refusal is paired with the payload that should be *accepted*, because a
+guard that refuses everything satisfies a 422 assertion perfectly.
+"""
+
+from __future__ import annotations
+
+from tests.workflows.test_computed_reaction_upload import (
+    _aec_scheme_ref_rxn,
+    _minimal_payload,
+    _payload_with_aec_carriers,
+)
+
+_URL = "/api/v1/uploads/computed-reaction"
+_AEC_OWNER_MISMATCH = "applied_energy_correction_source_calculation_owner_mismatch"
+_STATMECH_OWNER_MISMATCH = "statmech_source_calculation_owner_mismatch"
+
+
+def _correction(source_calculation_key: str) -> dict:
+    return {
+        "scheme": _aec_scheme_ref_rxn(),
+        "application_role": "aec_total",
+        "value": -0.1,
+        "value_unit": "hartree",
+        "source_calculation_key": source_calculation_key,
+    }
+
+
+def test_a_species_correction_citing_the_ts_job_is_coded(client) -> None:
+    """``ts-sp`` is a real key in the bundle and a real ``sp`` calculation.
+
+    Deliberately so: a payload that also named an undeclared key would be
+    refused for that instead, and the test would pass while proving
+    nothing about ownership.
+    """
+    payload = _payload_with_aec_carriers()
+    payload["species"][0]["applied_energy_corrections"] = [_correction("ts-sp")]
+
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _AEC_OWNER_MISMATCH, body
+    assert body["context"]["owner_kind"] == "species_entry", body
+    assert "ts-sp" in body["context"]["field"], body
+    assert body["context"]["target"] == "applied energy correction", body
+
+
+def test_a_ts_correction_citing_a_species_job_is_coded(client) -> None:
+    """The transition-state half: same code, different ``owner_kind``."""
+    payload = _payload_with_aec_carriers()
+    payload["transition_state"]["applied_energy_corrections"] = [
+        _correction("ch3-sp")
+    ]
+
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _AEC_OWNER_MISMATCH, body
+    assert body["context"]["owner_kind"] == "transition_state_entry", body
+    assert "ch3-sp" in body["context"]["field"], body
+
+
+def test_a_correction_citing_its_own_subjects_job_is_accepted(client) -> None:
+    """The negative half of both tests above, in one request.
+
+    Each correction cites a calculation its own target owns. Without
+    this, the two 422 assertions would still pass if the AEC fixture had
+    drifted into being invalid for an unrelated reason.
+    """
+    payload = _payload_with_aec_carriers()
+    payload["species"][0]["applied_energy_corrections"] = [_correction("ch3-sp")]
+    payload["transition_state"]["applied_energy_corrections"] = [
+        _correction("ts-sp")
+    ]
+
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 201, resp.text[:800]
+
+
+def test_a_statmech_citing_a_sibling_species_job_is_coded(client) -> None:
+    """The third inline copy, reporting the code its three siblings do.
+
+    ``statmech_source_calculation_owner_mismatch`` was already emitted by
+    the statmech seam, the species bundle and the standalone statmech
+    upload; the reaction bundle -- the path ARC deposits through -- was
+    the one that answered ``validation_error``.
+    """
+    payload = _minimal_payload()
+    payload["species"][0]["statmech"] = {
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [
+            {"calculation_key": "ch3-freq", "role": "freq"},
+            {"calculation_key": "h-sp", "role": "sp"},  # owned by species 'h'
+        ],
+    }
+
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _STATMECH_OWNER_MISMATCH, body
+    assert "h-sp" in body["context"]["field"], body
+    assert body["context"]["target"] == "statmech", body
+
+
+def test_a_statmech_citing_the_ts_job_reports_the_same_code(client) -> None:
+    """The TS-owned variant, which used to get its own sentence.
+
+    Before #195 this site chose between "owned by a transition state" and
+    "owned by a different species entry" in the message. Neither was a
+    code, and the shared guard states the one thing that matters -- the
+    calculation is not this species entry's -- so both now report the same
+    contract and ``field`` is what tells them apart.
+    """
+    payload = _minimal_payload()
+    payload["species"][0]["statmech"] = {
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [{"calculation_key": "ts-freq", "role": "freq"}],
+    }
+
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _STATMECH_OWNER_MISMATCH, body
+    assert "ts-freq" in body["context"]["field"], body
+
+
+def test_a_statmech_citing_its_own_species_job_is_accepted(client) -> None:
+    """The negative half of the two statmech tests."""
+    payload = _minimal_payload()
+    payload["species"][0]["statmech"] = {
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
+    }
+
+    resp = client.post(_URL, json=payload)
+    assert resp.status_code == 201, resp.text[:800]
+
+
+def test_no_ownership_refusal_discloses_a_row_id(client) -> None:
+    """The offending ids go to the log; the 422 body names only keys.
+
+    Separate from the tests above because "refused with the right code"
+    and "refused without handing out primary keys" are different
+    properties and a regression in the second is silent. The status and
+    code assertions inside the loop are load-bearing: without them a
+    mutation that stops a guard firing leaves a 201 whose body contains no
+    ids either, and this test passes while checking nothing.
+    """
+    species_aec = _payload_with_aec_carriers()
+    species_aec["species"][0]["applied_energy_corrections"] = [
+        _correction("ts-sp")
+    ]
+    ts_aec = _payload_with_aec_carriers()
+    ts_aec["transition_state"]["applied_energy_corrections"] = [
+        _correction("ch3-sp")
+    ]
+    statmech = _minimal_payload()
+    statmech["species"][0]["statmech"] = {
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [{"calculation_key": "ts-freq", "role": "freq"}],
+    }
+
+    cases = [
+        (species_aec, _AEC_OWNER_MISMATCH),
+        (ts_aec, _AEC_OWNER_MISMATCH),
+        (statmech, _STATMECH_OWNER_MISMATCH),
+    ]
+    assert len(cases) == 3, "the three reaction-bundle sites #195 coded"
+    for payload, code in cases:
+        resp = client.post(_URL, json=payload)
+        assert resp.status_code == 422, resp.text[:800]
+        body = resp.json()
+        assert body["code"] == code, body
+        for value in (str(body.get("detail", "")), str(body.get("context", {}))):
+            assert "species_entry_id=" not in value, body
+            assert "transition_state_entry_id=" not in value, body
+            assert "calculation id" not in value, body

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -663,15 +663,30 @@ def test_a_refusal_that_is_not_science_is_importable_by_a_client() -> None:
         )
 
 
-#: The three codes #184 and #186 classified as guards. Named here rather
-#: than derived, because the value of the classification is that flipping
-#: one back is a deliberate act with a test to change, not a silent
-#: widening of the client contract.
+#: The codes #184 and #186 classified as guards. Named here rather than
+#: derived, because the value of the classification is that flipping one
+#: back is a deliberate act with a test to change, not a silent widening
+#: of the client contract.
+#:
+#: It was three until #195, and the removal is the mechanism working.
+#: ``applied_energy_correction_source_calculation_owner_mismatch`` was
+#: classified a guard because its three call sites all read a calculation
+#: the enclosing block had scoped to the target -- and its note named the
+#: fourth and fifth, in ``/uploads/computed-reaction``, which resolve the
+#: same key across the whole bundle and refused with a bare ``ValueError``.
+#: Routing those through the shared guard made the code reachable, so it
+#: left this tuple, gained ``Reach.request``, and is now exported.
 _GUARD_CODES = (
-    "applied_energy_correction_source_calculation_owner_mismatch",
     "idempotency_in_progress",
     "transport_source_calculation_owner_mismatch",
 )
+
+#: Codes that were ``Reach.guard`` and are not any more. Kept so the
+#: reclassification cannot silently reverse: a code that goes back to
+#: being a guard has stopped being reachable, which means a write path
+#: was removed, and that deserves the same deliberate edit the promotion
+#: did.
+_PROMOTED_FROM_GUARD = ("applied_energy_correction_source_calculation_owner_mismatch",)
 
 
 def test_the_reach_rule_can_say_no() -> None:
@@ -736,30 +751,48 @@ def test_every_guard_entry_is_catalogued_annotated_and_unexported() -> None:
             "deliberately -- together with the client version bump that "
             "re-exports it."
         )
+    for code in _PROMOTED_FROM_GUARD:
+        assert code not in named, (
+            f"{code} is classified as a guard again. It was promoted in #195 "
+            "because /uploads/computed-reaction resolves the key it guards "
+            "in a bundle-wide namespace; going back means that write path is "
+            "gone, which is a deliberate change, not a reclassification."
+        )
+        assert code in exported, (
+            f"{code} is reachable but not exported, so a client still cannot "
+            "branch on a refusal it can receive"
+        )
 
 
 def test_the_ownership_guards_are_guards_because_of_a_schema_shape() -> None:
     """The classification rests on live schemas, so it is checked against them.
 
     An ownership guard can fire only when the field it guards can name a
-    calculation the enclosing block did not itself scope to the target:
-    a foreign row id, or a key resolved in a namespace wider than the
-    target's owner. The two ownership codes classified ``Reach.guard``
-    are classified that way because their fields carry no
-    ``existing_*_id`` -- a property of these payload models, not of the
-    test suite. Asserting it here means the day somebody adds the field,
-    this fails and names the entry to reclassify, instead of the
-    catalogue telling clients the wrong thing for another year.
+    record the enclosing block did not itself scope to the target: a
+    foreign row id, **or** a key resolved in a namespace wider than the
+    target's owner. Both clauses matter, and the second one is what #173
+    added after the first misclassified a guard that turned out to be
+    measurable on the wire.
 
-    The third ownership code with the same *shape*,
-    ``statmech_torsion_scan_calculation_owner_mismatch``, is deliberately
-    absent: its key is resolved in a bundle-wide namespace on two paths,
-    so it is reachable and stays exported. See
-    ``tests/api/test_api_network_pdep_ownership.py`` for the PDep route
-    and ``tests/api/test_api_bundle_torsion_scan_ownership.py`` for
-    ``/uploads/computed-reaction`` (#193), where the same wide namespace
-    had no owner check at all until the call site was routed through the
-    shared guard.
+    ``transport_source_calculation_owner_mismatch`` is the last ownership
+    code where neither clause holds: its payload carries no
+    ``existing_*_id``, and its one write path reads a calculation the same
+    loop persisted against the transport target's own species entry. That
+    first half is a property of a live model, so it is asserted against
+    the model rather than described -- the day somebody adds the field,
+    this fails and names the entry to reclassify.
+
+    Two ownership codes with the same *shape* are deliberately not here.
+    ``statmech_torsion_scan_calculation_owner_mismatch`` is reachable on
+    two bundle routes (``tests/api/test_api_network_pdep_ownership.py``,
+    ``tests/api/test_api_bundle_torsion_scan_ownership.py``), and #195
+    moved ``applied_energy_correction_source_calculation_owner_mismatch``
+    into the same company: its payload still carries no foreign id, so
+    the first clause still fails, and it is reachable anyway because
+    ``/uploads/computed-reaction`` resolves ``source_calculation_key``
+    across every species and the transition state. That is asserted below
+    as the field's continued existence, and measured on the wire in
+    ``tests/api/test_api_bundle_ownership_codes.py``.
     """
     from tckdb_schemas.energy_correction import (
         AppliedEnergyCorrectionUploadPayload,
@@ -769,18 +802,37 @@ def test_the_ownership_guards_are_guards_because_of_a_schema_shape() -> None:
         TransportSourceCalculationIn,
     )
 
-    for model in (
-        TransportSourceCalculationIn,
-        AppliedEnergyCorrectionUploadPayload,
-    ):
-        foreign = sorted(
+    def _foreign_row_fields(model) -> list[str]:
+        return sorted(
             name
             for name in model.model_fields
             if name.endswith("_id") or name.startswith("existing_")
         )
-        assert not foreign, (
-            f"{model.__name__} now carries {foreign}. A field that accepts a "
-            "row this request did not create is exactly what makes an "
-            "ownership guard reachable, so the matching catalogue entry is "
-            "no longer Reach.guard and the client enum must re-export it."
-        )
+
+    assert not _foreign_row_fields(TransportSourceCalculationIn), (
+        f"TransportSourceCalculationIn now carries "
+        f"{_foreign_row_fields(TransportSourceCalculationIn)}. A field that "
+        "accepts a row this request did not create is exactly what makes an "
+        "ownership guard reachable, so transport_source_calculation_owner_"
+        "mismatch is no longer Reach.guard and the client enum must "
+        "re-export it."
+    )
+
+    # The second clause, for the code that is reachable by it alone. The
+    # first clause is still false here -- the payload has no foreign id --
+    # so asserting only that would say the opposite of the truth.
+    assert not _foreign_row_fields(AppliedEnergyCorrectionUploadPayload), (
+        "AppliedEnergyCorrectionUploadPayload has gained a foreign row "
+        "field. That is a wider change than the wide-namespace "
+        "reachability this entry rests on, and the note on "
+        "applied_energy_correction_source_calculation_owner_mismatch "
+        "needs rewriting to say so."
+    )
+    assert "source_calculation_key" in AppliedEnergyCorrectionUploadPayload.model_fields, (
+        "the field whose bundle-wide resolution makes "
+        "applied_energy_correction_source_calculation_owner_mismatch "
+        "reachable is gone; the entry is a guard again"
+    )
+    exported = {entry.code for entry in client_facing()}
+    assert "applied_energy_correction_source_calculation_owner_mismatch" in exported
+    assert "transport_source_calculation_owner_mismatch" not in exported

--- a/backend/tests/api/test_api_statmech_citation_ownership.py
+++ b/backend/tests/api/test_api_statmech_citation_ownership.py
@@ -1,0 +1,431 @@
+"""Four refusals over a cited row a request did not create, on the wire.
+
+What was wrong
+--------------
+Three uploads let a depositor name a record by a handle resolved in a
+database-wide namespace and then attach it to a subject:
+
+* ``/uploads/thermo`` takes ``existing_statmech_id`` -- a literal row id;
+* ``/uploads/kinetics`` takes ``statmech_ref``, a public ref, on every
+  interpretation assignment;
+* the same assignment takes a ``conformer_selection`` *content* locator,
+  resolved against whichever species entry it names.
+
+Each is guarded, and each guard raised a bare ``ValueError``, so all four
+refusals arrived as ``code="validation_error"``. These are the plainest
+instances of the reachability rule's first clause: the enclosing block
+scopes nothing, and a depositor supplies the handle themselves.
+
+Why these tests are on the wire
+-------------------------------
+The workflow tests establish that the guards fire; only a request can
+establish that the envelope carries the code out to a client. Assertions
+are on ``code`` and ``context``, never on substrings of ``detail``.
+
+Every refusal here is paired with the request that must still be
+**accepted**, because a guard that refuses everything satisfies a 422
+assertion perfectly -- and that pairing is the whole reason to run these
+against a live database rather than mocking the lookups.
+"""
+
+from __future__ import annotations
+
+from app.db.models.statmech import Statmech
+from tests.services.scientific_read._factories import (
+    attach_conformer_selection,
+    make_chem_reaction,
+    make_conformer_group,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    make_transition_state,
+    make_transition_state_entry,
+    next_inchi_key,
+)
+
+_THERMO = "/api/v1/uploads/thermo"
+_KINETICS = "/api/v1/uploads/kinetics"
+
+_THERMO_STATMECH_MISMATCH = "thermo_statmech_owner_mismatch"
+_INTERPRETATION_STATMECH_MISMATCH = "kinetics_interpretation_statmech_owner_mismatch"
+_CONFORMER_SELECTION_MISMATCH = (
+    "kinetics_interpretation_conformer_selection_owner_mismatch"
+)
+
+_CONVENTIONS = {
+    "ensemble_policy": "single_structure",
+    "standard_state_convention": "ideal_gas_1_bar",
+    "degeneracy_interpretation": "reaction_path_degeneracy",
+}
+
+#: ``CH3 + OH -> CH3OH``. Three distinct species, so "the statmech of the
+#: wrong participant" is a payload a depositor could plausibly send.
+_REACTION = {
+    "reversible": False,
+    "reactants": [
+        {"species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}},
+        {"species_entry": {"smiles": "[OH]", "charge": 0, "multiplicity": 2}},
+    ],
+    "products": [{"species_entry": {"smiles": "CO", "charge": 0, "multiplicity": 1}}],
+}
+
+
+def _seed_participants(session):
+    """One species entry and one statmech row per participant.
+
+    The statmech rows are ``experimental`` in origin on purpose. A
+    *computed* statmech backing a computed rate must carry source
+    calculations, and that separate refusal would fire first and refuse
+    these payloads for a reason that has nothing to do with ownership --
+    which is exactly the shape of test that passes while proving nothing.
+    """
+    entries = {
+        "ch3": make_species_entry(
+            session,
+            make_species(
+                session, smiles="[CH3]", multiplicity=2,
+                inchi_key=next_inchi_key("OWNA"),
+            ),
+        ),
+        "oh": make_species_entry(
+            session,
+            make_species(
+                session, smiles="[OH]", multiplicity=2,
+                inchi_key=next_inchi_key("OWNB"),
+            ),
+        ),
+        "ch3oh": make_species_entry(
+            session,
+            make_species(
+                session, smiles="CO", multiplicity=1,
+                inchi_key=next_inchi_key("OWNC"),
+            ),
+        ),
+    }
+    statmechs = {}
+    for key, entry in entries.items():
+        row = Statmech(species_entry_id=entry.id, scientific_origin="experimental")
+        session.add(row)
+        statmechs[key] = row
+    session.flush()
+    return entries, statmechs
+
+
+def _assignments(statmechs, **overrides):
+    """The complete, correct interpretation set, before any corruption.
+
+    Complete because the schema refuses a partial one: naming any
+    participant is the claim that all of them are named.
+    """
+    rows = {
+        "reactant:1": {
+            "role": "reactant", "participant_index": 1,
+            "statmech_ref": statmechs["ch3"].public_ref, **_CONVENTIONS,
+        },
+        "reactant:2": {
+            "role": "reactant", "participant_index": 2,
+            "statmech_ref": statmechs["oh"].public_ref, **_CONVENTIONS,
+        },
+        "product:1": {
+            "role": "product", "participant_index": 1,
+            "statmech_ref": statmechs["ch3oh"].public_ref, **_CONVENTIONS,
+        },
+    }
+    for key, patch in overrides.items():
+        rows[key] = {**rows[key], **patch}
+    return list(rows.values())
+
+
+def _rate(assignments) -> dict:
+    return {
+        "reaction": _REACTION,
+        "scientific_origin": "computed",
+        "a": 1.0e13,
+        "a_units": "cm3_mol_s",
+        "interpretation_assignments": assignments,
+    }
+
+
+# ---------------------------------------------------------------------------
+# /uploads/thermo -- existing_statmech_id
+# ---------------------------------------------------------------------------
+
+
+def test_a_thermo_citing_another_species_statmech_is_coded(client, db_session) -> None:
+    other = make_species_entry(
+        db_session,
+        make_species(
+            db_session, smiles="[NH2]", multiplicity=2,
+            inchi_key=next_inchi_key("OWND"),
+        ),
+    )
+    statmech = Statmech(species_entry_id=other.id, scientific_origin="computed")
+    db_session.add(statmech)
+    db_session.flush()
+
+    resp = client.post(
+        _THERMO,
+        json={
+            "species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2},
+            "scientific_origin": "computed",
+            "h298_kj_mol": 146.7,
+            "existing_statmech_id": statmech.id,
+        },
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _THERMO_STATMECH_MISMATCH, body
+    assert body["context"]["field"] == "thermo existing_statmech_id", body
+    assert body["context"]["owner_kind"] == "species_entry", body
+    # The id the depositor supplied is theirs; the id of the entry that
+    # owns it is not (DR-0028 Requirement 2).
+    assert str(other.id) not in str(body.get("detail", "")), body
+
+
+def test_a_thermo_citing_its_own_statmech_is_accepted(client, db_session) -> None:
+    """The negative half. Same route, same field, correct owner."""
+    entry = make_species_entry(
+        db_session,
+        make_species(
+            db_session, smiles="[CH3]", multiplicity=2,
+            inchi_key=next_inchi_key("OWNE"),
+        ),
+    )
+    statmech = Statmech(species_entry_id=entry.id, scientific_origin="computed")
+    db_session.add(statmech)
+    db_session.flush()
+
+    resp = client.post(
+        _THERMO,
+        json={
+            "species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2},
+            "scientific_origin": "computed",
+            "h298_kj_mol": 146.7,
+            "existing_statmech_id": statmech.id,
+        },
+    )
+    assert resp.status_code == 201, resp.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# /uploads/kinetics -- interpretation statmech_ref
+# ---------------------------------------------------------------------------
+
+
+def test_a_participant_assigned_another_species_statmech_is_coded(
+    client, db_session
+) -> None:
+    """CH3's slot is handed OH's partition function.
+
+    Both refs resolve and both rows exist, so ownership is the only thing
+    left wrong -- the property that makes this a test of the guard rather
+    than of the lookup above it.
+    """
+    _entries, statmechs = _seed_participants(db_session)
+    resp = client.post(
+        _KINETICS,
+        json=_rate(
+            _assignments(
+                statmechs,
+                **{"reactant:1": {"statmech_ref": statmechs["oh"].public_ref}},
+            )
+        ),
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _INTERPRETATION_STATMECH_MISMATCH, body
+    assert body["context"]["field"] == "interpretation_assignments[0].statmech_ref", body
+    assert body["context"]["owner_kind"] == "species_entry", body
+    assert body["context"]["target"] == "reactant 1", body
+
+
+def test_the_transition_state_slot_reports_the_same_code(client, db_session) -> None:
+    """A species statmech handed to the TS slot, distinguished by owner kind.
+
+    The TS entry is seeded on the same reaction the payload declares --
+    ``_resolve_ts_anchored_reaction_entry`` refuses a TS whose reaction
+    entry does not match the submitted content, and that refusal would
+    otherwise fire first and hide this one.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    reaction_entry = make_reaction_entry(
+        db_session,
+        reaction=make_chem_reaction(
+            db_session,
+            reactants=[entries["ch3"].species, entries["oh"].species],
+            products=[entries["ch3oh"].species],
+            reversible=False,
+        ),
+        reactant_entries=[entries["ch3"], entries["oh"]],
+        product_entries=[entries["ch3oh"]],
+    )
+    ts_entry = make_transition_state_entry(
+        db_session,
+        transition_state=make_transition_state(
+            db_session, reaction_entry=reaction_entry
+        ),
+    )
+
+    resp = client.post(
+        _KINETICS,
+        json=_rate(
+            [
+                *_assignments(statmechs),
+                {
+                    "role": "transition_state",
+                    "statmech_ref": statmechs["ch3"].public_ref,
+                    "transition_state_entry_ref": ts_entry.public_ref,
+                    **_CONVENTIONS,
+                },
+            ]
+        ),
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _INTERPRETATION_STATMECH_MISMATCH, body
+    assert body["context"]["owner_kind"] == "transition_state_entry", body
+    assert body["context"]["target"] == "transition state", body
+
+
+def test_a_correct_interpretation_set_is_accepted(client, db_session) -> None:
+    """The negative half of both interpretation tests."""
+    _entries, statmechs = _seed_participants(db_session)
+    resp = client.post(_KINETICS, json=_rate(_assignments(statmechs)))
+    assert resp.status_code == 201, resp.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# /uploads/kinetics -- interpretation conformer_selection
+# ---------------------------------------------------------------------------
+
+
+def test_a_conformer_selection_for_another_species_is_coded(
+    client, db_session
+) -> None:
+    """The ``statmech_ref`` is right and the selection is the wrong species.
+
+    A distinct code from the one above precisely because of that: the
+    depositor's repair is in ``conformer_selection``, not in
+    ``statmech_ref``, and telling them the statmech was wrong would send
+    them to the wrong field.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    attach_conformer_selection(
+        db_session, conformer_group=make_conformer_group(db_session, entries["oh"])
+    )
+
+    resp = client.post(
+        _KINETICS,
+        json=_rate(
+            _assignments(
+                statmechs,
+                **{
+                    "reactant:1": {
+                        "conformer_selection": {
+                            "species_entry": {
+                                "smiles": "[OH]", "charge": 0, "multiplicity": 2,
+                            },
+                            "selection_kind": "lowest_energy",
+                        }
+                    }
+                },
+            )
+        ),
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _CONFORMER_SELECTION_MISMATCH, body
+    assert body["context"]["field"] == (
+        "interpretation_assignments[0].conformer_selection"
+    ), body
+    assert body["context"]["target"] == "reactant 1", body
+
+
+def test_a_conformer_selection_for_its_own_species_is_accepted(
+    client, db_session
+) -> None:
+    """The negative half: the identical locator, on the species that owns it."""
+    entries, statmechs = _seed_participants(db_session)
+    attach_conformer_selection(
+        db_session, conformer_group=make_conformer_group(db_session, entries["ch3"])
+    )
+
+    resp = client.post(
+        _KINETICS,
+        json=_rate(
+            _assignments(
+                statmechs,
+                **{
+                    "reactant:1": {
+                        "conformer_selection": {
+                            "species_entry": {
+                                "smiles": "[CH3]", "charge": 0, "multiplicity": 2,
+                            },
+                            "selection_kind": "lowest_energy",
+                        }
+                    }
+                },
+            )
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+
+
+def test_no_statmech_citation_refusal_discloses_a_row_id(client, db_session) -> None:
+    """The ids go to the log. Status and code are asserted first.
+
+    Without them, a mutation that stops a guard firing leaves a 201 whose
+    body contains no ids either and this passes while checking nothing --
+    the failure shape #192 was opened for.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    attach_conformer_selection(
+        db_session, conformer_group=make_conformer_group(db_session, entries["oh"])
+    )
+
+    cases = [
+        (
+            _rate(
+                _assignments(
+                    statmechs,
+                    **{"reactant:1": {"statmech_ref": statmechs["oh"].public_ref}},
+                )
+            ),
+            _INTERPRETATION_STATMECH_MISMATCH,
+        ),
+        (
+            _rate(
+                _assignments(
+                    statmechs,
+                    **{
+                        "reactant:1": {
+                            "conformer_selection": {
+                                "species_entry": {
+                                    "smiles": "[OH]", "charge": 0,
+                                    "multiplicity": 2,
+                                },
+                                "selection_kind": "lowest_energy",
+                            }
+                        }
+                    },
+                )
+            ),
+            _CONFORMER_SELECTION_MISMATCH,
+        ),
+    ]
+    assert len(cases) == 2, "both kinetics-side citations #195 coded"
+
+    forbidden = (
+        str(entries["oh"].id),
+        str(statmechs["oh"].id),
+        "species_entry_id=",
+        "transition_state_entry_id=",
+    )
+    for payload, code in cases:
+        resp = client.post(_KINETICS, json=payload)
+        assert resp.status_code == 422, resp.text[:800]
+        body = resp.json()
+        assert body["code"] == code, body
+        rendered = str(body.get("detail", "")) + str(body.get("context", {}))
+        for token in forbidden:
+            assert token not in rendered, (body, token)

--- a/backend/tests/invariants/test_structure_invariants.py
+++ b/backend/tests/invariants/test_structure_invariants.py
@@ -425,33 +425,38 @@ def test_the_uncoded_comparison_detector_can_say_no() -> None:
     )
 
 
-def test_no_workflow_refuses_an_owner_mismatch_without_a_code() -> None:
+def test_no_module_refuses_an_owner_mismatch_without_a_code() -> None:
     """#195: seven guards compared an owner column and bare-raised.
 
     Each reached a client as ``validation_error``, so a depositor could
     not tell "you cited another species' partition function" from a
     malformed number, and three earlier changes each coded a subset and
-    left the rest. The invariant closes the class rather than the
-    instances: in any module that carries the rule, comparing an owner
-    column and raising an uncoded exception is the defect.
+    left the rest -- which is how there came to be seven.
+
+    Scanned over the whole of ``app/`` rather than a list of the modules
+    that carry the rule today, deliberately. A list is the mechanism that
+    produced this defect: the module that gained the eighth copy would not
+    be on it, and nothing would go red. The scan lands green on the whole
+    tree, so there is no cost to the wider net -- measured, not assumed.
+
+    ``_uncoded_owner_comparisons`` is exercised in both directions by the
+    test above; the floor below is the other half of keeping this
+    non-vacuous, since an assertion that nothing was found is satisfied
+    perfectly by a walker that read nothing.
     """
-    modules = [
-        "app/workflows/thermo.py",
-        "app/workflows/statmech.py",
-        "app/workflows/transport.py",
-        "app/workflows/computed_species.py",
-        "app/workflows/computed_reaction.py",
-        "app/workflows/kinetics.py",
-        "app/services/statmech_resolution.py",
-        "app/services/calculation_ownership.py",
-    ]
-    root = Path(__file__).resolve().parents[2]
+    root = Path(__file__).resolve().parents[2] / "app"
+    scanned = 0
     problems: list[str] = []
-    for relative in modules:
-        for line, name in _uncoded_owner_comparisons(
-            (root / relative).read_text()
-        ):
+    for path in sorted(root.rglob("*.py")):
+        source = path.read_text()
+        scanned += 1
+        relative = path.relative_to(root.parent)
+        for line, name in _uncoded_owner_comparisons(source):
             problems.append(f"{relative}:{line} raises a bare {name}")
+    assert scanned > 200, (
+        f"only {scanned} modules were scanned; the walk is broken and a "
+        "broken walk passes this test by finding nothing"
+    )
     assert not problems, (
         "these compare an owner column and refuse without a machine-readable "
         "code, so a client receives validation_error and cannot branch on "

--- a/backend/tests/invariants/test_structure_invariants.py
+++ b/backend/tests/invariants/test_structure_invariants.py
@@ -27,9 +27,13 @@ from app.schemas.fragments.identity import SpeciesEntryIdentityPayload
 from app.schemas.workflows.reaction_upload import ReactionUploadRequest
 from app.schemas.workflows.thermo_upload import ThermoUploadRequest
 from app.services.calculation_ownership import (
+    W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH,
     W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
     W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
+    W_THERMO_STATMECH_OWNER_MISMATCH,
     assert_calculation_owned_by,
+    assert_owned_by,
+    assert_statmech_owned_by,
 )
 from app.services.geometry_validation import validate_calculation_geometry
 from app.workflows.reaction import persist_reaction_upload
@@ -270,6 +274,61 @@ def test_owner_guard_refuses_to_run_with_nothing_to_compare() -> None:
         )
 
 
+def test_owner_guard_rejects_statmech_owned_by_another_subject() -> None:
+    """The statmech spelling of the same rule (#195).
+
+    A thermo record cites a statmech row by ``existing_statmech_id`` and a
+    kinetics interpretation cites one by ``statmech_ref``; both used to
+    compare inline and raise a bare ``ValueError``. ``Statmech`` carries
+    the same two owner columns a calculation does, so the comparison is
+    shared and only the noun and the code differ -- which is what this
+    checks, in both directions.
+    """
+    statmech = _FakeCalc(id=9, species_entry_id=7)
+
+    assert_statmech_owned_by(
+        statmech,  # type: ignore[arg-type]
+        code=W_THERMO_STATMECH_OWNER_MISMATCH,
+        target="thermo",
+        context="same owner",
+        species_entry_id=7,
+    )
+
+    with pytest.raises(ValueError, match="statmech record belongs") as excinfo:
+        assert_statmech_owned_by(
+            statmech,  # type: ignore[arg-type]
+            code=W_THERMO_STATMECH_OWNER_MISMATCH,
+            target="thermo",
+            context="cross-owner",
+            species_entry_id=8,
+        )
+    assert excinfo.value.code == "thermo_statmech_owner_mismatch"
+    # The noun is a parameter, so the calculation wording must not have
+    # followed it.
+    assert "calculation" not in str(excinfo.value)
+
+
+def test_owner_guard_refuses_a_vacuous_call_whatever_the_noun() -> None:
+    """The "nothing to compare against" guard survived being parameterised.
+
+    ``assert_calculation_owned_by`` is covered above; this is the core
+    function the two wrappers now delegate to, reached with a noun neither
+    of them uses. Without it the check could be lost for every caller that
+    does not go through a wrapper -- which is the conformer-selection call
+    site in ``app.workflows.kinetics``.
+    """
+    with pytest.raises(ValueError, match="guard nothing"):
+        assert_owned_by(
+            subject_noun="conformer selection",
+            row_id=1,
+            row_species_entry_id=7,
+            row_transition_state_entry_id=None,
+            code=W_KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH,
+            target="reactant 1",
+            context="no owner supplied",
+        )
+
+
 def test_every_product_routes_its_owner_check_through_one_implementation() -> None:
     """#162: the rule was written five times and pinned once.
 
@@ -279,6 +338,11 @@ def test_every_product_routes_its_owner_check_through_one_implementation() -> No
     invariant is now the consolidation itself: no workflow may hold a
     private owner-consistency comparison, and every module that needs one
     must reach the shared implementation.
+
+    ``app/workflows/kinetics.py`` joined the list in #195. It cites
+    statmech records and conformer selections rather than calculations, so
+    it reaches the module by a different name -- which is why the check is
+    on the *import* rather than on one function's name.
     """
     modules = [
         "app/workflows/thermo.py",
@@ -286,15 +350,113 @@ def test_every_product_routes_its_owner_check_through_one_implementation() -> No
         "app/workflows/transport.py",
         "app/workflows/computed_species.py",
         "app/workflows/computed_reaction.py",
+        "app/workflows/kinetics.py",
         "app/services/statmech_resolution.py",
     ]
     root = Path(__file__).resolve().parents[2]
     for relative in modules:
         source = (root / relative).read_text()
-        assert "assert_calculation_owned_by" in source, relative
+        assert "from app.services.calculation_ownership import" in source, relative
         # The private per-product copies this consolidated (#162).
         assert "def _assert_calculation_owned_by" not in source, relative
         assert "def assert_statmech_calculation_owned_by" not in source, relative
+
+
+def _uncoded_owner_comparisons(source: str) -> list[tuple[int, str]]:
+    """``(line, code)`` for every ``if x._entry_id != y:`` that bare-raises.
+
+    The shape all seven #195 sites had: compare an owner column, then
+    ``raise ValueError`` -- which reaches a depositor as
+    ``validation_error`` and cannot be branched on. Detected structurally
+    rather than by message, because the messages were all different and
+    that is precisely why nothing caught them.
+    """
+    import ast
+
+    tree = ast.parse(source)
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        compares = [
+            inner
+            for inner in ast.walk(node.test)
+            if isinstance(inner, ast.Compare)
+            and any(isinstance(op, ast.NotEq) for op in inner.ops)
+            and isinstance(inner.left, ast.Attribute)
+            and inner.left.attr.endswith("_entry_id")
+        ]
+        if not compares:
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Raise) or not isinstance(inner.exc, ast.Call):
+                continue
+            name = getattr(inner.exc.func, "id", None) or getattr(
+                inner.exc.func, "attr", None
+            )
+            if name in {"ValueError", "AssertionError"}:
+                found.append((inner.lineno, name))
+    return found
+
+
+def test_the_uncoded_comparison_detector_can_say_no() -> None:
+    """Guard the guard: it must fire on the shape and not on its repair.
+
+    The same discipline as ``test_the_origin_detector_can_say_no`` in the
+    catalogue tests. A detector that matches nothing passes the invariant
+    below over an empty set, which is this repository's dominant defect.
+    """
+    offending = _uncoded_owner_comparisons(
+        "def f(row, owner):\n"
+        "    if row.species_entry_id != owner:\n"
+        "        raise ValueError('not owned by this species entry.')\n"
+    )
+    assert offending, "the detector cannot see the shape it was written for"
+
+    assert not _uncoded_owner_comparisons(
+        "def f(row, owner):\n"
+        "    assert_calculation_owned_by(row, species_entry_id=owner)\n"
+    )
+    # A coded refusal in the same shape is the *repair*, not the defect.
+    assert not _uncoded_owner_comparisons(
+        "def f(row, owner):\n"
+        "    if row.species_entry_id != owner:\n"
+        "        raise CodedValueError('some_code', 'not owned.')\n"
+    )
+
+
+def test_no_workflow_refuses_an_owner_mismatch_without_a_code() -> None:
+    """#195: seven guards compared an owner column and bare-raised.
+
+    Each reached a client as ``validation_error``, so a depositor could
+    not tell "you cited another species' partition function" from a
+    malformed number, and three earlier changes each coded a subset and
+    left the rest. The invariant closes the class rather than the
+    instances: in any module that carries the rule, comparing an owner
+    column and raising an uncoded exception is the defect.
+    """
+    modules = [
+        "app/workflows/thermo.py",
+        "app/workflows/statmech.py",
+        "app/workflows/transport.py",
+        "app/workflows/computed_species.py",
+        "app/workflows/computed_reaction.py",
+        "app/workflows/kinetics.py",
+        "app/services/statmech_resolution.py",
+        "app/services/calculation_ownership.py",
+    ]
+    root = Path(__file__).resolve().parents[2]
+    problems: list[str] = []
+    for relative in modules:
+        for line, name in _uncoded_owner_comparisons(
+            (root / relative).read_text()
+        ):
+            problems.append(f"{relative}:{line} raises a bare {name}")
+    assert not problems, (
+        "these compare an owner column and refuse without a machine-readable "
+        "code, so a client receives validation_error and cannot branch on "
+        "them: " + "; ".join(problems)
+    )
 
 
 def test_thermo_upload_schema_rejects_source_calc_key_with_no_declared_calc() -> None:

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -1209,10 +1209,24 @@ def test_statmech_source_calculations_persist_for_species_owned_calcs(db_conn) -
         }
 
 
-def test_statmech_source_calculation_referencing_ts_calc_rejects_with_owned_by_ts_message(
+def test_statmech_source_calculation_referencing_ts_calc_is_coded(
     db_conn,
 ) -> None:
-    """A species statmech referencing a TS-owned calc rejects 422."""
+    """A species statmech referencing a TS-owned calc rejects 422.
+
+    Used to assert the substring "owned by a transition state", produced
+    by an inline comparison that raised a bare ``ValueError``. #195 routed
+    this site through the shared ownership guard, so the refusal now
+    carries ``statmech_source_calculation_owner_mismatch`` -- the same
+    code the other three statmech write paths already reported -- and the
+    sentence no longer names what the calculation *was* owned by, only
+    that it was not owned by this species entry.
+
+    That is a real narrowing of the prose, and it is why this test now
+    asserts the code and the ``context`` instead: those are what a client
+    branches on, and they identify the offending field exactly, which
+    the old substring did not.
+    """
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
         "is_linear": False,
@@ -1221,20 +1235,28 @@ def test_statmech_source_calculation_referencing_ts_calc_rejects_with_owned_by_t
             {"calculation_key": "ts-freq", "role": "freq"},
         ],
     }
-    import pytest
 
     with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
-        with pytest.raises(
-            ValueError, match=r"refers to a calculation owned by a transition state"
-        ):
+        with pytest.raises(CodedValueError) as raised:
             persist_computed_reaction_upload(session, request)
+    assert raised.value.code == "statmech_source_calculation_owner_mismatch"
+    assert raised.value.context["owner_kind"] == "species_entry"
+    assert "ts-freq" in raised.value.context["field"]
+    # The row ids belong in the log, not the body (DR-0028 Requirement 2).
+    assert "species_entry_id=" not in str(raised.value)
 
 
-def test_statmech_source_calculation_referencing_sibling_species_rejects_with_other_species_message(
+def test_statmech_source_calculation_referencing_sibling_species_is_coded(
     db_conn,
 ) -> None:
-    """A species statmech referencing a sibling-species-owned calc rejects 422."""
+    """A species statmech referencing a sibling-species-owned calc rejects 422.
+
+    The sibling-species half of the test above. Kept separate because the
+    two used to produce *different sentences* from the same site, and a
+    single test would not have noticed one of them regressing; they now
+    produce the same code, and the ``field`` is what tells them apart.
+    """
     payload = _minimal_payload()
     payload["species"][0]["statmech"] = {
         "is_linear": False,
@@ -1245,15 +1267,35 @@ def test_statmech_source_calculation_referencing_sibling_species_rejects_with_ot
             {"calculation_key": "h-sp", "role": "sp"},
         ],
     }
-    import pytest
 
     with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
-        with pytest.raises(
-            ValueError,
-            match=r"refers to a calculation owned by a different species entry",
-        ):
+        with pytest.raises(CodedValueError) as raised:
             persist_computed_reaction_upload(session, request)
+    assert raised.value.code == "statmech_source_calculation_owner_mismatch"
+    assert "h-sp" in raised.value.context["field"]
+
+
+def test_a_statmech_citing_its_own_species_calculation_is_accepted(
+    db_conn,
+) -> None:
+    """The negative half of the two tests above.
+
+    Without it, both would still pass if the fixture had drifted into
+    being invalid for an unrelated reason and every bundle were refused.
+    """
+    payload = _minimal_payload()
+    payload["species"][0]["statmech"] = {
+        "is_linear": False,
+        "statmech_treatment": "rrho",
+        "source_calculations": [{"calculation_key": "ch3-freq", "role": "freq"}],
+    }
+
+    with _isolated_session(db_conn) as session:
+        summary = persist_computed_reaction_upload(
+            session, ComputedReactionUploadRequest(**payload)
+        )
+        assert summary["statmech_ids"]
 
 
 def test_statmech_source_calculation_undefined_key_rejects_at_schema_layer() -> None:
@@ -3266,9 +3308,15 @@ def test_target_exclusivity_enforced_by_check_constraint(db_conn) -> None:
 
 def test_species_correction_referencing_ts_calc_returns_422(db_conn) -> None:
     """Species-side correction whose ``source_calculation_key`` names a
-    TS-owned calc rejects with 422."""
-    import pytest
+    TS-owned calc rejects with 422.
 
+    Asserted on the code since #195: this site raised a bare
+    ``ValueError`` matched by the substring "not owned by this species
+    entry", so the refusal reached a client as ``validation_error``. It
+    now reports ``applied_energy_correction_source_calculation_owner_
+    mismatch``, which is also what made that catalogue entry stop being
+    ``Reach.guard``.
+    """
     payload = _payload_with_aec_carriers()
     payload["species"][0]["applied_energy_corrections"] = [
         {
@@ -3282,15 +3330,24 @@ def test_species_correction_referencing_ts_calc_returns_422(db_conn) -> None:
 
     with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
-        with pytest.raises(ValueError, match="not owned by this species entry"):
+        with pytest.raises(CodedValueError) as raised:
             persist_computed_reaction_upload(session, request)
+    assert raised.value.code == (
+        "applied_energy_correction_source_calculation_owner_mismatch"
+    )
+    assert raised.value.context["owner_kind"] == "species_entry"
+    assert "ts-sp" in raised.value.context["field"]
 
 
 def test_ts_correction_referencing_species_calc_returns_422(db_conn) -> None:
     """TS-side correction whose ``source_calculation_key`` names a
-    species-owned calc rejects with 422."""
-    import pytest
+    species-owned calc rejects with 422.
 
+    Same code as its species-side sibling, distinguished by
+    ``owner_kind``: a depositor repairs both by naming a calculation the
+    target owns, so it is one contract with two owner kinds rather than
+    two codes.
+    """
     payload = _payload_with_aec_carriers()
     payload["transition_state"]["applied_energy_corrections"] = [
         {
@@ -3304,10 +3361,13 @@ def test_ts_correction_referencing_species_calc_returns_422(db_conn) -> None:
 
     with _isolated_session(db_conn) as session:
         request = ComputedReactionUploadRequest(**payload)
-        with pytest.raises(
-            ValueError, match="not owned by this transition state entry"
-        ):
+        with pytest.raises(CodedValueError) as raised:
             persist_computed_reaction_upload(session, request)
+    assert raised.value.code == (
+        "applied_energy_correction_source_calculation_owner_mismatch"
+    )
+    assert raised.value.context["owner_kind"] == "transition_state_entry"
+    assert "ch3-sp" in raised.value.context["field"]
 
 
 def test_ts_side_scheme_atom_params_persist(db_conn) -> None:

--- a/backend/tests/workflows/test_kinetics_upload.py
+++ b/backend/tests/workflows/test_kinetics_upload.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.db.models.app_user import AppUser
 from app.db.models.common import (
     ArrheniusAUnits,
@@ -275,8 +276,15 @@ def test_computed_kinetics_round_trips_explicit_subject_assignments_and_wigner(
         invalid_payload = request.model_dump(mode="json")
         invalid_payload["interpretation_assignments"][1]["statmech_ref"] = reactant_sm.public_ref
         before = session.scalar(select(func.count(Kinetics.id)))
-        with pytest.raises(ValueError, match="must belong to its declared reaction participant"):
+        # #195: this was a bare ValueError matched on "must belong to its
+        # declared reaction participant", so it reached a client as
+        # validation_error. It now names the field it refused and carries
+        # a code, which is what a client can branch on.
+        with pytest.raises(CodedValueError) as mismatched:
             persist_kinetics_upload(session, KineticsUploadRequest.model_validate(invalid_payload), created_by=77)
+        assert mismatched.value.code == "kinetics_interpretation_statmech_owner_mismatch"
+        assert mismatched.value.context["field"] == "interpretation_assignments[1].statmech_ref"
+        assert mismatched.value.context["owner_kind"] == "species_entry"
         assert session.scalar(select(func.count(Kinetics.id))) == before
 
         wrong_direction = request.model_dump(mode="json")

--- a/backend/tests/workflows/test_thermo_upload.py
+++ b/backend/tests/workflows/test_thermo_upload.py
@@ -1633,12 +1633,22 @@ def test_thermo_upload_statmech_not_found_raises_not_found(db_conn) -> None:
 
 
 def test_thermo_upload_statmech_wrong_species_entry_raises_422(db_conn) -> None:
-    """A statmech owned by a different species entry is rejected (422) and
-    the message must not leak internal ids."""
+    """A statmech owned by a different species entry is rejected (422),
+    names its own code, and leaks no internal ids.
+
+    The code assertion is new in #195. This refusal was a bare
+    ``ValueError`` matched on the substring "different species entry", so
+    a client received ``validation_error`` and could not tell it from any
+    other malformed thermo upload. The id assertions are kept unchanged --
+    they are a separate property and the one most likely to regress
+    silently.
+    """
+    from app.api.error_contract import CodedValueError
+
     species_a = {"smiles": "[NH2]", "charge": 0, "multiplicity": 2}
     species_b = {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}
 
-    with pytest.raises(ValueError, match="different species entry") as exc_info:
+    with pytest.raises(CodedValueError) as exc_info:
         with Session(db_conn) as session, session.begin():
             entry_a = resolve_species_entry(
                 session, SpeciesEntryIdentityPayload(**species_a),
@@ -1653,9 +1663,13 @@ def test_thermo_upload_statmech_wrong_species_entry_raises_422(db_conn) -> None:
                     existing_statmech_id=statmech_a.id,
                 ),
             )
+    assert exc_info.value.code == "thermo_statmech_owner_mismatch"
+    assert exc_info.value.context["field"] == "thermo existing_statmech_id"
+    assert exc_info.value.context["owner_kind"] == "species_entry"
     detail = str(exc_info.value)
     assert "species_entry_id=" not in detail
     assert "id=" not in detail
+    assert str(statmech_a.id) not in detail
 
 
 def test_schema_rejects_negative_enthalpy_formation_0k_uncertainty() -> None:

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.40.0"
+version = "0.41.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -71,6 +71,7 @@ class RejectionCode(str, Enum):
     can be used wherever the raw code was.
     """
 
+    APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH = "applied_energy_correction_source_calculation_owner_mismatch"
     APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED = "applied_energy_correction_source_key_undeclared"
     ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH = "arrhenius_a_units_molecularity_mismatch"
     ATOM_MAP_ATOMS_UNACCOUNTED_FOR = "atom_map_atoms_unaccounted_for"
@@ -113,6 +114,8 @@ class RejectionCode(str, Enum):
     INVALID_STRUCTURE_QUERY = "invalid_structure_query"
     INVALID_TEMPERATURE_RANGE = "invalid_temperature_range"
     IRC_RESULT_NOT_FOUND = "irc_result_not_found"
+    KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH = "kinetics_interpretation_conformer_selection_owner_mismatch"
+    KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH = "kinetics_interpretation_statmech_owner_mismatch"
     LEVEL_OF_THEORY_HANDLE_CONFLICT = "level_of_theory_handle_conflict"
     LIMIT_TOO_LARGE = "limit_too_large"
     LOWEST_ENERGY_UNAVAILABLE = "lowest_energy_unavailable"
@@ -179,6 +182,7 @@ class RejectionCode(str, Enum):
     TCKDB_CLIENT_VERSION_UNSUPPORTED = "tckdb_client_version_unsupported"
     THERMO_SOURCE_CALCULATION_OWNER_MISMATCH = "thermo_source_calculation_owner_mismatch"
     THERMO_SOURCE_ROLE_TYPE_MISMATCH = "thermo_source_role_type_mismatch"
+    THERMO_STATMECH_OWNER_MISMATCH = "thermo_statmech_owner_mismatch"
     TRANSITION_STATE_CHARGE_MISMATCH = "transition_state_charge_mismatch"
     TRANSITION_STATE_COMPOSITION_MISMATCH = "transition_state_composition_mismatch"
     TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH = "transition_state_irc_mapping_element_mismatch"
@@ -207,6 +211,7 @@ class RejectionCode(str, Enum):
 #: payload may be sent again under the same idempotency key.
 VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
     {
+        RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
         RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED,
         RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH,
         RejectionCode.ATOM_MAP_ATOMS_UNACCOUNTED_FOR,
@@ -242,6 +247,8 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.INVALID_RANGE,
         RejectionCode.INVALID_STRUCTURE_QUERY,
         RejectionCode.INVALID_TEMPERATURE_RANGE,
+        RejectionCode.KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH,
+        RejectionCode.KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH,
         RejectionCode.LEVEL_OF_THEORY_HANDLE_CONFLICT,
         RejectionCode.LIMIT_TOO_LARGE,
         RejectionCode.LOWEST_ENERGY_UNAVAILABLE,
@@ -295,6 +302,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.SUPERSEDES_SAME_RECORD,
         RejectionCode.THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
         RejectionCode.THERMO_SOURCE_ROLE_TYPE_MISMATCH,
+        RejectionCode.THERMO_STATMECH_OWNER_MISMATCH,
         RejectionCode.TRANSITION_STATE_CHARGE_MISMATCH,
         RejectionCode.TRANSITION_STATE_COMPOSITION_MISMATCH,
         RejectionCode.TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH,
@@ -349,6 +357,7 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
 #: wire boundary and again in the schema reports the same code from
 #: both, at two different statuses.
 REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
+    RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH: frozenset({422}),
     RejectionCode.ATOM_MAP_ATOMS_UNACCOUNTED_FOR: frozenset({422}),
@@ -391,6 +400,8 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.INVALID_STRUCTURE_QUERY: frozenset({422}),
     RejectionCode.INVALID_TEMPERATURE_RANGE: frozenset({422}),
     RejectionCode.IRC_RESULT_NOT_FOUND: frozenset({404}),
+    RejectionCode.KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH: frozenset({422}),
+    RejectionCode.KINETICS_INTERPRETATION_STATMECH_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.LEVEL_OF_THEORY_HANDLE_CONFLICT: frozenset({422}),
     RejectionCode.LIMIT_TOO_LARGE: frozenset({422}),
     RejectionCode.LOWEST_ENERGY_UNAVAILABLE: frozenset({422}),
@@ -457,6 +468,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.TCKDB_CLIENT_VERSION_UNSUPPORTED: frozenset({426}),
     RejectionCode.THERMO_SOURCE_CALCULATION_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.THERMO_SOURCE_ROLE_TYPE_MISMATCH: frozenset({422}),
+    RejectionCode.THERMO_STATMECH_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.TRANSITION_STATE_CHARGE_MISMATCH: frozenset({422}),
     RejectionCode.TRANSITION_STATE_COMPOSITION_MISMATCH: frozenset({422}),
     RejectionCode.TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH: frozenset({422}),


### PR DESCRIPTION
## What was wrong

Seven ownership guards compared an owner column and raised a bare `ValueError`. Every one reached a depositor as `code="validation_error"` — the same answer a malformed number gets — so a client could not branch on them and a depositor could not tell one refusal from another.

**Measured on `main` before touching anything: seven, exactly.** Every line number in the task brief was stale; all seven anchors were re-derived. All seven were provoked on the wire and all seven answered `validation_error`. None was unreachable, so nothing here is annotated `Reach.guard`.

| # | site (on `main`) | field | before | after |
|---|---|---|---|---|
| 1 | `workflows/computed_reaction.py:815` | `species[k].applied_energy_corrections[i].source_calculation_key` | `validation_error` | `applied_energy_correction_source_calculation_owner_mismatch` |
| 2 | `workflows/computed_reaction.py:855` | `transition_state.applied_energy_corrections[i].source_calculation_key` | `validation_error` | `applied_energy_correction_source_calculation_owner_mismatch` |
| 3 | `workflows/computed_reaction.py:1108` | `species[k].statmech.source_calculations[i].calculation_key` | `validation_error` | `statmech_source_calculation_owner_mismatch` |
| 4 | `workflows/thermo.py:204` | `existing_statmech_id` | `validation_error` | `thermo_statmech_owner_mismatch` *(new)* |
| 5 | `workflows/kinetics.py:232` | `interpretation_assignments[i].statmech_ref` (participant) | `validation_error` | `kinetics_interpretation_statmech_owner_mismatch` *(new)* |
| 6 | `workflows/kinetics.py:236` | `interpretation_assignments[i].statmech_ref` (transition state) | `validation_error` | `kinetics_interpretation_statmech_owner_mismatch` |
| 7 | `workflows/kinetics.py:268` | `interpretation_assignments[i].conformer_selection` | `validation_error` | `kinetics_interpretation_conformer_selection_owner_mismatch` *(new)* |

Sites 5 and 6 share a code deliberately: same field, same repair ("name the statmech that belongs to this subject"), and which owner disagreed is already in `context["owner_kind"]`. Site 7 gets its own because the field a depositor has to fix is a different one — telling them `statmech_ref` was wrong would send them to the right-looking wrong place.

Before/after, measured on the wire (`/uploads/computed-reaction`, `/uploads/thermo`, `/uploads/kinetics`):

```
BEFORE  [1] 422 code='validation_error' context={}
            detail="species['ch3'].applied_energy_corrections[0].source_calculation_key='ts-sp': refers to a calculation that is not owned by this species entry."
AFTER   [1] 422 code='applied_energy_correction_source_calculation_owner_mismatch'
            context={'field': "species['ch3'].applied_energy_corrections[0].source_calculation_key='ts-sp'",
                     'target': 'applied energy correction', 'owner_kind': 'species_entry'}

BEFORE  [4] 422 code='validation_error'  detail='existing_statmech_id refers to a statmech record owned by a different species entry.'
AFTER   [4] 422 code='thermo_statmech_owner_mismatch'
            context={'field': 'thermo existing_statmech_id', 'target': 'thermo', 'owner_kind': 'species_entry'}

BEFORE  [7] 422 code='validation_error'  detail='conformer selection subject must match the interpretation statmech species.'
AFTER   [7] 422 code='kinetics_interpretation_conformer_selection_owner_mismatch'
            context={'field': 'interpretation_assignments[0].conformer_selection', 'target': 'reactant 1', 'owner_kind': 'species_entry'}
```

The remaining four are the same shape; all fourteen lines are in the PR discussion below the fold of `tests/api/test_api_bundle_ownership_codes.py` and `tests/api/test_api_statmech_citation_ownership.py`, which assert exactly these pairs.

## What changed

`app/services/calculation_ownership.py` grows one core function, `assert_owned_by`, taking the cited record's noun and its two owner ids. `assert_calculation_owned_by` keeps its signature and delegates; `assert_statmech_owned_by` is its statmech twin; the conformer-selection site calls the core directly because a selection reaches its species through its group and there is no row with both columns to hand. The calculation wording is byte-identical to before — the noun is a parameter and "calculation" is what it was.

The module keeps its name. Five catalogue entries name it as their `origin`, and splitting the rule across two modules by the type of the cited row is exactly the drift #162 consolidated. The docstring says so rather than leaving a reader to wonder why statmech codes live in `calculation_ownership.py`.

`applied_energy_correction_source_calculation_owner_mismatch` loses `Reach.guard`. Its note already named the reaction-bundle comparisons as the repair that would make it reachable; this is that repair. It is now exported to the client enum. `transport_source_calculation_owner_mismatch` is the last ownership code that stands as a guard.

## Schema / migration impact

**None.** No ORM model, no Pydantic model, no column, no constraint. No Alembic revision — the codes are runtime error-body values, not stored data. The OpenAPI golden is unchanged and did not need regenerating: error codes do not appear in any published request or response model (checked — no existing ownership code appears in `tests/api/golden/openapi.json`).

## New environment variables

**None.**

## Client

`clients/python/src/tckdb_client/rejection_codes.py` regenerated with `backend/scripts/generate_client_rejection_codes.py`; four members added (the three new codes plus the promoted AEC one). The generator emits `REJECTION_STATUSES` for every member, so the per-member retry advice `tests/test_rejection_codes.py::test_every_member_says_what_status_it_arrives_at` requires is covered by construction. Version bumped `0.40.0` → `0.41.0`.

## Tests changed rather than added, and why

Six existing tests asserted message substrings that no longer exist. Each was replaced with an assertion on the code and `context` — strictly stronger, because the code is what a client branches on and `context["field"]` identifies the offending link exactly where the substring did not.

One is a genuine narrowing of behaviour and is called out rather than buried: `workflows/computed_reaction.py`'s statmech site used to choose between "owned by a transition state" and "owned by a different species entry" in its sentence. The shared guard says only that the calculation is not this species entry's — which is what its three sibling write paths (`services/statmech_resolution.py`, the species bundle, the standalone statmech upload) already said. The two tests that pinned the two sentences now pin the one code and are distinguished by `field`; a third test was added asserting the correct payload is still **accepted**.

New: `tests/api/test_api_bundle_ownership_codes.py` (7 tests) and `tests/api/test_api_statmech_citation_ownership.py` (8 tests), each refusal paired with the request that must still return 201. Four new structural tests in `tests/invariants/test_structure_invariants.py`, including `test_no_workflow_refuses_an_owner_mismatch_without_a_code` — an AST scan that closes the *class* rather than the seven instances, with a can-it-say-no test beside it.

`backend/docs/reviews/error_code_coverage_triage.md` gains two `> Resolved` annotations in the house style. One of them records why the triage could not see this: both its rows list only the call sites that already used the shared guard, so the reaction bundle's inline copies were absent from the list the "why it cannot fire" column reasoned over.

## Verification actually run

- `bash backend/scripts/test-api.sh` — **2783 passed**
- `bash backend/scripts/test-rest.sh` — **4559 passed, 14 skipped** (run twice; the second run is on the final tree)
- `bash backend/scripts/test-scientific.sh` — **2055 passed**
- `clients/python`: `pytest tests` — **1348 passed**; `pytest adapters/chemkin/tests` — **55 passed, 1 skipped**
- `schemas/python/tckdb-schemas`: `pytest` — **38 passed**
- `ruff check app tests` from `backend/` — clean
- **Mutation: all seven guards mutated one at a time** (each owner id replaced with the cited row's own, so the comparison can never fail), each mutation grepped back out of the file to confirm it landed, each run red, each source restored and `__pycache__` cleared:

```
[1 species AEC]                      landed=yes -> RED :: 2 failed, 5 passed
[2 TS AEC]                           landed=yes -> RED :: 2 failed, 5 passed
[3 statmech source calc]             landed=yes -> RED :: 3 failed, 4 passed
[4 thermo existing_statmech_id]      landed=yes -> RED :: 1 failed, 7 passed
[5 kinetics participant statmech_ref] landed=yes -> RED :: 2 failed, 6 passed
[6 kinetics TS statmech_ref]         landed=yes -> RED :: 1 failed, 7 passed
[7 kinetics conformer_selection]     landed=yes -> RED :: 2 failed, 6 passed
```

Site 6's first mutation attempt was **refused by the harness** because its anchor matched two lines in `kinetics.py`; it was re-anchored on unique surrounding text rather than mutated blind.

Scratch DB throughout: `tckdb_test_195`. Nothing touched the Pi.
