### PR TITLE
Refuse a route handler that can swallow a coded refusal

### DIFF
--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -131,11 +131,21 @@ ValueError(message)``). No such site exists — a census of every string
 literal in both trees beginning with a ``token: `` prefix found 71 tokens
 (re-measured after #178), of which 66 are catalogued as ``message_prefix``
 and 5 are logger format strings that reach no response body
-(``geometry_validation``, ``manifest``, ``readyz``, ``startup``,
-``status``). The two accidental prefixes that made the count 73 are gone:
-they were reworded, not reclassified. So the set of error-reachable
-prefixes the catalogue does not cover is presently empty — measured, and
-re-measurable, rather than asserted.
+(``manifest``, ``readyz``, ``startup``, ``status``, and — until it was
+reworded — ``geometry_validation``). The two accidental prefixes that made
+the count 73 are gone: they were reworded, not reclassified. So the set of
+error-reachable prefixes the catalogue does not cover is presently empty —
+measured, and re-measurable, rather than asserted.
+
+One of those five was itself repaired rather than merely recorded. Only
+``geometry_validation`` contained an underscore, so it was the only logger
+prefix ``_CODE_POSITION_PATTERN`` could match — a string carrying the
+shape of a declaration while declaring nothing. It now reads ``"geometry
+validation: …"``, and
+``backend/tests/api/test_error_contract_catalogue_gate.py::
+TestNoLoggerFormatStringSitsInTheCodePosition`` fails on the next one
+written the old way. The remaining four cannot match that pattern and were
+left as they are.
 """
 
 from __future__ import annotations

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -448,6 +448,17 @@ def _operational_error_handler(
         orig,
         exc_info=exc,
     )
+    # ``fallback_code`` is unreachable here and is kept deliberately.
+    # ``code`` above is always one of two literals, so it is never falsy and
+    # ``error_envelope`` never reads the fallback. Three reasons it stays:
+    # ``fallback_code`` is a required keyword, so there is no "drop it" that
+    # leaves the call valid; ``code_catalogue.py`` carries a ``database_error``
+    # entry whose note records exactly this, and whose ``origin`` points at
+    # this file -- deleting the literal turns
+    # ``test_every_origin_still_defines_its_code`` red; and an edit that
+    # stopped setting ``code`` would then emit it, which is the case the
+    # enumeration exists to have already named. Not a code any response
+    # carries today.
     return JSONResponse(
         status_code=status,
         content=error_envelope(

--- a/backend/app/services/geometry_validation.py
+++ b/backend/app/services/geometry_validation.py
@@ -398,8 +398,18 @@ def run_and_persist_geometry_validation(
             rmsd_warning_threshold=rmsd_warning_threshold,
         )
     except Exception:
+        # "geometry validation", not "geometry_validation". A snake_case
+        # token in front of a colon is how this codebase *declares a code*
+        # (app.api.error_contract), and this string declares nothing -- it
+        # is a log line that reaches no response body. It was the only one
+        # of the five bare logger prefixes in the tree shaped like a code,
+        # because it was the only one containing an underscore; the other
+        # four ("manifest", "readyz", "startup", "status") cannot match the
+        # code-position pattern at all. Held by
+        # tests/api/test_error_contract_catalogue_gate.py::
+        # TestNoLoggerFormatStringSitsInTheCodePosition.
         logger.exception(
-            "geometry_validation: chemistry layer raised for calculation_id=%s; "
+            "geometry validation: chemistry layer raised for calculation_id=%s; "
             "skipping persistence",
             calculation.id,
         )

--- a/backend/tests/api/test_coded_exception_reraise_gate.py
+++ b/backend/tests/api/test_coded_exception_reraise_gate.py
@@ -63,6 +63,70 @@ asserted:
   outlive what it describes;
 * and the scan itself is provoked against a site known to exist, so a
   scan that silently matches nothing cannot pass as a clean sweep.
+
+The second rule: a handler that can *absorb* a coded refusal
+------------------------------------------------------------
+The rule above asks what a handler **raises**. It cannot see the other
+half, and the other half is where #212's last site actually lived:
+
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+That **passes** the rule above -- the message goes through -- and it is
+still a loss. ``CodedValidationError`` is a ``ValueError``, so this clause
+catches every coded refusal raised anywhere beneath it; ``detail=str(exc)``
+carries the code only where the catalogue lists it as ``message_prefix``,
+and it drops ``context`` and the handler's chosen status either way. It sat
+on ``GET /scientific/artifacts/integrity`` wrapping
+:func:`~app.services.scientific_read.artifact_integrity.search_artifact_integrity`,
+and the #176 census verdict on it -- "cannot receive a coded error" -- was
+**true**, established statically and empirically. It was true by accident:
+the wrapped function sits beside functions that do raise coded refusals
+(:func:`app.api.error_contract.reject_unsupported_filters` is one), so one
+refactor routing a coded refusal through it would have flattened the code
+with nothing failing.
+
+Rather than pin that one call graph, this second rule covers the shape.
+Every ``except`` in the API layer whose caught types can absorb a
+``CodedValidationError`` -- ``ValueError``, ``Exception``, ``BaseException``
+or a bare ``except`` -- must do one of three things:
+
+1. **re-raise the original** (``raise``, or ``raise exc``), so the
+   ``ValueError`` handler in :mod:`app.api.errors` still mints the code;
+2. **intercept the coded case first**, with an earlier
+   ``except CodedValidationError`` / ``except CodedValueError`` clause on
+   the same ``try`` that re-raises it as itself -- this is the shape #165
+   used on the kinetics wrapper, and it is the escape hatch for a handler
+   that genuinely needs to translate the *uncoded* case; or
+3. **be listed in** :data:`JUDGED_ABSORBING_HANDLERS` **with a reason**.
+
+Why the exemption list is a list and not an inference
+-----------------------------------------------------
+Four of the sites it finds translate a coded refusal on purpose, and a
+gate that broke them would be worse than no gate. Three are the lookup
+API, whose whole contract is that an unresolvable species is a *200 with a
+match block*, never a 422 -- the coded refusal is deliberately restated in
+that envelope's own reason vocabulary. The fourth is a health probe that
+must return rather than raise. None of that is derivable from the shape,
+so it is written down, per site, in the dict below. An entry is a standing
+claim; the staleness test makes it fail once it stops describing anything.
+
+Deliberately **not** covered: the same shape anywhere below the API layer.
+This is a scoping decision with a measured price. Running the identical
+scan over all of ``backend/app`` (measured 2026-08-16) finds **104**
+handlers that absorb without re-raising, against **8** in ``app/api`` --
+so widening the rule would demand 96 further judgements, nearly all of
+them chemistry parsers and service helpers restating one uncoded
+``ValueError`` as another. Every one would have to be read and written up
+before the gate could go green once, and a gate that opens with a hundred
+exemptions is a gate that gets deleted.
+
+The API layer is the right boundary on the merits, not only on cost: it is
+where an exception stops being an exception and becomes a response body,
+and a code that is never published is a code nobody could have branched
+on. A refusal re-raised through ten service frames and dropped in the
+eleventh is still caught here, because ``app/api`` is the last frame it
+must cross.
 """
 
 from __future__ import annotations
@@ -275,4 +339,407 @@ class TestTheSweepIsComplete:
             f"{path} has regrown a handler that catches an exception and "
             "raises an HTTPException with a new message -- the exact shape "
             "#212 repaired, twice in one function"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The second rule: a handler that can absorb a coded refusal
+# ---------------------------------------------------------------------------
+
+#: The caught types that swallow a ``CodedValidationError``. It subclasses
+#: ``ValueError``, so these three -- plus a bare ``except:``, normalised to
+#: ``BaseException`` by :func:`_caught_names` -- are exhaustive. Nothing
+#: narrower can absorb one, and nothing wider exists.
+ABSORBING_CATCHES = frozenset({"ValueError", "Exception", "BaseException"})
+
+#: Clauses that take the coded case out of a broader clause's way. Both
+#: spellings are live: wire-schema checks raise ``CodedValidationError``
+#: because ``tckdb_schemas`` may not import ``app``, and the backend raises
+#: the ``CodedValueError`` subclass.
+CODED_CATCHES = frozenset({"CodedValidationError", "CodedValueError"})
+
+#: Handlers in the API layer that absorb a coded refusal on purpose, keyed
+#: ``"<path>::<enclosing qualname>"``. Anchored on the function rather than
+#: a line number so that reformatting the module above them does not fail
+#: this gate -- the lesson ``test_the_artifact_routes_did_not_regrow_their_
+#: handlers`` records, applied to a list eight entries long instead of one.
+#:
+#: Every value must say what a client loses and why that is right. Adding
+#: an entry is the expensive path on purpose: re-raising (``raise``) or an
+#: earlier ``except CodedValueError`` clause needs no entry at all.
+JUDGED_ABSORBING_HANDLERS: dict[str, str] = {
+    # -- The four deliberate translations. ------------------------------
+    # These are the ones a rule written carelessly would have broken, and
+    # the reason the exemption mechanism is an explicit dict.
+    "backend/app/api/routes/lookup.py::_resolve_species_list": (
+        "The lookup contract answers 200 with a `match` block; an "
+        "unresolvable reactant or product is a *result*, not a refusal, so "
+        "there is no error body for a code to be lost from. "
+        "`canonical_species_identity` can raise CodedValueError "
+        "(`species_smiles_charge_mismatch`) and that is deliberately "
+        "restated as the envelope's own `reactant_not_found` / "
+        "`product_not_found` reason. The coded message is preserved "
+        "verbatim inside the reason text (`f\"...: {e}\"`), so nothing a "
+        "caller could read is dropped -- only the transport changes."
+    ),
+    "backend/app/api/routes/lookup.py::lookup_species": (
+        "Same contract as above, one subject rather than a list: the coded "
+        "refusal becomes `species_identity_none` in the match block, "
+        "carrying `str(e)` as its reason. A 422 here would make the lookup "
+        "API the only read route that refuses a query it simply cannot "
+        "satisfy."
+    ),
+    "backend/app/api/routes/lookup.py::lookup_species_calculation": (
+        "Same contract again, on the calculation lookup. Three separate "
+        "entries rather than one wildcard on `lookup.py`: a wildcard would "
+        "also exempt a fourth handler nobody had read."
+    ),
+    "backend/app/api/routes/health.py::_sanitized_endpoint": (
+        "Formats an object-store URL for /status by stripping credentials "
+        "from it. The only raiser under the try is `urlsplit`, which raises "
+        "a bare ValueError; the handler returns the literal "
+        "'(unparseable)'. No coded refusal is reachable, and the function "
+        "returns a display string rather than a response body, so there is "
+        "no `code` field for one to have reached."
+    ),
+    # -- Broad diagnostic handlers, none on a refusal path. --------------
+    "backend/app/api/routes/auth.py::_migrate_password_hash": (
+        "Opportunistic password-hash upgrade inside a nested transaction "
+        "on an *already successful* login. Deliberately broad: the comment "
+        "at the site says `never fail a valid login`. It logs and falls "
+        "through, and the response it falls through to is a 200. Nothing "
+        "under the try raises a coded refusal -- `hash_password` is pure "
+        "and the nested begin raises SQLAlchemy errors."
+    ),
+    "backend/app/api/routes/health.py::_probe_bucket": (
+        "`/status` must answer under every failure including ones this "
+        "module has not anticipated, so the handler returns a health block "
+        "rather than raising. A coded refusal cannot reach it: the try "
+        "calls `head_bucket` on the storage client only."
+    ),
+    "backend/app/api/startup_checks.py::report_database_encoding_at_startup._probe": (
+        "Boot diagnostic running on its own thread; a probe that raises "
+        "must not become the fault it exists to report. It runs before any "
+        "request exists, so there is no response body to lose a code from."
+    ),
+    "backend/app/api/startup_checks.py::report_artifact_storage_at_startup": (
+        "Same reasoning at boot rather than on a thread: the storage probe "
+        "raising must not take the process with it. Returns a diagnostic "
+        "dict, not a response."
+    ),
+}
+
+#: Measured 2026-08-16: nine handlers in ``backend/app/api`` can absorb a
+#: coded refusal. One (``get_write_db``) needs no entry because it
+#: re-raises; the other eight are judged above. The floor is well under
+#: nine and exists only to catch a scan that has stopped walking the tree,
+#: not to police the count.
+_MINIMUM_ABSORBING_HANDLERS_THE_SCAN_MUST_SEE = 6
+
+#: The handler that must be classified as *safe by re-raise*, so the
+#: classifier is caught saying "no entry needed" about a real site rather
+#: than only about a synthetic one. It is the write-session dependency:
+#: every write request in the application passes through it, it catches
+#: ``Exception`` to roll back and audit, and it ends with a bare ``raise``.
+_A_HANDLER_THAT_RERAISES = "backend/app/api/deps.py::get_write_db"
+
+
+def _caught_names(handler: ast.ExceptHandler) -> frozenset[str]:
+    """The exception names a handler catches; bare ``except:`` is broadest."""
+    node = handler.type
+    if node is None:
+        return frozenset({"BaseException"})
+    parts = node.elts if isinstance(node, ast.Tuple) else [node]
+    return frozenset(
+        getattr(part, "id", None) or getattr(part, "attr", None) or ast.unparse(part)
+        for part in parts
+    )
+
+
+def _reraises_the_original(handler: ast.ExceptHandler) -> bool:
+    """True for a bare ``raise`` or ``raise <the bound name>``."""
+    for sub in ast.walk(handler):
+        if not isinstance(sub, ast.Raise):
+            continue
+        if sub.exc is None:
+            return True
+        if (
+            handler.name
+            and isinstance(sub.exc, ast.Name)
+            and sub.exc.id == handler.name
+        ):
+            return True
+    return False
+
+
+def _qualnames(tree: ast.Module) -> dict[int, str]:
+    """``id(node) -> "outer.inner"`` for every node, by enclosing scope."""
+    resolved: dict[int, str] = {}
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                inner = f"{prefix}.{child.name}" if prefix else child.name
+                resolved[id(child)] = inner
+                walk(child, inner)
+            else:
+                resolved[id(child)] = prefix
+                walk(child, prefix)
+
+    walk(tree, "")
+    return resolved
+
+
+def _absorbing_handlers() -> dict[str, dict]:
+    """``"<path>::<qualname>" -> {caught, safe, lineno}`` for the API layer.
+
+    ``safe`` is true when the handler re-raises the original, or when an
+    earlier clause on the same ``try`` catches the coded type -- the two
+    shapes that keep a code nameable without needing an exemption.
+    """
+    found: dict[str, dict] = {}
+    for path in sorted(API_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        relative = str(path.relative_to(REPO_ROOT))
+        qualnames = _qualnames(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            coded_taken_first = False
+            for handler in node.handlers:
+                caught = _caught_names(handler)
+                if caught & CODED_CATCHES:
+                    coded_taken_first = True
+                    continue
+                if not (caught & ABSORBING_CATCHES):
+                    continue
+                key = f"{relative}::{qualnames.get(id(node), '<module>')}"
+                safe = coded_taken_first or _reraises_the_original(handler)
+                previous = found.get(key)
+                if previous is not None:
+                    # Two absorbing handlers in one function collide on the
+                    # key and one would vanish from the sweep. Keep the
+                    # unsafe verdict so a merge can never hide a defect, and
+                    # record the collision for the test that fails on it.
+                    previous["collided"] = True
+                    if previous["safe"] and not safe:
+                        previous["safe"] = False
+                        previous["lineno"] = handler.lineno
+                    continue
+                found[key] = {
+                    "caught": "|".join(sorted(caught)),
+                    "safe": safe,
+                    "lineno": handler.lineno,
+                    "collided": False,
+                }
+    return found
+
+
+def _unjudged_absorbing_handlers() -> dict[str, dict]:
+    """The sites the gate fails on: unsafe, and nobody has judged them."""
+    return {
+        key: info
+        for key, info in _absorbing_handlers().items()
+        if not info["safe"] and key not in JUDGED_ABSORBING_HANDLERS
+    }
+
+
+class TestTheAbsorbingScanSeesWhatItIsWrittenOver:
+    """A sweep that matched nothing would pass every assertion below it."""
+
+    def test_it_finds_the_handlers_that_can_absorb_a_code(self):
+        handlers = _absorbing_handlers()
+        assert len(handlers) >= _MINIMUM_ABSORBING_HANDLERS_THE_SCAN_MUST_SEE, (
+            f"only {len(handlers)} handlers able to absorb a coded refusal "
+            f"found under {API_ROOT}; the scan has probably stopped walking "
+            "the tree, and every assertion below it would then pass "
+            "vacuously"
+        )
+
+    def test_no_two_handlers_share_a_key(self):
+        """Two in one function would merge, and one would leave the sweep."""
+        collided = sorted(
+            key for key, info in _absorbing_handlers().items() if info["collided"]
+        )
+        assert not collided, (
+            "these functions hold more than one handler that can absorb a "
+            "coded refusal, so the sweep cannot address them separately: "
+            f"{collided}. Split the function, or key this scan on the "
+            "handler's line number as well as its qualname."
+        )
+
+    def test_a_bare_reraise_is_classified_as_safe(self):
+        """Caught saying 'no entry needed' about a real site, not a stub."""
+        handlers = _absorbing_handlers()
+        assert _A_HANDLER_THAT_RERAISES in handlers, (
+            f"{_A_HANDLER_THAT_RERAISES} is no longer found by the scan; the "
+            "anchor for this assertion has moved"
+        )
+        assert handlers[_A_HANDLER_THAT_RERAISES]["safe"], (
+            "the write-session dependency catches Exception, rolls back, "
+            "audits and then re-raises -- if the scan calls that unsafe it "
+            "will call every correct handler unsafe and be deleted"
+        )
+        assert _A_HANDLER_THAT_RERAISES not in JUDGED_ABSORBING_HANDLERS, (
+            "a re-raising handler must not need an exemption; an entry here "
+            "would hide a later edit that stopped re-raising"
+        )
+
+    def test_it_would_notice_a_handler_that_swallows_a_coded_error(self):
+        """Provoked against source, so the classifier is caught saying no."""
+        tree = ast.parse(
+            "try:\n"
+            "    search_artifact_integrity()\n"
+            "except ValueError as exc:\n"
+            "    raise HTTPException(status_code=422, detail=str(exc)) from exc\n"
+        )
+        handler = next(
+            node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)
+        )
+        assert _caught_names(handler) & ABSORBING_CATCHES
+        assert not _reraises_the_original(handler), (
+            "the exact shape #212 removed from the artifact-integrity route "
+            "was classified as safe; the gate would then permit its return"
+        )
+
+    def test_it_recognises_the_coded_first_escape_hatch(self):
+        """#165's shape must pass, or the sanctioned repair fails the gate."""
+        tree = ast.parse(
+            "try:\n"
+            "    check()\n"
+            "except CodedValueError as exc:\n"
+            "    raise CodedValueError(exc.code, f'{field}: {exc}') from exc\n"
+            "except ValueError as exc:\n"
+            "    raise ValueError(f'{field}: {exc}') from exc\n"
+        )
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.Try))
+        coded_first = False
+        verdicts = []
+        for handler in node.handlers:
+            caught = _caught_names(handler)
+            if caught & CODED_CATCHES:
+                coded_first = True
+                continue
+            if caught & ABSORBING_CATCHES:
+                verdicts.append(coded_first or _reraises_the_original(handler))
+        assert verdicts == [True], (
+            "the broad clause behind an `except CodedValueError` that "
+            "re-raises coded was not recognised as safe; option (a) would "
+            "then be unavailable as a repair and this gate would force "
+            "exemptions instead of fixes"
+        )
+
+    def test_the_order_of_the_clauses_matters(self):
+        """A coded clause *after* the broad one never runs, so it is no fix."""
+        tree = ast.parse(
+            "try:\n"
+            "    check()\n"
+            "except ValueError as exc:\n"
+            "    raise HTTPException(status_code=422, detail=str(exc)) from exc\n"
+            "except CodedValueError as exc:\n"
+            "    raise\n"
+        )
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.Try))
+        coded_first = False
+        verdicts = []
+        for handler in node.handlers:
+            caught = _caught_names(handler)
+            if caught & CODED_CATCHES:
+                coded_first = True
+                continue
+            if caught & ABSORBING_CATCHES:
+                verdicts.append(coded_first or _reraises_the_original(handler))
+        assert verdicts == [False], (
+            "a CodedValueError clause written *below* the ValueError clause "
+            "was treated as protecting it. Python never reaches it -- the "
+            "broad clause matches first -- so accepting that ordering would "
+            "bless a repair that does nothing"
+        )
+
+
+class TestTheAbsorbingSweepIsComplete:
+    """Both directions, so neither a new site nor a stale entry survives."""
+
+    def test_every_absorbing_handler_is_reraising_or_judged(self):
+        unjudged = {
+            key: info["caught"]
+            for key, info in _unjudged_absorbing_handlers().items()
+        }
+        assert not unjudged, (
+            "these handlers in the API layer catch a type that swallows a "
+            "CodedValidationError, and neither re-raise it nor let an "
+            "earlier `except CodedValueError` clause take it first: "
+            f"{unjudged}. A coded refusal raised anywhere beneath them "
+            "loses its `code` and its `context`. Either re-raise "
+            "(`raise`), add an `except CodedValueError as exc: raise` "
+            "clause above the broad one, or add an entry to "
+            "JUDGED_ABSORBING_HANDLERS saying what a client loses and why "
+            "that is right."
+        )
+
+    def test_no_entry_describes_a_handler_that_is_gone(self):
+        """A list nothing re-checks is how a stale survey stays believed."""
+        needs_judging = {
+            key for key, info in _absorbing_handlers().items() if not info["safe"]
+        }
+        stale = sorted(set(JUDGED_ABSORBING_HANDLERS) - needs_judging)
+        assert not stale, (
+            "JUDGED_ABSORBING_HANDLERS describes handlers that no longer "
+            f"absorb a coded refusal: {stale}. If they were repaired, "
+            "delete the entry; if they moved or were renamed, re-anchor it."
+        )
+
+    def test_the_four_deliberate_translations_are_still_exactly_four(self):
+        """The set a careless rule would have broken, pinned by name.
+
+        Three lookup routes and one health probe. They are the reason the
+        exemption mechanism is an explicit dict rather than an inference
+        from shape: every one of them is, mechanically, a coded refusal
+        being turned into something else, and every one of them is right.
+        """
+        deliberate = sorted(
+            key
+            for key in JUDGED_ABSORBING_HANDLERS
+            if "lookup.py" in key or "::_sanitized_endpoint" in key
+        )
+        assert deliberate == [
+            "backend/app/api/routes/health.py::_sanitized_endpoint",
+            "backend/app/api/routes/lookup.py::_resolve_species_list",
+            "backend/app/api/routes/lookup.py::lookup_species",
+            "backend/app/api/routes/lookup.py::lookup_species_calculation",
+        ], (
+            "the four deliberate translations are no longer the four this "
+            f"gate was written around: {deliberate}. If one was repaired, "
+            "say so here; if a fifth was added, it needs the same argument "
+            "the other four carry."
+        )
+        found = _absorbing_handlers()
+        for key in deliberate:
+            assert key in found, (
+                f"{key} is exempted but the scan no longer finds it, so the "
+                "exemption is protecting nothing and would hide a "
+                "regression at the same site"
+            )
+
+    def test_the_integrity_route_has_not_regrown_its_value_error_handler(self):
+        """Named, because this is the site the whole second rule is for.
+
+        ``GET /scientific/artifacts/integrity`` carried
+        ``except ValueError -> HTTPException(422, str(exc))`` until #212
+        removed it. The wire test that asserts what it publishes instead is
+        ``tests/api/scientific/test_api_scientific_artifact_integrity.py``
+        ``::test_client_sort_is_rejected_like_every_other_scientific_read``;
+        this is the shape half, which cannot see a response body.
+        """
+        path = "backend/app/api/routes/scientific/artifacts.py"
+        regrown = sorted(
+            key for key in _unjudged_absorbing_handlers() if key.startswith(path)
+        )
+        assert not regrown, (
+            f"{path} has regrown a handler that absorbs a coded refusal "
+            f"without re-raising it: {regrown}. `search_artifact_integrity` "
+            "raises `client_sort_not_supported` and `offset_too_large`; "
+            "wrapping it re-answers 422 as `http_422`"
         )

