### PR TITLE
Refuse an undeclared local key instead of 500ing on it, one namespace at a time

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -484,6 +484,17 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("freq_n_imag_disagrees_with_modes", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py"),
+    ApiCode("geometry_key_unresolved", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py",
+            note=(
+                "The one member of the local-key family that does not say "
+                "'undeclared'. A geometry key is declared on a species "
+                "conformer or a transition state and resolved as the workflow "
+                "walks those owners, so a TS calculation naming a later TS's "
+                "geometry names something the payload really contains and the "
+                "workflow really cannot resolve -- calling that undeclared "
+                "would be false."
+            )),
     ApiCode("geometry_too_large", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/geometry.py"),
     ApiCode("handle_not_found", 404, Surface.coded_exception,
@@ -586,12 +597,18 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/ml_dataset.py"),
     ApiCode("ml_export_seed_unresolved", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/ml_dataset.py"),
+    ApiCode("micro_reaction_key_undeclared", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py"),
     ApiCode("multiple_structure_queries", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/structure_search.py"),
     ApiCode("n_imag_contradicts_minimum", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
+    ApiCode("network_channel_key_undeclared", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py"),
     ApiCode("network_solve_reported_requires_literature", 409, Surface.database_constraint,
             "backend/app/scientific_checks/declarations.py"),
+    ApiCode("network_state_key_undeclared", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py"),
     ApiCode("non_finite_value", 422, Surface.message_prefix,
             "backend/app/services/release/artifacts.py"),
     ApiCode("offset_too_large", 422, Surface.message_prefix,
@@ -712,6 +729,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/species_resolution.py"),
     ApiCode("species_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py"),
+    ApiCode("species_key_undeclared", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py"),
     ApiCode("species_kind_conflict", 422, Surface.coded_exception,
             "backend/app/services/species_resolution.py"),
     ApiCode("species_smiles_charge_mismatch", 422, Surface.coded_exception,
@@ -760,6 +779,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/reaction_resolution.py"),
     ApiCode("transition_state_irc_mapping_element_mismatch", 422, Surface.coded_exception,
             "backend/app/services/reaction_resolution.py"),
+    ApiCode("transition_state_key_undeclared", 422, Surface.coded_exception,
+            "backend/app/services/local_key_resolution.py"),
     ApiCode("transition_state_no_imaginary_mode", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
     ApiCode("transition_state_reaction_coordinate_ambiguous", 422, Surface.coded_exception,

--- a/backend/app/services/local_key_resolution.py
+++ b/backend/app/services/local_key_resolution.py
@@ -36,6 +36,47 @@ they run in a client that never talks to a server, and a duplicated
 check costs nothing while a missing one costs a 500. What changes here is
 that the workflow no longer *depends* on them being right.
 
+The other six namespaces, and what measuring them found
+--------------------------------------------------------
+Calculation keys were done first and the work deliberately stopped
+there, because a species key and a channel key are different keys with
+different remedies. Six more namespaces were then measured across
+``computed_reaction`` and ``network_pdep`` — species, network state,
+network channel, micro reaction, transition state, geometry — for 27
+cross-reference reads. The expectation going in was that the schema
+coverage would be uneven. It was, and worse than the calculation-key
+pass found:
+
+* ``computed_reaction`` was clean. Every one of its cross-references is
+  narrowed by ``ComputedReactionUploadRequest.validate_species_key_refs``
+  before the workflow runs.
+* ``network_pdep`` had **five** wire-reachable 500s, in five of the six
+  namespaces. Four of them — a solve's ``state_energies[].state_key``
+  and its ``channel_barriers[]`` channel, micro-reaction and
+  transition-state keys — are guarded only inside the
+  ``kind == 'computed'`` branch of
+  ``validate_mechanistic_channel_evidence``, so a ``reported`` solve
+  (ADR 0010: k(T,P) transcribed from a paper, holding none of the
+  master-equation inputs) walked straight past them into a ``KeyError``.
+  The comment above that branch says a reported solve "still has to point
+  it at a real path"; for three of those four fields it did not.
+* The fifth is the #218 asymmetry again, on a different field.
+  ``NetworkSpeciesIn`` narrows a species calculation's ``geometry_key``
+  to that species's own conformer geometries; ``TransitionStateIn`` has
+  no such validator, and ``validate_key_references`` checks TS
+  calculations against the *global* geometry namespace. So a transition
+  state's calculation could legally name a later transition state's
+  geometry, which the workflow had not resolved yet. The same shape of
+  gap, found the same way: by asking whether the guard covers *both*
+  branches rather than assuming that one implies the other.
+
+The lesson the calculation-key pass drew — that a guard in a different
+distributable package drifts silently — is only half of it. Four of these
+five gaps are in ``backend/app/schemas``, the *same* package as the
+workflow. What they have in common is not distance but conditionality:
+a guard that runs for one member of an enum and not the other, and a
+workflow that runs for both.
+
 What the refusal carries
 ------------------------
 The offending field, the key as the depositor wrote it, and the keys that
@@ -79,6 +120,80 @@ CALCULATION_KEY_REMEDY = (
     "calculation key must match one of them."
 )
 
+# ---------------------------------------------------------------------------
+# The other five namespaces
+# ---------------------------------------------------------------------------
+#
+# One code each, and deliberately not one code between them. A calculation
+# key and a species key are both "a name this upload declared", but they are
+# not the same repair: an undeclared species key is fixed in the ``species``
+# list, an undeclared state key in ``states``, an undeclared channel key in
+# ``channels``. A client that wants to point the depositor at the right block
+# of their own payload can only do that if the code says which block, and a
+# single ``local_key_undeclared`` would have made ``context['field']`` the
+# only way to tell — which is a string a client would have to parse.
+#
+# The remedy sentences all have the same shape because the payload does: every
+# one of these collections gives its members a required ``key``. That shared
+# shape is the reason these are five parameterizations of one lookup rather
+# than five lookups.
+
+#: A payload names a species key that the same upload never declared.
+W_SPECIES_KEY_UNDECLARED = "species_key_undeclared"
+
+#: A payload names a network state key that the same upload never declared.
+W_NETWORK_STATE_KEY_UNDECLARED = "network_state_key_undeclared"
+
+#: A payload names a network channel key that the same upload never declared.
+W_NETWORK_CHANNEL_KEY_UNDECLARED = "network_channel_key_undeclared"
+
+#: A payload names a micro reaction key that the same upload never declared.
+W_MICRO_REACTION_KEY_UNDECLARED = "micro_reaction_key_undeclared"
+
+#: A payload names a transition state key that the same upload never declared.
+W_TRANSITION_STATE_KEY_UNDECLARED = "transition_state_key_undeclared"
+
+#: A calculation's ``geometry_key`` names no geometry this upload has resolved
+#: for it.
+#:
+#: The one code in this module that does not say *undeclared*, because it is
+#: the one namespace where the key can be real and still unusable. A geometry
+#: key is declared on a species conformer or on a transition state, and the
+#: workflow resolves geometries as it walks those owners in order — so a
+#: transition state's calculation naming a *later* transition state's geometry
+#: names something the payload genuinely contains and the workflow genuinely
+#: cannot resolve. Calling that "undeclared" would be a refusal telling the
+#: depositor something false about their own file. The repair is the same
+#: either way and it is one repair: point the calculation at a geometry its
+#: own species or transition state declares.
+W_GEOMETRY_KEY_UNRESOLVED = "geometry_key_unresolved"
+
+_SPECIES_KEY_REMEDY = (
+    "Every species in an upload carries a required 'key'; a species key must "
+    "match one of them."
+)
+_NETWORK_STATE_KEY_REMEDY = (
+    "Every entry in 'states' carries a required 'key'; a state key must match "
+    "one of them."
+)
+_NETWORK_CHANNEL_KEY_REMEDY = (
+    "Every entry in 'channels' carries a required 'key'; a channel key must "
+    "match one of them."
+)
+_MICRO_REACTION_KEY_REMEDY = (
+    "Every entry in 'micro_reactions' carries a required 'key'; a micro "
+    "reaction key must match one of them."
+)
+_TRANSITION_STATE_KEY_REMEDY = (
+    "Every entry in 'transition_states' carries a required 'key'; a "
+    "transition state key must match one of them."
+)
+_GEOMETRY_KEY_REMEDY = (
+    "A calculation's 'geometry_key' must name a geometry declared by the "
+    "species or transition state that owns the calculation, and declared "
+    "before it."
+)
+
 T = TypeVar("T")
 
 
@@ -90,6 +205,7 @@ def resolve_declared_key(
     code: str,
     subject: str,
     remedy: str,
+    scope: str = "declared in this upload",
 ) -> T:
     """Turn one local key into whatever the request declared under it.
 
@@ -111,9 +227,17 @@ def resolve_declared_key(
         energy correction's source key had its own published code before
         this function existed and keeping it is a contract, not a
         preference.
-    :param subject: Completes "does not name ``{subject}`` declared in
-        this upload" — ``"a calculation"``, or ``"anything"`` where the
-        field accepts more than one kind of name.
+    :param subject: Completes "does not name ``{subject}`` ``{scope}``" —
+        ``"a calculation"``, or ``"anything"`` where the field accepts
+        more than one kind of name.
+    :param scope: What the namespace *is*, completing the same sentence.
+        Defaults to "declared in this upload", which is true of every
+        namespace whose map is complete before anything reads it. The
+        geometry namespace is not one of those — it is filled as the
+        workflow walks the species and transition states that declare
+        geometries — so it overrides this rather than tell a depositor
+        their key was never declared when it was declared ten lines
+        further down their own file.
     :param remedy: Sentences appended after the list of declared names.
     :returns: The value ``declared`` holds for ``key``.
     :raises CodedValueError: if ``key`` names nothing declared.
@@ -128,7 +252,7 @@ def resolve_declared_key(
         available = "This upload declares no such name at all."
     raise CodedValueError(
         code,
-        f"{field}='{key}' does not name {subject} declared in this upload. "
+        f"{field}='{key}' does not name {subject} {scope}. "
         f"{available} {remedy}".rstrip(),
         context={
             "field": field,
@@ -169,4 +293,131 @@ def resolve_calculation_key(
         code=code,
         subject="a calculation",
         remedy=CALCULATION_KEY_REMEDY,
+    )
+
+
+def resolve_species_key(
+    key: str, declared: Mapping[str, T], *, field: str
+) -> T:
+    """Resolve one upload-local *species* key, or refuse with a code.
+
+    :param key: The species key the payload wrote.
+    :param declared: The workflow's species-key namespace.
+    :param field: Field path naming the offending key.
+    :raises CodedValueError: if ``key`` names no declared species.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_SPECIES_KEY_UNDECLARED,
+        subject="a species",
+        remedy=_SPECIES_KEY_REMEDY,
+    )
+
+
+def resolve_network_state_key(
+    key: str, declared: Mapping[str, T], *, field: str
+) -> T:
+    """Resolve one upload-local network *state* key, or refuse with a code.
+
+    :param key: The state key the payload wrote.
+    :param declared: The workflow's state-key namespace.
+    :param field: Field path naming the offending key.
+    :raises CodedValueError: if ``key`` names no declared state.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_NETWORK_STATE_KEY_UNDECLARED,
+        subject="a network state",
+        remedy=_NETWORK_STATE_KEY_REMEDY,
+    )
+
+
+def resolve_network_channel_key(
+    key: str, declared: Mapping[str, T], *, field: str
+) -> T:
+    """Resolve one upload-local network *channel* key, or refuse with a code.
+
+    :param key: The channel key the payload wrote.
+    :param declared: The workflow's channel-key namespace.
+    :param field: Field path naming the offending key.
+    :raises CodedValueError: if ``key`` names no declared channel.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_NETWORK_CHANNEL_KEY_UNDECLARED,
+        subject="a network channel",
+        remedy=_NETWORK_CHANNEL_KEY_REMEDY,
+    )
+
+
+def resolve_micro_reaction_key(
+    key: str, declared: Mapping[str, T], *, field: str
+) -> T:
+    """Resolve one upload-local *micro reaction* key, or refuse with a code.
+
+    :param key: The micro reaction key the payload wrote.
+    :param declared: The workflow's micro-reaction-key namespace.
+    :param field: Field path naming the offending key.
+    :raises CodedValueError: if ``key`` names no declared micro reaction.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_MICRO_REACTION_KEY_UNDECLARED,
+        subject="a micro reaction",
+        remedy=_MICRO_REACTION_KEY_REMEDY,
+    )
+
+
+def resolve_transition_state_key(
+    key: str, declared: Mapping[str, T], *, field: str
+) -> T:
+    """Resolve one upload-local *transition state* key, or refuse with a code.
+
+    :param key: The transition state key the payload wrote.
+    :param declared: The workflow's TS-key namespace.
+    :param field: Field path naming the offending key.
+    :raises CodedValueError: if ``key`` names no declared transition state.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_TRANSITION_STATE_KEY_UNDECLARED,
+        subject="a transition state",
+        remedy=_TRANSITION_STATE_KEY_REMEDY,
+    )
+
+
+def resolve_geometry_key(
+    key: str, declared: Mapping[str, T], *, field: str
+) -> T:
+    """Resolve one upload-local *geometry* key, or refuse with a code.
+
+    The one resolver here whose subject is not "declared in this upload".
+    See :data:`W_GEOMETRY_KEY_UNRESOLVED` for why: the geometry namespace
+    is built as the workflow walks the owners that declare geometries, so
+    a key can be present in the payload and absent from this map, and a
+    refusal claiming it was never declared would be false.
+
+    :param key: The geometry key the payload wrote.
+    :param declared: The geometry keys resolved so far in this upload.
+    :param field: Field path naming the offending key.
+    :raises CodedValueError: if ``key`` names no resolved geometry.
+    """
+    return resolve_declared_key(
+        key,
+        declared,
+        field=field,
+        code=W_GEOMETRY_KEY_UNRESOLVED,
+        subject="a geometry",
+        scope="this upload has resolved at this point",
+        remedy=_GEOMETRY_KEY_REMEDY,
     )

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -83,7 +83,10 @@ from app.services.kinetics_resolution import (
     assert_kinetics_source_role_compatible,
 )
 from app.services.literature_resolution import resolve_or_create_literature
-from app.services.local_key_resolution import resolve_calculation_key
+from app.services.local_key_resolution import (
+    resolve_calculation_key,
+    resolve_species_key,
+)
 from app.services.provenance_warnings import (
     NOT_APPLICABLE,
     collect_provenance_warnings,
@@ -587,8 +590,14 @@ def persist_computed_reaction_upload(
     # ------------------------------------------------------------------
     # 2. Resolve reaction
     # ------------------------------------------------------------------
-    reactant_entries = [species_key_to_entry[k] for k in request.reactant_keys]
-    product_entries = [species_key_to_entry[k] for k in request.product_keys]
+    reactant_entries = [
+        resolve_species_key(k, species_key_to_entry, field=f"reactant_keys[{i}]")
+        for i, k in enumerate(request.reactant_keys)
+    ]
+    product_entries = [
+        resolve_species_key(k, species_key_to_entry, field=f"product_keys[{i}]")
+        for i, k in enumerate(request.product_keys)
+    ]
 
     chem_reaction = resolve_chem_reaction(
         session,
@@ -623,7 +632,11 @@ def persist_computed_reaction_upload(
         for idx, key in enumerate(keys, start=1):
             participant_row = ReactionEntryStructureParticipant(
                 reaction_entry_id=canonical_reaction_entry.id,
-                species_entry_id=species_key_to_entry[key].id,
+                species_entry_id=resolve_species_key(
+                    key,
+                    species_key_to_entry,
+                    field=f"{role.value}_keys[{idx - 1}]",
+                ).id,
                 role=role,
                 participant_index=idx,
                 created_by=created_by,
@@ -847,10 +860,12 @@ def persist_computed_reaction_upload(
     # Frequency scale factors are intentionally not modeled here; they
     # continue to flow through ``statmech.frequency_scale_factor_id``.
     # ------------------------------------------------------------------
-    for sp in request.species:
+    for sp_index, sp in enumerate(request.species):
         if not sp.applied_energy_corrections:
             continue
-        species_entry = species_key_to_entry[sp.key]
+        species_entry = resolve_species_key(
+            sp.key, species_key_to_entry, field=f"species[{sp_index}].key"
+        )
         for i, ac in enumerate(sp.applied_energy_corrections):
             source_calc_id: int | None = None
             if ac.source_calculation_key is not None:
@@ -980,9 +995,11 @@ def persist_computed_reaction_upload(
     # linked to the statmech it was derived from. Keyed by species
     # participant local key, which is used consistently in both loops.
     thermo_by_species_key: dict[str, Thermo] = {}
-    for sp in request.species:
+    for sp_index, sp in enumerate(request.species):
         if sp.thermo is not None:
-            species_entry = species_key_to_entry[sp.key]
+            species_entry = resolve_species_key(
+                sp.key, species_key_to_entry, field=f"species[{sp_index}].key"
+            )
             t = sp.thermo
 
             # Per-thermo provenance overrides the bundle-level default.
@@ -1090,9 +1107,11 @@ def persist_computed_reaction_upload(
     # 4b. Statmech (per species, if provided)
     # ------------------------------------------------------------------
     statmech_ids = []
-    for sp in request.species:
+    for sp_index, sp in enumerate(request.species):
         if sp.statmech is not None:
-            species_entry = species_key_to_entry[sp.key]
+            species_entry = resolve_species_key(
+                sp.key, species_key_to_entry, field=f"species[{sp_index}].key"
+            )
             s = sp.statmech
 
             fsf_id = None
@@ -1277,7 +1296,7 @@ def persist_computed_reaction_upload(
     canonical_product_keys = list(request.product_keys)
 
     kinetics_ids = []
-    for kin in request.kinetics:
+    for kin_index, kin in enumerate(request.kinetics):
         # If the fit's participant ordering matches the bundle's canonical
         # direction exactly, reuse ``canonical_reaction_entry`` rather than
         # producing a duplicate row with identical participants. Reverse
@@ -1295,10 +1314,20 @@ def persist_computed_reaction_upload(
             kin_entry = canonical_reaction_entry
         else:
             kin_reactant_entries = [
-                species_key_to_entry[k] for k in kin.reactant_keys
+                resolve_species_key(
+                    k,
+                    species_key_to_entry,
+                    field=f"kinetics[{kin_index}].reactant_keys[{i}]",
+                )
+                for i, k in enumerate(kin.reactant_keys)
             ]
             kin_product_entries = [
-                species_key_to_entry[k] for k in kin.product_keys
+                resolve_species_key(
+                    k,
+                    species_key_to_entry,
+                    field=f"kinetics[{kin_index}].product_keys[{i}]",
+                )
+                for i, k in enumerate(kin.product_keys)
             ]
 
             kin_chem_rxn = resolve_chem_reaction(
@@ -1324,7 +1353,14 @@ def persist_computed_reaction_upload(
                 session.add(
                     ReactionEntryStructureParticipant(
                         reaction_entry_id=kin_entry.id,
-                        species_entry_id=species_key_to_entry[key].id,
+                        species_entry_id=resolve_species_key(
+                            key,
+                            species_key_to_entry,
+                            field=(
+                                f"kinetics[{kin_index}].reactant_keys"
+                                f"[{idx - 1}]"
+                            ),
+                        ).id,
                         role=ReactionRole.reactant,
                         participant_index=idx,
                         created_by=created_by,
@@ -1334,7 +1370,14 @@ def persist_computed_reaction_upload(
                 session.add(
                     ReactionEntryStructureParticipant(
                         reaction_entry_id=kin_entry.id,
-                        species_entry_id=species_key_to_entry[key].id,
+                        species_entry_id=resolve_species_key(
+                            key,
+                            species_key_to_entry,
+                            field=(
+                                f"kinetics[{kin_index}].product_keys"
+                                f"[{idx - 1}]"
+                            ),
+                        ).id,
                         role=ReactionRole.product,
                         participant_index=idx,
                         created_by=created_by,

--- a/backend/app/workflows/computed_reaction.py
+++ b/backend/app/workflows/computed_reaction.py
@@ -85,6 +85,7 @@ from app.services.kinetics_resolution import (
 from app.services.literature_resolution import resolve_or_create_literature
 from app.services.local_key_resolution import (
     resolve_calculation_key,
+    resolve_geometry_key,
     resolve_species_key,
 )
 from app.services.provenance_warnings import (
@@ -822,7 +823,11 @@ def persist_computed_reaction_upload(
         reaction_entry_id=canonical_reaction_entry.id,
         transition_state_entry_id=ts_entry.id if ts_entry is not None else None,
         transition_state_geometry_id=(
-            geometry_key_to_id[request.transition_state.geometry.key]
+            resolve_geometry_key(
+                request.transition_state.geometry.key,
+                geometry_key_to_id,
+                field="transition_state.geometry.key",
+            )
             if request.transition_state is not None
             else None
         ),

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -73,7 +73,14 @@ from app.services.calculation_resolution import (
 from app.services.conformer_resolution import resolve_conformer_group
 from app.services.geometry_resolution import resolve_geometry_payload
 from app.services.literature_resolution import resolve_or_create_literature
-from app.services.local_key_resolution import resolve_calculation_key
+from app.services.local_key_resolution import (
+    resolve_calculation_key,
+    resolve_geometry_key,
+    resolve_micro_reaction_key,
+    resolve_network_channel_key,
+    resolve_network_state_key,
+    resolve_transition_state_key,
+)
 from app.services.provenance_warnings import (
     collect_network_energy_transfer_warnings,
     collect_network_solve_kind_warnings,
@@ -147,7 +154,18 @@ def _persist_calculation(
 
     effective_geometry_id = geometry_id
     if calc_in.geometry_key is not None:
-        effective_geometry_id = geometry_key_map[calc_in.geometry_key]
+        # Not merely defensive. ``validate_key_references`` checks a
+        # calculation's geometry_key against the payload's *global* geometry
+        # namespace, while this map holds only what the workflow has resolved
+        # so far -- and ``TransitionStateIn``, unlike ``NetworkSpeciesIn``,
+        # has no validator narrowing a TS calculation's geometry_key to its
+        # own transition state. A TS naming a later TS's geometry therefore
+        # passed the schema and reached a raw subscript here.
+        effective_geometry_id = resolve_geometry_key(
+            calc_in.geometry_key,
+            geometry_key_map,
+            field=f"calculations['{calc_in.key}'].geometry_key",
+        )
 
     # The inline literature fragment is forwarded unresolved; the shared
     # persistence seam resolves it (#194). This route reaches the same
@@ -802,10 +820,21 @@ def persist_network_pdep_upload(
         )
         warning_sink.extend(collect_network_solve_kind_warnings(solve_in))
 
+        # The four lookups in this block and the next were guarded only
+        # inside the ``kind == 'computed'`` branch of
+        # ``validate_mechanistic_channel_evidence``: the coverage rules there
+        # compare the supplied state/path keys against the topology, which
+        # catches an undefined key as a side effect. A ``reported`` solve
+        # (ADR 0010) is exempt from those rules and so was exempt from the
+        # side effect, and reached these subscripts with whatever it wrote.
         for energy_index, energy_in in enumerate(solve_in.state_energies):
             session.add(NetworkSolveStateEnergy(
                 solve_id=solve.id,
-                state_id=state_key_to_row[energy_in.state_key].id,
+                state_id=resolve_network_state_key(
+                    energy_in.state_key,
+                    state_key_to_row,
+                    field=f"solve.state_energies[{energy_index}].state_key",
+                ).id,
                 energy_kj_mol=energy_in.energy_kj_mol,
                 energy_zero_convention=energy_in.energy_zero_convention,
                 correction_convention=energy_in.correction_convention,
@@ -825,9 +854,27 @@ def persist_network_pdep_upload(
         for barrier_index, barrier_in in enumerate(solve_in.channel_barriers):
             session.add(NetworkSolveChannelBarrier(
                 solve_id=solve.id,
-                channel_id=channel_key_to_row[barrier_in.channel_key].id,
-                reaction_entry_id=reaction_key_to_entry[barrier_in.micro_reaction_key].id,
-                transition_state_entry_id=ts_key_to_entry[barrier_in.transition_state_key].id,
+                channel_id=resolve_network_channel_key(
+                    barrier_in.channel_key,
+                    channel_key_to_row,
+                    field=f"solve.channel_barriers[{barrier_index}].channel_key",
+                ).id,
+                reaction_entry_id=resolve_micro_reaction_key(
+                    barrier_in.micro_reaction_key,
+                    reaction_key_to_entry,
+                    field=(
+                        f"solve.channel_barriers[{barrier_index}]."
+                        f"micro_reaction_key"
+                    ),
+                ).id,
+                transition_state_entry_id=resolve_transition_state_key(
+                    barrier_in.transition_state_key,
+                    ts_key_to_entry,
+                    field=(
+                        f"solve.channel_barriers[{barrier_index}]."
+                        f"transition_state_key"
+                    ),
+                ).id,
                 forward_barrier_kj_mol=barrier_in.forward_barrier_kj_mol,
                 reverse_barrier_kj_mol=barrier_in.reverse_barrier_kj_mol,
                 energy_zero_convention=barrier_in.energy_zero_convention,

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -478,8 +478,12 @@ def persist_network_pdep_upload(
     # ------------------------------------------------------------------
     # 5. Process transition states
     # ------------------------------------------------------------------
-    for ts_in in request.transition_states:
-        reaction_entry = reaction_key_to_entry[ts_in.micro_reaction_key]
+    for ts_index, ts_in in enumerate(request.transition_states):
+        reaction_entry = resolve_micro_reaction_key(
+            ts_in.micro_reaction_key,
+            reaction_key_to_entry,
+            field=f"transition_states[{ts_index}].micro_reaction_key",
+        )
 
         # Create TransitionState (concept level)
         ts = TransitionState(
@@ -718,14 +722,33 @@ def persist_network_pdep_upload(
     session.flush()
     channel_rows = session.query(NetworkChannel).filter(NetworkChannel.network_id == network.id).all()
     channel_key_to_row = {row.channel_key: row for row in channel_rows}
-    for ch_in in request.channels:
-        channel_row = channel_key_to_row[ch_in.key]
-        for path in ch_in.microreaction_paths:
+    for ch_index, ch_in in enumerate(request.channels):
+        # Read back from the rows just inserted rather than from the payload,
+        # so a channel the flush dropped is a named refusal and not a silent
+        # miss.
+        channel_row = resolve_network_channel_key(
+            ch_in.key, channel_key_to_row, field=f"channels[{ch_index}].key"
+        )
+        for path_index, path in enumerate(ch_in.microreaction_paths):
             session.add(NetworkChannelMicroReaction(
                 channel_id=channel_row.id,
-                reaction_entry_id=reaction_key_to_entry[path.micro_reaction_key].id,
+                reaction_entry_id=resolve_micro_reaction_key(
+                    path.micro_reaction_key,
+                    reaction_key_to_entry,
+                    field=(
+                        f"channels[{ch_index}].microreaction_paths"
+                        f"[{path_index}].micro_reaction_key"
+                    ),
+                ).id,
                 transition_state_entry_id=(
-                    ts_key_to_entry[path.transition_state_key].id
+                    resolve_transition_state_key(
+                        path.transition_state_key,
+                        ts_key_to_entry,
+                        field=(
+                            f"channels[{ch_index}].microreaction_paths"
+                            f"[{path_index}].transition_state_key"
+                        ),
+                    ).id
                     if path.transition_state_key is not None
                     else None
                 ),
@@ -986,8 +1009,12 @@ def persist_network_pdep_upload(
         # Fitted phenomenological k(T,P) per channel. Schema validation
         # guarantees exactly one model sub-block matching ``model_kind``
         # (Chebyshev or PLOG); tabulated is rejected upstream.
-        for nk_in in solve_in.channel_kinetics:
-            channel_row = channel_key_to_row[nk_in.channel_key]
+        for nk_index, nk_in in enumerate(solve_in.channel_kinetics):
+            channel_row = resolve_network_channel_key(
+                nk_in.channel_key,
+                channel_key_to_row,
+                field=f"solve.channel_kinetics[{nk_index}].channel_key",
+            )
             network_kinetics = NetworkKinetics(
                 channel_id=channel_row.id,
                 solve_id=solve.id,

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -79,6 +79,7 @@ from app.services.local_key_resolution import (
     resolve_micro_reaction_key,
     resolve_network_channel_key,
     resolve_network_state_key,
+    resolve_species_key,
     resolve_transition_state_key,
 )
 from app.services.provenance_warnings import (
@@ -303,8 +304,10 @@ def persist_network_pdep_upload(
     # ------------------------------------------------------------------
     # 2. Process conformers (geometry + opt calc + conformer observation)
     # ------------------------------------------------------------------
-    for sp in request.species:
-        species_entry = species_key_to_entry[sp.key]
+    for sp_index, sp in enumerate(request.species):
+        species_entry = resolve_species_key(
+            sp.key, species_key_to_entry, field=f"species[{sp_index}].key"
+        )
         for conf in sp.conformers:
             # Resolve geometry
             geom_payload = conf.geometry.to_payload()
@@ -364,8 +367,10 @@ def persist_network_pdep_upload(
     # ------------------------------------------------------------------
     # 3. Process species-level additional calculations (sp, freq, etc.)
     # ------------------------------------------------------------------
-    for sp in request.species:
-        species_entry = species_key_to_entry[sp.key]
+    for sp_index, sp in enumerate(request.species):
+        species_entry = resolve_species_key(
+            sp.key, species_key_to_entry, field=f"species[{sp_index}].key"
+        )
         for calc_in in sp.calculations:
             calculation = _persist_calculation(
                 session,
@@ -388,12 +393,16 @@ def persist_network_pdep_upload(
     # ------------------------------------------------------------------
     # 3b. Process species-level transport
     # ------------------------------------------------------------------
-    for sp in request.species:
+    for sp_index, sp in enumerate(request.species):
         if sp.transport is not None:
             transport_row = resolve_and_create_transport(
                 session,
                 sp.transport,
-                species_entry_id=species_key_to_entry[sp.key].id,
+                species_entry_id=resolve_species_key(
+                    sp.key,
+                    species_key_to_entry,
+                    field=f"species[{sp_index}].key",
+                ).id,
                 created_by=created_by,
             )
             review_targets.append(
@@ -403,13 +412,15 @@ def persist_network_pdep_upload(
     # ------------------------------------------------------------------
     # 3c. Process species-level statmech (reuses the bundle's shared seam)
     # ------------------------------------------------------------------
-    for sp in request.species:
+    for sp_index, sp in enumerate(request.species):
         if sp.statmech is None:
             continue
         statmech_row = _persist_statmech_block(
             session,
             sp.statmech,
-            species_entry_id=species_key_to_entry[sp.key].id,
+            species_entry_id=resolve_species_key(
+                sp.key, species_key_to_entry, field=f"species[{sp_index}].key"
+            ).id,
             calc_keys_to_id=calculation_key_to_calc,
             created_by=created_by,
             warnings=warning_sink,
@@ -422,24 +433,38 @@ def persist_network_pdep_upload(
     # ------------------------------------------------------------------
     # 4. Resolve micro reactions
     # ------------------------------------------------------------------
-    for rxn in request.micro_reactions:
+    for rxn_index, rxn in enumerate(request.micro_reactions):
         reaction_upload = ReactionUploadRequest(
             reversible=rxn.reversible,
             reaction_family=rxn.reaction_family,
             reaction_family_source_note=rxn.reaction_family_source_note,
             reactants=[
                 ReactionParticipantUpload(
-                    species_entry_id=species_key_to_entry[p.species_key].id,
+                    species_entry_id=resolve_species_key(
+                        p.species_key,
+                        species_key_to_entry,
+                        field=(
+                            f"micro_reactions[{rxn_index}].reactants[{i}]."
+                            f"species_key"
+                        ),
+                    ).id,
                     note=p.note,
                 )
-                for p in rxn.reactants
+                for i, p in enumerate(rxn.reactants)
             ],
             products=[
                 ReactionParticipantUpload(
-                    species_entry_id=species_key_to_entry[p.species_key].id,
+                    species_entry_id=resolve_species_key(
+                        p.species_key,
+                        species_key_to_entry,
+                        field=(
+                            f"micro_reactions[{rxn_index}].products[{i}]."
+                            f"species_key"
+                        ),
+                    ).id,
                     note=p.note,
                 )
-                for p in rxn.products
+                for i, p in enumerate(rxn.products)
             ],
         )
         reaction_entry = persist_reaction_upload(
@@ -623,10 +648,19 @@ def persist_network_pdep_upload(
     # 7. Create network states + participants
     # ------------------------------------------------------------------
     state_key_to_row: dict[str, NetworkState] = {}
-    for state_in in request.states:
+    for state_index, state_in in enumerate(request.states):
         participants = [
-            (species_key_to_entry[p.species_key].id, p.stoichiometry)
-            for p in state_in.participants
+            (
+                resolve_species_key(
+                    p.species_key,
+                    species_key_to_entry,
+                    field=(
+                        f"states[{state_index}].participants[{i}].species_key"
+                    ),
+                ).id,
+                p.stoichiometry,
+            )
+            for i, p in enumerate(state_in.participants)
         ]
         comp_hash = _composition_hash(participants)
 
@@ -639,11 +673,18 @@ def persist_network_pdep_upload(
         session.add(state)
         session.flush()
 
-        for p in state_in.participants:
+        for i, p in enumerate(state_in.participants):
             session.add(
                 NetworkStateParticipant(
                     state_id=state.id,
-                    species_entry_id=species_key_to_entry[p.species_key].id,
+                    species_entry_id=resolve_species_key(
+                        p.species_key,
+                        species_key_to_entry,
+                        field=(
+                            f"states[{state_index}].participants[{i}]."
+                            f"species_key"
+                        ),
+                    ).id,
                     stoichiometry=p.stoichiometry,
                 )
             )
@@ -689,15 +730,19 @@ def persist_network_pdep_upload(
     sink_state_keys = {ch.sink_state_key for ch in request.channels}
 
     seen_species_roles: set[tuple[int, NetworkSpeciesRole]] = set()
-    for state_in in request.states:
+    for state_index, state_in in enumerate(request.states):
         role = _infer_species_role(
             state_in.kind,
             state_in.key,
             source_state_keys=source_state_keys,
             sink_state_keys=sink_state_keys,
         )
-        for p in state_in.participants:
-            se_id = species_key_to_entry[p.species_key].id
+        for i, p in enumerate(state_in.participants):
+            se_id = resolve_species_key(
+                p.species_key,
+                species_key_to_entry,
+                field=f"states[{state_index}].participants[{i}].species_key",
+            ).id
             pair = (se_id, role)
             if pair not in seen_species_roles:
                 seen_species_roles.add(pair)
@@ -711,8 +756,12 @@ def persist_network_pdep_upload(
 
     # Bath gas species
     if request.solve:
-        for bg in request.solve.bath_gas:
-            se_id = species_key_to_entry[bg.species_key].id
+        for bg_index, bg in enumerate(request.solve.bath_gas):
+            se_id = resolve_species_key(
+                bg.species_key,
+                species_key_to_entry,
+                field=f"solve.bath_gas[{bg_index}].species_key",
+            ).id
             pair = (se_id, NetworkSpeciesRole.bath_gas)
             if pair not in seen_species_roles:
                 seen_species_roles.add(pair)
@@ -781,11 +830,15 @@ def persist_network_pdep_upload(
         )
 
         # Bath gas
-        for bg in solve_in.bath_gas:
+        for bg_index, bg in enumerate(solve_in.bath_gas):
             session.add(
                 NetworkSolveBathGas(
                     solve_id=solve.id,
-                    species_entry_id=species_key_to_entry[bg.species_key].id,
+                    species_entry_id=resolve_species_key(
+                        bg.species_key,
+                        species_key_to_entry,
+                        field=f"solve.bath_gas[{bg_index}].species_key",
+                    ).id,
                     mole_fraction=bg.mole_fraction,
                 )
             )
@@ -793,7 +846,7 @@ def persist_network_pdep_upload(
         # Energy transfer. A network-wide declaration carries no state and no
         # collider by declaration; ``scope`` is what tells a later reader that
         # the NULLs are the record, not a dropped field (ADR 0009).
-        for et in solve_in.energy_transfer:
+        for et_index, et in enumerate(solve_in.energy_transfer):
             session.add(
                 NetworkSolveEnergyTransfer(
                     solve_id=solve.id,
@@ -804,7 +857,14 @@ def persist_network_pdep_upload(
                         else None
                     ),
                     collider_species_entry_id=(
-                        species_key_to_entry[et.collider_species_key].id
+                        resolve_species_key(
+                            et.collider_species_key,
+                            species_key_to_entry,
+                            field=(
+                                f"solve.energy_transfer[{et_index}]."
+                                f"collider_species_key"
+                            ),
+                        ).id
                         if et.collider_species_key is not None
                         else None
                     ),

--- a/backend/app/workflows/network_pdep.py
+++ b/backend/app/workflows/network_pdep.py
@@ -697,11 +697,19 @@ def persist_network_pdep_upload(
     # 8. Create channels
     # ------------------------------------------------------------------
     channel_key_to_row: dict[str, NetworkChannel] = {}
-    for ch_in in request.channels:
+    for ch_index, ch_in in enumerate(request.channels):
         channel_row = NetworkChannel(
             network_id=network.id,
-            source_state_id=state_key_to_row[ch_in.source_state_key].id,
-            sink_state_id=state_key_to_row[ch_in.sink_state_key].id,
+            source_state_id=resolve_network_state_key(
+                ch_in.source_state_key,
+                state_key_to_row,
+                field=f"channels[{ch_index}].source_state_key",
+            ).id,
+            sink_state_id=resolve_network_state_key(
+                ch_in.sink_state_key,
+                state_key_to_row,
+                field=f"channels[{ch_index}].sink_state_key",
+            ).id,
             kind=ch_in.kind,
             mechanism=ch_in.mechanism,
             channel_key=ch_in.key,
@@ -852,7 +860,13 @@ def persist_network_pdep_upload(
                     solve_id=solve.id,
                     scope=et.scope,
                     state_id=(
-                        state_key_to_row[et.state_key].id
+                        resolve_network_state_key(
+                            et.state_key,
+                            state_key_to_row,
+                            field=(
+                                f"solve.energy_transfer[{et_index}].state_key"
+                            ),
+                        ).id
                         if et.state_key is not None
                         else None
                     ),

--- a/backend/tests/api/test_api_pdep_undeclared_local_keys.py
+++ b/backend/tests/api/test_api_pdep_undeclared_local_keys.py
@@ -1,0 +1,266 @@
+"""Five wire-reachable 500s on ``/uploads/networks/pdep``, and their codes.
+
+What was broken
+---------------
+Every one of these was a depositor typing a name wrong in their own
+payload and the server answering ``500 Internal Server Error`` — the
+server blaming itself for the user's mistake, with nothing in the body
+saying which key was wrong. Each was an unhandled ``KeyError`` out of the
+route: no ``KeyError`` handler is registered in
+``app.api.errors.register_exception_handlers``, so it reaches Starlette
+as an unhandled exception.
+
+Why the schema did not already stop them
+----------------------------------------
+Two different holes, and neither is the "the guard lives in another
+package" story that :mod:`app.services.local_key_resolution` was written
+for. All four validators involved live in ``backend/app/schemas``, beside
+the workflow.
+
+**Four of the five are conditional guards.** A solve's
+``state_energies[].state_key`` and its ``channel_barriers[]`` channel,
+micro-reaction and transition-state keys are only ever checked inside the
+``kind == 'computed'`` branch of
+``NetworkPDepUploadRequest.validate_mechanistic_channel_evidence``, where
+the coverage rules compare supplied keys against the network topology and
+reject an undefined one as a side effect. ADR 0010's ``reported`` solve —
+k(T,P) transcribed out of a published table, holding none of the
+master-equation inputs — is exempt from those coverage rules, and was
+therefore exempt from the side effect too. The comment above that branch
+says a reported solve "still has to point it at a real path"; for three of
+these four fields, it did not.
+
+**The fifth is the #218 asymmetry, on a new field.**
+``NetworkSpeciesIn.validate_calc_geometry_belongs_to_conformer`` narrows a
+species calculation's ``geometry_key`` to that species's own conformer
+geometries. ``TransitionStateIn`` has no counterpart, and
+``validate_key_references`` checks TS calculations against the *global*
+geometry namespace — so a transition state's calculation naming a *later*
+transition state's geometry passed validation and hit a workflow map that
+had not resolved it yet. Exactly the shape of #218's statmech gap: the
+species branch guarded, the transition-state branch not.
+
+How these assertions are written
+--------------------------------
+On the ``(status, code)`` pair, never on one alone — asserting only the
+status passes against any refusal, and asserting only the code lets the
+status drift to something a client retries differently. Never on a
+substring of ``detail``: Pydantic echoes rejected input back into its own
+error strings, so a substring check passes even where the field was
+wrongly *accepted*.
+
+The accept-side tests at the bottom are what stop the rest from being
+vacuous. A resolver that refused every key would satisfy every negative
+assertion in this file and fail every one of those.
+"""
+
+from __future__ import annotations
+
+from tests.workflows.test_network_pdep_upload import (
+    _CONVENTIONS,
+    _parallel_path_payload,
+    _reported_payload,
+)
+
+_PDEP_URL = "/api/v1/uploads/networks/pdep"
+
+
+def _post(client, payload: dict):
+    return client.post(_PDEP_URL, json=payload)
+
+
+def _assert_refused(response, *, code: str) -> dict:
+    """Pin the pair. Neither half is load-bearing on its own."""
+    assert (response.status_code, response.json().get("code")) == (422, code), (
+        f"expected (422, {code!r}), got "
+        f"({response.status_code}, {response.json().get('code')!r}). "
+        f"body={response.text}"
+    )
+    return response.json()
+
+
+def _assert_no_row_ids(body: dict) -> None:
+    """DR-0028 Requirement 2 -- the maps' *values* are row ids."""
+    assert set(body["context"]) == {"field", "key", "declared_keys"}, body
+    assert all(isinstance(k, str) for k in body["context"]["declared_keys"]), body
+
+
+def _barrier(**over) -> dict:
+    base = {
+        "channel_key": "elimination_path",
+        "micro_reaction_key": "rxn_ho2_elim",
+        "transition_state_key": "ts_elim",
+        "forward_barrier_kj_mol": 10.0,
+        "reverse_barrier_kj_mol": 20.0,
+        **_CONVENTIONS,
+    }
+    base.update(over)
+    return base
+
+
+def _state_energy(**over) -> dict:
+    base = {"state_key": "well_RO2", "energy_kj_mol": -120.0, **_CONVENTIONS}
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# The four conditional-guard defects, all on a `reported` solve
+# ---------------------------------------------------------------------------
+
+
+def test_reported_solve_state_energy_naming_no_state_is_a_coded_422(client) -> None:
+    payload = _reported_payload()
+    payload["solve"]["state_energies"] = [_state_energy(state_key="no_such_state")]
+    body = _assert_refused(_post(client, payload), code="network_state_key_undeclared")
+    assert body["context"]["field"] == "solve.state_energies[0].state_key", body
+    assert body["context"]["key"] == "no_such_state", body
+    # Naming the alternatives is what turns a typo into a mechanical fix.
+    assert "well_RO2" in body["context"]["declared_keys"], body
+    _assert_no_row_ids(body)
+
+
+def test_reported_solve_barrier_naming_no_channel_is_a_coded_422(client) -> None:
+    payload = _reported_payload()
+    payload["solve"]["channel_barriers"] = [_barrier(channel_key="no_such_channel")]
+    body = _assert_refused(
+        _post(client, payload), code="network_channel_key_undeclared"
+    )
+    assert body["context"]["field"] == "solve.channel_barriers[0].channel_key", body
+    assert body["context"]["key"] == "no_such_channel", body
+    assert "elimination_path" in body["context"]["declared_keys"], body
+    _assert_no_row_ids(body)
+
+
+def test_reported_solve_barrier_naming_no_micro_reaction_is_a_coded_422(
+    client,
+) -> None:
+    payload = _reported_payload()
+    payload["solve"]["channel_barriers"] = [_barrier(micro_reaction_key="no_such_rxn")]
+    body = _assert_refused(_post(client, payload), code="micro_reaction_key_undeclared")
+    assert (
+        body["context"]["field"] == "solve.channel_barriers[0].micro_reaction_key"
+    ), body
+    assert body["context"]["key"] == "no_such_rxn", body
+    assert "rxn_ho2_elim" in body["context"]["declared_keys"], body
+    _assert_no_row_ids(body)
+
+
+def test_reported_solve_barrier_naming_no_transition_state_is_a_coded_422(
+    client,
+) -> None:
+    payload = _reported_payload()
+    payload["solve"]["channel_barriers"] = [_barrier(transition_state_key="no_such_ts")]
+    body = _assert_refused(
+        _post(client, payload), code="transition_state_key_undeclared"
+    )
+    assert (
+        body["context"]["field"] == "solve.channel_barriers[0].transition_state_key"
+    ), body
+    assert body["context"]["key"] == "no_such_ts", body
+    assert "ts_elim" in body["context"]["declared_keys"], body
+    _assert_no_row_ids(body)
+
+
+def test_the_four_solve_keys_do_not_share_one_code(client) -> None:
+    """Four namespaces, four codes -- the point of not writing one.
+
+    A client pointing a depositor at the block of their own payload that
+    needs editing can only do that if the code says which block. If these
+    ever collapse to a single ``local_key_undeclared`` a client has to
+    parse ``context['field']`` to tell a state key from a channel key.
+    """
+    codes = set()
+    for solve_over in (
+        {"state_energies": [_state_energy(state_key="ghost")]},
+        {"channel_barriers": [_barrier(channel_key="ghost")]},
+        {"channel_barriers": [_barrier(micro_reaction_key="ghost")]},
+        {"channel_barriers": [_barrier(transition_state_key="ghost")]},
+    ):
+        payload = _reported_payload()
+        payload["solve"].update(solve_over)
+        response = _post(client, payload)
+        assert response.status_code == 422, response.text
+        codes.add(response.json()["code"])
+    assert len(codes) == 4, codes
+
+
+# ---------------------------------------------------------------------------
+# The geometry defect: the species branch is guarded, the TS branch was not
+# ---------------------------------------------------------------------------
+
+
+def test_ts_calculation_naming_a_later_ts_geometry_is_a_coded_422(client) -> None:
+    """The #218 asymmetry, found again on ``geometry_key``.
+
+    ``_parallel_path_payload`` declares three saddle points in the order
+    ``ts_elim, ts_elim_anti, ts_isomer``. The first one's ``sp``
+    calculation is pointed at the third one's geometry: a key the payload
+    really does declare, and one this workflow cannot resolve when it
+    persists ``ts_elim``.
+    """
+    payload = _parallel_path_payload()
+    assert [ts["key"] for ts in payload["transition_states"]] == [
+        "ts_elim",
+        "ts_elim_anti",
+        "ts_isomer",
+    ], "fixture TS order changed; this test depends on it"
+    payload["transition_states"][0]["calculations"][1]["geometry_key"] = (
+        "ts_isomer_geom"
+    )
+    body = _assert_refused(_post(client, payload), code="geometry_key_unresolved")
+    assert body["context"]["field"] == "calculations['ts_elim_sp'].geometry_key", body
+    assert body["context"]["key"] == "ts_isomer_geom", body
+    _assert_no_row_ids(body)
+
+
+def test_the_geometry_refusal_does_not_claim_the_key_was_undeclared(client) -> None:
+    """The reason this code is not spelled ``geometry_key_undeclared``.
+
+    ``ts_isomer_geom`` is in the payload the depositor sent. A refusal
+    saying it was never declared would be telling them something false
+    about their own file, and would send them looking for a typo that is
+    not there.
+    """
+    payload = _parallel_path_payload()
+    payload["transition_states"][0]["calculations"][1]["geometry_key"] = (
+        "ts_isomer_geom"
+    )
+    detail = _post(client, payload).json()["detail"]
+    assert "does not name a geometry declared in this upload" not in detail, detail
+    assert "has resolved at this point" in detail, detail
+    # And it says what would work instead.
+    assert "ts_elim_geom" in detail, detail
+
+
+# ---------------------------------------------------------------------------
+# The half that makes all of the above mean something
+# ---------------------------------------------------------------------------
+
+
+def test_a_reported_solve_with_every_key_right_is_still_accepted(client) -> None:
+    """A resolver that refused everything passes all five tests above."""
+    payload = _reported_payload()
+    payload["solve"]["state_energies"] = [_state_energy()]
+    payload["solve"]["channel_barriers"] = [_barrier()]
+    response = _post(client, payload)
+    assert response.status_code == 201, response.text
+
+
+def test_a_ts_calculation_naming_its_own_geometry_is_still_accepted(client) -> None:
+    """The geometry resolver resolves; it does not merely refuse."""
+    response = _post(client, _parallel_path_payload())
+    assert response.status_code == 201, response.text
+
+
+def test_a_ts_calculation_may_still_name_an_already_resolved_geometry(client) -> None:
+    """Species geometries are all resolved before any TS is persisted.
+
+    This is the control for the ``ts_isomer_geom`` test: it proves the
+    refusal there is about resolution order, not about a blanket ban on a
+    TS calculation citing a geometry it does not own.
+    """
+    payload = _parallel_path_payload()
+    payload["transition_states"][0]["calculations"][1]["geometry_key"] = "etoo_geom"
+    response = _post(client, payload)
+    assert response.status_code == 201, response.text

--- a/backend/tests/api/test_api_pdep_undeclared_local_keys.py
+++ b/backend/tests/api/test_api_pdep_undeclared_local_keys.py
@@ -30,15 +30,29 @@ therefore exempt from the side effect too. The comment above that branch
 says a reported solve "still has to point it at a real path"; for three of
 these four fields, it did not.
 
-**The fifth is the #218 asymmetry, on a new field.**
-``NetworkSpeciesIn.validate_calc_geometry_belongs_to_conformer`` narrows a
-species calculation's ``geometry_key`` to that species's own conformer
-geometries. ``TransitionStateIn`` has no counterpart, and
-``validate_key_references`` checks TS calculations against the *global*
-geometry namespace — so a transition state's calculation naming a *later*
-transition state's geometry passed validation and hit a workflow map that
-had not resolved it yet. Exactly the shape of #218's statmech gap: the
-species branch guarded, the transition-state branch not.
+**The fifth is the #218 asymmetry, on a field where it was already
+half-known.** ``NetworkSpeciesIn.validate_calc_geometry_belongs_to_
+conformer`` narrows a species calculation's ``geometry_key`` to that
+species's own conformer geometries. ``TransitionStateIn`` has no
+counterpart, and ``validate_key_references`` checks TS calculations
+against the *global* geometry namespace.
+
+That much was already on record: ``tests/services/test_calculation_
+geometry_composition.py::test_a_ts_calculation_may_not_borrow_a_
+reactants_geometry_by_key`` reproduces it on
+``/uploads/computed-reaction`` and pins the refusal that closed it —
+``calculation_geometry_composition_mismatch``, which catches the TS
+carrying the wrong *atoms*.
+
+What that defence cannot do is help when the key does not resolve at
+all, because it runs **downstream of the lookup**. On the PDep route the
+geometry map is filled as the workflow walks the transition states in
+order, so a TS calculation naming a *later* TS's geometry raised
+``KeyError`` before any composition check saw it. Same asymmetry, one
+layer earlier, and a 500 instead of a 422.
+``test_resolving_a_geometry_key_does_not_bypass_the_composition_rule``
+below pins the handoff: once the key resolves, the composition rule
+still owns the question of whether the geometry is the right molecule.
 
 How these assertions are written
 --------------------------------
@@ -256,11 +270,49 @@ def test_a_ts_calculation_naming_its_own_geometry_is_still_accepted(client) -> N
 def test_a_ts_calculation_may_still_name_an_already_resolved_geometry(client) -> None:
     """Species geometries are all resolved before any TS is persisted.
 
-    This is the control for the ``ts_isomer_geom`` test: it proves the
-    refusal there is about resolution order, not about a blanket ban on a
-    TS calculation citing a geometry it does not own.
+    The control for the ``ts_isomer_geom`` test: it proves the refusal
+    there is about resolution order, not a blanket ban on a TS
+    calculation citing a geometry it does not own.
+
+    ``etoo_geom`` is ethylperoxy and ``ts_elim`` is the C2H5O2 saddle
+    point, so the two agree on composition. That is deliberate and it is
+    what isolates *resolution* from the separate composition rule
+    exercised in the next test -- borrowing a geometry of the wrong
+    composition is refused, and this one is not being accepted because
+    the rule was skipped.
     """
     payload = _parallel_path_payload()
     payload["transition_states"][0]["calculations"][1]["geometry_key"] = "etoo_geom"
     response = _post(client, payload)
     assert response.status_code == 201, response.text
+
+
+def test_resolving_a_geometry_key_does_not_bypass_the_composition_rule(
+    client,
+) -> None:
+    """The geometry resolver hands off; it does not launder.
+
+    `calculation_geometry_composition_mismatch` is the existing,
+    scientific guard against a calculation carrying a geometry made of
+    the wrong atoms -- and on `/uploads/computed-reaction` it is what
+    already caught a TS calculation borrowing a reactant's geometry
+    (`tests/services/test_calculation_geometry_composition.py::
+    test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key`).
+
+    That guard sits *downstream* of the key lookup, which is exactly why
+    it could not defend the PDep 500 fixed above: a key that never
+    resolves never reaches it. Now that the key resolves or is refused by
+    code, this test pins the other half -- a geometry that resolves and
+    is still the wrong molecule is still refused, by the rule that owns
+    that question, and not silently accepted because a `KeyError` turned
+    into a return value.
+
+    `ethyl_geom` is C2H5; `ts_elim` is the C2H5O2 saddle point.
+    """
+    payload = _parallel_path_payload()
+    payload["transition_states"][0]["calculations"][1]["geometry_key"] = "ethyl_geom"
+    response = _post(client, payload)
+    assert (response.status_code, response.json().get("code")) == (
+        422,
+        "calculation_geometry_composition_mismatch",
+    ), response.text

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -93,7 +93,9 @@ _CALC_KEY_MAPS = {
 #: does not.
 _NAMESPACE_MAPS = {
     ("computed_reaction.py", "species_key_to_entry"),
+    ("computed_reaction.py", "geometry_key_to_id"),
     ("network_pdep.py", "species_key_to_entry"),
+    ("network_pdep.py", "geometry_key_to_id"),
     ("network_pdep.py", "state_key_to_row"),
     ("network_pdep.py", "channel_key_to_row"),
     ("network_pdep.py", "reaction_key_to_entry"),

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -22,9 +22,43 @@ import pytest
 from app.api.error_contract import CodedValueError
 from app.services.local_key_resolution import (
     W_CALCULATION_KEY_UNDECLARED,
+    W_GEOMETRY_KEY_UNRESOLVED,
+    W_MICRO_REACTION_KEY_UNDECLARED,
+    W_NETWORK_CHANNEL_KEY_UNDECLARED,
+    W_NETWORK_STATE_KEY_UNDECLARED,
+    W_SPECIES_KEY_UNDECLARED,
+    W_TRANSITION_STATE_KEY_UNDECLARED,
     resolve_calculation_key,
     resolve_declared_key,
+    resolve_geometry_key,
+    resolve_micro_reaction_key,
+    resolve_network_channel_key,
+    resolve_network_state_key,
+    resolve_species_key,
+    resolve_transition_state_key,
 )
+
+#: Every namespace resolver, with the code it is contracted to raise.
+#: ``resolve_calculation_key`` is on the list too: it is the one that
+#: existed first, and leaving it off would let a later edit collapse the
+#: family onto its code without anything going red.
+_RESOLVERS = [
+    (resolve_calculation_key, W_CALCULATION_KEY_UNDECLARED, "a calculation"),
+    (resolve_species_key, W_SPECIES_KEY_UNDECLARED, "a species"),
+    (resolve_network_state_key, W_NETWORK_STATE_KEY_UNDECLARED, "a network state"),
+    (
+        resolve_network_channel_key,
+        W_NETWORK_CHANNEL_KEY_UNDECLARED,
+        "a network channel",
+    ),
+    (resolve_micro_reaction_key, W_MICRO_REACTION_KEY_UNDECLARED, "a micro reaction"),
+    (
+        resolve_transition_state_key,
+        W_TRANSITION_STATE_KEY_UNDECLARED,
+        "a transition state",
+    ),
+    (resolve_geometry_key, W_GEOMETRY_KEY_UNRESOLVED, "a geometry"),
+]
 
 _WORKFLOWS = Path(__file__).resolve().parents[2] / "app" / "workflows"
 
@@ -121,6 +155,100 @@ def test_the_subject_and_remedy_are_the_callers() -> None:
     message = str(exc_info.value)
     assert "does not name anything declared in this upload" in message
     assert message.endswith("Do the thing.")
+
+
+# ---------------------------------------------------------------------------
+# The namespace family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("resolve", "code", "subject"),
+    _RESOLVERS,
+    ids=[fn.__name__ for fn, _, _ in _RESOLVERS],
+)
+def test_every_resolver_returns_what_the_workflow_stored(
+    resolve, code: str, subject: str
+) -> None:
+    """The half that makes every refusal below mean something."""
+    sentinel = object()
+    assert resolve("k", {"k": sentinel}, field="f") is sentinel
+
+
+@pytest.mark.parametrize(
+    ("resolve", "code", "subject"),
+    _RESOLVERS,
+    ids=[fn.__name__ for fn, _, _ in _RESOLVERS],
+)
+def test_every_resolver_refuses_an_undeclared_key_with_its_own_code(
+    resolve, code: str, subject: str
+) -> None:
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve("ghost", {"real": 1}, field="some.field[0].key")
+    error = exc_info.value
+    assert error.code == code
+    assert error.context == {
+        "field": "some.field[0].key",
+        "key": "ghost",
+        "declared_keys": ["real"],
+    }
+    assert f"does not name {subject} " in str(error)
+    # Naming the alternatives is what makes the fix mechanical.
+    assert "'real'" in str(error)
+
+
+def test_the_seven_namespaces_have_seven_distinct_codes() -> None:
+    """One code per namespace, and the reason it is not one between them.
+
+    A species key, a state key and a channel key are repaired in three
+    different blocks of the depositor's own payload. A client can only
+    point at the right block if the code says which one; collapse them and
+    ``context['field']`` becomes a string a client has to parse.
+    """
+    codes = [code for _, code, _ in _RESOLVERS]
+    assert len(set(codes)) == len(codes), codes
+
+
+@pytest.mark.parametrize(
+    ("resolve", "code", "subject"),
+    _RESOLVERS,
+    ids=[fn.__name__ for fn, _, _ in _RESOLVERS],
+)
+def test_no_resolver_leaks_a_row_id(resolve, code: str, subject: str) -> None:
+    """DR-0028 Requirement 2. The ids are every map's *values*."""
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve("ghost", {"real": 424242}, field="f")
+    assert "424242" not in str(exc_info.value)
+    assert 424242 not in exc_info.value.context.values()
+
+
+def test_only_the_geometry_resolver_declines_to_say_undeclared() -> None:
+    """The one namespace whose map is incomplete while it is read.
+
+    Geometry keys are resolved as the workflow walks the species and
+    transition states that declare them, so a key can be in the payload
+    and absent from the map. Every other namespace here is fully built
+    before anything reads it, so "declared in this upload" is true of
+    them and would be false of this one.
+    """
+    for resolve, _, _ in _RESOLVERS:
+        with pytest.raises(CodedValueError) as exc_info:
+            resolve("ghost", {"real": 1}, field="f")
+        message = str(exc_info.value)
+        if resolve is resolve_geometry_key:
+            assert "declared in this upload" not in message, message
+            assert "has resolved at this point" in message, message
+        else:
+            assert "declared in this upload" in message, message
+
+
+def test_the_scope_default_is_what_every_other_caller_relies_on() -> None:
+    """``scope`` is optional, and its default is the old fixed wording."""
+    with pytest.raises(CodedValueError) as exc_info:
+        resolve_declared_key(
+            "ghost", {"a": 1}, field="f", code="c", subject="a thing", remedy="Fix it."
+        )
+    assert "does not name a thing declared in this upload" in str(exc_info.value)
 
 
 def _map_accesses(source: str, name: str) -> tuple[list[str], list[str]]:

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -95,6 +95,9 @@ _NAMESPACE_MAPS = {
     ("computed_reaction.py", "species_key_to_entry"),
     ("network_pdep.py", "species_key_to_entry"),
     ("network_pdep.py", "state_key_to_row"),
+    ("network_pdep.py", "channel_key_to_row"),
+    ("network_pdep.py", "reaction_key_to_entry"),
+    ("network_pdep.py", "ts_key_to_entry"),
 }
 
 
@@ -312,22 +315,40 @@ def test_no_raw_subscript_reads_a_calc_key_namespace(
     )
 
 
+def _is_bound(source: str, name: str) -> bool:
+    """Whether ``name`` is assigned anywhere in ``source``.
+
+    The anti-vacuity anchor for the namespace guard below, and it is
+    deliberately not ``_CALC_KEY_MAPS``'s "does it have subscript
+    writes?". Two of these namespaces are never written by subscript at
+    all: ``channel_key_to_row`` is rebuilt wholesale from the rows the
+    flush returned, and a future one may well be a comprehension too.
+    Requiring a subscript write there would fail an honest map, and the
+    natural repair -- dropping the anchor -- is what would make the guard
+    vacuous. Asking "is this name bound here?" catches the rename this
+    exists to catch without caring how the map is filled.
+    """
+    return re.search(
+        rf"^\s*{re.escape(name)}\s*(?::[^=\n]+)?=(?!=)", source, re.MULTILINE
+    ) is not None
+
+
 @pytest.mark.parametrize(("module", "map_name"), sorted(_NAMESPACE_MAPS))
 def test_no_raw_subscript_reads_a_namespace(module: str, map_name: str) -> None:
     """The same structural guard, for the other six namespaces.
 
-    Written to be falsifiable the same way: it also asserts the pattern
-    still finds the *writes*, so a regex that stopped matching anything
-    at all fails instead of passing forever.
+    Falsifiable the same way, by a different anchor: it asserts the map
+    is still *bound* in the module, so a rename fails here instead of
+    silently reporting zero raw reads forever.
     """
     source = (_WORKFLOWS / module).read_text(encoding="utf-8")
     assert source, f"{module} is empty"
-    writes, reads = _map_accesses(source, map_name)
-    assert writes, (
-        f"{module} has no `{map_name}[...] = ...` at all, so this test "
-        f"is not looking at the namespace it thinks it is -- the map was "
-        f"probably renamed. Fix the name in _NAMESPACE_MAPS."
+    assert _is_bound(source, map_name), (
+        f"{module} never assigns `{map_name}` at all, so this test is not "
+        f"looking at the namespace it thinks it is -- the map was probably "
+        f"renamed. Fix the name in _NAMESPACE_MAPS."
     )
+    _writes, reads = _map_accesses(source, map_name)
     assert reads == [], (
         f"{module} reads {map_name} by raw subscript: {reads}. Every "
         f"cross-reference must go through the matching resolver in "

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -75,6 +75,27 @@ _CALC_KEY_MAPS = {
     "transport.py": "calculations_by_key",
 }
 
+#: The other local-key namespaces, and the workflows that hold them.
+#:
+#: Kept as a separate table from ``_CALC_KEY_MAPS`` rather than merged
+#: into it, because the two were closed at different times and by
+#: different arguments -- and a single table would let a future reader
+#: assume the whole family was audited in one pass, which is the
+#: assumption this work was filed to refute.
+#:
+#: Every read is routed, including the ones that look safe by
+#: construction -- ``species_key_to_entry[sp.key]`` immediately after the
+#: loop that wrote every ``sp.key``. "Safe because of the order the loops
+#: run in" is precisely the reasoning that was false for
+#: ``geometry_key_to_id``, where a transition state's calculation could
+#: name a geometry declared by a later transition state. A guard that
+#: admits exceptions has to be argued about every time it fires; this one
+#: does not.
+_NAMESPACE_MAPS = {
+    ("computed_reaction.py", "species_key_to_entry"),
+    ("network_pdep.py", "species_key_to_entry"),
+}
+
 
 def test_a_declared_key_returns_what_the_workflow_stored() -> None:
     """The half that makes every refusal below mean something."""
@@ -287,4 +308,28 @@ def test_no_raw_subscript_reads_a_calc_key_namespace(
         f"cross-reference must go through "
         f"app.services.local_key_resolution.resolve_calculation_key, or "
         f"an undeclared key is a 500 again."
+    )
+
+
+@pytest.mark.parametrize(("module", "map_name"), sorted(_NAMESPACE_MAPS))
+def test_no_raw_subscript_reads_a_namespace(module: str, map_name: str) -> None:
+    """The same structural guard, for the other six namespaces.
+
+    Written to be falsifiable the same way: it also asserts the pattern
+    still finds the *writes*, so a regex that stopped matching anything
+    at all fails instead of passing forever.
+    """
+    source = (_WORKFLOWS / module).read_text(encoding="utf-8")
+    assert source, f"{module} is empty"
+    writes, reads = _map_accesses(source, map_name)
+    assert writes, (
+        f"{module} has no `{map_name}[...] = ...` at all, so this test "
+        f"is not looking at the namespace it thinks it is -- the map was "
+        f"probably renamed. Fix the name in _NAMESPACE_MAPS."
+    )
+    assert reads == [], (
+        f"{module} reads {map_name} by raw subscript: {reads}. Every "
+        f"cross-reference must go through the matching resolver in "
+        f"app.services.local_key_resolution, or an undeclared key is a "
+        f"500 again."
     )

--- a/backend/tests/services/test_local_key_resolution.py
+++ b/backend/tests/services/test_local_key_resolution.py
@@ -94,6 +94,7 @@ _CALC_KEY_MAPS = {
 _NAMESPACE_MAPS = {
     ("computed_reaction.py", "species_key_to_entry"),
     ("network_pdep.py", "species_key_to_entry"),
+    ("network_pdep.py", "state_key_to_row"),
 }
 
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.47.0"
+version = "0.48.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.46.0"
+version = "0.47.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -104,6 +104,7 @@ class RejectionCode(str, Enum):
     FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM = "freq_list_exceeds_geometry_degrees_of_freedom"
     FREQ_MODE_INDEX_NOT_UNIQUE = "freq_mode_index_not_unique"
     FREQ_N_IMAG_DISAGREES_WITH_MODES = "freq_n_imag_disagrees_with_modes"
+    GEOMETRY_KEY_UNRESOLVED = "geometry_key_unresolved"
     GEOMETRY_TOO_LARGE = "geometry_too_large"
     HANDLE_NOT_FOUND = "handle_not_found"
     HANDLE_TYPE_MISMATCH = "handle_type_mismatch"
@@ -124,6 +125,7 @@ class RejectionCode(str, Enum):
     LOWEST_ENERGY_UNAVAILABLE = "lowest_energy_unavailable"
     MANIFEST_ALREADY_FROZEN = "manifest_already_frozen"
     MANIFEST_NOT_FROZEN = "manifest_not_frozen"
+    MICRO_REACTION_KEY_UNDECLARED = "micro_reaction_key_undeclared"
     MISSING_FILTER = "missing_filter"
     MISSING_IDENTIFIER = "missing_identifier"
     MISSING_REACTION_SEARCH_FILTER = "missing_reaction_search_filter"
@@ -134,7 +136,9 @@ class RejectionCode(str, Enum):
     ML_EXPORT_SEED_UNRESOLVED = "ml_export_seed_unresolved"
     MULTIPLE_STRUCTURE_QUERIES = "multiple_structure_queries"
     N_IMAG_CONTRADICTS_MINIMUM = "n_imag_contradicts_minimum"
+    NETWORK_CHANNEL_KEY_UNDECLARED = "network_channel_key_undeclared"
     NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE = "network_solve_reported_requires_literature"
+    NETWORK_STATE_KEY_UNDECLARED = "network_state_key_undeclared"
     NON_FINITE_VALUE = "non_finite_value"
     OFFSET_TOO_LARGE = "offset_too_large"
     OWNER_MISSING = "owner_missing"
@@ -169,6 +173,7 @@ class RejectionCode(str, Enum):
     SPECIES_GEOMETRY_COMPOSITION_MISMATCH = "species_geometry_composition_mismatch"
     SPECIES_GEOMETRY_ISOTOPE_MISMATCH = "species_geometry_isotope_mismatch"
     SPECIES_HANDLE_CONFLICT = "species_handle_conflict"
+    SPECIES_KEY_UNDECLARED = "species_key_undeclared"
     SPECIES_KIND_CONFLICT = "species_kind_conflict"
     SPECIES_SMILES_CHARGE_MISMATCH = "species_smiles_charge_mismatch"
     STATE_CONFLICT = "state_conflict"
@@ -189,6 +194,7 @@ class RejectionCode(str, Enum):
     TRANSITION_STATE_CHARGE_MISMATCH = "transition_state_charge_mismatch"
     TRANSITION_STATE_COMPOSITION_MISMATCH = "transition_state_composition_mismatch"
     TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH = "transition_state_irc_mapping_element_mismatch"
+    TRANSITION_STATE_KEY_UNDECLARED = "transition_state_key_undeclared"
     TRANSITION_STATE_NO_IMAGINARY_MODE = "transition_state_no_imaginary_mode"
     TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS = "transition_state_reaction_coordinate_ambiguous"
     TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED = "transition_state_reaction_coordinate_not_designated"
@@ -248,6 +254,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM,
         RejectionCode.FREQ_MODE_INDEX_NOT_UNIQUE,
         RejectionCode.FREQ_N_IMAG_DISAGREES_WITH_MODES,
+        RejectionCode.GEOMETRY_KEY_UNRESOLVED,
         RejectionCode.GEOMETRY_TOO_LARGE,
         RejectionCode.HANDLE_TYPE_MISMATCH,
         RejectionCode.INCLUDE_NOT_IMPLEMENTED_YET,
@@ -262,6 +269,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.LEVEL_OF_THEORY_HANDLE_CONFLICT,
         RejectionCode.LIMIT_TOO_LARGE,
         RejectionCode.LOWEST_ENERGY_UNAVAILABLE,
+        RejectionCode.MICRO_REACTION_KEY_UNDECLARED,
         RejectionCode.MISSING_FILTER,
         RejectionCode.MISSING_IDENTIFIER,
         RejectionCode.MISSING_REACTION_SEARCH_FILTER,
@@ -272,6 +280,8 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.ML_EXPORT_SEED_UNRESOLVED,
         RejectionCode.MULTIPLE_STRUCTURE_QUERIES,
         RejectionCode.N_IMAG_CONTRADICTS_MINIMUM,
+        RejectionCode.NETWORK_CHANNEL_KEY_UNDECLARED,
+        RejectionCode.NETWORK_STATE_KEY_UNDECLARED,
         RejectionCode.NON_FINITE_VALUE,
         RejectionCode.OFFSET_TOO_LARGE,
         RejectionCode.PARAMETER_VALUE_REQUIRES_KEY,
@@ -296,6 +306,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH,
         RejectionCode.SPECIES_GEOMETRY_ISOTOPE_MISMATCH,
         RejectionCode.SPECIES_HANDLE_CONFLICT,
+        RejectionCode.SPECIES_KEY_UNDECLARED,
         RejectionCode.SPECIES_KIND_CONFLICT,
         RejectionCode.SPECIES_SMILES_CHARGE_MISMATCH,
         RejectionCode.STATMECH_CALCULATION_KEY_UNDECLARED,
@@ -311,6 +322,7 @@ VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
         RejectionCode.TRANSITION_STATE_CHARGE_MISMATCH,
         RejectionCode.TRANSITION_STATE_COMPOSITION_MISMATCH,
         RejectionCode.TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH,
+        RejectionCode.TRANSITION_STATE_KEY_UNDECLARED,
         RejectionCode.TRANSITION_STATE_NO_IMAGINARY_MODE,
         RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS,
         RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED,
@@ -400,6 +412,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.FREQ_LIST_EXCEEDS_GEOMETRY_DEGREES_OF_FREEDOM: frozenset({422}),
     RejectionCode.FREQ_MODE_INDEX_NOT_UNIQUE: frozenset({422}),
     RejectionCode.FREQ_N_IMAG_DISAGREES_WITH_MODES: frozenset({422}),
+    RejectionCode.GEOMETRY_KEY_UNRESOLVED: frozenset({422}),
     RejectionCode.GEOMETRY_TOO_LARGE: frozenset({422}),
     RejectionCode.HANDLE_NOT_FOUND: frozenset({404}),
     RejectionCode.HANDLE_TYPE_MISMATCH: frozenset({422}),
@@ -420,6 +433,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.LOWEST_ENERGY_UNAVAILABLE: frozenset({422}),
     RejectionCode.MANIFEST_ALREADY_FROZEN: frozenset({409}),
     RejectionCode.MANIFEST_NOT_FROZEN: frozenset({404}),
+    RejectionCode.MICRO_REACTION_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.MISSING_FILTER: frozenset({422}),
     RejectionCode.MISSING_IDENTIFIER: frozenset({422}),
     RejectionCode.MISSING_REACTION_SEARCH_FILTER: frozenset({422}),
@@ -430,7 +444,9 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.ML_EXPORT_SEED_UNRESOLVED: frozenset({422}),
     RejectionCode.MULTIPLE_STRUCTURE_QUERIES: frozenset({422}),
     RejectionCode.N_IMAG_CONTRADICTS_MINIMUM: frozenset({422}),
+    RejectionCode.NETWORK_CHANNEL_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.NETWORK_SOLVE_REPORTED_REQUIRES_LITERATURE: frozenset({409}),
+    RejectionCode.NETWORK_STATE_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.NON_FINITE_VALUE: frozenset({422}),
     RejectionCode.OFFSET_TOO_LARGE: frozenset({422}),
     RejectionCode.OWNER_MISSING: frozenset({404}),
@@ -465,6 +481,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.SPECIES_GEOMETRY_COMPOSITION_MISMATCH: frozenset({422}),
     RejectionCode.SPECIES_GEOMETRY_ISOTOPE_MISMATCH: frozenset({422}),
     RejectionCode.SPECIES_HANDLE_CONFLICT: frozenset({422}),
+    RejectionCode.SPECIES_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.SPECIES_KIND_CONFLICT: frozenset({422}),
     RejectionCode.SPECIES_SMILES_CHARGE_MISMATCH: frozenset({422}),
     RejectionCode.STATE_CONFLICT: frozenset({409}),
@@ -485,6 +502,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.TRANSITION_STATE_CHARGE_MISMATCH: frozenset({422}),
     RejectionCode.TRANSITION_STATE_COMPOSITION_MISMATCH: frozenset({422}),
     RejectionCode.TRANSITION_STATE_IRC_MAPPING_ELEMENT_MISMATCH: frozenset({422}),
+    RejectionCode.TRANSITION_STATE_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.TRANSITION_STATE_NO_IMAGINARY_MODE: frozenset({422}),
     RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_AMBIGUOUS: frozenset({422}),
     RejectionCode.TRANSITION_STATE_REACTION_COORDINATE_NOT_DESIGNATED: frozenset({422}),


### PR DESCRIPTION
Closes #220. Closes #218.

## In plain language first

When you upload a reaction network to TCKDB, your file gives names to its own
parts — "call this species `ethyl`", "call this channel `elimination_path`" — and
then refers to those names elsewhere: "the barrier on `elimination_path`". Those
are **local keys**: they exist only inside your one upload and never touch the
database's own numbering.

The server turns each name into a database row by looking it up in a table it
builds as it reads your file. In Python, `table[name]` **crashes** if the name
isn't there. A crash inside a web server becomes **HTTP 500 — "Internal Server
Error"**, which means *the server broke*. Nothing was broken: you typed a name
wrong. The server took the blame for your typo, and the reply said nothing about
*which* name was wrong, so there was nothing to act on.

The fix is to look the name up through a function that, on a miss, returns **HTTP
422** ("I understood the request and won't accept it") with a machine-readable
**code**, the field you wrote it in, the name itself, and **the list of names that
would have worked**. That last part turns a refusal into a one-line fix instead of
a guessing game.

PR #190 did this for one kind of name — calculation keys — and deliberately
stopped, because a species name and a channel name are fixed in different places
and deserve different codes. This PR does the other six kinds, and found **five
real crashes** users can hit today.

Chemistry is assumed throughout; only software terms are defined.

## What was measured

The brief estimated "roughly 25" raw lookups. **Re-derived on this commit: 36**,
across six namespaces and two workflow files. All 36 now go through
`app/services/local_key_resolution.py`, and a structural test fails if a raw one
comes back.

### Site table — is a request-schema validator actually guarding it?

| namespace | file | sites | guarded? | live 500s |
|---|---|---|---|---|
| `species_key_to_entry` | `computed_reaction.py` | 10 | **Yes** — `ComputedReactionUploadRequest.validate_species_key_refs` covers the bundle's `reactant_keys`/`product_keys` **and** every kinetics fit's | 0 |
| `geometry_key_to_id` | `computed_reaction.py` | 1 | n/a — reads back the key it wrote from the same object | 0 |
| `species_key_to_entry` | `network_pdep.py` | 12 | **Yes** — `validate_key_references` covers micro-reaction participants, state participants, bath gas | 0 |
| `state_key_to_row` | `network_pdep.py` | 4 | **3 of 4.** `solve.state_energies[].state_key` checked **only** when `solve.kind == 'computed'` | **1** |
| `channel_key_to_row` | `network_pdep.py` | 3 | **2 of 3.** `solve.channel_barriers[].channel_key`, same condition | **1** |
| `reaction_key_to_entry` | `network_pdep.py` | 3 | **2 of 3.** `solve.channel_barriers[].micro_reaction_key`, same condition | **1** |
| `ts_key_to_entry` | `network_pdep.py` | 2 | **1 of 2.** `solve.channel_barriers[].transition_state_key`, same condition | **1** |
| `geometry_key_to_id` | `network_pdep.py` | 1 | **No, on the transition-state branch** | **1** |

### Both branches, asked separately — the #218 question

The brief was right that coverage would be uneven and right that it had to be
measured per branch. Asking the species and transition-state branches *separately*
is what found the fifth defect:

| field | species branch | transition-state branch |
|---|---|---|
| statmech source / torsion calc keys | narrowed to that species's own calcs | **not narrowed** — this was #218, fixed in #190 |
| calculation `geometry_key` | narrowed to that species's own conformer geometries by `NetworkSpeciesIn.validate_calc_geometry_belongs_to_conformer` | **not narrowed** — `TransitionStateIn` has no counterpart |
| calculation keys (global namespace) | guarded | guarded |

So #218's asymmetry is not a one-off in the statmech block. It is a property of
`TransitionStateIn`: it validates less about its calculations than
`NetworkSpeciesIn` does, and **every field where that difference matters is a
candidate defect.** That is the reusable finding here.

## The five live 500s — defects, not hardening

All five in `network_pdep.py`. Each was driven through the wire and observed as
**HTTP 500** *before* the fix (an unhandled `KeyError` out of the route — no
`KeyError` handler is registered in `app.api.errors.register_exception_handlers`),
and is pinned as a `(status, code)` **pair** afterwards.

| field a depositor writes | was | now |
|---|---|---|
| `solve.state_energies[i].state_key` | 500 | 422 `network_state_key_undeclared` |
| `solve.channel_barriers[i].channel_key` | 500 | 422 `network_channel_key_undeclared` |
| `solve.channel_barriers[i].micro_reaction_key` | 500 | 422 `micro_reaction_key_undeclared` |
| `solve.channel_barriers[i].transition_state_key` | 500 | 422 `transition_state_key_undeclared` |
| a TS calculation's `geometry_key` naming a later TS's geometry | 500 | 422 `geometry_key_unresolved` |

**Why the schema missed four of them — and it is *not* the #190 story.** #190
concluded the guard drifts because it lives in `tckdb_schemas`, a different
distributable package. Not what happened here: all four validators live in
`backend/app/schemas`, beside the workflow. What they share is **conditionality**.
Those keys are only checked inside the `kind == 'computed'` branch of
`validate_mechanistic_channel_evidence`, where the coverage rules reject an
undefined key as a *side effect* of comparing supplied keys against the topology.
ADR 0010's `reported` solve — k(T,P) transcribed from a published table, holding
none of the master-equation inputs — is exempt from those coverage rules, and so
was exempt from the side effect. The comment above that branch says a reported
solve "still has to point it at a real path"; for three of the four fields, it did
not.

The generalisation is stronger than #190's: **a guard that runs for one member of
an enum, and a workflow that runs for both, will drift regardless of which package
either lives in.**

**The fifth needs a correction to how I first described it.** The species/TS
asymmetry on `geometry_key` was *already on record*:
`tests/services/test_calculation_geometry_composition.py::test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key`
reproduces it on `/uploads/computed-reaction` and pins the refusal that closed it —
`calculation_geometry_composition_mismatch`, which catches the TS carrying the
wrong *atoms*. What is new is that **that defence sits downstream of the lookup**,
so it cannot help when the key does not resolve at all. On the PDep route the
geometry map is filled as the workflow walks the transition states in order, so a
TS calculation naming a later TS's geometry raised `KeyError` before any
composition check saw it. Same asymmetry, one layer earlier, 500 instead of 422.

Because that is a handoff and not a replacement, the last commit pins **both**
directions: an unresolvable key is refused with a code, and a *resolvable but
wrong* one is still refused by the rule that owns that question
(`test_resolving_a_geometry_key_does_not_bypass_the_composition_rule`: a TS
calculation naming `ethyl_geom`, C2H5, for the C2H5O2 saddle point resolves fine
and still gets 422 `calculation_geometry_composition_mismatch`).

## Why six codes and not one

Each namespace is one repair, made in a different block of the depositor's own
payload — `species`, `states`, `channels`, `micro_reactions`, `transition_states`.
A single `local_key_undeclared` would force a client to parse `context['field']` to
tell which. New codes:

`species_key_undeclared`, `network_state_key_undeclared`,
`network_channel_key_undeclared`, `micro_reaction_key_undeclared`,
`transition_state_key_undeclared`, `geometry_key_unresolved`.

**Why one of them does not say "undeclared".** The geometry namespace is the only
one still being filled while it is read. A transition state's calculation naming a
*later* transition state's geometry names something the payload **genuinely
contains** and the workflow genuinely cannot resolve. A refusal saying "not
declared in this upload" would tell a depositor something false about their own
file and send them hunting a typo that is not there. So `resolve_declared_key`
grew an optional `scope` (defaulting to the existing wording, so no other caller
changed) and the geometry refusal says "does not name a geometry this upload has
resolved at this point".
`test_the_geometry_refusal_does_not_claim_the_key_was_undeclared` pins it.

## Scope held

- **No request-schema validator was changed.** That is #219. The `TransitionStateIn`
  gap is a recommendation below, not a patch here.
- **No calculation-key site touched** — #190's territory.
- `app/services/reaction_atom_map.py`'s raw geometry subscripts are **deliberately
  left**: an unconditional `.get()` loop above them already raises
  `atom_map_indices_not_geometry_relative` for every participant with a non-`None`
  geometry key, so each later subscript runs on a key that service already checked.
  Routing them here would give one repair two codes.

## Recommended follow-up for #219

`TransitionStateIn` should narrow its calculations' `geometry_key` to that
transition state's own geometry, exactly as
`NetworkSpeciesIn.validate_calc_geometry_belongs_to_conformer` does for a species.
That makes the fifth defect unreachable rather than merely refused, and closes the
asymmetry at the contract level. It narrows a published contract, so it belongs in
#219's deliberate single pass.

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no new environment variable, no new
configuration. The only contract change is additive: six new error codes.

## Files outside `backend/` that this PR touches

Flagged explicitly because they are easy to miss:

- **`clients/python/pyproject.toml`** — version bumped **0.46.0 → 0.48.0**, skipping
  0.47.0. See "Merged with main" below: 0.47.0 is taken.
- **`clients/python/src/tckdb_client/rejection_codes.py`** — **regenerated, not
  hand-edited**, via `backend/scripts/generate_client_rejection_codes.py`; gained
  six `RejectionCode` members. `test_client_rejection_codes_generated.py` failed
  before I regenerated it — the gate works.

**Nothing under `schemas/` was modified.** That matters for what is locally
verified: a worktree's tests import the **main checkout's** `tckdb_schemas` via the
editable install (task #71), so any change to the wire package would be
**CI-verified rather than locally verified**. This PR makes no such change —
deliberately, since altering a request-schema validator is #219 — so the exposure
is limited to my *reading* of `ComputedReactionUploadRequest` to fill in the guard
table. I confirmed the main checkout's `computed_reaction_upload.py` is
byte-identical to the worktree's before relying on it.

`clients/python` has its own CI workflow; its 1348 tests pass locally, since that
package is not subject to the `tckdb_schemas` path problem.

## Merged with main

Merged `4bdcfd3e` (current `main`, containing #196 and #197) into this branch —
merge commit `cd721038`. Both auto-resolved; `code_catalogue.py` and
`rejection_codes.py` merged without conflict.

**A version collision that a conflict would have caught, and did not.** #197
merged while this branch was open and took `tckdb-client` **0.47.0** for its two
registration codes. This branch had also chosen 0.47.0. Because the version line
was *byte-identical* on both sides, git saw no conflict and silently settled on
one number describing two different packages — precisely the failure a version
exists to prevent, with none of the noise that would have made it visible. Bumped
to **0.48.0**, and `rejection_codes.py` regenerated from the merged catalogue
rather than hand-edited, so the enum is derived from the merge result and not from
either side's memory of it.

**Verified after merging, on the merged tree** — a clean textual merge is not
evidence the combination works, and #196 substantially rewrote
`test_coded_exception_reraise_gate.py`:

- all six of this branch's codes are present in `RejectionCode` (149 members total);
- #197's `email_taken` and `username_taken` are present in **both** the catalogue
  and the generated enum, so the merge dropped neither. `git diff HEAD origin/main
  -- clients/python/src/tckdb_client/rejection_codes.py` has no additions,
  i.e. `main` holds nothing this file lacks;
- all three gates re-run **on the merged result** (numbers below), not on the
  pre-merge tree.

## Commits

1. `a180244b` — seam: one resolver + one code per namespace (no call sites, no behaviour change)
2. `b4fffb00` — **defects**: the five live 500s
3. `9bc7bc2d` — species namespace
4. `7242d7d7` — network-state namespace
5. `85357a07` — channel / micro-reaction / TS namespaces
6. `03549cec` — geometry namespace; structural guard now covers all six
7. `94f63465` — pin that resolving a geometry key does not bypass the composition rule
8. `cd721038` — merge `main` (#196, #197)
9. `49c73c88` — client 0.48.0, regenerated (0.47.0 collided with #197)

## Exact commands run

```
# the three required gates, ON THE MERGED RESULT (head 49c73c88)
conda run -n tckdb_env bash backend/scripts/test-rest.sh         # 4630 passed, 14 skipped (2:16)  exit 0
conda run -n tckdb_env bash backend/scripts/test-api.sh          # 2900 passed             (4:34)  exit 0
conda run -n tckdb_env bash backend/scripts/test-scientific.sh   # 2055 passed             (3:06)  exit 0
cd clients/python && conda run -n tckdb_env python -m pytest tests/ -q   # 1349 passed

# the same three before merging main, for comparison
#   rest 4626+14 skipped / api 2875 / scientific 2055 — the deltas are #196's and
#   #197's own tests arriving, not this branch changing count.

# whole suite, serial, from backend/ on an isolated database
cd backend && DB_TEST_NAME=tckdb_test_a7290c57 \
  conda run -n tckdb_env python -m pytest tests/ -q -p no:randomly
                                                                 # 7976 passed, 14 skipped (48:07) exit 0

# targeted
cd backend && conda run -n tckdb_env python -m pytest tests/api/test_api_pdep_undeclared_local_keys.py -q   # 11 passed
cd backend && conda run -n tckdb_env python -m pytest tests/services/test_local_key_resolution.py -q        # 45 passed
conda run -n tckdb_env ruff check backend/app backend/tests                                                 # clean
conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py
cd clients/python && conda run -n tckdb_env python -m pytest tests/ -q                                      # 1348 passed
```

**One caution about the verify command in the issue.** `pytest backend/tests/` run
from the **repository root** produces one failure that has nothing to do with this
PR: `test_calculation_geometry_composition.py::test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key`
resolves a fixture through a **relative** `glob.glob("tests/fixtures/...")`, which
only matches when pytest's cwd is `backend/`. From the repo root it raises
`IndexError: list index out of range`. The file is untouched by this PR
(`git diff main...HEAD -- <that file>` is empty) and all three gates `cd` to
`backend/`, so CI never sees it. Worth a one-line `Path(__file__)` fix in its own
change; not smuggled into this one.

## Mutations landed

Every assertion in the new tests was checked by breaking what it watches,
confirming RED, restoring, and clearing `__pycache__`. Both directions were
mutated: a test asserting only that a 4xx arrived passes against a resolver that
refuses everything.

| mutation | expected | result |
|---|---|---|
| each of the five defect call sites reverted to its raw subscript | its own test RED | RED ✓ (×5) |
| `resolve_declared_key` made to refuse **every** key | all three accept-side tests RED | RED ✓ |
| the state and channel codes made identical | four-distinct-codes test RED | RED ✓ |
| a raw species subscript reintroduced in `network_pdep` | structural guard RED | RED ✓ |
| a raw geometry subscript reintroduced in `computed_reaction` | structural guard RED | RED ✓ |
| a guarded map renamed in `_NAMESPACE_MAPS` | anti-vacuity anchor fires | RED ✓ |
| the read/write splitter regex made to match nothing | anti-vacuity anchor fires | RED ✓ |
| borrowed geometry swapped to the composition-**compatible** `etoo_geom` | composition-handoff test RED | RED ✓ |

Baseline restored green after every one.

**One anti-vacuity anchor had to change, and the reason matters.** The existing
calc-key guard proves it is looking at a real map by asserting the map has
subscript *writes*. That is false of `channel_key_to_row`, which is rebuilt
wholesale from the rows a flush returned — so requiring a subscript write would
have failed an honest map, and the obvious repair (drop the anchor) is exactly
what makes a structural guard vacuous. The namespace guard asks "is this name
bound in this module?" instead: still catches the rename, does not care how the map
is filled. Mutation rows 6 and 7 exist to prove the replacement anchor still fires.
