### PR TITLE
Ask whether a trigger name had to be cut, not whether it was

### DIFF
--- a/backend/tests/db/test_accepted_science_trigger_registry.py
+++ b/backend/tests/db/test_accepted_science_trigger_registry.py
@@ -46,6 +46,30 @@ _EXTENSION_REVISIONS = (_ATOM_MAP_REVISION, _EVIDENCE_REVISION)
 #: adding to it. A second narrowing revision joins by being added here.
 _CORRECTION_REVISIONS = (_VERSIONS / "d4e9b1c7a253_scf_stability_provenance_is_not_ownership.py",)
 
+#: PostgreSQL's identifier limit. A ``CREATE TRIGGER`` naming anything longer
+#: does not fail — the server silently cuts the name to this length — which is
+#: why the limit has to be checked against the name a revision *meant* to mint
+#: rather than against the one that came back out of ``pg_trigger``.
+_IDENTIFIER_LIMIT = 63
+
+#: The two tables ``c6f2a9d4e7b1`` freezes with ``trg_append_only_<table>``.
+#: Spelled out because the revision holds them in an inline tuple rather than
+#: in a module constant the way it holds its other registries.
+#: ``test_database_trigger_set_matches_registry`` asserts set equality against
+#: the live database using these same two names, so drift here fails there.
+_APPEND_ONLY_TABLES = ("record_review_event", "scientific_record_supersession")
+
+#: The ``_trigger_name`` prefixes each revision is allowed to mint under.
+#: ``_generated_trigger_names`` below enumerates exactly these, and the test
+#: checks the enumeration against the revision sources — so a revision minting
+#: under a prefix nobody here knows about fails rather than going unmeasured,
+#: which is the way a length check quietly stops covering the corpus.
+_ROOT_PREFIXES = frozenset({"as_root", "append_only"})
+_EXTENSION_PREFIXES = frozenset({"as_child", "as_via", "as_truncate"})
+
+#: ``_trigger_name("as_child", table)`` — the prefix at a mint site.
+_TRIGGER_NAME_PREFIX = re.compile(r"""_trigger_name\(\s*["']([a-z_]+)["']""")
+
 
 def _revision_namespace() -> dict:
     return runpy.run_path(str(_REVISION))
@@ -453,7 +477,157 @@ def test_database_trigger_set_matches_registry(db_session) -> None:
         )
     }
     assert actual == expected