--- a/backend/tests/api/test_coded_exception_reraise_gate.py
+++ b/backend/tests/api/test_coded_exception_reraise_gate.py
@@ -457,19 +457,35 @@ def _caught_names(handler: ast.ExceptHandler) -> frozenset[str]:
 
 
 def _reraises_the_original(handler: ast.ExceptHandler) -> bool:
-    """True for a bare ``raise`` or ``raise <the bound name>``."""
-    for sub in ast.walk(handler):
-        if not isinstance(sub, ast.Raise):
-            continue
-        if sub.exc is None:
-            return True
-        if (
-            handler.name
-            and isinstance(sub.exc, ast.Name)
-            and sub.exc.id == handler.name
-        ):
-            return True
-    return False
+    """True for a bare ``raise`` or ``raise <the bound name>``.
+
+    Nested ``def``/``lambda`` bodies are **not** searched. A ``raise``
+    inside a closure the handler merely defines does not re-raise anything
+    when the handler runs, and counting it would make this classifier
+    permissive in the one direction that matters: calling an unsafe
+    handler safe is how a gate passes having checked nothing.
+    """
+
+    def search(node: ast.AST) -> bool:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+            ):
+                continue
+            if isinstance(child, ast.Raise):
+                if child.exc is None:
+                    return True
+                if (
+                    handler.name
+                    and isinstance(child.exc, ast.Name)
+                    and child.exc.id == handler.name
+                ):
+                    return True
+            if search(child):
+                return True
+        return False
+
+    return search(handler)
 
 
 def _qualnames(tree: ast.Module) -> dict[int, str]:
