### PR TITLE
Make a guard notice when it has nothing to look at

### DIFF
--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -554,10 +554,21 @@ def test_client_facing_excludes_what_a_client_cannot_use() -> None:
 
 
 def test_the_status_fallback_family_is_not_exported() -> None:
-    """``http_404`` and friends are the status line, spelled twice."""
+    """``http_404`` and friends are the status line, spelled twice.
+
+    The pattern is exercised in both directions before it is trusted, and
+    #192 added the floor under ``exported``: the final assertion is an
+    absence over a derived set, and an empty ``client_facing()`` would
+    satisfy it while the client enum published nothing at all.
+    """
     assert STATUS_FALLBACK_PATTERN.match("http_404")
     assert not STATUS_FALLBACK_PATTERN.match("handle_not_found")
     exported = {entry.code for entry in client_facing()}
+    assert len(exported) > 50, (
+        f"only {len(exported)} codes are exported (measured: 136); an "
+        "exclusion asserted over a set this small has stopped saying that "
+        "the status-fallback family in particular is kept out"
+    )
     assert not [code for code in exported if STATUS_FALLBACK_PATTERN.match(code)]
 
 

--- a/backend/tests/api/test_error_contract_catalogue_gate.py
+++ b/backend/tests/api/test_error_contract_catalogue_gate.py
@@ -51,6 +51,15 @@ answer that, and only the third lives here:
 Every assertion below runs over something non-empty and is stated in both
 directions, because a gate that can only say yes -- or only say no -- passes
 while proving nothing.
+
+#192 audited that claim rather than trusting it, and it was not true of
+four assertions here: three asserted an *absence* over a set nothing
+required to be populated, and ``_assert_no_token_in_the_code_position``
+ran a pattern nothing required to match. Each now states its floor where
+it makes its claim, rather than relying on a neighbour that happens to
+share a constant. The floors are measured, and the measurements are in
+the messages so the next reader can tell a real shrinkage from a broken
+scan.
 """
 
 from __future__ import annotations
@@ -84,6 +93,31 @@ def _promoted(message: str) -> str:
     return validation_detail_code(message, fallback="validation_error")
 
 
+#: A message that must be read as opening with a token in the code
+#: position. It is the exact shape #178 reworded out of ``keyset.py`` --
+#: see this module's docstring -- and it exists so that
+#: :func:`_opens_with_a_token` can be caught saying no to it.
+_A_REFUSAL_THAT_DOES_OPEN_WITH_A_TOKEN = (
+    "keyset_predicate: at least one sort key is required."
+)
+
+#: The shortest a real refusal gets. Measured against the two this file
+#: provokes, which are 11 and 17 words; the floor is well under both and
+#: exists only to reject the degenerate input, not to police wording.
+_MINIMUM_WORDS_IN_A_REFUSAL = 5
+
+
+def _opens_with_a_token(message: str) -> bool:
+    """Does *message* put a token in the code position?
+
+    One expression, used for both the positive control and the assertion
+    below, so that blinding the detector cannot blind only the half that
+    says no. Two spellings of the same question drift apart, and the
+    drift is invisible: both stay green.
+    """
+    return bool(_CODE_POSITION.match(message))
+
+
 def _assert_no_token_in_the_code_position(message: str) -> None:
     """The message must not open with ``some_token: ``.
 
@@ -93,8 +127,32 @@ def _assert_no_token_in_the_code_position(message: str) -> None:
     uncatalogued, and the test that was meant to hold the wording would
     stay green. #177 is the same lesson one layer down -- a guard that
     passes for a second reason stops guarding the first.
