### PR TITLE
Say which kind of wrong a refusal was, not just that it was

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -409,13 +409,14 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("curation_policy_version_conflict", 409, Surface.message_prefix,
             "backend/app/services/release/curation.py",
             note=(
-                "409, not the 422 its ValueError base would suggest. "
-                "ReleaseCurationError subclasses ValueError, so reading the "
-                "raise site says 422; the one route that can reach it wraps "
-                "it in HTTPException(409) instead "
-                "(api/routes/releases_admin.py). The status is a property of "
-                "the route, not of the raise, which is why it was recorded "
-                "wrong until the observer started checking the pair."
+                "409, not the 422 a bare ReleaseCurationError would reach. "
+                "It was recorded wrong for a long time because the status "
+                "used to be a property of the *route*: the raise site said "
+                "ValueError and one except clause said 409. Since #211 the "
+                "raise site says ReleaseStateConflict and the route reads "
+                "the status off the class, so the two can no longer "
+                "disagree. The observer checking the (status, code) pair is "
+                "what caught the original mismatch."
             )),
     ApiCode("curator_task_not_found", 404, Surface.coded_exception,
             "backend/app/services/machine_review/curator_task_lifecycle.py"),
@@ -440,8 +441,14 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("database_unavailable", 503, Surface.response_literal,
             "backend/app/api/errors.py"),
