### PR TITLE
Name a migration test's subject, not "head"

### DIFF
--- a/backend/docs/testing.md
+++ b/backend/docs/testing.md
@@ -458,6 +458,29 @@ the offender at its own teardown, so the class no longer depends on a serial run
 to be seen. Re-audit after adding a revision; do not treat the seed list as a
 standing guarantee.
 
+**The constant that caused it is gone, not annotated.** All three occurrences
+restored the database to a module constant named `_CURRENT_HEAD`, which never
+meant head — it meant *the revision under test*, and it read as head to each
+author in turn. The first two were fixed in place and left comments warning
+about it; the third happened anyway. So a migration test now names exactly one
+thing, its subject, and reads the rest of the chain from disk:
+
+```python
+from tests.db._migration_chain import revision_under_test
+
+_MIGRATION = revision_under_test("b7e4d1a9c026")
+
+command.downgrade(config, _MIGRATION.parent)     # its down_revision, not a copy
+command.upgrade(config, _MIGRATION.revision)     # the thing under test
+command.upgrade(config, "head")                  # putting the shared DB back
+```
+
+There is no way to spell "head" through that helper, and
+`tests/test_migration_revision_names.py` fails any test that binds a revision id
+to a name containing "head". `_PREVIOUS_HEAD` is gone for the same reason plus
+one more: a revision's parent is declared in the migration file, so copying it
+into a test creates a second place that can disagree with the first, silently.
+
 **Set `TCKDB_TEST_SEED=random` for an unpinned order.** The script draws a
 fresh seed per invocation and echoes it:
 