@@ -603,6 +619,45 @@ class TestTheAbsorbingScanSeesWhatItIsWrittenOver:
             "the exact shape #212 removed from the artifact-integrity route "
             "was classified as safe; the gate would then permit its return"
         )
+
+    def test_a_raise_inside_a_nested_def_is_not_a_reraise(self):
+        """The permissive direction, provoked: calling unsafe handlers safe.
+
+        A handler that defines a closure containing ``raise`` has not
+        re-raised anything. Counting it would silently exempt the site.
+        """
+        tree = ast.parse(
+            "try:\n"
+            "    check()\n"
+            "except ValueError as exc:\n"
+            "    def _later():\n"
+            "        raise\n"
+            "    register(_later)\n"
+        )
+        handler = next(
+            node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)
+        )
+        assert not _reraises_the_original(handler), (
+            "a `raise` inside a nested def was counted as the handler "
+            "re-raising; every such handler would then be exempted without "
+            "anybody writing a reason for it"
+        )
+
+    def test_a_real_reraise_beside_a_nested_def_still_counts(self):
+        """The other direction, so the narrowing did not break the rule."""
+        tree = ast.parse(
+            "try:\n"
+            "    check()\n"
+            "except ValueError as exc:\n"
+            "    def _later():\n"
+            "        pass\n"
+            "    log(exc)\n"
+            "    raise\n"
+        )
+        handler = next(
+            node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)
+        )
+        assert _reraises_the_original(handler)
 
     def test_it_recognises_the_coded_first_escape_hatch(self):
         """#165's shape must pass, or the sanctioned repair fails the gate."""

