### PR TITLE
Say which field registration refused, not that one was

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -451,6 +451,22 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("domain_error", 400, Surface.generic_fallback,
             "backend/app/api/errors.py"),
+    ApiCode("email_taken", 409, Surface.message_prefix,
+            "backend/app/api/routes/auth.py",
+            note=(
+                "Registration only, and paired with username_taken. Both "
+                "arrive at 23505 -- a unique violation says nothing about "
+                "which rule fired -- so the two are told apart by the "
+                "constraint name psycopg reports in exc.orig.diag, not by "
+                "the SQLSTATE and not by parsing the driver's message. "
+                "Before #225 both answered http_409 with one sentence "
+                "covering two fields, which is why a sign-up form could "
+                "not highlight the input at fault; unique_conflict, the "
+                "only code the SQLSTATE alone supports, would have been "
+                "the same problem with a code attached. Discloses nothing "
+                "registration does not already disclose by refusing at "
+                "all -- and that argument covers this endpoint only."
+            )),
     ApiCode("energy_transfer_scope_columns_disagree", 409, Surface.database_constraint,
             "backend/app/scientific_checks/declarations.py"),
     ApiCode("export_all_cap_exceeded", 422, Surface.message_prefix,
@@ -856,6 +872,16 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/chemistry/units.py"),
     ApiCode("unsupported_release_record_type", 422, Surface.message_prefix,
             "backend/app/services/release/records.py"),
+    ApiCode("username_taken", 409, Surface.message_prefix,
+            "backend/app/api/routes/auth.py",
+            note=(
+                "The sibling of email_taken; see that entry for why the "
+                "pair exists and how they are told apart. 409 rather than "
+                "422 under Calvin's 2026-08-16 decision: the payload is "
+                "well formed and the name is simply spoken for, which is "
+                "a state conflict. There is no corrected body for the "
+                "same username, only a different one."
+            )),
     ApiCode("validation_error", 422, Surface.generic_fallback,
             "backend/app/api/errors.py"),
     ApiCode("withdraw_reason_required", 422, Surface.message_prefix,

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -39,6 +39,42 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+#: The ``app_user`` uniqueness rules registration can trip, mapped to the
+#: refusal each one produces, keyed on the name PostgreSQL reports for the
+#: constraint. ``NAMING_CONVENTION`` spells these
+#: ``uq_%(table_name)s_%(column_0_name)s``; the model declares both in
+#: :class:`app.db.models.app_user.AppUser.__table_args__`.
+#:
+#: Two codes rather than one is the whole point. A taken username and a
+#: taken email address raise the same SQLSTATE (23505), so anything
+#: derived from the SQLSTATE alone can only say ``unique_conflict`` --
+#: which is *less* than the English sentence this replaced, because a
+#: form has two fields and no way to tell which one to highlight. The
+#: constraint name is the only thing in the error that distinguishes
+#: them.
+#:
+#: Read from ``exc.orig.diag.constraint_name`` -- psycopg's structured
+#: diagnostics -- and never from the driver's message text, matching
+#: :func:`app.services.idempotency._is_idempotency_unique_violation` and
+#: :func:`app.api.errors._integrity_error_handler`. The message text is
+#: prose PostgreSQL is free to reword between versions and locales; the
+#: diagnostic field is part of the wire protocol.
+#:
+#: ``backend/tests/db/test_auth_registration_constraint_names.py`` checks
+#: both names against live ``pg_constraint``, so renaming one in a
+#: migration fails there rather than silently demoting a registration
+#: refusal back to the generic sentence.
+REGISTRATION_CONFLICTS: dict[str, str] = {
+    "uq_app_user_username": "username_taken: That username is already in use.",
+    "uq_app_user_email": "email_taken: That email address is already in use.",
+}
+
+#: What registration says when the write was refused by something other
+#: than the two rules above. Deliberately the sentence that was there
+#: before: an unrecognised constraint is exactly the case where naming a
+#: field would be a guess.
+REGISTRATION_CONFLICT_FALLBACK = "Username or email already in use."
+
 
 # ---------------------------------------------------------------------------
 # Schemas
@@ -150,6 +186,45 @@ def _migrate_password_hash(session: Session, user: AppUser, plain: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _registration_conflict_detail(exc: IntegrityError) -> str:
+    """Name the field registration refused, when the driver named it.
+
+    Returns a ``"code: message"`` detail, which
+    :func:`app.api.error_contract.error_envelope` promotes into the
+    ``code`` field of the body. Before this, both refusals arrived as
+    ``http_409`` with one sentence covering two fields, so a sign-up form
+    could not highlight the offending input without string-matching
+    English.
+
+    Call this *before* ``session.rollback()``. Rollback does not clear
+    ``exc.orig``, but reading the classification off the exception while
+    it is still the live failure keeps the two from drifting apart if the
+    rollback ever grows a retry.
+
+    Discloses nothing registration did not already disclose. Refusing a
+    taken username is inherent to letting anyone choose one, and the same
+    is true of an address the deployment has agreed to hold at most once.
+    That is an argument about *this* endpoint only: no other route may
+    grow a "does this account exist" answer on the strength of it.
+    """
+    constraint = getattr(getattr(exc.orig, "diag", None), "constraint_name", None)
+    detail = REGISTRATION_CONFLICTS.get(constraint or "")
+    if detail is not None:
+        return detail
+    # A 23505 on some other rule, or a driver that reported no constraint
+    # at all. The old sentence is the honest answer: something unique
+    # collided and this function cannot say which. Logged with the
+    # constraint name -- not returned with it -- so the next such refusal
+    # can be classified instead of guessed at.
+    logger.warning(
+        "registration refused by an unmapped integrity rule: constraint=%r "
+        "sqlstate=%r",
+        constraint,
+        getattr(exc.orig, "sqlstate", None),
+    )
+    return REGISTRATION_CONFLICT_FALLBACK
+
+
 @router.post("/register", response_model=MeResponse, status_code=201)
 def register(
     request: RegisterRequest,
@@ -178,11 +253,10 @@ def register(
     session.add(user)
     try:
         session.flush()
-    except IntegrityError:
+    except IntegrityError as exc:
+        detail = _registration_conflict_detail(exc)
         session.rollback()
-        raise HTTPException(
-            status_code=409, detail="Username or email already in use."
-        ) from None
+        raise HTTPException(status_code=409, detail=detail) from None
 
     ttl = session_ttl_for_role(user.role)
     _, token = create_session(session, user, ttl=ttl)

--- a/backend/tests/api/test_api_auth.py
+++ b/backend/tests/api/test_api_auth.py
@@ -20,7 +20,7 @@ from app.api.app import create_app
 from app.api.code_catalogue import CATALOGUE
 from app.api.config import settings
 from app.api.deps import get_db, get_write_db
-from app.api.error_contract import _CODE_POSITION_PATTERN as _CODE_POSITION
+from app.api.error_contract import detail_code
 from app.api.routes import auth as auth_routes
 from app.db.models.app_user import AppUser
 from app.db.models.common import AppUserRole
@@ -820,9 +820,11 @@ class TestRegistrationConflictCodes:
         detail = auth_routes._registration_conflict_detail(exc)
         assert detail == auth_routes.REGISTRATION_CONFLICT_FALLBACK
         assert "uq_app_user_something_new" not in detail
-        # Nothing in the code position, so the envelope reports http_409
-        # rather than inventing a code for a rule nobody classified.
-        assert not _CODE_POSITION.match(detail)
+        # Nothing in the code position, so the envelope reports the
+        # status fallback rather than inventing a code for a rule nobody
+        # classified. Asserted through the promotion helper the handler
+        # actually uses, not against a copy of its regex.
+        assert detail_code(detail, fallback="http_409") == "http_409"
 
     def test_a_driver_reporting_no_constraint_falls_back(self):
         """``diag`` is absent on some wrapped errors; that must not raise."""
@@ -840,17 +842,21 @@ class TestRegistrationConflictCodes:
         code, and break no other assertion in this file that a wire test
         happens not to cover.
 
+        Read through :func:`~app.api.error_contract.detail_code`, the
+        helper the ``HTTPException`` handler itself calls, so this also
+        covers the half a regex cannot see: promotion is gated on the
+        catalogue, so a code present in the sentence but *absent from*
+        ``CATALOGUE`` as ``message_prefix`` is silently not promoted.
+
         The codes are also required to be *distinct*, which is the whole
         premise: two constraints answering one code is exactly the
         under-specified ``unique_conflict`` this replaced, wearing a more
         specific name.
         """
-        codes = {}
-        for constraint, detail in auth_routes.REGISTRATION_CONFLICTS.items():
-            match = _CODE_POSITION.match(detail)
-            assert match is not None, (constraint, detail)
-            codes[constraint] = match.group(1)
-
+        codes = {
+            constraint: detail_code(detail, fallback="http_409")
+            for constraint, detail in auth_routes.REGISTRATION_CONFLICTS.items()
+        }
         assert codes == {
             "uq_app_user_username": "username_taken",
             "uq_app_user_email": "email_taken",

--- a/backend/tests/api/test_api_auth.py
+++ b/backend/tests/api/test_api_auth.py
@@ -14,10 +14,13 @@ from datetime import timedelta
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from app.api.app import create_app
+from app.api.code_catalogue import CATALOGUE
 from app.api.config import settings
 from app.api.deps import get_db, get_write_db
+from app.api.error_contract import _CODE_POSITION_PATTERN as _CODE_POSITION
 from app.api.routes import auth as auth_routes
 from app.db.models.app_user import AppUser
 from app.db.models.common import AppUserRole
@@ -660,3 +663,214 @@ class TestLoginAccountEnumeration:
         assert len(verify_calls) == 1
         # `verify_password` burns an equivalent hash internally for this case.
         assert verify_calls[0] is None
+
+
+# ---------------------------------------------------------------------------
+# 10. Registration conflicts name the field they refused
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationConflictCodes:
+    """Which field was taken, as a code, not as an English sentence.
+
+    A taken username and a taken email address both arrive as SQLSTATE
+    23505, so nothing derived from the SQLSTATE can tell them apart --
+    ``unique_conflict`` would be a code that says less than the prose it
+    replaced. The route reads the constraint name out of psycopg's
+    structured diagnostics instead, and these tests hold it to reporting
+    a *different* code for each, because a handler answering one code for
+    both would pass any test asserting only that a 409 arrived.
+
+    Each conflict gets its own test function. Registration's rollback on
+    conflict unwinds the transaction the fixture holds open, which takes
+    the first account with it -- so provoking both conflicts inside one
+    test makes the second one register successfully and prove nothing.
+    That is not a quirk of the route; in production every request has its
+    own session. It is a property of the shared txn-scoped fixture, and
+    it silently turned a two-conflict reproduction into a 201.
+    """
+
+    def test_a_free_username_and_email_are_accepted(self, raw_client):
+        """The accepted case, so the codes below are not vacuous.
+
+        A route that 409'd on every registration would satisfy both
+        conflict tests. This is what says the 409s are refusals of
+        something specific rather than the endpoint's only behaviour.
+        """
+        resp = raw_client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "novel-name",
+                "email": "novel-name@example.org",
+                "password": "password-123",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        body = resp.json()
+        assert body["username"] == "novel-name"
+        assert "code" not in body
+
+    def test_a_taken_username_reports_username_taken(self, raw_client):
+        first = raw_client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "taken-name",
+                "email": "first@example.org",
+                "password": "password-123",
+            },
+        )
+        assert first.status_code == 201, first.json()
+        raw_client.cookies.clear()
+
+        resp = raw_client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "taken-name",
+                # A free address, so only the username can be the cause.
+                "email": "second@example.org",
+                "password": "password-123",
+            },
+        )
+        assert resp.status_code == 409, resp.json()
+        body = resp.json()
+        assert body["code"] == "username_taken", body
+        assert body["code"] != "email_taken"
+        # The sentence stays useful to a human reading a traceback, and
+        # now says which field -- the old one could not. The ``"code: "``
+        # prefix stays in ``detail`` as well; that is the convention
+        # every other message_prefix refusal follows, not an oversight.
+        assert "username" in body["detail"].lower()
+        assert body["detail"] != auth_routes.REGISTRATION_CONFLICT_FALLBACK
+        # No row id reaches the client (DR-0028 Requirement 2), and there
+        # is nothing structured to carry here beyond the code.
+        assert body["context"] == {}
+
+    def test_a_taken_email_reports_email_taken(self, raw_client):
+        first = raw_client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "first-name",
+                "email": "taken@example.org",
+                "password": "password-123",
+            },
+        )
+        assert first.status_code == 201, first.json()
+        raw_client.cookies.clear()
+
+        resp = raw_client.post(
+            "/api/v1/auth/register",
+            json={
+                # A free username, so only the address can be the cause.
+                "username": "second-name",
+                "email": "taken@example.org",
+                "password": "password-123",
+            },
+        )
+        assert resp.status_code == 409, resp.json()
+        body = resp.json()
+        assert body["code"] == "email_taken", body
+        assert body["code"] != "username_taken"
+        assert "email" in body["detail"].lower()
+        assert body["detail"] != auth_routes.REGISTRATION_CONFLICT_FALLBACK
+        assert body["context"] == {}
+
+    def test_an_omitted_email_is_not_a_conflict(self, raw_client):
+        """NULL is not equal to NULL, so address-less accounts coexist.
+
+        Worth pinning: ``email`` is nullable *and* unique, and a reader
+        who sees ``UniqueConstraint("email")`` may reasonably expect the
+        second address-less registration to be refused. PostgreSQL's
+        default ``NULLS DISTINCT`` is what makes registration without an
+        address usable at all, and a migration adding ``NULLS NOT
+        DISTINCT`` would take that away silently.
+        """
+        first = raw_client.post(
+            "/api/v1/auth/register",
+            json={"username": "no-address-one", "password": "password-123"},
+        )
+        assert first.status_code == 201, first.json()
+        raw_client.cookies.clear()
+
+        second = raw_client.post(
+            "/api/v1/auth/register",
+            json={"username": "no-address-two", "password": "password-123"},
+        )
+        assert second.status_code == 201, second.json()
+
+    def test_an_unmapped_constraint_falls_back_without_naming_a_field(self):
+        """The fallback must not guess, and must not leak the constraint.
+
+        Exercised against the classifier directly: provoking an unmapped
+        ``app_user`` uniqueness rule through the wire would mean adding
+        one to the schema, and the point of the branch is what it does
+        about a rule that is *not* in the model today -- one a future
+        migration adds and nobody remembers to classify.
+        """
+
+        class _Diag:
+            constraint_name = "uq_app_user_something_new"
+
+        class _Orig:
+            diag = _Diag()
+            sqlstate = "23505"
+
+        exc = IntegrityError("stmt", {}, Exception())
+        exc.orig = _Orig()  # type: ignore[assignment]
+
+        detail = auth_routes._registration_conflict_detail(exc)
+        assert detail == auth_routes.REGISTRATION_CONFLICT_FALLBACK
+        assert "uq_app_user_something_new" not in detail
+        # Nothing in the code position, so the envelope reports http_409
+        # rather than inventing a code for a rule nobody classified.
+        assert not _CODE_POSITION.match(detail)
+
+    def test_a_driver_reporting_no_constraint_falls_back(self):
+        """``diag`` is absent on some wrapped errors; that must not raise."""
+        exc = IntegrityError("stmt", {}, Exception())
+        assert (
+            auth_routes._registration_conflict_detail(exc)
+            == auth_routes.REGISTRATION_CONFLICT_FALLBACK
+        )
+
+    def test_both_mapped_details_declare_their_code(self):
+        """Each mapping value must actually carry a code in the code position.
+
+        The promotion is by convention -- a ``"code: message"`` prefix --
+        so a value edited into plain prose would keep the 409, lose the
+        code, and break no other assertion in this file that a wire test
+        happens not to cover.
+
+        The codes are also required to be *distinct*, which is the whole
+        premise: two constraints answering one code is exactly the
+        under-specified ``unique_conflict`` this replaced, wearing a more
+        specific name.
+        """
+        codes = {}
+        for constraint, detail in auth_routes.REGISTRATION_CONFLICTS.items():
+            match = _CODE_POSITION.match(detail)
+            assert match is not None, (constraint, detail)
+            codes[constraint] = match.group(1)
+
+        assert codes == {
+            "uq_app_user_username": "username_taken",
+            "uq_app_user_email": "email_taken",
+        }, codes
+        assert len(set(codes.values())) == len(codes), codes
+
+    def test_the_two_codes_are_catalogued_at_the_status_they_arrive_at(self):
+        """A code a client cannot import is a code it cannot branch on.
+
+        The catalogue gates the generated ``RejectionCode`` enum, and an
+        entry filed at the wrong status would give a caller the wrong
+        retry advice -- 422 says "resend a corrected payload", which is
+        false of a username somebody else holds.
+        """
+        entries = {
+            entry.code: entry
+            for entry in CATALOGUE
+            if entry.code in {"username_taken", "email_taken"}
+        }
+        assert set(entries) == {"username_taken", "email_taken"}
+        for entry in entries.values():
+            assert entry.status == 409, entry
+            assert entry.is_client_facing, entry

--- a/backend/tests/api/test_coded_exception_reraise_gate.py
+++ b/backend/tests/api/test_coded_exception_reraise_gate.py
@@ -81,16 +81,28 @@ API_ROOT = REPO_ROOT / "backend" / "app" / "api"
 #: Keep this small. An entry is a standing claim that a client loses
 #: nothing, and every one of them should name the test that checked it.
 JUDGED_SITES: dict[str, str] = {
-    "backend/app/api/routes/auth.py:181": (
-        "Registration catches IntegrityError to roll back before answering. "
-        "Letting it through would reach the IntegrityError handler and "
-        "publish `unique_conflict` -- a real code, but one that says less "
-        "than the message it would replace ('Username or email already in "
-        "use'), because a duplicate username and a duplicate email are the "
-        "same SQLSTATE. The honest repair is a code of its own for this "
-        "condition, which needs a catalogue entry and a client release; it "
-        "is filed separately rather than smuggled in here. Deliberately "
-        "left as `http_409`."
+    "backend/app/api/routes/auth.py:256": (
+        "Registration catches IntegrityError to roll back before answering, "
+        "and this entry is the *completed* half of the one it replaces. "
+        "That entry said letting the exception through would publish "
+        "`unique_conflict` -- a real code that says less than the sentence "
+        "it replaced, because a duplicate username and a duplicate email "
+        "are the same SQLSTATE -- and that the honest repair was a code of "
+        "its own, filed separately rather than smuggled in. #225 is that "
+        "repair: the site now reads `exc.orig.diag.constraint_name` and "
+        "raises `username_taken` or `email_taken`, so it mints a *stricter* "
+        "code than the handler it bypasses rather than losing one. "
+        "Still listed, and still a replaced message, because the scan's "
+        "question is mechanical -- `detail=` is not built from `str(exc)` "
+        "-- and answering it by inlining the call into the `raise` would "
+        "reorder the classification after `session.rollback()` to satisfy a "
+        "text match. What a client loses: nothing, and it gains the field "
+        "name. Checked by test_api_auth.py::TestRegistrationConflictCodes "
+        "on the wire, and by "
+        "test_auth_registration_constraint_names.py against pg_constraint. "
+        "An unrecognised constraint still answers `http_409`, which is the "
+        "old behaviour kept deliberately for the case where naming a field "
+        "would be a guess."
     ),
 }
 

--- a/backend/tests/db/test_auth_registration_constraint_names.py
+++ b/backend/tests/db/test_auth_registration_constraint_names.py
@@ -1,0 +1,156 @@
+"""The constraint names registration classifies on must be real names.
+
+``/auth/register`` tells a client *which* field it refused --
+``username_taken`` or ``email_taken`` -- and the only thing in a unique
+violation that distinguishes the two is the constraint name PostgreSQL
+reports. Both raise SQLSTATE 23505; nothing else in the error says which
+rule fired.
+
+That makes the mapping in
+:data:`app.api.routes.auth.REGISTRATION_CONFLICTS` a set of string keys
+that have to match a name in the live catalog, and a lookup miss is
+*silent*: the route falls back to the sentence it had before, both
+refusals collapse back into one, and every test asserting "a 409 arrived"
+still passes. So the keys are measured against ``pg_constraint`` here
+rather than trusted, and a migration that renames either uniqueness rule
+fails on this file instead of quietly demoting a published code.
+
+The check is deliberately in both directions. Missing the name is the
+failure above. Having ``app_user`` grow a uniqueness rule that a
+registration payload *can* trip and the route does not classify is the
+other one -- it would answer the generic sentence, which is honest but is
+a gap somebody should be told about rather than discover from a support
+ticket.
+
+``app_user`` already carries a third uniqueness rule, ``uq_app_user_orcid``,
+and it is deliberately unclassified: ``RegisterRequest`` has no ``orcid``
+field, so no registration payload can name the column and no registration
+can collide on it. Reachability is derived from the request schema rather
+than asserted here, so the day someone adds ``orcid`` to registration the
+gap fails this file instead of shipping.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+import app.db.models  # noqa: F401  (populates Base.metadata)
+from app.api.routes.auth import REGISTRATION_CONFLICTS, RegisterRequest
+from app.db.models.app_user import AppUser
+
+
+def _live_unique_constraints(db_session, table: str) -> dict[str, set[str]]:
+    """``{constraint name: {column, ...}}`` for every UNIQUE on *table*."""
+    rows = db_session.execute(
+        text(
+            "SELECT con.conname, att.attname"
+            "  FROM pg_constraint con"
+            "  JOIN unnest(con.conkey) AS k(attnum) ON TRUE"
+            "  JOIN pg_attribute att"
+            "    ON att.attrelid = con.conrelid AND att.attnum = k.attnum"
+            " WHERE con.contype = 'u'"
+            "   AND con.connamespace = current_schema()::regnamespace"
+            "   AND con.conrelid = :table ::regclass"
+        ),
+        {"table": table},
+    ).all()
+    out: dict[str, set[str]] = {}
+    for name, column in rows:
+        out.setdefault(name, set()).add(column)
+    return out
+
+
+def _live_unique_constraint_names(db_session, table: str) -> set[str]:
+    return set(_live_unique_constraints(db_session, table))
+
+
+def _registration_writable_columns() -> set[str]:
+    """``app_user`` columns a registration payload can put a value in.
+
+    Derived from the request schema intersected with the table, so it
+    tracks a new field automatically. ``password`` is excluded by the
+    intersection -- it is stored as ``password_hash`` and is not unique
+    anyway.
+    """
+    return set(RegisterRequest.model_fields) & set(
+        AppUser.__table__.columns.keys()
+    )
+
+
+def test_every_classified_constraint_exists_in_the_live_schema(db_session):
+    live = _live_unique_constraint_names(db_session, AppUser.__tablename__)
+    missing = sorted(set(REGISTRATION_CONFLICTS) - live)
+    assert not missing, (
+        "app.api.routes.auth.REGISTRATION_CONFLICTS is keyed on constraint "
+        f"names the database does not have: {missing}. The lookup fails "
+        "silently -- registration keeps answering 409 with the generic "
+        "sentence and username_taken/email_taken stop being emitted at "
+        "all. If a migration renamed one of these, update the mapping; if "
+        "it dropped one, drop the catalogue entry and regenerate the "
+        f"client enum. Live names on {AppUser.__tablename__}: "
+        f"{sorted(live)}."
+    )
+
+
+def test_every_reachable_uniqueness_rule_is_classified(db_session):
+    """A rule registration can trip and cannot name is a silent gap.
+
+    "Reachable" is computed, not listed: a rule is reachable if any of
+    its columns is one a ``RegisterRequest`` can fill. That is what makes
+    ``uq_app_user_orcid``'s exclusion a derivation rather than an
+    exception -- adding ``orcid`` to the request schema makes it reachable
+    and fails this test on the same commit.
+    """
+    writable = _registration_writable_columns()
+    assert writable, (
+        "no RegisterRequest field maps to an app_user column, which cannot "
+        "be right and would make this test vacuous"
+    )
+    reachable = {
+        name
+        for name, columns in _live_unique_constraints(
+            db_session, AppUser.__tablename__
+        ).items()
+        if columns & writable
+    }
+    unclassified = sorted(reachable - set(REGISTRATION_CONFLICTS))
+    assert not unclassified, (
+        f"{AppUser.__tablename__} has uniqueness rules a registration "
+        f"payload can trip and the route cannot name: {unclassified}. "
+        "Tripping one answers 409 with 'Username or email already in "
+        "use.', which is wrong about which field and gives a client "
+        "nothing to branch on. Add a code for it to "
+        "REGISTRATION_CONFLICTS and to the code catalogue, then "
+        "regenerate the client enum."
+    )
+
+
+def test_the_unreachable_rule_is_unreachable_for_the_stated_reason(db_session):
+    """Pin why ``uq_app_user_orcid`` is left out, so the reason can rot loudly.
+
+    Without this, the derivation above quietly covers a shrinking set: if
+    ``RegisterRequest`` lost ``email``, ``uq_app_user_email`` would drop
+    out of ``reachable`` and the test would still pass. Naming the
+    columns registration can fill is what stops "reachable" from becoming
+    "empty".
+    """
+    assert _registration_writable_columns() == {"username", "email", "full_name"}
+    live = _live_unique_constraints(db_session, AppUser.__tablename__)
+    assert live.get("uq_app_user_orcid") == {"orcid"}, live
+    assert "orcid" not in RegisterRequest.model_fields
+
+
+def test_the_mapping_covers_the_two_columns_the_model_declares_unique(db_session):
+    """Tie the names back to the columns, not just to the catalog.
+
+    The two tests above would both stay green if ``uq_app_user_username``
+    were quietly redefined over a different column: the name would still
+    exist and still be classified, while ``username_taken`` started
+    reporting something else. Reading the column list out of the catalog
+    is what makes the code's claim about *which field* checkable.
+    """
+    columns = _live_unique_constraints(db_session, AppUser.__tablename__)
+    assert columns.get("uq_app_user_username") == {"username"}, columns
+    assert columns.get("uq_app_user_email") == {"email"}, columns
+    assert "username_taken" in REGISTRATION_CONFLICTS["uq_app_user_username"]
+    assert "email_taken" in REGISTRATION_CONFLICTS["uq_app_user_email"]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.46.0"
+version = "0.47.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -97,6 +97,7 @@ class RejectionCode(str, Enum):
     CURSOR_OFFSET_CONFLICT = "cursor_offset_conflict"
     CURSOR_QUERY_MISMATCH = "cursor_query_mismatch"
     DOI_ALREADY_RECORDED = "doi_already_recorded"
+    EMAIL_TAKEN = "email_taken"
     ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE = "energy_transfer_scope_columns_disagree"
     EXPORT_ALL_CAP_EXCEEDED = "export_all_cap_exceeded"
     EXPORT_SEED_EMPTY = "export_seed_empty"
@@ -211,6 +212,7 @@ class RejectionCode(str, Enum):
     UNSUPPORTED_RANKING_FOR_CALCULATION_TYPE = "unsupported_ranking_for_calculation_type"
     UNSUPPORTED_REACTION_MOLECULARITY = "unsupported_reaction_molecularity"
     UNSUPPORTED_RELEASE_RECORD_TYPE = "unsupported_release_record_type"
+    USERNAME_TAKEN = "username_taken"
     WITHDRAW_REASON_REQUIRED = "withdraw_reason_required"
 
 
@@ -339,6 +341,7 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.ATOM_MAP_NOT_A_BIJECTION,
         RejectionCode.CURATION_POLICY_VERSION_CONFLICT,
         RejectionCode.DOI_ALREADY_RECORDED,
+        RejectionCode.EMAIL_TAKEN,
         RejectionCode.ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE,
         RejectionCode.IDEMPOTENCY_CONFLICT,
         RejectionCode.MANIFEST_ALREADY_FROZEN,
@@ -352,6 +355,7 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.STATE_CONFLICT,
         RejectionCode.STATMECH_SUBJECT_NOT_EXACTLY_ONE,
         RejectionCode.UNIQUE_CONFLICT,
+        RejectionCode.USERNAME_TAKEN,
     }
 )
 
@@ -393,6 +397,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.CURSOR_OFFSET_CONFLICT: frozenset({422}),
     RejectionCode.CURSOR_QUERY_MISMATCH: frozenset({422}),
     RejectionCode.DOI_ALREADY_RECORDED: frozenset({409}),
+    RejectionCode.EMAIL_TAKEN: frozenset({409}),
     RejectionCode.ENERGY_TRANSFER_SCOPE_COLUMNS_DISAGREE: frozenset({409}),
     RejectionCode.EXPORT_ALL_CAP_EXCEEDED: frozenset({422}),
     RejectionCode.EXPORT_SEED_EMPTY: frozenset({422}),
@@ -507,6 +512,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.UNSUPPORTED_RANKING_FOR_CALCULATION_TYPE: frozenset({422}),
     RejectionCode.UNSUPPORTED_REACTION_MOLECULARITY: frozenset({422}),
     RejectionCode.UNSUPPORTED_RELEASE_RECORD_TYPE: frozenset({422}),
+    RejectionCode.USERNAME_TAKEN: frozenset({409}),
     RejectionCode.WITHDRAW_REASON_REQUIRED: frozenset({422}),
 }
 

--- a/clients/python/tests/test_rejection_codes.py
+++ b/clients/python/tests/test_rejection_codes.py
@@ -125,3 +125,29 @@ def test_the_enum_is_not_empty_and_covers_the_conservation_laws() -> None:
     assert RejectionCode.REACTION_MASS_BALANCE_FAILED in VALIDATION_REJECTION_CODES
     assert RejectionCode.REACTION_CHARGE_NOT_CONSERVED in VALIDATION_REJECTION_CODES
     assert RejectionCode.ATOM_MAP_ELEMENT_NOT_CONSERVED in CONFLICT_REJECTION_CODES
+
+
+def test_registration_says_which_field_was_taken() -> None:
+    """Two codes, not one, and each carrying its own retry advice.
+
+    The single obvious code for this refusal is ``UNIQUE_CONFLICT``, and
+    the server can still send it -- both of these arrive as the same
+    SQLSTATE, so anything classifying by SQLSTATE alone cannot do better.
+    That is precisely why the pair has to be checked as a *pair*: a
+    client branching on one of them is highlighting a field on a sign-up
+    form, and collapsing them back into one code, or letting one drift to
+    422, turns a correct highlight into the wrong one rather than into an
+    error anybody sees.
+
+    409 is the retry advice that matters here. 422 would tell a caller
+    "the payload was malformed, correct it and resend"; the payload was
+    fine and the name is simply spoken for, so the only useful retry is
+    with a *different* username or address.
+    """
+    assert RejectionCode.USERNAME_TAKEN != RejectionCode.EMAIL_TAKEN
+    for member in (RejectionCode.USERNAME_TAKEN, RejectionCode.EMAIL_TAKEN):
+        assert member in CONFLICT_REJECTION_CODES
+        assert member not in VALIDATION_REJECTION_CODES
+        assert REJECTION_STATUSES[member] == frozenset({409})
+        # A caller comparing against the raw ``code`` field must match.
+        assert rejection_code(member.value) is member


### PR DESCRIPTION
## Plain language first

When you sign up for an account, TCKDB can turn you away for two different
reasons: somebody already has that username, or somebody already registered
that email address. Until now it said the same thing for both — *"Username or
email already in use."* — and attached no machine-readable label. A sign-up
form receiving that has no way to know which of its two boxes to put a red
outline around. It would have to search the English sentence for the word
"username", which breaks the moment anybody rewords the sentence or translates
it.

This adds two labels, `username_taken` and `email_taken`, so a program can tell
the two apart without reading English.

**Why that is less obvious than it sounds.** The database refuses both with the
*same* error number (PostgreSQL calls it SQLSTATE 23505, "something that was
supposed to be unique wasn't"). So the one label you can derive from the error
number alone is a generic `unique_conflict` — which tells a form *less* than
the sentence it would replace. Publishing that would have been a downgrade
wearing the costume of an improvement, and it is explicitly not what this does.

What actually distinguishes the two is the **name of the rule** that refused
the write: `uq_app_user_username` versus `uq_app_user_email`. PostgreSQL
reports that name in a structured field alongside the error, and the route now
reads it.

### Terms used below

- **Constraint** — a rule the database enforces itself, independently of the
  application code. "No two accounts may share a username" is one.
- **SQLSTATE** — a five-character error code in the PostgreSQL wire protocol.
  Coarse: one value covers every uniqueness rule in the database.
- **Structured diagnostics** — extra machine-readable fields psycopg (the
  PostgreSQL driver) exposes on an error, including `constraint_name`. Distinct
  from the human-readable message text.
- **Rejection code** — TCKDB's own stable string in the `code` field of an error
  body, which clients branch on.

## Detail

### The problem, reproduced before it was changed

Both registration conflicts returned an identical body:

```
{'code': 'http_409', 'detail': 'Username or email already in use.', 'context': {}}
```

`http_409` is the fallback the envelope emits when a refusal declares no code;
it carries nothing the HTTP status line does not. Confirmed on the wire against
a real PostgreSQL, one conflict per test — see the note on test isolation below.

### How the constraint name is obtained

`exc.orig.diag.constraint_name` — psycopg's structured diagnostics, read
defensively via `getattr`. **This matches existing practice**, in three places:

- `backend/app/services/idempotency.py:246` (`_is_idempotency_unique_violation`)
- `backend/app/api/errors.py:295` (the global integrity-error handler)
- `backend/app/services/calculation_resolution.py:293`

**One outlier exists and is reported rather than quietly matched or fixed.**
`backend/app/services/cccbdb_molecular_property_import.py:364` does
`if _DEDUPE_CONSTRAINT_NAME in str(exc.orig)` — a substring search against the
driver's rendered message. That is the brittle form the brief warned about: the
message is prose PostgreSQL may reword between versions and locales, whereas the
diagnostic field is part of the wire protocol. It is an offline bulk-import
path, not an API path, and changing it is out of scope here; flagged so the
choice is a decision rather than an oversight.

### What changed

- `backend/app/api/routes/auth.py` — a module-level `REGISTRATION_CONFLICTS`
  mapping constraint name to a `"code: message"` detail, and
  `_registration_conflict_detail()` which reads the name off the exception. An
  unrecognised constraint keeps the previous sentence and logs the name it could
  not classify, so the next such refusal can be classified instead of guessed at.
  The constraint name is logged, never returned.
- `backend/app/api/code_catalogue.py` — two entries at 409,
  `Surface.message_prefix`, origin `backend/app/api/routes/auth.py`.
- `clients/python/src/tckdb_client/rejection_codes.py` — regenerated. Both
  members land in `REJECTION_STATUSES` at `frozenset({409})` and in
  `CONFLICT_REJECTION_CODES`, which is the retry advice: the payload was fine,
  so the only useful retry is with a *different* username or address.

### Status

409, per Calvin's 2026-08-16 decision, unchanged by this PR: a taken username
is a state conflict, not a malformed payload. Only the code was missing.

### A gate caught this, and it had predicted the task

`backend/tests/api/test_coded_exception_reraise_gate.py` keeps a list of
handlers that catch an exception and answer with a *new* message, each entry a
standing claim that no code is lost. The registration handler was on it, and
the entry read:

> "The honest repair is a code of its own for this condition, which needs a
> catalogue entry and a client release; it is filed separately rather than
> smuggled in here. Deliberately left as `http_409`."

This PR is that filed repair, so the entry is re-anchored (`auth.py:181` →
`:256`) and rewritten to record what landed. The site stays listed rather than
being deleted: the scan's question is mechanical — is `detail=` built from
`str(exc)`? — and mine is not, because it is built from the exception's
*diagnostics*. Satisfying the scan textually would mean inlining the call into
the `raise`, which reorders the classification to after `session.rollback()`
purely to please a string match. The entry now says so, and says a client
loses nothing and gains the field name.

Both halves of that gate failed before the fix and pass after.

### Two things found along the way

**A third uniqueness rule exists on `app_user`.** `uq_app_user_orcid` is real
and is deliberately left unclassified: `RegisterRequest` has no `orcid` field
and nothing in `backend/app` writes `AppUser.orcid`, so no registration payload
can collide on it. That exclusion is *derived* in the test from
`set(RegisterRequest.model_fields) & set(AppUser.__table__.columns)`, not
hard-coded — adding `orcid` to registration makes it reachable and fails the
test on the same commit.

**The shared test session made the first reproduction lie.** Registration's
`session.rollback()` on conflict unwinds the transaction the `db_session`
fixture holds open, which takes the *first* account with it. Provoking both
conflicts in one test therefore let the second registration succeed with a
201 — a false "these are distinguishable" reading. Not a defect in the route
(each production request has its own session); a property of the fixture. Each
conflict now gets its own test, and the class docstring records why.

### Not vacuous — measured by mutation

Five mutations, each confirmed RED, then reverted and `__pycache__` cleared:

| mutation | went red |
|---|---|
| both constraints map to `username_taken` | `test_a_taken_email_reports_email_taken`, `test_both_mapped_details_declare_their_code` |
| classifier ignores the constraint name | both wire tests |
| `register` raises `IntegrityError` unconditionally | 4 tests, incl. the accepted case |
| `uq_app_user_email` key misspelled | all 3 live-schema tests |
| client status map flipped to 422 | 2 client tests |

A sixth was landed by the code itself: the re-anchored gate entry above was
found by a red gate, not by inspection.

The third is the one the brief asked for specifically: a handler that 409s on
everything is caught by `test_a_free_username_and_email_are_accepted`.

## Schema / migration impact

**None.** No model change, no Alembic revision, no new column, no constraint
added or renamed. Both constraints already exist — `uq_app_user_username` and
`uq_app_user_email` come from `d861dfd60891` via `AppUser.__table_args__`. The
new test *reads* `pg_constraint`; it writes nothing.

## New environment variables

**None.**

## Package versions bumped

- `tckdb-client`: **0.46.0 → 0.47.0** (`clients/python/pyproject.toml`).

Additive and backward-compatible: `rejection_code()` returns `None` for a code
an older client does not know, so a client pinned below 0.47.0 keeps working
against a server carrying this change. The server's client-version floor
(`min_supported_tckdb_client_version = "0.11.0"`) is unchanged.

## Verification — and what is NOT locally verified

Commands actually run, with their results:

```bash
# The three CI gates — all green, on the final tree
conda run -n tckdb_env bash backend/scripts/test-rest.sh
#   4598 passed, 14 skipped in 172.72s
conda run -n tckdb_env bash backend/scripts/test-api.sh
#   2872 passed in 314.36s
conda run -n tckdb_env bash backend/scripts/test-scientific.sh
#   2055 passed in 191.80s

conda run -n tckdb_env python -m pytest clients/python/tests/ -q
#   1349 passed

conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py
conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py --check
#   "... is up to date."

# Targeted, during development
DB_USER=tckdb DB_PASSWORD=tckdb DB_HOST=127.0.0.1 DB_PORT=5432 \
  conda run -n tckdb_env python -m pytest \
  backend/tests/api/test_api_auth.py \
  backend/tests/db/test_auth_registration_constraint_names.py -q
#   42 passed

# Reproduction, before any edit (a temporary test file, since deleted)
DB_USER=tckdb DB_PASSWORD=tckdb DB_HOST=127.0.0.1 DB_PORT=5432 \
  conda run -n tckdb_env python -m pytest \
  backend/tests/api/test_zz_repro_scratch.py -v -s -p no:randomly
```

**One reported failure was mine to explain, not to fix.** A whole-suite run
invoked as `pytest backend/tests/` **from the repository root** failed
`test_calculation_geometry_composition.py::test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key`
with `IndexError`. That test does
`glob.glob("tests/fixtures/arc_runs/...")` — a path relative to the working
directory — and the gate scripts `cd` into `backend/` before running pytest.
So it is cwd-sensitive, it is untouched by this diff, and it passes in the
`rest` gate above. Recorded rather than quietly dropped, because "it passed
when I ran it a different way" is exactly the shape that should be stated.

**The client change is CI-verified, not locally verified.** Tests run inside a
git worktree import `tckdb_schemas` from the **main checkout** via the editable
install, not from the worktree's own tree. Any wire-package edit is therefore
exercised only in CI, and a green local client run does not prove the client
half of this change. The `clients/python/` job is also a **separate CI job from
the backend gates**, so a green backend run does not cover it either. Both are
stated here rather than papered over.

## Invariants

- No test weakened, skipped, xfailed or deleted. Two assertions in the new tests
  were corrected *before* being committed, both because my expectation was wrong
  rather than the code: the `"code: "` prefix stays in `detail` (that is the
  convention every other `message_prefix` refusal follows), and `app_user` has
  a third unique constraint.
- No database primary keys in user-facing error detail (DR-0028 Req 2) — the
  bodies carry a code and a sentence, `context` is `{}`, and the constraint name
  goes to the log rather than the response.
- **Account-existence disclosure is not widened.** Registration already
  discloses "this username is taken" — that is inherent in letting anyone choose
  one, and refusing without saying so would make the endpoint unusable. The same
  now applies to an address on a deployment that holds each at most once. That
  argument covers `/auth/register` and nothing else: no other endpoint gained an
  account-existence answer, and `login` still returns an identical 401 for an
  unknown username and a wrong password, still burning the KDF against a decoy
  so the response time is not an oracle.