--- a/backend/tests/db/_migration_chain.py
+++ b/backend/tests/db/_migration_chain.py
@@ -1,0 +1,134 @@
+"""What a migration test may know about the revision chain, and how.
+
+Every test in this directory that drives ``alembic.command`` needs two
+revision ids: the one whose ``upgrade`` is under test, and the one to
+stand on while running it. Four files used to write both down, under the
+names ``_CURRENT_HEAD`` and ``_PREVIOUS_HEAD``.
+
+Only one of those two is information, and neither name is true:
+
+* **The parent is not information.** It is the revision's own
+  ``down_revision``, declared in the migration file. Copying it into a
+  test creates a second place that can disagree with the first, and a
+  disagreement does not surface as a failure -- the test downgrades to
+  some other point and usually still passes.
+* **Neither is "head".** ``_CURRENT_HEAD`` never meant head. It meant
+  *the revision under test*, which is head only between the day it is
+  written and the day the next revision lands. ``_PREVIOUS_HEAD`` is
+  time-relative in the same way: a revision's parent is fixed forever,
+  but "what head used to be" is a statement about a calendar.
+
+The name is not a cosmetic complaint. It is the defect. Three tests have
+now downgraded the shared per-run database and restored it to
+``_CURRENT_HEAD`` believing that meant head; the third
+(``test_imaginary_mode_tau_basis_constraint.py``, #197) did it after the
+first two had been fixed in place and had left comments warning about it.
+A name that says the wrong thing outlasts every comment written to
+explain that it does.
+
+So a test names exactly one thing here -- its subject -- and gets the
+rest from the script directory::
+
+    _MIGRATION = revision_under_test("b7e4d1a9c026")
+
+    command.downgrade(config, _MIGRATION.parent)
+    command.upgrade(config, _MIGRATION.revision)
+
+``revision_under_test`` deliberately refuses to resolve "head", so a
+subject cannot be named that way even by accident. Head is a separate
+question with a separate answer -- ``current_head`` below, exposed as the
+``alembic_head`` fixture -- and *restoring* the shared database is a third
+one again: the literal string ``"head"`` passed to ``command.upgrade``,
+with ``conftest.py::_must_leave_the_database_at_head`` failing the test
+that gets it wrong. Keeping the three apart is the entire point; the bug
+this module exists to prevent is one of them being mistaken for another.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+@lru_cache(maxsize=1)
+def script_directory() -> ScriptDirectory:
+    """The migration chain as it exists on disk, read once per process.
+
+    The single place in this tree that opens ``alembic.ini``. Reading the
+    chain rather than restating it is the whole point of the module, so
+    there is one reader and everything else asks it.
+    """
+    return ScriptDirectory.from_config(Config(str(_BACKEND_ROOT / "alembic.ini")))
+
+
+def current_head() -> str:
+    """The revision ``alembic upgrade head`` would stop at, read from disk.
+
+    Read rather than written down. Every hard-coded copy of "the current
+    head" in this tree has gone stale within days of being typed, because
+    the thing that makes it stale is the next revision landing -- which is
+    the one event nobody grepping for the old hash is present for.
+    """
+    return script_directory().get_current_head()
+
+
+@dataclass(frozen=True)
+class RevisionUnderTest:
+    """A migration test's subject, and the revision it runs from.
+
+    ``revision`` is the id the test named. ``parent`` is that revision's
+    ``down_revision``, read from the migration file rather than copied
+    into the test, so the two can never drift apart.
+    """
+
+    revision: str
+    parent: str
+
+
+def revision_under_test(revision: str) -> RevisionUnderTest:
+    """Resolve the revision a test is about, and the one below it.
+
+    Refuses a symbolic selector -- ``"head"``, ``"heads"``, ``"base"``,
+    ``"<id>-1"``, or an abbreviated hash. Alembic resolves all of those
+    happily, and accepting them would put back exactly the ambiguity this
+    module exists to remove: a test whose subject silently changes when a
+    revision lands is a test that measures a different thing each week.
+    The check is that the resolved id is the id that was asked for, which
+    is true only of a full literal revision id.
+
+    Raises rather than returning a sentinel, and does it at import time
+    because that is when the call sites run. A test that cannot identify
+    its own subject has nothing to fall back to, and a collection error
+    naming the revision beats a downgrade to somewhere unexpected. An
+    unknown id surfaces as alembic's own ``CommandError``; everything else
+    here raises ``ValueError``.
+    """
+    resolved = script_directory().get_revision(revision)
+    if resolved is None or resolved.revision != revision:
+        raise ValueError(
+            f"{revision!r} is not a literal revision id -- alembic resolved it "
+            f"to {resolved and resolved.revision!r}. A migration test must name "
+            "the revision it is about, because a selector like 'head' or a "
+            "partial hash points somewhere else as soon as the chain grows, "
+            "and the test then measures a revision nobody chose."
+        )
+
+    parent = resolved.down_revision
+    if isinstance(parent, tuple):
+        raise ValueError(
+            f"{revision!r} is a merge point with parents {parent!r}; there is "
+            "no single revision to stand on, so this helper cannot pick one. "
+            "Name the intended parent explicitly in the test."
+        )
+    if parent is None:
+        raise ValueError(
+            f"{revision!r} is the base revision and has nothing below it, so "
+            "there is no state for a test to downgrade to."
+        )
+    return RevisionUnderTest(revision=resolved.revision, parent=parent)

--- a/backend/tests/db/conftest.py
+++ b/backend/tests/db/conftest.py
@@ -33,15 +33,12 @@ command line and in deployment, where ``env.py`` is untouched.
 from __future__ import annotations
 
 import logging.config
-from pathlib import Path
 from typing import Iterator
 
 import pytest
-from alembic.config import Config
-from alembic.script import ScriptDirectory
 from sqlalchemy import text
 
-_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+from tests.db._migration_chain import current_head
 
 #: Node id of the first test observed to finish with the shared database
 #: below alembic head, so later failures can point at it instead of each
@@ -70,14 +67,13 @@ def _alembic_must_not_reconfigure_logging(monkeypatch) -> Iterator[None]:
 def alembic_head() -> str:
     """The revision ``alembic upgrade head`` would stop at, read from disk.
 