+
+    #192: this helper used to be that same failure one layer down again.
+    It matched a pattern and asserted the match was empty, so a blinded
+    pattern made it report success having read nothing -- measured, both
+    callers green with the detector replaced by one that matches nothing.
+    The file did go red, but in ``TestOneMessageDeclaresOneCode``, whose
+    floor happens to share this module constant; that coupling is an
+    accident of spelling, not a guard, and it is how the defect surfaced
+    at all. So the detector is now run against a message it must accept
+    before it is trusted to reject one, and the message has to be a
+    sentence -- ``""`` opens with no token either.
     """
-    assert not _CODE_POSITION.match(message), (
+    assert _opens_with_a_token(_A_REFUSAL_THAT_DOES_OPEN_WITH_A_TOKEN), (
+        "the code-position detector no longer recognises "
+        f"{_A_REFUSAL_THAT_DOES_OPEN_WITH_A_TOKEN!r}, which is the exact "
+        "shape it exists to reject. Every assertion it makes below is "
+        "therefore vacuous: it would pass over a refusal that had gone "
+        "back to naming the function it was raised in."
+    )
+    assert len(message.split()) >= _MINIMUM_WORDS_IN_A_REFUSAL, (
+        f"the refusal is {message!r}, which is too short to be the prose "
+        "this guard is written over. A message with no words opens with no "
+        "token, so the assertion below would pass without examining a "
+        "refusal at all."
+    )
+    assert not _opens_with_a_token(message), (
         f"the refusal opens with a token in the code position: {message!r}. "
         "A message says what went wrong; it does not name the function it "
         "went wrong in, and a leading token is read as a code by anyone "
@@ -183,11 +241,28 @@ class TestTheGateIsTheCatalogue:
     """The set consulted is derived, not a second hand-written list."""
 
     def test_it_is_exactly_the_catalogue_message_prefix_codes(self):
-        assert MESSAGE_PREFIX_CODES == {
+        """Both sides are read from ``CATALOGUE``, so both empty is equal.
+
+        #192: an equality between two derivations of one source is
+        satisfied when that source is empty, and this is the assertion
+        that says the gate *is* the catalogue. The floor is repeated here
+        rather than left to ``test_it_is_large_enough_to_be_the_read_api``
+        below, in the same style as the ``>= 6`` floor that appears in
+        both of ``TestTheShapeTheRaiseSiteScanCannotRead``'s assertions:
+        a test that can only fail because of its neighbour is a test that
+        stops working when its neighbour moves.
+        """
+        derived = {
             entry.code
             for entry in CATALOGUE
             if entry.surface is Surface.message_prefix
         }
+        assert len(derived) > 50, (
+            f"only {len(derived)} codes carry Surface.message_prefix, so this "
+            "equality is comparing two nearly-empty sets and would hold "
+            "however badly the derivation had broken"
+        )
+        assert MESSAGE_PREFIX_CODES == derived
 
     def test_it_is_large_enough_to_be_the_read_api(self):
         """A gate over a nearly-empty set would degrade the whole read API.
