### PR TITLE
Restore the shared test database to head, not to a revision

### DIFF
--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -441,6 +441,23 @@ full suite is verified green at seeds **1, 2, 3, 4, 5, 7, 11, 90210 and
 since it puts all ~6,770 tests in one process against one database and so
 exercises every cross-file adjacency the sharded runs hide.
 
+**That audit is a measurement of a commit, not a property of the suite.** One
+real order dependence appeared four days after it was taken, and it is worth
+knowing its shape because the shape recurs:
+`tests/db/test_imaginary_mode_tau_basis_constraint.py` downgraded the shared
+database and restored it to the revision it was written against rather than to
+`head`. That revision stopped being `head` the day `b7e4d1a9c026` landed on top
+of it, so from then on the file left every later test in its process running
+against a schema one revision old — surfacing as three failures in
+`tests/db/test_statmech_torsion_index_uniqueness.py` asserting that a unique
+constraint had the wrong name. The eight-way gates stayed green throughout: with
+eight workers and eight databases, the offender and its victim only share a
+process about one run in eight, which is exactly the blind spot the paragraph
+above names. `tests/db/conftest.py::_must_leave_the_database_at_head` now fails
+the offender at its own teardown, so the class no longer depends on a serial run
+to be seen. Re-audit after adding a revision; do not treat the seed list as a
+standing guarantee.
+
 **Set `TCKDB_TEST_SEED=random` for an unpinned order.** The script draws a
 fresh seed per invocation and echoes it:
 

--- a/backend/tests/db/conftest.py
+++ b/backend/tests/db/conftest.py
@@ -33,9 +33,20 @@ command line and in deployment, where ``env.py`` is untouched.
 from __future__ import annotations
 
 import logging.config
+from pathlib import Path
 from typing import Iterator
 
 import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+#: Node id of the first test observed to finish with the shared database
+#: below alembic head, so later failures can point at it instead of each
+#: opening its own investigation. See ``_must_leave_the_database_at_head``.
+_FIRST_OFFENDER: str | None = None
 
 
 @pytest.fixture(autouse=True)
@@ -48,7 +59,88 @@ def _alembic_must_not_reconfigure_logging(monkeypatch) -> Iterator[None]:
 
     Any future test elsewhere that calls ``alembic.command`` in-process needs
     this too; move the fixture up to ``tests/conftest.py`` rather than