-    Read rather than written down. Every hard-coded copy of "the current
-    head" in this tree has gone stale within days of being typed, because
-    the thing that makes it stale is the next revision landing — which is
-    the one event nobody grepping for the old hash is present for.
+    See ``_migration_chain.current_head``, which this exposes as a fixture
+    and which explains why it is read rather than written down. A test that
+    needs its own *subject* wants ``_migration_chain.revision_under_test``
+    instead: that is a different concept, and conflating the two is the
+    mistake ``_must_leave_the_database_at_head`` below exists to catch.
     """
-    return ScriptDirectory.from_config(
-        Config(str(_BACKEND_ROOT / "alembic.ini"))
-    ).get_current_head()
+    return current_head()
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/db/test_constraint_rename_migration.py
+++ b/backend/tests/db/test_constraint_rename_migration.py
@@ -35,10 +35,13 @@ from alembic.config import Config
 from sqlalchemy import create_engine, text
 
 from alembic import command
+from tests.db._migration_chain import revision_under_test
 
 _BACKEND_ROOT = Path(__file__).resolve().parents[2]
-_PREVIOUS_HEAD = "e2a7c9d4b615"
-_CURRENT_HEAD = "b7e4d1a9c026"
+
+#: The subject of this file, and the revision below it -- read from the
+#: chain rather than written down twice. See ``_migration_chain``.
+_MIGRATION = revision_under_test("b7e4d1a9c026")
 
 #: The pair exercised here. ``calculation_artifact.bytes > 0`` is chosen
 #: for having a one-clause definition that can be spelled out below
@@ -57,8 +60,12 @@ _OTHER_OLD = "ck_calc_freq_mode_ck_calc_freq_mode_imaginary_dispositi_ddc2"
 
 
 @pytest.fixture
-def alembic_at_previous_head(db_engine, monkeypatch, alembic_head):
-    """Hold the database one revision below head for the duration.
+def database_below_the_migration(db_engine, monkeypatch, alembic_head):
+    """Hold the database at the migration's parent for the duration.
+
+    "Below the migration", not "below head": those coincide only while
+    ``_MIGRATION`` happens to be the newest revision, and this fixture
+    wants the former whatever the chain does afterwards.
 
     Restores head in teardown whatever the test did to the catalog, so a
     failure here fails this test rather than every test that follows it.
@@ -75,13 +82,15 @@ def alembic_at_previous_head(db_engine, monkeypatch, alembic_head):
     as a schema-wide sweep failure with no obvious author. Forcing the
     version back down first makes the final ``upgrade`` real work again.
 
-    The final ``upgrade`` targets ``head``, not ``_CURRENT_HEAD``.
-    ``_CURRENT_HEAD`` is the revision under test, and it is head only until
-    the next revision lands; upgrading to it would leave every revision after
-    it un-applied on the database the rest of the process is sharing. Also
-    not hypothetical: it is what
+    The final ``upgrade`` targets ``head``, not ``_MIGRATION.revision``.
+    Those are two different things: the revision under test is head only
+    until the next revision lands, and upgrading to it would leave every
+    revision after it un-applied on the database the rest of the process
+    is sharing. Also not hypothetical: it is what
     ``test_imaginary_mode_tau_basis_constraint.py`` did to *this file's*
-    subject the day ``b7e4d1a9c026`` landed on top of the revision it named.
+    subject the day ``b7e4d1a9c026`` landed on top of the revision it named
+    -- while that revision was still called ``_CURRENT_HEAD``, which is why
+    it no longer is.
     """
     url = db_engine.url.render_as_string(hide_password=False)
     for key, value in (
@@ -96,7 +105,7 @@ def alembic_at_previous_head(db_engine, monkeypatch, alembic_head):
 
     config = Config(str(_BACKEND_ROOT / "alembic.ini"))
     engine = create_engine(url)
-    command.downgrade(config, _PREVIOUS_HEAD)
+    command.downgrade(config, _MIGRATION.parent)
     try:
         yield config, engine
     finally:
@@ -104,7 +113,7 @@ def alembic_at_previous_head(db_engine, monkeypatch, alembic_head):
         # meets a catalog it can act on, then the version stamp back down
         # so the final upgrade actually runs the rename.
         _restore_pre_upgrade_names(engine)
-        command.downgrade(config, _PREVIOUS_HEAD)
+        command.downgrade(config, _MIGRATION.parent)
         command.upgrade(config, "head")
         _assert_left_at_head(engine, alembic_head)
         engine.dispose()
@@ -169,16 +178,16 @@ def _assert_left_at_head(engine, alembic_head: str) -> None:
     )
 
 
-def test_a_constraint_already_correctly_named_is_left_alone(alembic_at_previous_head):
+def test_a_constraint_already_correctly_named_is_left_alone(database_below_the_migration):
     """The re-run and the built-from-scratch host: no-op, deploy proceeds.
 
     Refusing here would block an upgrade on a database that is already in
     the state this revision exists to produce.
     """
-    config, engine = alembic_at_previous_head
+    config, engine = database_below_the_migration
     _execute(engine, f'ALTER TABLE {_TABLE} RENAME CONSTRAINT "{_OLD}" TO "{_NEW}"')
 
-    command.upgrade(config, _CURRENT_HEAD)
+    command.upgrade(config, _MIGRATION.revision)
 
     names = _constraint_names(engine)
     assert _NEW in names, "the correctly named constraint was disturbed"
