### PR TITLE
Name the frequency list that numbers two modes the same

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -463,6 +463,18 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "whichever code its blocking finding carries, so the scan "
                 "cannot see it and the origin is the defining module."
             )),
+    ApiCode("freq_mode_index_not_unique", 422, Surface.coded_exception,
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py",
+            note=(
+                "Catalogued but deliberately absent from the scientific "
+                "check register, unlike its file neighbour "
+                "freq_n_imag_disagrees_with_modes. A repeated mode_index is "
+                "a malformed list -- a concatenated serialisation, a "
+                "restarted counter -- and asserts nothing about the "
+                "potential energy surface, so it fails the register's "
+                "inclusion test. That is the case this module exists for: a "
+                "code a client must branch on, about no chemistry at all."
+            )),
     ApiCode("freq_n_imag_disagrees_with_modes", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py"),
     ApiCode("geometry_too_large", 422, Surface.message_prefix,

--- a/backend/tests/api/test_api_freq_mode_index_uniqueness.py
+++ b/backend/tests/api/test_api_freq_mode_index_uniqueness.py
@@ -1,0 +1,168 @@
+"""A frequency list that numbers two modes the same, on the wire.
+
+What was wrong
+--------------
+``FreqResultPayload.validate_modes_consistency`` has always refused a
+``modes`` list carrying the same ``mode_index`` twice, and refused it
+with a bare ``ValueError``. Through a request that reaches the payload as
+a nested model, FastAPI wraps it in a ``RequestValidationError`` and the
+envelope reports ``code = "request_validation_error"`` — a code shared
+with every other malformed field in the body, so a client could tell
+"renumber your frequency list" from "your charge is a string" only by
+matching English inside ``detail``.
+
+Why this one is not a scientific check
+--------------------------------------
+Its immediate neighbour in the same validator,
+``freq_n_imag_disagrees_with_modes``, *is* declared in
+``app.scientific_checks``: a scalar and the evidence beside it answering
+the same question about chemistry two different ways is a position a
+referee could argue with, and the register's end-to-end proof of it lives
+in ``test_api_scientific_rejection_codes.py``.
+
+A repeated ``mode_index`` is not that. It is a malformed list — a
+serialiser that concatenated two blocks, a producer that restarted its
+counter — and asserts nothing about the potential energy surface. It
+belongs in ``app.api.code_catalogue``, which enumerates what the API can
+return and claims nothing about chemistry, and it reaches the client enum
+from there. That split is what #161 built the catalogue for, and it is
+why this file sits beside the scientific one rather than inside it.
+
+What is asserted
+----------------
+``code`` and ``context``, never a substring of ``detail`` — a code
+spelled inside a sentence is exactly the defect the catalogue's promotion
+rule was narrowed to reject. Each refusal is paired with the payload that
+must still be **accepted**, because a 422 assertion is satisfied just as
+well by a guard that refuses every frequency list it is shown.
+"""
+
+from __future__ import annotations
+
+from tckdb_schemas.fragments.calculation import (
+    W_FREQ_MODE_INDEX_NOT_UNIQUE,
+    W_FREQ_N_IMAG_DISAGREES_WITH_MODES,
+)
+
+_ROUTE = "/api/v1/uploads/conformers"
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+#: Water, non-linear: 3 atoms, 3N - 6 = 3 vibrational modes. Chosen so a
+#: complete list is three rows long, which keeps the accepted half free of
+#: the completeness warning and the assertion on ``warnings == []`` honest.
+_WATER_XYZ = (
+    "3\nwater\n"
+    "O  0.000000  0.000000  0.117300\n"
+    "H  0.000000  0.757200 -0.469200\n"
+    "H  0.000000 -0.757200 -0.469200"
+)
+_WATER_SPECTRUM = [1595.0, 3657.0, 3756.0]
+
+
+def _payload(*, indices: list[int], label: str, n_imag: int = 0) -> dict:
+    """A water conformer whose freq result numbers its modes as given.
+
+    ``indices`` is the only thing that varies between the refused and the
+    accepted half: same species, same geometry, same three frequencies,
+    same everything the workflow touches after validation.
+    """
+    modes = [
+        {
+            "mode_index": index,
+            "frequency_cm1": frequency,
+            "is_imaginary": frequency < 0,
+        }
+        for index, frequency in zip(indices, _WATER_SPECTRUM, strict=True)
+    ]
+    return {
+        "species_entry": {"smiles": "O", "charge": 0, "multiplicity": 1},
+        "geometry": {"xyz_text": _WATER_XYZ},
+        "calculation": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [
+            {
+                "type": "freq",
+                "software_release": _SOFTWARE,
+                "level_of_theory": _LOT,
+                "freq_result": {
+                    "n_imag": n_imag,
+                    "zpe_hartree": 0.02,
+                    "modes": modes,
+                },
+            }
+        ],
+        "label": label,
+    }
+
+
+def test_a_repeated_mode_index_is_named_on_the_wire(client) -> None:
+    """The refusal reaches the ``code`` field, not just the prose."""
+    resp = client.post(
+        _ROUTE, json=_payload(indices=[1, 2, 2], label="dup-index")
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == W_FREQ_MODE_INDEX_NOT_UNIQUE, body
+    assert body["context"] == {
+        "field": "modes",
+        "duplicate_mode_indices": [2],
+        "mode_count": 3,
+    }, body
+
+
+def test_the_published_sentence_is_unmoved(client) -> None:
+    """Attaching a code was additive: a prose-matching client is undisturbed.
+
+    Separate from the code assertion because they can fail
+    independently, and a rewrite of the message is a breaking change to a
+    published contract while a new code is not.
+    """
+    resp = client.post(
+        _ROUTE, json=_payload(indices=[1, 1, 3], label="dup-prose")
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    assert "mode_index values must be unique within a freq result." in str(
+        resp.json()["detail"]
+    )
+
+
+def test_a_correctly_numbered_frequency_list_is_still_accepted(client) -> None:
+    """The negative half. Same three modes, numbered 1-2-3."""
+    resp = client.post(
+        _ROUTE, json=_payload(indices=[1, 2, 3], label="unique-index")
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert resp.json()["warnings"] == [], resp.text[:800]
+
+
+def test_out_of_order_indices_are_not_duplicates(client) -> None:
+    """Order is not the rule; uniqueness is.
+
+    A list arriving 3-1-2 is unusual but says which row is which mode,
+    which is the whole property. Pinned because "sorted ascending" is the
+    tempting stronger rule, and it would refuse a correct deposit.
+    """
+    resp = client.post(
+        _ROUTE, json=_payload(indices=[3, 1, 2], label="shuffled-index")
+    )
+    assert resp.status_code == 201, resp.text[:800]
+
+
+def test_the_neighbouring_disagreement_keeps_its_own_code(client) -> None:
+    """One code per repair: the two refusals in this validator stay apart.
+
+    ``n_imag`` disagreeing with the modes is a different thing to fix
+    from a list that numbers two rows the same, and a client branches on
+    which. Asserting it here guards the specific regression of a new code
+    swallowing the older one when both checks live in one validator.
+    """
+    assert W_FREQ_MODE_INDEX_NOT_UNIQUE != W_FREQ_N_IMAG_DISAGREES_WITH_MODES
+    resp = client.post(
+        _ROUTE, json=_payload(indices=[1, 2, 3], label="n-imag-clash", n_imag=2)
+    )
+    assert resp.status_code == 422, resp.text[:800]
+    assert resp.json()["code"] == W_FREQ_N_IMAG_DISAGREES_WITH_MODES

--- a/backend/tests/services/test_freq_modes.py
+++ b/backend/tests/services/test_freq_modes.py
@@ -14,6 +14,7 @@ from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 from tckdb_schemas.coded_error import CodedValidationError
 from tckdb_schemas.fragments.calculation import (
+    W_FREQ_MODE_INDEX_NOT_UNIQUE,
     W_FREQ_N_IMAG_DISAGREES_WITH_MODES,
 )
 
@@ -96,7 +97,14 @@ class TestFreqResultPayloadModes:
         assert payload.modes is None
 
     def test_duplicate_mode_index_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="mode_index values must be unique"):
+        """The refusal is named, and names which index collided.
+
+        The prose match is kept because the first sentence is published
+        and attaching a code was meant to be additive; the code and the
+        context are the new contract, and a client branching on either
+        is the reason ``freq_mode_index_not_unique`` exists at all.
+        """
+        with pytest.raises(ValidationError, match="mode_index values must be unique") as excinfo:
             FreqResultPayload(
                 modes=[
                     FrequencyModePayload(
@@ -107,6 +115,56 @@ class TestFreqResultPayloadModes:
                     ),
                 ]
             )
+        errors = excinfo.value.errors()
+        assert len(errors) == 1, errors
+        coded = errors[0]["ctx"]["error"]
+        assert isinstance(coded, CodedValidationError)
+        assert coded.code == W_FREQ_MODE_INDEX_NOT_UNIQUE
+        assert coded.context == {
+            "field": "modes",
+            "duplicate_mode_indices": [1],
+            "mode_count": 2,
+        }
+
+    def test_a_unique_mode_index_list_is_accepted(self) -> None:
+        """The negative half. Same two rows, renumbered, and it validates.
+
+        Without it the assertion above passes just as well against a
+        validator that refuses every ``modes`` list it is given.
+        """
+        payload = FreqResultPayload(
+            n_imag=0,
+            modes=[
+                FrequencyModePayload(
+                    mode_index=1, frequency_cm1=1100.0, is_imaginary=False
+                ),
+                FrequencyModePayload(
+                    mode_index=2, frequency_cm1=1200.0, is_imaginary=False
+                ),
+            ],
+        )
+        assert [m.mode_index for m in payload.modes or []] == [1, 2]
+
+    def test_every_repeated_index_is_named_not_just_the_first(self) -> None:
+        """Two collisions in one list report both, sorted.
+
+        A depositor whose serialiser concatenated two blocks has more
+        than one duplicate, and being told about one of them is a repair
+        loop rather than a repair.
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            FreqResultPayload(
+                modes=[
+                    FrequencyModePayload(
+                        mode_index=index, frequency_cm1=1000.0 + index,
+                        is_imaginary=False,
+                    )
+                    for index in (3, 1, 3, 1, 2)
+                ]
+            )
+        coded = excinfo.value.errors()[0]["ctx"]["error"]
+        assert coded.context["duplicate_mode_indices"] == [1, 3]
+        assert coded.context["mode_count"] == 5
 
     def test_n_imag_mismatch_rejected(self) -> None:
         with pytest.raises(ValidationError, match="does not match imaginary mode count"):

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.44.0"
+version = "0.45.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -102,6 +102,7 @@ class RejectionCode(str, Enum):
     EXPORT_SEED_EMPTY = "export_seed_empty"
     EXPORT_SEED_UNRESOLVED = "export_seed_unresolved"
     FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM = "freq_list_exceeds_geometry_degrees_of_freedom"
+    FREQ_MODE_INDEX_NOT_UNIQUE = "freq_mode_index_not_unique"
     FREQ_N_IMAG_DISAGREES_WITH_MODES = "freq_n_imag_disagrees_with_modes"
     GEOMETRY_TOO_LARGE = "geometry_too_large"
     HANDLE_NOT_FOUND = "handle_not_found"
@@ -241,6 +242,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.EXPORT_SEED_EMPTY,
         RejectionCode.EXPORT_SEED_UNRESOLVED,
         RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM,
+        RejectionCode.FREQ_MODE_INDEX_NOT_UNIQUE,
         RejectionCode.FREQ_N_IMAG_DISAGREES_WITH_MODES,
         RejectionCode.GEOMETRY_TOO_LARGE,
         RejectionCode.HANDLE_TYPE_MISMATCH,
@@ -392,6 +394,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.EXPORT_SEED_EMPTY: frozenset({422}),
     RejectionCode.EXPORT_SEED_UNRESOLVED: frozenset({422}),
     RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM: frozenset({422}),
+    RejectionCode.FREQ_MODE_INDEX_NOT_UNIQUE: frozenset({422}),
     RejectionCode.FREQ_N_IMAG_DISAGREES_WITH_MODES: frozenset({422}),
     RejectionCode.GEOMETRY_TOO_LARGE: frozenset({422}),
     RejectionCode.HANDLE_NOT_FOUND: frozenset({404}),

--- a/schemas/python/tckdb-schemas/README.md
+++ b/schemas/python/tckdb-schemas/README.md
@@ -24,6 +24,55 @@ rather than inside the server.
 
 ## Changelog
 
+### 0.34.0 — a frequency list that numbers two modes the same says so by name
+
+**Not breaking.** No field is added, renamed or removed, and the set of
+payloads that validate is byte-for-byte the set that validated under
+0.33.0 — **every 0.33.0 payload validates unchanged under 0.34.0**, and
+every payload 0.33.0 refused is still refused. What changes is what a
+client is *told* when one is refused.
+
+`FreqResultPayload.validate_modes_consistency` has always refused a
+`modes` list carrying the same `mode_index` twice. It refused with a bare
+`ValueError`, so the 422 envelope reported `code =
+"request_validation_error"` (or `"validation_error"`, depending on which
+handler saw it) and a client wanting to distinguish "renumber your
+frequency list" from any other validation failure had to match English.
+
+It now raises `CodedValidationError` under the new module-level constant
+`W_FREQ_MODE_INDEX_NOT_UNIQUE = "freq_mode_index_not_unique"`, with
+`context = {"field", "duplicate_mode_indices", "mode_count"}`. The first
+sentence of the message is byte-identical to the one 0.33.0 emitted
+(`message_prefix=False`), so a client matching prose is undisturbed; the
+duplicated indices and the repair follow it.
+
+Minor rather than patch because the envelope's `code` field is part of
+the published contract: a consumer may now branch on this refusal, which
+it could not before.
+
+**Deliberately not a scientific check.** Its neighbour
+`freq_n_imag_disagrees_with_modes` (0.28.0) is declared in the backend's
+scientific check register, because two fields of one record answering the
+same question about chemistry differently is a position a referee could
+argue with. A repeated `mode_index` is not: it is a malformed list — a
+concatenated serialisation, a producer that restarted its counter — and
+asserts nothing about the potential energy surface. It is catalogued in
+`app.api.code_catalogue` and reaches the client enum from there, which is
+the split that module exists for.
+
+### 0.33.0 — **BREAKING**: `CalculationPayload.literature_id` is removed
+
+Recorded after the fact: the version was published without a changelog
+entry, and this note is reconstructed from the commit that made it
+(#177). It says only what that change did.
+
+`CalculationPayload.literature_id` is **removed** and replaced by
+`literature`, the inline `LiteratureUploadRequest` fragment — the same
+repair 0.32.0 made to `CalculationIn`, applied to the other shared
+calculation payload. The generalised no-FK-ids gate that found it now
+walks every upload root discovered from the live route table, rather than
+the single root it used to check.
+
 ### 0.32.0 — **BREAKING**: a calculation cites literature inline, and the reaction bundle's 201 names its statmech
 
 **Breaking:** `CalculationIn.literature_id` is **removed**. It was a

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.33.0"
+version = "0.34.0"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py
@@ -162,6 +162,25 @@ class OptResultPayload(SchemaBase):
 #: and nothing in it is imaginary" — and is judged like any other list.
 W_FREQ_N_IMAG_DISAGREES_WITH_MODES = "freq_n_imag_disagrees_with_modes"
 
+#: Two mode rows in one frequency list claiming the same ``mode_index``.
+#:
+#: Its neighbour above is a scientific position — two fields of one record
+#: answering the same question about chemistry differently — and is declared
+#: in ``app.scientific_checks``. This one deliberately is not, and the
+#: distinction is the reason it needed a code of its own rather than a place
+#: in that register. ``mode_index`` is the ESS's 1-based ordering, so a
+#: repeated value is a malformed list: a serialiser that concatenated two
+#: blocks, or a producer that restarted its counter. Nothing about the
+#: potential energy surface is being claimed, so there is no position a
+#: referee could argue with — and a register whose entries are not all
+#: arguable claims is a register that dilutes the ones that are.
+#:
+#: It still needs a name. "Your frequency list is malformed, renumber the
+#: modes" is a different repair from every other 422 the same request can
+#: produce, and a client could previously tell it apart only by matching
+#: English inside a ``request_validation_error``.
+W_FREQ_MODE_INDEX_NOT_UNIQUE = "freq_mode_index_not_unique"
+
 
 class FrequencyModePayload(BaseModel):
     """One vibrational mode within a frequency calculation result.
@@ -255,7 +274,25 @@ class FreqResultPayload(SchemaBase):
             return self
         indices = [m.mode_index for m in self.modes]
         if len(set(indices)) != len(indices):
-            raise ValueError("mode_index values must be unique within a freq result.")
+            duplicates = sorted({i for i in indices if indices.count(i) > 1})
+            raise CodedValidationError(
+                W_FREQ_MODE_INDEX_NOT_UNIQUE,
+                # First sentence unchanged, byte for byte: attaching a code
+                # is additive and must not move published prose.
+                "mode_index values must be unique within a freq result. "
+                f"Index {', '.join(str(i) for i in duplicates)} appears "
+                f"more than once, so the list does not say which row is "
+                f"which mode and a consumer reading it cannot "
+                f"reconstruct the spectrum "
+                f"({W_FREQ_MODE_INDEX_NOT_UNIQUE}). Renumber the modes to "
+                f"the ESS's own 1-based ordering.",
+                context={
+                    "field": "modes",
+                    "duplicate_mode_indices": duplicates,
+                    "mode_count": len(self.modes),
+                },
+                message_prefix=False,
+            )
         if self.n_imag is not None:
             imaginary_count = sum(1 for m in self.modes if m.is_imaginary)
             if imaginary_count != self.n_imag:


### PR DESCRIPTION
Closes #170. Closes #166 — as already done; see below.

## Both anchors, re-derived

**#166 — `backend/app/workflows/thermo.py:204`.** The line is now
`backend/app/workflows/thermo.py:218`, and the refusal it names **is already
coded**. PR #178 ("Name the seven ownership refusals that arrived uncoded")
routed it through the shared guard: `_resolve_statmech_id` calls
`assert_statmech_owned_by(..., code=W_THERMO_STATMECH_OWNER_MISMATCH, ...)`,
the catalogue carries `thermo_statmech_owner_mismatch` at 422
(`backend/app/api/code_catalogue.py:690`), the client enum exports it, and
`backend/tests/api/test_api_statmech_citation_ownership.py` provokes it
through `POST /api/v1/uploads/thermo` **and** pairs it with the
correctly-owned deposit that must still be accepted. Verified by running
that file: 8 passed. Nothing in this PR touches it.

That is why `test_api_ownership_branch_route_coverage.py` (#188) is green
without a new provocation from me: this PR adds no `W_*` ownership code.

**#170 — `schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py:246`.**
The line is now `:277`, and the refusal was still a bare `ValueError`. Fixed
here.

## The two codes

| task | code | status |
|---|---|---|
| #166 | `thermo_statmech_owner_mismatch` | already shipped in #178 |
| #170 | `freq_mode_index_not_unique` | new in this PR |

They are different repairs and do not share a code — `freq_mode_index_not_unique`
also stays distinct from its file-neighbour `freq_n_imag_disagrees_with_modes`
(#160), which is the other refusal raised by the same validator and is a
different thing to fix. A test asserts both that the constants differ and that
an `n_imag` disagreement still reports its own code.

## Before / after, through the route

`POST /api/v1/uploads/conformers` with two mode rows both numbered
`mode_index: 1`:

Before — the code is shared with every other malformed field in the body:

```json
{"code": "request_validation_error",
 "detail": [{"loc": ["body","calculation","freq_result"],
             "msg": "Value error, mode_index values must be unique within a freq result."}],
 "context": {}}
```

After:

```json
{"code": "freq_mode_index_not_unique",
 "detail": [{"loc": ["body","calculation","freq_result"],
             "msg": "Value error, mode_index values must be unique within a freq result. Index 1 appears more than once, so the list does not say which row is which mode and a consumer reading it cannot reconstruct the spectrum (freq_mode_index_not_unique). Renumber the modes to the ESS's own 1-based ordering."}],
 "context": {"field": "modes", "duplicate_mode_indices": [1], "mode_count": 2}}
```

Note the *actual* before-code is `request_validation_error`, not
`validation_error` as the task assumed: through a route the payload is a
nested model, so FastAPI wraps the `ValueError` in a `RequestValidationError`
and `_request_validation_error_handler` supplies that fallback. Same defect,
different generic — and it is the one a client actually receives.

First sentence is byte-identical to the published one (`message_prefix=False`),
so a prose-matching client is undisturbed. `context` names the field the way
the depositor wrote it and carries only values from their own payload; no row
id appears anywhere (DR-0028 Req 2).

## Where the non-chemistry code lives — the #164 answer, followed not invented

#161 built `backend/app/api/code_catalogue.py` precisely so a code could be
client-facing without being a scientific claim, and its own docstring names
"every code #166 and #170 will add" as the motivating set. So
`freq_mode_index_not_unique` is:

- **catalogued** — `Surface.coded_exception`, origin the wire module that
  defines the literal, with a note saying why it is not in the register;
- **not** declared in `app.scientific_checks`. A repeated `mode_index` is a
  malformed list (a concatenated serialisation, a restarted counter) and
  asserts nothing about the potential energy surface, so it fails the
  register's "could this be wrong in an interesting way?" test. Its neighbour
  `freq_n_imag_disagrees_with_modes` passes it and stays there;
- exported to the client enum by regeneration, since membership is derived
  from `ApiCode.is_client_facing`.

Its route test sits in a new file rather than in
`test_api_scientific_rejection_codes.py`, which is the register's end-to-end
proof and would be the wrong claim.

## The sibling-helper design question (#166)

Moot, and answered the way I would have argued it. #178 did not grow a second
near-identical helper: `backend/app/services/calculation_ownership.py` now has
**one** implementation, `assert_owned_by`, taking the two owner ids, a
`subject_noun` and the code as parameters, with
`assert_calculation_owned_by` and `assert_statmech_owned_by` as thin typed
spellings that read the owner columns off their row so a caller cannot pass
the wrong pair. A third caller with neither row — a conformer selection,
whose species is reached through its group — calls the generic one directly.

That is the shape to keep, and it is the opposite of the #162 duplication:
the comparison, the logging of row ids, and the "guard with nothing to check
against" refusal exist once. The typed wrappers earn their place by removing
a call-site error (passing `species_entry_id` where
`transition_state_entry_id` belongs), not by re-implementing anything. No
change proposed.

## Schema / client impact and version bumps

- Migration impact: **none**. No model, no ORM, no Alembic revision — the
  change is a wire-schema validator, a catalogue entry and a generated enum.
- No new environment variable.
- `schemas/python/tckdb-schemas` **0.33.0 → 0.34.0**. Minor, matching the
  0.28.0 precedent: the accepted set is byte-for-byte unchanged, but the
  envelope's `code` is published contract and a consumer may now branch on
  this refusal. README changelog entry added.
- `clients/python` **0.44.0 → 0.45.0**, with the regenerated
  `rejection_codes.py` (new member, `VALIDATION_REJECTION_CODES` entry, and a
  `REJECTION_STATUSES` mapping to `{422}` — the retry advice
  `tests/test_rejection_codes.py` requires).
- **The wire-package floor stays at `>=0.33.0`.** #189 raised it to "the
  version it needs", and the client needs nothing from 0.34.0: its enum is a
  generated standalone copy that imports nothing from `tckdb_schemas`, and the
  0.34.0 change refuses no payload 0.33.0 accepted. A client pinned to 0.33.0
  simply never receives the new code, which is exactly the newer-server
  degradation `rejection_code()` returning `None` is designed for. Raising it
  would force an upgrade for a string a consumer can already branch on from
  the server's response, and #189's own comment warns against settling the
  lockstep question (#112) inside a dependency line.

Also recorded: **0.33.0 shipped a breaking change with no changelog entry** —
`CalculationPayload.literature_id` was removed in #177 and the README jumps
0.32.0 → 0.34.0 without it. A short entry reconstructed from that commit is
added so the published history is not missing a breaking release.

## Verification actually run

All with `PYTHONPATH` pointed at this worktree's `schemas/python/tckdb-schemas`
and `DB_TEST_NAME=tckdb_test_166`.

- `backend/tests/api/test_api_freq_mode_index_uniqueness.py` (new, 5 tests) +
  `backend/tests/services/test_freq_modes.py` — 25 passed
- `backend/tests/api/test_api_statmech_citation_ownership.py` — 8 passed
  (the #166 evidence)
- `backend/tests/api/test_api_code_catalogue.py`,
  `test_client_rejection_codes_generated.py`,
  `test_api_ownership_branch_route_coverage.py`, `backend/tests/invariants/`
  — 80 passed
- `backend/tests/api backend/tests/schemas backend/tests/services` — **5535
  passed** in 34m53s
- `clients/python`: `pytest tests` — 1348 passed;
  `pytest adapters/chemkin/tests` — 55 passed, 1 skipped
- `schemas/python/tckdb-schemas`: `pytest` — 38 passed
- `cd backend && ruff check app tests scripts` — clean;
  `ruff check tckdb_schemas` in the wire package — clean
Reproduced first: the generic `request_validation_error` body above was
captured from the live route before any edit.

### Mutation checks (each `git diff`-ed from the repo root, then restored)

| mutation | result |
|---|---|
| `!=` → `>` in the uniqueness condition, so the guard never fires | **red**: 4 tests — the two route provocations and two unit tests. The route one fails as a **500** from the `calc_freq_mode` unique constraint, which is what a duplicate reaches without the wire guard |
| code literal `freq_mode_index_not_unique` → `freq_mode_index_duplicated` | **red**: `test_api_code_catalogue.py::test_every_raise_site_code_is_catalogued` and `::test_every_origin_still_defines_its_code`, plus the two route tests erroring out through the runtime code observer |
| `duplicate_mode_indices` truncated to `[:1]` | **red**: `test_every_repeated_index_is_named_not_just_the_first` — the multi-duplicate assertion is not satisfied by naming one |

Working tree restored and `__pycache__` cleared after each; the six affected
files re-run green (56 passed).

Only one new refusal exists to mutate — #166's was shipped in #178 and is not
this PR's to test by mutation.