-    rediscovering the symptom.
+    rediscovering the symptom. The same applies to
+    ``_must_leave_the_database_at_head`` below, for the same reason.
     """
     monkeypatch.setattr(logging.config, "fileConfig", lambda *args, **kwargs: None)
     yield
+
+
+@pytest.fixture(scope="session")
+def alembic_head() -> str:
+    """The revision ``alembic upgrade head`` would stop at, read from disk.
+
+    Read rather than written down. Every hard-coded copy of "the current
+    head" in this tree has gone stale within days of being typed, because
+    the thing that makes it stale is the next revision landing — which is
+    the one event nobody grepping for the old hash is present for.
+    """
+    return ScriptDirectory.from_config(
+        Config(str(_BACKEND_ROOT / "alembic.ini"))
+    ).get_current_head()
+
+
+@pytest.fixture(autouse=True)
+def _must_leave_the_database_at_head(request, db_engine, alembic_head) -> Iterator[None]:
+    """Fail the test that downgraded the shared database, not its victims.
+
+    Four files in this tree run ``alembic.command`` in-process against the
+    *per-run database every other test in the session is sharing*. A test
+    that downgrades it and does not put it back does not fail: it succeeds,
+    and the damage lands on whatever runs next, in files with no connection
+    to migrations at all. The symptom is a red test asserting something that
+    is true, against a schema that is a few revisions old.
+
+    That has now happened three times, each time with the same shape and
+    each time diagnosed from scratch:
+
+    * ``test_upload_job_lease_migration.py`` -- ``species_entry.isotope_key
+      does not exist``, hundreds of tests later.
+    * ``test_dataset_release_migration.py`` -- the same, in files that had
+      nothing to do with releases.
+    * ``test_imaginary_mode_tau_basis_constraint.py`` -- three failures in
+      ``test_statmech_torsion_index_uniqueness.py`` reporting that a
+      duplicate torsion index had been refused by the *wrong* unique
+      constraint. It had not; ``b7e4d1a9c026`` renames that index, the
+      database was one revision below it, and the rule the test cares about
+      was enforced correctly the whole time.
+
+    The first two were each fixed in place, by the author who happened to
+    tread on them, and the comment they left did not stop the third. So the
+    check lives here instead: it costs one query per test in this directory
+    and it names the test that did it.
+
+    Teardown-only. A test is entitled to move the version around while it
+    runs -- that is what these files are for. What it may not do is finish
+    with the version somewhere other than where it found it.
+
+    Every test after the offender fails too, and deliberately: each of them
+    really did run against the wrong schema, so a green result from one
+    would be a result about a database nobody meant to test. Only the first
+    is *blamed*, though -- ``_FIRST_OFFENDER`` carries that name into every
+    later message, so a hundred red tests still point at one line of one
+    file rather than a hundred investigations.
+    """
+    yield
+    with db_engine.connect() as connection:
+        version = connection.scalar(text("SELECT version_num FROM alembic_version"))
+    if version == alembic_head:
+        return
+
+    global _FIRST_OFFENDER
+    if _FIRST_OFFENDER is None:
+        _FIRST_OFFENDER = request.node.nodeid
+        blame = "This test left it there."
+    else:
+        blame = (
+            f"{_FIRST_OFFENDER} left it there; this test is downstream of "
+            "that, and its result means nothing until that one is fixed."
+        )
+    raise AssertionError(
+        f"the shared test database is at alembic revision {version!r}, not "
+        f"head ({alembic_head!r}). {blame} Every test that follows runs "
+        "against a schema missing every revision above that point, and will "
+        "fail somewhere unrelated with no sign of what moved. Restore it "
+        'with ``command.upgrade(config, "head")`` -- the literal string, not '
+        "a revision id: a revision id is head only until the next one lands."
+    )

--- a/backend/tests/db/test_constraint_rename_migration.py
+++ b/backend/tests/db/test_constraint_rename_migration.py
@@ -57,7 +57,7 @@ _OTHER_OLD = "ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2"
 
 
 @pytest.fixture
-def alembic_at_previous_head(db_engine, monkeypatch):
+def alembic_at_previous_head(db_engine, monkeypatch, alembic_head):
     """Hold the database one revision below head for the duration.
 
     Restores head in teardown whatever the test did to the catalog, so a
@@ -74,6 +74,14 @@ def alembic_at_previous_head(db_engine, monkeypatch):
     did, and ``test_constraint_names_match_the_model.py`` caught it in CI
     as a schema-wide sweep failure with no obvious author. Forcing the
     version back down first makes the final ``upgrade`` real work again.
+
+    The final ``upgrade`` targets ``head``, not ``_CURRENT_HEAD``.
+    ``_CURRENT_HEAD`` is the revision under test, and it is head only until
+    the next revision lands; upgrading to it would leave every revision after
+    it un-applied on the database the rest of the process is sharing. Also
+    not hypothetical: it is what
+    ``test_imaginary_mode_tau_basis_constraint.py`` did to *this file's*
+    subject the day ``b7e4d1a9c026`` landed on top of the revision it named.
     """
     url = db_engine.url.render_as_string(hide_password=False)
     for key, value in (
@@ -97,8 +105,8 @@ def alembic_at_previous_head(db_engine, monkeypatch):
         # so the final upgrade actually runs the rename.
         _restore_pre_upgrade_names(engine)
         command.downgrade(config, _PREVIOUS_HEAD)
-        command.upgrade(config, _CURRENT_HEAD)
-        _assert_left_at_head(engine)
+        command.upgrade(config, "head")
+        _assert_left_at_head(engine, alembic_head)
         engine.dispose()
 
 
@@ -138,7 +146,7 @@ def _restore_pre_upgrade_names(engine) -> None:
         )
 
 
-def _assert_left_at_head(engine) -> None:
+def _assert_left_at_head(engine, alembic_head: str) -> None:
     """Fail loudly here rather than quietly somewhere downstream.
 
     This file is the only thing in the suite that alters the schema of