@@ -227,6 +302,12 @@ class TestTheGateIsTheCatalogue:
         gone back to naming the function it was raised in.
         """
         catalogued = {entry.code for entry in CATALOGUE}
+        assert len(catalogued) > 100, (
+            f"only {len(catalogued)} codes are catalogued at all (measured: "
+            "149). Absence from a set this small says nothing about whether "
+            "these two names came back -- the assertions below would pass "
+            "over an empty catalogue."
+        )
         for name in ("create_applied_group_additivity", "keyset_predicate"):
             assert name not in catalogued
             assert name not in MESSAGE_PREFIX_CODES
@@ -504,9 +585,21 @@ class TestOneMessageDeclaresOneCode:
             assert expected in codes, sorted(codes)
 
     def test_no_coded_message_names_a_second_code(self):
+        """The floor is repeated here, not borrowed from the test above.
+
+        #192: this is an absence asserted over a scan, and the scan's own
+        floor lives in a different test. Carrying it here too costs a line
+        and means the assertion cannot be made vacuous by an edit that
+        leaves its neighbour untouched.
+        """
+        messages = _messages_opening_with_a_promotable_code()
+        assert len(messages) > 40, (
+            f"only {len(messages)} coded messages found (measured: 125), so "
+            "there is nothing to be ambiguous and this test proves nothing"
+        )
         ambiguous = [
             (path, line, text)
-            for path, line, text in _messages_opening_with_a_promotable_code()
+            for path, line, text in messages
             if len(set(_NESTED_CODE_PATTERN.findall(text))) > 1
         ]
         assert not ambiguous, (


### PR DESCRIPTION
Closes #192.

`_assert_no_token_in_the_code_position` matched a pattern and asserted the match
was empty. Blind the pattern and it passes over an empty result, reporting
success having checked nothing.

**Schema/migration impact:** none. Test-only, two files. No new environment
variable.

## The measured defect

Two mutations, `git diff`-confirmed before each run:

| # | Mutation | Result |
|---|---|---|
| A | `_CODE_POSITION` (module constant) → a regex matching nothing | **1 failed**, 18 passed — and the failure was `TestOneMessageDeclaresOneCode::test_the_scan_sees_the_messages_it_is_written_over`, a *different class*. Both callers of the helper stayed green. |
| B | Only the helper's own detector blinded, module constant left intact | **19 passed.** Nothing noticed. |

Mutation A is worth stating precisely because it partly refutes the issue's
premise: the file as a whole *does* go red under a whole-module blinding. But it
goes red in a guard written for something else, which happens to share the same
module constant — the coupling is an accident of spelling. Mutation B removes the
accident and the helper is revealed as completely unguarded. That is also exactly
how the issue says the defect surfaced: as a side effect of a mutation aimed at a
different guard.

A third vacuity was found in the same helper and is independent of any pattern:
`_assert_no_token_in_the_code_position("")` passes, and so does the
`_promoted(message) == "validation_error"` assertion its callers pair it with. A
refusal that degenerated to an empty message would satisfy both.

## Audit — every assertion helper and test in the two files

Question asked of each: *would this pass if its input were empty?*

### `test_error_contract_catalogue_gate.py`

| Helper / test | Verdict |
|---|---|
| `_promoted` | Sound — a wrapper, asserts nothing. |
| **`_assert_no_token_in_the_code_position`** | **VACUOUS — fixed.** Blind detector (mutation B) and both callers pass; empty message also passes. |
| `_sources` | Sound by callers — every consumer carries a floor. |
| `_helpers_that_raise_a_parameter_as_the_code` | Sound — `test_the_scan_finds_the_helper_it_is_written_for` asserts positive membership. |
| `_codes_passed_to` | Sound — floored `>= 6` at both call sites. |
| `_static_message` | Sound by caller — returning `None` always empties the scan, caught by the `> 40` floor. |
| `_messages_opening_with_a_promotable_code` | Sound as a producer; one consumer was not (below). |
| `test_it_is_exactly_the_catalogue_message_prefix_codes` | **VACUOUS in isolation — fixed.** Equality between two derivations of one source; both empty is equal. Floored only by a neighbour. |
| `test_it_is_large_enough_to_be_the_read_api` | Sound — `> 50`. |
| `test_it_excludes_every_code_that_arrives_some_other_way` | Sound — `len(other) > 50`. |
| `test_a_function_name_is_in_no_surface_at_all` | **VACUOUS — fixed.** Pure absence assertion over `catalogued`; an empty catalogue satisfies it. Nothing else in the test carries weight. |
| `test_every_catalogued_message_prefix_code_is_still_promoted` | Sound — carries its own count floor, and its docstring already records why it is a loop and not a `parametrize`. |
| `test_a_code_still_survives_pydantic_wrapping_its_sentence` | Sound — fixed literal. |
| `test_the_keyset_guard_no_longer_advertises_its_own_name` | Sound once the helper is fixed. |
| `test_the_length_guard_is_the_same_shape` | Sound once the helper is fixed. |
| `test_an_uncatalogued_token_in_the_code_position_is_not_promoted` | Sound — negative, but the positive direction is held by `test_every_catalogued_message_prefix_code_is_still_promoted`. |
| `test_a_field_path_is_still_not_promoted` | Sound — same both-directions argument. |
| `test_the_scan_finds_the_helper_it_is_written_for` | Sound — positive membership. |
| `test_every_code_minted_from_a_parameter_is_catalogued` | Sound — `>= 6`. |
| `test_they_are_catalogued_as_arriving_by_this_mechanism` | Sound — `>= 6`. |
| `test_the_scan_sees_the_messages_it_is_written_over` | Sound — `> 40` plus three named codes. |
| `test_no_coded_message_names_a_second_code` | **VACUOUS in isolation — fixed.** Absence over a scan whose floor lives in a different test. |
| `test_the_scan_would_notice_a_second_token` | Sound — a positive control on the detector. This is the shape the fix below copies. |
| `test_a_catalogued_prefix_is_still_lifted` | Sound — positive. |
| `test_an_uncatalogued_prefix_falls_back_to_the_status` | Sound — paired with the positive above. |
| `test_a_declared_code_in_a_dict_detail_is_not_second_guessed` | Sound — positive plus a negative. |

### `test_api_code_catalogue.py` (sibling, same shape)

| Test | Verdict |
|---|---|
| `test_a_code_is_listed_once_per_status_it_arrives_at` | Sound — `> 50`. |
| `test_every_raise_site_code_is_catalogued` | Sound — `> 80`. |
| `test_the_origin_detector_can_say_no` | Sound — positive and negative literals; the docstring records the mutation that motivated it. |
| `test_every_origin_still_defines_its_code` | Sound — `checked > 50`. |
| `test_the_register_is_a_strict_subset_of_the_catalogue` | Sound — `assert scientific`. |
| `test_the_catalogue_is_not_the_register_wearing_a_different_name` | Sound — two floors. |
| `test_client_facing_excludes_what_a_client_cannot_use` | Sound — `assert exported` and `excluded > 5`. |
| `test_the_status_fallback_family_is_not_exported` | **VACUOUS in isolation — fixed.** Absence over `exported`; the pattern has a positive control but the set does not. |
| `test_the_runtime_observer_is_actually_watching` | Sound — positive membership. |
| `test_the_observer_watches_the_status_and_not_only_the_code` | Sound — `CATALOGUE[0]` raises on empty; stated both directions. |
| `test_a_refusal_that_is_not_science_is_importable_by_a_client` | Sound — positive membership. |
| `test_the_reach_rule_can_say_no` | Sound — constructed literals. |
| `test_every_guard_entry_is_catalogued_annotated_and_unexported` | Sound — `assert guards` plus a proportion bound. |
| `test_the_ownership_guards_are_guards_because_of_a_schema_shape` | Sound — the `model_fields` absences are anchored by a positive `"source_calculation_key" in ...` on the same models. |

### `test_error_contract_coded_promotion.py`

Audited, no changes. Every test drives fixed literals; there is no discovery
scan and therefore no empty-input path.

### `pytest.mark.parametrize`

The issue flags `parametrize` over an empty set silently becoming a skip.
Neither file parametrizes over anything. The single textual hit in the gate file
is prose in `test_every_catalogued_message_prefix_code_is_still_promoted`
explaining why the loop form was chosen over `parametrize` for exactly that
reason — a finding already recorded, not a new one.

## The fix, and the floors

**Measured first, floors set below the measurement** (`151` catalogue entries,
`149` codes, `74` `message_prefix`, `75` non-`message_prefix`, `136` exported,
`125` coded messages, `434` modules parsed, `6` parameter-minted codes; the two
provoked refusals are 11 and 17 words).

| Location | Floor added | Measured |
|---|---|---|
| `_assert_no_token_in_the_code_position` | detector must match a message that *does* open with a token; message must be ≥ 5 words | 11 and 17 words |
| `test_it_is_exactly_the_catalogue_message_prefix_codes` | `len(derived) > 50` | 74 |
| `test_a_function_name_is_in_no_surface_at_all` | `len(catalogued) > 100` | 149 |
| `test_no_coded_message_names_a_second_code` | `len(messages) > 40` | 125 |
| `test_the_status_fallback_family_is_not_exported` | `len(exported) > 50` | 136 |

The helper's repair is the positive-control form already used by
`test_the_scan_would_notice_a_second_token` in the same file and by #185's
`test_the_scan_recognises_the_shape_it_is_looking_for`: run the detector against
something it must accept before trusting it to reject. It is placed *inside* the
helper rather than in a neighbouring test, and both the control and the assertion
go through one `_opens_with_a_token` expression — so a blinding cannot reach only
the half that says no.

## The fix is not itself vacuous

Every floor was blinded and confirmed to fail, `git diff`-verified before each
run, then restored:

| Floor | Blinding mutation | Result |
|---|---|---|
| helper positive control | `_opens_with_a_token` → regex matching nothing (this is mutation B, which was green before) | **2 failed** — both callers, at the control |
| helper word floor | caller passes `message = ""` | **1 failed** — and `_promoted("")` still returned `validation_error`, confirming the paired assertion could not have caught it |
| `derived > 50` | comprehension filter `and False` | **failed** |
| `catalogued > 100` | comprehension filtered to a code that does not exist | **failed** |
| `messages > 40` | `messages = []` | **failed** |
| `exported > 50` | `exported = set()` | **failed** |

All four set-floors were blinded in one run and produced exactly four failures,
one per floor. After restoring: `git status` clean, `__pycache__` cleared between
every run.

One process note, since it is the kind of thing this issue is about: my first
`git diff` confirmation of the set-floor mutations printed nothing, which would
have read as "the mutation did not land." It had landed — the `git diff` was
running from `backend/` with repo-root-relative paths. Re-checked from the
worktree root before drawing any conclusion.

## Verification actually run

```
conda run -n tckdb_env python -m pytest \
  tests/api/test_error_contract_catalogue_gate.py \
  tests/api/test_api_code_catalogue.py \
  tests/api/test_error_contract_coded_promotion.py \
  tests/test_migration_revision_names.py -q
# 47 passed

conda run -n tckdb_env ruff check \
  tests/api/test_error_contract_catalogue_gate.py \
  tests/api/test_api_code_catalogue.py
# All checks passed!
```

`ruff format --check` reports both files as unformatted, but it does so for
regions this branch never touched (`_sources`, `_helpers_that_raise_a_parameter_as_the_code`)
— the files are already non-conformant at `main`, so no reformatting is included
here.

## Not changed

No guard's claim about the code was weakened, tightened, or relaxed; nothing was
skipped, xfailed or deleted. No guard was found to be vacuous *and* regressed —
every subject still holds, so none of these floors lands red.
