### PR TITLE
Raise the client's wire-package floor to the version it needs

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.43.0"
+version = "0.44.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -40,7 +40,16 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27",
-    "tckdb-schemas>=0.10.0",
+    # Floor raised 0.10.0 -> 0.33.0 (2026-08-16). The old floor predated
+    # twenty-three minor releases of the wire package, several of them
+    # breaking -- 0.33.0 alone removed `literature_id` from
+    # `CalculationPayload`. A resolver was free to pick any of them and the
+    # client would import cleanly and fail at upload time instead.
+    #
+    # No upper bound here on purpose: whether these two packages should be
+    # pinned in lockstep is the coupling question tracked in #112, and
+    # guessing at it in a dependency line is how the 0.10.0 floor survived.
+    "tckdb-schemas>=0.33.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes item 1 of #196.

`tckdb-client` declared `tckdb-schemas>=0.10.0`. The wire package is at **0.33.0** — twenty-three minor releases later, several of them breaking. 0.33.0 alone removed `literature_id` from `CalculationPayload`; earlier releases changed three `RejectionCode` members.

A resolver was therefore free to install anything back to 0.10.0. The client would import cleanly, and the mismatch would surface as a **rejected upload against a live server** rather than as an install-time error.

**Nothing is broken today** — the client's suite passes and it emits none of the changed fields. That is precisely what makes the constraint worth fixing now rather than after it has cost someone an afternoon diagnosing a 422.

## No upper bound, deliberately

Whether these two packages should move in lockstep is the coupling question tracked in **#112**. Answering it inside a dependency line — rather than deciding it — is how the 0.10.0 floor survived this long. The comment in `pyproject.toml` records that, so the next reader does not re-derive it.

## Also in scope of #196, and needing no change

**Item 3** flagged a docstring in `tckdb_schemas/energy_correction.py` as overstating the contract: it claims both correction source keys are refused with `applied_energy_correction_source_key_undeclared`, which was true of `source_conformer_key` on both bundle roots and of `source_calculation_key` only on `/uploads/conformers`.

PR #187 routed **all four** applied-energy-correction sites through `resolve_applied_correction_source_key`. Verified on `main` at `474df96e`: it is now called from `conformer.py` (×2), `computed_reaction.py` (×4) and `computed_species.py` (×4), and raises that code. **The claim became true; the docstring needs no edit.**

**Item 2** — both bundles write `applied_energy_correction` rows and neither names them in the upload result — remains open and is a workflow change, not a metadata one.

## Schema / migration impact

**None.** No backend, model or migration change; the wire package is untouched. **No new environment variables.**

## Verification actually run

- `clients/python`: **1348 passed**
- floor and version confirmed by `grep` after the edit