### PR TITLE
Re-raise a caught coded exception, not a bare 404/502

### DIFF
--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -37,6 +37,7 @@ from app.services.machine_review import (
     assign_curator_task,
     build_curator_tasks_for_submission,
     build_submission_machine_review_inspection,
+    get_curator_task_or_404,
     reopen_curator_task,
     resolve_curator_task,
     run_admin_fake_machine_review,
@@ -382,15 +383,6 @@ def _to_curator_task_response(
     )
 
 
-def _get_curator_task_or_404(
-    session: Session, task_id: int
-) -> MachineReviewCuratorTask:
-    task = session.get(MachineReviewCuratorTask, task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail="Curator task not found.")
-    return task
-
-
 @router.get(
     _CURATOR_TASK_BASE,
     response_model=PaginatedResponse[AdminCuratorTaskResponse],
@@ -472,8 +464,15 @@ def get_curator_task(
     _admin: AppUser = Depends(require_admin),
     session: Session = Depends(get_db),
 ) -> AdminCuratorTaskResponse:
-    """Return one curator task by id (admin only); 404 if missing."""
-    return _to_curator_task_response(_get_curator_task_or_404(session, task_id))
+    """Return one curator task by id (admin only); 404 ``curator_task_not_found``.
+
+    The 404 comes from the same service helper the four write routes use.
+    It used to come from a private copy in this module that raised a bare
+    ``HTTPException``, so reading a missing task said ``http_404`` while
+    assigning the same missing task said ``curator_task_not_found`` — one
+    condition with two contracts, and a client could branch on only one.
+    """
+    return _to_curator_task_response(get_curator_task_or_404(session, task_id))
 
 
 @router.post(

--- a/backend/app/api/routes/scientific/artifacts.py
+++ b/backend/app/api/routes/scientific/artifacts.py
@@ -58,6 +58,11 @@ from app.services.scientific_read.internal_ids import (
 from app.services.scientific_read.profile import current_read_profile
 
 router = APIRouter(prefix="/artifacts")
+#: No call sites at present. The two lines this module used to log became
+#: duplicates of what the handlers in ``app.api.errors`` log for the same
+#: exceptions, once the download route stopped swallowing them (#212) --
+#: one event, one journal entry. The logger stays because the next thing
+#: this module needs to say will not be an exception the handlers see.
 logger = logging.getLogger(__name__)
 
 # Query-string keys allowed alongside POST. None in v0 — POST search
@@ -207,18 +212,21 @@ def artifact_integrity_search(
     deployment rather than science about a record -- the same reasoning
     that gates raw artifact bytes (ADR 0004).
     """
-    try:
-        payload = search_artifact_integrity(
-            session,
-            sha256=sha256,
-            calculation_ref=calculation_ref,
-            only_currently_broken=only_currently_broken,
-            sort=sort,
-            offset=offset,
-            limit=limit,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    # No ``except ValueError -> HTTPException(422)`` here, deliberately.
+    # The service raises the same coded refusals every other scientific read
+    # raises (``client_sort_not_supported``, ``offset_too_large``), and the
+    # ValueError handler in app.api.errors answers 422 with the code and its
+    # context. Wrapping them re-answered 422 with ``code="http_422"``: the
+    # same refusal, named on ``/search`` and anonymous here.
+    payload = search_artifact_integrity(
+        session,
+        sha256=sha256,
+        calculation_ref=calculation_ref,
+        only_currently_broken=only_currently_broken,
+        sort=sort,
+        offset=offset,
+        limit=limit,
+    )
     return apply_internal_ids_visibility(payload)
 
 
@@ -305,36 +313,29 @@ def download_approved_artifact(
             sha256,
             expected_bytes=artifact.bytes,
         )
-    # These two are converted to HTTPException, which means they bypass the
-    # ArtifactStorageUnavailable handler in app.api.errors and its logging.
-    # Without these lines the download path reproduces the exact problem that
-    # made the 2026-08-05 storage outage undiagnosable: a bare access-log 5xx
-    # naming a subsystem, with no record of why that subsystem failed.
+    # Both are caught for their side effect and then **re-raised typed**, so
+    # the handlers in app.api.errors still mint the code and still log with
+    # the request's method and path. The earlier version of these blocks did
+    # the side effect and then raised a bare ``HTTPException``, which is what
+    # made this route answer ``code="http_502"`` where the upload path answers
+    # ``artifact_integrity_failed`` for the identical condition — one break,
+    # two contracts, decided by which route noticed it. A caught exception
+    # that must keep its meaning has to leave the handler as itself.
     except ArtifactIntegrityError as exc:
-        logger.error(
-            "Artifact integrity verification failed on download: %s",
-            exc,
-            exc_info=exc,
-        )
         # A log is not a record. This reader gets a 502 either way; the
         # row is what makes the break visible to the *next* reader, and
         # to the trust evaluator, without anyone having to grep. Written
         # in its own transaction and best-effort, so it cannot turn a
-        # 502 into a 500. See ADR 0014.
+        # 502 into a 500. See ADR 0014. Recorded *before* the re-raise:
+        # nothing after this line can skip it.
         record_from_error(
             exc,
             detected_during=ArtifactIntegrityDetectionContext.download,
             artifact=artifact,
             detected_by=user.id,
         )
-        raise HTTPException(
-            status_code=502,
-            detail="Stored artifact failed integrity verification.",
-        ) from exc
+        raise
     except ArtifactStorageUnavailable as exc:
-        logger.warning(
-            "Artifact storage unavailable on download: %s", exc, exc_info=exc
-        )
         # An unreachable store says nothing about the object and must not
         # be recorded as a custody break — but a store that answered and
         # said the object is *not there*, for a digest a row still
@@ -350,10 +351,7 @@ def download_approved_artifact(
                 detected_by=user.id,
                 detail=str(exc),
             )
-        raise HTTPException(
-            status_code=503,
-            detail="Artifact storage is unavailable.",
-        ) from exc
+        raise
 
     media_type = guess_type(artifact.filename)[0] or "application/octet-stream"
     encoded_filename = quote(artifact.filename, safe="")

--- a/backend/app/services/machine_review/__init__.py
+++ b/backend/app/services/machine_review/__init__.py
@@ -39,6 +39,7 @@ from app.services.machine_review.context_hash import (
 )
 from app.services.machine_review.curator_task_lifecycle import (
     assign_curator_task,
+    get_curator_task_or_404,
     reopen_curator_task,
     resolve_curator_task,
     start_curator_task_review,
@@ -208,6 +209,7 @@ __all__ = [
     "event_is_machine_review",
     "execute_record_machine_rereview_plan",
     "get_active_machine_review_recipe",
+    "get_curator_task_or_404",
     "get_latest_record_machine_review_row",
     "get_machine_review_summaries_for_record",
     "get_record_machine_review_currency_for_record",

--- a/backend/app/services/machine_review/curator_task_lifecycle.py
+++ b/backend/app/services/machine_review/curator_task_lifecycle.py
@@ -62,7 +62,20 @@ def _now_naive_utc() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-def _get_task_or_404(session: Session, task_id: int) -> MachineReviewCuratorTask:
+def get_curator_task_or_404(
+    session: Session, task_id: int
+) -> MachineReviewCuratorTask:
+    """Load one task, or raise the 404 that names *why* it is a 404.
+
+    Public, and deliberately so. This was private, and the read endpoint
+    consequently grew its own copy in ``app.api.routes.admin`` that raised
+    a bare ``HTTPException(404)``. One condition — a task id naming no row
+    — then answered ``code="http_404"`` on ``GET`` and
+    ``code="curator_task_not_found"`` on every write route, decided by
+    which route noticed. A private helper that four writers need and one
+    reader also needs is not private; exporting it is what makes the
+    duplicate unnecessary rather than merely discouraged.
+    """
     task = session.get(MachineReviewCuratorTask, task_id)
     if task is None:
         raise not_found(
@@ -85,7 +98,7 @@ def assign_curator_task(
     be (re)assigned unless ``allow_terminal=True`` — reassigning a closed task
     is almost always a mistake, so it must be explicit.
     """
-    task = _get_task_or_404(session, task_id)
+    task = get_curator_task_or_404(session, task_id)
 
     if task.workflow_state.is_terminal and not allow_terminal:
         raise DomainError(
@@ -114,7 +127,7 @@ def start_curator_task_review(
     acting user (``actor_id``) is assigned as a side effect. Touches no
     human-review state.
     """
-    task = _get_task_or_404(session, task_id)
+    task = get_curator_task_or_404(session, task_id)
     state = task.workflow_state
 
     if state.is_terminal:
@@ -168,7 +181,7 @@ def resolve_curator_task(
     if not note:
         raise DomainError("resolution_note is required and must be non-empty.")
 
-    task = _get_task_or_404(session, task_id)
+    task = get_curator_task_or_404(session, task_id)
 
     if task.workflow_state.is_terminal:
         if task.workflow_state is resolution:
@@ -214,7 +227,7 @@ def reopen_curator_task(
             f"{target_state.value!r}."
         )
 
-    task = _get_task_or_404(session, task_id)
+    task = get_curator_task_or_404(session, task_id)
 
     if not task.workflow_state.is_terminal:
         raise DomainError(

--- a/backend/app/services/scientific_read/artifact_integrity_reads.py
+++ b/backend/app/services/scientific_read/artifact_integrity_reads.py
@@ -29,7 +29,10 @@ from app.schemas.reads.scientific_artifact_integrity import (
     ScientificArtifactIntegrityResponse,
 )
 from app.schemas.reads.scientific_common import Pagination
-from app.services.scientific_read.common import validate_pagination
+from app.services.scientific_read.common import (
+    reject_client_sort,
+    validate_pagination,
+)
 
 #: The findings that assert a break, taken from the enum rather than
 #: restated, so a new finding cannot quietly count as clean here while
@@ -220,8 +223,11 @@ def search_artifact_integrity(
         sort (the vocabulary is v0-frozen, as on every other scientific
         read).
     """
-    if sort is not None:
-        raise ValueError("client_sort_not_supported")
+    # The shared helper, not a hand-rolled ``raise ValueError("<token>")``.
+    # A bare token is not in the code position (``<code>: <prose>``), so
+    # ``validation_detail_code`` would not promote it and the refusal
+    # arrived uncoded even once the route stopped wrapping it.
+    reject_client_sort(sort)
     offset, limit = validate_pagination(offset, limit)
     records, total = _summaries(
         session,

--- a/backend/docs/reviews/error_code_coverage_triage.md
+++ b/backend/docs/reviews/error_code_coverage_triage.md
@@ -474,7 +474,20 @@ fixture, which is the next round's work).
 
 | code | anchor | provoke with |
 |---|---|---|
-| `artifact_integrity_failed` | handler `api/errors.py:359`; detected at `services/artifact_storage.py:474`, `:484` | corrupt the stored object so its sha256 no longer matches, then download it. 502, deliberately not 503 |
+| `artifact_integrity_failed` | handler `api/errors.py:331`; detected at `services/artifact_storage.py:474`, `:484` | corrupt the stored object so its sha256 no longer matches, then download it. 502, deliberately not 503 |
+
+> **Corrected, then made true, in #212.** Measured when Tier E was first
+> written, the *download* route did not produce this code: it caught
+> `ArtifactIntegrityError` itself — legitimately, to record the custody
+> break ADR 0014 requires — and re-raised a bare `HTTPException(502)`, so
+> a client received `http_502`. The row above was right about the
+> condition and wrong about the route, and the code was reached only from
+> the *upload* path. The route now records the break and re-raises the
+> exception unchanged, so the anchor and the "provoke with" column are
+> both accurate. Both paths are asserted:
+> `tests/api/test_api_untested_refusals_tier_de.py`
+> `::test_uploading_over_a_corrupt_content_addressed_object_is_refused`
+> and `::test_the_download_route_publishes_the_same_code_for_the_same_break`.
 
 ---
 
@@ -625,6 +638,28 @@ Three things noticed while reading that are not about coverage:
    `api/routes/admin.py:385` has its own `_get_curator_task_or_404` that
    raises `HTTPException(404, "Curator task not found.")` instead of using the
    service helper. Same condition, two contracts.
+
+   > **Resolved in #209.** The private helper is gone; the service helper
+   > it duplicated is now public (`get_curator_task_or_404`) and all five
+   > routes call it. Held by
+   > `tests/api/test_admin_machine_review_curator_tasks.py`
+   > `::test_every_curator_task_route_names_a_missing_task_the_same_way`,
+   > which asserts the *set* of `(status, code)` answers across the five
+   > routes is a single element, so a sixth route cannot diverge quietly.
+   >
+   > This item and the Tier E row above are the same defect — a route that
+   > catches or duplicates a coded refusal and answers with a bare
+   > `HTTPException` — so the PR that fixed them swept for the rest of the
+   > family rather than fixing two. It found two more that nothing had
+   > reported: the sibling `except ArtifactStorageUnavailable` in the same
+   > download function (`http_503` for `artifact_storage_unavailable`),
+   > and `GET /scientific/artifacts/integrity` (`http_422` for
+   > `client_sort_not_supported`, which needed a fix on *both* sides —
+   > the route's wrapper and a service message that spelled the code as a
+   > bare token rather than in the code position). The sweep is kept from
+   > going stale by `tests/api/test_coded_exception_reraise_gate.py`,
+   > which fails on a new catch-and-replace site *and* on a listed site
+   > that no longer exists.
 3. **`_operational_error_handler` passes `fallback_code="database_error"`**
    (`api/errors.py:433`), a code the catalogue does not list. Harmless today —
    `code=` is always supplied explicitly on that path — but it is a string

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -48063,7 +48063,7 @@
     },
     "/api/v1/admin/machine-review/curator-tasks/{task_id}": {
       "get": {
-        "description": "Return one curator task by id (admin only); 404 if missing.",
+        "description": "Return one curator task by id (admin only); 404 ``curator_task_not_found``.\n\nThe 404 comes from the same service helper the four write routes use.\nIt used to come from a private copy in this module that raised a bare\n``HTTPException``, so reading a missing task said ``http_404`` while\nassigning the same missing task said ``curator_task_not_found`` — one\ncondition with two contracts, and a client could branch on only one.",
         "operationId": "get_curator_task_api_v1_admin_machine_review_curator_tasks__task_id__get",
         "parameters": [
           {

--- a/backend/tests/api/scientific/test_api_scientific_artifact_download.py
+++ b/backend/tests/api/scientific/test_api_scientific_artifact_download.py
@@ -23,7 +23,23 @@ from app.services.artifact_storage import (
 )
 from tests.services.test_artifact_integrity import _SessionProxy
 
-_ROUTE_LOGGER = "app.api.routes.scientific.artifacts"
+#: Where the explanatory log line for a download 502/503 is now emitted.
+#:
+#: It used to be the route: the route caught the typed exception and
+#: re-raised a bare ``HTTPException``, which bypassed both the handler in
+#: ``app.api.errors`` *and* that handler's logging, so the route had to log
+#: for itself or the 2026-08-05 storage outage would have been a bare
+#: access-log 5xx again. #212 made the route re-raise the exception
+#: unchanged — which is what lets the handler mint
+#: ``artifact_integrity_failed`` / ``artifact_storage_unavailable`` instead
+#: of ``http_502`` / ``http_503`` — and the handler logs the same
+#: exception, with ``exc_info`` and with the request's method and path.
+#:
+#: So the *claim* the two tests below make is unchanged and still asserted:
+#: an operator can read the reason and a traceback out of the journal. Only
+#: the logger name moved. Keeping a duplicate log in the route would mean
+#: two records of one event.
+_ERROR_HANDLER_LOGGER = "app.api.errors"
 from tests.api.scientific.test_api_scientific_artifacts import (
     _make_species_owned_calc,
 )
@@ -148,8 +164,18 @@ def test_artifact_download_maps_integrity_failure_to_502(
     )
 
     assert response.status_code == 502
-    assert response.json()["detail"] == (
-        "Stored artifact failed integrity verification."
+    body = response.json()
+    # The code, not the prose. The prose used to be the route's own
+    # sentence, because the route raised its own ``HTTPException``; that
+    # is exactly what made this route answer ``http_502`` where the
+    # upload path answered ``artifact_integrity_failed`` for the same
+    # break (#212). Asserting the code is what would notice if the route
+    # started minting its own answer again — asserting a sentence would
+    # not.
+    assert body["code"] == "artifact_integrity_failed", body
+    assert body["detail"] == (
+        "A stored artifact failed integrity verification. This has "
+        "been recorded; retrying will not clear it."
     )
 
 
@@ -158,17 +184,24 @@ def test_artifact_download_maps_storage_outage_to_503(
 ) -> None:
     """A storage outage on the download path is a 503 — and is logged.
 
-    This route converts the exception to ``HTTPException``, so it bypasses
-    the ``ArtifactStorageUnavailable`` handler in ``app.api.errors`` and
-    that handler's logging. Without a log line here, a storage outage
-    appears in the journal as a bare access-log 503 naming a subsystem
-    with no record of why — the exact thing that made the 2026-08-05
-    outage take so long to diagnose.
+    Without an explanatory log line, a storage outage appears in the
+    journal as a bare access-log 503 naming a subsystem with no record of
+    why — the exact thing that made the 2026-08-05 outage take so long to
+    diagnose. That claim is unchanged; where it is satisfied has moved.
+
+    The route used to convert the exception to an ``HTTPException``,
+    which bypassed the ``ArtifactStorageUnavailable`` handler in
+    ``app.api.errors`` *and* its logging, so the route logged for itself.
+    It also meant the download answered ``http_503`` where the rest of
+    the API answers ``artifact_storage_unavailable``. The route now
+    re-raises the exception unchanged, so the handler both logs it and
+    names it — see ``_ERROR_HANDLER_LOGGER``. The assertions below are
+    the same assertions against that logger, plus the code.
     """
     artifact, _content = _downloadable_artifact(
         db_session, status=RecordReviewStatus.approved
     )
-    caplog.set_level(logging.WARNING, logger=_ROUTE_LOGGER)
+    caplog.set_level(logging.WARNING, logger=_ERROR_HANDLER_LOGGER)
 
     def fake_load(*_args, **_kwargs):
         raise ArtifactStorageUnavailable(
@@ -184,14 +217,17 @@ def test_artifact_download_maps_storage_outage_to_503(
     )
 
     assert response.status_code == 503
-    assert response.json()["detail"] == "Artifact storage is unavailable."
+    assert response.json()["code"] == "artifact_storage_unavailable", response.text
 
-    records = [rec for rec in caplog.records if rec.name == _ROUTE_LOGGER]
+    records = [rec for rec in caplog.records if rec.name == _ERROR_HANDLER_LOGGER]
     assert records, "storage 503 on download produced no explanatory log record"
     # The reason, not just the verdict: the endpoint it could not reach.
     assert "EndpointConnectionError" in records[0].getMessage()
     assert "127.0.0.1:9000" in records[0].getMessage()
     assert records[0].exc_info is not None
+    # And the request it happened on, which the route's own log line never
+    # carried: the handler is given the Request object, the route is not.
+    assert "/download" in records[0].getMessage()
 
 
 def test_artifact_download_logs_why_integrity_verification_failed(
@@ -200,12 +236,15 @@ def test_artifact_download_logs_why_integrity_verification_failed(
     """A 502 here means stored bytes no longer match their digest.
 
     That is data corruption, and the public body says nothing about which
-    object or why. If it is not in the log it is nowhere.
+    object or why. If it is not in the log it is nowhere. Emitted by the
+    handler rather than the route since #212 — see
+    ``_ERROR_HANDLER_LOGGER`` — because the route now re-raises the typed
+    exception instead of replacing it.
     """
     artifact, _content = _downloadable_artifact(
         db_session, status=RecordReviewStatus.approved
     )
-    caplog.set_level(logging.ERROR, logger=_ROUTE_LOGGER)
+    caplog.set_level(logging.ERROR, logger=_ERROR_HANDLER_LOGGER)
 
     def fake_load(*_args, **_kwargs):
         raise ArtifactIntegrityError(
@@ -224,7 +263,8 @@ def test_artifact_download_logs_why_integrity_verification_failed(
     )
 
     assert response.status_code == 502
-    records = [rec for rec in caplog.records if rec.name == _ROUTE_LOGGER]
+    assert response.json()["code"] == "artifact_integrity_failed", response.text
+    records = [rec for rec in caplog.records if rec.name == _ERROR_HANDLER_LOGGER]
     assert records, "integrity 502 produced no explanatory log record"
     assert "retrieved sha=deadbeef" in records[0].getMessage()
     assert records[0].exc_info is not None

--- a/backend/tests/api/scientific/test_api_scientific_artifact_integrity.py
+++ b/backend/tests/api/scientific/test_api_scientific_artifact_integrity.py
@@ -351,12 +351,29 @@ def test_an_admin_may_read_the_custody_record(
 def test_client_sort_is_rejected_like_every_other_scientific_read(
     client, db_session, login_as, _api_curator_user
 ):
+    """Rejected *and named*, which is the part that was not true.
+
+    This asserted the token appeared anywhere in ``response.text``, and
+    it did — inside ``detail``. The ``code`` field said ``http_422``, for
+    two independent reasons the sweep behind #209/#212 separated: the
+    route wrapped the service's ``ValueError`` in a bare
+    ``HTTPException(422)``, and the service raised the bare token
+    ``"client_sort_not_supported"`` instead of the house
+    ``"<code>: <prose>"`` form, which is the only form
+    ``validation_detail_code`` promotes. Fixing either alone leaves the
+    code generic; a substring assertion could not tell.
+    """
     login_as(_api_curator_user)
 
     response = client.get(LIST_URL, params={"sort": "sha256:asc"})
 
     assert response.status_code == 422
-    assert "client_sort_not_supported" in response.text
+    assert response.json()["code"] == "client_sort_not_supported", response.text
+
+    # The accept-half: the same request without ``sort=`` is served, so
+    # the 422 is about the sort vocabulary and not about the endpoint.
+    accepted = client.get(LIST_URL)
+    assert accepted.status_code == 200, accepted.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_admin_machine_review_curator_tasks.py
+++ b/backend/tests/api/test_admin_machine_review_curator_tasks.py
@@ -230,8 +230,70 @@ def test_get_task_returns_task(client, db_session, login_as, _api_admin_user):
 
 
 def test_get_task_404(client, login_as, _api_admin_user):
+    """404 *and* the code, because the status alone proved nothing.
+
+    This asserted ``status_code == 404`` only, which passes against a
+    handler that 404s on everything -- and it did pass while ``GET``
+    answered ``code="http_404"`` and every write route answered
+    ``curator_task_not_found`` for the identical condition.
+    """
     login_as(_api_admin_user)
-    assert client.get(f"{_BASE}/999999").status_code == 404
+    resp = client.get(f"{_BASE}/999999")
+    assert resp.status_code == 404, resp.text
+    body = resp.json()
+    assert body["code"] == "curator_task_not_found", body
+    # DR-0028 Req. 2: the looked-up row id goes to the operator's log, never
+    # into the body. 999999 is the caller's own path parameter.
+    assert body["context"] == {}, body
+
+
+def test_every_curator_task_route_names_a_missing_task_the_same_way(
+    client, db_session, login_as, _api_admin_user
+):
+    """One condition, one code, on all five routes that can meet it.
+
+    ``GET`` used to answer ``http_404`` because ``api/routes/admin.py``
+    kept a private ``_get_curator_task_or_404`` raising its own
+    ``HTTPException`` rather than calling the service helper the four
+    write routes call. An admin UI that branches on
+    ``curator_task_not_found`` to drop a vanished task from its queue got
+    the branch on assign and not on read.
+
+    Asserting the *set* rather than five separate equalities is the
+    point: a sixth route added later that reaches for the bare
+    ``HTTPException`` again fails here, and the failure names it.
+    """
+    login_as(_api_admin_user)
+    missing = 999999
+    requests = {
+        "GET": lambda: client.get(f"{_BASE}/{missing}"),
+        "assign": lambda: client.post(
+            f"{_BASE}/{missing}/assign", json={"assignee_id": None}
+        ),
+        "start-review": lambda: client.post(f"{_BASE}/{missing}/start-review", json={}),
+        "resolve": lambda: client.post(
+            f"{_BASE}/{missing}/resolve",
+            json={"resolution_state": "resolved_no_action", "resolution_note": "x"},
+        ),
+        "reopen": lambda: client.post(f"{_BASE}/{missing}/reopen", json={}),
+    }
+    answers = {}
+    for name, send in requests.items():
+        resp = send()
+        answers[name] = (resp.status_code, resp.json().get("code"))
+    assert set(answers.values()) == {(404, "curator_task_not_found")}, answers
+
+    # The accept-half. Without it the assertion above is satisfied by a
+    # route that 404s on every id, including ids that exist.
+    submission = _new_submission(db_session, _api_admin_user)
+    task = _make_task(db_session, submission.id)
+    found = client.get(f"{_BASE}/{task.id}")
+    assert found.status_code == 200, found.text
+    assert found.json()["id"] == task.id
+    assigned = client.post(
+        f"{_BASE}/{task.id}/assign", json={"assignee_id": _api_admin_user}
+    )
+    assert assigned.status_code == 200, assigned.text
 
 
 def test_list_tasks_filters_by_workflow_state(

--- a/backend/tests/api/test_api_untested_refusals_tier_de.py
+++ b/backend/tests/api/test_api_untested_refusals_tier_de.py
@@ -34,14 +34,20 @@ docstring states what makes the payload valid apart from the one fault.
 Two corrections to the triage, recorded where the test is
 ---------------------------------------------------------
 * Tier E's row says to provoke ``artifact_integrity_failed`` by
-  corrupting a stored object and **downloading** it. Measured, the
-  download route answers ``code="http_502"``: it catches
-  ``ArtifactIntegrityError`` itself and re-raises a bare
+  corrupting a stored object and **downloading** it. When this file was
+  written that was measurably false — the download route caught
+  ``ArtifactIntegrityError`` itself and re-raised a bare
   ``HTTPException(502)``, so the app-level handler that mints the code
-  never runs. The code does reach a client — from the *upload* path,
-  where ``store_artifact`` verifies an existing content-addressed object
-  before attaching a second row to the shared key. See
-  ``test_uploading_over_a_corrupt_content_addressed_object_is_refused``.
+  never ran and a client received ``http_502``. #212 repaired it: the
+  route still records the custody break ADR 0014 requires, then re-raises
+  the exception unchanged. The triage row is now right, and both paths
+  are asserted here — the upload one at
+  ``test_uploading_over_a_corrupt_content_addressed_object_is_refused``,
+  the download one at
+  ``test_the_download_route_publishes_the_same_code_for_the_same_break``.
+  The sweep that came with #212 found the sibling ``except
+  ArtifactStorageUnavailable`` in the same function doing the same thing
+  at 503, which no task had noticed; it is asserted here too.
 * Tier D calls ``composed_search_candidate_limit_exceeded`` and
   ``composed_search_pagination_changed`` "upload payloads". They are
   composed *reads*; the tier heading is loose, the anchors are right.
@@ -787,26 +793,12 @@ def test_a_second_upload_of_the_same_bytes_verifies_the_stored_object(
     )
 
 
-def test_the_download_route_publishes_a_different_code_for_the_same_break(
-    client, db_session, monkeypatch
-) -> None:
-    """The contract defect the triage's Tier E row rests on, pinned as it is.
+def _an_approved_artifact(db_session):
+    """One approved artifact whose row claims ``_ARTIFACT_SHA256``.
 
-    Corrupting a stored object and downloading it is what the triage says
-    produces ``artifact_integrity_failed``. It does not: the route
-    catches ``ArtifactIntegrityError`` itself — so that it can record the
-    custody break before answering — and re-raises a bare
-    ``HTTPException(502)``, which the generic handler labels ``http_502``.
-    One condition, two contracts, decided by which route noticed it; the
-    same shape as the two curator-task codes the triage records under
-    "worth a second look".
-
-    This test asserts what a client receives **today**, deliberately, so
-    the divergence cannot be closed by accident and unnoticed. If the
-    route is changed to let the typed exception reach the app-level
-    handler — which is the repair — this test goes red and should be
-    rewritten to assert ``artifact_integrity_failed``, not deleted: the
-    property worth keeping is that this route's code is *decided*.
+    The store is left to the caller, which is the whole variable: what
+    the download route answers is decided by what the object store hands
+    back for this key, and each test below hands back something else.
     """
     from app.db.models.common import RecordReviewStatus, SubmissionRecordType
     from tests.api.scientific.test_api_scientific_artifacts import (
@@ -825,14 +817,121 @@ def test_the_download_route_publishes_a_different_code_for_the_same_break(
         status=RecordReviewStatus.approved,
     )
     db_session.flush()
+    return artifact
+
+
+def test_the_download_route_publishes_the_same_code_for_the_same_break(
+    client, db_session, monkeypatch
+) -> None:
+    """One condition, one contract, whichever route noticed the break.
+
+    This is the rewrite the previous version of this test asked for. It
+    used to assert ``http_502`` — what the route really answered — and
+    said in its own docstring that the repair was to let the typed
+    exception reach the app-level handler, and that it should then be
+    rewritten to assert ``artifact_integrity_failed`` rather than
+    deleted. The route now records the custody break and re-raises the
+    exception unchanged, so the handler in ``app.api.errors`` mints the
+    code, exactly as it does on the upload path.
+
+    The property being kept is the one the old docstring named: a client
+    must be able to tell an integrity break from a generic gateway
+    failure. Losing it still costs a red test — this one — because
+    ``http_502`` is what any bare ``HTTPException(502)`` here would
+    produce.
+
+    The custody record is asserted below and not merely assumed. Letting
+    the exception through is only correct if the row is still written
+    first; a repair that traded ADR 0014's durable record for a nicer
+    code would be a worse contract, not a better one.
+    """
+    artifact = _an_approved_artifact(db_session)
 
     _use_object_store(
         monkeypatch,
         db_session,
         _InMemoryObjectStore({_ARTIFACT_KEY: b"bytes that hash to something else"}),
     )
-    _assert_code(
+    body = _assert_code(
         client.get(f"/api/v1/scientific/artifacts/{_ARTIFACT_SHA256}/download"),
-        "http_502",
+        "artifact_integrity_failed",
         status=502,
     )
+    # DR-0028 Req. 2 — a subsystem is named and nothing else. No digest,
+    # no artifact id, nothing a caller could use to probe stored content.
+    assert body["context"] == {}, body
+    assert str(artifact.id) not in str(body.get("detail")), body
+
+    # ADR 0014: the break outlives the request that discovered it. This is
+    # the half that must survive the code change.
+    events = db_session.scalars(
+        select(ArtifactIntegrityEvent).where(
+            ArtifactIntegrityEvent.sha256 == _ARTIFACT_SHA256
+        )
+    ).all()
+    assert len(events) == 1, events
+    assert events[0].detected_during.value == "download", events[0].detected_during
+
+
+def test_an_intact_object_still_downloads(client, db_session, monkeypatch) -> None:
+    """The accept-half: nothing about the request or the row is wrong.
+
+    Without it, the 502 above is satisfied by a route that refuses every
+    download, and the custody assertion by a route that records a break
+    on every read.
+    """
+    _an_approved_artifact(db_session)
+    _use_object_store(
+        monkeypatch,
+        db_session,
+        _InMemoryObjectStore({_ARTIFACT_KEY: _ARTIFACT_BYTES}),
+    )
+    response = client.get(
+        f"/api/v1/scientific/artifacts/{_ARTIFACT_SHA256}/download"
+    )
+    assert response.status_code == 200, response.text
+    assert response.content == _ARTIFACT_BYTES
+
+    events = db_session.scalars(
+        select(ArtifactIntegrityEvent).where(
+            ArtifactIntegrityEvent.sha256 == _ARTIFACT_SHA256
+        )
+    ).all()
+    assert events == [], events
+
+
+def test_a_missing_object_names_the_storage_subsystem_too(
+    client, db_session, monkeypatch
+) -> None:
+    """The sibling ``except`` in the same function, found by the sweep.
+
+    ``ArtifactStorageUnavailable`` had the identical defect and nobody
+    had filed it: caught for its side effect — recording ``object_missing``,
+    which is durable information about custody, not an outage — and then
+    re-raised as a bare ``HTTPException(503)``, so the download answered
+    ``http_503`` where the upload path answers
+    ``artifact_storage_unavailable``.
+
+    Two typed exceptions, one function, one defect: fixing only the one
+    with a task number would have left the other exactly as it was.
+    """
+    artifact = _an_approved_artifact(db_session)
+
+    # An empty store: the object store answers, and says the key is not
+    # there. That is the ``missing=True`` branch, not an outage.
+    _use_object_store(monkeypatch, db_session, _InMemoryObjectStore())
+    body = _assert_code(
+        client.get(f"/api/v1/scientific/artifacts/{_ARTIFACT_SHA256}/download"),
+        "artifact_storage_unavailable",
+        status=503,
+    )
+    assert body["context"] == {}, body
+    assert str(artifact.id) not in str(body.get("detail")), body
+
+    events = db_session.scalars(
+        select(ArtifactIntegrityEvent).where(
+            ArtifactIntegrityEvent.sha256 == _ARTIFACT_SHA256
+        )
+    ).all()
+    assert len(events) == 1, events
+    assert events[0].finding.value == "object_missing", events[0].finding

--- a/backend/tests/api/test_coded_exception_reraise_gate.py
+++ b/backend/tests/api/test_coded_exception_reraise_gate.py
@@ -1,0 +1,278 @@
+"""A caught coded exception must leave the handler still able to be named.
+
+The defect this gate exists for
+-------------------------------
+A route catches a typed exception for a reason it genuinely has -- to pick
+the right status, to roll back, to write a durable record -- and then
+raises a plain ``HTTPException``. The typed exception's app-level handler
+in :mod:`app.api.errors` never runs, so the ``code`` a client branches on
+is replaced by ``http_<status>``. The condition did not change; only the
+route that noticed it did.
+
+Two instances were filed (#209, #212) and, measured, they were not the
+only two. The sweep behind them found four:
+
+* ``GET /admin/machine-review/curator-tasks/{id}`` answered ``http_404``
+  where the four write routes on the same row answered
+  ``curator_task_not_found``;
+* ``GET /scientific/artifacts/{sha}/download`` answered ``http_502``
+  where the upload path answered ``artifact_integrity_failed``;
+* the sibling ``except ArtifactStorageUnavailable`` **in the same
+  function**, ``http_503`` against ``artifact_storage_unavailable``,
+  which no task had noticed;
+* ``GET /scientific/artifacts/integrity`` answered ``http_422`` where
+  every other scientific read answers ``client_sort_not_supported``.
+
+Three of the four were found by sweeping rather than by being reported,
+which is the reason this file is a gate and not a changelog entry.
+
+Why a bare ``HTTPException`` is not always the defect
+-----------------------------------------------------
+Most of the sites this scan finds are correct, and a gate that failed on
+all of them would be deleted within a month. TCKDB has a second, working
+mechanism for carrying a code: :func:`app.api.error_contract.detail_code`
+promotes a leading ``"<code>: <prose>"`` token when the catalogue lists
+that code as arriving by ``message_prefix``. So
+
+    except ReleaseCurationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+publishes ``release_tag_taken``, not ``http_409``, while choosing a status
+the generic ``ValueError`` handler could not have chosen. Passing the
+message through is the *idiom*; replacing it with new prose is what drops
+the code on the floor.
+
+So the rule enforced here is narrow and mechanical: an ``except`` handler
+in the API layer that raises ``HTTPException`` must pass the caught
+exception's message through, or be listed below with a reason. It is
+deliberately a shape test -- whether a specific code actually arrives is a
+wire question, and the wire tests that ask it are named beside each entry.
+
+Staleness, in both directions
+-----------------------------
+``docs/reviews/error_code_coverage_triage.md`` reasoned over call sites it
+could not see, and #165 established the sharper form of the lesson: a set
+of individually-correct behaviours can still have an unheld completeness
+claim. A list that nothing re-checks becomes that. Both directions are
+asserted:
+
+* a **new** catch-and-replace site fails :meth:`test_every_site_that_
+  replaces_the_message_is_accounted_for`, and the failure names it;
+* a listed site that has been fixed, moved or deleted fails
+  :meth:`test_no_entry_describes_a_site_that_is_gone`, so the list cannot
+  outlive what it describes;
+* and the scan itself is provoked against a site known to exist, so a
+  scan that silently matches nothing cannot pass as a clean sweep.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+API_ROOT = REPO_ROOT / "backend" / "app" / "api"
+
+#: Sites that catch an exception and raise an ``HTTPException`` carrying a
+#: *new* message, keyed ``"<path>:<except lineno>"``. Each value says why
+#: that is not a lost code. Anything not here must pass ``str(exc)``
+#: through so a ``message_prefix`` code survives.
+#:
+#: Keep this small. An entry is a standing claim that a client loses
+#: nothing, and every one of them should name the test that checked it.
+JUDGED_SITES: dict[str, str] = {
+    "backend/app/api/routes/auth.py:181": (
+        "Registration catches IntegrityError to roll back before answering. "
+        "Letting it through would reach the IntegrityError handler and "
+        "publish `unique_conflict` -- a real code, but one that says less "
+        "than the message it would replace ('Username or email already in "
+        "use'), because a duplicate username and a duplicate email are the "
+        "same SQLSTATE. The honest repair is a code of its own for this "
+        "condition, which needs a catalogue entry and a client release; it "
+        "is filed separately rather than smuggled in here. Deliberately "
+        "left as `http_409`."
+    ),
+}
+
+#: A site the scan must find, so a scan that matches nothing cannot pass.
+#: It is the ``ReleaseCurationError`` handler on the release-publish route
+#: -- the canonical *correct* shape, ``detail=str(exc)``.
+_A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH = "backend/app/api/routes/releases_admin.py"
+
+#: Measured 2026-08-16, after the repairs: 13 handlers in
+#: ``backend/app/api`` raise an ``HTTPException``, of which 12 pass the
+#: caught message through and one is judged below. The floor is well under
+#: 13 and exists only to catch a scan that has stopped seeing the tree,
+#: not to police the count.
+_MINIMUM_SITES_THE_SCAN_MUST_SEE = 8
+
+
+def _raised_http_exceptions(node: ast.AST) -> list[ast.Call]:
+    """Every ``raise HTTPException(...)`` lexically inside *node*."""
+    found: list[ast.Call] = []
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Raise) or not isinstance(sub.exc, ast.Call):
+            continue
+        func = sub.exc.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name in {"HTTPException", "StarletteHTTPException"}:
+            found.append(sub.exc)
+    return found
+
+
+def _mentions(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(sub, ast.Name) and sub.id == name for sub in ast.walk(node)
+    )
+
+
+def _passes_the_message_through(call: ast.Call, bound: str | None) -> bool:
+    """True when ``detail=`` is built from the caught exception.
+
+    ``str(exc)`` and ``f"...{exc}"`` both count: either way the raiser's
+    own sentence -- and therefore any code in its leading position --
+    reaches :func:`app.api.error_contract.detail_code`.
+    """
+    if bound is None:
+        return False
+    for keyword in call.keywords:
+        if keyword.arg == "detail" and _mentions(keyword.value, bound):
+            return True
+    for argument in call.args:
+        if _mentions(argument, bound):
+            return True
+    return False
+
+
+def _scan() -> dict[str, str]:
+    """``"<path>:<lineno>" -> caught type(s)`` for catch-and-replace sites."""
+    replaced: dict[str, str] = {}
+    for path in sorted(API_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        relative = str(path.relative_to(REPO_ROOT))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            raises = _raised_http_exceptions(node)
+            if not raises:
+                continue
+            if all(_passes_the_message_through(call, node.name) for call in raises):
+                continue
+            replaced[f"{relative}:{node.lineno}"] = ast.unparse(node.type or ast.Name("BaseException"))
+    return replaced
+
+
+def _all_sites() -> dict[str, str]:
+    """Every ``except`` in the API layer that raises an ``HTTPException``."""
+    sites: dict[str, str] = {}
+    for path in sorted(API_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        relative = str(path.relative_to(REPO_ROOT))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and _raised_http_exceptions(node):
+                sites[f"{relative}:{node.lineno}"] = ast.unparse(
+                    node.type or ast.Name("BaseException")
+                )
+    return sites
+
+
+class TestTheScanSeesTheCodeItIsWrittenOver:
+    """A survey that checked nothing passes; these say what it checked."""
+
+    def test_it_finds_more_than_a_handful_of_handlers(self):
+        sites = _all_sites()
+        assert len(sites) >= _MINIMUM_SITES_THE_SCAN_MUST_SEE, (
+            f"only {len(sites)} except-and-raise sites found under {API_ROOT}; "
+            "the scan has probably stopped walking the tree"
+        )
+
+    def test_it_recognises_the_message_passthrough_idiom(self):
+        """The correct shape must be *classified* correctly, not just seen."""
+        sites = _all_sites()
+        passthrough = {
+            site
+            for site in sites
+            if site.startswith(_A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH)
+        }
+        assert passthrough, (
+            f"no handler found in {_A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH}; "
+            "the anchor for this assertion has moved"
+        )
+        assert not (passthrough & set(_scan())), (
+            "`raise HTTPException(status, detail=str(exc))` was classified as "
+            "replacing the message; the scan would then flag every correct "
+            "site and this gate would be deleted rather than obeyed"
+        )
+
+    def test_it_would_notice_a_replaced_message(self):
+        """Provoked against source, so the classifier is caught saying no."""
+        tree = ast.parse(
+            "try:\n"
+            "    f()\n"
+            "except SomeError as exc:\n"
+            "    raise HTTPException(status_code=502, detail='new prose') from exc\n"
+        )
+        handler = next(
+            node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)
+        )
+        call = _raised_http_exceptions(handler)[0]
+        assert not _passes_the_message_through(call, handler.name)
+
+
+class TestTheSweepIsComplete:
+    """Both directions, so neither a new site nor a stale entry survives."""
+
+    def test_every_site_that_replaces_the_message_is_accounted_for(self):
+        unlisted = {
+            site: caught
+            for site, caught in _scan().items()
+            if site not in JUDGED_SITES
+        }
+        assert not unlisted, (
+            "these handlers catch an exception and raise an HTTPException with "
+            "a new message, so the caught exception's handler never mints its "
+            f"code: {unlisted}. Either re-raise the exception (`raise`), pass "
+            "its message through (`detail=str(exc)`), or add an entry to "
+            "JUDGED_SITES saying what a client loses and why that is right."
+        )
+
+    def test_no_entry_describes_a_site_that_is_gone(self):
+        """A list nothing re-checks is how a stale survey stays believed."""
+        found = _scan()
+        stale = sorted(set(JUDGED_SITES) - set(found))
+        assert not stale, (
+            f"JUDGED_SITES describes sites that no longer replace the caught "
+            f"exception's message: {stale}. If they were repaired, delete the "
+            "entry; if they moved, re-anchor it."
+        )
+
+    def test_the_artifact_routes_did_not_regrow_their_handlers(self):
+        """Named, because this is the file where it had already happened.
+
+        Anchored on file rather than line so a reformat does not fail it,
+        and paired with the wire tests that assert the code each handler
+        now publishes -- this is a shape test and cannot see a response
+        body:
+
+        * ``tests/api/test_api_untested_refusals_tier_de.py``
+          ``::test_the_download_route_publishes_the_same_code_for_the_same_break``
+          and ``::test_a_missing_object_names_the_storage_subsystem_too``;
+        * ``tests/api/scientific/test_api_scientific_artifact_integrity.py``
+          ``::test_client_sort_is_rejected_like_every_other_scientific_read``.
+
+        ``routes/admin.py`` is deliberately **not** listed. #209 was not
+        a catch-and-replace at all -- it was a private
+        ``_get_curator_task_or_404`` duplicating a coded service helper,
+        which this scan cannot see and should not pretend to. Asserting
+        it here would be a guard covering a shape its target never had.
+        What holds that one is
+        ``test_every_curator_task_route_names_a_missing_task_the_same_way``,
+        verified by mutation: reinstating the private guard turns it red.
+        """
+        replaced_by_file = {site.split(":")[0] for site in _scan()}
+        path = "backend/app/api/routes/scientific/artifacts.py"
+        assert path not in replaced_by_file, (
+            f"{path} has regrown a handler that catches an exception and "
+            "raises an HTTPException with a new message -- the exact shape "
+            "#212 repaired, twice in one function"
+        )


### PR DESCRIPTION
## What this changes, in plain terms

When something goes wrong deep in TCKDB, the code raises an error object that
carries a short machine-readable label — a *code* — so a client program can
tell exactly what happened without reading English prose. `curator_task_not_found`
means "that task is gone, drop it from the queue"; `artifact_integrity_failed`
means "the bytes we stored no longer match their fingerprint, and retrying will
never fix it". A client can branch on those. `http_404` and `http_502` are just
the HTTP status spelled twice; a client can branch on nothing.

Four route handlers were catching one of those error objects — each for a good
reason — and then throwing a *plain* error instead. The label was lost. So the
same thing going wrong answered differently depending on which door you knocked
on:

| you did this | before | after |
|---|---|---|
| read a curator task that doesn't exist | `http_404` | `curator_task_not_found` |
| assign that same missing task | `curator_task_not_found` | unchanged |
| download a stored file whose bytes have rotted | `http_502` | `artifact_integrity_failed` |
| upload over that same rotted file | `artifact_integrity_failed` | unchanged |
| download a file the store says is simply gone | `http_503` | `artifact_storage_unavailable` |
| ask the custody log to sort itself | `http_422` | `client_sort_not_supported` |
| ask any other read endpoint to sort itself | `client_sort_not_supported` | unchanged |

The right-hand column is what the rest of the API already did. Nothing new was
invented: all four labels already existed and were already published elsewhere.
They just could not get out through these four doors.

**The one thing that must not have been traded away.** The download route
catches the integrity error *on purpose*: before answering, it writes a
permanent row saying "TCKDB's custody of this evidence is broken", which then
hard-fails the owning calculation for every later reader. That is required by
ADR 0014, and a log line is not a substitute. The repair is not "stop
catching it" — it is "record the break, then re-raise the error unchanged".
The row is still written, before the re-raise, and there is now a test that
asserts the row exists rather than assuming it.

Two of these four were filed as tasks. The other two were found by sweeping for
the shape, and one of them was the line directly below the filed one.

---

## The sweep

Scope: every `except` handler under `backend/app/api/` that raises an
`HTTPException`. **13 sites**, all listed, including the correct ones — a
survey is only worth reading if it says what it checked.

The key finding is that a bare `HTTPException` is **not** automatically the
defect. TCKDB has a second, working mechanism: `error_contract.detail_code`
promotes a leading `"<code>: <prose>"` token when the catalogue lists that code
as arriving by `message_prefix`. So `raise HTTPException(409, detail=str(exc))`
publishes `release_tag_taken`, *while* choosing a status the generic
`ValueError` handler could not have chosen. Passing the caught message through
is the idiom. Replacing it with fresh prose is what drops the code.

| # | site | catches | verdict |
|---|---|---|---|
| 1 | `routes/auth.py:181` | `IntegrityError` | **Loss, judged, not fixed.** `http_409`. Letting it through gives `unique_conflict` — real, but it says *less* than the message it would replace ("Username or email already in use"), because a duplicate username and a duplicate email are the same SQLSTATE. The honest repair is a code of its own, which needs a catalogue entry and a client release. Filed as its own task rather than smuggled in. Listed in the new gate with this reasoning. |
| 2–9 | `routes/releases_admin.py:151, 199, 234, 269, 300, 323, 342, 362` | `ReleaseCurationError`, `ReleaseStateError` | **Correct.** `detail=str(exc)`; every raise site uses the `"<code>: <prose>"` form. Measured: `release_tag_taken`, `withdraw_reason_required`, `unknown_record`, `rationale_required` all promote. `ReleaseStateError` has no handler at all, so catching it is what stops a 500. |
| 10 | `routes/releases_admin.py:375` | `UnknownReleaseError` | **Correct.** Publishes `unknown_release` at 404. Verified on the wire. |
| 11 | `routes/scientific/_profile.py:71` | `UnknownReleaseError` | **Correct.** Publishes `release_scoping_not_implemented` at 422. |
| 12 | `routes/scientific/releases.py:112` | `ManifestNotFrozenError` | **Correct.** Publishes `manifest_not_frozen` at 404. |
| 13 | `routes/scientific/releases.py:218` | `UnknownReleaseError` | **Correct.** `unknown_release`, verified on the wire. |
| 14 | `routes/scientific/artifacts.py:220` | `ValueError` | **Loss — fixed.** Not filed by anyone. `http_422` where `/search` and every sibling read publish `client_sort_not_supported`. Needed a fix on *both* sides. |
| 15 | `routes/scientific/artifacts.py:313` | `ArtifactIntegrityError` | **Loss — fixed. (#212)** |
| 16 | `routes/scientific/artifacts.py:334` | `ArtifactStorageUnavailable` | **Loss — fixed.** Not filed by anyone. The line directly below #212. |

Plus one site the `except` scan structurally cannot see, and does not pretend
to:

| site | verdict |
|---|---|
| `routes/admin.py:385` `_get_curator_task_or_404` | **Loss — fixed. (#209)** Not a catch at all: a private helper *duplicating* a coded service helper. Held by a wire test, not by the static gate. |

---

## Anchors, re-derived

Every anchor in the brief was checked against the tree at `eed4c257` rather
than trusted. All four held; two needed correcting.

| brief said | found |
|---|---|
| `#209`: `admin.py` has a private `_get_curator_task_or_404` raising its own `HTTPException` | **Confirmed**, at `admin.py:385`. Sole caller was `get_curator_task`. |
| `#209`: `GET` → `http_404`, `POST .../assign` → `curator_task_not_found` | **Confirmed on the wire.** Also true of `start-review`, `resolve` and `reopen` — the divergence was 1 route against 4, not 1 against 1. |
| `#212`: `POST /calculations/{id}/artifacts` → 502 `artifact_integrity_failed` | **Confirmed on the wire.** |
| `#212`: `GET .../download` → 502 `http_502` | **Confirmed on the wire.** |
| `#212`: the handler that attaches the code is at `errors.py:359` | **Corrected.** `_artifact_integrity_handler` is at `errors.py:331`; line 359 is inside its `JSONResponse`. The doc anchor is updated. |
| "the repair is not *stop catching it*" | **Confirmed and load-bearing** — see the custody section above. |
| `#212` is one instance | **Refuted.** It is two: the sibling `except ArtifactStorageUnavailable` at `artifacts.py:334` had the identical defect at 503 and no task number. |
| the two known instances are the whole shape | **Refuted.** Four, not two. |
| current versions `tckdb-schemas` 0.34.0, `tckdb-client` 0.45.0 | Confirmed, and **unchanged** — see below. |

Nothing was already fixed; all four were live at `eed4c257`.

---

## Schema / client impact

**None.** No new code was added, so:

* no `code_catalogue.py` entry — all four codes were already catalogued
  (`curator_task_not_found` 404, `artifact_integrity_failed` 502,
  `artifact_storage_unavailable` 503, `client_sort_not_supported` 422). Each was
  reachable from *somewhere*; the fix is that it is now reachable from here too;
* no client regeneration — `generate_client_rejection_codes.py --check` reports
  the committed enum up to date;
* no `clients/python/pyproject.toml` bump, no `tckdb-schemas` bump;
* no ORM, schema or migration change.

`backend/tests/api/golden/openapi.json` changes by exactly one line: the
`get_curator_task` description. No path, parameter or response shape moves.

---

## Verification actually run

Environment: `DB_TEST_NAME=tckdb_test_209`, `PYTHONPATH` pointed at the
worktree's own `tckdb-schemas`.

**All three required gates, green on the final tree:**

```
backend/scripts/test-api.sh          2852 passed in 233.35s
backend/scripts/test-scientific.sh   2055 passed in 153.48s
backend/scripts/test-rest.sh         4591 passed, 14 skipped in 110.29s
```

`ruff check app tests` from `backend/`: clean.
`generate_client_rejection_codes.py --check`: up to date.
`clients/python` `pytest tests/test_rejection_codes.py`: 11 passed (separate CI job).

**Measured on the wire, before and after**, by driving the real routes through
`TestClient` as an authenticated admin:

```
                                                     before            after
GET  curator-tasks/99999999                          http_404          curator_task_not_found
POST curator-tasks/99999999/assign                   curator_task…     curator_task_not_found
POST curator-tasks/99999999/{start-review,resolve,reopen}
                                                     curator_task…     curator_task_not_found
GET  artifacts/{sha}/download   (corrupt object)     http_502   502    artifact_integrity_failed   502
GET  artifacts/{sha}/download   (object missing)     http_503   503    artifact_storage_unavailable 503
GET  artifacts/integrity?sort=                       http_422   422    client_sort_not_supported   422
```

**Mutation-tested, each fix separately**, with the mutation confirmed present
by `git diff` run **from the repository root** before believing the result:

| mutation | went red |
|---|---|
| reinstate the private `_get_curator_task_or_404` in `admin.py` | `test_get_task_404`, `test_every_curator_task_route_names_a_missing_task_the_same_way` |
| put `HTTPException(502, "MUTANT")` / `HTTPException(503, "MUTANT")` back in the download route | both wire tests **and** both directions of the new static gate |
| restore `raise ValueError("client_sort_not_supported")` (bare token) with the route fix kept | `test_client_sort_is_rejected_like_every_other_scientific_read` — answered `validation_error`, proving both halves were needed and neither alone sufficed |
| add a non-existent site to `JUDGED_SITES` | `test_no_entry_describes_a_site_that_is_gone` |

The third of those is the useful one: it shows the `/integrity` defect had two
independent causes, and that fixing either alone would have left the code
generic while a substring assertion carried on passing.

**Custody record: still written.** Asserted, not assumed —
`test_the_download_route_publishes_the_same_code_for_the_same_break` reads the
`artifact_integrity_event` row back and checks `detected_during == "download"`;
`test_a_missing_object_names_the_storage_subsystem_too` checks
`finding == "object_missing"`. `test_an_intact_object_still_downloads` is the
accept-half for both: 200, correct bytes, and **zero** rows — without it, "a row
was written" is satisfied by a route that writes one on every read.

---

## Tests

**The pinned test was honoured, not deleted.**
`test_the_download_route_publishes_a_different_code_for_the_same_break`
documented that the repair was to let the typed exception through and that it
should then be *rewritten*, not removed. It is now
`test_the_download_route_publishes_the_same_code_for_the_same_break`, asserting
`artifact_integrity_failed`. The property it named — a client can tell an
integrity break from a generic gateway failure — still costs a red test to
lose, because `http_502` is what any bare `HTTPException(502)` there produces.

No test was weakened, skipped, xfailed or deleted. Three were **strengthened**,
each of which was a live vacuous pass:

* `test_get_task_404` asserted only `status_code == 404` — which passes against
  a handler that 404s on everything, and did pass throughout the divergence;
* `test_client_sort_is_rejected_like_every_other_scientific_read` asserted the
  token appeared anywhere in `response.text` — it did, inside `detail`, while
  `code` said `http_422`;
* the two download log tests asserted a log record on the *route's* logger.

**One change here deserves scrutiny.** The route's own `logger.error` /
`logger.warning` calls are gone, because the handlers in `app.api.errors` log
the same exceptions with `exc_info` — the route logged for itself precisely
*because* it was swallowing them. Those two tests exist to stop the 2026-08-05
storage outage recurring as an undiagnosable bare 5xx, so the claim was kept and
only re-pointed: same assertions (`EndpointConnectionError` present, the
endpoint URL present, `exc_info is not None`), against `app.api.errors`, plus a
new assertion that the log now carries the request path — which the route's own
line never did, because the route is not handed the `Request`. One event, one
journal entry.

New: `backend/tests/api/test_coded_exception_reraise_gate.py`, 6 tests. It
enforces the mechanical rule (pass the message through, or be listed with a
reason) and fails in **both** directions — a new catch-and-replace site, and a
listed site that no longer exists. Its own scan is provoked against a site known
to exist and against a synthetic replaced-message handler, so a scan that
silently matches nothing cannot pass as a clean sweep. It deliberately does
*not* claim to cover `routes/admin.py`: #209 was never a catch, and asserting it
there would be a guard covering a shape its target never had.

`backend/docs/reviews/error_code_coverage_triage.md` had two claims this PR
makes false — its Tier E row and item 2 of "worth a second look". Both are
marked resolved in place, with the corrected `errors.py` anchor.

---

## Worth its own task

1. **Registration's 409 deserves a code of its own.** `auth.py:181` is the one
   judged entry in the new gate. `unique_conflict` cannot distinguish a taken
   username from a taken email — same SQLSTATE — so publishing it would trade a
   useful sentence for a code that under-specifies. A `username_taken` /
   `email_taken` pair needs a catalogue entry, a client regeneration and a
   version bump, which is a release, not a rider on this PR.
2. **A missing object may not be an "unavailable store".** The download route
   now answers `artifact_storage_unavailable` for both an unreachable store and
   a store that answers "that key is not there". The second is durable
   information — the route already records it as `object_missing` — and its
   retry advice is the opposite of the first's. This PR made the download agree
   with the upload path rather than inventing a code; whether the *pair* of them
   should split is a real question.
3. **DR-0028 Req. 2 is asserted per-test, not gated.** Several tests check no
   row id appears in a body, one body at a time. There is no equivalent of the
   runtime code observer for internal ids.