@@ -155,8 +163,9 @@ def _assert_left_at_head(engine) -> None:
     )
     with engine.connect() as connection:
         version = connection.scalar(text("SELECT version_num FROM alembic_version"))
-    assert version == _CURRENT_HEAD, (
-        f"teardown left alembic_version at {version!r}, not {_CURRENT_HEAD!r}"
+    assert version == alembic_head, (
+        f"teardown left alembic_version at {version!r}, not head "
+        f"({alembic_head!r})"
     )
 
 

--- a/backend/tests/db/test_imaginary_mode_tau_basis_constraint.py
+++ b/backend/tests/db/test_imaginary_mode_tau_basis_constraint.py
@@ -326,8 +326,20 @@ def test_the_migration_refuses_rather_than_guesses(db_engine, monkeypatch):
     finally:
         # Leave the database at head whatever happened, so a failure here
         # fails this test and not every test that follows it.
+        #
+        # ``head``, not ``_CURRENT_HEAD``. This test downgrades the *per-run
+        # database every other test in the process is using*, and
+        # ``_CURRENT_HEAD`` is the revision under test, which stops being head
+        # the moment anything lands on top of it. It did, one day later:
+        # ``b7e4d1a9c026`` renames a unique index and six CHECK constraints, so
+        # stopping at ``e2a7c9d4b615`` handed every later test a
+        # ``statmech_torsion`` whose unique index was still called
+        # ``uq_statmech_torsion_statmech_id``. That surfaced as three failures
+        # in ``test_statmech_torsion_index_uniqueness.py`` -- a file with
+        # nothing to do with tau bases -- claiming the wrong constraint had
+        # refused a duplicate, when the only thing wrong was its name.
         _purge_planted_rows(engine, planted)
-        command.upgrade(config, _CURRENT_HEAD)
+        command.upgrade(config, "head")
         engine.dispose()
 
 

--- a/backend/tests/db/test_statmech_torsion_index_uniqueness.py
+++ b/backend/tests/db/test_statmech_torsion_index_uniqueness.py
@@ -21,7 +21,13 @@ the invariant came to be reported as unenforced below the request layer.
 This file settles it by provocation rather than by reading either the
 name or the declaration:
 
-1. The database refuses the duplicate.
+1. The database refuses the duplicate -- and refuses it *on
+   ``(statmech_id, torsion_index)``*, read off the key columns PostgreSQL
+   reports in the violation rather than off the constraint's name. "An
+   ``IntegrityError`` was raised" would pass against a NOT NULL or a
+   foreign key; "the message mentions this name" would pass against a
+   rule of that name covering different columns, and fails for the
+   uninteresting reason whenever something renames it.
 2. It refuses it under ``session_replication_role = replica`` -- the mode
    bulk loaders, importers and ``pg_restore`` run in, which suspends
    triggers and foreign keys. Those are exactly the writers that do not
@@ -37,6 +43,8 @@ name or the declaration:
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
@@ -50,6 +58,47 @@ from tests.services.scientific_read._factories import (
 )
 
 _INDEX = "uq_statmech_torsion_statmech_id_torsion_index"
+_COLUMNS = ["statmech_id", "torsion_index"]
+
+#: ``DETAIL:  Key (statmech_id, torsion_index)=(299, 1) already exists.``
+_KEY_COLUMNS = re.compile(r"Key \(([^)]*)\)=")
+
+
+def _violated(excinfo) -> tuple[str, list[str]]:
+    """The name *and* the key columns of the constraint that refused.
+
+    Both come out of the error itself, from ``psycopg``'s structured
+    diagnostics rather than from a substring search of the rendered
+    message. The columns are the point: an assertion that only names the
+    constraint passes for any constraint of that name, and an assertion
+    that only catches ``IntegrityError`` passes for a NOT NULL, a foreign
+    key, or a uniqueness rule on the wrong column -- which is the failure
+    mode this file exists to rule out.
+    """
+    diagnostic = excinfo.value.orig.diag
+    match = _KEY_COLUMNS.search(diagnostic.message_detail or "")
+    assert match is not None, (
+        "the violation reported no key columns, so what it refused on "
+        f"cannot be checked: {diagnostic.message_detail!r}"
+    )
+    return diagnostic.constraint_name, [
+        column.strip() for column in match.group(1).split(",")
+    ]
+
+
+def _assert_refused_on_the_rotor_key(excinfo) -> None:
+    name, columns = _violated(excinfo)
+    assert columns == _COLUMNS, (
+        f"the duplicate was refused on {columns}, not {_COLUMNS}: a rule "
+        "that is not 'one rotor per (statmech record, torsion index)' "
+        f"stopped this insert ({name})"
+    )
+    assert name == _INDEX, (
+        f"the rule was enforced, but by {name!r} rather than {_INDEX!r}. "
+        "Something renamed it; see test_the_index_is_unique_and_spans_"
+        "both_columns, and check nothing in this session left the "
+        "database below alembic head"
+    )
 
 
 @pytest.fixture
@@ -83,10 +132,7 @@ def test_a_repeated_torsion_index_is_refused(db_session, statmech_ids):
         _add_torsion(db_session, statmech_id, 1)
         with pytest.raises(IntegrityError) as excinfo:
             _add_torsion(db_session, statmech_id, 1)
-        assert _INDEX in str(excinfo.value), (
-            "the duplicate was refused by something other than "
-            f"{_INDEX}: {excinfo.value}"
-        )
+        _assert_refused_on_the_rotor_key(excinfo)
     finally:
         savepoint.rollback()
 
@@ -150,7 +196,7 @@ def test_the_index_holds_under_a_bulk_load_session(db_session, statmech_ids):
                 )
             )
             db_session.flush()