--- a/backend/tests/api/test_coded_exception_reraise_gate.py
+++ b/backend/tests/api/test_coded_exception_reraise_gate.py
@@ -76,7 +76,21 @@ That **passes** the rule above -- the message goes through -- and it is
 still a loss. ``CodedValidationError`` is a ``ValueError``, so this clause
 catches every coded refusal raised anywhere beneath it; ``detail=str(exc)``
 carries the code only where the catalogue lists it as ``message_prefix``,
-and it drops ``context`` and the handler's chosen status either way. It sat
+and drops ``context`` unconditionally.
+
+What is at stake depends on how broad the clause is, and the two cases are
+worth keeping straight:
+
+* ``except ValueError`` costs the ``code`` and the ``context``, but not
+  the status -- ``_value_error_handler`` answers 422 and so does the
+  ``HTTPException`` above.
+* ``except Exception`` costs the status as well. ``NotFoundError``,
+  ``DomainError`` and ``DataIntegrityError`` are **not** ``ValueError``
+  subclasses (verified by ``issubclass``); they have their own handlers
+  answering 404, 400 and 500. A broad clause that re-answers them as 422
+  changes what the response *means*, not only what it is called.
+
+The site that prompted this rule sat
 on ``GET /scientific/artifacts/integrity`` wrapping
 :func:`~app.services.scientific_read.artifact_integrity.search_artifact_integrity`,
 and the #176 census verdict on it -- "cannot receive a coded error" -- was

