### PR TITLE
Hold trigger names to the convention three files describe

### DIFF
--- a/backend/tests/db/test_accepted_science_trigger_registry.py
+++ b/backend/tests/db/test_accepted_science_trigger_registry.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ast
+import re
 import runpy
+from collections import defaultdict
 from pathlib import Path
 
 from sqlalchemy import text
@@ -59,6 +62,192 @@ def _removed_children() -> set[tuple[str, str, str]]:
     for path in _CORRECTION_REVISIONS:
         removed.update(runpy.run_path(str(path))["_REMOVED_CHILDREN"])
     return removed
+
+
+#: A ``CREATE TRIGGER`` / ``CREATE OR REPLACE TRIGGER`` site and the name it
+#: mints. The name is frequently an f-string placeholder rather than a literal,
+#: which is the whole reason this scan resolves module constants below.
+_TRIGGER_SITE = re.compile(r"CREATE\s+(?:OR\s+REPLACE\s+)?TRIGGER\s+(\S+)", re.IGNORECASE)
+
+#: ``{_TRIGGER}`` — a whole name supplied by one module-level constant.
+_PLACEHOLDER = re.compile(r"^\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+
+#: ``trg_as_child_{index:02d}`` — a name minted from a positional sequence.
+_POSITIONAL_FAMILY = re.compile(r"^(trg_as_(?:child|via|truncate))_\{[a-z_]*index")
+
+#: ``trg_as_child_19`` — a single member of such a sequence, named outright.
+_POSITIONAL_MEMBER = re.compile(r"^(trg_as_(?:child|via|truncate))_\d{2}$")
+
+_LITERAL_NAME = re.compile(r"^trg_[a-z0-9_]+$")
+
+#: The revision that owns the positional sequences. Named once so the assertion
+#: below reads as the convention it enforces rather than as a filename match.
+_POSITIONAL_OWNER = _REVISION.name
+
+#: Trigger names deliberately minted by more than one revision, each mapped to
+#: the exact set of revisions allowed to mint it. Anything else that appears
+#: twice is the defect this test exists to catch: a second revision silently
+#: taking over a name an earlier one already installed, which PostgreSQL
+#: accepts without complaint when the second drops before it creates.
+#:
+#: Both entries are checked for staleness as well as for breadth — a name
+#: listed here that is no longer minted twice fails, so an allowance cannot
+#: outlive the reuse that justified it.
+_DECLARED_REUSE: dict[str, frozenset[str]] = {
+    # ``d4e9b1c7a253`` narrows this guard to the ownership column alone. It
+    # reuses ``c6f2a9d4e7b1``'s name on purpose, and says why in its docstring:
+    # minting a new one would make the positional sequence depend on two files
+    # at once. This is the reuse that motivated the whole check.
+    "trg_as_child_19": frozenset(
+        {
+            _POSITIONAL_OWNER,
+            "d4e9b1c7a253_scf_stability_provenance_is_not_ownership.py",
+        }
+    ),
+    # ``6a9d2e4c7b1f`` drops this trigger for the duration of a public-ref
+    # backfill and recreates it identically before the upgrade finishes. The
+    # name is reused because it is the same guard, restored.
+    "trg_repro_assessment_append_only": frozenset(
+        {
+            "b4e8c1f6a2d9_add_reproducibility_assessments.py",
+            "6a9d2e4c7b1f_add_repro_assessment_public_ref.py",
+        }
+    ),
+}
+
+
+def _module_string_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = "..."`` bindings, annotated or not."""
+
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    constants[target.id] = node.value.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            constants[node.target.id] = node.value.value
+    return constants
+
+
+def _minted_trigger_names() -> tuple[dict[str, set[str]], dict[str, set[str]], int, int]:
+    """Scan every revision for the trigger names it creates.
+
+    Returns ``(names, families, sites, files)`` where ``names`` maps a resolved
+    trigger name to the revision filenames that create it, and ``families``
+    maps a positional prefix such as ``trg_as_child`` to the revisions that
+    mint names from its sequence.
+
+    Names are resolved from string literals and from module-level string
+    constants. They are deliberately *not* resolved by executing the revision:
+    a name built inside a loop from table names cannot be recovered statically,
+    and those are exactly the names the table-suffixed convention makes safe
+    anyway. ``sites`` and ``files`` are returned so the caller can prove the
+    scan found the corpus before asserting anything about it.
+    """
+
+    names: dict[str, set[str]] = defaultdict(set)
+    families: dict[str, set[str]] = defaultdict(set)
+    sites = 0
+    files = 0
+
+    for path in sorted(_VERSIONS.glob("*.py")):
+        source = path.read_text()
+        targets = _TRIGGER_SITE.findall(source)
+        if not targets:
+            continue
+        files += 1
+        sites += len(targets)
+        constants = _module_string_constants(ast.parse(source))
+        for target in targets:
+            if _LITERAL_NAME.fullmatch(target):
+                names[target].add(path.name)
+                continue
+            placeholder = _PLACEHOLDER.match(target)
+            if placeholder and placeholder.group(1) in constants:
+                resolved = constants[placeholder.group(1)]
+                if _LITERAL_NAME.fullmatch(resolved):
+                    names[resolved].add(path.name)
+                continue
+            family = _POSITIONAL_FAMILY.match(target)
+            if family:
+                families[family.group(1)].add(path.name)
+
+    # A revision that mints a whole positional sequence mints every member of
+    # it, but never spells one: ``c6f2a9d4e7b1`` writes
+    # ``trg_as_child_{index:02d}``, so the string ``trg_as_child_19`` appears
+    # in that file only inside a comment. Crediting the sequence's owner with
+    # each member found elsewhere is what lets the reuse show up as a reuse.
+    # Without this the scan sees ``trg_as_child_19`` claimed by one revision
+    # and reports no collision at all — the vacuous answer.
+    for name in list(names):
+        member = _POSITIONAL_MEMBER.fullmatch(name)
+        if member:
+            names[name].update(families.get(member.group(1), set()))
+
+    return dict(names), dict(families), sites, files
+
+
+def test_trigger_names_have_exactly_one_minting_revision() -> None:
+    """No revision may take over a trigger name another revision installed.
+
+    ``c6f2a9d4e7b1`` names its accepted-science child guards
+    ``trg_as_child_NN``, where ``NN`` is the position of a ``(table,
+    record_type)`` group in its own registry. ``b6c1f4a8e703`` and
+    ``a1f6c3e9b527`` both decline to extend that sequence and say why in their
+    ``_trigger_name`` docstrings: appending to it from a second file would make
+    each revision's numbering depend on the other's registry. Until now that
+    convention was written down in three places and enforced in none.
+
+    PostgreSQL only refuses the collision when the second revision uses a plain
+    ``CREATE TRIGGER`` against a name already present *on the same table*. It
+    accepts a drop-then-create, which is how a guard gets silently replaced
+    with one that enforces something else, and it accepts the same name on a
+    different table outright. This test refuses the reuse at the source, before
+    either migration runs, so the answer does not depend on which of those
+    three paths a future revision happens to take.
+    """
+
+    names, families, sites, files = _minted_trigger_names()
+
+    # Prove the scan found the corpus before asserting anything about it. A
+    # regex that silently stopped matching would otherwise turn every
+    # assertion below into a pass over an empty set. Floors sit below the
+    # measured 27 sites across 11 files minting 11 statically resolvable
+    # names, so ordinary growth does not touch them.
+    assert sites >= 20, sites
+    assert files >= 9, files
+    assert len(names) >= 9, sorted(names)
+
+    # The positional sequences belong to one revision each, and that revision
+    # is ``c6f2a9d4e7b1``. This is the convention stated in the two
+    # ``_trigger_name`` docstrings, asserted.
+    assert families == {
+        "trg_as_child": {_POSITIONAL_OWNER},
+        "trg_as_via": {_POSITIONAL_OWNER},
+        "trg_as_truncate": {_POSITIONAL_OWNER},
+    }, families
+
+    # A name minted by two revisions must be one of the declared reuses, and a
+    # declared reuse must still be minted by exactly the revisions it names.
+    # The second half is what keeps this list from outliving its reasons.
+    reused = {name: owners for name, owners in names.items() if len(owners) > 1}
+    assert reused == {name: set(owners) for name, owners in _DECLARED_REUSE.items()}, reused
+
+    # A member of a positional sequence spelled out in some other revision is
+    # the specific hazard: the number has to be counted out of
+    # ``c6f2a9d4e7b1``'s registry by hand, and nothing re-counts it if that
+    # registry ever moves. Allowed only where declared.
+    for name, owners in names.items():
+        if not _POSITIONAL_MEMBER.fullmatch(name):
+            continue
+        outsiders = owners - {_POSITIONAL_OWNER}
+        assert not outsiders or name in _DECLARED_REUSE, (name, sorted(outsiders))
 
 
 def _referenced_tables(tables, table: str, column: str, *, hops: int) -> set[str]:
@@ -265,3 +454,114 @@ def test_database_trigger_set_matches_registry(db_session) -> None:
     }
     assert actual == expected
     assert all(len(name) <= 63 for _, name in actual)
+
+
+def _corrected_direct_groups(
+    revision: dict, removed: set[tuple[str, str, str]]
+) -> list[tuple[str, str, tuple[str, ...]]]:
+    """``c6f2a9d4e7b1``'s child groups with the corrections' entries taken out.
+
+    The grouping — and therefore every ``trg_as_child_NN`` index — is computed
+    from the *original* registry, because a correction that narrows a group's
+    argument list must not renumber the triggers either side of it. Only the
+    columns inside a group shrink.
+    """
+
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for entry in revision["_DIRECT_CHILDREN"]:
+        table, record_type, column = entry
+        columns = grouped.setdefault((table, record_type), [])
+        if entry not in removed:
+            columns.append(column)
+    return [(table, record_type, tuple(columns)) for (table, record_type), columns in grouped.items()]
+
+
+def _guard_call(function: str, arguments: tuple[str, ...]) -> str:
+    return f"{function}({', '.join(repr(argument) for argument in arguments)})"
+
+
+def test_database_trigger_definitions_match_registry(db_session) -> None:
+    """Pin what each child guard *enforces*, not merely that it exists.
+
+    ``test_database_trigger_set_matches_registry`` compares ``(table, name)``
+    pairs. That catches a guard added or removed, and it catches a name
+    appearing on a table it does not belong to. It cannot catch a guard being
+    replaced by a different one under the same name on the same table, because
+    the pair is unchanged — and a drop-then-create is precisely how
+    ``d4e9b1c7a253`` legitimately rewrote ``trg_as_child_19``'s argument list.
+    Run that way by mistake, or by a revision that miscounts the positional
+    sequence and lands on an occupied number, the registry and the database
+    disagree about which columns are guarded and every existing test passes.
+
+    The argument list is the guard. ``tckdb_guard_accepted_child`` treats each
+    argument as a column that binds the row to an accepted root, so adding one
+    refuses writes that should be allowed and dropping one allows writes that
+    should be refused. Both are silent until a contributor hits them.
+    """
+
+    revision = _revision_namespace()
+    removed = _removed_children()
+
+    expected: dict[tuple[str, str], str] = {}
+    for index, (table, record_type, columns) in enumerate(_corrected_direct_groups(revision, removed)):
+        # A group emptied by a correction would mean the trigger should have
+        # been dropped rather than narrowed; it would also render an empty
+        # argument list, which the guard function cannot act on.
+        assert columns, (table, record_type)
+        expected[(table, f"trg_as_child_{index:02d}")] = _guard_call(
+            "tckdb_guard_accepted_child", (record_type, *columns)
+        )
+    for index, item in enumerate(revision["_VIA_CHILDREN"]):
+        table, record_type, child_column, parent_table, parent_pk, root_column = item
+        expected[(table, f"trg_as_via_{index:02d}")] = _guard_call(
+            "tckdb_guard_accepted_via_child",
+            (record_type, child_column, parent_table, parent_pk, root_column),
+        )
+
+    for extension in _extension_namespaces():
+        trigger_name = extension["_trigger_name"]
+        for table, record_type, columns in extension["_child_groups"]():
+            assert columns, (table, record_type)
+            expected[(table, trigger_name("as_child", table))] = _guard_call(
+                "tckdb_guard_accepted_child", (record_type, *columns)
+            )
+        for item in extension["_VIA_CHILDREN"]:
+            table, record_type, child_column, parent_table, parent_pk, root_column = item
+            expected[(table, trigger_name("as_via", table))] = _guard_call(
+                "tckdb_guard_accepted_via_child",
+                (record_type, child_column, parent_table, parent_pk, root_column),
+            )
+
+    actual = {
+        (row.table_name, row.trigger_name): re.sub(
+            r"\s+", " ", row.definition.split("EXECUTE FUNCTION ", 1)[1]
+        ).strip()
+        for row in db_session.execute(
+            text(
+                """
+                SELECT relation.relname AS table_name,
+                       trigger.tgname AS trigger_name,
+                       pg_get_triggerdef(trigger.oid) AS definition
+                FROM pg_trigger AS trigger
+                JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+                JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+                WHERE NOT trigger.tgisinternal
+                  AND namespace.nspname = 'public'
+                  AND (
+                      trigger.tgname LIKE 'trg_as_child_%'
+                      OR trigger.tgname LIKE 'trg_as_via_%'
+                  )
+                """
+            )
+        )
+    }
+
+    # Prove the query found the guards before comparing what they say. A
+    # predicate that stopped matching would make the comparison below a pass
+    # over two empty dicts. The measured population is 61 child and via
+    # guards; the floor sits under it so the registry can grow without
+    # touching this number.
+    assert len(actual) >= 55, len(actual)
+    assert len(expected) >= 55, len(expected)
+
+    assert actual == expected


### PR DESCRIPTION
Closes #122.

## Anchors, re-derived

Every anchor in the issue still exists and still says what it was said to say.

| Anchor | Found |
|---|---|
| `c6f2a9d4e7b1` `_DIRECT_CHILDREN` | `backend/alembic/versions/c6f2a9d4e7b1_enforce_accepted_science_immutability.py:36`. 54 entries; `_direct_child_groups()` (`:166`) collapses them to 48 `(table, record_type)` groups. |
| `trg_as_child_NN` minting | `:736`, `f"CREATE TRIGGER trg_as_child_{index:02d}"`. Also `trg_as_via_{index:02d}` (`:754`) and `trg_as_truncate_{index:02d}` (`:809`). |
| `a1f6c3e9b527:136-145` | Correct within a line: the `_trigger_name` docstring is at `:135-145`. It says the names are table-suffixed "because `c6f2a9d4e7b1` owns the `trg_as_child_NN` sequence, and appending to it from a third revision would make every revision's numbering depend on the others'." `b6c1f4a8e703:195-205` says the same thing first. |
| `trg_as_child_19` reuse | `d4e9b1c7a253_scf_stability_provenance_is_not_ownership.py:105`, `_TRIGGER = "trg_as_child_19"`. Installed by `DROP TRIGGER` then `CREATE TRIGGER` (`:124-135`), not `CREATE OR REPLACE`. |
| Already asserted? | **Partly — and this changes the shape of the work.** `backend/tests/db/test_accepted_science_trigger_registry.py::test_database_trigger_set_matches_registry` already asserts set *equality* of `(table, name)` pairs against `pg_trigger`. Candidate (1) in the issue is therefore already done, and better than a static pin: the expectation is derived from the registries, so it cannot rot. |

## The hazard, demonstrated

Reproduced against a live database at head before writing anything. Three cases, and only one of them is the hazard:

| | What a future revision does | Result |
|---|---|---|
| E1 | `DROP TRIGGER trg_as_child_19` then `CREATE TRIGGER trg_as_child_19` on `calc_scf_stability` with a different argument list | **Accepted, and silent.** `test_database_trigger_set_matches_registry` passes — the `(table, name)` pair is unchanged. |
| E2 | plain `CREATE TRIGGER trg_as_child_19` on `calc_scf_stability` | PostgreSQL refuses: `DuplicateObject: trigger "trg_as_child_19" for relation "calc_scf_stability" already exists`. |
| E3 | `CREATE TRIGGER trg_as_child_19` on a *different* table | Legal in PostgreSQL, but the existing parity test fails on the extra pair. |

**This refutes the issue's premise as stated.** A `trg_as_child_NN` collision does not "collide silently" — E2 is a hard migration failure and E3 is already caught. The exposure is not the name. It is the *argument list behind* a reused name, and E1 is exactly the mechanism `d4e9b1c7a253` legitimately uses. `tckdb_guard_accepted_child` treats every argument as a column binding the row to an accepted root, so an added argument refuses writes that should be allowed and a dropped one allows writes that should be refused — the failure `d4e9b1c7a253` itself exists to correct.

A second finding from the same scan: `trg_repro_assessment_append_only` is **already** minted by two revisions — `b4e8c1f6a2d9` creates it, `6a9d2e4c7b1f` drops it for a public-ref backfill and recreates it. I verified the recreation is byte-identical, so it is correct; it is a second, undocumented-as-such precedent for cross-revision name reuse, and it is declared here.

## Which shape, and why

**Both — but neither as the issue framed them.**

Candidate (1) is already in the tree, so re-pinning names would add nothing.

Candidate (2), taken literally as "a source-level check that no two revisions mint the same name", **is a vacuous pass as usually written**. A literal-text scan of `backend/alembic/versions/` finds `trg_as_child_19` in `c6f2a9d4e7b1` exactly once — inside a comment. The revision that actually creates the trigger never spells its name; it is an f-string. Of the 27 `CREATE TRIGGER` sites across 11 revisions, 12 name their target through a variable. A naive scan sees zero collisions and passes.

So:

- **`test_trigger_names_have_exactly_one_minting_revision`** (source-level, no DB). Resolves names from string literals *and* module-level string constants via `ast`, and recognises positional templates as families. Critically, it credits a sequence's owner with every member of that sequence found spelled out elsewhere — without that step it sees `trg_as_child_19` claimed by one revision and reports nothing. It then asserts each positional family has exactly one minting revision, that any name minted twice is one of two declared reuses, and that a declared reuse is still a real one (so an allowance cannot outlive its reason). This catches the collision before either migration runs, which is the thing a DB-level check structurally cannot do.
- **`test_database_trigger_definitions_match_registry`** (DB-level). Pins the function and argument list each `trg_as_child_*` / `trg_as_via_*` trigger actually runs with, derived from the registries with `d4e9b1c7a253`'s `_REMOVED_CHILDREN` applied to the columns but *not* to the grouping — a correction that narrows a group must not renumber the triggers either side of it. This is the only thing that closes E1.

They protect different things and neither subsumes the other: the source check catches intent in a file that has never been applied; the definition pin catches ground truth in a database whose migration may have been written by hand.

## Measured populations behind the floors

Measured on a database at head:

- 177 non-internal public triggers; **152** `trg_as_*`, all 152 names distinct, none shared across tables.
- Positional: 48 `trg_as_child_NN`, 6 `trg_as_via_NN`, 70 `trg_as_truncate_NN`. Table-suffixed: 10 `trg_as_root_*`, 6 `trg_as_child_*`, 1 `trg_as_via_*`, 9 `trg_as_truncate_*`.
- **61** `trg_as_child_*` + `trg_as_via_*` guards carry an argument list. Floor set to **55**.
- Source scan: **27** create sites across **11** files, minting **11** statically resolvable names and 3 positional families. Floors set to **20** / **9** / **9**.

## Verification actually run

Six checks, each written as a temporary test, run, and then deleted:

1. E1 mutation applied in-transaction — `test_database_trigger_set_matches_registry` **passes**, `test_database_trigger_definitions_match_registry` **fails**. Both asserted in the same test, so the contrast is the evidence.
2. `pg_trigger` predicate blinded to match nothing — fails on `assert 0 >= 55`, not on an empty-vs-empty comparison.
3. `_TRIGGER_SITE` regex blinded to match nothing — fails on `assert 0 >= 20`.
4. Synthetic future revision minting `trg_as_child_20` in its own file (real versions symlinked into a tmp dir alongside it) — source test fails naming `trg_as_child_20`.
5. Synthetic future revision starting its own `trg_as_child_{index:02d}` loop — source test fails naming the file.
6. A `_DECLARED_REUSE` entry that no longer describes a real reuse — source test fails.

Then:

- `pytest tests/db/test_accepted_science_trigger_registry.py` — 4 passed.
- `pytest tests/db/` — **216 passed**, database left at head (`_must_leave_the_database_at_head` did not fire). `tests/db/` is covered by the **Backend complement gate** per `backend/scripts/test-rest.sh:19`.
- `ruff check tests/db/test_accepted_science_trigger_registry.py` — clean. `ruff format --check` is not clean on this file, but it was not clean before this change either, so it is not a gate here.

## Impact

- **Schema impact: none. Migration impact: none** — no file under `backend/alembic/versions/` is touched, not even a comment. `backend/app/db/base.py` is untouched.
- No new environment variable.
- Test-only: one file, +300 lines. No test weakened, skipped, xfailed or deleted.

## Worth its own task

`test_database_trigger_set_matches_registry` ends with `assert all(len(name) <= 63 for _, name in actual)`. Every name it checks was produced by `_trigger_name`, which already truncates with `[:63]`, so the assertion cannot fail by construction. The longest name in the database is 52 characters, so the truncation has never bitten — but if it ever does, two long table names sharing a 63-byte prefix would silently collapse to one trigger name, and this assertion would still pass. The real check is that no name *needs* truncating.
