### PR TITLE
Compare a calculation's geometries against its own subject

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -360,6 +360,22 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
     ApiCode("atom_map_without_transition_state", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
+    ApiCode("calculation_geometry_composition_mismatch", 422, Surface.coded_exception,
+            "backend/app/services/calculation_geometry_composition.py",
+            note=(
+                "A geometry linked to a calculation is not made of the atoms "
+                "of the subject the calculation is filed under. One code "
+                "across both owner kinds -- a species entry's own formula, or "
+                "a transition state's reaction reactant sum -- because the "
+                "field is the same geometry link and the repair is the same "
+                "sentence; context['owner_kind'] says which reference "
+                "disagreed. Distinct from "
+                "species_geometry_composition_mismatch (a conformer geometry "
+                "against its species entry) and "
+                "transition_state_composition_mismatch (the saddle point a "
+                "TS entry is resolved from): those are repaired in a "
+                "payload's identity block, this one on a calculation."
+            )),
     ApiCode("calculation_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py"),
     ApiCode("canonical_parameter_value_requires_key", 422, Surface.message_prefix,

--- a/backend/app/chemistry/species.py
+++ b/backend/app/chemistry/species.py
@@ -598,7 +598,10 @@ def canonical_species_identity(
 
 CHECK_SMILES_CHARGE_MATCHES_DECLARED = ScientificCheck(
     group="A structure against its own label",
-    sort_key=3,
+    # Shifted from 3 to 4 by #143 so that the calculation-geometry composition
+    # rule sits beside the two conformer-geometry rules it mirrors, rather
+    # than after the charge rules that have nothing to do with it.
+    sort_key=4,
     code=W_SPECIES_SMILES_CHARGE_MISMATCH,
     asserts=(
         "A species entry's declared charge equals the summed formal charge of "

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -80,6 +80,7 @@ from app.scientific_checks import (
     collect_registered_checks,
 )
 from app.services import (
+    calculation_geometry_composition,
     charge_multiplicity_reconciliation,
     reaction_resolution,
     species_resolution,
@@ -1295,6 +1296,7 @@ CHECK_REPRODUCIBILITY_IS_ITS_OWN_JUDGEMENT = ScientificCheck(
 #: listed here, so forgetting to register a module is caught rather than
 #: silently omitted from the register.
 DECLARING_MODULES: tuple[ModuleType, ...] = (
+    calculation_geometry_composition,
     chemistry_species,
     chemistry_units,
     charge_multiplicity_reconciliation,

--- a/backend/app/services/calculation_geometry_composition.py
+++ b/backend/app/services/calculation_geometry_composition.py
@@ -1,0 +1,450 @@
+"""One composition rule for every geometry linked to a calculation.
+
+What the rule is
+----------------
+A geometry linked to a calculation must be made of the atoms of the subject
+that calculation is filed under. The identity says what the thing is; the
+coordinates are what every number on that calculation — energies, gradients,
+frequencies, Hessians — is computed from. If the two name different
+collections of atoms, the record is internally contradictory and every
+consumer that trusts the label gets numbers for something nobody deposited.
+
+Why it did not exist
+--------------------
+A *conformer* geometry has been compared against its species entry since
+:func:`app.services.species_resolution.assert_geometry_composition_matches_identity`
+landed. A *calculation* geometry was compared against nothing, on any path,
+for any subject — that function's own docstring said so and called the input
+half "a genuine open gap". Benzene coordinates attached to a ``smiles: "C"``
+species entry were accepted, and so was methane attached to a C2H5O saddle
+point. Both are reproduced in
+``tests/services/test_calculation_geometry_composition.py``.
+
+Which subject, and what it is made of
+-------------------------------------
+``calculation`` carries a ``one_owner`` CHECK constraint, so exactly one of
+``species_entry_id`` and ``transition_state_entry_id`` is set and the question
+has exactly two answers. Both references already existed:
+
+* **species entry** -- the element counts of ``species.smiles``, which is what
+  the conformer rule compares against.
+* **transition-state entry** -- the *sum* of the element counts of the
+  reaction's reactants, which is what
+  :func:`app.services.reaction_resolution.validate_transition_state_composition`
+  compares the saddle point itself against. A transition state is a stationary
+  point on the potential energy surface of the whole reacting system; for
+  ``CH3 + H -> CH4`` its geometry holds five atoms and is neither participant.
+  ``transition_state.reaction_entry_id`` is ``NOT NULL``, so the sum is always
+  reachable.
+
+Deriving the TS reference any other way would refuse correct science on the
+first deposit: all 31 calculation geometries in the repository's ARC-derived
+fixture payloads are TS-owned, and every one of them is the whole reacting
+system rather than any participant.
+
+Output geometries are checked too, contrary to the note that stood here
+----------------------------------------------------------------------
+Two modules said closing the output half would be wrong because "an
+optimisation that dissociated is science to record". That argument is correct
+about **connectivity** and does not transfer to **composition**. Every one of
+the seven ``CalculationType`` values is a map over a fixed set of nuclei --
+no electronic-structure program adds or removes one -- so dissociation,
+isomerisation, proton transfer and ring opening all *conserve* element counts.
+:mod:`app.services.geometry_validation` records the demonstration one
+paragraph above the exemption it justified: "Methane with one hydrogen pulled
+out to 5 A, i.e. a dissociated fragment pair -- passes." The case cited to
+justify the exemption is a case this rule accepts, so the exemption protected
+no correct science while leaving the larger half unchecked (1806 output
+geometries against 326 inputs on the live instance).
+
+What is deliberately not compared
+---------------------------------
+**Elements, not nuclides.** ``D`` and ``T`` count as the hydrogen they are and
+``[2H]`` counts as ``H``, so an isotopologue is never a mismatch. Isotope
+agreement is a separate rule with its own code
+(:func:`~app.services.species_resolution.assert_geometry_isotopes_match_identity`),
+which owns it under ADR 0008 section 9.
+
+**Counts, not positions.** No coordinate is read. A scan point at 5 A, an IRC
+endpoint in a product well, a constitutional isomer and a dissociated fragment
+pair all pass. A check that drifted from composition into plausibility would
+refuse exactly the deliberately-distorted structures this database exists to
+hold.
+
+**Absence does not block.** A ``pseudo`` owner, a transition state whose
+reaction records no reactants or records a ``pseudo`` reactant, and a stored
+SMILES RDKit will not parse are all incompleteness rather than contradiction,
+and get the tier an absent atom map gets. A free electron is *not* absence:
+its composition is empty rather than unknown, so any geometry contradicts it.
+
+What never appears in the refusal
+---------------------------------
+Row ids. ``context`` names the field the depositor wrote, which is the
+identifier they can act on; the ids of the rows that disagreed go to the log,
+where the operator is (DR-0028 Requirement 2).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.error_contract import CodedValueError
+from app.chemistry.geometry import resolve_element_symbol
+from app.chemistry.species import element_counts_from_smiles, format_element_counts
+from app.db.models.calculation import Calculation
+from app.db.models.common import MoleculeKind, ReactionRole
+from app.db.models.geometry import GeometryAtom
+from app.db.models.reaction import ReactionEntryStructureParticipant
+from app.db.models.species import Species, SpeciesEntry
+from app.db.models.transition_state import TransitionState, TransitionStateEntry
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    PythonCheck,
+    ScientificCheck,
+)
+
+logger = logging.getLogger(__name__)
+
+#: A geometry linked to a calculation is not made of the atoms of the subject
+#: the calculation is filed under.
+#:
+#: One code across both owner kinds, deliberately, on the precedent of
+#: ``kinetics_interpretation_statmech_owner_mismatch``. The reference differs
+#: -- a species entry's own formula, or a reaction's reactant sum -- but the
+#: field is the same geometry link and the repair is the same sentence: attach
+#: the structure this calculation was actually run on, or file the calculation
+#: under the subject that structure belongs to. Which owner disagreed is a
+#: fact about the request and is carried in ``context["owner_kind"]``, not a
+#: different contract.
+#:
+#: Distinct from ``species_geometry_composition_mismatch``, which is about a
+#: *conformer* geometry deposited with a species entry, and from
+#: ``transition_state_composition_mismatch``, which is about the saddle point
+#: a transition-state entry is resolved from. Those two are repaired in the
+#: identity block of a payload; this one is repaired on a calculation.
+W_CALCULATION_GEOMETRY_COMPOSITION_MISMATCH = (
+    "calculation_geometry_composition_mismatch"
+)
+
+#: Cache key under which per-session reference compositions are memoised.
+#: Scoped to the ``Session`` rather than the module so that nothing survives a
+#: rolled-back test or leaks between requests.
+_CACHE_KEY = "_calculation_geometry_composition_reference_cache"
+
+
+def _species_entry_reference(
+    session: Session, species_entry_id: int
+) -> Counter[str] | None:
+    """Return the element counts a species entry's own identity declares.
+
+    ``None`` means "do not judge": a pseudo-species has no atom-resolved
+    composition, and a stored SMILES RDKit will not parse is an absence this
+    function is not the right place to report. A free electron returns an
+    *empty* counter rather than ``None`` -- zero atoms is a fact, not a gap.
+    """
+
+    species = session.scalar(
+        select(Species)
+        .join(SpeciesEntry, SpeciesEntry.species_id == Species.id)
+        .where(SpeciesEntry.id == species_entry_id)
+    )
+    if species is None:
+        return None
+    if species.kind == MoleculeKind.pseudo:
+        return None
+    if species.kind == MoleculeKind.electron:
+        return Counter()
+    try:
+        return element_counts_from_smiles(species.smiles)
+    except ValueError:
+        # Named by its public ref in any message; the row id goes here only.
+        logger.warning(
+            "Unparseable stored SMILES on species id=%s public_ref=%s: %r; "
+            "calculation geometry composition not judged.",
+            species.id,
+            species.public_ref,
+            species.smiles,
+        )
+        return None
+
+
+def _transition_state_entry_reference(
+    session: Session, transition_state_entry_id: int
+) -> Counter[str] | None:
+    """Return the element counts of the reaction a TS entry sits in.
+
+    The reactant side, summed -- the same reference
+    :func:`app.services.reaction_resolution.validate_transition_state_composition`
+    compares the saddle point against, and for the same reason: a transition
+    state is a stationary point on the potential energy surface of the whole
+    reacting system.
+
+    ``None`` where the comparison would be meaningless: no reactants recorded
+    yet, or any reactant a pseudo-species. The pseudo exemption is scoped to
+    the *reactant* side only, exactly as it is in that function -- a pseudo
+    product leaves the reactant side fully atom-resolved and does not make the
+    sum unknowable.
+    """
+
+    reactants = session.scalars(
+        select(Species)
+        .select_from(ReactionEntryStructureParticipant)
+        .join(
+            TransitionState,
+            TransitionState.reaction_entry_id
+            == ReactionEntryStructureParticipant.reaction_entry_id,
+        )
+        .join(
+            TransitionStateEntry,
+            TransitionStateEntry.transition_state_id == TransitionState.id,
+        )
+        .join(
+            SpeciesEntry,
+            SpeciesEntry.id == ReactionEntryStructureParticipant.species_entry_id,
+        )
+        .join(Species, Species.id == SpeciesEntry.species_id)
+        .where(
+            TransitionStateEntry.id == transition_state_entry_id,
+            ReactionEntryStructureParticipant.role == ReactionRole.reactant,
+        )
+    ).all()
+    if not reactants:
+        return None
+    if any(species.kind == MoleculeKind.pseudo for species in reactants):
+        return None
+
+    totals: Counter[str] = Counter()
+    for species in reactants:
+        if species.kind == MoleculeKind.electron:
+            continue
+        try:
+            totals += element_counts_from_smiles(species.smiles)
+        except ValueError:
+            logger.warning(
+                "Unparseable stored SMILES on species id=%s public_ref=%s: %r; "
+                "calculation geometry composition not judged.",
+                species.id,
+                species.public_ref,
+                species.smiles,
+            )
+            return None
+    return totals
+
+
+def _reference_for(
+    calc: Calculation, session: Session
+) -> tuple[str, Counter[str]] | None:
+    """Return ``(owner_kind, element counts)`` for a calculation's subject.
+
+    ``None`` means the subject has no atom-resolved composition to compare
+    against, which is an absence and never a refusal.
+    """
+
+    owner_kind: str
+    owner_id: int
+    if calc.species_entry_id is not None:
+        owner_kind, owner_id = "species_entry", calc.species_entry_id
+    elif calc.transition_state_entry_id is not None:
+        owner_kind, owner_id = (
+            "transition_state_entry",
+            calc.transition_state_entry_id,
+        )
+    else:
+        # The ``one_owner`` CHECK forbids this, but the row may not have
+        # reached the database yet. Nothing to compare against is an absence.
+        return None
+
+    # Memoised per ``Session`` rather than per module, so nothing survives a
+    # rolled-back transaction or leaks between requests. One upload links many
+    # geometries to calculations that share a handful of subjects.
+    cache: dict[tuple[str, int], Counter[str]] = session.info.setdefault(
+        _CACHE_KEY, {}
+    )
+    key = (owner_kind, owner_id)
+    if key in cache:
+        return owner_kind, cache[key]
+
+    if owner_kind == "species_entry":
+        reference = _species_entry_reference(session, owner_id)
+    else:
+        reference = _transition_state_entry_reference(session, owner_id)
+
+    # Only a resolved answer is memoised. ``None`` can mean "the reactants are
+    # not persisted yet", which a later call in the same upload may legitimately
+    # answer differently; caching it would freeze an accident of ordering into
+    # a permanent exemption.
+    if reference is None:
+        return None
+    cache[key] = reference
+    return owner_kind, reference
+
+
+def _geometry_element_counts(session: Session, geometry_id: int) -> Counter[str]:
+    """Count a stored geometry's elements the way every comparison counts them."""
+
+    elements = session.scalars(
+        select(GeometryAtom.element).where(GeometryAtom.geometry_id == geometry_id)
+    ).all()
+    return Counter(resolve_element_symbol(element) for element in elements)
+
+
+def assert_calculation_geometry_composition(
+    session: Session,
+    *,
+    calc: Calculation,
+    geometry_id: int,
+    field: str,
+) -> None:
+    """Refuse a geometry not made of the atoms of the calculation's subject.
+
+    The one implementation. Every site that inserts a
+    ``calculation_input_geometry`` or ``calculation_output_geometry`` row calls
+    it, on both the producer-explicit branch and the ``geometry_key`` /
+    fallback branch. Checking only the explicit branch would leave the second
+    reproduction in the spec open: on the computed-reaction and PDep bundles
+    the fallback id is not fixed, and a transition state's calculations resolve
+    ``geometry_key`` against a bundle-global map that the wire schema narrows
+    for a species' calculations and not for a transition state's.
+
+    :param session: Active SQLAlchemy session.
+    :param calc: The calculation the geometry is being linked to. Its owner
+        columns must already be set; they are what the reference is derived
+        from.
+    :param geometry_id: The resolved geometry row. Its atoms must already be
+        flushed, which ``resolve_geometry_payload`` guarantees.
+    :param field: Field path naming the offending link the way the depositor
+        wrote it, echoed verbatim into the refusal. Never a row id.
+    :raises CodedValueError: If the geometry's element counts contradict the
+        composition of the subject the calculation is filed under.
+    """
+
+    resolved = _reference_for(calc, session)
+    if resolved is None:
+        return
+    owner_kind, reference = resolved
+
+    observed = _geometry_element_counts(session, geometry_id)
+    if observed == reference:
+        return
+
+    geometry_formula = format_element_counts(observed) or "empty"
+    if owner_kind == "species_entry":
+        subject = "the species this calculation belongs to"
+        subject_formula = format_element_counts(reference) or "no atoms at all"
+        repair = (
+            "Attach the structure this calculation was actually run on, or "
+            "file the calculation under the species that structure belongs "
+            "to. A calculation's numbers describe its geometry; if the "
+            "geometry is a different molecule than the identity, every one of "
+            "them is attributed to the wrong species."
+        )
+    else:
+        subject = "the reaction this transition state sits in"
+        subject_formula = format_element_counts(reference) or "no atoms at all"
+        repair = (
+            "A transition state is a stationary point on the potential energy "
+            "surface of its whole reacting system, so its calculations run on "
+            "all of those atoms -- not on one participant. Attach the "
+            "saddle-point structure, or declare the extra species as "
+            "participants of the reaction."
+        )
+
+    logger.warning(
+        "Calculation geometry composition mismatch: calculation id=%s "
+        "species_entry_id=%s transition_state_entry_id=%s geometry id=%s "
+        "field=%s observed=%s reference=%s",
+        calc.id,
+        calc.species_entry_id,
+        calc.transition_state_entry_id,
+        geometry_id,
+        field,
+        geometry_formula,
+        subject_formula,
+    )
+
+    raise CodedValueError(
+        W_CALCULATION_GEOMETRY_COMPOSITION_MISMATCH,
+        f"{field}: geometry is {geometry_formula}, but {subject} is "
+        f"{subject_formula} "
+        "(calculation_geometry_composition_mismatch). "
+        + repair
+        + " Hydrogens are counted explicitly on both sides, and isotope "
+        "labels are counted as their element -- SMILES [2H] and the XYZ "
+        "symbols D and T all count as H -- so an isotopologue is not a "
+        "mismatch, and only atom counts are compared, so a scan point, an "
+        "IRC point or a dissociated optimisation is not one either.",
+        context={
+            "field": field,
+            "owner_kind": owner_kind,
+            "geometry_formula": geometry_formula,
+            "subject_formula": subject_formula,
+        },
+        message_prefix=False,
+    )
+
+
+CHECK_CALCULATION_GEOMETRY_COMPOSITION = ScientificCheck(
+    group="A structure against its own label",
+    sort_key=3,
+    code=W_CALCULATION_GEOMETRY_COMPOSITION_MISMATCH,
+    asserts=(
+        "Every geometry linked to a calculation is made of the atoms of the "
+        "subject that calculation is filed under -- the species entry's own "
+        "formula, or, for a transition state, the sum of its reaction's "
+        "reactants."
+    ),
+    tier=CheckTier.block,
+    channel=CodeChannel.error_envelope,
+    tier_rationale=(
+        "Definitional. A calculation's numbers are computed from its geometry "
+        "and attributed to its subject; a geometry made of different atoms "
+        "than the subject makes that attribution false rather than weak. No "
+        "correct calculation can produce one, because no electronic-structure "
+        "program adds or removes a nucleus -- which is also why this holds for "
+        "output geometries and not only input ones: dissociation, "
+        "isomerisation and proton transfer all conserve element counts."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            assert_calculation_geometry_composition,
+            note=(
+                "Called from every site that inserts a "
+                "``calculation_input_geometry`` or "
+                "``calculation_output_geometry`` row -- eight of them across "
+                "four modules -- on both the producer-explicit branch and the "
+                "``geometry_key``/fallback branch. A guard test fails if a "
+                "ninth appears unchecked."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "Declare the structure's real composition: give the calculation the "
+        "geometry it was run on, or file it under the subject that geometry "
+        "belongs to. Absence does not block -- a ``pseudo`` owner, a "
+        "transition state whose reaction records no reactants or a pseudo "
+        "reactant, and an unparseable stored SMILES are all left unjudged. "
+        "Only atom counts are compared, so isotopologues, scan and IRC "
+        "points, constitutional isomers and dissociated optimisations all "
+        "pass."
+    ),
+    divergence=(
+        "A documented false *acceptance*, restated because a referee will "
+        "ask: counts alone cannot tell a constitutional isomer from its "
+        "partner, so an ethanol calculation carrying dimethyl ether "
+        "coordinates passes. Catching that needs bond perception from XYZ, "
+        "which fails silently on exactly the strained, radical and stretched "
+        "structures where it would matter -- the same reasoning that keeps "
+        "``species_geometry_composition_mismatch`` to counts. It also refuses "
+        "a geometry carrying ghost or dummy centres (counterpoise/BSSE), "
+        "because ``Bq`` appears in no SMILES; that refusal is correct while "
+        "``geometry_atom`` has no way to say 'no nucleus here', since such a "
+        "row is already miscounted by ``natoms`` and every "
+        "degrees-of-freedom read downstream."
+    ),
+)

--- a/backend/app/services/calculation_resolution.py
+++ b/backend/app/services/calculation_resolution.py
@@ -60,6 +60,9 @@ from app.schemas.fragments.refs import (
     SoftwareReleaseRef,
     WorkflowToolReleaseRef,
 )
+from app.services.calculation_geometry_composition import (
+    assert_calculation_geometry_composition,
+)
 from app.services.execution_environment_integrity import manifest_integrity_evidence
 from app.services.geometry_resolution import resolve_geometry_payload
 from app.services.literature_resolution import resolve_or_create_literature
@@ -579,6 +582,12 @@ def _persist_irc_result(
             and role is not None
             and geometry_id not in linked_geometry_ids
         ):
+            assert_calculation_geometry_composition(
+                session,
+                calc=calculation,
+                geometry_id=geometry_id,
+                field=f"irc_result.points[{point.point_index}].geometry",
+            )
             session.add(
                 CalculationOutputGeometry(
                     calculation_id=calculation.id,
@@ -650,6 +659,12 @@ def _persist_path_search_result(
         )
 
         if geometry_id is not None and geometry_id not in linked_geometry_ids:
+            assert_calculation_geometry_composition(
+                session,
+                calc=calculation,
+                geometry_id=geometry_id,
+                field=f"path_search_result.points[{point.point_index}].geometry",
+            )
             session.add(
                 CalculationOutputGeometry(
                     calculation_id=calculation.id,
@@ -1271,6 +1286,12 @@ def attach_calculation_input_geometries(
                     f"geometry at most once per calculation."
                 )
             seen_geometry_ids.add(geom.id)
+            assert_calculation_geometry_composition(
+                session,
+                calc=calc,
+                geometry_id=geom.id,
+                field=f"{context}: input_geometries[{input_order - 1}]",
+            )
             session.add(
                 CalculationInputGeometry(
                     calculation_id=calc.id,
@@ -1281,6 +1302,12 @@ def attach_calculation_input_geometries(
         return
 
     if fallback_geometry_id is not None and calc.type in _INPUT_GEOMETRY_TYPES:
+        assert_calculation_geometry_composition(
+            session,
+            calc=calc,
+            geometry_id=fallback_geometry_id,
+            field=f"{context}: geometry_key",
+        )
         session.add(
             CalculationInputGeometry(
                 calculation_id=calc.id,
@@ -1336,6 +1363,12 @@ def attach_calculation_output_geometries(
                     f"geometry at most once per calculation."
                 )
             seen_geometry_ids.add(geom.id)
+            assert_calculation_geometry_composition(
+                session,
+                calc=calc,
+                geometry_id=geom.id,
+                field=f"{context}: output_geometries[{output_order - 1}].geometry",
+            )
             session.add(
                 CalculationOutputGeometry(
                     calculation_id=calc.id,
@@ -1350,6 +1383,12 @@ def attach_calculation_output_geometries(
         if fallback_geometry_id not in _pending_output_geometry_ids(
             session, calc.id
         ):
+            assert_calculation_geometry_composition(
+                session,
+                calc=calc,
+                geometry_id=fallback_geometry_id,
+                field=f"{context}: geometry_key",
+            )
             session.add(
                 CalculationOutputGeometry(
                     calculation_id=calc.id,

--- a/backend/app/services/charge_multiplicity_reconciliation.py
+++ b/backend/app/services/charge_multiplicity_reconciliation.py
@@ -320,7 +320,7 @@ def reconcile_charge_multiplicity(
 
 CHECK_CHARGE_MULTIPLICITY_VS_LOG = ScientificCheck(
     group="A structure against its own label",
-    sort_key=4,
+    sort_key=5,  # Shifted from 4 by #143; see CHECK_SMILES_CHARGE_MATCHES_DECLARED.
     code=(W_CHARGE_MISMATCH, W_MULTIPLICITY_MISMATCH),
     asserts=(
         "The charge and spin multiplicity a depositor declares match the ones "

--- a/backend/app/services/geometry_validation.py
+++ b/backend/app/services/geometry_validation.py
@@ -42,13 +42,27 @@ Where the formula rule blocks
 -----------------------------
 Per ADR 0008 §9, where the same fact is checked in more than one tier the
 blocking tier owns it and the others cite it. Formula agreement between a
-structure and the identity it is deposited under is owned by
-:func:`app.services.species_resolution.assert_geometry_composition_matches_identity`,
-which refuses the upload outright — but only for **conformer** geometries. A
-calculation's input and output geometries reach no composition check on any
-upload path, so for those this service's advisory row is the only place the
-comparison happens at all. That is deliberate for an *output* geometry: an
-optimisation that drifted is science to record, not a payload to refuse.
+structure and the identity it is deposited under is owned by two blocking
+rules that between them cover every geometry:
+:func:`app.services.species_resolution.assert_geometry_composition_matches_identity`
+for a **conformer** geometry, and
+:func:`app.services.calculation_geometry_composition.assert_calculation_geometry_composition`
+for every geometry linked to a **calculation** (#143). Both refuse outright.
+
+**Consequence for this service: ``validation_status=fail`` is no longer
+reachable through any upload path.** The ``fail`` branch fires when
+``is_isomorphic`` is false, and — as the verified consequences above record —
+that happens only when the element counts disagree. No calculation can change
+an element count, so that verdict was only ever reachable by depositing a
+geometry no calculation could have produced, and such a deposit is now refused
+before this service runs. What stays live, and is why the row still exists, is
+the RMSD signal: a ``warning`` on a converged structure that moved further
+than the threshold from its input is a suspicion about a *correct-formula*
+deposit, which is exactly the expectation tier this service belongs to. The
+note that used to stand here — that refusing an output geometry would wrongly
+reject "an optimisation that drifted" — confused connectivity with
+composition. A drifted or dissociated optimisation keeps its atoms and passes
+the blocking rule, as the methane-at-5-A case above shows.
 
 Not in scope here:
 
@@ -426,7 +440,7 @@ def run_and_persist_geometry_validation(
 
 CHECK_OPT_GEOMETRY_MATCHES_DECLARED_SPECIES = ScientificCheck(
     group="A structure against its own label",
-    sort_key=5,
+    sort_key=6,  # Shifted from 5 by #143; see CHECK_SMILES_CHARGE_MATCHES_DECLARED.
     code=None,
     asserts=(
         "An optimisation's output geometry still describes the species it was "
@@ -441,7 +455,12 @@ CHECK_OPT_GEOMETRY_MATCHES_DECLARED_SPECIES = ScientificCheck(
         "unreliable for exactly the weak complexes, radicals, ions and "
         "stretched geometries where a genuine rearrangement would matter. The "
         "result is written as an evidence row that grades the record at read "
-        "time; it never refuses an upload."
+        "time; it never refuses an upload. Since #143 the tier is also the "
+        "only one left to it: the *composition* half of what this row reports "
+        "is owned by ``calculation_geometry_composition_mismatch``, which "
+        "blocks, so what this row can still say on its own is the RMSD "
+        "suspicion — a correct-formula structure that moved further than "
+        "expected, which is an expectation by construction."
     ),
     adr="0008, 0002",
     emitted=False,
@@ -455,7 +474,14 @@ CHECK_OPT_GEOMETRY_MATCHES_DECLARED_SPECIES = ScientificCheck(
                 "missing output geometry, unparseable coordinates or a raising "
                 "chemistry layer all write nothing and let the upload "
                 "continue. A Kabsch RMSD above 1.0 A against the input "
-                "geometry is recorded as a separate suspicion signal."
+                "geometry is recorded as a separate suspicion signal. Its "
+                "``fail`` outcome is no longer reachable through an upload "
+                "path: ``is_isomorphic=False`` fires only on an element-count "
+                "mismatch, no calculation can change an element count, and "
+                "``assert_calculation_geometry_composition`` refuses such a "
+                "deposit before this runs. The pure seam keeps the verdict "
+                "and is pinned directly by "
+                "``tests/workflows/test_geometry_validation_wiring.py``."
             ),
         ),
     ),

--- a/backend/app/services/species_resolution.py
+++ b/backend/app/services/species_resolution.py
@@ -399,19 +399,25 @@ def assert_geometry_composition_matches_identity(
     computed-reaction bundle and the PDep bundle, because all four resolve
     their conformer geometries through this one seam.
 
-    **Calculation geometries are not reached, on any path.**
+    **Calculation geometries are reached by a sibling rule, not by this one.**
     ``CalculationIn.input_geometries`` and ``output_geometries`` are attached
-    to a ``calculation`` row, never resolved through
-    :func:`resolve_species_entry`, and no composition check runs on them
-    anywhere: benzene coordinates can be attached as a calculation geometry
-    under a ``smiles: "C"`` species entry and the deposit is accepted. The
-    only comparison they get is
-    :mod:`app.services.geometry_validation`, which is advisory rather than
-    blocking, runs only for ``opt`` calculations, and — despite its
-    ``is_isomorphic`` field name — compares formulas too (see that module's
-    docstring). Closing that gap for *output* geometries would be wrong: an
-    optimisation that dissociated is science to record. Closing it for *input*
-    geometries is a genuine open gap and is not attempted here.
+    to a ``calculation`` row and never resolved through
+    :func:`resolve_species_entry`, so this function does not see them. Until
+    #143 nothing else did either, and benzene coordinates could be attached as
+    a calculation geometry under a ``smiles: "C"`` species entry. They are now
+    owned by
+    :func:`app.services.calculation_geometry_composition.assert_calculation_geometry_composition`,
+    which applies the same comparison against whichever subject the
+    calculation is filed under — this entry's own formula for a species-owned
+    calculation, the reaction's reactant sum for a transition-state-owned one.
+
+    The note that stood here said closing the gap for *output* geometries
+    would be wrong because "an optimisation that dissociated is science to
+    record". That is true of connectivity and false of composition: every
+    calculation type is a map over a fixed set of nuclei, so a dissociated
+    optimisation has exactly the atoms it started with. The sibling rule
+    therefore covers both directions; see
+    ``backend/docs/specs/calculation_geometry_composition.md``.
 
     What is compared, and what deliberately is not
     ----------------------------------------------

--- a/backend/app/services/transition_state_resolution.py
+++ b/backend/app/services/transition_state_resolution.py
@@ -14,6 +14,9 @@ from app.db.models.calculation import Calculation, CalculationOutputGeometry
 from app.db.models.common import CalculationGeometryRole
 from app.db.models.transition_state import TransitionState, TransitionStateEntry
 from app.schemas.fragments.calculation import CalculationWithResultsPayload
+from app.services.calculation_geometry_composition import (
+    assert_calculation_geometry_composition,
+)
 from app.services.calculation_resolution import (
     persist_additional_calculations,
     resolve_and_persist_calculation_with_results,
@@ -92,6 +95,20 @@ def persist_ts_calculations(
         primary_opt_upload,
         transition_state_entry_id=transition_state_entry_id,
         created_by=created_by,
+    )
+    # The saddle geometry has already been compared against this reaction's
+    # reactants by ``validate_transition_state_composition``, so this call
+    # cannot refuse anything the caller has not already been refused for. It
+    # is here so that the invariant is stated at every site that writes the
+    # row rather than at all-but-one of them: this is the only site that adds
+    # a ``calculation_output_geometry`` without going through
+    # ``attach_calculation_output_geometries``, and a future caller passing a
+    # different ``geometry_id`` would otherwise inherit an unchecked path.
+    assert_calculation_geometry_composition(
+        session,
+        calc=primary_calc,
+        geometry_id=geometry_id,
+        field="primary_opt: geometry",
     )
     session.add(
         CalculationOutputGeometry(

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -63,6 +63,9 @@ from app.schemas.workflows.reaction_upload import (
     ReactionUploadRequest,
 )
 from app.services.artifact_persistence import persist_artifact
+from app.services.calculation_geometry_composition import (
+    assert_calculation_geometry_composition,
+)
 from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
     resolve_workflow_tool_release_ref,
@@ -159,6 +162,17 @@ def _persist_calculation(
     )
 
     if effective_geometry_id is not None:
+        # ``geometry_key`` resolves against a map spanning every species and
+        # every transition state in the bundle, so this is a real refusal
+        # rather than a restatement: a well's calculation naming another
+        # well's geometry, or a transition state's naming a participant's,
+        # reaches here with the wrong atoms.
+        assert_calculation_geometry_composition(
+            session,
+            calc=calculation,
+            geometry_id=effective_geometry_id,
+            field=f"calculation '{calc_in.key}': geometry_key",
+        )
         session.add(
             CalculationOutputGeometry(
                 calculation_id=calculation.id,

--- a/backend/docs/specs/calculation_geometry_composition.md
+++ b/backend/docs/specs/calculation_geometry_composition.md
@@ -211,13 +211,13 @@ chemistry seam's `is_isomorphic=False` verdict by direct call, so the
 
 ## Fixture rot the rule found on its first run
 
-Three test fixtures were chemically incoherent in the way the conformer rule
-found in the pressure-dependent fixtures ("ethyl as three atoms, HO2 as two"),
-and nothing had looked:
+Five geometry fixtures across two files were chemically incoherent in the way
+the conformer rule found in the pressure-dependent fixtures ("ethyl as three
+atoms, HO2 as two"), and nothing had looked:
 
-* `tests/workflows/test_transition_state_upload.py` — the IRC endpoints and
-  NEB images of an H + H2 → H2 + H saddle point were **single hydrogen atoms**.
-  One atom on the reaction path of a three-atom system.
+* `tests/workflows/test_transition_state_upload.py` — the two IRC endpoints and
+  the two NEB images of an H + H2 → H2 + H saddle point were **single hydrogen
+  atoms**. One atom on the reaction path of a three-atom system.
 * `tests/workflows/test_computed_reaction_upload.py` — the `irc_reverse`
   endpoint of a CH3 + H → CH4 path was `_XYZ_CH3`, four atoms where every
   point on that path has five.
@@ -247,6 +247,23 @@ Deliberately **out of scope**, and stated rather than left to be discovered:
 Both are real remaining holes. They are narrower than the one closed here,
 they reach different tables, and folding them in would mean four more call
 sites checked less carefully rather than eight checked properly.
+
+## Found while tracing the seam, not fixed here
+
+`persist_ts_calculations` (`app/services/transition_state_resolution.py`) is
+the only caller that links the primary calculation's geometry directly instead
+of going through `attach_calculation_output_geometries`. A consequence, which
+is nothing to do with composition and predates this change: on
+`/uploads/transition-state`, `primary_opt.input_geometries` and
+`primary_opt.output_geometries` **are never read**. A producer declaring a
+pre-optimisation TS guess gets zero rows and no warning — verified by direct
+probe: *"primary_opt declared 1 input_geometry; calculation_input_geometry rows
+persisted = 0"*. Every other upload root routes its primary calculation through
+the shared attach helpers, so this route is the odd one out.
+
+Silent field loss is its own defect with its own repair and its own test, and
+it is a behaviour change to a write path, so it is reported rather than folded
+in here.
 
 ## Schema and migration impact
 

--- a/backend/docs/specs/calculation_geometry_composition.md
+++ b/backend/docs/specs/calculation_geometry_composition.md
@@ -1,0 +1,276 @@
+# A calculation's geometries must be made of its subject's atoms
+
+## The gap
+
+A **conformer** geometry is compared against the species entry it is deposited
+under by `assert_geometry_composition_matches_identity`
+(`backend/app/services/species_resolution.py:364`). A **calculation's**
+geometries were compared against nothing, on any path, for any subject. That
+function's own docstring said so, and called the input half "a genuine open
+gap" (`species_resolution.py:414`).
+
+Two deposits, both accepted on `main` before this change:
+
+```
+=== UPLOAD ACCEPTED ===
+species_entry smiles declared: C  (methane, CH4)
+calc type=opt owner_species_entry=True input_geometry_formulas=['C 6H 6'] output_geometry_formulas=['C 1H 4']
+calc type=sp  owner_species_entry=True input_geometry_formulas=['C 1H 4'] output_geometry_formulas=['C 6H 6']
+```
+
+```
+=== UPLOAD ACCEPTED ===
+reaction: [CH]=O + C -> C=O + [CH3]   (reactant sum = C2H5O)
+TS-owned calc type=opt  input_geometry_formulas=['C 2H 5O 1']
+TS-owned calc type=freq input_geometry_formulas=['C 1H 4']     <-- methane
+TS-owned calc type=sp   input_geometry_formulas=['C 2H 5O 1']
+TS-owned calc type=irc  input_geometry_formulas=['C 2H 5O 1']
+```
+
+The second reached the database by a different route than the first, and that
+route is what shaped the design — see "Two routes, not one" below.
+
+## The rule
+
+> **Every geometry linked to a calculation must be made of the atoms of the
+> subject that calculation is filed under.**
+
+`calculation` carries a `one_owner` CHECK constraint
+(`app/db/models/calculation.py:302`): exactly one of `species_entry_id` and
+`transition_state_entry_id` is set. So "which subject do I compare against?"
+has exactly two answers, and both references already exist in the codebase:
+
+| Owner | Reference composition | Already used by |
+|---|---|---|
+| species entry | element counts of `species.smiles` | `assert_geometry_composition_matches_identity` |
+| transition-state entry | **sum of the element counts of the reaction's reactants** | `validate_transition_state_composition` |
+
+`transition_state.reaction_entry_id` is `NOT NULL`, so the reactant sum is
+always reachable from a TS-owned calculation.
+
+What is compared, and what deliberately is not — inherited verbatim from the
+conformer rule so the two cannot drift:
+
+* **Elements, not nuclides.** `D` and `T` in the XYZ element column count as
+  `H` (`resolve_element_symbol`); `[2H]` in a SMILES counts as `H`
+  (`element_counts_from_smiles`). Isotopologues pass. Isotope agreement is a
+  separate rule with its own code.
+* **Counts, not positions.** No connectivity, no RMSD, no geometric predicate
+  of any kind.
+* **Absence never blocks.** A `pseudo` owner, a TS whose reaction records no
+  reactants or records a `pseudo` reactant, or a stored SMILES RDKit will not
+  parse — all return without judging. Incompleteness is not contradiction.
+* **A free electron is not absence.** Its composition is empty, not unknown,
+  so any geometry contradicts it. (In practice the wire schema refuses this
+  earlier, since #151; the branch exists so the function is safe anywhere.)
+
+Tier, in ADR 0008's terms: **block**. The ADR's test is whether the check
+could plausibly fire on a correct novel result. It cannot. A structure that is
+not made of its own subject's atoms is not a weaker record, it is a
+contradictory one, and every number computed from it describes something
+nobody deposited. Same tier as both of its neighbours.
+
+## Case analysis
+
+The three cases the design had to survive, plus the one found while checking.
+
+### 1. A transition-state geometry spans the whole reacting system
+
+For `CH3 + H -> CH4` the saddle point holds all five atoms and is neither
+reactant nor product. Handled by the owner table above: a TS-owned calculation
+is compared against the **reactant sum**, never against a participant. This is
+not a new rule — `validate_transition_state_composition` has compared the
+saddle point itself against exactly that sum since it landed.
+
+Evidence, not assertion: the rule was run over every calculation geometry in
+the thirteen ARC-derived fixture payloads under
+`backend/tests/fixtures/arc_runs/`. All 31 are TS-owned — NEB path-search
+images, IRC points, scan points, freq and sp inputs — and **none is refused**.
+Had the reference been the TS's own `unmapped_smiles`, or any single
+participant, all 31 would have gone red.
+
+### 2. Isotopologues
+
+CH4 and CD4 are both C + 4H by element. The check never sees the difference:
+both sides fold nuclides onto elements before counting. `assert_geometry_isotopes_match_identity`
+owns isotope agreement, blocks on it, and is untouched here — per ADR 0008 §9
+the blocking tier owns a rule and the others cite it.
+
+### 3. Scan and IRC points are deliberately not the equilibrium structure
+
+They have the right atoms in a distorted arrangement. The rule counts atoms
+and looks at no coordinate, so a scan point at 5 Å, an IRC endpoint in a
+product well, and a dissociated fragment pair all pass. Nothing in the
+implementation can drift toward plausibility, because no coordinate is read.
+
+### 4. Ghost and dummy centres — found, and refused on purpose
+
+`parse_xyz` accepts any one- or two-character token as an element symbol; `X`,
+`Bq`, `Gh` and `Xx` all store successfully (verified by direct call). So a
+counterpoise/BSSE geometry — a monomer in the dimer basis, with ghost centres
+carrying basis functions and no nucleus — is storable today, and under this
+rule it is refused, because `Bq` appears in no SMILES.
+
+That refusal is correct, and the reason is worth writing down rather than
+carving an exemption for. `geometry_atom` has `element`, `x/y/z` and
+`isotope_mass_number` and nothing that says *no nucleus here*. A ghost centre
+stored as an atom is already a misrepresentation: `geometry.natoms` counts it,
+every degrees-of-freedom count downstream reads it as a nucleus, and the
+frequency-count check would compare against the wrong `3N-6`. The conformer
+rule has refused such geometries since it landed and nothing has complained.
+Carving an exemption here would preserve a corrupt representation; the repair
+belongs at the representation layer — either a `is_ghost` column or a refusal
+at parse time — and deserves its own task.
+
+### Considered and rejected as a legitimate case
+
+**A microsolvated or clustered calculation filed under the bare species** —
+ethanol's entry carrying an `sp` on ethanol plus three explicit waters. Real
+science, wrong filing: the cluster is a different chemical species with its own
+identity, and depositing it under ethanol makes "ethanol's energy" the
+cluster's energy. That is precisely the corruption the rule exists to refuse.
+
+## Two routes, not one — why the fallback path is checked
+
+`attach_calculation_input_geometries` / `attach_calculation_output_geometries`
+have two branches: a **producer-explicit** one that resolves
+`input_geometries` / `output_geometries` from the payload, and a **fallback**
+one that links a `fallback_geometry_id` the workflow passes in. It would be
+tempting to check only the explicit branch, on the reasoning that the fallback
+geometry is the conformer or saddle geometry that the owner-level check has
+already validated.
+
+That reasoning is wrong on two of the routes. On `/uploads/computed-reaction`
+and `/uploads/networks/pdep` the fallback id is not fixed — a calculation may
+name any geometry in the bundle through `geometry_key`, resolved against a
+**single bundle-global map** (`computed_reaction.py:417`, populated with every
+species' conformer geometry at :461 *and* the TS geometry at :646). For a
+species' calculations the wire schema narrows that key to the species' own
+conformers (`computed_reaction_upload.py:691`). For a **transition state's**
+calculations it does not — `BundleTransitionStateIn` has no equivalent
+validator — which is the second reproduction above: a TS frequency calculation
+naming a reactant's geometry key and getting methane attached to a C2H5O
+saddle point.
+
+This is the same asymmetry already recorded for statmech torsion scan keys in
+`app/services/calculation_ownership.py`. Narrowing the key in the wire schema
+would close this instance; checking composition at the database seam closes it
+for every route at once, including the ones nobody has thought of. Both
+branches are therefore checked.
+
+## Why output geometries are checked, contrary to the note that stood here
+
+Two modules said closing the output half would be wrong:
+
+> Closing that gap for *output* geometries would be wrong: an optimisation that
+> dissociated is science to record. — `species_resolution.py:412`
+
+> That is deliberate for an *output* geometry: an optimisation that drifted is
+> science to record, not a payload to refuse. — `geometry_validation.py`
+
+That argument is correct about **connectivity** and does not transfer to
+**composition**. Every one of the seven `CalculationType` values — `opt`,
+`freq`, `sp`, `irc`, `scan`, `path_search`, `conf` — is a map over a fixed set
+of nuclei. No electronic-structure program adds or removes a nucleus during
+one. Dissociation, isomerisation, proton transfer and ring opening all
+*conserve* element counts.
+
+`geometry_validation.py`'s own recorded evidence says exactly this, one
+paragraph above the exemption it justifies:
+
+> Methane with one hydrogen pulled out to 5 Å, i.e. a dissociated fragment
+> pair — **passes**.
+
+The case cited to justify exempting output geometries is a case the
+composition rule accepts. The exemption protected no correct science, and it
+was protecting the larger half: the live database holds 1806 calculation
+output geometries against 326 inputs.
+
+## What this does to the advisory row beside it
+
+`calc_geometry_validation` records an advisory verdict on a species-owned
+`opt` calculation's output geometry, with three outcomes: `passed`, `warning`
+(RMSD above threshold) and `fail` (`is_isomorphic=False`). Its own module
+docstring records, by direct call, that `is_isomorphic` is false **only** when
+the per-element atom counts disagree — ethanol declared with dimethyl ether
+deposited passes; methane with a hydrogen at 5 Å passes.
+
+Combine that with the paragraph above and the conclusion is unavoidable: the
+`fail` verdict was only ever reachable by depositing a geometry that no
+calculation could have produced. It is now unreachable through any upload
+path, because such a deposit is refused first. Per ADR 0008 §9 the blocking
+tier owns the fact and the others cite it, so this is the rule working as the
+ADR intends rather than a capability lost. What the row still says on its own
+is the RMSD suspicion — a *correct-formula* structure that moved further than
+expected — which is an expectation by construction and correctly non-blocking.
+
+`tests/workflows/test_geometry_validation_wiring.py` was asserting the `fail`
+row. It now asserts the refusal that replaced it, and separately pins the pure
+chemistry seam's `is_isomorphic=False` verdict by direct call, so the
+`passed` verdict on every accepted deposit does not become vacuous.
+
+## Fixture rot the rule found on its first run
+
+Three test fixtures were chemically incoherent in the way the conformer rule
+found in the pressure-dependent fixtures ("ethyl as three atoms, HO2 as two"),
+and nothing had looked:
+
+* `tests/workflows/test_transition_state_upload.py` — the IRC endpoints and
+  NEB images of an H + H2 → H2 + H saddle point were **single hydrogen atoms**.
+  One atom on the reaction path of a three-atom system.
+* `tests/workflows/test_computed_reaction_upload.py` — the `irc_reverse`
+  endpoint of a CH3 + H → CH4 path was `_XYZ_CH3`, four atoms where every
+  point on that path has five.
+
+All were replaced with the whole reacting system at different path
+coordinates. Every assertion in those tests — point counts, roles, orders,
+linkage — is unchanged.
+
+## Where the check runs
+
+One function, `assert_calculation_geometry_composition`, called from every site
+that inserts a `calculation_input_geometry` or `calculation_output_geometry`
+row. There are eight, in four modules, and a guard test
+(`tests/services/test_calculation_geometry_composition_guard.py`) fails if a
+ninth appears without one — the same device the scientific-check register uses
+to stop a declaration going unregistered.
+
+Deliberately **out of scope**, and stated rather than left to be discovered:
+
+* `calc_scan_point.geometry_id`, `calc_irc_point.geometry_id` and
+  `calc_path_search_point.geometry_id` where they do *not* also produce an
+  output-geometry row. IRC and path-search points do produce one and are
+  therefore covered; a scan point's geometry is stored on the point row only.
+* `calc_hessian.geometry_id`. It is resolved from its own payload and bound to
+  the Hessian, not to the calculation's geometry lists.
+
+Both are real remaining holes. They are narrower than the one closed here,
+they reach different tables, and folding them in would mean four more call
+sites checked less carefully rather than eight checked properly.
+
+## Schema and migration impact
+
+**None.** No model change, no migration, no new column, no new environment
+variable. The rule reads `species.smiles`, `geometry_atom.element` and the
+existing reaction-participant rows, and raises before the link row is added.
+
+## Behavioural impact on existing deposits
+
+The refusal is new, so a payload accepted yesterday can be refused today. On
+the evidence available:
+
+* The live instance holds 326 calculation input geometries and 1806 output
+  geometries across 448 species-entry-owned and 124 TS-owned calculations, and
+  no species entry's calculation geometries disagree among themselves. The
+  check is preventative there.
+* Every calculation geometry in the repository's thirteen ARC-derived fixture
+  payloads passes (31 of 31, all TS-owned).
+* The only deposits the rule refuses on re-run are the three incoherent test
+  fixtures above and the deliberately-mismatched payload in the
+  geometry-validation wiring test.
+
+A backfill is neither required nor possible: the rule refuses at write time
+and reads nothing that a stored row would have to be migrated to satisfy. A
+survey of stored rows against the rule would be worth running against the live
+instance before the next release; it is not attempted here because this branch
+cannot reach that database.

--- a/backend/docs/specs/calculation_geometry_composition.md
+++ b/backend/docs/specs/calculation_geometry_composition.md
@@ -281,8 +281,10 @@ the evidence available:
   no species entry's calculation geometries disagree among themselves. The
   check is preventative there.
 * Every calculation geometry in the repository's thirteen ARC-derived fixture
-  payloads passes (31 of 31, all TS-owned).
-* The only deposits the rule refuses on re-run are the three incoherent test
+  payloads passes (31 of 31, all TS-owned). Not only against a reimplementation
+  of the rule: `tests/api/test_api_arc_run_fixtures.py` uploads those payloads
+  through the real API, and all fourteen of its tests pass with the check live.
+* The only deposits the rule refuses on re-run are the incoherent test
   fixtures above and the deliberately-mismatched payload in the
   geometry-validation wiring test.
 

--- a/backend/tests/api/test_api_scientific_rejection_codes.py
+++ b/backend/tests/api/test_api_scientific_rejection_codes.py
@@ -157,6 +157,27 @@ class TestAStructureAgainstItsOwnLabel:
         body = _assert_code(response, "species_geometry_composition_mismatch")
         assert "species_geometry_composition_mismatch" in str(body["detail"])
 
+    def test_a_calculation_geometry_of_another_molecule_names_its_own_code(
+        self, client
+    ):
+        """The conformer geometry is right; the calculation's is not.
+
+        Deliberately a *different* code from the check above, and this is the
+        payload that shows why one would not do: the species entry's own
+        structure is correct methane, so ``species_geometry_composition_mismatch``
+        cannot fire, and the only thing wrong is a geometry attached to a
+        calculation. A client repairing that edits a calculation's
+        ``input_geometries``; a client repairing the other edits the
+        conformer. Different fields, different repairs, different codes.
+        """
+        payload = _conformer_payload(
+            species_entry=_METHANE, xyz_text=_METHANE_XYZ
+        )
+        payload["calculation"]["input_geometries"] = [{"xyz_text": _METHYL_XYZ}]
+        response = client.post("/api/v1/uploads/conformers", json=payload)
+        body = _assert_code(response, "calculation_geometry_composition_mismatch")
+        assert "calculation_geometry_composition_mismatch" in str(body["detail"])
+
     def test_isotope_labels_that_disagree_name_the_isotope_check(self, client):
         # CH3D by SMILES, all-protium by geometry. Same formula, so the
         # composition check above passes and only the isotope one can fire.

--- a/backend/tests/services/test_calculation_geometry_composition.py
+++ b/backend/tests/services/test_calculation_geometry_composition.py
@@ -1,0 +1,652 @@
+"""A calculation's geometries must be made of its subject's atoms.
+
+Nothing compared them before. A conformer geometry has been checked against
+its species entry since ``assert_geometry_composition_matches_identity``
+landed; a *calculation's* geometries were checked against nothing, on any
+path, for any subject — that function's own docstring said so and called the
+input half "a genuine open gap". Two deposits that succeeded on ``main``:
+
+* a species entry declaring methane (``smiles: "C"``) whose optimisation
+  carried benzene coordinates as its input geometry and whose single point
+  carried benzene as its *output* geometry;
+* a transition state for ``[CH]=O + C -> C=O + [CH3]`` whose frequency
+  calculation carried methane, reached by naming a reactant's ``geometry_key``
+  in a bundle-global namespace.
+
+Both are reproduced below as refusals.
+
+**The accepting half of this file is the point.** A blocking check that
+refuses correct science is worse than no check (ADR 0008), and the three
+shapes that had to survive the design are each pinned here as an *acceptance*:
+
+1. a transition state's geometry spans the whole reacting system and is
+   neither reactant nor product;
+2. an isotopologue is the same molecule by element, and D and T are hydrogen;
+3. a scan point, an IRC endpoint and a dissociated optimisation are
+   deliberately not the equilibrium structure.
+
+Plus the case the rule's shape turns on, which the two blocking neighbours
+had already settled and which is easy to get wrong here: composition is
+conserved by every calculation type, so an *output* geometry is checked
+exactly like an input one.
+
+The full argument, including the cases considered and rejected, is in
+``backend/docs/specs/calculation_geometry_composition.md``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.error_contract import CodedValueError
+from app.db.models.app_user import AppUser
+from app.db.models.calculation import (
+    Calculation,
+    CalculationInputGeometry,
+    CalculationOutputGeometry,
+)
+from app.schemas.workflows.computed_species_upload import (
+    ComputedSpeciesUploadRequest,
+)
+from app.schemas.workflows.transition_state_upload import (
+    TransitionStateUploadRequest,
+)
+from app.workflows.computed_species import persist_computed_species_upload
+from app.workflows.transition_state import persist_transition_state_upload
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "wb97xd", "basis": "def2tzvp"}
+_USER_ID = 50_721
+
+#: Methane, CH4.
+_XYZ_CH4 = (
+    "5\nmethane\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.629 -0.629 -0.629"
+)
+#: Methane with one C-H stretched to 5 A: a dissociated fragment pair. Still
+#: CH4 by composition, because dissociation moves nuclei rather than deleting
+#: them. This is the geometry the exemption for output geometries was written
+#: to protect, and it passes.
+_XYZ_CH4_DISSOCIATED = (
+    "5\nmethane, one hydrogen at 5 A\n"
+    "C  0.000  0.000  0.000\n"
+    "H  0.629  0.629  0.629\n"
+    "H -0.629 -0.629  0.629\n"
+    "H -0.629  0.629 -0.629\n"
+    "H  0.000  0.000  5.000"
+)
+#: Benzene, C6H6. Nothing to do with methane.
+_XYZ_BENZENE = (
+    "12\nbenzene\n"
+    "C  1.396  0.000  0.000\n"
+    "C  0.698  1.209  0.000\n"
+    "C -0.698  1.209  0.000\n"
+    "C -1.396  0.000  0.000\n"
+    "C -0.698 -1.209  0.000\n"
+    "C  0.698 -1.209  0.000\n"
+    "H  2.479  0.000  0.000\n"
+    "H  1.240  2.147  0.000\n"
+    "H -1.240  2.147  0.000\n"
+    "H -2.479  0.000  0.000\n"
+    "H -1.240 -2.147  0.000\n"
+    "H  1.240 -2.147  0.000"
+)
+#: Fully deuterated methane, with the hydrogens written ``D`` — a spelling
+#: Gaussian, ORCA, Molpro and CFOUR all emit or accept.
+_XYZ_CD4 = (
+    "5\nperdeuteromethane\n"
+    "C  0.000  0.000  0.000\n"
+    "D  0.629  0.629  0.629\n"
+    "D -0.629 -0.629  0.629\n"
+    "D -0.629  0.629 -0.629\n"
+    "D  0.629 -0.629 -0.629"
+)
+#: Ethane, C2H6, at its equilibrium-ish geometry.
+_XYZ_ETHANE = (
+    "8\nethane\n"
+    "C  0.000  0.000  0.765\n"
+    "C  0.000  0.000 -0.765\n"
+    "H  1.017  0.000  1.163\n"
+    "H -0.508  0.881  1.163\n"
+    "H -0.508 -0.881  1.163\n"
+    "H  1.017  0.000 -1.163\n"
+    "H -0.508  0.881 -1.163\n"
+    "H -0.508 -0.881 -1.163"
+)
+#: The same ethane with its C-C-H-H dihedral driven to eclipsed and the C-C
+#: bond stretched: a rotor-scan point, deliberately not the minimum.
+_XYZ_ETHANE_SCAN_POINT = (
+    "8\nethane, eclipsed, C-C stretched\n"
+    "C  0.000  0.000  0.900\n"
+    "C  0.000  0.000 -0.900\n"
+    "H  1.017  0.000  1.300\n"
+    "H -0.508  0.881  1.300\n"
+    "H -0.508 -0.881  1.300\n"
+    "H  1.017  0.000 -1.300\n"
+    "H -0.508  0.881 -1.300\n"
+    "H -0.508 -0.881 -1.300"
+)
+
+#: The H + H2 -> H2 + H saddle point: three atoms, the whole reacting system.
+_XYZ_H3_TS = "3\nH...H...H\nH 0.0 0.0 0.0\nH 0.0 0.0 0.9\nH 0.0 0.0 1.8"
+#: The reactant end of that IRC. Still three atoms.
+_XYZ_H3_IRC_R = "3\nR\nH 0.0 0.0 0.00\nH 0.0 0.0 0.74\nH 0.0 0.0 2.50"
+#: The product end. Still three atoms.
+_XYZ_H3_IRC_F = "3\nF\nH 0.0 0.0 0.00\nH 0.0 0.0 1.76\nH 0.0 0.0 2.50"
+#: One hydrogen atom — a *participant* of that reaction, not a point on it.
+_XYZ_H = "1\nH\nH 0.0 0.0 0.0"
+
+
+@contextmanager
+def _isolated_session(db_conn) -> Iterator[Session]:
+    session = Session(bind=db_conn, expire_on_commit=False)
+    try:
+        session.add(AppUser(id=_USER_ID, username="calc_geometry_composition"))
+        session.flush()
+        yield session
+    finally:
+        session.close()
+
+
+def _species_bundle(
+    *,
+    smiles: str,
+    conformer_xyz: str,
+    charge: int = 0,
+    multiplicity: int = 1,
+    isotopes: dict[int, int] | None = None,
+    opt_input_xyz: str | None = None,
+    sp_output_xyz: str | None = None,
+) -> dict:
+    geometry: dict = {"xyz_text": conformer_xyz}
+    if isotopes is not None:
+        geometry["isotopes"] = isotopes
+    primary: dict = {
+        "key": "opt0",
+        "type": "opt",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "opt_result": {"converged": True},
+    }
+    if opt_input_xyz is not None:
+        primary["input_geometries"] = [{"xyz_text": opt_input_xyz}]
+    additional: list[dict] = []
+    if sp_output_xyz is not None:
+        additional.append(
+            {
+                "key": "sp0",
+                "type": "sp",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "sp_result": {"electronic_energy_hartree": -40.5},
+                "output_geometries": [
+                    {"geometry": {"xyz_text": sp_output_xyz}, "role": "final"}
+                ],
+            }
+        )
+    return {
+        "species_entry": {
+            "smiles": smiles,
+            "charge": charge,
+            "multiplicity": multiplicity,
+        },
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": geometry,
+                "primary_calculation": primary,
+                "additional_calculations": additional,
+            }
+        ],
+    }
+
+
+def _upload_species(session: Session, payload: dict):
+    return persist_computed_species_upload(
+        session,
+        ComputedSpeciesUploadRequest(**payload),
+        created_by=_USER_ID,
+    )
+
+
+def _ts_payload(*, irc_point_xyz: str | None = None) -> dict:
+    """A standalone TS upload for ``[H] + [H][H] -> [H] + [H][H]``."""
+
+    additional: list[dict] = [
+        {
+            "type": "freq",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "freq_result": {"n_imag": 1, "imag_freq_cm1": -1500.0},
+        }
+    ]
+    if irc_point_xyz is not None:
+        additional.append(
+            {
+                "type": "irc",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "output_geometries": [
+                    {"geometry": {"xyz_text": irc_point_xyz}, "role": "irc_forward"}
+                ],
+            }
+        )
+    return {
+        "charge": 0,
+        "multiplicity": 2,
+        "geometry": {"xyz_text": _XYZ_H3_TS},
+        "reaction": {
+            "reversible": True,
+            "reactants": [
+                {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+                {"species_entry": {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}},
+            ],
+            "products": [
+                {"species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2}},
+                {"species_entry": {"smiles": "[H][H]", "charge": 0, "multiplicity": 1}},
+            ],
+        },
+        "primary_opt": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+            "opt_result": {"converged": True},
+        },
+        "additional_calculations": additional,
+    }
+
+
+def _upload_ts(session: Session, payload: dict):
+    return persist_transition_state_upload(
+        session,
+        TransitionStateUploadRequest(**payload),
+        created_by=_USER_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# It fires — and says which repair, not merely that something went wrong
+# ---------------------------------------------------------------------------
+
+
+def test_an_input_geometry_of_another_molecule_is_refused(db_conn) -> None:
+    """The first reproduction: benzene as methane's optimisation input."""
+
+    with _isolated_session(db_conn) as session:
+        with pytest.raises(CodedValueError) as excinfo:
+            _upload_species(
+                session,
+                _species_bundle(
+                    smiles="C", conformer_xyz=_XYZ_CH4, opt_input_xyz=_XYZ_BENZENE
+                ),
+            )
+
+    error = excinfo.value
+    assert error.code == "calculation_geometry_composition_mismatch"
+    assert error.context["owner_kind"] == "species_entry"
+    assert error.context["geometry_formula"] == "C6H6"
+    assert error.context["subject_formula"] == "CH4"
+    assert "input_geometries[0]" in error.context["field"]
+
+
+def test_an_output_geometry_of_another_molecule_is_refused(db_conn) -> None:
+    """The output half, which the note that stood here said to leave open.
+
+    The argument for leaving it open was that "an optimisation that
+    dissociated is science to record". Benzene is not a dissociated methane —
+    it has seven more nuclei, and no calculation creates a nucleus. The
+    genuinely dissociated case is accepted below.
+    """
+
+    with _isolated_session(db_conn) as session:
+        with pytest.raises(CodedValueError) as excinfo:
+            _upload_species(
+                session,
+                _species_bundle(
+                    smiles="C", conformer_xyz=_XYZ_CH4, sp_output_xyz=_XYZ_BENZENE
+                ),
+            )
+
+    error = excinfo.value
+    assert error.code == "calculation_geometry_composition_mismatch"
+    assert error.context["geometry_formula"] == "C6H6"
+    assert error.context["subject_formula"] == "CH4"
+    assert "output_geometries[0]" in error.context["field"]
+
+
+def test_a_transition_states_calculation_may_not_carry_a_participant(
+    db_conn,
+) -> None:
+    """One hydrogen atom as an IRC point of a three-atom saddle.
+
+    A participant of the reaction is exactly the wrong reference: the TS sits
+    on the potential energy surface of *all* the atoms, so every point on its
+    IRC has all three. This is the shape the rule's TS branch exists to get
+    right in both directions — it must refuse the participant here and accept
+    the whole system in the acceptance tests below.
+    """
+
+    with _isolated_session(db_conn) as session:
+        with pytest.raises(CodedValueError) as excinfo:
+            _upload_ts(session, _ts_payload(irc_point_xyz=_XYZ_H))
+
+    error = excinfo.value
+    assert error.code == "calculation_geometry_composition_mismatch"
+    assert error.context["owner_kind"] == "transition_state_entry"
+    assert error.context["geometry_formula"] == "H"
+    assert error.context["subject_formula"] == "H3"
+
+
+def test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key(
+    db_conn,
+) -> None:
+    """The second reproduction, and the reason the fallback branch is checked.
+
+    On ``/uploads/computed-reaction`` a calculation may name any geometry in
+    the bundle through ``geometry_key``, resolved against a single
+    bundle-global map. The wire schema narrows that key to a species' own
+    conformers for a *species'* calculations and does not do the same for a
+    *transition state's*, so a TS frequency calculation could name a
+    reactant's geometry and have it attached. Nothing objected: the deposit
+    below stored methane as the input geometry of a C2H5O saddle point's
+    frequency job.
+
+    This arrives on the fallback branch, not the producer-explicit one, which
+    is why checking only ``input_geometries`` / ``output_geometries`` would
+    have left it open.
+    """
+
+    import glob
+    import json
+
+    from app.schemas.workflows.computed_reaction_upload import (
+        ComputedReactionUploadRequest,
+    )
+    from app.workflows.computed_reaction import persist_computed_reaction_upload
+
+    fixture = glob.glob(
+        "tests/fixtures/arc_runs/reaction_1/tckdb_payloads/computed_reaction/*.json"
+    )[0]
+    with open(fixture) as handle:
+        doc = json.load(handle)
+
+    ts_freq = next(
+        calc
+        for calc in doc["transition_state"]["calculations"]
+        if calc["type"] == "freq"
+    )
+    ts_freq["input_geometries"] = []
+    ts_freq["geometry_key"] = "r1_CH4_geom"  # a reactant. The TS is C2H5O.
+
+    with _isolated_session(db_conn) as session:
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_computed_reaction_upload(
+                session,
+                ComputedReactionUploadRequest(**doc),
+                created_by=_USER_ID,
+            )
+
+    error = excinfo.value
+    assert error.code == "calculation_geometry_composition_mismatch"
+    assert error.context["owner_kind"] == "transition_state_entry"
+    assert error.context["geometry_formula"] == "CH4"
+    assert error.context["subject_formula"] == "C2H5O"
+    assert "geometry_key" in error.context["field"]
+
+
+def test_the_refusal_carries_no_row_id(db_conn) -> None:
+    """DR-0028 Requirement 2: ``context`` names fields, never primary keys."""
+
+    with _isolated_session(db_conn) as session:
+        with pytest.raises(CodedValueError) as excinfo:
+            _upload_species(
+                session,
+                _species_bundle(
+                    smiles="C", conformer_xyz=_XYZ_CH4, opt_input_xyz=_XYZ_BENZENE
+                ),
+            )
+
+    context = excinfo.value.context
+    assert set(context) == {
+        "field",
+        "owner_kind",
+        "geometry_formula",
+        "subject_formula",
+    }
+    # Formulas legitimately carry digits ("C6H6"); a leaked primary key would
+    # be a bare integer or an all-digit string. Neither may appear.
+    for value in context.values():
+        assert not isinstance(value, int)
+        assert not str(value).isdigit()
+    # And the message body carries no id either.
+    assert "id=" not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# It accepts — the half that stops this refusing correct science later
+# ---------------------------------------------------------------------------
+
+
+def test_case_1_a_transition_states_geometries_span_the_whole_system(
+    db_conn,
+) -> None:
+    """CASE 1. The saddle point is neither reactant nor product.
+
+    For ``H + H2 -> H2 + H`` the TS holds three atoms; neither participant
+    does. Every calculation the TS owns — the opt, the freq, the IRC — runs on
+    all three, and each must be accepted against the *sum* of the reactants
+    rather than against any one of them.
+    """
+
+    with _isolated_session(db_conn) as session:
+        _upload_ts(session, _ts_payload(irc_point_xyz=_XYZ_H3_IRC_F))
+        session.flush()
+
+        ts_calcs = session.scalars(
+            select(Calculation).where(
+                Calculation.created_by == _USER_ID,
+                Calculation.transition_state_entry_id.is_not(None),
+            )
+        ).all()
+        assert {calc.type.value for calc in ts_calcs} == {"opt", "freq", "irc"}
+
+        irc = next(calc for calc in ts_calcs if calc.type.value == "irc")
+        linked = session.scalars(
+            select(CalculationOutputGeometry.geometry_id).where(
+                CalculationOutputGeometry.calculation_id == irc.id
+            )
+        ).all()
+        assert len(linked) == 1
+
+
+def test_case_2_deuterium_in_the_element_column_is_hydrogen(db_conn) -> None:
+    """CASE 2, the ESS spelling: ``D`` written in the element column.
+
+    Gaussian, ORCA, Molpro and CFOUR all emit or accept it, and ingestion
+    deliberately preserves the token. A calculation geometry spelling its
+    hydrogens ``D`` is CH4 by element, so it matches a ``smiles: "C"``
+    identity. Comparing raw symbols would read this as containing an element
+    the SMILES never mentions and refuse every such deposit.
+    """
+
+    with _isolated_session(db_conn) as session:
+        _upload_species(
+            session,
+            _species_bundle(
+                smiles="C",
+                conformer_xyz=_XYZ_CH4,
+                opt_input_xyz=_XYZ_CD4,
+                sp_output_xyz=_XYZ_CD4,
+            ),
+        )
+        session.flush()
+        assert (
+            session.scalar(
+                select(Calculation.id).where(
+                    Calculation.created_by == _USER_ID,
+                    Calculation.type == "sp",
+                )
+            )
+            is not None
+        )
+
+
+def test_case_2b_a_labelled_isotopologue_identity_is_not_a_mismatch(
+    db_conn,
+) -> None:
+    """CASE 2, the canonical spelling: ``[2H]`` in the SMILES.
+
+    CD3H's identity carries three isotope labels and its geometries carry the
+    matching per-atom mass numbers. By element both sides are CH4, which is
+    the whole point: a mass-aware composition comparison would refuse every
+    isotopologue in the database, and isotope agreement is a separate rule
+    that checks it exactly.
+    """
+
+    with _isolated_session(db_conn) as session:
+        _upload_species(
+            session,
+            _species_bundle(
+                smiles="[2H]C([2H])[2H]",
+                conformer_xyz=_XYZ_CH4,
+                # Atom 1 is the carbon; atoms 2-4 are the three deuterons.
+                isotopes={2: 2, 3: 2, 4: 2},
+                opt_input_xyz=_XYZ_CH4,
+                sp_output_xyz=_XYZ_CH4_DISSOCIATED,
+            ),
+        )
+        session.flush()
+        assert (
+            session.scalar(
+                select(Calculation.id).where(
+                    Calculation.created_by == _USER_ID,
+                    Calculation.type == "sp",
+                )
+            )
+            is not None
+        )
+
+
+def test_case_3_a_scan_point_is_deliberately_not_the_minimum(db_conn) -> None:
+    """CASE 3. An eclipsed, stretched rotor-scan point of ethane.
+
+    Right atoms, wrong arrangement, on purpose — that is what a scan point is.
+    Nothing in the rule reads a coordinate, so distortion is invisible to it.
+    A check that drifted into geometric plausibility would refuse exactly the
+    structures a torsional potential is built from.
+    """
+
+    with _isolated_session(db_conn) as session:
+        _upload_species(
+            session,
+            _species_bundle(
+                smiles="CC",
+                conformer_xyz=_XYZ_ETHANE,
+                opt_input_xyz=_XYZ_ETHANE_SCAN_POINT,
+                sp_output_xyz=_XYZ_ETHANE_SCAN_POINT,
+            ),
+        )
+        session.flush()
+        inputs = session.scalars(
+            select(CalculationInputGeometry.geometry_id)
+            .join(
+                Calculation,
+                Calculation.id == CalculationInputGeometry.calculation_id,
+            )
+            .where(Calculation.created_by == _USER_ID)
+        ).all()
+        assert inputs
+
+
+def test_case_3b_an_irc_endpoint_in_a_product_well_is_accepted(db_conn) -> None:
+    """CASE 3, the transition-state spelling: an IRC endpoint is not the TS.
+
+    ``_XYZ_H3_IRC_F`` is the product side of the path — H2 formed, the third
+    atom 2.5 A away. It is three atoms in an arrangement that is not the
+    saddle point, and it is accepted, because only the atoms are compared.
+    """
+
+    with _isolated_session(db_conn) as session:
+        _upload_ts(session, _ts_payload(irc_point_xyz=_XYZ_H3_IRC_R))
+        session.flush()
+        assert session.scalar(
+            select(Calculation.id).where(
+                Calculation.created_by == _USER_ID,
+                Calculation.type == "irc",
+            )
+        )
+
+
+def test_a_dissociated_optimisation_is_science_to_record(db_conn) -> None:
+    """The case the output-geometry exemption was written to protect.
+
+    Methane with one hydrogen pulled out to 5 A: a dissociated fragment pair,
+    reported as the *output* of the optimisation and as a single point on it.
+    It has the same five nuclei it started with, so it is accepted — which is
+    why the exemption was unnecessary. Composition is conserved by every
+    calculation type; connectivity is not, and connectivity is not checked.
+    """
+
+    with _isolated_session(db_conn) as session:
+        _upload_species(
+            session,
+            _species_bundle(
+                smiles="C",
+                conformer_xyz=_XYZ_CH4,
+                opt_input_xyz=_XYZ_CH4_DISSOCIATED,
+                sp_output_xyz=_XYZ_CH4_DISSOCIATED,
+            ),
+        )
+        session.flush()
+        outputs = session.scalars(
+            select(CalculationOutputGeometry.geometry_id)
+            .join(
+                Calculation,
+                Calculation.id == CalculationOutputGeometry.calculation_id,
+            )
+            .where(Calculation.created_by == _USER_ID)
+        ).all()
+        assert outputs
+
+
+def test_a_charged_species_is_compared_on_atoms_only(db_conn) -> None:
+    """Charge is owned elsewhere and is not re-derived here.
+
+    ``canonical_species_identity`` blocks a SMILES/charge disagreement, so per
+    ADR 0008 section 9 this rule does not check charge — a second copy could
+    only disagree with the first. An ammonium deposit therefore passes on its
+    atoms.
+    """
+
+    xyz_nh4 = (
+        "5\nammonium\n"
+        "N  0.000  0.000  0.000\n"
+        "H  0.589  0.589  0.589\n"
+        "H -0.589 -0.589  0.589\n"
+        "H -0.589  0.589 -0.589\n"
+        "H  0.589 -0.589 -0.589"
+    )
+    with _isolated_session(db_conn) as session:
+        _upload_species(
+            session,
+            _species_bundle(
+                smiles="[NH4+]",
+                conformer_xyz=xyz_nh4,
+                charge=1,
+                opt_input_xyz=xyz_nh4,
+                sp_output_xyz=xyz_nh4,
+            ),
+        )
+        session.flush()
+        assert session.scalar(
+            select(Calculation.id).where(Calculation.created_by == _USER_ID)
+        )

--- a/backend/tests/services/test_calculation_geometry_composition_guard.py
+++ b/backend/tests/services/test_calculation_geometry_composition_guard.py
@@ -1,0 +1,100 @@
+"""Every site that links a geometry to a calculation must check its composition.
+
+The rule in ``app.services.calculation_geometry_composition`` is only as good
+as its coverage, and coverage here is not a property of one function: rows in
+``calculation_input_geometry`` and ``calculation_output_geometry`` are inserted
+from eight places across four modules, which is exactly the shape that let the
+gap exist in the first place — ``attach_calculation_output_geometries`` was
+never the only writer, and a reader who found the check there would reasonably
+conclude the seam was covered.
+
+This guard makes the omission loud instead of silent. It parses the source for
+constructions of the two ORM link classes and requires each enclosing function
+to call ``assert_calculation_geometry_composition``. It is the same device the
+scientific-check register uses to stop a declaration going unregistered, and it
+is deliberately structural rather than behavioural: a new write path added
+without a check fails here even if no test happens to exercise it.
+
+If a future site legitimately cannot check — it links a geometry before the
+calculation's owner is known, say — the honest fix is to make that explicit
+here with the reason, not to widen the pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_APP = Path(__file__).resolve().parents[2] / "app"
+
+_LINK_CLASSES = {"CalculationInputGeometry", "CalculationOutputGeometry"}
+_CHECKER = "assert_calculation_geometry_composition"
+
+#: The construction sites as of #143, as ``module::function``. Listed so that
+#: a *removed* check is as visible as an added-and-unchecked one: if this set
+#: shrinks, someone deleted a write path and should say so.
+_EXPECTED_SITES = {
+    "services/calculation_resolution.py::_persist_irc_result",
+    "services/calculation_resolution.py::_persist_path_search_result",
+    "services/calculation_resolution.py::attach_calculation_input_geometries",
+    "services/calculation_resolution.py::attach_calculation_output_geometries",
+    "services/transition_state_resolution.py::persist_ts_calculations",
+    "workflows/network_pdep.py::_persist_calculation",
+}
+
+
+def _enclosing_functions_that_construct_links() -> dict[str, ast.FunctionDef]:
+    """Map ``module::function`` to the function node, for every write site."""
+
+    found: dict[str, ast.FunctionDef] = {}
+    for path in sorted(_APP.rglob("*.py")):
+        if path.name == "__init__.py" or "db/models" in path.as_posix():
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            constructs = any(
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Name)
+                and inner.func.id in _LINK_CLASSES
+                for inner in ast.walk(node)
+            )
+            if constructs:
+                key = f"{path.relative_to(_APP).as_posix()}::{node.name}"
+                found[key] = node
+    return found
+
+
+def test_every_geometry_link_site_checks_composition() -> None:
+    sites = _enclosing_functions_that_construct_links()
+    assert sites, "found no geometry-link write sites at all — the AST walk broke"
+
+    unchecked = sorted(
+        key
+        for key, node in sites.items()
+        if not any(
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == _CHECKER
+            for inner in ast.walk(node)
+        )
+    )
+    assert not unchecked, (
+        "These functions insert a calculation_input_geometry or "
+        "calculation_output_geometry row without calling "
+        f"{_CHECKER}: {unchecked}. A geometry linked to a calculation must be "
+        "made of the atoms of the subject that calculation is filed under; see "
+        "backend/docs/specs/calculation_geometry_composition.md."
+    )
+
+
+def test_the_known_write_sites_have_not_silently_disappeared() -> None:
+    """A shrinking set means a write path was removed, which is also news."""
+
+    sites = set(_enclosing_functions_that_construct_links())
+    missing = sorted(_EXPECTED_SITES - sites)
+    assert not missing, (
+        f"These geometry-link write sites no longer exist: {missing}. If that "
+        "is intended, update _EXPECTED_SITES and say why in the commit."
+    )

--- a/backend/tests/workflows/test_computed_reaction_upload.py
+++ b/backend/tests/workflows/test_computed_reaction_upload.py
@@ -124,6 +124,17 @@ _XYZ_TS_CH3H = (
     "H -0.629  0.629 -0.629\n"
     "H  0.000  0.000  1.400"
 )
+#: The reactant end of that IRC: methyl with the transferring hydrogen 3 A
+#: away. Five atoms, like every other point on the path — an IRC endpoint is
+#: the same nuclei as the saddle point, separated, not a smaller molecule.
+_XYZ_IRC_CH3_PLUS_H = (
+    "5\nCH3 + H, separated\n"
+    "C  0.000  0.000  0.000\n"
+    "H  1.080  0.000  0.000\n"
+    "H -0.540  0.935  0.000\n"
+    "H -0.540 -0.935  0.000\n"
+    "H  0.000  0.000  3.000"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -2305,9 +2316,14 @@ def test_output_geometries_persist_with_declared_role_and_order(db_conn) -> None
     # Attach an explicit output_geometries to the TS-IRC calc with two
     # entries (forward + reverse). These must canonicalize to *distinct*
     # Geometry rows, so we use two different xyz texts.
+    #
+    # Both ends carry all five atoms of the CH3 + H -> CH4 system. The
+    # reverse end used to be ``_XYZ_CH3`` — four atoms as an endpoint of a
+    # five-atom reaction path, which no IRC can produce and which
+    # ``assert_calculation_geometry_composition`` now refuses.
     payload["transition_state"]["calculations"][1]["output_geometries"] = [
-        {"geometry": {"xyz_text": _XYZ_CH3}, "role": "irc_forward"},
-        {"geometry": {"xyz_text": _XYZ_CH4}, "role": "irc_reverse"},
+        {"geometry": {"xyz_text": _XYZ_CH4}, "role": "irc_forward"},
+        {"geometry": {"xyz_text": _XYZ_IRC_CH3_PLUS_H}, "role": "irc_reverse"},
     ]
     # Note: index 1 above is "ts-irc" (index 0 is "ts-freq", index 1 is "ts-irc",
     # index 2 is "ts-sp" since _payload_with_ts_irc appends them in that order).

--- a/backend/tests/workflows/test_geometry_validation_wiring.py
+++ b/backend/tests/workflows/test_geometry_validation_wiring.py
@@ -5,7 +5,7 @@ computed-species and computed-reaction upload workflows for opt
 calculations only. These tests verify the wiring contract:
 
 * matching identity → ``passed`` row written
-* mismatched identity → ``fail`` row written (evidence, not a gate)
+* mismatched identity → the deposit is **refused** before any row is written
 * missing data → upload still succeeds, no row written
 * non-opt calcs → no row written in this phase
 * TS opt → deferred (no row written)
@@ -13,15 +13,24 @@ calculations only. These tests verify the wiring contract:
 The pure chemistry seam is exercised separately in
 ``tests/services/test_geometry_validation.py``.
 
-**How narrow ``is_isomorphic=False`` really is.** ``resolve_atom_mapping``
+**The ``fail`` status is no longer reachable through any upload path, and
+that is a conclusion rather than a regression.** ``resolve_atom_mapping``
 falls back to ``_find_matches_using_smiles_graph`` whenever bond perception
-from coordinates yields no substructure match, and that fallback bails out
-only on an element-count mismatch. So the ``fail`` branch here fires on a
-*formula* disagreement, not on a connectivity one: ethanol and dimethyl ether,
-constitutional isomers with identical element counts, are reported isomorphic.
-Since ``assert_geometry_composition_matches_identity`` now blocks a formula
-disagreement on the species entry's own geometry, an explicitly declared
-output geometry is the last place this row's ``fail`` status is reachable.
+from coordinates yields no substructure match, and that fallback bails out on
+one condition only: an element-count mismatch. So ``is_isomorphic=False`` has
+only ever meant *the formula disagrees* — ethanol and dimethyl ether,
+constitutional isomers with identical element counts, are reported isomorphic;
+methane with one hydrogen pulled to 5 A is reported isomorphic.
+
+But no calculation can change an element count. Every ``CalculationType`` is a
+map over a fixed set of nuclei, so a formula disagreement between a
+calculation's geometry and its subject is not a result, it is a contradiction
+— which is why ``assert_calculation_geometry_composition`` now blocks it, and
+why the advisory row's ``fail`` branch was only ever reachable by depositing
+something no calculation could have produced. Per ADR 0008 §9 the blocking
+tier owns the fact; this row keeps its ``passed``/``warning`` outcomes, where
+the RMSD signal still lives, and the test below records the refusal that
+replaced the ``fail`` row.
 """
 
 from __future__ import annotations
@@ -29,9 +38,11 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Iterator
 
+import pytest
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.db.models.calculation import (
     Calculation,
     CalculationGeometryValidation,
@@ -248,48 +259,80 @@ def test_computed_species_opt_persists_passed_row(db_conn) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2. computed-species opt: mismatched identity → fail row, upload still OK
+# 2. computed-species opt: mismatched identity → the deposit is refused
 # ---------------------------------------------------------------------------
 
 
-def test_computed_species_opt_records_fail_when_identity_mismatch(
+def test_computed_species_opt_refuses_an_output_geometry_of_another_molecule(
     db_conn,
 ) -> None:
-    """The declared species is ethanol and the opt calculation reports a
-    methane output geometry — the chemistry layer must reject isomorphism, and
-    the wiring layer must persist that as evidence (validation_status=fail)
-    rather than abort the upload. This is the policy: phase-1 is non-blocking.
+    """Ethanol's opt calculation reporting a methane output geometry.
 
-    The mismatch is on the *output* geometry, not the conformer geometry.
-    This test used to declare water and deposit methane as the conformer
-    geometry, which is now refused outright by
-    ``assert_geometry_composition_matches_identity``: a species entry's own
-    structure must be made of the atoms its own identifier declares, and H2O
-    is not CH4. That blocking rule owns the species entry's geometry, so the
-    non-blocking evidence rule is exercised where it still applies — an output
-    geometry, which the species entry is deliberately *not* checked against
-    because an optimisation that rearranged or dissociated the molecule is
-    exactly the science this row exists to record rather than refuse.
+    This used to be accepted and recorded as ``validation_status=fail`` on the
+    advisory ``calc_geometry_validation`` row, on the reasoning that "an
+    optimisation that rearranged or dissociated the molecule is exactly the
+    science this row exists to record rather than refuse".
 
-    Ethanol is nine atoms (C2H6O); methane is five (CH4). The atom counts
-    differ, which is what ``resolve_atom_mapping`` actually detects — see the
-    note in this module's docstring about how narrow ``is_isomorphic=False``
-    has become."""
+    That reasoning is right about *connectivity* and does not survive contact
+    with *composition*. A rearrangement keeps its atoms; a dissociation keeps
+    its atoms; a proton transfer keeps its atoms. Ethanol is nine atoms and
+    methane is five, and no optimisation of ethanol has ever returned five
+    atoms, because no electronic-structure program removes a nucleus. So the
+    payload this test deposits is not a rearranged ethanol — it is a
+    calculation filed under the wrong species, or coordinates from the wrong
+    job, and ``assert_calculation_geometry_composition`` refuses it.
+
+    That is also, precisely, the whole reachable surface of the advisory row's
+    ``fail`` verdict: ``is_isomorphic=False`` fires on an element-count
+    mismatch and on nothing else (see this module's docstring), so the only
+    deposits it ever caught were the impossible ones.
+    """
     with _isolated_session(db_conn) as session:
         bundle = _species_bundle(
             smiles="CCO", xyz=_XYZ_ETHANOL, output_xyz=_XYZ_METHANE
         )
-        outcome = persist_computed_species_upload(session, bundle)
-        primary_id = outcome.conformers[0].primary_calculation.id
-        row = session.scalar(
-            select(CalculationGeometryValidation).where(
-                CalculationGeometryValidation.calculation_id == primary_id
-            )
-        )
-        assert row is not None
-        assert row.is_isomorphic is False
-        assert row.validation_status == ValidationStatus.fail
-        assert row.validation_reason is not None
+        with pytest.raises(CodedValueError) as excinfo:
+            persist_computed_species_upload(session, bundle)
+
+    assert excinfo.value.code == "calculation_geometry_composition_mismatch"
+    assert excinfo.value.context["owner_kind"] == "species_entry"
+    assert excinfo.value.context["geometry_formula"] == "CH4"
+    assert excinfo.value.context["subject_formula"] == "C2H6O"
+    # The field the depositor wrote, not a row id (DR-0028 Requirement 2).
+    assert "output_geometries[0]" in excinfo.value.context["field"]
+    assert not any(
+        str(value).isdigit() for value in excinfo.value.context.values()
+    )
+
+
+def test_the_chemistry_layer_still_reports_a_formula_mismatch(db_conn) -> None:
+    """The pure seam keeps its verdict even though no upload can reach it.
+
+    The blocking rule owns the *consequence*; it does not delete the
+    chemistry. ``validate_calculation_geometry`` is a pure function over
+    parsed atoms and a SMILES, and it must keep returning
+    ``is_isomorphic=False`` for a formula disagreement — otherwise the
+    ``passed`` verdict on every accepted deposit would be vacuous, since a
+    predicate that never says no says nothing when it says yes.
+    """
+    from app.chemistry.geometry import parse_xyz
+    from app.schemas.fragments.geometry import GeometryPayload
+    from app.services.geometry_validation import validate_calculation_geometry
+
+    methane_atoms = parse_xyz(GeometryPayload(xyz_text=_XYZ_METHANE)).atoms
+    ethanol_atoms = parse_xyz(GeometryPayload(xyz_text=_XYZ_ETHANOL)).atoms
+
+    mismatch = validate_calculation_geometry(
+        output_atoms=methane_atoms, species_smiles="CCO"
+    )
+    assert mismatch.is_isomorphic is False
+    assert mismatch.validation_status == ValidationStatus.fail
+
+    match = validate_calculation_geometry(
+        output_atoms=ethanol_atoms, species_smiles="CCO"
+    )
+    assert match.is_isomorphic is True
+    assert match.validation_status == ValidationStatus.passed
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/workflows/test_species_geometry_composition.py
+++ b/backend/tests/workflows/test_species_geometry_composition.py
@@ -20,13 +20,13 @@ of its own molecule's atoms — so it blocks.
 ``resolve_species_entry``, so it reaches every conformer geometry on the
 computed-species bundle, ``/uploads/conformers``, the computed-reaction bundle
 and the PDep bundle. It does **not** reach ``CalculationIn.input_geometries``
-or ``output_geometries`` on any path: benzene coordinates can still be attached
-as a calculation geometry under a ``smiles: "C"`` species entry and the deposit
-is accepted. That gap is stated rather than closed here — for an *output*
-geometry, an optimisation that drifted is science to record, not a payload to
-refuse; for an *input* geometry it is simply open. The only comparison those
-geometries get is the advisory ``calc_geometry_validation`` row, which is
-formula-based too (see ``app.services.geometry_validation``).
+or ``output_geometries``, which are attached to a ``calculation`` row and
+never resolved through ``resolve_species_entry``. Those were unchecked
+everywhere until #143 and are now owned by
+``app.services.calculation_geometry_composition``, tested in
+``tests/services/test_calculation_geometry_composition.py``. The two rules
+compare the same way on purpose; what differs is the subject each compares
+against.
 
 The interesting half of this file is the accepting half. A blocking check that
 refuses correct science is worse than no check, so isotopologues, charged

--- a/backend/tests/workflows/test_transition_state_upload.py
+++ b/backend/tests/workflows/test_transition_state_upload.py
@@ -360,10 +360,22 @@ def test_schema_allows_irc_additional():
 # ---------------------------------------------------------------------------
 
 
-_XYZ_IRC_F = "1\nF1\nH  0.0  0.0  1.2\n"
-_XYZ_IRC_R = "1\nR1\nH  0.0  0.0  0.8\n"
-_XYZ_PS_0 = "1\nI0\nH  0.0  0.0  0.0\n"
-_XYZ_PS_2 = "1\nI2\nH  0.0  0.0  1.5\n"
+# Points along the H + H2 -> H2 + H path. Each is the whole three-atom
+# reacting system at a different path coordinate, because that is what a point
+# on an IRC or a NEB string is: the same nuclei, moved. These used to be
+# *single* hydrogen atoms — one atom on the reaction path of a three-atom
+# saddle point, which no calculation can produce — and nothing looked until
+# ``assert_calculation_geometry_composition`` compared them against the
+# reaction they belong to. Same fixture-rot shape the conformer composition
+# check found in the pressure-dependent fixtures.
+#: Reactant side: H2 bonded at left, the transferring atom far right.
+_XYZ_IRC_R = "3\nR1\nH  0.0  0.0  0.00\nH  0.0  0.0  0.74\nH  0.0  0.0  2.50\n"
+#: Product side: the transferring atom far left, H2 bonded at right.
+_XYZ_IRC_F = "3\nF1\nH  0.0  0.0  0.00\nH  0.0  0.0  1.76\nH  0.0  0.0  2.50\n"
+#: NEB image 0, reactant-like but not identical to the IRC endpoint.
+_XYZ_PS_0 = "3\nI0\nH  0.0  0.0  0.00\nH  0.0  0.0  0.78\nH  0.0  0.0  2.40\n"
+#: NEB image 2, product-like.
+_XYZ_PS_2 = "3\nI2\nH  0.0  0.0  0.00\nH  0.0  0.0  1.62\nH  0.0  0.0  2.40\n"
 
 
 def test_ts_upload_with_irc_additional_persists_irc_result(db_conn) -> None:

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.41.0"
+version = "0.42.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -83,6 +83,7 @@ class RejectionCode(str, Enum):
     ATOM_MAP_NOT_A_BIJECTION = "atom_map_not_a_bijection"
     ATOM_MAP_PARTICIPANT_NOT_DECLARED = "atom_map_participant_not_declared"
     ATOM_MAP_WITHOUT_TRANSITION_STATE = "atom_map_without_transition_state"
+    CALCULATION_GEOMETRY_COMPOSITION_MISMATCH = "calculation_geometry_composition_mismatch"
     CALCULATION_HANDLE_CONFLICT = "calculation_handle_conflict"
     CANONICAL_PARAMETER_VALUE_REQUIRES_KEY = "canonical_parameter_value_requires_key"
     CLIENT_SORT_NOT_SUPPORTED = "client_sort_not_supported"
@@ -223,6 +224,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.ATOM_MAP_NOT_A_BIJECTION,
         RejectionCode.ATOM_MAP_PARTICIPANT_NOT_DECLARED,
         RejectionCode.ATOM_MAP_WITHOUT_TRANSITION_STATE,
+        RejectionCode.CALCULATION_GEOMETRY_COMPOSITION_MISMATCH,
         RejectionCode.CALCULATION_HANDLE_CONFLICT,
         RejectionCode.CANONICAL_PARAMETER_VALUE_REQUIRES_KEY,
         RejectionCode.CLIENT_SORT_NOT_SUPPORTED,
@@ -369,6 +371,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.ATOM_MAP_NOT_A_BIJECTION: frozenset({409, 422}),
     RejectionCode.ATOM_MAP_PARTICIPANT_NOT_DECLARED: frozenset({422}),
     RejectionCode.ATOM_MAP_WITHOUT_TRANSITION_STATE: frozenset({422}),
+    RejectionCode.CALCULATION_GEOMETRY_COMPOSITION_MISMATCH: frozenset({422}),
     RejectionCode.CALCULATION_HANDLE_CONFLICT: frozenset({422}),
     RejectionCode.CANONICAL_PARAMETER_VALUE_REQUIRES_KEY: frozenset({422}),
     RejectionCode.CLIENT_SORT_NOT_SUPPORTED: frozenset({422}),

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -84,32 +84,33 @@ disagree, this one is right by construction.
 
 | Tier | Entries | Meaning |
 | --- | --- | --- |
-| `block` | 19 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
+| `block` | 20 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
 | `warn` | 8 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
 | `label` | 1 | Labels a stored record at read time without refusing anything — a `HardFailReason` in the trust evaluator. For facts TCKDB observes about a record after it was accepted, which no upload-time check could have refused because they did not exist yet. |
 | `review` | 0 | Referred to `machine_review` under a versioned rubric. ADR 0008 puts every cross-check against external reference data here. |
 | `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
-| **total** | **33** | |
+| **total** | **34** | |
 
 ## Where a check's code reaches a client
 
 | Channel | Entries | What a consumer can do with it |
 | --- | --- | --- |
-| `error_envelope` | 20 | the `code` field of the 422 error body — a client can branch on it |
+| `error_envelope` | 21 | the `code` field of the 422 error body — a client can branch on it |
 | `upload_warning` | 9 | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | `trust_label` | 1 | a read-time trust label (`HardFailReason`), not any refusal |
 | `database_constraint` | 1 | PostgreSQL only, so the refusal is a 409 rather than a 422 — named, where the constraint declares a rejection code |
 | `none` | 2 | *nothing carries a code* |
-| **total** | **33** | |
+| **total** | **34** | |
 
 ## Recorded divergences
 
 Where a check's documentation and its behaviour disagree, or where a guarantee is narrower than its name suggests. Every one of these is reported, never silently fixed — the register changes no check behaviour.
 
 - **[8]** The multiset of isotopic substitutions declared in a species entry's SMILES equals the multiset carried by the geometry deposited under it.
-- **[11]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
-- **[15]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
-- **[30]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+- **[9]** Every geometry linked to a calculation is made of the atoms of the subject that calculation is filed under -- the species entry's own formula, or, for a transition state, the sum of its reaction's reactants.
+- **[12]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
+- **[16]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
+- **[31]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 ## Entries
 
@@ -263,7 +264,27 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** Not a divergence but a documented false *acceptance*, restated here because a referee will ask: only the multiset is compared, so isotopomers are not distinguished. An identity of `[2H]OC` (CH3-OD) accepts a geometry labelling a methyl hydrogen instead (CH2D-OH) — different molecules with different zero-point energies. Closing it needs an atom-level SMILES-to-XYZ correspondence the repository does not have. Where the two disagree invisibly, the geometry is authoritative for masses and the SMILES only for identity.
 
-### 9. A species entry's declared charge equals the summed formal charge of its own SMILES.
+### 9. Every geometry linked to a calculation is made of the atoms of the subject that calculation is filed under -- the species entry's own formula, or, for a transition state, the sum of its reaction's reactants.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `block` |
+| **Code** | `calculation_geometry_composition_mismatch` |
+| **Code reaches a client via** | the `code` field of the 422 error body — a client can branch on it |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** Definitional. A calculation's numbers are computed from its geometry and attributed to its subject; a geometry made of different atoms than the subject makes that attribution false rather than weak. No correct calculation can produce one, because no electronic-structure program adds or removes a nucleus -- which is also why this holds for output geometries and not only input ones: dissociation, isomerisation and proton transfer all conserve element counts.
+
+**Enforced at.**
+
+- `assert_calculation_geometry_composition` — `backend/app/services/calculation_geometry_composition.py::assert_calculation_geometry_composition`
+  *Called from every site that inserts a `calculation_input_geometry` or `calculation_output_geometry` row -- eight of them across four modules -- on both the producer-explicit branch and the `geometry_key`/fallback branch. A guard test fails if a ninth appears unchecked.*
+
+**Escape hatch.** Declare the structure's real composition: give the calculation the geometry it was run on, or file it under the subject that geometry belongs to. Absence does not block -- a `pseudo` owner, a transition state whose reaction records no reactants or a pseudo reactant, and an unparseable stored SMILES are all left unjudged. Only atom counts are compared, so isotopologues, scan and IRC points, constitutional isomers and dissociated optimisations all pass.
+
+**Recorded divergence.** A documented false *acceptance*, restated because a referee will ask: counts alone cannot tell a constitutional isomer from its partner, so an ethanol calculation carrying dimethyl ether coordinates passes. Catching that needs bond perception from XYZ, which fails silently on exactly the strained, radical and stretched structures where it would matter -- the same reasoning that keeps `species_geometry_composition_mismatch` to counts. It also refuses a geometry carrying ghost or dummy centres (counterpoise/BSSE), because `Bq` appears in no SMILES; that refusal is correct while `geometry_atom` has no way to say 'no nucleus here', since such a row is already miscounted by `natoms` and every degrees-of-freedom read downstream.
+
+### 10. A species entry's declared charge equals the summed formal charge of its own SMILES.
 
 | Field | Value |
 | --- | --- |
@@ -281,7 +302,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** A free electron short-circuits before the comparison, returning a pinned identity pair. Multiplicity is deliberately **not** validated against the SMILES at all: standard SMILES does not encode spin state, so RDKit's inferred radical count is only a hint and the uploaded multiplicity is authoritative — which is what lets singlet CH2 (whose SMILES `[CH2]` implies a triplet) and the singlet and triplet states of O2 be represented.
 
-### 10. The charge and spin multiplicity a depositor declares match the ones the electronic-structure log says the calculation was actually run at.
+### 11. The charge and spin multiplicity a depositor declares match the ones the electronic-structure log says the calculation was actually run at.
 
 | Field | Value |
 | --- | --- |
@@ -299,7 +320,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Absence is not contradiction: if the producing program is not one of the wired parsers, the artifact is missing, the log is truncated, or the declarations inside a single log disagree with each other, the value is left unknown and **no** warning is emitted. Only a value genuinely read from the log may contradict a declaration — emitting a mismatch because parsing failed would fabricate a contradiction out of ignorance.
 
-### 11. An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
+### 12. An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
 
 | Field | Value |
 | --- | --- |
@@ -308,12 +329,12 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 | **Code reaches a client via** | *nothing carries a code* |
 | **Governing ADR** | 0008, 0002 |
 
-**Why this tier.** An expectation, and correctly non-blocking. An optimisation that rearranged, dissociated or transferred a proton is science to record, not a payload to refuse, and connectivity perception from XYZ is unreliable for exactly the weak complexes, radicals, ions and stretched geometries where a genuine rearrangement would matter. The result is written as an evidence row that grades the record at read time; it never refuses an upload.
+**Why this tier.** An expectation, and correctly non-blocking. An optimisation that rearranged, dissociated or transferred a proton is science to record, not a payload to refuse, and connectivity perception from XYZ is unreliable for exactly the weak complexes, radicals, ions and stretched geometries where a genuine rearrangement would matter. The result is written as an evidence row that grades the record at read time; it never refuses an upload. Since #143 the tier is also the only one left to it: the *composition* half of what this row reports is owned by `calculation_geometry_composition_mismatch`, which blocks, so what this row can still say on its own is the RMSD suspicion — a correct-formula structure that moved further than expected, which is an expectation by construction.
 
 **Enforced at.**
 
 - `validate_calculation_geometry` — `backend/app/services/geometry_validation.py::validate_calculation_geometry`
-  *Species-owned `opt` calculations only. Transition states are deliberately excluded, having no canonical SMILES to compare against. Best-effort by policy: a missing SMILES, a missing output geometry, unparseable coordinates or a raising chemistry layer all write nothing and let the upload continue. A Kabsch RMSD above 1.0 A against the input geometry is recorded as a separate suspicion signal.*
+  *Species-owned `opt` calculations only. Transition states are deliberately excluded, having no canonical SMILES to compare against. Best-effort by policy: a missing SMILES, a missing output geometry, unparseable coordinates or a raising chemistry layer all write nothing and let the upload continue. A Kabsch RMSD above 1.0 A against the input geometry is recorded as a separate suspicion signal. Its `fail` outcome is no longer reachable through an upload path: `is_isomorphic=False` fires only on an element-count mismatch, no calculation can change an element count, and `assert_calculation_geometry_composition` refuses such a deposit before this runs. The pure seam keeps the verdict and is pinned directly by `tests/workflows/test_geometry_validation_wiring.py`.*
 
 **Escape hatch.** The whole check is advisory, so there is nothing to escape. What a consumer must not do is read a `fail` row as 'this calculation is scientifically invalid'; it means only that the automated identity validator found a mismatch.
 
@@ -323,7 +344,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Stationary points
 
-### 12. A transition state has at least one imaginary vibrational mode, exactly one of them is designated the reaction coordinate, and no undeclared mode is stiff enough to make that designation meaningless.
+### 13. A transition state has at least one imaginary vibrational mode, exactly one of them is designated the reaction coordinate, and no undeclared mode is stiff enough to make that designation meaningless.
 
 | Field | Value |
 | --- | --- |
@@ -342,7 +363,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Three, and they are the point of the rule. Deposit no frequency evidence: `n_imag=None` produces no findings at all, because absence is never contradiction. Or deposit the extra imaginary modes honestly — designate the reaction coordinate and give each other mode a disposition (`torsion`, `rigid_body_residue`, `intermolecular`, `ring_pucker`, `symmetry_breaking`, or an explicit `unassigned`) — and a genuine higher-order saddle is accepted with a warning and a structural flag. Or, if the extra mode really is the barrier, designate *it*. What has no door is refusing to say which mode is the reaction coordinate.
 
-### 13. A species entry declared a minimum has no imaginary vibrational modes.
+### 14. A species entry declared a minimum has no imaginary vibrational modes.
 
 | Field | Value |
 | --- | --- |
@@ -360,7 +381,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Declare `species_entry_kind='vdw_complex'`, which records the same mode with a warning instead, or deposit the structure through a transition-state payload if the single imaginary mode is real.
 
-### 14. A van der Waals complex is formally a minimum, so an imaginary mode on one is recorded and flagged rather than refused — unless the mode is too stiff to be an intermolecular one, which suggests a genuine reaction coordinate.
+### 15. A van der Waals complex is formally a minimum, so an imaginary mode on one is recorded and flagged rather than refused — unless the mode is too stiff to be an intermolecular one, which suggests a genuine reaction coordinate.
 
 | Field | Value |
 | --- | --- |
@@ -378,7 +399,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** This *is* the escape hatch for the blocking minimum rule. Its own cost is that a genuinely mislabelled saddle point deposited as a van der Waals complex is accepted with a warning.
 
-### 15. A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
+### 16. A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
 
 | Field | Value |
 | --- | --- |
@@ -413,7 +434,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** ADR 0012 recommends replacing the threshold with a determination — projecting each imaginary eigenvector onto the six rigid-body vectors (more than about 90 percent overlap means projection residue) and onto dihedral-rotation vectors (more than about 70 percent means a torsion) — and says those should be implemented *before* tau is tuned, because a determination beats a threshold wherever one is available. Tau shipped first, so that ordering was not followed; the projections themselves now exist. They are computed at *read* time from `calc_hessian` -- whose eigenvectors, mass-weighted by the per-atom masses `geometry_atom` carries, are the displacement vectors ADR 0012 wanted -- and nothing about them is stored, so no schema change was involved and no historical record was re-decided. See `include=imaginary_mode_projections` on the scientific calculation read, and ADR 0013 as amended. The disposition on each extra mode remains *declared by the depositor*; the determination is reported beside it and a disagreement is surfaced as one, never silently resolved. Under ADR 0008 a projection is an expectation about a record, so it informs this check and does not gate it. Where no Hessian is stored the projection reads 'not determinable', which is not the same answer as 'no residue found' — and is not a shrug either: that block carries this check's own stored judgement beside the refusal, being the tau applied, the row of the protocol table it came from, the recorded parameters that chose that row, the structural flag, and every imaginary mode ranked by magnitude against the tau. It reports the comparison and stops there. Magnitude cannot separate a spurious mode from a real one that is not the reaction coordinate — a transition state can sit at a maximum of a torsional profile while being a perfectly correct reactive bottleneck — so no mode in that block is labelled, and the only assignment on it is the one the depositor declared.
 
-### 16. A transition state's reaction coordinate should exceed roughly 100 cm-1 in magnitude.
+### 17. A transition state's reaction coordinate should exceed roughly 100 cm-1 in magnitude.
 
 | Field | Value |
 | --- | --- |
@@ -448,7 +469,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None is needed — the check never refuses. A referee should read the threshold as a tunable reporting line, not a claim about physics.
 
-### 17. A deposited saddle point should carry passing intrinsic-reaction-coordinate evidence that it connects the declared reactants and products.
+### 18. A deposited saddle point should carry passing intrinsic-reaction-coordinate evidence that it connects the declared reactants and products.
 
 | Field | Value |
 | --- | --- |
@@ -466,7 +487,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None needed — the warning is the accommodation. Note the warning fires on absence of a *passing* record, so evidence that was run and failed is stored and still warns.
 
-### 18. A frequency result that deposits both a scalar imaginary-mode count and a frequency list agrees with itself about how many imaginary modes it has.
+### 19. A frequency result that deposits both a scalar imaginary-mode count and a frequency list agrees with itself about how many imaginary modes it has.
 
 | Field | Value |
 | --- | --- |
@@ -484,7 +505,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Omit `modes`. A record that deposits only the scalar is incomplete, warns nowhere and is refused nowhere — ADR 0012 asks for the complete signed frequency list, and asking is as far as this tier goes. What has no door is depositing both and letting them contradict each other.
 
-### 19. A frequency list carries no more modes than the geometry it is attached to has degrees of freedom: at most `3N` for `N` atoms, the six rigid-body modes included.
+### 20. A frequency list carries no more modes than the geometry it is attached to has degrees of freedom: at most `3N` for `N` atoms, the six rigid-body modes included.
 
 | Field | Value |
 | --- | --- |
@@ -506,7 +527,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Atom mapping across a reaction
 
-### 20. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
+### 21. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
 
 | Field | Value |
 | --- | --- |
@@ -527,7 +548,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Case is not load-bearing, and no longer needs a special provision to stop it becoming so. The comparison used to be case-insensitive on both sides, because the two ends quote two different geometries and nothing guaranteed they spelled an element the same way — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not, and refusing the second would have refused correct chemistry. `b4e7c1d20f83` canonicalised the symbol on the way into `geometry_atom.element` and `c5a1f8e3d074` made that a CHECK, so one element now has one spelling in every state the database can be in and both the constraint and the service compare the stored values directly. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
-### 21. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
+### 22. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 
 | Field | Value |
 | --- | --- |
@@ -551,7 +572,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Per leg, not globally: the reactant and product legs each claim the whole saddle point, which is the point of storing two maps both pointing at it. A `side` column exists on the pair row purely so this can be a unique constraint, because SQL cannot dereference the participant to find its role.
 
-### 22. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
+### 23. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
 
 | Field | Value |
 | --- | --- |
@@ -575,7 +596,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None, and the cost is stated in ADR 0011: the map is welded to the geometries it names, so depositing a second conformer or re-optimising at another level of theory does not carry it across. Canonical-order-relative indexing would be portable, and was rejected because its failure mode is a map that looks fine and refers to a different atom order than the depositor intended. Portability can be added later as a derived view; correctness cannot be retrofitted onto records nobody can verify.
 
-### 23. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
+### 24. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
 
 | Field | Value |
 | --- | --- |
@@ -593,7 +614,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Leave the map incomplete, or deposit an unbalanced reaction — either drops the rule to the warning tier by design rather than by accident.
 
-### 24. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
+### 25. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
 
 | Field | Value |
 | --- | --- |
@@ -611,7 +632,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction. A participant with no atoms is not an absence: both surfaces can say it has none -- an empty atom list -- so a reaction releasing a free electron carries a complete partition on both and is compared like any other, with the electron contributing no atoms to either side of the comparison.
 
-### 25. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
+### 26. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
 
 | Field | Value |
 | --- | --- |
@@ -629,7 +650,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
 
-### 26. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
+### 27. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
 
 | Field | Value |
 | --- | --- |
@@ -647,7 +668,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-### 27. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
+### 28. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
 
 | Field | Value |
 | --- | --- |
@@ -671,7 +692,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Rate coefficients
 
-### 28. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
+### 29. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
 
 | Field | Value |
 | --- | --- |
@@ -691,7 +712,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Statistical mechanics
 
-### 29. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
+### 30. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
 
 | Field | Value |
 | --- | --- |
@@ -712,7 +733,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Pressure-dependent networks
 
-### 30. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+### 31. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 | Field | Value |
 | --- | --- |
@@ -735,7 +756,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
 
-### 31. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
+### 32. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
 
 | Field | Value |
 | --- | --- |
@@ -756,7 +777,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Custody of the evidence
 
-### 32. The bytes TCKDB serves for a stored artifact are the bytes it stored, and a record whose evidence is known not to be is labelled as such at read time rather than graded as if it were intact.
+### 33. The bytes TCKDB serves for a stored artifact are the bytes it stored, and a record whose evidence is known not to be is labelled as such at read time rather than graded as if it were intact.
 
 | Field | Value |
 | --- | --- |
@@ -784,7 +805,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Reproducibility
 
-### 33. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
+### 34. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
 
 | Field | Value |
 | --- | --- |

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/identity.py
@@ -118,10 +118,16 @@ def raise_for_atomless_structure(
     ``assert_geometry_composition_matches_identity`` through
     ``resolve_species_entry``, which refused it mid-transaction. A
     *calculation* geometry — ``geometry_key``, ``input_geometries``,
-    ``output_geometries`` — reaches no composition check on any path, by
+    ``output_geometries`` — reached no composition check on any path, by
     that function's own account, so an electron carrying one was accepted
     and the structure stored. Stating the rule here covers both, names the
     field that was wrong, and answers before any species is resolved.
+
+    The database-side half of that asymmetry has since been closed too, by
+    ``app.services.calculation_geometry_composition`` (#143), which compares
+    every geometry linked to a calculation against its subject. This check
+    stays: it answers on the wire, names the offending field path, and does
+    not depend on a species being resolvable first.
 
     ``pseudo`` is out of scope here for the same reason it is absent from
     :data:`ATOMLESS_MOLECULE_KINDS`: a lumped construct's composition is


### PR DESCRIPTION
Closes #143.

## The gap, reproduced first

`species_resolution.py:414` called this "a genuine open gap" in its own comment. The anchor resolves and the paragraph is accurate: a **conformer** geometry is compared against its species entry; a **calculation's** geometries were compared against nothing, on any path, for any subject.

Two deposits accepted on `main` before this change, as real output:

```
=== UPLOAD ACCEPTED ===
species_entry smiles declared: C  (methane, CH4)
calc type=opt owner_species_entry=True input_geometry_formulas=['C 6H 6'] output_geometry_formulas=['C 1H 4']
calc type=sp  owner_species_entry=True input_geometry_formulas=['C 1H 4'] output_geometry_formulas=['C 6H 6']
```

```
=== UPLOAD ACCEPTED ===
reaction: [CH]=O + C -> C=O + [CH3]   (reactant sum = C2H5O)
TS-owned calc type=opt  input_geometry_formulas=['C 2H 5O 1']
TS-owned calc type=freq input_geometry_formulas=['C 1H 4']     <-- methane
TS-owned calc type=sp   input_geometry_formulas=['C 2H 5O 1']
TS-owned calc type=irc  input_geometry_formulas=['C 2H 5O 1']
```

The second is not the same defect by another name. It reaches the database through a different branch, and it is what shaped the design — see "Two routes" below.

## The rule

> **Every geometry linked to a calculation must be made of the atoms of the subject that calculation is filed under.**

`calculation` carries a `one_owner` CHECK (`models/calculation.py:302`): exactly one of `species_entry_id` / `transition_state_entry_id` is set. So "which subject?" has exactly two answers, and both references already existed in the codebase:

| Owner | Reference composition | Already used by |
|---|---|---|
| species entry | element counts of `species.smiles` | `assert_geometry_composition_matches_identity` |
| transition-state entry | **sum of the element counts of the reaction's reactants** | `validate_transition_state_composition` |

`transition_state.reaction_entry_id` is `NOT NULL`, so the reactant sum is always reachable.

Comparison rules, inherited verbatim from the conformer rule so the two cannot drift:

- **Elements, not nuclides.** `D`/`T` → `H`; SMILES `[2H]` → `H`.
- **Counts, not positions.** No connectivity, no RMSD, no geometric predicate at all.
- **Absence never blocks.** A `pseudo` owner, a TS whose reaction records no reactants or a `pseudo` reactant, and an unparseable stored SMILES are all left unjudged.
- **A free electron is not absence** — zero atoms is a fact, so any geometry contradicts it.

Tier: **block**, under ADR 0008. The ADR's test is whether the check could fire on a correct novel result. It cannot: a structure not made of its own subject's atoms is contradictory, not merely weak.

## Case analysis

### 1. A TS geometry spans the whole reacting system

Handled by the owner table: a TS-owned calculation is compared against the **reactant sum**, never a participant. Not a new rule — `validate_transition_state_composition` has used exactly that reference for the saddle point since it landed.

Evidence rather than assertion: the rule was run over every calculation geometry in the thirteen ARC-derived fixture payloads under `backend/tests/fixtures/arc_runs/`. All 31 are TS-owned — NEB path-search images, IRC points, scan points, freq and sp inputs — and **none is refused**. Had the reference been the TS's own `unmapped_smiles`, or any single participant, all 31 would have gone red.

### 2. Isotopologues

CH4 and CD4 are both C + 4H by element, and both sides fold nuclides onto elements before counting. Two spellings are pinned as *acceptances*: `D` in the XYZ element column under an unlabelled SMILES, and `[2H]` in the SMILES with a matching per-atom isotope map. Isotope agreement stays owned by `assert_geometry_isotopes_match_identity`, untouched (ADR 0008 §9).

### 3. Scan and IRC points are deliberately not the equilibrium structure

Counts, not positions. An eclipsed stretched rotor-scan point, an IRC endpoint in a product well, and a dissociated optimisation are each pinned as acceptances. Nothing in the implementation can drift toward plausibility, because no coordinate is read.

### 4. Ghost and dummy centres — found, and refused on purpose

`parse_xyz` accepts any two-character token as an element symbol; `X`, `Bq`, `Gh` and `Xx` all store successfully (verified by direct call). So a counterpoise/BSSE geometry is storable today, and under this rule it is refused, because `Bq` appears in no SMILES.

I argue that refusal is correct rather than carving an exemption. `geometry_atom` has `element`, `x/y/z` and `isotope_mass_number` and nothing that says *no nucleus here*. A ghost centre stored as an atom is already a misrepresentation: `geometry.natoms` counts it and every degrees-of-freedom read downstream treats it as a nucleus. The conformer rule has refused such geometries since it landed and nothing has complained. The repair belongs at the representation layer and deserves its own task; an exemption here would preserve a corrupt representation.

### Considered and rejected as legitimate

A **microsolvated or clustered calculation filed under the bare species** — ethanol's entry carrying an `sp` on ethanol plus three waters. Real science, wrong filing: the cluster is a different chemical species, and depositing it under ethanol makes "ethanol's energy" the cluster's energy. That is the corruption the rule exists to refuse.

## A premise refuted: output geometries

Two modules said closing the output half would be wrong:

> Closing that gap for *output* geometries would be wrong: an optimisation that dissociated is science to record. — `species_resolution.py:412`

> That is deliberate for an *output* geometry: an optimisation that drifted is science to record, not a payload to refuse. — `geometry_validation.py`

That argument is correct about **connectivity** and does not transfer to **composition**. Every one of the seven `CalculationType` values is a map over a fixed set of nuclei; no electronic-structure program adds or removes one. Dissociation, isomerisation, proton transfer and ring opening all *conserve* element counts — and `geometry_validation.py` records the demonstration one paragraph above the exemption it justified:

> Methane with one hydrogen pulled out to 5 Å, i.e. a dissociated fragment pair — **passes**.

The case cited to justify the exemption is a case the composition rule accepts. So the exemption protected no correct science while leaving the larger half unchecked: 1806 output geometries against 326 inputs on the live instance. Both halves are now checked, and the dissociated case is pinned as an acceptance.

## Consequence for the advisory row beside it

`calc_geometry_validation`'s **`fail` verdict is no longer reachable through any upload path**, and that is a conclusion rather than a regression. `is_isomorphic=False` fires only when element counts disagree (that module's own verified consequences), and no calculation can change an element count — so the verdict was only ever reachable by depositing something no calculation could have produced. ADR 0008 §9 gives the fact to the blocking tier. The row keeps `passed`/`warning`, where the RMSD suspicion lives, which is the half that was ever an expectation.

`tests/workflows/test_geometry_validation_wiring.py` asserted that `fail` row. It now asserts the refusal that replaced it, **and separately pins the pure chemistry seam's `is_isomorphic=False` verdict by direct call** — so the `passed` verdict on every accepted deposit does not quietly become vacuous. Nothing was weakened, skipped or xfailed.

## Two routes, not one — why the fallback branch is checked

The `attach_calculation_*_geometries` functions have a producer-explicit branch and a fallback branch. Checking only the explicit one would have been the obvious scoping, on the reasoning that the fallback geometry is the already-validated conformer or saddle geometry.

That is false on two routes. On `/uploads/computed-reaction` and `/uploads/networks/pdep`, a calculation may name any geometry in the bundle through `geometry_key`, resolved against a **single bundle-global map** (`computed_reaction.py:417`, populated with every species' conformer geometry at `:461` and the TS geometry at `:646`). The wire schema narrows that key to a species' own conformers for a *species'* calculations (`computed_reaction_upload.py:691`) and has **no equivalent validator on `BundleTransitionStateIn`** — the second reproduction above. This is the same asymmetry already recorded for statmech torsion scan keys in `calculation_ownership.py`.

Mutation testing confirms it: neutering only the fallback branches leaves the explicit tests green and kills exactly the `geometry_key` test.

## Fixture rot the rule found on its first run

Three fixtures were chemically incoherent in the way the conformer rule found in the PDep fixtures, and nothing had looked:

- `test_transition_state_upload.py` — the IRC endpoints and NEB images of an H + H2 → H2 + H saddle point were **single hydrogen atoms**. One atom on the reaction path of a three-atom system.
- `test_computed_reaction_upload.py` — the `irc_reverse` endpoint of a CH3 + H → CH4 path was `_XYZ_CH3`, four atoms where every point on that path has five. (This is the brief's own case-1 example, deposited the wrong way round.)

Replaced with the whole reacting system at different path coordinates. Every assertion in those tests — point counts, roles, orders, linkage — is unchanged.

## Where the check runs, and what is deliberately not checked

One function called from all **eight** sites that insert a `calculation_input_geometry` or `calculation_output_geometry` row, across four modules, on both branches. `tests/services/test_calculation_geometry_composition_guard.py` parses the source and fails if a ninth appears unchecked — the device the scientific-check register already uses.

Stated rather than left to be discovered, **out of scope**:

- `calc_scan_point.geometry_id` and `calc_hessian.geometry_id`, which reach different tables and do not produce a geometry-link row. (`calc_irc_point` and `calc_path_search_point` **are** covered, because they also write an output-geometry row.)
- The `BundleTransitionStateIn.geometry_key` narrowing in the wire schema. The database seam closes the hole for every route at once; narrowing the key would additionally close it one route earlier and is worth its own task.

Both are narrower than the hole closed here. Folding them in would mean four more call sites checked less carefully rather than eight checked properly.

## Schema / migration impact

**None.** No model change, no migration, no new column. **No new environment variable.**

New machine-readable code: `calculation_geometry_composition_mismatch` (422, `Surface.coded_exception`), catalogued in `code_catalogue.py` with a note saying why it is distinct from `species_geometry_composition_mismatch` and `transition_state_composition_mismatch` — the field and the repair differ. One code across both owner kinds, on the precedent of `kinetics_interpretation_statmech_owner_mismatch`; `context["owner_kind"]` says which reference disagreed. `context` carries only field paths and formulas; row ids go to the log (DR-0028 Req 2), asserted by a test.

Regenerated: `docs/guides/scientific_check_register.md` (34 entries) and `clients/python/src/tckdb_client/rejection_codes.py`; client version bumped 0.41.0 → 0.42.0.

Three unrelated `sort_key` values in the "A structure against its own label" register group shifted by one (3→4, 4→5, 5→6) so the new blocking rule sits beside the two conformer-geometry rules it mirrors rather than after the advisory row that now cites it. Comment on each says so.

## Verification actually run

All from the worktree, `conda run -n tckdb_env`, `DB_TEST_NAME=tckdb_test_143`, with the worktree's `schemas/python/tckdb-schemas` first on `PYTHONPATH`.

- **Reproduction before the fix** — both deposits above, printed from real upload runs against a real database. After the fix both are refused with `calculation_geometry_composition_mismatch` and distinct, correct messages.
- **Corpus check** — the proposed rule applied to every calculation geometry in all thirteen ARC-derived fixture payloads: `31 checkable, 0 refused`.
- `pytest tests/services/test_calculation_geometry_composition.py tests/services/test_calculation_geometry_composition_guard.py` — 14 passed.
- `pytest tests/workflows tests/services` — was 4 failed / 2634 passed on the first run (the four analysed above); green after.
- `pytest tests/db/test_scientific_check_register.py tests/api/test_api_scientific_rejection_codes.py` — 69 passed (both gates initially red: sort-key collision, and the register's demand that a new `error_envelope` code be proved end-to-end on a real 422 body; both addressed rather than exempted).
- `pytest tests/api/test_api_code_catalogue.py tests/api/test_error_contract_catalogue_gate.py tests/api/test_client_rejection_codes_generated.py tests/api/test_openapi_snapshot.py` — passed.
- `ruff check app tests scripts` from `backend/` — clean.
- `python scripts/check_runtime_ascii.py` and `--audit` — clean.
- Full `pytest tests/` — see the comment below for the run against the final tree.

### Mutation testing

Each mutation was applied by script, **confirmed to have landed by diff before the run**, then restored with `__pycache__` cleared:

| Mutation | Expected to kill | Result |
|---|---|---|
| 1. `assert_calculation_geometry_composition` returns immediately | every refusal test | 5 failed |
| 2b. drop the `D`/`T` → `H` fold, keep case normalisation | the deuterium acceptance only | exactly 1 failed |
| 3. compare a TS against its *first* reactant, not the sum | every TS test, both directions | 4 failed |
| 4. skip both fallback branches, keep the explicit ones | the `geometry_key` route only | exactly 1 failed |
| 5. delete the check from `_persist_irc_result` | the anti-drift guard | guard named the exact function |

Mutation 2 in its first form (`Counter(elements)` raw) killed eleven tests rather than one, because it also dropped the `CHAR(2)` padding strip — a mutation that turns too much red proves as little as one that turns nothing red, so it was narrowed to 2b to isolate the isotope case.

`git diff` after the sweep confirms no mutation survived in the tree.