-        assert _INDEX in str(excinfo.value)
+        _assert_refused_on_the_rotor_key(excinfo)
     finally:
         savepoint.rollback()
 


### PR DESCRIPTION
## What was wrong

`tests/db/test_statmech_torsion_index_uniqueness.py` failed 3-of-4 in a full local
run and passed when run alone. The failure said the duplicate had been refused by
`uq_statmech_torsion_statmech_id` rather than
`uq_statmech_torsion_statmech_id_torsion_index`.

Nothing was wrong with the constraint, and nothing was wrong with that test's claim.
The database it was reading was **one alembic revision old**.

`tests/db/test_imaginary_mode_tau_basis_constraint.py::test_the_migration_refuses_rather_than_guesses`
downgrades the per-run database — the one every other test in the process is
sharing — to exercise a guard inside `e2a7c9d4b615`. Its teardown then restores
`_CURRENT_HEAD`, the revision it was written against. That was head when the file
landed (#149, 2026-08-12). It stopped being head one day later, when `b7e4d1a9c026`
landed on top of it (#150, 2026-08-13) and renamed one unique index and six CHECK
constraints. From then on the file finished by leaving the shared database at
`e2a7c9d4b615`, and every test that ran after it in the same process read a schema
carrying the pre-rename names.

Reproduced in 6 seconds, two tests, no concurrency involved:

```
pytest -p no:randomly -k "refuses_rather_than_guesses or torsion" \
  tests/db/test_imaginary_mode_tau_basis_constraint.py \
  tests/db/test_statmech_torsion_index_uniqueness.py
# 3 failed, 2 passed
```

Catalog, polled from a second connection across that test:

```
b7e4d1a9c026 | uq_statmech_torsion_statmech_id_torsion_index | ck_calculation_artifact_bytes_gt_0
d4e9b1c7a253 | uq_statmech_torsion_statmech_id               | ck_calculation_artifact_ck_calculation_artifact_bytes_gt_0
e2a7c9d4b615 | uq_statmech_torsion_statmech_id               | ck_calculation_artifact_ck_calculation_artifact_bytes_gt_0   <- left here
```

A database built by `alembic upgrade head` carries the long name, and so does one
built by `Base.metadata.create_all()` from the model. The name does **not** differ
between two legitimately-built databases; it differed between head and head-minus-one.

The eight-way gates stayed green because eight workers means eight databases, so
the offender and its victim share a process about one run in eight —
`backend/docs/testing.md` already names that blind spot.

## What changed

1. **`test_imaginary_mode_tau_basis_constraint.py`** — teardown upgrades to
   `"head"`, not to `_CURRENT_HEAD`. This is the fix.
2. **`test_constraint_rename_migration.py`** — same latent trap (its `_CURRENT_HEAD`
   is head only until the next revision lands); now upgrades to `"head"` and checks
   the exit version against the head read from the script directory. The identical
   fix was already applied by hand to `test_upload_job_lease_migration.py` and
   `test_dataset_release_migration.py` after they each caused this once.
3. **`tests/db/conftest.py`** — `_must_leave_the_database_at_head`, an autouse
   teardown check that fails the test which left the shared database below head,
   naming it. Three files have now caused this bug and been fixed in place; the
   comments they left did not prevent the next one. One query per test in
   `tests/db/` (156 tests). Subsequent tests fail too — each really did run against
   the wrong schema — but only the first is blamed, and its node id is quoted in
   every later message.
4. **`test_statmech_torsion_index_uniqueness.py`** — the two provocation tests now
   assert the **key columns** of the constraint that refused, taken from psycopg's
   structured diagnostics, in addition to its exact name. Strictly stronger, not
   weaker: `test_the_index_is_unique_and_spans_both_columns` still pins the name
   against `pg_index`.
5. **`backend/docs/testing.md`** — records that the seed/worker order-independence
   audit is a measurement of a commit, not a standing property, and what this
   dependence looked like.

## Mutation testing

Each assertion was mutated and confirmed to go red, and each mutation was confirmed
present in the file before the run:

| mutation | result |
|---|---|
| teardown back to `command.upgrade(config, _CURRENT_HEAD)` | the guard ERRORs `test_the_migration_refuses_rather_than_guesses` itself and names it in every downstream message |
| second insert violates `ck_statmech_torsion_dimension_ge_1` instead of the unique index | `the violation reported no key columns, so what it refused on cannot be checked` — "an IntegrityError was raised" is not what this asserts |
| replace the index with a **single-column** unique index **of the same name** | all four tests red, incl. `the duplicate was refused on ['statmech_id'], not ['statmech_id', 'torsion_index']`. The old `_INDEX in str(e)` assertion **passed** this mutation |

All mutations reverted; `__pycache__` cleared; `grep -rn MUTATION tests/` clean.

## Schema / migration impact

None. No model, schema or migration file is touched, no new environment variable.

## Verification actually run

```
conda run -n tckdb_env bash backend/scripts/test-rest.sh        # 4559 passed, 14 skipped (2:26)
conda run -n tckdb_env bash backend/scripts/test-api.sh         # 2786 passed (4:03)
conda run -n tckdb_env bash backend/scripts/test-scientific.sh  # 2055 passed (2:49)
conda run -n tckdb_env ruff check tests/                        # All checks passed
```

plus the targeted reproduction and the three mutations above, and a from-scratch
`alembic upgrade head` into a fresh database confirming it carries
`uq_statmech_torsion_statmech_id_torsion_index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