@@ -189,7 +198,7 @@ def test_a_constraint_already_correctly_named_is_left_alone(alembic_at_previous_
 
 
 def test_a_missing_constraint_is_refused_rather_than_recreated(
-    alembic_at_previous_head,
+    database_below_the_migration,
 ):
     """Neither name present means a rule was dropped, not renamed.
 
@@ -197,11 +206,11 @@ def test_a_missing_constraint_is_refused_rather_than_recreated(
     report success -- leaving an operator believing the schema is intact
     when something in their environment is dropping constraints.
     """
-    config, engine = alembic_at_previous_head
+    config, engine = database_below_the_migration
     _execute(engine, f'ALTER TABLE {_TABLE} DROP CONSTRAINT "{_OLD}"')
 
     with pytest.raises(RuntimeError) as excinfo:
-        command.upgrade(config, _CURRENT_HEAD)
+        command.upgrade(config, _MIGRATION.revision)
 
     message = str(excinfo.value)
     assert _OLD in message and _NEW in message, (
@@ -228,25 +237,25 @@ def test_a_missing_constraint_is_refused_rather_than_recreated(
         engine,
         f'ALTER TABLE {_TABLE} ADD CONSTRAINT "{_OLD}" CHECK ({_DEFINITION})',
     )
-    command.upgrade(config, _CURRENT_HEAD)
+    command.upgrade(config, _MIGRATION.revision)
     assert _NEW in _constraint_names(engine)
 
 
-def test_both_names_present_is_refused_rather_than_merged(alembic_at_previous_head):
+def test_both_names_present_is_refused_rather_than_merged(database_below_the_migration):
     """A rename cannot merge two constraints, so it declines to try.
 
     Which of the two to keep depends on how the second one arrived, and
     the migration has no way to find that out. Dropping either would
     discard a rule somebody added on purpose.
     """
-    config, engine = alembic_at_previous_head
+    config, engine = database_below_the_migration
     _execute(
         engine,
         f'ALTER TABLE {_TABLE} ADD CONSTRAINT "{_NEW}" CHECK ({_DEFINITION})',
     )
 
     with pytest.raises(RuntimeError) as excinfo:
-        command.upgrade(config, _CURRENT_HEAD)
+        command.upgrade(config, _MIGRATION.revision)
 
     message = str(excinfo.value)
     assert _OLD in message and _NEW in message, (
@@ -258,5 +267,5 @@ def test_both_names_present_is_refused_rather_than_merged(alembic_at_previous_he
     assert _OLD in names and _NEW in names
 
     _execute(engine, f'ALTER TABLE {_TABLE} DROP CONSTRAINT "{_NEW}"')
-    command.upgrade(config, _CURRENT_HEAD)
+    command.upgrade(config, _MIGRATION.revision)
     assert _NEW in _constraint_names(engine)

--- a/backend/tests/db/test_dataset_release_migration.py
+++ b/backend/tests/db/test_dataset_release_migration.py
@@ -18,10 +18,13 @@ from alembic.config import Config
 from sqlalchemy import create_engine, text
 
 from alembic import command
+from tests.db._migration_chain import revision_under_test
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PREVIOUS_HEAD = "d2e3f4a5b6c7"
-CURRENT_HEAD = "e3f4a5b6c7d8"
+
+#: The subject of this file, and the revision below it -- read from the
+#: chain rather than written down twice. See ``_migration_chain``.
+_MIGRATION = revision_under_test("e3f4a5b6c7d8")
 
 _NEW_TABLES = (
     "curation_policy",
@@ -50,15 +53,15 @@ def _configure(db_engine, monkeypatch) -> Config:
 
 
 def _restore_head(config: Config) -> None:
-    """Put the shared test database back at ``head``, not at ``CURRENT_HEAD``.
+    """Put the shared database back at ``head``, not at the revision under test.
 
     These tests downgrade the *per-run database every other test in the process
-    is using*, so restoring it is not optional. Restoring to ``CURRENT_HEAD``
-    is not enough either: that is a historical revision, and every migration
-    after it stays un-applied, which is how one file in ``tests/db/`` used to
-    take the rest of the suite down with it — ``species_entry.isotope_key does
-    not exist`` and similar, hundreds of tests later, in files that had nothing
-    to do with releases.
+    is using*, so restoring it is not optional. Restoring to
+    ``_MIGRATION.revision`` is not enough either: that is a historical revision,
+    and every migration after it stays un-applied, which is how one file in
+    ``tests/db/`` used to take the rest of the suite down with it —
+    ``species_entry.isotope_key does not exist`` and similar, hundreds of tests
+    later, in files that had nothing to do with releases.
     """
     command.upgrade(config, "head")
 
@@ -86,7 +89,7 @@ def test_downgrade_then_upgrade_round_trips(db_engine, monkeypatch):
         with engine.connect() as connection:
             assert set(_NEW_TABLES) <= _table_names(connection)
 
-        command.downgrade(config, PREVIOUS_HEAD)
+        command.downgrade(config, _MIGRATION.parent)
         with engine.connect() as connection:
             assert not (set(_NEW_TABLES) & _table_names(connection))
             # The revision owns these enums and must clean them up, or a
@@ -95,7 +98,7 @@ def test_downgrade_then_upgrade_round_trips(db_engine, monkeypatch):
             # …but not the pre-existing vocabulary it merely reuses.
             assert "submission_record_type" in _enum_names(connection)
 
-        command.upgrade(config, CURRENT_HEAD)
+        command.upgrade(config, _MIGRATION.revision)
         with engine.connect() as connection:
             assert set(_NEW_TABLES) <= _table_names(connection)
             assert set(_OWNED_ENUMS) <= _enum_names(connection)
@@ -137,7 +140,7 @@ def test_downgrade_refuses_to_orphan_a_published_citation(db_engine, monkeypatch
             )
 
         with pytest.raises(RuntimeError, match="released datasets"):
-            command.downgrade(config, PREVIOUS_HEAD)
+            command.downgrade(config, _MIGRATION.parent)
 
         # Still at head, still intact.
         with engine.connect() as connection:
@@ -200,7 +203,7 @@ def test_downgrade_also_refuses_when_the_release_was_withdrawn(
             )
 
         with pytest.raises(RuntimeError, match="released datasets"):
-            command.downgrade(config, PREVIOUS_HEAD)
+            command.downgrade(config, _MIGRATION.parent)
 
         with engine.connect() as connection:
             assert set(_NEW_TABLES) <= _table_names(connection)

--- a/backend/tests/db/test_imaginary_mode_tau_basis_constraint.py
+++ b/backend/tests/db/test_imaginary_mode_tau_basis_constraint.py
@@ -49,6 +49,7 @@ from tckdb_schemas.stationary_point import TauBasis
 
 from alembic import command
 from app.db.models.common import IMAGINARY_MODE_TAU_BASIS_VALUES, CalculationType
+from tests.db._migration_chain import revision_under_test
 from tests.services.scientific_read._factories import (
     make_calculation,
     make_lot,
@@ -58,8 +59,10 @@ from tests.services.scientific_read._factories import (
 )
 
 _BACKEND_ROOT = Path(__file__).resolve().parents[2]
-_PREVIOUS_HEAD = "d4e9b1c7a253"
-_CURRENT_HEAD = "e2a7c9d4b615"
+
+#: The subject of this file, and the revision below it -- read from the
+#: chain rather than written down twice. See ``_migration_chain``.
+_MIGRATION = revision_under_test("e2a7c9d4b615")
 _CONSTRAINT = "ck_calc_freq_result_imaginary_mode_tau_basis_known"
 
 #: Values that are not rows of ADR 0012's protocol table. The first three
@@ -277,7 +280,7 @@ def test_the_migration_refuses_rather_than_guesses(db_engine, monkeypatch):
     planted = "DELETE FROM calc_freq_result WHERE calculation_id IN (-901, -902)"
 
     try:
-        command.downgrade(config, _PREVIOUS_HEAD)
+        command.downgrade(config, _MIGRATION.parent)
 
         # One unclassifiable value and one legitimate one. The foreign key
         # onto ``calculation`` is suspended rather than satisfied: what is
@@ -295,7 +298,7 @@ def test_the_migration_refuses_rather_than_guesses(db_engine, monkeypatch):
             )
 
         with pytest.raises(RuntimeError) as excinfo:
-            command.upgrade(config, _CURRENT_HEAD)
+            command.upgrade(config, _MIGRATION.revision)
         message = str(excinfo.value)
         assert "nonsense-basis" in message, (
             "the migration must name what it refused to classify; it said: "
@@ -320,17 +323,17 @@ def test_the_migration_refuses_rather_than_guesses(db_engine, monkeypatch):
         # Repaired the way an operator would -- by deciding what the row
         # meant -- the same migration goes through.
         _purge_planted_rows(engine, planted)
-        command.upgrade(config, _CURRENT_HEAD)
+        command.upgrade(config, _MIGRATION.revision)
         with engine.connect() as connection:
             assert _constraint_count(connection) == 1
     finally:
         # Leave the database at head whatever happened, so a failure here
         # fails this test and not every test that follows it.
         #
-        # ``head``, not ``_CURRENT_HEAD``. This test downgrades the *per-run
-        # database every other test in the process is using*, and
-        # ``_CURRENT_HEAD`` is the revision under test, which stops being head
-        # the moment anything lands on top of it. It did, one day later:
+        # ``head``, not ``_MIGRATION.revision``. This test downgrades the
+        # *per-run database every other test in the process is using*, and the
+        # revision under test stops being head the moment anything lands on
+        # top of it. It did, one day later:
         # ``b7e4d1a9c026`` renames a unique index and six CHECK constraints, so
         # stopping at ``e2a7c9d4b615`` handed every later test a
         # ``statmech_torsion`` whose unique index was still called
@@ -338,6 +341,10 @@ def test_the_migration_refuses_rather_than_guesses(db_engine, monkeypatch):
         # in ``test_statmech_torsion_index_uniqueness.py`` -- a file with
         # nothing to do with tau bases -- claiming the wrong constraint had
         # refused a duplicate, when the only thing wrong was its name.
+        #
+        # This line said ``_CURRENT_HEAD`` when it did that, and the constant
+        # read as head to whoever wrote it. That name is gone from the tree
+        # for exactly that reason; see ``_migration_chain``.
         _purge_planted_rows(engine, planted)
         command.upgrade(config, "head")
         engine.dispose()

--- a/backend/tests/db/test_upload_job_lease_migration.py
+++ b/backend/tests/db/test_upload_job_lease_migration.py
@@ -8,10 +8,13 @@ from alembic.config import Config
 from sqlalchemy import create_engine, text
 
 from alembic import command
+from tests.db._migration_chain import revision_under_test
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PREVIOUS_HEAD = "a8b9c0d1e2f3"
-CURRENT_HEAD = "b1c2d3e4f5a6"
+
+#: The subject of this file, and the revision below it -- read from the
+#: chain rather than written down twice. See ``_migration_chain``.
+_MIGRATION = revision_under_test("b1c2d3e4f5a6")
 
 
 def test_lease_upgrade_recovers_processing_rows_and_creates_index(db_engine, monkeypatch):
@@ -24,7 +27,7 @@ def test_lease_upgrade_recovers_processing_rows_and_creates_index(db_engine, mon
     monkeypatch.setenv("DB_HOST", "127.0.0.1")
     monkeypatch.setenv("DB_PORT", "5432")
     config = Config(str(REPO_ROOT / "alembic.ini"))
-    command.downgrade(config, PREVIOUS_HEAD)
+    command.downgrade(config, _MIGRATION.parent)
 
     engine = create_engine(db_engine.url.render_as_string(hide_password=False))
     inserted_ids = []
@@ -40,7 +43,7 @@ def test_lease_upgrade_recovers_processing_rows_and_creates_index(db_engine, mon
             """)
                 )
             )
-        command.upgrade(config, CURRENT_HEAD)
+        command.upgrade(config, _MIGRATION.revision)
         with engine.connect() as connection:
             rows = connection.execute(
                 text("""
@@ -72,7 +75,7 @@ def test_lease_upgrade_recovers_processing_rows_and_creates_index(db_engine, mon
         engine.dispose()
         # Put the schema back where this test found it. It downgrades the
         # *per-run database every other test in the process is using*, and
-        # ``CURRENT_HEAD`` above is a historical revision — stopping there
+        # ``_MIGRATION.revision`` above is a historical revision — stopping there
         # leaves every later migration un-applied, which is how this one file
         # used to take the rest of the suite down with it
         # (``species_entry.isotope_key does not exist``, hundreds of tests

--- a/backend/tests/test_migration_revision_names.py
+++ b/backend/tests/test_migration_revision_names.py
@@ -1,0 +1,100 @@
+"""No test may call a pinned revision id "head".
+
+A migration test has to name the revision it is about. What it must not do
+is name it ``CURRENT_HEAD``, because the two words disagree: the value is
+fixed the moment it is typed, and head moves every time a revision lands.
+The name wins. Three separate tests have downgraded the shared per-run
+database and restored it to a constant called ``_CURRENT_HEAD`` on the
+reasonable belief that this put it back at head -- and each time the damage
+landed on unrelated files hundreds of tests later, because the constant had
+gone stale in between.
+
+The third of those (#197) happened *after* the first two had been fixed in
+place, each leaving a comment warning the next author about it. That is the
+finding this file encodes: a comment explaining a misleading name is weaker
+than not having the misleading name, so the name is now asserted against
+rather than annotated.
+
+``tests/db/_migration_chain.py`` is the sanctioned way to name a subject --
+``revision_under_test("b1c2d3e4f5a6")`` -- and ``tests/db/conftest.py``
+holds the two runtime halves: ``alembic_head``, which reads head from disk,
+and ``_must_leave_the_database_at_head``, which fails the test that leaves
+the shared database somewhere else.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent
+
+#: An alembic revision id as this repo generates them: twelve hex digits.
+_REVISION_ID = re.compile(r"\A[0-9a-f]{12}\Z")
+
+
+def _binds_a_revision_to_a_head_name(node: ast.AST) -> list[str]:
+    """Names in one statement that say "head" but hold a fixed revision."""
+    if isinstance(node, ast.AnnAssign):
+        targets, value = [node.target], node.value
+    elif isinstance(node, ast.Assign):
+        targets, value = node.targets, node.value
+    else:
+        return []
+    if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+        return []
+    if not _REVISION_ID.match(value.value):
+        return []
+    return [target.id for target in targets if isinstance(target, ast.Name) and "HEAD" in target.id.upper()]
+
+
+def _python_files() -> list[Path]:
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(TESTS_ROOT):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        found.extend(Path(dirpath) / name for name in filenames if name.endswith(".py"))
+    return sorted(found)
+
+
+def test_no_test_binds_a_revision_id_to_a_name_saying_head() -> None:
+    offenders: dict[str, list[str]] = {}
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        names = [name for node in ast.walk(tree) for name in _binds_a_revision_to_a_head_name(node)]
+        if names:
+            offenders[path.relative_to(TESTS_ROOT).as_posix()] = sorted(names)
+
+    assert not offenders, (
+        f"these constants hold a fixed revision under a name that says head: "
+        f"{offenders}. A revision id is head only until the next one lands, so "
+        "the name will be wrong and nobody will be present when it becomes "
+        "wrong. If it means 'the revision this file is about', say that: "
+        'tests/db/_migration_chain.revision_under_test("<id>") gives it and '
+        "its parent. If it means head, do not write an id at all -- use the "
+        "literal string 'head', or the alembic_head fixture."
+    )
+
+
+def test_the_scan_recognises_the_shape_it_is_looking_for() -> None:
+    """The assertion above passes trivially if the matcher matches nothing.
+
+    Its whole job is to find something that is currently absent from the
+    tree, so a typo in the regex or in the ``ast`` walk would make it green
+    forever and silently. These are the exact spellings the four files
+    carried before they were converted, plus the ones they must not be
+    replaced with.
+    """
+    caught = 'CURRENT_HEAD = "b1c2d3e4f5a6"\n_PREVIOUS_HEAD: str = "a8b9c0d1e2f3"\n'
+    names = [name for node in ast.walk(ast.parse(caught)) for name in _binds_a_revision_to_a_head_name(node)]
+    assert names == ["CURRENT_HEAD", "_PREVIOUS_HEAD"], names
+
+    # Not the target: an honestly named subject, and head read from disk.
+    allowed = (
+        'STAGE2_REVISION = "c1d2e3f4a5b6"\n'
+        '_MIGRATION = revision_under_test("b7e4d1a9c026")\n'
+        "head = script.get_current_head()\n"
+        'RESTORE_TO_HEAD = "head"\n'
+    )
+    assert not [name for node in ast.walk(ast.parse(allowed)) for name in _binds_a_revision_to_a_head_name(node)]


### PR DESCRIPTION
## The real file count

**Four**, as expected — but `git grep "_CURRENT_HEAD"` finds only two. The other
two spell it without the leading underscore, so the obvious grep under-reports by
half:

| File | Constants |
|---|---|
| `tests/db/test_constraint_rename_migration.py` | `_PREVIOUS_HEAD`, `_CURRENT_HEAD` |
| `tests/db/test_imaginary_mode_tau_basis_constraint.py` | `_PREVIOUS_HEAD`, `_CURRENT_HEAD` |
| `tests/db/test_upload_job_lease_migration.py` | `PREVIOUS_HEAD`, `CURRENT_HEAD` |
| `tests/db/test_dataset_release_migration.py` | `PREVIOUS_HEAD`, `CURRENT_HEAD` |

Eight other files in `tests/db/` also pin revision pairs, and every one of them
already uses an honest name — `BASE_REVISION`/`STAGE2_REVISION`,
`PREVIOUS_REVISION`/`TRIGGER_REVISION`, `_GEOMETRY_REVISION`. The four above were
the outliers, not the convention.

## Does the trap still bite, given #180's guard?

**Yes, but attributably.** Reproduced before changing anything: pointing
`test_imaginary_mode_tau_basis_constraint.py`'s teardown back at `_CURRENT_HEAD`
still takes down three tests in `test_statmech_torsion_index_uniqueness.py` in the
same process. What #180 changed is that the offender now fails too, at its own
teardown, by name:

```
ERROR tests/db/test_imaginary_mode_tau_basis_constraint.py::test_the_migration_refuses_rather_than_guesses
E  AssertionError: the shared test database is at alembic revision 'e2a7c9d4b615',
   not head ('b7e4d1a9c026'). This test left it there.
```

So this is a cleanup of the *cause* rather than a fix for an open defect: #180
made the failure diagnosable in one step, and this makes the name that caused it
three times unavailable. Both halves matter — the guard catches the mistake after
it is made, the rename stops it being the natural thing to write.

## What was collapsed

`_CURRENT_HEAD` never meant head. It meant **the revision under test**, which is
head only between the day it is typed and the day the next revision lands. New
helper `tests/db/_migration_chain.py` resolves the chain from the Alembic script
directory, and each file now names exactly one thing — its subject:

```python
_MIGRATION = revision_under_test("b7e4d1a9c026")

command.downgrade(config, _MIGRATION.parent)     # its down_revision, read not copied
command.upgrade(config, _MIGRATION.revision)     # the thing under test
command.upgrade(config, "head")                  # putting the shared DB back
```

`revision_under_test` refuses a symbolic selector — `"head"`, `"heads"`,
`"base"`, a partial hash — by checking that the id Alembic resolved is the id it
was handed. A subject cannot be spelled "head" through it even by accident. It
also refuses a merge point and the base revision, and raises at import time, so a
bad id is a collection error naming the revision rather than a downgrade to
somewhere unexpected.

**`_PREVIOUS_HEAD` is derived, not kept.** Verified against the script directory:
in all four files it was character-for-character the revision's own
`down_revision`. It is not independent information, it is a copy of a fact the
migration file declares — a second place that can disagree with the first, where
the disagreement does not fail (the test downgrades somewhere else and usually
still passes). Its name is time-relative in the same way as `_CURRENT_HEAD`: a
revision's parent is fixed forever, but "what head used to be" is a statement
about a calendar. The one argument for keeping it — pinning against a rewrite of
`down_revision` — is a rewrite `migration-rules.md` forbids on deployed
revisions, and if it happened, downgrading to the declared parent is the correct
behaviour anyway.

`tests/db/conftest.py::alembic_head` now delegates to the same module, so exactly
one place in the tree opens `alembic.ini`. Also renamed the fixture
`alembic_at_previous_head` → `database_below_the_migration` for the same reason.

**The helper cannot go stale.** Its only literal is the path to `alembic.ini`,
resolved from `__file__`. No revision id appears in it.

## Schema / migration impact

**None.** Nothing under `alembic/versions/` is touched, no model or schema
changes, no new environment variable. Test-tree and one doc section only.

## New regression test

`tests/test_migration_revision_names.py` fails any test binding a revision id to
a name containing "head". Because a scan for something absent from the tree
passes trivially if the matcher matches nothing, it carries a second test
asserting the matcher recognises the exact spellings the four files used to
carry — and it was verified against the real thing: restoring `origin/main`'s
`test_upload_job_lease_migration.py` into the tree makes it fail, naming both
constants.

## Verification actually run

- `pytest tests/db/ -p no:randomly -q` — **214 passed** before, **218 passed**
  after (one process, fixed order, since order-dependence is the defect class).
- **Guard mutation, before the change**: teardown → `_CURRENT_HEAD`; offender
  ERRORs by node id, three downstream tests fail. Confirmed the mutation was in
  the file first.
- **Guard mutation, after the change**: teardown → `_MIGRATION.revision`; guard
  still fails *that* test by name. `_must_leave_the_database_at_head` is
  untouched and not redundant.
- **Regression-test mutation**: `git show origin/main:...test_upload_job_lease_migration.py`
  dropped into `tests/db/` → new test fails naming `CURRENT_HEAD`, `PREVIOUS_HEAD`.
  Probe removed, `__pycache__` cleared.
- Helper branches exercised directly: `head`, `heads`, partial hash, `<id>-1`,
  unknown id, and the base revision are each refused; `b7e4d1a9c026` resolves to
  parent `e2a7c9d4b615`.
- `ruff check app tests scripts` and `ruff format --check` from `backend/` — clean.
- Full serial `pytest tests/ -p no:randomly` in progress; result reported on the PR.

## Premise refuted

The task brief said `d861dfd60891` is the base revision. It is not —
`60b67e360daf` sits below it. `CLAUDE.md` and `migration-rules.md` both describe
`d861dfd60891` as "the schema baseline", which is true of what it *does*
(`create_all` + seed data) but not of its position in the chain. Not changed
here; flagging it because anything reasoning about "the bottom of the chain" from
those docs would be wrong.