-    ApiCode("doi_already_recorded", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+    ApiCode("doi_already_recorded", 409, Surface.message_prefix,
+            "backend/app/services/release/curation.py",
+            note=(
+                "409 since #211. Recording the DOI the release already cites "
+                "succeeds; only a *different* one refuses, and it refuses "
+                "because a citation is already pointing somewhere. There is "
+                "no corrected body -- the deposit would have to be redone."
+            )),
     ApiCode("domain_error", 400, Surface.generic_fallback,
             "backend/app/api/errors.py"),
     ApiCode("energy_transfer_scope_columns_disagree", 409, Surface.database_constraint,
@@ -549,8 +556,18 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("lowest_energy_unavailable", 422, Surface.coded_exception,
             "backend/app/services/scientific_read/species_calculations_search.py"),
-    ApiCode("manifest_already_frozen", 422, Surface.message_prefix,
-            "backend/app/services/release/manifest.py"),
+    ApiCode("manifest_already_frozen", 409, Surface.message_prefix,
+            "backend/app/services/release/manifest.py",
+            note=(
+                "409 since #211, for consistency with its module neighbour "
+                "release_not_published rather than because a caller reported "
+                "it: no route reaches it, because POST /publish calls "
+                "publish_release first and that raises release_not_draft. The "
+                "branch is live all the same -- a service-level test calls "
+                "freeze_manifest directly -- so it keeps an entry. Whether it "
+                "should be Reach.guard, and therefore unexported, is a "
+                "separate question this pass did not settle."
+            )),
     ApiCode("manifest_not_frozen", 404, Surface.message_prefix,
             "backend/app/api/routes/scientific/releases.py"),
     ApiCode("missing_filter", 422, Surface.message_prefix,
@@ -627,10 +644,25 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/api/errors.py"),
     ApiCode("release_artifact_corrupt", 500, Surface.message_prefix,
             "backend/app/api/routes/scientific/releases.py"),
-    ApiCode("release_not_draft", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
-    ApiCode("release_not_published", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+    ApiCode("release_not_draft", 409, Surface.message_prefix,
+            "backend/app/services/release/curation.py",
+            note=(
+                "409 since #211. A published release is frozen and cited; no "
+                "corrected body makes a second publish or a late selection "
+                "succeed, so 422 was telling a client to resend something "
+                "that could never be accepted. It raises ReleaseStateConflict, "
+                "and the route reads the status off the class."
+            )),
+    ApiCode("release_not_published", 409, Surface.message_prefix,
+            "backend/app/services/release/curation.py",
+            note=(
+                "409 since #211, from two modules: curation.py refuses to "
+                "withdraw or attach a DOI to a release that was never "
+                "published, and manifest.py refuses to freeze one. Both are "
+                "the same sentence about the same state, so they share a "
+                "code and now share a status; the curation.py literal is the "
+                "one the drift guard checks."
+            )),
     ApiCode("release_scoping_not_implemented", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/profile.py"),
     ApiCode("release_selects_nothing", 422, Surface.message_prefix,
@@ -639,9 +671,10 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/release/curation.py",
             note=(
                 "409 for the same reason as "
-                "curation_policy_version_conflict: the route wraps the "
-                "ReleaseCurationError in HTTPException(409) rather than "
-                "letting its ValueError base reach the 422 handler."
+                "curation_policy_version_conflict, and by the same mechanism "
+                "since #211: it raises ReleaseStateConflict, which the route "
+                "maps to 409. A tag that is taken is taken; there is no "
+                "corrected body, only a different tag."
             )),
     ApiCode("request_validation_error", 422, Surface.generic_fallback,
             "backend/app/api/errors.py"),
@@ -651,10 +684,22 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/calculation_paths.py"),
     ApiCode("schema_not_initialized", 503, Surface.response_literal,
             "backend/app/api/routes/health.py"),
-    ApiCode("selection_already_stands", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
-    ApiCode("selection_already_superseded", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+    ApiCode("selection_already_stands", 409, Surface.message_prefix,
+            "backend/app/services/release/curation.py",
+            note=(
+                "409 since #211, and it moved with its sibling rather than "
+                "after it: this and selection_already_superseded are the same "
+                "refusal seen from the two ends of a chain -- a row already "
+                "exists that blocks the write -- and leaving one at 422 would "
+                "have kept the inconsistency the pass was opened to remove."
+            )),
+    ApiCode("selection_already_superseded", 409, Surface.message_prefix,
+            "backend/app/services/release/curation.py",
+            note=(
+                "409 since #211. Supersession chains stay linear, so the row "
+                "to replace is the one that currently stands -- a different "
+                "URL, not a different body."
+            )),
     ApiCode("selection_no_longer_approved", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
     ApiCode("smiles_too_long", 422, Surface.message_prefix,
@@ -739,12 +784,34 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("unique_conflict", 409, Surface.sqlstate_category,
             "backend/app/api/errors.py"),
+    ApiCode("unknown_calculation_artifact_ref", 404, Surface.coded_exception,
+            "backend/app/services/upload_reference.py",
+            note=(
+                "An artifact locator is a (calculation_ref, sha256) pair, and "
+                "it has its own code rather than sharing "
+                "unknown_calculation_ref because the pair fails for two "
+                "reasons a depositor repairs differently: no such "
+                "calculation, or that calculation holds no file with that "
+                "digest. context carries both halves."
+            )),
+    ApiCode("unknown_calculation_ref", 404, Surface.coded_exception,
+            "backend/app/services/upload_reference.py"),
     ApiCode("unknown_curation_policy", 404, Surface.message_prefix,
             "backend/app/api/routes/releases_admin.py"),
     ApiCode("unknown_include_token", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py"),
-    ApiCode("unknown_record", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+    ApiCode("unknown_network_kinetics_ref", 404, Surface.coded_exception,
+            "backend/app/services/upload_reference.py"),
+    ApiCode("unknown_record", 404, Surface.message_prefix,
+            "backend/app/services/release/curation.py",
+            note=(
+                "404 since #211. It was the fourth unknown_* on this router "
+                "and the only one at 422: unknown_release, unknown_selection "
+                "and unknown_curation_policy all answered 404 for the same "
+                "condition. Distinct from record_ref_not_selectable, which "
+                "stays 422 -- there the prefix is not a selectable kind at "
+                "all, which is a malformed ref rather than a missing row."
+            )),
     ApiCode("unknown_record_type", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/literature_records.py"),
     ApiCode("unknown_release", 404, Surface.message_prefix,
@@ -753,6 +820,30 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/api/routes/scientific/releases.py"),
     ApiCode("unknown_selection", 404, Surface.message_prefix,
             "backend/app/api/routes/releases_admin.py"),
+    ApiCode("unknown_statmech_ref", 404, Surface.coded_exception,
+            "backend/app/services/upload_reference.py",
+            note=(
+                "404 since #204. Every ref-names-nothing refusal on "
+                "/uploads/kinetics used to be a bare ValueError, so a client "
+                "received 422 validation_error with no context and had to "
+                "read English to find out which of four refs was wrong. The "
+                "status matched neither the condition nor the sibling roots: "
+                "/uploads/thermo and /uploads/statmech already answered 404 "
+                "when a caller-supplied existing_*_id named no row, so the "
+                "status depended on how the caller spelled the name."
+            )),
+    ApiCode("unknown_transition_state_entry_ref", 404, Surface.coded_exception,
+            "backend/app/services/upload_reference.py",
+            note=(
+                "One code, three raise sites in workflows/kinetics.py, and "
+                "only the first is reachable through a route: the schema "
+                "confines an interpretation's transition_state_entry_ref to "
+                "role='transition_state', and the TS-anchored reaction lookup "
+                "collects every such ref plus the tunneling one and resolves "
+                "them before either of the other two sites runs. The other "
+                "two stay as tripwires against a reordering. context['field'] "
+                "says which ref asked."
+            )),
     ApiCode("unsafe_lowest_energy_comparison", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/species_calculations_search.py"),
     ApiCode("unsupported_direction", 422, Surface.message_prefix,

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -40,13 +40,29 @@ class NotFoundError(Exception):
     """Explicit 404 raised by service code.
 
     Pass ``code`` to attach a stable application-facing code to the
-    response envelope. Without a code the handler emits only
-    ``{"detail": ...}`` (legacy behavior).
+    response envelope. Without a code the envelope falls back to the
+    generic ``resource_not_found``, which tells a client nothing the status
+    line did not.
+
+    ``context`` carries the structured half of the refusal — which field
+    named the missing row, and what it named. A 404 raised from inside an
+    upload payload needs it: "statmech not found" is useless when the
+    payload cited four refs, and the alternative is a client string-matching
+    prose. It is deep-sanitised by :func:`app.api.error_contract.error_envelope`
+    like any other context, and must never carry a database primary key
+    (DR-0028 Requirement 2).
     """
 
-    def __init__(self, message: str, *, code: str | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        context: dict[str, object] | None = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
+        self.context = dict(context or {})
 
 
 def not_found(
@@ -55,6 +71,7 @@ def not_found(
     row_id: object = None,
     ref: str | None = None,
     code: str | None = None,
+    context: dict[str, object] | None = None,
 ) -> NotFoundError:
     """Build a 404 that names the resource without disclosing its row id.
 
@@ -78,13 +95,14 @@ def not_found(
         returned.
     :param ref: A public ref the caller supplied, echoed into the body.
     :param code: Stable application code for the envelope.
+    :param context: Structured detail for the envelope — never a row id.
     """
     if row_id is not None:
         logger.info("404 %s not found: row_id=%s ref=%s", kind, row_id, ref)
     detail = f"{kind} not found"
     if ref is not None:
         detail += f" ({kind}_ref={ref!r})"
-    return NotFoundError(detail, code=code)
+    return NotFoundError(detail, code=code, context=context)
 
 
 class DataIntegrityError(Exception):
@@ -177,7 +195,10 @@ def _not_found_handler(_request: Request, exc: NotFoundError) -> JSONResponse:
     return JSONResponse(
         status_code=404,
         content=error_envelope(
-            str(exc), code=code, fallback_code="resource_not_found"
+            str(exc),
+            code=code,
+            context=getattr(exc, "context", None),
+            fallback_code="resource_not_found",
         ),
     )
 

--- a/backend/app/api/routes/releases_admin.py
+++ b/backend/app/api/routes/releases_admin.py
@@ -37,6 +37,8 @@ from app.schemas.reads.scientific_release import (
 )
 from app.services.release.curation import (
     ReleaseCurationError,
+    ReleaseRecordNotFound,
+    ReleaseStateConflict,
     add_selection,
     create_release,
     publish_release,
@@ -47,7 +49,11 @@ from app.services.release.curation import (
     withdraw_release,
     withdraw_selection,
 )
-from app.services.release.manifest import ReleaseStateError, freeze_manifest
+from app.services.release.manifest import (
+    ReleaseManifestStateConflict,
+    ReleaseStateError,
+    freeze_manifest,
+)
 from app.services.scientific_read.releases import (
     UnknownReleaseError,
     get_release,
@@ -56,6 +62,32 @@ from app.services.scientific_read.releases import (
 )
 
 router = APIRouter()
+
+
+def _refusal_status(exc: ReleaseCurationError | ReleaseStateError) -> int:
+    """The status a curation refusal arrives at, read off the exception.
+
+    Three answers, and a client retries differently for each:
+
+    * **409** — the body is fine and the world is not how it assumed. No
+      corrected payload helps: the release has to be published, a new one
+      cut, or a different row superseded first.
+    * **404** — the request named a record that is not there.
+    * **422** — the body itself is wrong, and a corrected one is accepted.
+
+    Deriving the status from the exception class rather than from the route
+    is the point. ``release_tag_taken`` and
+    ``curation_policy_version_conflict`` were 409 because two ``except``
+    clauses said so, which is why :mod:`app.api.code_catalogue` had to carry
+    a note explaining that reading the raise site gave the wrong answer.
+    Now the raise site *is* the answer, and a new refusal gets its status by
+    choosing a class instead of by remembering which handler catches it.
+    """
+    if isinstance(exc, (ReleaseStateConflict, ReleaseManifestStateConflict)):
+        return 409
+    if isinstance(exc, ReleaseRecordNotFound):
+        return 404
+    return 422
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +181,7 @@ def create_curation_policy(
             created_by=user.id,
         )
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return CurationPolicyResponse(
         curation_policy_ref=policy.public_ref, name=policy.name, version=policy.version
     )
@@ -197,7 +229,7 @@ def create_dataset_release(
             created_by=user.id,
         )
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return get_release(session, release.tag).record
 
 
@@ -214,9 +246,11 @@ def append_selection(
 ) -> ReleaseSelectionRecord:
     """Append an attributed selection to a draft release.
 
-    :raises HTTPException: 404 unknown release; 422 for anything incoherent
-        (record not selectable, subject already has a standing selection,
-        release not a draft).
+    :raises HTTPException: 404 unknown release, or a ``record_ref`` naming no
+        record; 409 when the release is no longer a draft or the subject
+        already has a standing selection (supersede it instead); 422 for a
+        body that can be corrected and resent — an unselectable ref, a
+        blank rationale, a record below the approval floor.
     """
     release = _release(session, release_handle)
     try:
@@ -232,7 +266,7 @@ def append_selection(
             selected_by=user.id,
         )
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return _selection_record(session, release_handle, selection.public_ref)
 
 
@@ -252,8 +286,10 @@ def supersede(
 
     201, not 200: this creates a new row. Nothing is edited.
 
-    :raises HTTPException: 404 unknown release or selection; 422 when the row
-        has already been superseded or the replacement is incoherent.
+    :raises HTTPException: 404 unknown release, unknown selection, or a
+        ``record_ref`` naming no record; 409 when the row has already been
+        superseded or the release is no longer a draft; 422 when the
+        replacement is incoherent.
     """
     release = _release(session, release_handle)
     superseded = _selection(session, selection_ref, release=release)
@@ -267,7 +303,7 @@ def supersede(
             selected_by=user.id,
         )
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return _selection_record(session, release_handle, selection.public_ref)
 
 
@@ -285,8 +321,9 @@ def withdraw_a_selection(
 ) -> ReleaseSelectionRecord:
     """Append a withdrawal: the release now recommends nothing for this subject.
 
-    :raises HTTPException: 404 unknown release or selection; 422 when the row
-        has already been superseded.
+    :raises HTTPException: 404 unknown release or selection; 409 when the row
+        has already been superseded or the release is no longer a draft; 422
+        when no reason was given.
     """
     release = _release(session, release_handle)
     superseded = _selection(session, selection_ref, release=release)
@@ -298,7 +335,7 @@ def withdraw_a_selection(
             selected_by=user.id,
         )
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return _selection_record(session, release_handle, selection.public_ref)
 
 
@@ -313,15 +350,16 @@ def publish(
     Publishing and freezing are one operation because a published release
     without a manifest would be citable but unverifiable — the worst of both.
 
-    :raises HTTPException: 404 unknown release; 422 when the release is not a
-        draft or a manifest already exists.
+    :raises HTTPException: 404 unknown release; 409 when the release is not a
+        draft or a manifest already exists; 422 when the release selects
+        nothing or a selected record holds a non-finite value.
     """
     release = _release(session, release_handle)
     try:
         publish_release(session, release)
         freeze_manifest(session, release, created_by=user.id)
     except (ReleaseCurationError, ReleaseStateError) as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return get_release(session, release.tag).record
 
 
@@ -334,13 +372,14 @@ def withdraw(
 ) -> DatasetReleaseSummary:
     """Retract a published release, keeping its row and manifest readable.
 
-    :raises HTTPException: 404 unknown release; 422 when it is not published.
+    :raises HTTPException: 404 unknown release; 409 when it is not published;
+        422 when no reason was given.
     """
     release = _release(session, release_handle)
     try:
         withdraw_release(session, release, reason=body.reason)
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return get_release(session, release.tag).record
 
 
@@ -353,14 +392,14 @@ def attach_doi(
 ) -> DatasetReleaseSummary:
     """Record a DOI that was minted out-of-band for a published release.
 
-    :raises HTTPException: 404 unknown release; 422 when the release is not
+    :raises HTTPException: 404 unknown release; 409 when the release is not
         published or already cites a different DOI.
     """
     release = _release(session, release_handle)
     try:
         record_doi(session, release, doi=body.doi)
     except ReleaseCurationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(_refusal_status(exc), detail=str(exc)) from exc
     return get_release(session, release.tag).record
 
 

--- a/backend/app/services/kinetics_resolution.py
+++ b/backend/app/services/kinetics_resolution.py
@@ -13,6 +13,10 @@ from app.schemas.workflows.kinetics_upload import KineticsUploadRequest
 from app.services.calculation_resolution import resolve_workflow_tool_release_ref
 from app.services.literature_resolution import resolve_or_create_literature
 from app.services.software_resolution import resolve_software_release_ref
+from app.services.upload_reference import (
+    W_UNKNOWN_NETWORK_KINETICS_REF,
+    unknown_reference,
+)
 
 # ---------------------------------------------------------------------------
 # Kinetics source-calculation role/type/owner compatibility
@@ -187,8 +191,15 @@ def resolve_kinetics_upload(
             )
         )
         if network_kinetics is None:
-            raise ValueError(
-                "network_kinetics_ref does not reference an existing network_kinetics row."
+            raise unknown_reference(
+                code=W_UNKNOWN_NETWORK_KINETICS_REF,
+                field="network_kinetics_ref",
+                kind="network_kinetics",
+                ref=request.network_kinetics_ref,
+                remedy=(
+                    "Deposit the pressure-dependent network solve this rate "
+                    "came out of first, or correct the ref."
+                ),
             )
         network_kinetics_id = network_kinetics.id
 

--- a/backend/app/services/release/curation.py
+++ b/backend/app/services/release/curation.py
@@ -41,7 +41,42 @@ from app.services.scientific_read.profile import CURATED_REVIEW_FLOOR
 
 
 class ReleaseCurationError(ValueError):
-    """Raised when a curation request is not coherent."""
+    """Raised when a curation request is not coherent.
+
+    The base carries the *malformed request* meaning and reaches a client as
+    422: the body said something the curator can correct and resend. The two
+    subclasses below exist because that is not true of every refusal on this
+    router, and answering 422 for a condition no corrected body repairs
+    invites a client to resend the same request forever.
+    """
+
+
+class ReleaseStateConflict(ReleaseCurationError):
+    """The request is coherent; the release is not in the state it assumes.
+
+    409, and the status is a property of *this class* rather than of the
+    route that catches it. That distinction is not cosmetic: it is exactly
+    the confusion :mod:`app.api.code_catalogue` recorded against
+    ``curation_policy_version_conflict``, whose entry had to explain that
+    reading the raise site said 422 while the one route that could reach it
+    wrapped it in 409. Both of those codes now raise this class, so the raise
+    site and the wire agree.
+
+    Membership test: *no corrected body makes this request succeed.* A
+    curator must publish the release, cut a new one, supersede a different
+    row, or accept the DOI already cited. Nothing they can retype helps,
+    which is what separates a conflict from a malformed payload.
+    """
+
+
+class ReleaseRecordNotFound(ReleaseCurationError):
+    """A public ref the request named resolves to no row -- 404.
+
+    This router already answers 404 for an unknown release, an unknown
+    selection and an unknown curation policy. A candidate record was the
+    fourth ``unknown_*`` on the same router and the only one answering 422,
+    which is an inconsistency inside a single file rather than between two.
+    """
 
 
 def _naive_utcnow() -> datetime:
@@ -82,7 +117,7 @@ def resolve_curation_policy(
     payload = dict(criteria or {})
     if existing is not None:
         if existing.description != description or existing.criteria_json != payload:
-            raise ReleaseCurationError(
+            raise ReleaseStateConflict(
                 "curation_policy_version_conflict: policy "
                 f"{name!r} version {version!r} already exists with different "
                 "content. Publish a new version instead of editing a version "
@@ -133,7 +168,7 @@ def create_release(
     if session.scalars(
         select(DatasetRelease).where(DatasetRelease.tag == tag)
     ).first() is not None:
-        raise ReleaseCurationError(f"release_tag_taken: {tag!r} already exists.")
+        raise ReleaseStateConflict(f"release_tag_taken: {tag!r} already exists.")
 
     release = DatasetRelease(
         tag=tag,
@@ -166,7 +201,7 @@ def publish_release(session: Session, release: DatasetRelease) -> DatasetRelease
         selection now names a record below the approval floor.
     """
     if release.status is not DatasetReleaseStatus.draft:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             f"release_not_draft: cannot publish a release in status "
             f"{release.status.value!r}."
         )
@@ -221,7 +256,7 @@ def withdraw_release(
         was given.
     """
     if release.status is not DatasetReleaseStatus.published:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             f"release_not_published: cannot withdraw a release in status "
             f"{release.status.value!r}."
         )
@@ -246,11 +281,11 @@ def record_doi(session: Session, release: DatasetRelease, *, doi: str) -> Datase
         a different DOI.
     """
     if release.status is not DatasetReleaseStatus.published:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             "release_not_published: only a published release can carry a DOI."
         )
     if release.doi is not None and release.doi != doi:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             "doi_already_recorded: this release already cites a different DOI."
         )
     release.doi = doi
@@ -271,7 +306,7 @@ def _assert_record_exists(
         select(table.c.id).where(table.c.id == record_id)
     ).first()
     if found is None:
-        raise ReleaseCurationError(
+        raise ReleaseRecordNotFound(
             f"unknown_record: no {record_type.value} record matches the request."
         )
 
@@ -354,7 +389,7 @@ def resolve_selectable_record(session: Session, record_ref: str) -> ResolvedCand
         select(table.c.id).where(table.c.public_ref == record_ref)
     ).first()
     if row is None:
-        raise ReleaseCurationError(f"unknown_record: no record matches {record_ref!r}.")
+        raise ReleaseRecordNotFound(f"unknown_record: no record matches {record_ref!r}.")
     record_id = row[0]
 
     model, fk_attr, subject_type = CANDIDATE_SOURCES[record_type]
@@ -460,7 +495,7 @@ def add_selection(
         record_type=record_type,
     )
     if standing is not None:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             "selection_already_stands: this subject already has a standing "
             "selection in this release. Supersede it rather than adding a "
             "second one -- selections are append-only, not additive."
@@ -621,7 +656,7 @@ def current_selection(
 
 def _assert_draft(release: DatasetRelease) -> None:
     if release.status is not DatasetReleaseStatus.draft:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             "release_not_draft: selections may only be appended while a release "
             "is a draft. A published release is frozen, checksummed and cited."
         )
@@ -636,7 +671,7 @@ def _assert_not_already_superseded(
         )
     ).first()
     if replacement is not None:
-        raise ReleaseCurationError(
+        raise ReleaseStateConflict(
             "selection_already_superseded: this selection has already been "
             "replaced; supersede the row that currently stands."
         )
@@ -645,6 +680,8 @@ def _assert_not_already_superseded(
 __all__ = [
     "SELECTABLE_REF_PREFIXES",
     "ReleaseCurationError",
+    "ReleaseRecordNotFound",
+    "ReleaseStateConflict",
     "ResolvedCandidate",
     "add_selection",
     "create_release",

--- a/backend/app/services/release/manifest.py
+++ b/backend/app/services/release/manifest.py
@@ -95,6 +95,17 @@ class ReleaseStateError(RuntimeError):
     """Raised when a release is not in a state that permits the operation."""
 
 
+class ReleaseManifestStateConflict(ReleaseStateError):
+    """A manifest operation the release's current state forbids -- 409.
+
+    Split from the base so the status is a property of the raise rather than
+    of the route. Its sibling ``release_selects_nothing`` stays a plain
+    :class:`ReleaseStateError` and a 422: that one refuses on what the
+    release *contains*, and a curator repairs it by appending a selection,
+    not by waiting for the release to be in a different state.
+    """
+
+
 @dataclass(frozen=True)
 class VerificationReport:
     """Integrity of the *frozen* release. Independent of the live corpus."""
@@ -284,7 +295,7 @@ def freeze_manifest(
         would make "which manifest does this citation mean?" ambiguous).
     """
     if release.status is not DatasetReleaseStatus.published:
-        raise ReleaseStateError(
+        raise ReleaseManifestStateConflict(
             "release_not_published: a manifest may only be frozen for a "
             "published release."
         )
@@ -292,7 +303,7 @@ def freeze_manifest(
         select(ReleaseManifest).where(ReleaseManifest.dataset_release_id == release.id)
     ).first()
     if existing is not None:
-        raise ReleaseStateError(
+        raise ReleaseManifestStateConflict(
             "manifest_already_frozen: this release already has an immutable "
             "manifest; a release has exactly one."
         )
@@ -602,6 +613,7 @@ def _require_manifest(
 __all__ = [
     "DivergenceReport",
     "ManifestSnapshot",
+    "ReleaseManifestStateConflict",
     "ReleaseStateError",
     "VerificationReport",
     "freeze_manifest",

--- a/backend/app/services/upload_reference.py
+++ b/backend/app/services/upload_reference.py
@@ -1,0 +1,126 @@
+"""Refusing an upload that cites a row the database does not have.
+
+The condition
+-------------
+A deposit names an already-stored record by its **public ref** — the
+statmech an interpretation was built from, the transition-state entry a
+rate is anchored to, the calculation a tunneling correction was read out
+of — and nothing in the database answers to that ref. The thing the
+depositor pointed at is not there.
+
+Why 404 and not 422
+-------------------
+The three statuses say different things to a program, and a client
+retries differently for each. 422 means "your message is malformed: fix
+it and resend". 409 means "your message is fine, the world is not how you
+assumed". 404 means "the thing you named does not exist". A ref naming no
+row is the third, and answering 422 invited a client to resend a payload
+that could only ever fail again — or, worse, to treat the ref as a typo
+when the real repair is to deposit the record first.
+
+This is also what the *other* upload roots already do. ``/uploads/thermo``
+answers 404 when ``existing_statmech_id`` or a source link's
+``existing_calculation_id`` names no row, and ``/uploads/statmech`` does
+the same; ``/uploads/kinetics`` answered 422 for the identical condition
+expressed as a public ref instead of a row id. The status was a property
+of *how the caller spelled the name*, which is not a distinction a
+depositor can act on.
+
+Not the same thing as a local key
+----------------------------------
+:mod:`app.services.local_key_resolution` refuses a ``*_key`` that names
+nothing **declared in the same payload**. That stays 422 and must: the
+payload is self-contained, the declared names are printed back, and a
+corrected body is accepted. Here the namespace is the whole database and
+no corrected body can conjure the row.
+
+Why one code per kind of row, and not one code for all of them
+---------------------------------------------------------------
+``calculation_key_undeclared`` is deliberately *one* code across a dozen
+fields, because they resolve against one namespace and are repaired one
+way. These are the opposite case, and it is the test
+:mod:`app.api.code_catalogue` already applies: a missing statmech, a
+missing transition-state entry and a missing calculation are repaired by
+depositing three different things through three different endpoints. Two
+fields needing two different right answers is what earns two codes.
+``context['field']`` still says which ref asked, because a payload can
+cite several of the same kind.
+"""
+
+from __future__ import annotations
+
+from app.api.errors import NotFoundError
+
+#: An interpretation assignment's ``statmech_ref`` names no statmech row.
+W_UNKNOWN_STATMECH_REF = "unknown_statmech_ref"
+
+#: A ``transition_state_entry_ref`` names no transition-state entry. One
+#: code for three raise sites — the TS-anchored reaction lookup, the
+#: interpretation assignment and the tunneling block — because they are
+#: one condition about one namespace and ``context['field']`` separates
+#: them. Only the first is reachable through a route: the schema confines
+#: an interpretation's ref to ``role='transition_state'``, and every such
+#: ref plus the tunneling one is collected and resolved by the anchor
+#: lookup before either of the other two runs. The other two stay as
+#: tripwires against a future reordering, which is cheap; what is not
+#: cheap is a depositor discovering the difference.
+W_UNKNOWN_TRANSITION_STATE_ENTRY_REF = "unknown_transition_state_entry_ref"
+
+#: A ``source_calculation_ref`` names no calculation row.
+W_UNKNOWN_CALCULATION_REF = "unknown_calculation_ref"
+
+#: An artifact locator — ``(calculation_ref, sha256)`` — names no stored
+#: artifact. Its own code rather than :data:`W_UNKNOWN_CALCULATION_REF`
+#: because the pair can fail for two reasons a depositor repairs
+#: differently: the calculation is missing, or the calculation is there
+#: and holds no file with that digest. ``context`` carries both halves so
+#: the caller can tell which.
+W_UNKNOWN_CALCULATION_ARTIFACT_REF = "unknown_calculation_artifact_ref"
+
+#: A ``network_kinetics_ref`` names no network_kinetics row.
+W_UNKNOWN_NETWORK_KINETICS_REF = "unknown_network_kinetics_ref"
+
+
+def unknown_reference(
+    *,
+    code: str,
+    field: str,
+    kind: str,
+    ref: str,
+    remedy: str,
+    **extra: object,
+) -> NotFoundError:
+    """Build the 404 for a payload ref that resolves to nothing.
+
+    :param code: One of the ``W_UNKNOWN_*`` constants above.
+    :param field: The payload path the depositor must look at, e.g.
+        ``"interpretation_assignments[1].statmech_ref"``. Goes into
+        ``context['field']`` as well as the sentence, because a payload
+        can cite several refs of the same kind and "statmech not found"
+        does not say which one.
+    :param kind: The record kind, in the API's own vocabulary.
+    :param ref: The ref the caller supplied, echoed back — the caller
+        wrote it, so quoting it is what makes the refusal diagnosable.
+    :param remedy: What to do about it, in one sentence.
+    :param extra: Further structured context. Never a database primary
+        key (DR-0028 Requirement 2); a public ref or a digest is fine.
+    """
+    # No ``"code: "`` prefix on the message: the exception carries the code
+    # as an attribute and the handler passes it through unparsed, which is
+    # the surface every new refusal should use. Writing it in the prose as
+    # well would put a second copy where a reword can silently drop it.
+    return NotFoundError(
+        f"{field} {ref!r} does not name a {kind} in this database. {remedy}",
+        code=code,
+        context={"field": field, "kind": kind, "ref": ref, **extra},
+    )
+
+
+__all__ = [
+    "W_UNKNOWN_CALCULATION_ARTIFACT_REF",
+    "W_UNKNOWN_CALCULATION_REF",
+    "W_UNKNOWN_NETWORK_KINETICS_REF",
+    "W_UNKNOWN_STATMECH_REF",
+    "W_UNKNOWN_TRANSITION_STATE_ENTRY_REF",
+    "unknown_reference",
+]

--- a/backend/app/workflows/kinetics.py
+++ b/backend/app/workflows/kinetics.py
@@ -55,6 +55,13 @@ from app.services.record_review import (
     apply_review_policy,
 )
 from app.services.species_resolution import resolve_species, resolve_species_entry
+from app.services.upload_reference import (
+    W_UNKNOWN_CALCULATION_ARTIFACT_REF,
+    W_UNKNOWN_CALCULATION_REF,
+    W_UNKNOWN_STATMECH_REF,
+    W_UNKNOWN_TRANSITION_STATE_ENTRY_REF,
+    unknown_reference,
+)
 from app.workflows.reaction import persist_reaction_upload
 
 
@@ -132,7 +139,17 @@ def _resolve_ts_anchored_reaction_entry(
         .where(TransitionStateEntry.public_ref == ts_ref)
     )
     if reaction_entry_id is None:
-        raise ValueError("transition_state_entry_ref does not reference an existing TS entry.")
+        raise unknown_reference(
+            code=W_UNKNOWN_TRANSITION_STATE_ENTRY_REF,
+            field="transition_state_entry_ref",
+            kind="transition_state_entry",
+            ref=ts_ref,
+            remedy=(
+                "Deposit the transition state first, or correct the ref. This "
+                "is the ref that anchors the rate to an already-deposited "
+                "reaction entry, so it is read before anything else."
+            ),
+        )
     reaction_entry = session.get(ReactionEntry, reaction_entry_id)
     assert reaction_entry is not None
 
@@ -191,7 +208,15 @@ def _resolve_interpretation_assignments(
             select(Statmech).where(Statmech.public_ref == assignment.statmech_ref)
         )
         if statmech is None:
-            raise ValueError("interpretation statmech_ref does not reference an existing statmech record.")
+            raise unknown_reference(
+                code=W_UNKNOWN_STATMECH_REF,
+                field=f"{field}.statmech_ref",
+                kind="statmech",
+                ref=assignment.statmech_ref,
+                remedy=(
+                    "Deposit the partition function first, or correct the ref."
+                ),
+            )
         # This is the point at which a rate coefficient actually *depends* on
         # a partition function, so this is where the reproducibility claim is
         # made and enforced. Deposit-time statmech only warns about a missing
@@ -216,8 +241,18 @@ def _resolve_interpretation_assignments(
                     TransitionStateEntry.public_ref == assignment.transition_state_entry_ref
                 )
             )
+            # Unreachable through a route: the schema confines this ref to
+            # role='transition_state', and every such ref is resolved by the
+            # TS-anchored reaction lookup above, which refuses first with the
+            # same code. Kept as a tripwire against a reordering.
             if ts_entry_id is None:
-                raise ValueError("interpretation transition_state_entry_ref does not reference an existing TS entry.")
+                raise unknown_reference(
+                    code=W_UNKNOWN_TRANSITION_STATE_ENTRY_REF,
+                    field=f"{field}.transition_state_entry_ref",
+                    kind="transition_state_entry",
+                    ref=assignment.transition_state_entry_ref,
+                    remedy="Deposit the transition state first, or correct the ref.",
+                )
 
         species_entry_id: int | None = None
         if assignment.role in {"reactant", "product"}:
@@ -522,9 +557,23 @@ def persist_kinetics_upload(
                 TransitionStateEntry.public_ref == tunneling.transition_state_entry_ref
             )
         )
+        # Unreachable through a route for the same reason as its sibling in
+        # _resolve_interpretation_assignments: the anchor lookup resolves the
+        # tunneling ref too, and refuses first with the same code.
         if ts_entry_id is None:
-            raise ValueError("tunneling transition_state_entry_ref does not reference an existing TS entry.")
-        def resolve_artifact(calculation_ref: str | None, sha256: str | None, label: str) -> int | None:
+            raise unknown_reference(
+                code=W_UNKNOWN_TRANSITION_STATE_ENTRY_REF,
+                field="tunneling_application.transition_state_entry_ref",
+                kind="transition_state_entry",
+                ref=tunneling.transition_state_entry_ref,
+                remedy="Deposit the transition state first, or correct the ref.",
+            )
+        def resolve_artifact(
+            calculation_ref: str | None,
+            sha256: str | None,
+            label: str,
+            field_name: str,
+        ) -> int | None:
             if calculation_ref is None:
                 return None
             artifact_id = session.scalar(
@@ -536,15 +585,30 @@ def persist_kinetics_upload(
                 )
             )
             if artifact_id is None:
-                raise ValueError(f"tunneling {label} artifact locator does not reference an existing artifact.")
+                raise unknown_reference(
+                    code=W_UNKNOWN_CALCULATION_ARTIFACT_REF,
+                    field=f"tunneling_application.{field_name}",
+                    kind="calculation_artifact",
+                    ref=calculation_ref,
+                    remedy=(
+                        f"The {label} artifact locator is a (calculation ref, "
+                        "SHA-256) pair and no stored artifact matches it. "
+                        "Upload the artifact, or correct either half."
+                    ),
+                    sha256=sha256,
+                )
             return artifact_id
         result_artifact_id = resolve_artifact(
-            tunneling.result_artifact_calculation_ref, tunneling.result_artifact_sha256, "result"
+            tunneling.result_artifact_calculation_ref,
+            tunneling.result_artifact_sha256,
+            "result",
+            "result_artifact_calculation_ref",
         )
         sct_path_artifact_id = resolve_artifact(
             tunneling.sct_path_integral_artifact_calculation_ref,
             tunneling.sct_path_integral_artifact_sha256,
             "SCT path-integral",
+            "sct_path_integral_artifact_calculation_ref",
         )
         # A rate's tunneling TS must be one of this reaction's TS concepts.
         ts_reaction_id = session.scalar(
@@ -562,8 +626,15 @@ def persist_kinetics_upload(
                 )
             )
             if tunneling_source_calculation_id is None:
-                raise ValueError(
-                    "tunneling source_calculation_ref does not reference an existing calculation."
+                raise unknown_reference(
+                    code=W_UNKNOWN_CALCULATION_REF,
+                    field="tunneling_application.source_calculation_ref",
+                    kind="calculation",
+                    ref=tunneling.source_calculation_ref,
+                    remedy=(
+                        "Deposit the calculation the tunneling energies were "
+                        "read from first, or correct the ref."
+                    ),
                 )
         session.add(KineticsTunnelingApplication(
             kinetics_id=kinetics.id, model=tunneling.model,

--- a/backend/docs/reviews/error_code_coverage_triage.md
+++ b/backend/docs/reviews/error_code_coverage_triage.md
@@ -11,6 +11,19 @@ established. They need opposite fixes. This document classifies all 53.
 
 It is an *analysis*. No production file is changed by the PR that carries it.
 
+> **Statuses recorded here have since moved (#211/#204, 2026-08-16.)** The
+> reproduction recipes below are still correct — the same request still
+> provokes the same code — but seven of the statuses are not. On the release
+> router `release_not_draft`, `release_not_published`,
+> `selection_already_stands`, `selection_already_superseded`,
+> `doi_already_recorded` and `manifest_already_frozen` are now **409**, and
+> `unknown_record` is now **404**; on `/uploads/kinetics` every "ref names no
+> row" refusal is now a coded **404** instead of a generic 422. The rule
+> applied was: 409 for a state conflict, 404 for a missing thing, 422 only
+> for a malformed payload. `app/api/code_catalogue.py` is the current
+> authority for any `(status, code)` pair; this document is a measurement
+> taken on 2026-08-13 and is not maintained against it.
+
 ---
 
 ## Lead: four things that change the picture

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -57654,7 +57654,7 @@
     },
     "/api/v1/releases/{release_handle}/doi": {
       "post": {
-        "description": "Record a DOI that was minted out-of-band for a published release.\n\n:raises HTTPException: 404 unknown release; 422 when the release is not\n    published or already cites a different DOI.",
+        "description": "Record a DOI that was minted out-of-band for a published release.\n\n:raises HTTPException: 404 unknown release; 409 when the release is not\n    published or already cites a different DOI.",
         "operationId": "attach_doi_api_v1_releases__release_handle__doi_post",
         "parameters": [
           {
@@ -57773,7 +57773,7 @@
     },
     "/api/v1/releases/{release_handle}/publish": {
       "post": {
-        "description": "Publish a draft release and freeze its immutable, checksummed manifest.\n\nPublishing and freezing are one operation because a published release\nwithout a manifest would be citable but unverifiable — the worst of both.\n\n:raises HTTPException: 404 unknown release; 422 when the release is not a\n    draft or a manifest already exists.",
+        "description": "Publish a draft release and freeze its immutable, checksummed manifest.\n\nPublishing and freezing are one operation because a published release\nwithout a manifest would be citable but unverifiable — the worst of both.\n\n:raises HTTPException: 404 unknown release; 409 when the release is not a\n    draft or a manifest already exists; 422 when the release selects\n    nothing or a selected record holds a non-finite value.",
         "operationId": "publish_api_v1_releases__release_handle__publish_post",
         "parameters": [
           {
@@ -57882,7 +57882,7 @@
     },
     "/api/v1/releases/{release_handle}/selections": {
       "post": {
-        "description": "Append an attributed selection to a draft release.\n\n:raises HTTPException: 404 unknown release; 422 for anything incoherent\n    (record not selectable, subject already has a standing selection,\n    release not a draft).",
+        "description": "Append an attributed selection to a draft release.\n\n:raises HTTPException: 404 unknown release, or a ``record_ref`` naming no\n    record; 409 when the release is no longer a draft or the subject\n    already has a standing selection (supersede it instead); 422 for a\n    body that can be corrected and resent — an unselectable ref, a\n    blank rationale, a record below the approval floor.",
         "operationId": "append_selection_api_v1_releases__release_handle__selections_post",
         "parameters": [
           {
@@ -58001,7 +58001,7 @@
     },
     "/api/v1/releases/{release_handle}/selections/{selection_ref}/supersede": {
       "post": {
-        "description": "Append a replacement selection. The superseded row is left untouched.\n\n201, not 200: this creates a new row. Nothing is edited.\n\n:raises HTTPException: 404 unknown release or selection; 422 when the row\n    has already been superseded or the replacement is incoherent.",
+        "description": "Append a replacement selection. The superseded row is left untouched.\n\n201, not 200: this creates a new row. Nothing is edited.\n\n:raises HTTPException: 404 unknown release, unknown selection, or a\n    ``record_ref`` naming no record; 409 when the row has already been\n    superseded or the release is no longer a draft; 422 when the\n    replacement is incoherent.",
         "operationId": "supersede_api_v1_releases__release_handle__selections__selection_ref__supersede_post",
         "parameters": [
           {
@@ -58131,7 +58131,7 @@
     },
     "/api/v1/releases/{release_handle}/selections/{selection_ref}/withdraw": {
       "post": {
-        "description": "Append a withdrawal: the release now recommends nothing for this subject.\n\n:raises HTTPException: 404 unknown release or selection; 422 when the row\n    has already been superseded.",
+        "description": "Append a withdrawal: the release now recommends nothing for this subject.\n\n:raises HTTPException: 404 unknown release or selection; 409 when the row\n    has already been superseded or the release is no longer a draft; 422\n    when no reason was given.",
         "operationId": "withdraw_a_selection_api_v1_releases__release_handle__selections__selection_ref__withdraw_post",
         "parameters": [
           {
@@ -58261,7 +58261,7 @@
     },
     "/api/v1/releases/{release_handle}/withdraw": {
       "post": {
-        "description": "Retract a published release, keeping its row and manifest readable.\n\n:raises HTTPException: 404 unknown release; 422 when it is not published.",
+        "description": "Retract a published release, keeping its row and manifest readable.\n\n:raises HTTPException: 404 unknown release; 409 when it is not published;\n    422 when no reason was given.",
         "operationId": "withdraw_api_v1_releases__release_handle__withdraw_post",
         "parameters": [
           {

--- a/backend/tests/api/test_api_dataset_releases.py
+++ b/backend/tests/api/test_api_dataset_releases.py
@@ -486,11 +486,14 @@ def test_doi_is_recorded_not_minted(client, login_as, _api_curator_user, corpus)
     assert attached.status_code == 200, attached.text
     assert attached.json()["doi"] == "10.5281/zenodo.1"
 
+    # 409 since #211, not 422: the body is well formed and the release
+    # already cites a DOI. No corrected payload repoints a citation, so a
+    # client must not be told to fix and resend.
     repointed = client.post(
         f"/api/v1/releases/{RELEASE['tag']}/doi", json={"doi": "10.5281/zenodo.2"}
     )
-    assert repointed.status_code == 422
-    assert "doi_already_recorded" in repointed.text
+    assert repointed.status_code == 409, repointed.text
+    assert repointed.json()["code"] == "doi_already_recorded", repointed.text
 
 
 def test_unknown_release_is_404_not_422(client):
@@ -528,11 +531,13 @@ def test_a_non_selectable_record_ref_is_refused(
 # The two refusals that arrive at 409, and why the status is the assertion
 # ---------------------------------------------------------------------------
 #
-# Both raise ``ReleaseCurationError``, which subclasses ``ValueError`` -- so
-# reading the raise site says 422, and the catalogue recorded 422 for both.
-# The routes that reach them wrap the error in ``HTTPException(409)`` instead
-# (``api/routes/releases_admin.py``), because in both cases the tag or the
-# policy version *already exists*: the caller is colliding with state, not
+# Both used to raise a bare ``ReleaseCurationError``, which subclasses
+# ``ValueError`` -- so reading the raise site said 422, and the catalogue
+# recorded 422 for both, while the routes that reach them wrapped the error
+# in ``HTTPException(409)``. Since #211 they raise ``ReleaseStateConflict``
+# and the route reads the status off the class, so the raise site and the
+# wire can no longer disagree: in both cases the tag or the policy version
+# *already exists*, and the caller is colliding with state rather than
 # sending a malformed payload. Nothing in the suite emitted either code, so
 # the runtime observer had never seen the disagreement, and it was comparing
 # codes rather than ``(status, code)`` pairs and could not have reported it

--- a/backend/tests/api/test_api_kinetics_unknown_reference_codes.py
+++ b/backend/tests/api/test_api_kinetics_unknown_reference_codes.py
@@ -1,0 +1,442 @@
+"""Every ``/uploads/kinetics`` ref that names no row, asserted on the wire.
+
+What changed, and why the status is the assertion
+--------------------------------------------------
+A kinetics deposit cites already-stored records by public ref: the
+statmech an interpretation was built from, the transition-state entry the
+rate is anchored to, the calculation a tunneling correction was read out
+of, the artifact holding its output, the network solve it came from. Every
+one of those lookups used to raise a bare ``ValueError``, so a depositor
+received **422 ``validation_error`` with an empty ``context``** and had to
+read English prose to find out which of five refs was wrong.
+
+Both halves of that were wrong:
+
+* **422 says "your message is malformed, fix it and resend".** Nothing a
+  depositor can retype makes a missing statmech exist. The honest answer
+  is 404 — the thing you named is not there — and it is what a client
+  needs in order to retry differently (deposit the dependency, *then*
+  resend) instead of resending forever.
+* **A generic code with no context** left the client string-matching a
+  sentence. Each refusal now carries its own code and a ``context``
+  naming the field, the kind of row and the ref that failed.
+
+It was also inconsistent *across upload roots*, which is the part no
+single route could have shown: ``/uploads/thermo`` and ``/uploads/statmech``
+already answered 404 when ``existing_statmech_id`` or
+``existing_calculation_id`` named no row. The status therefore depended on
+whether the caller spelled the name as a row id or as a public ref, which
+is not a distinction a depositor can act on. That neighbouring behaviour
+is asserted here too, so "consistent across roots" is a checked claim
+rather than a sentence in a commit message.
+
+The shape of every test here
+----------------------------
+* the **exact status and code**, plus the structured ``context`` — never a
+  substring of ``detail``, which quotes the caller's own input back and so
+  can match a request that was wrongly accepted;
+* a **neighbouring request that must still be accepted**, because a test
+  asserting only "a 4xx arrived" passes against a handler that refuses
+  everything;
+* no database primary key anywhere in the body (DR-0028 Requirement 2).
+
+One refusal here is deliberately *not* a separate test
+-------------------------------------------------------
+``unknown_transition_state_entry_ref`` is written at three raise sites and
+only one of them is reachable through a route. The upload schema confines
+an interpretation's ``transition_state_entry_ref`` to
+``role='transition_state'``, and the TS-anchored reaction lookup collects
+every such ref *plus* the tunneling block's and resolves them before
+either of the other two sites runs. Both routes into the condition are
+asserted below and both arrive at the anchor lookup — which is the fact,
+and the reason this file does not claim three tests' worth of coverage for
+one reachable branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.models.statmech import Statmech
+from tests.services.scientific_read._factories import (
+    make_chem_reaction,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    make_transition_state,
+    make_transition_state_entry,
+    next_inchi_key,
+)
+
+_KINETICS = "/api/v1/uploads/kinetics"
+_THERMO = "/api/v1/uploads/thermo"
+
+_CONVENTIONS = {
+    "ensemble_policy": "single_structure",
+    "standard_state_convention": "ideal_gas_1_bar",
+    "degeneracy_interpretation": "reaction_path_degeneracy",
+}
+
+#: ``CH3 + OH -> CH3OH``. Element-balanced, so a refusal here is about the
+#: ref under test and not about the reaction.
+_REACTION = {
+    "reversible": False,
+    "reactants": [
+        {"species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}},
+        {"species_entry": {"smiles": "[OH]", "charge": 0, "multiplicity": 2}},
+    ],
+    "products": [{"species_entry": {"smiles": "CO", "charge": 0, "multiplicity": 1}}],
+}
+
+
+@pytest.fixture
+def corpus(db_session):
+    """The reaction entry, its TS entry, and a statmech for every subject.
+
+    The statmech rows are ``experimental`` in origin on purpose: a
+    *computed* statmech backing a computed rate must carry source
+    calculations, and that separate refusal would fire first and refuse
+    these payloads for a reason that has nothing to do with the ref under
+    test — the shape of test that passes while proving nothing.
+    """
+    ch3 = make_species_entry(
+        db_session,
+        make_species(
+            db_session, smiles="[CH3]", multiplicity=2,
+            inchi_key=next_inchi_key("UREF"),
+        ),
+    )
+    oh = make_species_entry(
+        db_session,
+        make_species(
+            db_session, smiles="[OH]", multiplicity=2,
+            inchi_key=next_inchi_key("UREG"),
+        ),
+    )
+    ch3oh = make_species_entry(
+        db_session,
+        make_species(
+            db_session, smiles="CO", multiplicity=1,
+            inchi_key=next_inchi_key("UREH"),
+        ),
+    )
+    reaction = make_chem_reaction(
+        db_session,
+        reactants=[ch3.species, oh.species],
+        products=[ch3oh.species],
+        reversible=False,
+    )
+    entry = make_reaction_entry(
+        db_session,
+        reaction=reaction,
+        reactant_entries=[ch3, oh],
+        product_entries=[ch3oh],
+    )
+    ts_entry = make_transition_state_entry(
+        db_session,
+        transition_state=make_transition_state(db_session, reaction_entry=entry),
+        multiplicity=2,
+    )
+    statmechs = {
+        "ch3": Statmech(species_entry_id=ch3.id, scientific_origin="experimental"),
+        "oh": Statmech(species_entry_id=oh.id, scientific_origin="experimental"),
+        "ch3oh": Statmech(species_entry_id=ch3oh.id, scientific_origin="experimental"),
+        "ts": Statmech(
+            transition_state_entry_id=ts_entry.id, scientific_origin="experimental"
+        ),
+    }
+    db_session.add_all(statmechs.values())
+    db_session.flush()
+    return ts_entry, statmechs
+
+
+def _rate(**overrides) -> dict:
+    body = {
+        "reaction": _REACTION,
+        "scientific_origin": "computed",
+        "a": 1.0e13,
+        "a_units": "cm3_mol_s",
+        "interpretation_assignments": [],
+    }
+    body.update(overrides)
+    return body
+
+
+def _assignments(statmechs, ts_entry=None, **overrides) -> list[dict]:
+    """The complete interpretation set — the schema refuses a partial one."""
+    rows = {
+        "reactant:1": {
+            "role": "reactant", "participant_index": 1,
+            "statmech_ref": statmechs["ch3"].public_ref, **_CONVENTIONS,
+        },
+        "reactant:2": {
+            "role": "reactant", "participant_index": 2,
+            "statmech_ref": statmechs["oh"].public_ref, **_CONVENTIONS,
+        },
+        "product:1": {
+            "role": "product", "participant_index": 1,
+            "statmech_ref": statmechs["ch3oh"].public_ref, **_CONVENTIONS,
+        },
+    }
+    if ts_entry is not None:
+        rows["transition_state"] = {
+            "role": "transition_state",
+            "statmech_ref": statmechs["ts"].public_ref,
+            "transition_state_entry_ref": ts_entry.public_ref,
+            **_CONVENTIONS,
+        }
+    for key, patch in overrides.items():
+        rows[key] = {**rows[key], **patch}
+    return list(rows.values())
+
+
+def _missing(response, *, code: str, field: str, kind: str, ref: str) -> dict:
+    """Assert the 404 a client branches on, and return the body.
+
+    ``detail`` is deliberately not matched: it quotes the caller's own ref
+    back, so a substring check would pass against a request that had been
+    accepted and echoed elsewhere.
+    """
+    assert response.status_code == 404, response.text[:800]
+    body = response.json()
+    assert body["code"] == code, body
+    context = body["context"]
+    assert context["field"] == field, body
+    assert context["kind"] == kind, body
+    assert context["ref"] == ref, body
+    leaked = [key for key in context if key == "id" or key.endswith("_id")]
+    assert not leaked, f"{code} leaked database ids into context: {leaked}"
+    return body
+
+
+# ---------------------------------------------------------------------------
+# The five refusals
+# ---------------------------------------------------------------------------
+
+
+def test_an_interpretation_naming_no_statmech_is_a_coded_404(client, corpus):
+    """A rate cannot be built from a partition function that is not there.
+
+    The repair is to deposit the statmech, which is a different request —
+    so the depositor is told the row is missing rather than that their
+    payload is malformed.
+    """
+    _ts_entry, statmechs = corpus
+    refused = client.post(
+        _KINETICS,
+        json=_rate(
+            interpretation_assignments=_assignments(
+                statmechs, **{"reactant:1": {"statmech_ref": "sm_notdeposited"}}
+            )
+        ),
+    )
+    _missing(
+        refused,
+        code="unknown_statmech_ref",
+        field="interpretation_assignments[0].statmech_ref",
+        kind="statmech",
+        ref="sm_notdeposited",
+    )
+
+    # The same request with every ref resolving is accepted.
+    accepted = client.post(
+        _KINETICS, json=_rate(interpretation_assignments=_assignments(statmechs))
+    )
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+def test_a_ts_anchor_naming_no_transition_state_entry_is_a_coded_404(client, corpus):
+    """Both ways of naming a TS reach the same anchor lookup.
+
+    Asserted from the interpretation side *and* the tunneling side, because
+    the two are the only routes into the condition and a test of one would
+    read as a test of both.
+    """
+    ts_entry, statmechs = corpus
+
+    from_interpretation = client.post(
+        _KINETICS,
+        json=_rate(
+            interpretation_assignments=_assignments(
+                statmechs, ts_entry=ts_entry,
+                **{"transition_state": {"transition_state_entry_ref": "tse_gone"}},
+            ),
+            tunneling_application={
+                "model": "wigner",
+                "transition_state_entry_ref": "tse_gone",
+                "imaginary_frequency_cm1": -1500.0,
+            },
+        ),
+    )
+    _missing(
+        from_interpretation,
+        code="unknown_transition_state_entry_ref",
+        field="transition_state_entry_ref",
+        kind="transition_state_entry",
+        ref="tse_gone",
+    )
+
+    from_tunneling = client.post(
+        _KINETICS,
+        json=_rate(
+            tunneling_application={
+                "model": "wigner",
+                "transition_state_entry_ref": "tse_gone",
+                "imaginary_frequency_cm1": -1500.0,
+            }
+        ),
+    )
+    _missing(
+        from_tunneling,
+        code="unknown_transition_state_entry_ref",
+        field="transition_state_entry_ref",
+        kind="transition_state_entry",
+        ref="tse_gone",
+    )
+
+    accepted = client.post(
+        _KINETICS,
+        json=_rate(
+            interpretation_assignments=_assignments(statmechs, ts_entry=ts_entry),
+            tunneling_application={
+                "model": "wigner",
+                "transition_state_entry_ref": ts_entry.public_ref,
+                "imaginary_frequency_cm1": -1500.0,
+            },
+        ),
+    )
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+def test_a_tunneling_source_calculation_that_is_not_there_is_a_coded_404(
+    client, corpus
+):
+    """Without the job the energies were read from, the block is untraceable."""
+    ts_entry, _statmechs = corpus
+    tunneling = {
+        "model": "wigner",
+        "transition_state_entry_ref": ts_entry.public_ref,
+        "imaginary_frequency_cm1": -1500.0,
+    }
+    refused = client.post(
+        _KINETICS,
+        json=_rate(
+            tunneling_application={**tunneling, "source_calculation_ref": "calc_gone"}
+        ),
+    )
+    _missing(
+        refused,
+        code="unknown_calculation_ref",
+        field="tunneling_application.source_calculation_ref",
+        kind="calculation",
+        ref="calc_gone",
+    )
+
+    # Omitting the optional ref entirely is still accepted: the guard
+    # refuses a ref that names nothing, not the act of citing one.
+    accepted = client.post(_KINETICS, json=_rate(tunneling_application=tunneling))
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+def test_a_tunneling_artifact_locator_that_matches_nothing_is_a_coded_404(
+    client, corpus
+):
+    """The locator is a pair, and the refusal says so.
+
+    ``context`` carries the digest as well as the calculation ref, because
+    the pair can fail two ways — no such calculation, or that calculation
+    holds no file with that SHA-256 — and a depositor repairs them
+    differently.
+    """
+    ts_entry, _statmechs = corpus
+    tunneling = {
+        "model": "wigner",
+        "transition_state_entry_ref": ts_entry.public_ref,
+        "imaginary_frequency_cm1": -1500.0,
+    }
+    refused = client.post(
+        _KINETICS,
+        json=_rate(
+            tunneling_application={
+                **tunneling,
+                "result_artifact_calculation_ref": "calc_gone",
+                "result_artifact_sha256": "a" * 64,
+            }
+        ),
+    )
+    body = _missing(
+        refused,
+        code="unknown_calculation_artifact_ref",
+        field="tunneling_application.result_artifact_calculation_ref",
+        kind="calculation_artifact",
+        ref="calc_gone",
+    )
+    assert body["context"]["sha256"] == "a" * 64, body
+
+    accepted = client.post(_KINETICS, json=_rate(tunneling_application=tunneling))
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+def test_a_network_kinetics_ref_that_is_not_there_is_a_coded_404(client, corpus):
+    """The bridge to a pressure-dependent solve names a row or it names nothing."""
+    _ts_entry, statmechs = corpus
+    refused = client.post(
+        _KINETICS, json=_rate(network_kinetics_ref="nkin_gone")
+    )
+    _missing(
+        refused,
+        code="unknown_network_kinetics_ref",
+        field="network_kinetics_ref",
+        kind="network_kinetics",
+        ref="nkin_gone",
+    )
+
+    accepted = client.post(
+        _KINETICS, json=_rate(interpretation_assignments=_assignments(statmechs))
+    )
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# The neighbouring root, which is why these are 404 and not 409 or 422
+# ---------------------------------------------------------------------------
+
+
+def test_the_thermo_root_already_answered_404_for_the_same_condition(
+    client, db_session
+):
+    """``/uploads/thermo`` was the precedent, and it is pinned here.
+
+    Before #204 the status for "you named a record that is not there"
+    depended on whether the caller spelled the name as a row id (404, on
+    thermo and statmech) or as a public ref (422, on kinetics). This test
+    holds the half that did *not* change, so a later edit cannot restore
+    the split by moving thermo instead of kinetics.
+
+    It also records what is still owed: this 404 carries the generic
+    ``resource_not_found`` rather than a code of its own, so a client can
+    read the status but not branch on the field. Giving the ``existing_*_id``
+    404s real codes is a separate pass — asserting the current answer here
+    is what keeps it from being forgotten.
+    """
+    refused = client.post(
+        _THERMO,
+        json={
+            "species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2},
+            "scientific_origin": "computed",
+            "h298_kj_mol": 146.7,
+            "existing_statmech_id": 2_000_000_000,
+        },
+    )
+    assert refused.status_code == 404, refused.text[:800]
+    assert refused.json()["code"] == "resource_not_found", refused.json()
+
+    accepted = client.post(
+        _THERMO,
+        json={
+            "species_entry": {"smiles": "[CH3]", "charge": 0, "multiplicity": 2},
+            "scientific_origin": "computed",
+            "h298_kj_mol": 146.7,
+        },
+    )
+    assert accepted.status_code == 201, accepted.text[:800]

--- a/backend/tests/api/test_api_untested_refusals_tier_a.py
+++ b/backend/tests/api/test_api_untested_refusals_tier_a.py
@@ -565,6 +565,13 @@ def test_selecting_a_record_ref_that_names_nothing_is_refused(
 
     The sibling ``record_ref_not_selectable`` covers a *wrong prefix*;
     this is the right prefix and no row.
+
+    404 since #211, and asserted here at the new status deliberately. The
+    body is well formed and the prefix is selectable — the only thing
+    wrong is that nothing answers to the ref, which is the definition of
+    a 404. It was the fourth ``unknown_*`` on this router and the only one
+    that had not reached one. The sibling's 422 is untouched, because a
+    wrong prefix *is* a payload a curator corrects and resends.
     """
     entry = make_species_entry(
         db_session, species=make_species(db_session, smiles="CCCO")
@@ -586,7 +593,7 @@ def test_selecting_a_record_ref_that_names_nothing_is_refused(
             "rationale": "Composite single point, frequencies all real.",
         },
     )
-    _assert_refusal(refused, status=422, code="unknown_record")
+    _assert_refusal(refused, status=404, code="unknown_record")
 
     accepted = curator.post(
         f"{_RELEASES}/{draft_release}/selections",

--- a/backend/tests/api/test_api_untested_refusals_tier_bc.py
+++ b/backend/tests/api/test_api_untested_refusals_tier_bc.py
@@ -42,6 +42,24 @@ What each test asserts, and why in that shape
   the dependency-overridden test session does not), it is, and the comment
   says so.
 
+Six expected statuses changed in #211, and none of them was relaxed
+----------------------------------------------------------------------
+``release_not_draft`` (twice), ``release_not_published`` (twice),
+``selection_already_stands`` and ``selection_already_superseded`` were
+asserted here at **422** and are now asserted at **409**. That is not a
+test bending to fit the code: it is this file recording a decision made
+about the contract — 409 for a state conflict, 404 for a missing thing,
+422 only for a malformed payload. Every one of the six refuses a request
+whose body is correct, and no corrected body makes it succeed, so 422 was
+telling a client to resend something that could never be accepted.
+
+The assertion is *stronger* after the change, not weaker: the pair is
+still exact, and the same tests still require the neighbouring valid
+request to be accepted. ``release_tag_taken`` and
+``curation_policy_version_conflict`` had already been settled at 409 in
+#170, so this removed an inconsistency inside one router rather than
+creating one.
+
 Fixtures live in this file rather than in a conftest deliberately: they are
 one round old and shared by nothing else yet.
 """
@@ -219,7 +237,7 @@ def test_publishing_a_published_release_is_release_not_draft(
     assert first.status_code == 200, first.text
 
     again = as_curator.post(f"/api/v1/releases/{TAG}/publish")
-    _refusal(again, status=422, code="release_not_draft")
+    _refusal(again, status=409, code="release_not_draft")
 
 
 def test_selecting_into_a_published_release_is_release_not_draft(
@@ -239,7 +257,7 @@ def test_selecting_into_a_published_release_is_release_not_draft(
     assert as_curator.post(f"/api/v1/releases/{TAG}/publish").status_code == 200
 
     refused = _select(as_curator, other.public_ref)
-    _refusal(refused, status=422, code="release_not_draft")
+    _refusal(refused, status=409, code="release_not_draft")
 
 
 def test_withdrawing_a_draft_release_is_release_not_published(
@@ -258,7 +276,7 @@ def test_withdrawing_a_draft_release_is_release_not_published(
     refused = as_curator.post(
         f"/api/v1/releases/{TAG}/withdraw", json={"reason": "Systematic AEC error."}
     )
-    _refusal(refused, status=422, code="release_not_published")
+    _refusal(refused, status=409, code="release_not_published")
 
     # The same request, after publication, is accepted.
     assert as_curator.post(f"/api/v1/releases/{TAG}/publish").status_code == 200
@@ -284,7 +302,7 @@ def test_attaching_a_doi_to_a_draft_release_is_release_not_published(
 
     doi = {"doi": "10.5281/zenodo.1234567"}
     refused = as_curator.post(f"/api/v1/releases/{TAG}/doi", json=doi)
-    _refusal(refused, status=422, code="release_not_published")
+    _refusal(refused, status=409, code="release_not_published")
 
     assert as_curator.post(f"/api/v1/releases/{TAG}/publish").status_code == 200
     accepted = as_curator.post(f"/api/v1/releases/{TAG}/doi", json=doi)
@@ -387,7 +405,7 @@ def test_a_second_selection_for_the_same_subject_is_refused(
 
     _refusal(
         _select(as_curator, other.public_ref),
-        status=422,
+        status=409,
         code="selection_already_stands",
     )
 
@@ -396,6 +414,28 @@ def test_a_second_selection_for_the_same_subject_is_refused(
         as_curator, first.json()["selection_ref"], other.public_ref
     )
     assert replacement.status_code == 201, replacement.text
+
+
+def test_a_selectable_ref_that_names_no_record_is_a_404(as_curator, candidates):
+    """The fourth ``unknown_*`` on this router, and the last to reach 404.
+
+    ``unknown_release``, ``unknown_selection`` and ``unknown_curation_policy``
+    all answered 404 for the same condition; a candidate record answered 422,
+    which told a client to correct a body that was already correct. The ref
+    below is well formed and its prefix *is* selectable — the only thing
+    wrong with it is that nothing answers to it, which is what separates it
+    from ``record_ref_not_selectable`` (still 422, and still right: there the
+    prefix names no selectable kind at all).
+    """
+    _entry, chosen, _other = candidates
+    _open_draft(as_curator)
+
+    refused = _select(as_curator, "thm_0123456789abcdef")
+    _refusal(refused, status=404, code="unknown_record")
+
+    # A ref that does resolve, on the same route, is accepted.
+    accepted = _select(as_curator, chosen.public_ref)
+    assert accepted.status_code == 201, accepted.text
 
 
 def test_superseding_a_selection_with_itself_is_refused(as_curator, candidates):
@@ -441,7 +481,7 @@ def test_superseding_an_already_superseded_selection_is_refused(
 
     _refusal(
         _supersede(as_curator, first_ref, chosen.public_ref),
-        status=422,
+        status=409,
         code="selection_already_superseded",
     )
 

--- a/backend/tests/workflows/test_kinetics_upload.py
+++ b/backend/tests/workflows/test_kinetics_upload.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api.error_contract import CodedValueError
+from app.api.errors import NotFoundError
 from app.db.models.app_user import AppUser
 from app.db.models.common import (
     ArrheniusAUnits,
@@ -868,13 +869,28 @@ def test_network_bridge_resolves(db_conn, monkeypatch):
 
 
 def test_network_bridge_unknown_id_rejected(db_conn, monkeypatch):
+    """A ref naming no row is a 404 with a code, not a bare ValueError.
+
+    Changed in #204: this used to match a substring of the message, which
+    is the assertion that survives any status and any code. It now asserts
+    the ``code`` and the structured ``context`` a client actually branches
+    on. ``NotFoundError`` is not a ``ValueError``, so the old
+    ``pytest.raises(ValueError, ...)`` would have gone red rather than
+    silently passing -- which is how this one was found.
+    """
     _patch_doi(monkeypatch)
     with Session(db_conn) as session, session.begin():
-        with pytest.raises(ValueError, match="does not reference an existing"):
+        with pytest.raises(NotFoundError) as refused:
             persist_kinetics_upload(
                 session,
                 _kinetics_request(network_kinetics_ref="nkin_missing"),
             )
+    assert refused.value.code == "unknown_network_kinetics_ref"
+    assert refused.value.context == {
+        "field": "network_kinetics_ref",
+        "kind": "network_kinetics",
+        "ref": "nkin_missing",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.45.0"
+version = "0.46.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -193,13 +193,18 @@ class RejectionCode(str, Enum):
     TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS = "transition_state_reaction_coordinate_ambiguous"
     TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED = "transition_state_reaction_coordinate_not_designated"
     UNIQUE_CONFLICT = "unique_conflict"
+    UNKNOWN_CALCULATION_ARTIFACT_REF = "unknown_calculation_artifact_ref"
+    UNKNOWN_CALCULATION_REF = "unknown_calculation_ref"
     UNKNOWN_CURATION_POLICY = "unknown_curation_policy"
     UNKNOWN_INCLUDE_TOKEN = "unknown_include_token"
+    UNKNOWN_NETWORK_KINETICS_REF = "unknown_network_kinetics_ref"
     UNKNOWN_RECORD = "unknown_record"
     UNKNOWN_RECORD_TYPE = "unknown_record_type"
     UNKNOWN_RELEASE = "unknown_release"
     UNKNOWN_RELEASE_ARTIFACT = "unknown_release_artifact"
     UNKNOWN_SELECTION = "unknown_selection"
+    UNKNOWN_STATMECH_REF = "unknown_statmech_ref"
+    UNKNOWN_TRANSITION_STATE_ENTRY_REF = "unknown_transition_state_entry_ref"
     UNSAFE_LOWEST_ENERGY_COMPARISON = "unsafe_lowest_energy_comparison"
     UNSUPPORTED_DIRECTION = "unsupported_direction"
     UNSUPPORTED_FILTER = "unsupported_filter"
@@ -237,7 +242,6 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.COMPOSED_SEARCH_PAGINATION_STALLED,
         RejectionCode.CURSOR_OFFSET_CONFLICT,
         RejectionCode.CURSOR_QUERY_MISMATCH,
-        RejectionCode.DOI_ALREADY_RECORDED,
         RejectionCode.EXPORT_ALL_CAP_EXCEEDED,
         RejectionCode.EXPORT_SEED_EMPTY,
         RejectionCode.EXPORT_SEED_UNRESOLVED,
@@ -258,7 +262,6 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.LEVEL_OF_THEORY_HANDLE_CONFLICT,
         RejectionCode.LIMIT_TOO_LARGE,
         RejectionCode.LOWEST_ENERGY_UNAVAILABLE,
-        RejectionCode.MANIFEST_ALREADY_FROZEN,
         RejectionCode.MISSING_FILTER,
         RejectionCode.MISSING_IDENTIFIER,
         RejectionCode.MISSING_REACTION_SEARCH_FILTER,
@@ -285,12 +288,8 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.RECORD_REF_NOT_SELECTABLE,
         RejectionCode.RECORD_SUBJECT_MISMATCH,
         RejectionCode.RECORD_TYPE_NOT_SELECTABLE,
-        RejectionCode.RELEASE_NOT_DRAFT,
-        RejectionCode.RELEASE_NOT_PUBLISHED,
         RejectionCode.RELEASE_SCOPING_NOT_IMPLEMENTED,
         RejectionCode.RELEASE_SELECTS_NOTHING,
-        RejectionCode.SELECTION_ALREADY_STANDS,
-        RejectionCode.SELECTION_ALREADY_SUPERSEDED,
         RejectionCode.SELECTION_NO_LONGER_APPROVED,
         RejectionCode.SMILES_TOO_LONG,
         RejectionCode.SPECIES_ENTRY_HANDLE_CONFLICT,
@@ -316,7 +315,6 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS,
         RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED,
         RejectionCode.UNKNOWN_INCLUDE_TOKEN,
-        RejectionCode.UNKNOWN_RECORD,
         RejectionCode.UNKNOWN_RECORD_TYPE,
         RejectionCode.UNSAFE_LOWEST_ENERGY_COMPARISON,
         RejectionCode.UNSUPPORTED_DIRECTION,
@@ -340,11 +338,17 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.ATOM_MAP_ELEMENT_NOT_CONSERVED,
         RejectionCode.ATOM_MAP_NOT_A_BIJECTION,
         RejectionCode.CURATION_POLICY_VERSION_CONFLICT,
+        RejectionCode.DOI_ALREADY_RECORDED,
         RejectionCode.ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE,
         RejectionCode.IDEMPOTENCY_CONFLICT,
+        RejectionCode.MANIFEST_ALREADY_FROZEN,
         RejectionCode.NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE,
         RejectionCode.REFERENCE_CONFLICT,
+        RejectionCode.RELEASE_NOT_DRAFT,
+        RejectionCode.RELEASE_NOT_PUBLISHED,
         RejectionCode.RELEASE_TAG_TAKEN,
+        RejectionCode.SELECTION_ALREADY_STANDS,
+        RejectionCode.SELECTION_ALREADY_SUPERSEDED,
         RejectionCode.STATE_CONFLICT,
         RejectionCode.STATMECH_SUBJECT_NOT_EXACTLY_ONE,
         RejectionCode.UNIQUE_CONFLICT,
@@ -388,7 +392,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.CURATOR_TASK_NOT_FOUND: frozenset({404}),
     RejectionCode.CURSOR_OFFSET_CONFLICT: frozenset({422}),
     RejectionCode.CURSOR_QUERY_MISMATCH: frozenset({422}),
-    RejectionCode.DOI_ALREADY_RECORDED: frozenset({422}),
+    RejectionCode.DOI_ALREADY_RECORDED: frozenset({409}),
     RejectionCode.ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE: frozenset({409}),
     RejectionCode.EXPORT_ALL_CAP_EXCEEDED: frozenset({422}),
     RejectionCode.EXPORT_SEED_EMPTY: frozenset({422}),
@@ -414,7 +418,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.LEVEL_OF_THEORY_HANDLE_CONFLICT: frozenset({422}),
     RejectionCode.LIMIT_TOO_LARGE: frozenset({422}),
     RejectionCode.LOWEST_ENERGY_UNAVAILABLE: frozenset({422}),
-    RejectionCode.MANIFEST_ALREADY_FROZEN: frozenset({422}),
+    RejectionCode.MANIFEST_ALREADY_FROZEN: frozenset({409}),
     RejectionCode.MANIFEST_NOT_FROZEN: frozenset({404}),
     RejectionCode.MISSING_FILTER: frozenset({422}),
     RejectionCode.MISSING_IDENTIFIER: frozenset({422}),
@@ -447,14 +451,14 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.RECORD_SUBJECT_MISMATCH: frozenset({422}),
     RejectionCode.RECORD_TYPE_NOT_SELECTABLE: frozenset({422}),
     RejectionCode.REFERENCE_CONFLICT: frozenset({409}),
-    RejectionCode.RELEASE_NOT_DRAFT: frozenset({422}),
-    RejectionCode.RELEASE_NOT_PUBLISHED: frozenset({422}),
+    RejectionCode.RELEASE_NOT_DRAFT: frozenset({409}),
+    RejectionCode.RELEASE_NOT_PUBLISHED: frozenset({409}),
     RejectionCode.RELEASE_SCOPING_NOT_IMPLEMENTED: frozenset({422}),
     RejectionCode.RELEASE_SELECTS_NOTHING: frozenset({422}),
     RejectionCode.RELEASE_TAG_TAKEN: frozenset({409}),
     RejectionCode.SCAN_RESULT_NOT_FOUND: frozenset({404}),
-    RejectionCode.SELECTION_ALREADY_STANDS: frozenset({422}),
-    RejectionCode.SELECTION_ALREADY_SUPERSEDED: frozenset({422}),
+    RejectionCode.SELECTION_ALREADY_STANDS: frozenset({409}),
+    RejectionCode.SELECTION_ALREADY_SUPERSEDED: frozenset({409}),
     RejectionCode.SELECTION_NO_LONGER_APPROVED: frozenset({422}),
     RejectionCode.SMILES_TOO_LONG: frozenset({422}),
     RejectionCode.SPECIES_ENTRY_HANDLE_CONFLICT: frozenset({422}),
@@ -485,13 +489,18 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS: frozenset({422}),
     RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED: frozenset({422}),
     RejectionCode.UNIQUE_CONFLICT: frozenset({409}),
+    RejectionCode.UNKNOWN_CALCULATION_ARTIFACT_REF: frozenset({404}),
+    RejectionCode.UNKNOWN_CALCULATION_REF: frozenset({404}),
     RejectionCode.UNKNOWN_CURATION_POLICY: frozenset({404}),
     RejectionCode.UNKNOWN_INCLUDE_TOKEN: frozenset({422}),
-    RejectionCode.UNKNOWN_RECORD: frozenset({422}),
+    RejectionCode.UNKNOWN_NETWORK_KINETICS_REF: frozenset({404}),
+    RejectionCode.UNKNOWN_RECORD: frozenset({404}),
     RejectionCode.UNKNOWN_RECORD_TYPE: frozenset({422}),
     RejectionCode.UNKNOWN_RELEASE: frozenset({404}),
     RejectionCode.UNKNOWN_RELEASE_ARTIFACT: frozenset({404}),
     RejectionCode.UNKNOWN_SELECTION: frozenset({404}),
+    RejectionCode.UNKNOWN_STATMECH_REF: frozenset({404}),
+    RejectionCode.UNKNOWN_TRANSITION_STATE_ENTRY_REF: frozenset({404}),
     RejectionCode.UNSAFE_LOWEST_ENERGY_COMPARISON: frozenset({422}),
     RejectionCode.UNSUPPORTED_DIRECTION: frozenset({422}),
     RejectionCode.UNSUPPORTED_FILTER: frozenset({422}),


### PR DESCRIPTION
## In plain terms

When the server refuses a request it returns a number saying *what kind* of wrong it was:

- **422** — "your message is malformed." Fix it and resend.
- **409** — "your message is fine, but the world isn't how you assumed." Resending cannot help until something changes.
- **404** — "the thing you named doesn't exist."

This matters because a client program *retries differently* for each. Telling it 422 when the truth is 409 invites it to resend the same request forever; telling it 422 when the truth is 404 invites it to treat a missing record as a typo.

Two surfaces were getting this wrong, and they are one rule, so they land together — one release, one notification, not two.

**Cutting a dataset release.** Publishing a release that is already published, withdrawing one that was never published, adding a second recommendation for a species that already has one, replacing a decision that has already been replaced, repointing a DOI that is already cited — all of these answered "your message is malformed". None of them is. A curator cannot retype anything that makes them succeed; they have to publish the release, cut a new one, or supersede a different row. Those now answer **409**. And naming a record that isn't in the database now answers **404**, which is what the same router already answered for an unknown release, an unknown selection and an unknown policy.

**Depositing a rate coefficient.** A kinetics upload cites records that are already stored: the partition function it was built from, the transition state it is anchored to, the calculation its tunneling correction was read out of. When one of those names nothing, the depositor was told "422, malformed" with no machine-readable indication of *which* of the five references was the problem — they had to read an English sentence. Those now answer **404** with a code and a structured `context` naming the field, the kind of record and the reference. This also removes a split nobody could act on: `/uploads/thermo` and `/uploads/statmech` already answered 404 for exactly this condition, so the status depended on whether the depositor spelled the name as a row id or as a public reference.

**This is a breaking change** for any client that branches on these statuses. See "What ARC is owed" below.

---

## Enumeration, with a verdict for every refusal

I enumerated every conflict-shaped and missing-thing-shaped refusal on both routers, including the ones already correct, rather than fixing only the six named in the tasks. Verdicts and reasoning below; **9 changed, 16 deliberately unchanged**.

### `/api/v1/releases/*` (`app/api/routes/releases_admin.py`)

The test applied: *is there a corrected request body that would be accepted?* If yes, 422 is right. If the named thing is absent, 404. Otherwise 409.

| code | was | now | verdict |
|---|---|---|---|
| `release_not_draft` | 422 | **409** | State conflict. Publishing twice, or selecting into a published release. No body fixes it. **Named in #211.** |
| `release_not_published` | 422 | **409** | State conflict. Withdrawing or DOI-ing a draft; also raised by `freeze_manifest`. **Named in #211.** |
| `selection_already_superseded` | 422 | **409** | State conflict. The chain has moved on; supersede the row that stands. **Named in #211.** |
| `selection_already_stands` | 422 | **409** | **Found by enumeration.** The same refusal as `selection_already_superseded` seen from the other end of a chain — a row already exists that blocks the write. Fixing one and not the other would have left the inconsistency in place. |
| `doi_already_recorded` | 422 | **409** | **Found by enumeration.** Recording the DOI already cited *succeeds*; only a different one refuses, because a citation is already pointing somewhere. |
| `manifest_already_frozen` | 422 | **409** | **Found by enumeration.** State conflict, moved for consistency with its module neighbour. Unreachable through any route (`publish` calls `publish_release` first, which raises `release_not_draft`) — the branch is live only from a service-level test. Recorded in the catalogue note. |
| `unknown_record` | 422 | **404** | **Found by enumeration.** It was the fourth `unknown_*` on this router and the only one not at 404. |
| `release_tag_taken` | 409 | 409 | Already correct (#170). Mechanism changed: it now *raises* the conflict class instead of being wrapped in one by the route. |
| `curation_policy_version_conflict` | 409 | 409 | Already correct (#170). Same mechanism change. |
| `unknown_release`, `unknown_selection`, `unknown_curation_policy` | 404 | 404 | Already correct. |
| `record_ref_not_selectable` | 422 | 422 | Correct. A prefix that names no selectable *kind* is a malformed ref, not a missing row. This is the near-miss `unknown_record` had to be distinguished from. |
| `record_type_not_selectable`, `record_subject_mismatch`, `subject_type_mismatch`, `supersedes_same_record`, `rationale_required`, `withdraw_reason_required` | 422 | 422 | Correct. Every one is repaired by a corrected body. |
| `record_has_no_subject` | 422 | 422 | Correct. The record exists; it is the wrong *sort* of record to recommend, and a different `record_ref` is accepted. |
| `record_not_approved` | 422 | 422 | **Deliberately deferred — see below.** |
| `selection_no_longer_approved` | 422 | 422 | **Deliberately deferred — see below.** |
| `release_selects_nothing` | 422 | 422 | **Deliberately deferred — see below.** |
| `non_finite_value` | 422 | 422 | **Deliberately deferred — see below.** |
| `release_artifact_corrupt` | 500 | 500 | Correct. Not a refusal of anything the caller did. |

**Where I drew the line, and why.** The six that moved to 409 all say *a row already exists, or the release is already in a state* — the same family as `release_tag_taken` and `curation_policy_version_conflict`, which #170 settled at 409. That family is now complete.

`record_not_approved` and `selection_no_longer_approved` are a *different* family: they refuse on **review status**, which is a curation judgement rather than a lifecycle state. By the strict rule they arguably belong at 409 too (`POST /publish` has no body to malform). I left them, and I want that decision made explicitly rather than smuggled in here — it is the exact parallel to #204's group 2, which you deferred for the same reason. `release_selects_nothing` (refuses on the release's *contents*) and `non_finite_value` (refuses on *stored data* being unserialisable, deliberately softened from a 500 in #187) are each a family of one and want the same explicit decision. **Suggested follow-up task below.**

### `/api/v1/uploads/kinetics` (`app/workflows/kinetics.py`, `app/services/kinetics_resolution.py`)

Every one of these was a bare `ValueError` arriving as **422 `validation_error` with an empty `context`** — so this is not "a catalogued 422 became a 404", it is "a generic 422 became a coded 404". Five new codes, six raise sites.

| condition | was | now | verdict |
|---|---|---|---|
| interpretation `statmech_ref` names no statmech | 422 `validation_error` | **404 `unknown_statmech_ref`** | Missing thing. **Named in #204.** |
| `transition_state_entry_ref` names no TS entry — TS-anchored reaction lookup (`kinetics.py:139`) | 422 `validation_error` | **404 `unknown_transition_state_entry_ref`** | Missing thing. **Named in #204.** The only route-reachable of its three sites. |
| …same, interpretation assignment (`kinetics.py:248`) | 422 | **404**, same code | **Unreachable through a route** — see refutation 2. Kept as a tripwire. |
| …same, tunneling block (`kinetics.py:561`) | 422 | **404**, same code | **Unreachable through a route** — same reason. Kept as a tripwire. |
| tunneling `source_calculation_ref` names no calculation | 422 `validation_error` | **404 `unknown_calculation_ref`** | Missing thing. **Named in #204.** |
| tunneling artifact locator `(calculation_ref, sha256)` matches no artifact | 422 `validation_error` | **404 `unknown_calculation_artifact_ref`** | **Found by enumeration.** Its own code, not `unknown_calculation_ref`: the pair fails two ways a depositor repairs differently, and `context` carries both halves. |
| `network_kinetics_ref` names no network_kinetics row | 422 `validation_error` | **404 `unknown_network_kinetics_ref`** | **Found by enumeration.** Same router, same condition. |

Out of scope and untouched, as #204 says (one pass per group):

| refusal | why untouched |
|---|---|
| statmech has no source calculations, so the rate is not reproducible | #204 group 2 |
| submitted reaction content/direction disagree with the TS's reaction entry | #204 group 3 |
| tunneling TS "does not belong to this reaction entry" | #204 group 3 |
| interpretation and tunneling "must reference the same TS entry" | #204 group 3 |
| `conformer_selection content locator must resolve exactly one selection` | Mixes "resolves to none" with "resolves to several". Two conditions, two right answers; needs its own decision. |

### What the other upload roots do with the same condition

Checked, because consistency across roots matters more than any one route:

- **`/uploads/thermo`** — `existing_statmech_id` / `existing_calculation_id` naming no row already answer **404** (`app/workflows/thermo.py:168`, `:214`).
- **`/uploads/statmech`** — `existing_calculation_id` naming no row already answers **404** (`app/services/statmech_resolution.py:168`).
- So the pre-existing split was **by how the caller spelled the name**, not by root: a row id got 404, a public ref got 422. This PR removes that. `test_the_thermo_root_already_answered_404_for_the_same_condition` pins the half that did *not* change, so a later edit cannot restore the split by moving thermo instead.
- **Local keys stay 422.** `calculation_key_undeclared`, `statmech_calculation_key_undeclared` and `applied_energy_correction_source_key_undeclared` refuse a `*_key` that names nothing *declared in the same payload*. That is genuinely a malformed body — the namespace is the payload and a corrected one is accepted. `app/services/upload_reference.py` states this distinction so the next reader does not "fix" it.

---

## Before / after, on the wire

Reproduced with a throwaway probe through `TestClient` against a real database, before any change and again after. Real output, trimmed.

### Release router

| request | before | after |
|---|---|---|
| `POST /releases/{tag}/publish` twice | `422 release_not_draft` | `409 release_not_draft` |
| `POST /releases/{tag}/selections` into a published release | `422 release_not_draft` | `409 release_not_draft` |
| `POST /releases/{tag}/withdraw` on a draft | `422 release_not_published` | `409 release_not_published` |
| `POST /releases/{tag}/doi` on a draft | `422 release_not_published` | `409 release_not_published` |
| second selection for the same subject | `422 selection_already_stands` | `409 selection_already_stands` |
| supersede an already-superseded row | `422 selection_already_superseded` | `409 selection_already_superseded` |
| DOI on a release citing a different DOI | `422 doi_already_recorded` | `409 doi_already_recorded` |
| `record_ref: "thm_deadbeefdeadbeef"` | `422 unknown_record` | `404 unknown_record` |

### `/uploads/kinetics`

Before — all six identical apart from the prose:

```
status  = 422
code    = 'validation_error'
context = {}
detail  = 'interpretation statmech_ref does not reference an existing statmech record.'
```

After:

```
status  = 404
code    = 'unknown_statmech_ref'
context = {'field': 'interpretation_assignments[0].statmech_ref', 'kind': 'statmech', 'ref': 'sm_missing'}

status  = 404
code    = 'unknown_transition_state_entry_ref'
context = {'field': 'transition_state_entry_ref', 'kind': 'transition_state_entry', 'ref': 'tse_missing'}

status  = 404
code    = 'unknown_calculation_ref'
context = {'field': 'tunneling_application.source_calculation_ref', 'kind': 'calculation', 'ref': 'calc_missing'}

status  = 404
code    = 'unknown_calculation_artifact_ref'
context = {'field': 'tunneling_application.result_artifact_calculation_ref',
           'kind': 'calculation_artifact', 'ref': 'calc_missing', 'sha256': 'aaaa…aaaa'}

status  = 404
code    = 'unknown_network_kinetics_ref'
context = {'field': 'network_kinetics_ref', 'kind': 'network_kinetics', 'ref': 'nkin_missing'}
```

The valid neighbouring payload returned **201** before and after, in the same probe run.

---

## Two premises in the brief that the wire refuted

**1. #204 group 1 is not "422 → 404" — it is "generic 422 → coded 404".** The three named refusals do not arrive at a catalogued 422; they arrive at the *generic* `validation_error` with an empty `context`, because every one is a bare `ValueError`. So there was no code for a client to branch on at all, and no field to read. Fixing only the status would have left a depositor string-matching prose to find out which of five refs was wrong.

**2. "`transition_state_entry_ref` does not reference an existing TS entry" is one condition at three sites, and only one is reachable.** `KineticsInterpretationAssignmentUpload` confines the ref to `role='transition_state'`, and `_resolve_ts_anchored_reaction_entry` collects every such ref *plus* the tunneling block's and resolves them before either of the other two sites runs. Proved on the wire: a bogus ref supplied through the interpretation set and a bogus ref supplied through tunneling both return the anchor lookup's message, never the other two. The two unreachable sites keep the same code as tripwires against a reordering; the catalogue note and the test file both say which is which, so the file does not claim three tests' worth of coverage for one branch.

**3. A smaller correction to the brief's framing.** "409 for a state conflict, 404 for a missing thing" was already partly true on the release router — `release_tag_taken` and `curation_policy_version_conflict` were 409 — but only because two `except` clauses said so, which is why the catalogue carried a note explaining that reading the raise site gave the wrong answer. This PR moves the status onto the exception class (`ReleaseStateConflict`, `ReleaseRecordNotFound`, `ReleaseManifestStateConflict`), so a new refusal gets its status by choosing a class rather than by remembering which handler catches it, and the raise site and the wire can no longer disagree. Both stale catalogue notes are rewritten.

---

## Tests whose expected status I changed, and why

Every one was updated deliberately. Nothing was weakened, skipped, xfailed or deleted; each still asserts an **exact** `(status, code)` pair, and every one still requires the neighbouring valid request to be accepted.

| test | was | now |
|---|---|---|
| `test_api_untested_refusals_tier_bc.py::test_publishing_a_published_release_is_release_not_draft` | 422 | 409 |
| `…::test_selecting_into_a_published_release_is_release_not_draft` | 422 | 409 |
| `…::test_withdrawing_a_draft_release_is_release_not_published` | 422 | 409 |
| `…::test_attaching_a_doi_to_a_draft_release_is_release_not_published` | 422 | 409 |
| `…::test_a_second_selection_for_the_same_subject_is_refused` | 422 | 409 |
| `…::test_superseding_an_already_superseded_selection_is_refused` | 422 | 409 |
| `test_api_dataset_releases.py::test_doi_is_recorded_not_minted` | 422 + `"doi_already_recorded" in text` | 409 + `body["code"] == "doi_already_recorded"` (also upgraded off a substring check) |
| `test_api_untested_refusals_tier_a.py::test_selecting_a_record_ref_that_names_nothing_is_refused` | 422 | 404 |
| `test_kinetics_upload.py::test_network_bridge_unknown_id_rejected` | `pytest.raises(ValueError, match="does not reference an existing")` | `pytest.raises(NotFoundError)` + exact `code` and `context` |

That last one is worth naming: it matched a **substring of the message**, which is the assertion that survives any status and any code. `NotFoundError` is not a `ValueError`, so it went red rather than silently passing — which is how it was found.

Added, not changed:

- `backend/tests/api/test_api_kinetics_unknown_reference_codes.py` — 6 tests, all five new codes on the wire, each paired with an accepted neighbour, plus the thermo-root pin.
- `test_api_untested_refusals_tier_bc.py::test_a_selectable_ref_that_names_no_record_is_a_404` — `unknown_record` had no wire test at all.

Regenerated: `backend/tests/api/golden/openapi.json` (docstring-only diff — six route `:raises` lines; reviewed, no schema/path/operation-id change).

---

## Vacuous-pass checks

Every change was mutated and confirmed to go red. Each mutation was applied, proved to have landed with `git diff --stat` **run from the repository root**, tested, and reverted by text substitution (no `git stash` / `checkout` / `reset` / `clean`).

| mutation | result |
|---|---|
| `_refusal_status` → `return 422` unconditionally | 6 failed |
| `selection_already_stands` back to the base class | `test_a_second_selection_for_the_same_subject_is_refused` failed |
| `unknown_record` back to the base class | `test_a_selectable_ref_that_names_no_record_is_a_404` failed |
| `doi_already_recorded` back to the base class | `test_doi_is_recorded_not_minted` failed |
| `selection_already_superseded` back to the base class | `test_superseding_an_already_superseded_selection_is_refused` failed |
| each of the 5 kinetics raise sites back to a bare `ValueError` | the matching wire test failed, one per mutation; `network_kinetics_ref` failed in **both** the wire and the workflow test |
| drop `context=` from `_not_found_handler` | 5 of 6 kinetics tests failed |
| catalogue says 422 while the wire says 409 | the **runtime error-code observer** errored on 4 tests, exactly as designed |

The last one is the important one: it confirms the observer's `(status, code)` pair comparison is load-bearing, so a future status change with no catalogue update cannot pass quietly.

Also asserted, because a guard that refuses everything satisfies a status assertion perfectly: every refusal test in the new file is paired with the same request minus the one bad reference, which must return **201**.

---

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no new environment variable, no database change of any kind.

---

## What ARC is owed — this is a breaking change

Any client branching on the status of these codes must be updated. There is nothing subtle to migrate; the codes and messages are unchanged, only the status.

- `clients/python/src/tckdb_client/rejection_codes.py` **regenerated**. `REJECTION_STATUSES` moves 6 codes 422 → 409 and `unknown_record` 422 → 404; `DOI_ALREADY_RECORDED`, `MANIFEST_ALREADY_FROZEN`, `RELEASE_NOT_DRAFT`, `RELEASE_NOT_PUBLISHED`, `SELECTION_ALREADY_STANDS`, `SELECTION_ALREADY_SUPERSEDED` move from `VALIDATION_REJECTION_CODES` to `CONFLICT_REJECTION_CODES`. Five new members: `UNKNOWN_STATMECH_REF`, `UNKNOWN_TRANSITION_STATE_ENTRY_REF`, `UNKNOWN_CALCULATION_REF`, `UNKNOWN_CALCULATION_ARTIFACT_REF`, `UNKNOWN_NETWORK_KINETICS_REF`.
- `clients/python/pyproject.toml` **bumped 0.45.0 → 0.46.0**.
- `clients/python/tests/test_rejection_codes.py` needed no edit: it derives retry advice from `REJECTION_STATUSES` for every member, so the regeneration carries it. Its CI job is separate from the backend gates and was run — see below.
- **Retry advice, in one line for the release notes:** if you were catching 422 for release lifecycle refusals, catch 409. If you were catching 422 for a kinetics upload citing a record that is not deposited yet, catch 404 and deposit the dependency before retrying.

---

## Verification actually run

All from the worktree, `conda run -n tckdb_env`, `PYTHONPATH` pointed at the worktree's own `tckdb-schemas` and `clients/python/src` (verified by printing `tckdb_client.rejection_codes.__file__` — it resolved inside the worktree, not the main checkout).

```
bash backend/scripts/test-api.sh          2864 passed in 282.35s
bash backend/scripts/test-rest.sh         4594 passed, 14 skipped in 122.60s
bash backend/scripts/test-scientific.sh   2055 passed in 178.20s

clients/python:  python -m pytest                      1348 passed
clients/python:  python -m pytest adapters/chemkin/tests  55 passed, 1 skipped
schemas/python/tckdb-schemas: python -m pytest            38 passed

ruff check (from backend/) on all 13 changed .py files: All checks passed
```

`ruff check .` reports 24 pre-existing `I001` findings, every one in `backend/alembic/versions/`, which this PR does not touch.

`detect_changes` against the working tree: 80 changed symbols, 24 affected processes, risk **critical** — expected, and every affected process is a release-router route or the kinetics upload path. Nothing outside the intended blast radius; all of them are covered by the three gates above.

---

## Suggested follow-up tasks

1. **The approval-floor family.** `record_not_approved` and `selection_no_longer_approved` refuse on review status rather than lifecycle state. By the strict rule they belong at 409 (`POST /publish` has no body to malform); they are left at 422 pending an explicit decision, exactly as #204's group 2 was.
2. **`release_selects_nothing` and `non_finite_value`.** Each a family of one on `POST /publish`, a route with no body — so 422 is not right for either, but the right answer differs (409 vs. arguably 500-softened-to-422).
3. **The uncoded 404s on the other upload roots.** `/uploads/thermo` and `/uploads/statmech` answer 404 for a missing `existing_*_id` with the generic `resource_not_found` — right status, no code, no `context`, so a client can read the status but not the field. `app/services/upload_reference.py` is the seam they can adopt. Pinned by `test_the_thermo_root_already_answered_404_for_the_same_condition` so it is not forgotten.
4. **`conformer_selection content locator must resolve exactly one selection`.** One message for two conditions (none, or several) with two different repairs.
5. **`manifest_already_frozen`'s reach.** No route reaches it, so it may belong at `Reach.guard` and be unexported from the client enum. Recorded in its catalogue note; not settled here.
6. **A `reported` PDep solve can 500.** Found while enumerating: `solve.state_energies[].state_key` and `solve.channel_barriers[].{channel_key, micro_reaction_key, transition_state_key}` are validated for membership **only** when `solve.kind is computed`. For a `reported` solve an undeclared key reaches `app/workflows/network_pdep.py:808/828/829/830` as a raw `KeyError` — an unhandled **500**, not a refusal. Unrelated to this PR's rule but the same underlying gap, and it deserves its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