--- a/backend/tests/api/test_error_contract_catalogue_gate.py
+++ b/backend/tests/api/test_error_contract_catalogue_gate.py
@@ -631,9 +631,13 @@ class TestTheLegacyDetailPathIsGatedToo:
 
     Its character test does not even require an underscore, so before this
     change ``raise HTTPException(422, "manifest: ...")`` would have
-    published ``code="manifest"``. Two of the five bare prefixes written in
-    the tree (``manifest``, ``readyz``, ``startup``, ``status``,
-    ``geometry_validation``) are one refactor away from an error body.
+    published ``code="manifest"``. The four bare prefixes written in the
+    tree (``manifest``, ``readyz``, ``startup``, ``status``) are one
+    refactor away from an error body, and the gate below is what stops
+    them arriving as codes. A fifth, ``geometry_validation``, was reworded
+    rather than gated -- it was the only one shaped like a code to the
+    *narrowed* pattern as well, and is now held by
+    :class:`TestNoLoggerFormatStringSitsInTheCodePosition`.
     """
 
     def test_a_catalogued_prefix_is_still_lifted(self):
@@ -667,3 +671,168 @@ class TestTheLegacyDetailPathIsGatedToo:
             == "tckdb_client_version_unsupported"
         )
         assert "tckdb_client_version_unsupported" not in MESSAGE_PREFIX_CODES
+
+
+# ---------------------------------------------------------------------------
+# Logger format strings: the code position, in a place with no response body
+# ---------------------------------------------------------------------------
+
+#: ``logger.<level>(...)`` calls whose first argument is a string literal.
+#: ``.log(level, msg)`` is deliberately absent -- its first argument is the
+#: level, not the message -- and no site in the tree uses it with a prefix.
+_LOG_LEVEL_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "exception", "critical"}
+)
+
+#: Any leading ``token: `` at all, code-shaped or not. Looser than
+#: :data:`_CODE_POSITION` on purpose: it is the *population* the gate is
+#: measured against, so that "nothing matched" and "nothing is wrong" cannot
+#: be confused.
+_ANY_LEADING_TOKEN = re.compile(r"^([A-Za-z][A-Za-z0-9_]*): ")
+
+#: The bare logger prefixes written in the tree that are **not** code-shaped,
+#: because none contains an underscore. Named so the scan has a positive
+#: control: a sweep that found none of these has stopped reading files, and
+#: every "no code-shaped prefix found" below it would then be vacuous.
+_PREFIXES_THAT_ARE_NOT_CODE_SHAPED = frozenset(
+    {"manifest", "readyz", "startup", "status"}
+)
+
+
+def _logger_format_strings() -> list[tuple[str, int, str]]:
+    """``(path, lineno, message)`` for every logger call with a literal.
+
+    ``/importers/`` is scanned here although :data:`SKIPPED` excludes it
+    from the raise-site sweep. That exclusion is about *raises*, which an
+    offline importer cannot turn into a response; a log line is a
+    readability hazard wherever it is written, and ``manifest:`` -- one of
+    the five -- lives there.
+    """
+    found: list[tuple[str, int, str]] = []
+    for root in SCANNED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            if "/tests/" in str(path):
+                continue
+            tree = ast.parse(path.read_text())
+            relative = str(path.relative_to(REPO_ROOT))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if (
+                    not isinstance(func, ast.Attribute)
+                    or func.attr not in _LOG_LEVEL_METHODS
+                    or not node.args
+                ):
+                    continue
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    found.append((relative, node.lineno, first.value))
+                elif isinstance(first, ast.JoinedStr) and first.values:
+                    head = first.values[0]
+                    if isinstance(head, ast.Constant) and isinstance(head.value, str):
+                        found.append((relative, node.lineno, head.value))
+    return found
+
+
+def _logger_prefixes() -> dict[str, list[str]]:
+    """``token -> ["path:lineno", ...]`` for logger messages opening with one."""
+    prefixes: dict[str, list[str]] = {}
+    for relative, lineno, message in _logger_format_strings():
+        match = _ANY_LEADING_TOKEN.match(message)
+        if match:
+            prefixes.setdefault(match.group(1), []).append(f"{relative}:{lineno}")
+    return prefixes
+
+
+class TestNoLoggerFormatStringSitsInTheCodePosition:
+    """A log line is not a response, and must not read like a declaration.
+
+    ``geometry_validation: chemistry layer raised for calculation_id=%s``
+    reached no response body, so nothing was ever advertised wrongly. It
+    was still worth rewording, and the reason is the one #161, #173 and
+    #178 each cost a PR to learn: in this codebase a snake_case token in
+    front of a colon *is* how a code is declared. A string that carries
+    that shape without being a code is read as one -- by a person, and by
+    the next scan somebody widens.
+
+    ``geometry_validation`` was the only one of the five bare logger
+    prefixes that could be, because it was the only one containing an
+    underscore, and :data:`_CODE_POSITION` requires one. ``manifest``,
+    ``readyz``, ``startup`` and ``status`` cannot match it and are left
+    alone -- reworded strings nobody needed to rewrite are their own
+    kind of noise.
+
+    Note what this does **not** claim. ``detail_code``'s legacy character
+    test does not require an underscore, so all five would be code-shaped
+    to *it*; what stops them reaching a body is that promotion is gated on
+    the catalogue, asserted directly by
+    :meth:`TestTheLegacyDetailPathIsGatedToo.
+    test_an_uncatalogued_prefix_falls_back_to_the_status`. This gate is
+    about the shape a reader sees, and it is the durable answer to "a
+    string in the code position that is not a code", which is the shape
+    that has now produced four tasks.
+    """
+
+    def test_the_scan_reads_the_logger_calls_in_the_tree(self):
+        """Assert the population, so an empty sweep cannot pass as clean.
+
+        Measured 2026-08-16: 96 logger calls with a literal first argument,
+        16 of which open with a bare ``token: ``. The floor is well under
+        96 and exists to catch a scan that has stopped walking the tree,
+        not to police the count -- the same reasoning as
+        ``_MINIMUM_SITES_THE_SCAN_MUST_SEE`` in the re-raise gate.
+        """
+        messages = _logger_format_strings()
+        assert len(messages) >= 60, (
+            f"only {len(messages)} logger calls with a literal format string "
+            f"found under {[str(r) for r in SCANNED_ROOTS]}; the scan has "
+            "stopped reading files and every assertion below is vacuous"
+        )
+
+    def test_it_finds_the_bare_prefixes_that_are_written(self):
+        """The positive control: known non-code-shaped prefixes are seen."""
+        prefixes = _logger_prefixes()
+        missing = sorted(_PREFIXES_THAT_ARE_NOT_CODE_SHAPED - set(prefixes))
+        assert not missing, (
+            f"the scan no longer sees these logger prefixes: {missing}. They "
+            "are the evidence that it can see a prefix at all; without them "
+            "'no code-shaped prefix found' means nothing"
+        )
+
+    def test_no_logger_format_string_opens_in_the_code_position(self):
+        offenders = {
+            token: sites
+            for token, sites in _logger_prefixes().items()
+            if _CODE_POSITION.match(f"{token}: ")
+        }
+        assert not offenders, (
+            "these logger format strings open with a snake_case token in "
+            "front of a colon, which is how this codebase declares an error "
+            f"code: {offenders}. A log line declares nothing. Reword it -- "
+            "'geometry validation: ...' rather than 'geometry_validation: "
+            "...' -- so a reader, and the next scan somebody widens, cannot "
+            "mistake it for a code."
+        )
+
+    def test_the_remaining_prefixes_are_not_code_shaped(self):
+        """Says *why* four were left alone, rather than leaving it implied."""
+        for token in sorted(_PREFIXES_THAT_ARE_NOT_CODE_SHAPED):
+            assert "_" not in token
+            assert not _CODE_POSITION.match(f"{token}: "), (
+                f"{token!r} is code-shaped after all, so leaving it unchanged "
+                "was wrong and this gate should be failing on it"
+            )
+
+    def test_the_scan_would_notice_one(self):
+        """Provoked on source, so the detector is caught saying yes."""
+        tree = ast.parse('logger.warning("some_new_code: it went wrong")\n')
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
+        assert isinstance(node.func, ast.Attribute)
+        assert node.func.attr in _LOG_LEVEL_METHODS
+        message = node.args[0].value
+        assert _ANY_LEADING_TOKEN.match(message)
+        assert _CODE_POSITION.match(message), (
+            "the detector did not recognise a snake_case logger prefix; the "
+            "gate above would then pass over a real one"
+        )


### PR DESCRIPTION
Tasks #181 (route-boundary `except ValueError`) and #182 (two inert strings in the code position), done together because both touch the error contract and #182 asked to be folded into other work on `errors.py`.

## In plain language, first

An **error code** is a short machine-readable string like `offset_too_large` that TCKDB puts in the `code` field of an error response. Client programs branch on it — "if the code is `offset_too_large`, page back". The prose sentence beside it is for humans and may be reworded at any time; the code is a promise.

Deep in the backend, a refusal is thrown as a Python **exception** carrying that code. It travels up through many layers of function calls before FastAPI turns it into an HTTP response. Along the way, any layer can *catch* it. If a layer catches it and throws a different exception instead, the code is gone — the client gets a generic `http_422` and cannot tell one refusal from another.

Python's catching is by **type**, and it catches subclasses too. TCKDB's coded refusals are a subclass of the built-in `ValueError`. So a line reading `except ValueError` catches every coded refusal that passes through it, whether or not the author was thinking about codes. That is the hazard both halves of this PR are about.

This PR adds two automated checks — **"gates"**, meaning tests that read the source code rather than run it — and changes two strings. It changes **nothing** a client receives today.

---

## Part 1 — #181: which option, and why

**Option (c): a general rule, enforced by a test over the shape.** It proved feasible. Option (a) was not needed as a fallback.

### The premise is stale, and the site is already gone

The brief points at `backend/app/api/routes/scientific/artifacts.py:221` and a route-level `except ValueError` wrapping `search_artifact_integrity`. **That handler no longer exists on `main`.** PR #194 (`128f7da7`, *Re-raise a caught coded exception, not a bare 404/502*) removed it and left a comment in its place at `artifacts.py:215`, and in the same PR built `backend/tests/api/test_coded_exception_reraise_gate.py`.

So option (a) was already applied to this specific site by someone else, four commits ago. What is *not* done is the general rule, and that is what this PR adds.

### Why the gate that already exists does not cover it

`test_coded_exception_reraise_gate.py` enforces: *an `except` in the API layer that raises an `HTTPException` must pass the caught exception's message through.* That is a rule about what a handler **raises**.

The #181 shape passes that rule and is still a loss:

```python
except ValueError as exc:
    raise HTTPException(status_code=422, detail=str(exc)) from exc
```

The message *does* go through. But `detail=str(exc)` carries the code only where the catalogue lists it as arriving by `message_prefix`, and it drops `context` unconditionally. The existing rule cannot see this, because it asks the wrong half of the question.

What is at stake depends on how broad the clause is. I got this wrong on the first pass and corrected it after checking `issubclass` rather than assuming:

- **`except ValueError`** costs the `code` and the `context`, but **not** the status. `_value_error_handler` answers 422 and so does the `HTTPException` above it.
- **`except Exception`** costs the status too. `NotFoundError`, `DomainError` and `DataIntegrityError` are **not** `ValueError` subclasses; they have their own handlers answering 404, 400 and 500. A broad clause re-answering them as 422 changes what the response *means*, not just what it is called.

That second case is why `Exception` and `BaseException` are in the rule's trigger set and not only `ValueError`, even though the brief scoped #181 to `except ValueError`.

**Measured, not argued.** Mutation M5 below reinstates this shape on a *different* route: the existing rule stays green while the new one goes red.

### The rule added

Every `except` in `backend/app/api/**` whose caught types can absorb a `CodedValidationError` — `ValueError`, `Exception`, `BaseException`, or a bare `except:` — must do one of three things:

1. **re-raise the original** (`raise`, or `raise exc`), so `app.api.errors`'s `ValueError` handler still mints the code;
2. **intercept the coded case first**, with an earlier `except CodedValidationError` / `except CodedValueError` clause on the same `try` — this is #165's shape, i.e. option (a), deliberately kept available as the sanctioned repair;
3. **be listed in `JUDGED_ABSORBING_HANDLERS` with a written reason.**

Clause **order** is checked, because Python never reaches a `CodedValueError` clause written *below* a `ValueError` clause. Accepting that ordering would bless a repair that does nothing (mutation M3).

### Scope: the API layer only, with the price measured

The identical scan over all of `backend/app` finds **104** absorbing handlers that do not re-raise, against **8** in `app/api`. Widening the rule would demand 96 further judgements — almost all chemistry parsers and service helpers restating one *uncoded* `ValueError` as another. That is precisely the false-positive load the brief warned would get a guard disabled within a month, so the gate does not carry it.

The boundary is right on the merits too, not only on cost: `app/api` is where an exception stops being an exception and becomes a response body, and a code that is never published is a code nobody could have branched on. A refusal re-raised through ten service frames and dropped in the eleventh is still caught here, because `app/api` is the last frame it must cross.

---

## Re-derived census numbers

The brief's figures (19 sites, 18 handlers, one live loss, four deliberate translations) come from PR #165. **#165's analyser was a throwaway and is not in the repo**, so its exact 19/18 cannot be reproduced. I wrote a scan to #165's stated definition — *an `except` of a `ValueError`-family exception whose handler raises something that is not the original* — and validated it by running it against the tree **at #165's own merge commit** (`2ea4eeb8`) as well as against today's:

| stated definition, over `backend/app` + `schemas/python/tckdb-schemas` | at `2ea4eeb8` (#165 merge) | today (`703d0457`) |
|---|---|---|
| translating raise-sites | 14 | 13 |
| distinct handlers | 14 | 13 |
| distinct files | 11 | 10 |

Neither column reproduces 19/18. The one site that disappears between them is `artifacts.py:220` — the #181 site, removed by #194 — which the scan **does** find at the #165 commit, spelled exactly as the brief describes it. So the scan is reading the right thing; the 19/18 figure is either a wider definition than the sentence describing it, or it counted something the sentence does not say.

**This is a finding, not a footnote:** a census whose analyser was not committed is a number nobody can re-derive. It is the same "a list nothing re-checks" failure that `test_coded_exception_reraise_gate.py`'s own docstring warns about, applied to the survey rather than to the list. Both scans in this PR are committed as tests, so the next person re-derives them by running `pytest`.

Re-derived against the rule this PR actually enforces (**the absorbing definition**, over `backend/app/api`), measured 2026-08-16:

| | count |
|---|---|
| handlers that can absorb a coded refusal | **9** |
| of those, safe by bare re-raise (no entry needed) | **1** — `deps.py::get_write_db` |
| judged, with a written reason | **8** |
| unlisted / failing the gate | **0** |
| the same scan over all of `backend/app` | **104** |

Live losses on `main` today: **none found.** The `artifacts.py` one was the last, and #194 fixed it. Nothing in this PR repairs a live defect; it stops the next one.

---

## The four deliberate translations, and how they stay exempt

These are exactly the four handlers catching plain `ValueError` in the API layer. Every one is, mechanically, a coded refusal being turned into something else, and every one is right. They are the reason the exemption mechanism is an **explicit dict with a written reason per site**, not an inference from shape.

| handler | what it does | why it is right |
|---|---|---|
| `routes/lookup.py::_resolve_species_list` | `canonical_species_identity` can raise `CodedValueError` (`species_smiles_charge_mismatch`); becomes `reactant_not_found` / `product_not_found` in the match block | The lookup contract answers **200 with a `match` block**. An unresolvable reactant is a *result*, not a refusal — there is no error body for a code to be lost from. The coded message survives verbatim inside the reason text (`f"...: {e}"`). |
| `routes/lookup.py::lookup_species` | same, one subject; becomes `species_identity_none` | A 422 here would make lookup the only read route that refuses a query it simply cannot satisfy. |
| `routes/lookup.py::lookup_species_calculation` | same, on the calculation lookup | Three separate entries rather than one `lookup.py` wildcard: a wildcard would also exempt a fourth handler nobody had read. |
| `routes/health.py::_sanitized_endpoint` | `urlsplit` fails → returns the literal `"(unparseable)"` | Formats an object-store URL for `/status`. The only raiser under the `try` is `urlsplit`, which raises a bare `ValueError`; the function returns a display string, not a response body, so there is no `code` field for one to have reached. |

Verified live rather than assumed: `canonical_species_identity` really does raise `CodedValueError` (`backend/app/chemistry/species.py:584`), so three of the four are genuine coded-refusal absorptions today, not hypothetical ones.

`test_the_four_deliberate_translations_are_still_exactly_four` pins the set **by name**, and additionally asserts the scan still finds each one — so an exemption that has stopped protecting anything fails, rather than silently covering a later regression at the same site.

The other four entries are broad `except Exception` diagnostics on no refusal path: `auth.py::_migrate_password_hash` (opportunistic password rehash on an already-successful login), `health.py::_probe_bucket`, and two boot probes in `startup_checks.py`. The ninth handler — `deps.py::get_write_db`, the write-session dependency every write request passes through — needs no entry at all, because it ends in a bare `raise`. That is asserted directly, so the classifier is caught saying "no entry needed" about a *real* site and not only about a synthetic one.

---

## Part 2 — #182

### `fallback_code="database_error"` — **kept**, and now stated at the site

The brief offered remove-or-justify. Keeping it is not a matter of taste here; removing it is blocked twice, and both blocks are measured rather than reasoned:

1. **`fallback_code` is a required keyword-only parameter** of `error_envelope` (no default — checked by introspection). There is no "drop the dead argument" that leaves the call valid.
2. **`code_catalogue.py` names `errors.py` as `database_error`'s origin.** I mutated the call to `fallback_code=code` and ran `pytest tests/api/test_api_code_catalogue.py -k origin`: `test_every_origin_still_defines_its_code` goes **red** with `database_error: not written as a literal in backend/app/api/errors.py`. Removing the literal would additionally require deleting a catalogued 503 code from the enumeration the client's `RejectionCode` enum is generated from.

The catalogue entry already explains the deadness. What was missing is that a reader at the call site saw only a dead string. An eleven-line comment now says it is unreachable, why it stays, and where the fuller record lives. **Comment only** — `git diff` on `errors.py` is additive comment lines and nothing else.

### `geometry_validation: ` — **reworded**, and gated

`backend/app/services/geometry_validation.py` opened a `logger.exception` format string with `geometry_validation: `. It reaches no response body, so nothing was ever advertised wrongly. It is still worth changing, for the reason #161, #173 and #178 each cost a PR to learn: **in this codebase a snake_case token in front of a colon *is* how a code is declared.** A string carrying that shape without being a code is read as one — by a person, and by the next scan somebody widens.

The sharp reason it was the one singled out, re-derived: across `backend/app` + `tckdb_schemas` there are **16** logger calls whose format string opens with a bare `token: `, spanning **5** distinct tokens — `geometry_validation`, `manifest`, `readyz`, `startup`, `status`. Exactly one, `geometry_validation`, matches `_CODE_POSITION_PATTERN`, **because it is the only one containing an underscore**. The other four cannot match it and are deliberately left alone; reworded strings nobody needed to rewrite are their own kind of noise.

It now reads `"geometry validation: …"` (space, not underscore), with a comment saying why, plus a new gate `TestNoLoggerFormatStringSitsInTheCodePosition` that fails on the next one written the old way. This is the #178 repair shape — reword so the token is not in the code position — rather than an annotation.

Note what the new gate does **not** claim. `detail_code`'s legacy character test does not require an underscore, so all five would be code-shaped to *it*. What stops those reaching a body is that promotion is gated on the catalogue, already asserted by `test_an_uncatalogued_prefix_falls_back_to_the_status`. The new gate is about the shape a *reader* sees, and it is the durable answer to "a string in the code position that is not a code" — the shape that has now produced four tasks.

The two census docstrings that enumerated all five (`app/api/error_contract.py` and the catalogue gate file) are updated so the record does not go stale.

---

## Guarding against a vacuous pass

The deliverable is two source-scanning gates, which is the shape most exposed to passing having checked nothing. Both carry:

- **an asserted population floor**, derived the way the real code derives it — `_MINIMUM_ABSORBING_HANDLERS_THE_SCAN_MUST_SEE = 6` against 9 measured, and `>= 60` logger calls against 96 measured;
- **a positive control** — the absorbing scan must find and classify `deps.py::get_write_db` as safe-by-re-raise; the logger scan must find the four known non-code-shaped prefixes, so "no code-shaped prefix found" cannot silently mean "found nothing at all";
- **a negative control provoked on source** — the classifier is caught saying *no* to the exact `except ValueError -> HTTPException(422, str(exc))` shape, and *yes* to a synthetic `logger.warning("some_new_code: ...")`;
- **a key-collision test** — two absorbing handlers in one function would merge on the qualname key and one would leave the sweep; the merge keeps the *unsafe* verdict and fails loudly rather than hiding it;
- **staleness in both directions** — a new unlisted site fails, and a listed site that no longer absorbs fails.

No `all(...)` over a possibly-empty sequence carries an assertion on its own anywhere in either gate.

The floors are not decorative. My first draft asserted `> 200` logger calls and the population test **caught my own guess** — the real number is 96. It was corrected from the measurement rather than deleted.

One permissiveness hole was found while reviewing the classifier and closed in a follow-up commit. `_reraises_the_original` originally searched the handler's whole subtree with `ast.walk`, so a `raise` inside a closure the handler merely *defines* would have counted as re-raising and silently exempted the site. It now skips nested `def`/`lambda` bodies, provoked in both directions: a `raise` inside a nested `def` is not a re-raise, and a real re-raise standing beside a nested `def` still counts. No live site was affected — this was permissiveness waiting to be used, which is the direction that matters for a gate.

### Mutations landed

Each was confirmed present by `git diff` before the run, then restored with `__pycache__` cleared.

| # | mutation | expected | result |
|---|---|---|---|
| M1 | reinstate `except ValueError: raise HTTPException(422, str(exc))` on `artifacts.py::artifact_integrity_search` — the #181 site verbatim | RED | **RED**, 2 tests, naming the site |
| M2 | add `except CodedValueError: raise` **above** it (option (a), the sanctioned repair) | GREEN | **GREEN**, all passed |
| M3 | move that same clause **below** the `ValueError` clause, where Python never reaches it | RED | **RED**, 2 tests |
| M4 | restore the `geometry_validation: ` logger prefix | RED | **RED**, naming file and line |
| M5 | the same swallow on a **different** route — `scientific/thermo.py::species_thermo`, wrapping `resolve_species_entry_handle`, which does raise coded refusals | RED | **RED** — and the *pre-existing* rule stayed green, which is the evidence that the new rule covers a shape the old one cannot see |

M2 matters as much as M1: a gate that cannot be satisfied by the correct repair forces exemptions instead of fixes. M5 matters because it proves the gate is general rather than anchored to the one file it was written about.

`git status` is clean after the sweep — no mutation survived in the tree.

---

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no Pydantic schema, no new environment variable. `app/api/code_catalogue.py` is unchanged, so the generated `clients/python/src/tckdb_client/rejection_codes.py` is unchanged and `clients/python/pyproject.toml` needs no version bump.

## What a client sees

**Nothing changes on the wire.** The three production files touched are:

- `app/api/errors.py` — comment lines only;
- `app/api/error_contract.py` — module docstring only;
- `app/services/geometry_validation.py` — one **log** message string plus a comment.

Log output is not the response contract, so the only externally visible effect of any kind is that an operator grepping server logs for the exact string `geometry_validation:` should now grep `geometry validation:`. Called out explicitly because it is the single observable change in this PR.

No existing test was weakened, skipped, xfailed or deleted. No database primary key appears in any user-facing error detail (DR-0028 Req 2); neither gate touches response bodies at all.

## Exact commands run

From the worktree, `conda run -n tckdb_env`, `DB_TEST_NAME=tckdb_test_181182`. `git diff` taken from the repository root throughout.

```
python -m pytest tests/api/test_coded_exception_reraise_gate.py -q -p no:randomly
    # 18 passed
python -m pytest tests/api/test_error_contract_catalogue_gate.py -q -p no:randomly
    # 24 passed
python -m pytest tests/api/test_coded_exception_reraise_gate.py \
                tests/api/test_error_contract_catalogue_gate.py \
                tests/api/test_api_code_catalogue.py \
                tests/api/test_error_contract_coded_promotion.py \
                tests/workflows/test_geometry_validation_wiring.py -q -p no:randomly
    # 75 passed
python -m pytest tests/ -q -p no:randomly
    # 7949 passed, 14 skipped in 2958.13s (0:49:18)
ruff check app tests                     # All checks passed! (from backend/)
python scripts/check_runtime_ascii.py    # clean, 438 files under app
```

One sequencing caveat, stated rather than left to be noticed: the 49-minute full run started before the last two commits, which are **test-file-only** edits to `test_coded_exception_reraise_gate.py` (the nested-`def` narrowing and the docstring correction). No other module imports that file — checked by grep — so re-running it against the final tree is complete coverage of the delta:

```
python -m pytest tests/api/test_coded_exception_reraise_gate.py \
                tests/api/test_error_contract_catalogue_gate.py \
                tests/api/test_api_code_catalogue.py -q -p no:randomly
    # 56 passed, against the final tree
```

No production file changed after the full run began.

The census re-derivation was run against both the current tree and a `git archive` extraction of `2ea4eeb8` (#165's merge commit), so the analyser could be validated against the numbers it was meant to reproduce.

Three other pytest runs shared this PostgreSQL server during the session (concurrent agents). Runs were scoped to a private `DB_TEST_NAME`; no scratch database outside `tckdb_test*` was created, and nothing touched the Pi, `.env.pi`, or any deployed database.
