### PR TITLE
Name the undeclared calculation key instead of crashing

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -378,6 +378,22 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("calculation_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py"),
+    ApiCode("calculation_key_undeclared", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py",
+            note=(
+                "One code for every bundle field that names a calculation by "
+                "local key -- thermo and statmech source links, a torsion's "
+                "rotor scan, a dependency's parent, IRC evidence, a PDep "
+                "solve's energies, barriers and source calculations -- "
+                "because they resolve against one namespace and are repaired "
+                "one way: declare the calculation, or fix the spelling "
+                "against the list the refusal prints. context['field'] says "
+                "which one asked. That is the test the ownership family "
+                "fails, where two fields need two different right answers. "
+                "An applied energy correction's source key keeps its own "
+                "older code for the same reason in reverse: there, a "
+                "conformer name and a calculation name are one repair."
+            )),
     ApiCode("canonical_parameter_value_requires_key", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/calculations_search.py"),
     ApiCode("client_sort_not_supported", 422, Surface.message_prefix,

--- a/backend/app/services/energy_correction_resolution.py
+++ b/backend/app/services/energy_correction_resolution.py
@@ -7,11 +7,11 @@ and creates applied correction rows with resolved FK IDs.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import TypeVar
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.error_contract import CodedValueError
 from app.db.models.energy_correction import (
     AppliedEnergyCorrection,
     AppliedEnergyCorrectionComponent,
@@ -31,12 +31,15 @@ from app.services.calculation_resolution import (
     resolve_workflow_tool_release_ref,
 )
 from app.services.literature_resolution import resolve_or_create_literature
+from app.services.local_key_resolution import resolve_declared_key
 from app.services.software_resolution import resolve_software
 
 #: An applied correction names a source the enclosing upload never declared.
 W_APPLIED_CORRECTION_SOURCE_KEY_UNDECLARED = (
     "applied_energy_correction_source_key_undeclared"
 )
+
+T = TypeVar("T")
 
 
 # ---------------------------------------------------------------------------
@@ -46,11 +49,11 @@ W_APPLIED_CORRECTION_SOURCE_KEY_UNDECLARED = (
 
 def resolve_applied_correction_source_key(
     key: str | None,
-    declared: Mapping[str, int],
+    declared: Mapping[str, T],
     *,
     field: str,
     declares: str,
-) -> int | None:
+) -> T | None:
     """Turn one applied-correction source key into the row it names.
 
     Blocking, and ADR 0008 permits it because this asserts a *contract*
@@ -67,37 +70,42 @@ def resolve_applied_correction_source_key(
     the refusal into something fixable. Row ids never appear -- they are
     values of this map, not part of any message.
 
+    The lookup itself moved to
+    :func:`app.services.local_key_resolution.resolve_declared_key` when
+    nineteen raw subscripts in the bundle workflows were routed through
+    the same seam; what stays here is this field's *code* and its closing
+    sentence. The code stays because it was published before that seam
+    existed and is pinned on ``/uploads/conformers``, and because a
+    correction's source is one repair whether the key names a conformer
+    or a calculation -- splitting it by which kind of name the depositor
+    used would answer the same question two ways on two routes.
+
+    Generic in the value type: ``computed_species`` hands this a map of
+    ``Calculation`` rows because its next move is an ownership check that
+    needs one, while the other callers hand it ids.
+
     :param key: The key the payload wrote, or ``None`` for no link.
-    :param declared: Declared local name -> persisted row id.
+    :param declared: Declared local name -> the row or id it names.
     :param field: Field path naming the offending key, echoed verbatim.
     :param declares: How a depositor declares a name in this namespace,
         phrased as the remedy sentence's object.
-    :returns: The row id the key names, or ``None`` when ``key`` is
-        ``None``.
+    :returns: What ``declared`` holds for ``key``, or ``None`` when
+        ``key`` is ``None``.
     :raises CodedValueError: if ``key`` is set but names nothing declared.
     """
     if key is None:
         return None
-    row_id = declared.get(key)
-    if row_id is not None:
-        return row_id
-
-    known = sorted(declared)
-    if known:
-        available = "Declared names here: " + ", ".join(repr(k) for k in known) + "."
-    else:
-        available = "This upload declares no such name at all."
-    raise CodedValueError(
-        W_APPLIED_CORRECTION_SOURCE_KEY_UNDECLARED,
-        f"{field}='{key}' does not name anything declared in this upload. "
-        f"{available} {declares} An energy correction whose source cannot be "
-        f"named is a correction nobody can trace back to what it corrected.",
-        context={
-            "field": field,
-            "key": key,
-            "declared_keys": known,
-        },
-        message_prefix=False,
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_APPLIED_CORRECTION_SOURCE_KEY_UNDECLARED,
+        subject="anything",
+        remedy=(
+            f"{declares} An energy correction whose source cannot be "
+            f"named is a correction nobody can trace back to what it "
+            f"corrected."
+        ),
     )
 
 

--- a/backend/app/services/local_key_resolution.py
+++ b/backend/app/services/local_key_resolution.py
@@ -12,10 +12,11 @@ the payload is resolved through it.
 
 Why the lookup is a function and not a subscript
 ------------------------------------------------
-It was a subscript, nineteen times, across three bundle workflows. A key
-naming nothing was a ``KeyError``: an unhandled 500 with nothing in it
-saying which key was wrong, where the honest answer is a 422 naming the
-key and the keys that *are* declared.
+It was a subscript, twenty-one times: nineteen across the three bundle
+workflows and one each in the standalone thermo and transport product
+workflows. A key naming nothing was a ``KeyError``: an unhandled 500
+with nothing in it saying which key was wrong, where the honest answer
+is a 422 naming the key and the keys that *are* declared.
 
 The usual defence was that the request schema already refuses an
 undeclared key before the workflow runs. That defence was true of most
@@ -92,13 +93,13 @@ def resolve_declared_key(
 ) -> T:
     """Turn one local key into whatever the request declared under it.
 
-    Generic in the value type on purpose. The three bundle workflows do
-    not agree on what their calc-key map holds — ``computed_species``
+    Generic in the value type on purpose. The workflows do not agree on
+    what their calc-key map holds — ``computed_species``
     keeps ``Calculation`` rows because its next move is an ownership
     check that needs one, ``computed_reaction`` and ``network_pdep`` keep
     ids — and a helper that forced one shape would have been adopted by
     whichever workflows it happened to fit, which is how there came to be
-    nineteen subscripts instead of one lookup.
+    twenty-one subscripts instead of one lookup.
 
     :param key: The key the payload wrote. Never ``None`` — a caller
         with an optional field decides for itself what absence means,
@@ -145,10 +146,14 @@ def resolve_calculation_key(
     field: str,
     code: str = W_CALCULATION_KEY_UNDECLARED,
 ) -> T:
-    """Resolve one bundle-local *calculation* key, or refuse with a code.
+    """Resolve one upload-local *calculation* key, or refuse with a code.
 
-    The seam every raw ``calc_keys_to_id[...]`` subscript in the three
-    bundle workflows now goes through.
+    The seam every raw calc-key subscript now goes through, in all five
+    workflows that resolve a calculation by local key —
+    ``computed_species``, ``computed_reaction``, ``network_pdep``,
+    ``thermo`` and ``transport``.
+    ``tests/services/test_local_key_resolution.py`` fails if a raw one
+    comes back to any of them.
 
     :param key: The calculation key the payload wrote.
     :param declared: The workflow's calc-key namespace.

--- a/backend/app/services/local_key_resolution.py
+++ b/backend/app/services/local_key_resolution.py
@@ -1,0 +1,167 @@
+"""One lookup, for every local key an upload uses to name its own parts.
+
+What a local key is
+-------------------
+An upload payload never carries a database id (DR-0029 Requirement 1).
+When a thermo record has to say which calculations produced its number,
+or a torsion has to name its rotor scan, or a solve has to cite the jobs
+behind it, the payload writes a *local key* — a string the same request
+declared on a calculation it also sent. The workflow builds a map from
+those keys to the rows it just persisted, and every cross-reference in
+the payload is resolved through it.
+
+Why the lookup is a function and not a subscript
+------------------------------------------------
+It was a subscript, nineteen times, across three bundle workflows. A key
+naming nothing was a ``KeyError``: an unhandled 500 with nothing in it
+saying which key was wrong, where the honest answer is a 422 naming the
+key and the keys that *are* declared.
+
+The usual defence was that the request schema already refuses an
+undeclared key before the workflow runs. That defence was true of most
+sites and *false* of two, and it was false in the way this arrangement
+always fails: the guard lives in ``tckdb_schemas`` — a different
+distributable package from the workflow it protects — so the two drift
+without anything going red. ``NetworkPDepUploadRequest`` narrows a
+**species** statmech's source and torsion keys to that species's own
+calculations and does not do the same for a **transition state**'s, so a
+PDep TS statmech naming a key nothing declared reached
+``_persist_statmech_block`` and raised ``KeyError`` out of the route.
+That is not a hypothetical: ``tests/api/test_api_pdep_ts_statmech_
+undeclared_key.py`` provokes it on the wire.
+
+Keeping the schema checks is deliberate. They refuse one layer earlier,
+they run in a client that never talks to a server, and a duplicated
+check costs nothing while a missing one costs a 500. What changes here is
+that the workflow no longer *depends* on them being right.
+
+What the refusal carries
+------------------------
+The offending field, the key as the depositor wrote it, and the keys that
+are declared — because naming the alternatives is what turns a refusal
+into a mechanical fix. Never a row id: the ids are the *values* of these
+maps and they stay there, out of anything a depositor reads (DR-0028
+Requirement 2).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeVar
+
+from app.api.error_contract import CodedValueError
+
+#: A payload names a calculation key that the same upload never declared.
+#:
+#: One code for every such field, and the field is in ``context``. An
+#: undeclared key on a thermo source link and on a torsion's rotor scan
+#: are the *same* repair — declare the calculation, or fix the spelling
+#: against the list the refusal prints — resolved against the *same*
+#: bundle-global namespace. That is the test the ownership family
+#: (:mod:`app.services.calculation_ownership`) fails and this one passes:
+#: there, a thermo link and a torsion's scan are repaired by finding two
+#: different right answers, so they get two codes; here there is one
+#: right answer and it is spelled the same way whichever field asked.
+#:
+#: Deliberately *not* used for an applied energy correction's source key.
+#: That field already had a code before this one existed
+#: (``applied_energy_correction_source_key_undeclared``), it is pinned by
+#: ``tests/api/test_api_upload_key_and_role_contracts.py`` on
+#: ``/uploads/conformers``, and it spans a conformer key as well as a
+#: calculation key — so a correction's source is one repair on that
+#: route and would become two if the bundle routes answered differently.
+W_CALCULATION_KEY_UNDECLARED = "calculation_key_undeclared"
+
+#: How a depositor declares a calculation key in a bundle namespace.
+CALCULATION_KEY_REMEDY = (
+    "Every calculation in an upload carries a required 'key'; a "
+    "calculation key must match one of them."
+)
+
+T = TypeVar("T")
+
+
+def resolve_declared_key(
+    key: str,
+    declared: Mapping[str, T],
+    *,
+    field: str,
+    code: str,
+    subject: str,
+    remedy: str,
+) -> T:
+    """Turn one local key into whatever the request declared under it.
+
+    Generic in the value type on purpose. The three bundle workflows do
+    not agree on what their calc-key map holds — ``computed_species``
+    keeps ``Calculation`` rows because its next move is an ownership
+    check that needs one, ``computed_reaction`` and ``network_pdep`` keep
+    ids — and a helper that forced one shape would have been adopted by
+    whichever workflows it happened to fit, which is how there came to be
+    nineteen subscripts instead of one lookup.
+
+    :param key: The key the payload wrote. Never ``None`` — a caller
+        with an optional field decides for itself what absence means,
+        and none of them mean "look it up anyway".
+    :param declared: Local name -> the row or id it names.
+    :param field: Field path naming the offending key, echoed verbatim
+        into the message and the context.
+    :param code: The refusal's code. A parameter because the applied
+        energy correction's source key had its own published code before
+        this function existed and keeping it is a contract, not a
+        preference.
+    :param subject: Completes "does not name ``{subject}`` declared in
+        this upload" — ``"a calculation"``, or ``"anything"`` where the
+        field accepts more than one kind of name.
+    :param remedy: Sentences appended after the list of declared names.
+    :returns: The value ``declared`` holds for ``key``.
+    :raises CodedValueError: if ``key`` names nothing declared.
+    """
+    if key in declared:
+        return declared[key]
+
+    known = sorted(declared)
+    if known:
+        available = "Declared names here: " + ", ".join(repr(k) for k in known) + "."
+    else:
+        available = "This upload declares no such name at all."
+    raise CodedValueError(
+        code,
+        f"{field}='{key}' does not name {subject} declared in this upload. "
+        f"{available} {remedy}".rstrip(),
+        context={
+            "field": field,
+            "key": key,
+            "declared_keys": known,
+        },
+        message_prefix=False,
+    )
+
+
+def resolve_calculation_key(
+    key: str,
+    declared: Mapping[str, T],
+    *,
+    field: str,
+    code: str = W_CALCULATION_KEY_UNDECLARED,
+) -> T:
+    """Resolve one bundle-local *calculation* key, or refuse with a code.
+
+    The seam every raw ``calc_keys_to_id[...]`` subscript in the three
+    bundle workflows now goes through.
+
+    :param key: The calculation key the payload wrote.
+    :param declared: The workflow's calc-key namespace.
+    :param field: Field path naming the offending key.
+    :param code: Overridable so the statmech upload path can keep the
+        code it published before this seam existed.
+    :raises CodedValueError: if ``key`` names no declared calculation.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=code,
+        subject="a calculation",
+        remedy=CALCULATION_KEY_REMEDY,
+    )

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -48,6 +48,7 @@ from app.services.calculation_ownership import (
 from app.services.calculation_resolution import resolve_workflow_tool_release_ref
 from app.services.energy_correction_resolution import resolve_or_create_freq_scale_factor_ref
 from app.services.literature_resolution import resolve_or_create_literature
+from app.services.local_key_resolution import resolve_calculation_key
 from app.services.software_resolution import resolve_software_release_ref
 
 logger = logging.getLogger(__name__)
@@ -98,22 +99,23 @@ def _resolve_calculation_key(
     map. It is still raised rather than allowed to ``KeyError``: a missing
     provenance link must be a named failure, not a 500.
 
+    The lookup delegates to
+    :func:`app.services.local_key_resolution.resolve_calculation_key`,
+    which is the same seam the three bundle workflows use. This keeps its
+    own code — published, and catalogued against this module — and gains
+    what the shared seam adds: the refusal now prints the keys that *are*
+    declared, which is the difference between a message that names the
+    mistake and one that also fixes it.
+
     :raises CodedValueError: if the key is absent from
-        ``calculations_by_key``. The sentence is unchanged from when this
-        rejection carried no code; only the envelope's ``code`` moves,
-        from the generic ``validation_error`` to one a client can branch
-        on.
+        ``calculations_by_key``.
     """
-    calculation_id = calculations_by_key.get(key)
-    if calculation_id is None:
-        raise CodedValueError(
-            W_STATMECH_CALCULATION_KEY_UNDECLARED,
-            f"{context}: calculation_key '{key}' does not name a calculation "
-            f"declared in this upload.",
-            context={"field": context, "calculation_key": key},
-            message_prefix=False,
-        )
-    return calculation_id
+    return resolve_calculation_key(
+        key,
+        calculations_by_key,
+        field=context,
+        code=W_STATMECH_CALCULATION_KEY_UNDECLARED,
+    )
 
 
 def _chained_calculation_id(source: object) -> int | None:

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -83,6 +83,7 @@ from app.services.kinetics_resolution import (
     assert_kinetics_source_role_compatible,
 )
 from app.services.literature_resolution import resolve_or_create_literature
+from app.services.local_key_resolution import resolve_calculation_key
 from app.services.provenance_warnings import (
     NOT_APPLICABLE,
     collect_provenance_warnings,
@@ -112,6 +113,18 @@ from app.services.transition_state_validation import (
     persist_transition_state_validation_evidence,
 )
 from app.workflows.thermo import assert_thermo_role_matches_calculation_type
+
+#: How a computed-reaction bundle declares a name in the calculation
+#: namespace, phrased as the object of the remedy sentence in
+#: ``resolve_applied_correction_source_key``. A correction's source key
+#: keeps that function's published code whichever kind of name it
+#: carries; only the remedy sentence changes.
+_BUNDLE_CALCULATION_KEY_REMEDY = (
+    "Every calculation in this bundle carries a required 'key'; "
+    "'source_calculation_key' must match one of them. The namespace "
+    "spans every species and the transition state, so a key that "
+    "resolves may still be refused for ownership."
+)
 
 
 def _persist_calculation(
@@ -262,11 +275,21 @@ def _index_species_sp_calcs(
     not declare ``source_calculations`` explicitly. Each species's
     ``calculations`` list is scanned for ``type=sp`` entries and their
     persisted calculation ids are returned in declaration order.
+
+    The keys read here are the bundle's *own* declarations rather than a
+    cross-reference, so the map cannot miss one unless persistence
+    skipped a calculation it was handed. It still goes through the coded
+    seam: the failure that says a workflow lost one of its own rows is
+    exactly the one that should not surface as ``KeyError``.
     """
     by_species: dict[str, list[int]] = {}
     for sp in request.species:
         sp_ids = [
-            calculation_key_to_id[calc.key]
+            resolve_calculation_key(
+                calc.key,
+                calculation_key_to_id,
+                field=f"species['{sp.key}'].calculations[].key",
+            )
             for calc in sp.calculations
             if calc.type == CalculationType.sp
         ]
@@ -693,8 +716,15 @@ def persist_computed_reaction_upload(
             ts_in.validation_evidence,
             transition_state_entry_id=ts_entry.id,
             reconstruction_calculation_ids=[
-                calculation_key_to_id[record.source_calculation_key]
-                for record in ts_in.validation_evidence
+                resolve_calculation_key(
+                    record.source_calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"transition_state.validation_evidence[{index}]."
+                        f"source_calculation_key"
+                    ),
+                )
+                for index, record in enumerate(ts_in.validation_evidence)
             ],
             subject_label=ts_in.label or "transition state",
             field_path="transition_state.validation_evidence",
@@ -714,15 +744,28 @@ def persist_computed_reaction_upload(
     # helper rejects self-edges, role mismatches against existing edges,
     # and per-role one-parent-per-child violations.
     # ------------------------------------------------------------------
-    def _persisted_calc(calc_key: str) -> Calculation:
-        return session.get(Calculation, calculation_key_to_id[calc_key])
+    def _persisted_calc(calc_key: str, *, field: str) -> Calculation:
+        return session.get(
+            Calculation,
+            resolve_calculation_key(
+                calc_key, calculation_key_to_id, field=field
+            ),
+        )
 
     def _wire_depends_on(calc_in: ComputedReactionCalculationIn) -> None:
         if not calc_in.depends_on:
             return
-        child_calc = _persisted_calc(calc_in.key)
+        child_calc = _persisted_calc(
+            calc_in.key, field=f"calculations['{calc_in.key}'].key"
+        )
         for dep in calc_in.depends_on:
-            parent_calc = _persisted_calc(dep.parent_calculation_key)
+            parent_calc = _persisted_calc(
+                dep.parent_calculation_key,
+                field=(
+                    f"calculations['{calc_in.key}'].depends_on."
+                    f"parent_calculation_key"
+                ),
+            )
             context = (
                 f"calculation '{calc_in.key}'.depends_on "
                 f"parent='{dep.parent_calculation_key}'"
@@ -811,7 +854,15 @@ def persist_computed_reaction_upload(
         for i, ac in enumerate(sp.applied_energy_corrections):
             source_calc_id: int | None = None
             if ac.source_calculation_key is not None:
-                source_calc_id = calculation_key_to_id[ac.source_calculation_key]
+                source_calc_id = resolve_applied_correction_source_key(
+                    ac.source_calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"species['{sp.key}'].applied_energy_corrections[{i}]."
+                        f"source_calculation_key"
+                    ),
+                    declares=_BUNDLE_CALCULATION_KEY_REMEDY,
+                )
                 source_calc = session.get(Calculation, source_calc_id)
                 assert_calculation_owned_by(
                     source_calc,
@@ -854,7 +905,15 @@ def persist_computed_reaction_upload(
         ):
             source_calc_id = None
             if ac.source_calculation_key is not None:
-                source_calc_id = calculation_key_to_id[ac.source_calculation_key]
+                source_calc_id = resolve_applied_correction_source_key(
+                    ac.source_calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"transition_state.applied_energy_corrections[{i}]."
+                        f"source_calculation_key"
+                    ),
+                    declares=_BUNDLE_CALCULATION_KEY_REMEDY,
+                )
                 source_calc = session.get(Calculation, source_calc_id)
                 assert_calculation_owned_by(
                     source_calc,
@@ -977,12 +1036,21 @@ def persist_computed_reaction_upload(
             thermo_ids.append(thermo.id)
             thermo_by_species_key[sp.key] = thermo
 
-            # Which calculations produced this number. The schema already
-            # refused a key that names nothing in the bundle; ownership is
+            # Which calculations produced this number. The schema also
+            # refuses a key that names nothing in the bundle; the refusal
+            # is stated here too because the schema lives in a different
+            # package and the two have drifted before. Ownership is
             # checked here because this is the layer that knows which
             # species entry each key resolved to.
             for index, sc in enumerate(t.source_calculations):
-                source_calc_id = calculation_key_to_id[sc.calculation_key]
+                source_calc_id = resolve_calculation_key(
+                    sc.calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"species['{sp.key}'].thermo.source_calculations"
+                        f"[{index}].calculation_key"
+                    ),
+                )
                 source_calc = session.get(Calculation, source_calc_id)
                 assert_calculation_owned_by(
                     source_calc,
@@ -1105,7 +1173,14 @@ def persist_computed_reaction_upload(
             # calc is rejected with 422 (mirrors the AEC ownership
             # check above).
             for i, sc in enumerate(s.source_calculations):
-                calc_id = calculation_key_to_id[sc.calculation_key]
+                calc_id = resolve_calculation_key(
+                    sc.calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"species['{sp.key}'].statmech.source_calculations"
+                        f"[{i}].calculation_key"
+                    ),
+                )
                 calc_row = session.get(Calculation, calc_id)
                 assert_calculation_owned_by(
                     calc_row,
@@ -1139,9 +1214,14 @@ def persist_computed_reaction_upload(
             for ti, torsion_in in enumerate(s.torsions):
                 scan_calc_id: int | None = None
                 if torsion_in.source_scan_calculation_key is not None:
-                    scan_calc_id = calculation_key_to_id[
-                        torsion_in.source_scan_calculation_key
-                    ]
+                    scan_calc_id = resolve_calculation_key(
+                        torsion_in.source_scan_calculation_key,
+                        calculation_key_to_id,
+                        field=(
+                            f"species['{sp.key}'].statmech.torsions[{ti}]."
+                            f"source_scan_calculation_key"
+                        ),
+                    )
                     # ``calculation_key_to_id`` spans the whole bundle --
                     # every species and the transition state -- so a key
                     # resolving here says nothing about who owns what it
@@ -1328,8 +1408,15 @@ def persist_computed_reaction_upload(
         # we run the legacy auto-link to preserve existing behavior for
         # producers that haven't migrated to declaring source calcs.
         if kin.source_calculations:
-            for entry in kin.source_calculations:
-                calc_id = calculation_key_to_id[entry.calculation_key]
+            for entry_index, entry in enumerate(kin.source_calculations):
+                calc_id = resolve_calculation_key(
+                    entry.calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"kinetics.source_calculations[{entry_index}]."
+                        f"calculation_key"
+                    ),
+                )
                 source_calc = session.get(Calculation, calc_id)
                 assert_kinetics_source_role_compatible(
                     calculation=source_calc,

--- a/backend/app/workflows/computed_species.py
+++ b/backend/app/workflows/computed_species.py
@@ -85,6 +85,7 @@ from app.services.hessian_extraction import (
     try_extract_hessian_from_artifact_upload,
 )
 from app.services.literature_resolution import resolve_or_create_literature
+from app.services.local_key_resolution import resolve_calculation_key
 from app.services.provenance_warnings import (
     collect_provenance_warnings,
     collect_statmech_content_warnings,
@@ -109,6 +110,16 @@ from app.workflows.thermo import assert_thermo_role_matches_calculation_type
 _BUNDLE_CONFORMER_KEY_REMEDY = (
     "Every conformer in this bundle carries a required 'key'; "
     "'source_conformer_key' must match one of them."
+)
+
+#: The same, for the calculation namespace. A correction's source key is
+#: one repair whichever kind of name it uses, so it keeps
+#: ``resolve_applied_correction_source_key`` and its published code
+#: rather than the bundle-wide ``calculation_key_undeclared``; only the
+#: remedy sentence changes.
+_BUNDLE_CALCULATION_KEY_REMEDY = (
+    "Every calculation in this bundle carries a required 'key'; "
+    "'source_calculation_key' must match one of them."
 )
 
 
@@ -510,7 +521,14 @@ def persist_computed_species_upload(
             ),
         ):
             for dep in child_in.depends_on:
-                parent_calc = calc_keys_to_id[dep.parent_calculation_key]
+                parent_calc = resolve_calculation_key(
+                    dep.parent_calculation_key,
+                    calc_keys_to_id,
+                    field=(
+                        f"calculations['{child_in.key}'].depends_on."
+                        f"parent_calculation_key"
+                    ),
+                )
                 context = (
                     f"calculation '{child_in.key}'.depends_on "
                     f"parent='{dep.parent_calculation_key}'"
@@ -758,8 +776,12 @@ def _persist_thermo_block(
 
     # Resolve source_calculations by local key with role/type checks.
     resolved_sources: list[ThermoSourceCalculationCreate] = []
-    for sc in thermo_in.source_calculations:
-        calc_row = calc_keys_to_id[sc.calculation_key]
+    for index, sc in enumerate(thermo_in.source_calculations):
+        calc_row = resolve_calculation_key(
+            sc.calculation_key,
+            calc_keys_to_id,
+            field=f"thermo.source_calculations[{index}].calculation_key",
+        )
         assert_calculation_owned_by(
             calc_row,
             code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
@@ -805,7 +827,15 @@ def _persist_thermo_block(
     for i, ac in enumerate(thermo_in.applied_energy_corrections):
         source_calc_id: int | None = None
         if ac.source_calculation_key is not None:
-            calc_row = calc_keys_to_id[ac.source_calculation_key]
+            calc_row = resolve_applied_correction_source_key(
+                ac.source_calculation_key,
+                calc_keys_to_id,
+                field=(
+                    f"thermo.applied_energy_corrections[{i}]."
+                    f"source_calculation_key"
+                ),
+                declares=_BUNDLE_CALCULATION_KEY_REMEDY,
+            )
             assert_calculation_owned_by(
                 calc_row,
                 code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
@@ -869,7 +899,15 @@ def _persist_top_level_applied_corrections(
     for i, ac in enumerate(request.applied_energy_corrections):
         source_calc_id: int | None = None
         if ac.source_calculation_key is not None:
-            calc_row = calc_keys_to_id[ac.source_calculation_key]
+            calc_row = resolve_applied_correction_source_key(
+                ac.source_calculation_key,
+                calc_keys_to_id,
+                field=(
+                    f"applied_energy_corrections[{i}]."
+                    f"source_calculation_key"
+                ),
+                declares=_BUNDLE_CALCULATION_KEY_REMEDY,
+            )
             assert_calculation_owned_by(
                 calc_row,
                 code=W_APPLIED_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
@@ -994,8 +1032,21 @@ def _persist_statmech_block(
             )
         )
 
-    for sc in s.source_calculations:
-        calc_row = calc_keys_to_id[sc.calculation_key]
+    # The one seam in this file that two routes reach with two different
+    # namespaces, and the reason the lookup below cannot be a subscript.
+    # ``/uploads/computed-species`` hands it one species entry's own keys
+    # and its schema has already refused an undeclared one;
+    # ``/uploads/networks/pdep`` hands it a map spanning every species and
+    # every transition state, and ``NetworkPDepUploadRequest`` narrows a
+    # *species* statmech's keys and not a *transition state*'s. So a TS
+    # statmech naming nothing declared arrives here, and used to leave as
+    # a ``KeyError``.
+    for index, sc in enumerate(s.source_calculations):
+        calc_row = resolve_calculation_key(
+            sc.calculation_key,
+            calc_keys_to_id,
+            field=f"statmech.source_calculations[{index}].calculation_key",
+        )
         assert_calculation_owned_by(
             calc_row,
             code=W_STATMECH_SOURCE_CALCULATION_OWNER_MISMATCH,
@@ -1027,10 +1078,17 @@ def _persist_statmech_block(
             )
         )
 
-    for torsion_in in s.torsions:
+    for torsion_index, torsion_in in enumerate(s.torsions):
         scan_calc_id: int | None = None
         if torsion_in.source_scan_calculation_key is not None:
-            scan_calc_row = calc_keys_to_id[torsion_in.source_scan_calculation_key]
+            scan_calc_row = resolve_calculation_key(
+                torsion_in.source_scan_calculation_key,
+                calc_keys_to_id,
+                field=(
+                    f"statmech.torsions[{torsion_index}]."
+                    f"source_scan_calculation_key"
+                ),
+            )
             assert_calculation_owned_by(
                 scan_calc_row,
                 code=W_STATMECH_TORSION_SCAN_CALCULATION_OWNER_MISMATCH,

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -73,6 +73,7 @@ from app.services.calculation_resolution import (
 from app.services.conformer_resolution import resolve_conformer_group
 from app.services.geometry_resolution import resolve_geometry_payload
 from app.services.literature_resolution import resolve_or_create_literature
+from app.services.local_key_resolution import resolve_calculation_key
 from app.services.provenance_warnings import (
     collect_network_energy_transfer_warnings,
     collect_network_solve_kind_warnings,
@@ -526,8 +527,15 @@ def persist_network_pdep_upload(
             ts_in.validation_evidence,
             transition_state_entry_id=ts_entry.id,
             reconstruction_calculation_ids=[
-                calculation_key_to_id[evidence_in.source_calculation_key]
-                for evidence_in in ts_in.validation_evidence
+                resolve_calculation_key(
+                    evidence_in.source_calculation_key,
+                    calculation_key_to_id,
+                    field=(
+                        f"transition_states['{ts_in.key}']."
+                        f"validation_evidence[{index}].source_calculation_key"
+                    ),
+                )
+                for index, evidence_in in enumerate(ts_in.validation_evidence)
             ],
             subject_label=ts_in.key,
             field_path=f"transition_states[{ts_in.key}].validation_evidence",
@@ -794,7 +802,7 @@ def persist_network_pdep_upload(
         )
         warning_sink.extend(collect_network_solve_kind_warnings(solve_in))
 
-        for energy_in in solve_in.state_energies:
+        for energy_index, energy_in in enumerate(solve_in.state_energies):
             session.add(NetworkSolveStateEnergy(
                 solve_id=solve.id,
                 state_id=state_key_to_row[energy_in.state_key].id,
@@ -802,11 +810,19 @@ def persist_network_pdep_upload(
                 energy_zero_convention=energy_in.energy_zero_convention,
                 correction_convention=energy_in.correction_convention,
                 convention_note=energy_in.convention_note,
-                source_calculation_id=(calculation_key_to_id[energy_in.source_calculation_key]
+                source_calculation_id=(
+                    resolve_calculation_key(
+                        energy_in.source_calculation_key,
+                        calculation_key_to_id,
+                        field=(
+                            f"solve.state_energies[{energy_index}]."
+                            f"source_calculation_key"
+                        ),
+                    )
                     if energy_in.source_calculation_key else None),
             ))
 
-        for barrier_in in solve_in.channel_barriers:
+        for barrier_index, barrier_in in enumerate(solve_in.channel_barriers):
             session.add(NetworkSolveChannelBarrier(
                 solve_id=solve.id,
                 channel_id=channel_key_to_row[barrier_in.channel_key].id,
@@ -817,16 +833,31 @@ def persist_network_pdep_upload(
                 energy_zero_convention=barrier_in.energy_zero_convention,
                 correction_convention=barrier_in.correction_convention,
                 convention_note=barrier_in.convention_note,
-                source_calculation_id=(calculation_key_to_id[barrier_in.source_calculation_key]
+                source_calculation_id=(
+                    resolve_calculation_key(
+                        barrier_in.source_calculation_key,
+                        calculation_key_to_id,
+                        field=(
+                            f"solve.channel_barriers[{barrier_index}]."
+                            f"source_calculation_key"
+                        ),
+                    )
                     if barrier_in.source_calculation_key else None),
             ))
 
         # Source calculations
-        for sc in solve_in.source_calculations:
+        for sc_index, sc in enumerate(solve_in.source_calculations):
             session.add(
                 NetworkSolveSourceCalculation(
                     solve_id=solve.id,
-                    calculation_id=calculation_key_to_id[sc.calculation_key],
+                    calculation_id=resolve_calculation_key(
+                        sc.calculation_key,
+                        calculation_key_to_id,
+                        field=(
+                            f"solve.source_calculations[{sc_index}]."
+                            f"calculation_key"
+                        ),
+                    ),
                     role=sc.role,
                 )
             )

--- a/backend/app/workflows/thermo.py
+++ b/backend/app/workflows/thermo.py
@@ -33,6 +33,7 @@ from app.services.calculation_resolution import (
 )
 from app.services.energy_correction_resolution import create_applied_energy_correction
 from app.services.group_additivity_resolution import create_applied_group_additivity
+from app.services.local_key_resolution import resolve_calculation_key
 from app.services.record_review import (
     RecordRef,
     ReviewPolicy,
@@ -155,7 +156,11 @@ def _resolve_source_calculation(
     """
     field_path = f"source_calculations[{index}]"
     if entry.calculation_key is not None:
-        calc_row = calculations_by_key[entry.calculation_key]
+        calc_row = resolve_calculation_key(
+            entry.calculation_key,
+            calculations_by_key,
+            field=f"{field_path}.calculation_key",
+        )
         context = f"{field_path}.calculation_key='{entry.calculation_key}'"
     else:
         calc_row = session.get(Calculation, entry.existing_calculation_id)

--- a/backend/app/workflows/transport.py
+++ b/backend/app/workflows/transport.py
@@ -18,6 +18,7 @@ from app.services.calculation_ownership import (
 from app.services.calculation_resolution import (
     resolve_and_persist_calculation_with_results,
 )
+from app.services.local_key_resolution import resolve_calculation_key
 from app.services.record_review import (
     RecordRef,
     ReviewPolicy,
@@ -81,10 +82,14 @@ def persist_transport_upload(
 
     resolved_source_calcs = [
         TransportSourceCalculationCreate(
-            calculation_id=calculations_by_key[sc.calculation_key].id,
+            calculation_id=resolve_calculation_key(
+                sc.calculation_key,
+                calculations_by_key,
+                field=f"source_calculations[{index}].calculation_key",
+            ).id,
             role=sc.role,
         )
-        for sc in request.source_calculations
+        for index, sc in enumerate(request.source_calculations)
     ]
 
     transport = resolve_and_create_transport(

--- a/backend/tests/api/test_api_pdep_ts_statmech_undeclared_key.py
+++ b/backend/tests/api/test_api_pdep_ts_statmech_undeclared_key.py
@@ -1,0 +1,159 @@
+"""A PDep transition state may not name a calculation nobody declared.
+
+The 500 this file removes
+-------------------------
+``/uploads/networks/pdep`` hands ``_persist_statmech_block`` a calc-key
+map spanning every species and every transition state in the bundle, and
+``NetworkPDepUploadRequest.validate_key_references`` narrows a *species*
+statmech's source and torsion keys to that species's own calculations
+without doing the same for a *transition state*'s. The seam then looked
+the key up with a raw subscript, so a TS statmech naming a key nothing
+declared left the route as an unhandled ``KeyError``:
+
+    E   KeyError: 'no_such_calc'
+    app/workflows/computed_species.py:998: KeyError
+
+That is a 500 whose body says nothing about which key was wrong, for a
+mistake whose whole repair is spelling. It is now a 422 carrying
+``calculation_key_undeclared``, the offending field, the key, and the
+keys that *are* declared.
+
+Why it is worth a file when the schema "already checks"
+-------------------------------------------------------
+It did not. The claim that a request schema refuses every undeclared key
+before a workflow runs was true of seventeen of the nineteen lookups and
+false of these two, and it was false in the way that arrangement always
+fails: the schema lives in ``tckdb_schemas``, a different distributable
+package from the workflow it is supposed to protect, so the two drift
+with nothing going red. These two are the drift, caught.
+
+The assertions are on ``code`` and ``context``, never on a substring of
+``detail``: Pydantic echoes rejected input back into its error string, so
+a substring check passes even where the field was wrongly accepted. The
+last test is the one that keeps the rest honest — a resolver that refused
+*everything* would satisfy every negative assertion here.
+"""
+
+from __future__ import annotations
+
+from tests.workflows.test_network_pdep_upload import (
+    _LOT_DFT,
+    _SOFTWARE,
+    _full_payload,
+)
+
+_PDEP_URL = "/api/v1/uploads/networks/pdep"
+
+_KEY_UNDECLARED = "calculation_key_undeclared"
+
+
+def _assert_code(response, expected: str) -> dict:
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body.get("code") == expected, (
+        f"expected code={expected!r}, got {body.get('code')!r}. "
+        f"detail={body.get('detail')!r}"
+    )
+    return body
+
+
+def _payload_with_ts_statmech_naming_nothing() -> dict:
+    payload = _full_payload(include_solve=False)
+    payload["transition_states"][0]["statmech"] = {
+        "statmech_treatment": "rrho",
+        "source_calculations": [
+            {"calculation_key": "no_such_calc", "role": "freq"}
+        ],
+    }
+    return payload
+
+
+def _payload_with_ts_torsion_naming_nothing() -> dict:
+    payload = _full_payload(include_solve=False)
+    payload["transition_states"][0]["statmech"] = {
+        "statmech_treatment": "rrho_1d",
+        "source_calculations": [
+            {"calculation_key": "ts_elim_freq", "role": "freq"}
+        ],
+        "torsions": [
+            {"torsion_index": 1, "source_scan_calculation_key": "no_such_scan"}
+        ],
+    }
+    return payload
+
+
+def test_ts_statmech_source_key_naming_nothing_is_a_coded_422(client) -> None:
+    body = _assert_code(
+        client.post(_PDEP_URL, json=_payload_with_ts_statmech_naming_nothing()),
+        _KEY_UNDECLARED,
+    )
+    assert body["context"]["field"] == (
+        "statmech.source_calculations[0].calculation_key"
+    ), body
+    assert body["context"]["key"] == "no_such_calc", body
+    # The alternatives are the point: a refusal that names them turns a
+    # typo into a mechanical fix rather than a guess.
+    assert "ts_elim_freq" in body["context"]["declared_keys"], body
+    # DR-0028 Requirement 2 -- the map's *values* are row ids and they
+    # stay there.
+    assert set(body["context"]) == {"field", "key", "declared_keys"}, body
+
+
+def test_ts_torsion_scan_key_naming_nothing_is_a_coded_422(client) -> None:
+    """Same code, different field.
+
+    An undeclared source link and an undeclared rotor scan are one repair
+    -- declare the calculation, or fix the spelling -- against one
+    namespace, so they share a code and ``context['field']`` carries the
+    difference. That is the opposite call from the ownership family, and
+    deliberately: there, the two fields need two *different* right
+    answers, so they get two codes.
+    """
+    body = _assert_code(
+        client.post(_PDEP_URL, json=_payload_with_ts_torsion_naming_nothing()),
+        _KEY_UNDECLARED,
+    )
+    assert body["context"]["field"] == (
+        "statmech.torsions[0].source_scan_calculation_key"
+    ), body
+    assert body["context"]["key"] == "no_such_scan", body
+
+
+def test_a_declared_ts_statmech_key_is_still_accepted(client) -> None:
+    """The half that makes the two above mean anything.
+
+    A resolver that refused every key would pass both negative tests. It
+    fails this one.
+    """
+    payload = _payload_with_ts_statmech_naming_nothing()
+    payload["transition_states"][0]["statmech"]["source_calculations"] = [
+        {"calculation_key": "ts_elim_freq", "role": "freq"}
+    ]
+    resp = client.post(_PDEP_URL, json=payload)
+    assert resp.status_code == 201, resp.text
+
+
+def test_a_declared_ts_torsion_scan_key_is_still_accepted(client) -> None:
+    """A real scan, owned by the transition state, resolves and persists."""
+    payload = _full_payload(include_solve=False)
+    ts = payload["transition_states"][0]
+    ts["calculations"].append(
+        {
+            "key": "ts_elim_scan",
+            "type": "scan",
+            "geometry_key": "ts_elim_geom",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT_DFT,
+        }
+    )
+    ts["statmech"] = {
+        "statmech_treatment": "rrho_1d",
+        "source_calculations": [
+            {"calculation_key": "ts_elim_freq", "role": "freq"}
+        ],
+        "torsions": [
+            {"torsion_index": 1, "source_scan_calculation_key": "ts_elim_scan"}
+        ],
+    }
+    resp = client.post(_PDEP_URL, json=payload)
+    assert resp.status_code == 201, resp.text

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -1,0 +1,156 @@
+"""The one seam every bundle-local key lookup goes through.
+
+Two halves, and the second is the one that matters. A resolver that
+refused every key would satisfy every "this is refused" assertion here;
+what pins it down is that a *declared* key comes back with the value the
+workflow put under it, unchanged and untouched.
+
+The last test is structural rather than behavioural: it asserts that the
+three bundle workflows contain no raw ``map[key]`` *read* of a calc-key
+namespace. It is written to be falsifiable -- it also asserts that the
+same pattern still finds the *writes*, so a regex that stopped matching
+anything at all fails instead of passing forever.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.api.error_contract import CodedValueError
+from app.services.local_key_resolution import (
+    W_CALCULATION_KEY_UNDECLARED,
+    resolve_calculation_key,
+    resolve_declared_key,
+)
+
+_WORKFLOWS = Path(__file__).resolve().parents[2] / "app" / "workflows"
+
+#: The three bundle workflows and the name each gives its calc-key map.
+_CALC_KEY_MAPS = {
+    "computed_species.py": "calc_keys_to_id",
+    "computed_reaction.py": "calculation_key_to_id",
+    "network_pdep.py": "calculation_key_to_id",
+}
+
+
+def test_a_declared_key_returns_what_the_workflow_stored() -> None:
+    """The half that makes every refusal below mean something."""
+    assert resolve_calculation_key(
+        "opt1", {"opt1": 17, "sp1": 18}, field="thermo.x"
+    ) == 17
+
+
+def test_the_value_type_is_whatever_the_caller_put_in() -> None:
+    """Generic on purpose: two workflows keep ids, one keeps ORM rows."""
+    sentinel = object()
+    assert resolve_calculation_key(
+        "opt1", {"opt1": sentinel}, field="thermo.x"
+    ) is sentinel
+
+
+def test_an_undeclared_key_is_a_coded_refusal() -> None:
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_calculation_key(
+            "ghost",
+            {"opt1": 17, "sp1": 18},
+            field="thermo.source_calculations[0].calculation_key",
+        )
+    error = exc_info.value
+    assert error.code == W_CALCULATION_KEY_UNDECLARED
+    assert error.context == {
+        "field": "thermo.source_calculations[0].calculation_key",
+        "key": "ghost",
+        "declared_keys": ["opt1", "sp1"],
+    }
+
+
+def test_the_refusal_names_the_declared_alternatives() -> None:
+    """Naming what *is* declared is what makes the fix mechanical."""
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_calculation_key("ghost", {"opt1": 17}, field="f")
+    assert "'opt1'" in str(exc_info.value)
+    assert "does not name a calculation declared in this upload" in str(
+        exc_info.value
+    )
+
+
+def test_an_empty_namespace_says_so_rather_than_listing_nothing() -> None:
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_calculation_key("ghost", {}, field="f")
+    assert "declares no such name at all" in str(exc_info.value)
+    assert exc_info.value.context["declared_keys"] == []
+
+
+def test_no_row_id_reaches_the_depositor() -> None:
+    """DR-0028 Requirement 2. The ids are the map's *values*."""
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_calculation_key("ghost", {"opt1": 424242}, field="f")
+    assert "424242" not in str(exc_info.value)
+    assert 424242 not in exc_info.value.context.values()
+
+
+def test_the_code_is_overridable_for_a_published_one() -> None:
+    """``statmech_calculation_key_undeclared`` predates this seam."""
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_calculation_key(
+            "ghost", {"opt1": 1}, field="f", code="a_published_code"
+        )
+    assert exc_info.value.code == "a_published_code"
+
+
+def test_the_subject_and_remedy_are_the_callers() -> None:
+    """The applied-correction wrapper reuses the lookup, not the sentence."""
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_declared_key(
+            "ghost",
+            {"a": 1},
+            field="f",
+            code="c",
+            subject="anything",
+            remedy="Do the thing.",
+        )
+    message = str(exc_info.value)
+    assert "does not name anything declared in this upload" in message
+    assert message.endswith("Do the thing.")
+
+
+def _map_accesses(source: str, name: str) -> tuple[list[str], list[str]]:
+    """Split ``name[...]`` occurrences into writes and reads.
+
+    A write is an assignment into the namespace -- the workflow filling
+    its own map -- and is exactly what the lookup helper is not for. A
+    read is the cross-reference that used to be able to ``KeyError``.
+    """
+    pattern = re.compile(rf"\b{re.escape(name)}\[(.*?)\]", re.DOTALL)
+    writes: list[str] = []
+    reads: list[str] = []
+    for match in pattern.finditer(source):
+        tail = source[match.end():match.end() + 40].lstrip()
+        (writes if tail.startswith("=") and not tail.startswith("==")
+         else reads).append(match.group(0))
+    return writes, reads
+
+
+@pytest.mark.parametrize(("module", "map_name"), sorted(_CALC_KEY_MAPS.items()))
+def test_no_raw_subscript_reads_a_calc_key_namespace(
+    module: str, map_name: str
+) -> None:
+    source = (_WORKFLOWS / module).read_text(encoding="utf-8")
+    # Without this the whole test is vacuous against a renamed map: a
+    # pattern that matches nothing would report zero reads forever.
+    assert source, f"{module} is empty"
+    writes, reads = _map_accesses(source, map_name)
+    assert writes, (
+        f"{module} has no `{map_name}[...] = ...` at all, so this test "
+        f"is not looking at the namespace it thinks it is -- the map was "
+        f"probably renamed. Fix the name in _CALC_KEY_MAPS."
+    )
+    assert reads == [], (
+        f"{module} reads {map_name} by raw subscript: {reads}. Every "
+        f"cross-reference must go through "
+        f"app.services.local_key_resolution.resolve_calculation_key, or "
+        f"an undeclared key is a 500 again."
+    )

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -28,11 +28,17 @@ from app.services.local_key_resolution import (
 
 _WORKFLOWS = Path(__file__).resolve().parents[2] / "app" / "workflows"
 
-#: The three bundle workflows and the name each gives its calc-key map.
+#: Every workflow that resolves a calculation by local key, and the name
+#: it gives that namespace. The two standalone product workflows are on
+#: the list for the same reason as the three bundle ones: the issue was
+#: filed against the bundles, and stopping there would have left two raw
+#: subscripts behind a PR whose title says there are none.
 _CALC_KEY_MAPS = {
     "computed_species.py": "calc_keys_to_id",
     "computed_reaction.py": "calculation_key_to_id",
     "network_pdep.py": "calculation_key_to_id",
+    "thermo.py": "calculations_by_key",
+    "transport.py": "calculations_by_key",
 }
 
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.42.0"
+version = "0.43.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -85,6 +85,7 @@ class RejectionCode(str, Enum):
     ATOM_MAP_WITHOUT_TRANSITION_STATE = "atom_map_without_transition_state"
     CALCULATION_GEOMETRY_COMPOSITION_MISMATCH = "calculation_geometry_composition_mismatch"
     CALCULATION_HANDLE_CONFLICT = "calculation_handle_conflict"
+    CALCULATION_KEY_UNDECLARED = "calculation_key_undeclared"
     CANONICAL_PARAMETER_VALUE_REQUIRES_KEY = "canonical_parameter_value_requires_key"
     CLIENT_SORT_NOT_SUPPORTED = "client_sort_not_supported"
     COMPOSED_SEARCH_CANDIDATE_LIMIT_EXCEEDED = "composed_search_candidate_limit_exceeded"
@@ -226,6 +227,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.ATOM_MAP_WITHOUT_TRANSITION_STATE,
         RejectionCode.CALCULATION_GEOMETRY_COMPOSITION_MISMATCH,
         RejectionCode.CALCULATION_HANDLE_CONFLICT,
+        RejectionCode.CALCULATION_KEY_UNDECLARED,
         RejectionCode.CANONICAL_PARAMETER_VALUE_REQUIRES_KEY,
         RejectionCode.CLIENT_SORT_NOT_SUPPORTED,
         RejectionCode.COMPOSED_SEARCH_CANDIDATE_LIMIT_EXCEEDED,
@@ -373,6 +375,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.ATOM_MAP_WITHOUT_TRANSITION_STATE: frozenset({422}),
     RejectionCode.CALCULATION_GEOMETRY_COMPOSITION_MISMATCH: frozenset({422}),
     RejectionCode.CALCULATION_HANDLE_CONFLICT: frozenset({422}),
+    RejectionCode.CALCULATION_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.CANONICAL_PARAMETER_VALUE_REQUIRES_KEY: frozenset({422}),
     RejectionCode.CLIENT_SORT_NOT_SUPPORTED: frozenset({422}),
     RejectionCode.COMPOSED_SEARCH_CANDIDATE_LIMIT_EXCEEDED: frozenset({422}),


### PR DESCRIPTION
Closes #150. Closes #190.

## The real site count is 21, not eleven

Both issues' line anchors were stale, as expected. Re-derived from `bf250988`, counting **reads** of a calc-key namespace (a `map[k] = v` write is not a lookup and is left alone):

| File | Map | Read sites |
|---|---|---|
| `backend/app/workflows/computed_species.py` | `calc_keys_to_id` | 6 |
| `backend/app/workflows/computed_reaction.py` | `calculation_key_to_id` | 9 |
| `backend/app/workflows/network_pdep.py` | `calculation_key_to_id` | 4 |
| `backend/app/workflows/thermo.py` | `calculations_by_key` | 1 |
| `backend/app/workflows/transport.py` | `calculations_by_key` | 1 |

19 in the three files the issues named, plus 2 a sweep found outside them — the standalone thermo and transport product workflows resolve a source calculation by local key the same way. Both are latent (their upload schemas check the key), and both are the same repair, so leaving them would have been a subset PR under a title claiming there are none left — the #195/#162 failure this task was explicitly framed to avoid.

Of the 19, 4 are #190's applied-energy-correction `source_calculation_key` sites (2 per bundle file) and 15 are #150's. #190's note anticipating "a third AEC site near `computed_species.py:890`" does not hold: the call there is `resolve_applied_correction_source_key` on the *conformer* key, already coded by #171. There are exactly two AEC calculation-key sites per file.

## The bigger premise that was wrong: two of these were live 500s

The brief said every site is guarded today by a request-schema validator, so none is currently reachable. That is true of 17 and **false of 2**, and it is false in exactly the way the arrangement invites — the guard lives in `tckdb_schemas`, a *different distributable package* from the workflow it protects.

`NetworkPDepUploadRequest.validate_key_references` narrows a **species** statmech's `source_calculations[].calculation_key` and `torsions[].source_scan_calculation_key` to that species's own calculations. It does not do the same for a **transition state**'s. `_persist_statmech_block` is shared by `/uploads/computed-species` and `/uploads/networks/pdep`, so a PDep TS statmech naming a key nothing declared reached the seam and left the route as an unhandled `KeyError`.

Reproduced on the wire, before:

```
E           KeyError: 'no_such_calc'
app/workflows/computed_species.py:998: KeyError
FAILED tests/api/test_probe_a190.py::test_probe_ts_statmech_undeclared_source_key
FAILED tests/api/test_probe_a190.py::test_probe_ts_torsion_undeclared_scan_key
```

After:

```
PROBE A status=422 body={"code":"calculation_key_undeclared","detail":"statmech.source_calculations[0].calculation_key='no_such_calc' does not name a calculation declared in this upload. Declared names here: 'HO2_opt', 'HO2_sp', 'O2_opt', 'O2_sp', 'ethene_opt', 'ethene_sp', 'ethyl_freq', 'ethyl_opt', 'ethyl_sp', 'etoo_opt', 'etoo_sp', 'ts_elim_freq', 'ts_elim_irc', 'ts_elim_opt', 'ts_elim_sp'. Every calculation in an upload carries a required 'key'; ..."}

PROBE B status=422 body={"code":"calculation_key_undeclared","detail":"statmech.torsions[0].source_scan_calculation_key='no_such_scan' does not name a calculation declared in this upload. ..."}
```

The interesting note in `tests/api/test_api_network_pdep_ownership.py` — written when #195 measured the TS-side ownership codes — already flagged the species/TS asymmetry as "a better refusal one layer earlier, if it lands". It landed as the *workflow* refusal instead, which is the direction the ordering note in this task demands.

## What was routed

One seam: `backend/app/services/local_key_resolution.py`.

* `resolve_declared_key(key, declared, *, field, code, subject, remedy)` — the lookup. Generic in the value type, because `computed_species` keeps `Calculation` rows (its next move is an ownership check that needs one) while the other two keep ids. A helper that forced one shape is how there came to be nineteen subscripts instead of one lookup.
* `resolve_calculation_key(...)` — the calculation-flavoured wrapper, code `calculation_key_undeclared`.

17 sites route through `resolve_calculation_key`. The 4 AEC sites route through the **existing** `resolve_applied_correction_source_key`, which now delegates to the same lookup.

Two pre-existing near-identical helpers were folded in rather than left beside a third:

* `energy_correction_resolution.resolve_applied_correction_source_key` — keeps its published code and its closing sentence, loses its copy of the lookup.
* `statmech_resolution._resolve_calculation_key` — keeps its published code, loses its copy of the lookup, and **gains** the declared-alternatives list it never printed.

### One code, and why not seven

`calculation_key_undeclared` covers every non-AEC field: thermo and statmech source links, a torsion's rotor scan, a dependency's parent, IRC evidence, a PDep solve's energies/barriers/source calcs. They resolve against **one** namespace and are repaired **one** way — declare the calculation, or fix the spelling against the list the refusal prints — so `context['field']` carries the difference. That is deliberately the opposite call from `app.services.calculation_ownership`, where two fields need two *different* right answers and therefore get two codes.

An applied correction's source key keeps `applied_energy_correction_source_key_undeclared`: there a conformer name and a calculation name are one repair, the code is pinned on `/uploads/conformers` by `tests/api/test_api_upload_key_and_role_contracts.py`, and splitting it by which kind of name the depositor used would answer the same question two ways on two routes.

## Schema validators removed: none

The ordering in the task is what made this safe, and it is also what makes removal unnecessary:

1. They refuse one layer earlier and run in a client that never contacts a server (offline bundle validation, contribution-bundle dry run).
2. Most of them do more than existence — `must reference a scan-type calculation`, `not one of that species's own calculations` — so removing the existence half is surgery inside a validator with other jobs.
3. A duplicated check costs nothing; a missing one costs a 500, as two of these just demonstrated.

## Schema / migration / client impact

* **No schema change. No migration.** Nothing touched under `backend/alembic/`.
* **No wire-schema change** — `schemas/python/tckdb-schemas/` is untouched, so the OpenAPI golden snapshot is unchanged.
* **Client**: one new enum member. `clients/python/src/tckdb_client/rejection_codes.py` regenerated with `backend/scripts/generate_client_rejection_codes.py` (3 lines: `RejectionCode`, `VALIDATION_REJECTION_CODES`, `REJECTION_STATUSES` → `{422}`, which is where `test_rejection_codes.py`'s per-member retry advice comes from). `clients/python/pyproject.toml` bumped 0.42.0 → 0.43.0.
* **Catalogue**: `calculation_key_undeclared`, 422, `Surface.coded_exception`, `Reach.request` (proven reachable on the wire, not assumed).
* **No new environment variable.**

## Verification actually run

Env: `DB_TEST_NAME=tckdb_test_190`, `PYTHONPATH` pointed at **this worktree's** `schemas/python/tckdb-schemas` (a worktree otherwise imports the main checkout's copy).

```
ruff check app tests                              All checks passed
scripts/check_runtime_ascii.py [--audit]          clean; every file scanned or declared
scripts/generate_client_rejection_codes.py        regenerated, 3-line diff
clients/python: pytest tests/test_rejection_codes.py   11 passed
backend: pytest tests/workflows tests/services    2664 passed
backend: pytest tests/api/test_api_code_catalogue.py
         tests/api/test_api_upload_key_and_role_contracts.py
         tests/workflows/test_conformer_upload.py
         tests/api/test_api_network_pdep_ownership.py
         tests/api/test_api_statmech_upload.py
         tests/api/test_wire_only_upload_contracts.py
         tests/schemas/test_conformer_upload_schema.py     112 passed
backend: pytest tests                             7904 passed, 14 skipped (39m25s)
```

### Mutation testing

Every new refusal was mutated, the mutation verified **on disk** before the run, and reverted with `__pycache__` cleared. A mutation that turned nothing red would be the finding; none did.

| Mutation | Went red |
|---|---|
| Raw subscript restored at the statmech source site | wire test + anti-subscript guard |
| Raw subscript restored at the torsion scan site | wire test + anti-subscript guard |
| Resolver accepts everything (returns an arbitrary declared row) | 9 tests |
| Resolver refuses everything | 5 tests — **including both accepted-upload tests**, which is the vacuous-pass shape they exist to catch |
| Declared alternatives dropped from the message | 1 test |
| Row ids leaked into `context` (DR-0028 Req 2) | 2 tests |

The harness itself caught one non-landing mutation (the replacement string contained the original, so `frm not in after` failed) rather than reporting a green run against unmutated code.

The anti-subscript guard in `tests/services/test_local_key_resolution.py` is written to be falsifiable: it also asserts the same pattern still finds the map's **writes**, so a regex that stopped matching anything at all fails instead of passing forever. Three raw-subscript mutations confirm it fires — two in `computed_species.py` and one in `transport.py`, the latter specifically to check the guard was not merely vacuous on the two files added last.

### Demonstrated vs. changed by analogy

* **Demonstrated on the wire**: the 2 PDep TS statmech sites in `computed_species.py` (`_persist_statmech_block`), before and after.
* **Demonstrated at the seam**: the resolver's full contract (code, `context`, alternatives, empty namespace, id suppression, code override, caller-supplied subject/remedy) in `tests/services/test_local_key_resolution.py`.
* **Changed by analogy**: the other 19. They are shadowed by a schema validator, so the wire cannot reach them today. The structural guard is what keeps them routed.

## Deserving its own task

**1. Codes for the shadowed refusals.** The 19 shadowed sites are refused by the schema as a bare `ValueError`, which surfaces as the generic **`validation_error`** — not a code a client can branch on. `tckdb_schemas.coded_error.CodedValidationError` exists precisely so a schema check can carry a code. Promoting those refusals to `calculation_key_undeclared` at the wire boundary would give one code for one repair on every route, but it is a contract change across ~8 validators in two upload schemas and belongs in its own PR.

**2. The same defect on every other local-key namespace.** `species_key_to_entry`, `state_key_to_row`, `channel_key_to_row`, `reaction_key_to_entry`, `ts_key_to_entry` and `geometry_key_to_id` are read by raw subscript in `computed_reaction.py` and `network_pdep.py` — roughly 25 more sites of identical shape. This PR deliberately did not widen into them: they are different namespaces with different remedies, they need their own codes, and the PDep species/TS asymmetry found here is reason to expect their schema coverage is uneven too rather than to assume it is fine. `resolve_declared_key` is already the seam they would use.

## CI on the final head (`27ab1c99`)

All gates green, including all three backend gates:

```
Backend API gate                          pass   9m53s
Backend complement gate                   pass   7m44s
Scientific read and service gate          pass  13m55s
Client, adapter, and wire-contract tests  pass     59s
CI gate coverage                          pass     19s
Required gates                            pass  13m22s
CodeQL / Analyze (python, js-ts, actions) pass
```