-    assert all(len(name) <= 63 for _, name in actual)
+
+    # This test used to end by asserting that no name in ``actual`` exceeded
+    # 63 characters. It could not fail: ``pg_trigger.tgname`` is a ``name``,
+    # which PostgreSQL has already cut to 63 on the way in, and every name on
+    # the ``expected`` side comes out of a ``_trigger_name`` ending in
+    # ``[:63]``. The question the limit actually poses — whether any name had
+    # to be cut to get there — is asked by
+    # ``test_trigger_names_need_no_truncation_to_fit`` below.
+
+
+def _generated_trigger_names() -> list[tuple[str, str, str, str, str]]:
+    """``(revision, prefix, table, untruncated, minted)`` per ``_trigger_name`` call.
+
+    ``untruncated`` is the name as it stands before ``_trigger_name``'s
+    ``[:63]`` reaches it. It cannot be read back out of the revision, so it is
+    rebuilt here — and the rebuild is pinned against the function itself by the
+    caller, which asserts ``minted == untruncated[:63]``. A revision that
+    changes how it spells a name therefore fails loudly instead of being
+    measured against a formula that has silently gone stale.
+    """
+
+    revision = _revision_namespace()
+    root_name = revision["_trigger_name"]
+
+    minted: list[tuple[str, str, str, object]] = []
+    for table in sorted(set(revision["_ROOT_TYPES"].values())):
+        minted.append((_REVISION.name, "as_root", table, root_name))
+    for table in _APPEND_ONLY_TABLES:
+        minted.append((_REVISION.name, "append_only", table, root_name))
+    for path, extension in zip(_EXTENSION_REVISIONS, _extension_namespaces(), strict=True):
+        extension_name = extension["_trigger_name"]
+        for table, _record_type, _columns in extension["_child_groups"]():
+            minted.append((path.name, "as_child", table, extension_name))
+        for item in extension["_VIA_CHILDREN"]:
+            minted.append((path.name, "as_via", item[0], extension_name))
+        for table in extension["_TRUNCATE_TABLES"]:
+            minted.append((path.name, "as_truncate", table, extension_name))
+
+    return [
+        (revision_name, prefix, table, f"trg_{prefix}_{table}", mint(prefix, table))
+        for revision_name, prefix, table, mint in minted
+    ]
+
+
+def test_trigger_names_need_no_truncation_to_fit(db_session) -> None:
+    """No guard name has to be cut to reach PostgreSQL's 63 characters.
+
+    The limit is real, and ``_trigger_name`` respects it by ending in
+    ``[:63]``. That truncation is correct and stays: a name must fit. But it
+    means "is this name within the limit?" is not a question worth asking of
+    the result — the answer is yes by construction, on both sides of every
+    comparison this file makes. The question worth asking is whether any name
+    was long enough to *need* cutting.
+
+    It matters because of what gets cut. These names end in the table they
+    guard, and ``[:63]`` takes from the end. A truncated name is one whose
+    table has been shortened or removed, and the table suffix is the entire
+    reason these names are unique: ``test_trigger_names_have_exactly_one_
+    minting_revision`` deliberately does not resolve them, on the stated
+    grounds that "the table-suffixed convention makes them safe". Cut the
+    suffix and it does not. Two tables sharing a long enough head then mint one
+    name, and a later revision guarding a table an earlier one already guards
+    mints the name that revision installed — a drop-then-create replaces the
+    guard and PostgreSQL says nothing, which is precisely the failure the
+    static scan exists to catch and cannot see here.
+
+    Nothing is close today: the longest name is 52 characters and the longest
+    table in the schema is 40. This closes the gap before the first long table
+    name makes it live, which is the moment nobody will be reading this file.
+    """
+
+    generated = _generated_trigger_names()
+
+    # Prove the enumeration found the corpus before asserting anything about
+    # it. A registry read that came back empty would otherwise turn every
+    # check below into a pass over nothing. The floor sits under the measured
+    # 26 names minted across the three revisions.
+    assert len(generated) >= 22, len(generated)
+
+    # ...and prove the enumeration covers every prefix the revisions mint
+    # under. A revision that grew a fourth prefix would otherwise be measured
+    # on only the part of its output this list happens to know about.
+    assert set(_TRIGGER_NAME_PREFIX.findall(_REVISION.read_text())) == _ROOT_PREFIXES
+    for path in _EXTENSION_REVISIONS:
+        prefixes = set(_TRIGGER_NAME_PREFIX.findall(path.read_text()))
+        assert prefixes, path.name
+        assert prefixes <= _EXTENSION_PREFIXES, (path.name, sorted(prefixes - _EXTENSION_PREFIXES))
+
+    # Pin the reconstructed untruncated name against the function that mints
+    # the real one. Without this the length assertion below would be measuring
+    # a formula of this test's own invention.
+    for revision_name, prefix, table, untruncated, name in generated:
+        assert name == untruncated[:_IDENTIFIER_LIMIT], (revision_name, prefix, table, untruncated, name)
+
+    # The invariant the old assertion only appeared to state.
+    for revision_name, prefix, table, untruncated, _name in generated:
+        assert len(untruncated) <= _IDENTIFIER_LIMIT, (revision_name, prefix, table, len(untruncated))
+
+    # Two mint inputs may not land on one name. Truncation is one way that
+    # happens; a second revision guarding a table an earlier one already
+    # guards is the other, and that one needs no truncation at all — it is
+    # invisible to ``test_trigger_names_have_exactly_one_minting_revision``,
+    # which cannot statically resolve a name built in a loop from a table.
+    owners: dict[str, set[tuple[str, str, str]]] = defaultdict(set)
+    for revision_name, prefix, table, _untruncated, name in generated:
+        owners[name].add((revision_name, prefix, table))
+    collided = {name: sorted(inputs) for name, inputs in owners.items() if len(inputs) > 1}
+    assert not collided, collided
+
+    # Today's mint inputs are not the only ones these templates will ever see.
+    # Asked of the whole schema, the same question turns red on the day a long
+    # table name is added rather than on the day someone gets round to
+    # guarding it. Measured headroom: the longest stem is ``trg_as_truncate_``
+    # at 16 and the longest table is 40, for 56 of 63.
+    stems = {f"trg_{prefix}_" for _revision_name, prefix, _table, _untruncated, _name in generated}
+    assert stems == {f"trg_{prefix}_" for prefix in _ROOT_PREFIXES | _EXTENSION_PREFIXES}, sorted(stems)
+    longest_table = max(Base.metadata.tables, key=len)
+    longest_stem = max(stems, key=len)
+    assert len(longest_stem) + len(longest_table) <= _IDENTIFIER_LIMIT, (longest_stem, longest_table)
+
+    # Hand-written names are subject to the same cut, and no ``[:63]`` stands
+    # between them and it. These are read from the revision sources, so unlike
+    # the old assertion the value being measured is the one the author wrote.
+    literals, _families, _sites, files = _minted_trigger_names()
+    assert files >= 9, files
+    assert len(literals) >= 9, sorted(literals)
+    over_limit = {name: sorted(revisions) for name, revisions in literals.items() if len(name) > _IDENTIFIER_LIMIT}
+    assert not over_limit, over_limit
+
+    # Finally, tie the enumeration to the database: every name reasoned about
+    # above is a trigger that exists. An enumeration that had drifted off the
+    # registries would otherwise satisfy every assertion in this test while
+    # describing guards nobody installed.
+    installed = {
+        (row.table_name, row.trigger_name)
+        for row in db_session.execute(
+            text(
+                """
+                SELECT relation.relname AS table_name, trigger.tgname AS trigger_name
+                FROM pg_trigger AS trigger
+                JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+                JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+                WHERE NOT trigger.tgisinternal AND namespace.nspname = 'public'
+                """
+            )
+        )
+    }
+    # Floor under the measured 177 public triggers.
+    assert len(installed) >= 150, len(installed)
+    absent = {(table, name) for _revision_name, _prefix, table, _untruncated, name in generated} - installed
+    assert not absent, sorted(absent)
 
 
 def _corrected_direct_groups(


### PR DESCRIPTION
## In plain terms

PostgreSQL will not accept an identifier longer than 63 characters. The code that
builds our accepted-science trigger names therefore chops every name at 63. A test
then checked that no name was longer than 63 — which is guaranteed, because the
chopping already happened. It was checking that the chopper worked, not that the
names were right.

That is not merely redundant. It reads as protection against the identifier limit
while providing none, and the thing it hides is the failure that actually matters.
Truncation cuts from the **end**, and the end of these names is the table they
guard. A name that gets cut is a name that has stopped identifying its own table —
and the table suffix is the entire reason these names are unique. Two long table
names sharing a head would chop down to one name; a later migration guarding a
table an earlier one already guards would mint the name that migration installed,
and a drop-then-create would silently replace one guard with another. In every one
of those cases the old assertion still passes, because both names are ≤ 63 by
construction.

So the real invariant is not "no name exceeds 63". It is:

1. **No name needed truncating** — the name before the cut already fits.
2. **No two names collide** — the failure that actually loses a guard.

**This is not urgent and nothing is broken.** The longest generated name today is
52 characters and the longest table in the schema is 40, leaving 7 characters of
headroom. This has never bitten. It becomes live the first time someone adds a
table with a long name, which is exactly the moment nobody will be reading this
assertion. A latent gap is being closed, not a defect fixed.

## What changed

`backend/tests/db/test_accepted_science_trigger_registry.py` only. No schema
change, no migration, no new environment variable, no production code touched.
No revision under `backend/alembic/versions/` was edited, and `_trigger_name`'s
`[:63]` is untouched — the truncation is correct, a name must fit. The question
is whether any name should be reaching it long enough to be cut.

Removed, from the end of `test_database_trigger_set_matches_registry`:

```python
assert all(len(name) <= 63 for _, name in actual)
```

A comment now stands in its place naming where the real check lives, so a reader
does not wonder whether the limit stopped being checked.

Added `test_trigger_names_need_no_truncation_to_fit`, which is strictly stronger.
For each of the 26 names the three revisions mint through `_trigger_name` it
reconstructs the **untruncated** name and asserts:

- the reconstruction is right — `_trigger_name(prefix, table) == untruncated[:63]`,
  so a revision that changes how it spells a name fails loudly rather than being
  measured against a formula this test invented;
- `len(untruncated) <= 63` — nothing had to be cut;
- no two mint inputs produce one name;
- asked of the whole schema rather than only today's inputs: the longest name stem
  plus the longest table name still fits, so this turns red on the day a long table
  is *added*, not on the day someone gets round to guarding it;
- hand-written literal trigger names, read out of the revision sources rather than
  out of `pg_trigger`, are also within the limit;
- every name reasoned about above is a trigger that actually exists in the database.

## Measured counts behind the floors

Re-derived on this branch, not carried over from #190.

| measurement | value | floor asserted |
|---|---|---|
| names minted via `_trigger_name` across the three revisions | 26 | `>= 22` |
| public non-internal triggers installed | 177 | `>= 150` |
| `trg_as_*` triggers installed | 152 | (not floored directly) |
| revision files containing a `CREATE TRIGGER` site | 11 | `>= 9` |
| `CREATE TRIGGER` sites found by the static scan | 27 | — |
| statically resolvable literal names | 11 | `>= 9` |
| longest hand-written literal name | 45 — `trg_calculation_execution_environment_binding` | `<= 63` |
| longest untruncated generated name | **52** — `trg_as_truncate_transition_state_validation_evidence` | `<= 63` |
| longest name stem | 16 — `trg_as_truncate_` | — |
| longest table in `Base.metadata` | 40 — `energy_correction_scheme_component_param` | 16 + 40 = 56 `<= 63` |
| names currently truncated | **0** | |
| name collisions | **0** | |

## The collision case constructed

A collision check that has never seen a collision is a check nobody has tested.
Two were built, and each was confirmed red:

**Truncation collision** — two table names that differ but chop identically. The
names `trg_as_root_<55×z>_one` and `trg_as_root_<55×z>_two` are 71 characters and
distinct; both cut to the same 63-character name. Because the length assertion
fires first on this input, it was temporarily neutralised to prove the *collision*
assertion is what catches the merge, and it did:

```
E  AssertionError: {'trg_as_root_zzz…zzz': [(…'as_root', '…_two')]}
```

**Collision without truncation** — the case truncation is not required for, and
the one that actually loses a guard. `a1f6c3e9b527` and `b6c1f4a8e703` both minting
`as_child` on `reaction_atom_map`: a 30-character name, comfortably inside the
limit, minted twice. This is invisible to `test_trigger_names_have_exactly_one_
minting_revision`, which cannot statically resolve a name built in a loop from a
table name. Red:

```
E  AssertionError: {'trg_as_child_reaction_atom_map': [
E    ('a1f6c3e9b527_…py', 'as_child', 'reaction_atom_map'),
E    ('b6c1f4a8e703_…py', 'as_child', 'reaction_atom_map')]}
```

## Verification actually run

Every assertion in the new test was mutated and confirmed to fail on the intended
line — including blinding the test's own scans, since a guard against a vacuous
assertion must not be vacuous itself. Each mutation was applied, run, and reverted;
the revert was confirmed by `git diff` **from the repository root**.

| mutation | assertion that fired |
|---|---|
| enumeration returns `[]` | `len(generated) >= 22` → `0 >= 22` |
| prefix regex matches nothing | prefix-coverage equality → `set() == {'as_root', 'append_only'}` |
| `pg_trigger` query scoped to a nonexistent schema | `len(installed) >= 150` → `0 >= 150` |
| a 60-character table name | `len(untruncated) <= 63` → `72 <= 63` |
| two tables differing only after the cut | collision (with length assert neutralised) |
| two revisions minting one name, no truncation | collision |
| a revision minting under an unenumerated prefix | `prefixes <= _EXTENSION_PREFIXES` |
| a hand-written literal over the limit | `not over_limit` |
| a 50-character table added to the schema | `16 + 50 <= 63` |
| a mint input naming a guard nobody installed | `not absent` → `[('software', 'trg_as_root_software')]` |

Three of those are blindings that make a scan match nothing, and each failed **on
its floor** rather than passing over an empty set. No `parametrize` was used, so
there is no empty-set-becomes-skip path.

Suites:

```
tests/db/test_accepted_science_trigger_registry.py   5 passed  (was 4)
tests/db/                                          217 passed
backend/scripts/test-rest.sh                      4592 passed, 14 skipped
ruff check app tests scripts                       All checks passed
```

`test-rest.sh` is the gate that owns `tests/db/`; the change touches no file
selected by `test-api.sh` or `test-scientific.sh`. `tests/db/` was left at head —
this change runs no migration.

## Noted, not fixed here

`f9b2e6c4a1d7_network_solve_computed_evidence_trigger.py` mints
`CREATE TRIGGER {table}_computed_evidence_truncate` with **no `[:63]` at all**. Its
longest current name is 56 characters — longer than anything in the family this PR
covers — and the 27-character suffix leaves only 36 characters of table-name
headroom, while the schema already contains a 40-character table. It is safe today
because the site iterates its own short table list, but it is the least protected
trigger-name site in the repo. Out of scope for this file, which is the
accepted-science registry; worth its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
