### PR TITLE
Say which storage failure a download hit

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -327,8 +327,38 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/chemistry/units.py"),
     ApiCode("artifact_integrity_failed", 502, Surface.response_literal,
             "backend/app/api/errors.py"),
+    ApiCode("artifact_object_missing", 502, Surface.response_literal,
+            "backend/app/api/errors.py",
+            note=(
+                "Split from artifact_storage_unavailable in #226, which "
+                "carried both 'the store did not answer' and 'the store "
+                "answered and the object is not there' — opposite retry "
+                "advice under one code. Told apart by "
+                "ArtifactStorageUnavailable.missing, set from the S3 error "
+                "code in load_artifact_bytes; the exception type is "
+                "deliberately not split, so every opportunistic "
+                "'except ArtifactStorageUnavailable' still catches both. "
+                "502 rather than 404 or 410 although the bytes are gone: "
+                "the request was well formed and the artifact record is "
+                "still published, so the failure is TCKDB's custody and "
+                "not the caller's mistake. 404 would also collide with "
+                "this route's deliberate unknown-or-unapproved-digest "
+                "answer, and 410 would invite a client to drop the "
+                "reference that makes reclaim_restore possible. Its "
+                "sibling artifact_integrity_failed sits at the same "
+                "status for the same reason; the two differ in which "
+                "artifact_integrity_event finding was recorded "
+                "(object_missing vs digest/size mismatch) and therefore "
+                "in what an operator does next."
+            )),
     ApiCode("artifact_storage_unavailable", 503, Surface.response_literal,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            note=(
+                "Now means only what its sentence says: the store did not "
+                "answer, and retrying is the right response. The case "
+                "where it answered 'no such key' left this code in #226 — "
+                "see artifact_object_missing."
+            )),
     ApiCode("atom_map_atoms_unaccounted_for", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
     ApiCode("atom_map_contradicts_irc_mapping", 422, Surface.coded_exception,

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -386,18 +386,73 @@ def _artifact_integrity_handler(
 def _artifact_storage_unavailable_handler(
     request: Request, exc: ArtifactStorageUnavailable
 ) -> JSONResponse:
-    """503 for the client; the actual reason for the operator.
+    """503 for a store that did not answer; 502 for one that said "not there".
+
+    One exception type, two facts, and opposite retry advice. Until #226
+    both left here as ``503 artifact_storage_unavailable`` with "Retry
+    later." — true of an outage, and a false instruction for the other
+    case: a store that answered ``NoSuchKey`` for a digest a committed
+    row still points at will keep saying so no matter how long the client
+    waits. ``exc.missing`` is the discriminator, set at the one place that
+    can tell the two apart (:func:`app.services.artifact_storage.
+    load_artifact_bytes`, from the S3 error code); reading it here rather
+    than at each raise site is the same shape as the constraint-name split
+    behind ``username_taken``/``email_taken``.
+
+    Why the missing case is a **5xx and not a 404 or a 410**: the caller
+    did nothing wrong. The artifact record exists, is findable, and is
+    still published; what is gone are bytes TCKDB undertook to keep. A
+    404 would additionally be indistinguishable from this route's
+    deliberate "unknown or unapproved digest" answer, which would recreate
+    the very ambiguity this split removes — one pair meaning both "you may
+    not see this" and "we lost it". A 410 carries the right retry advice
+    but the wrong instruction: it tells a client the resource was
+    withdrawn and its references may be dropped, and that reference is
+    what lets an operator put the object back (see ``restore_held_object``
+    and ``reclaim_restore``). ``ApiCode.is_client_facing`` states the same
+    rule from the other end — a 5xx is not a refusal of anything the
+    caller did — which is why neither code is in the client's
+    ``RejectionCode`` enum.
 
     The public body stays deliberately vague -- it names a subsystem and
-    says retry. That is right for a caller and useless for whoever has to
-    fix it: before this log line, a storage outage appeared in the journal
-    as a bare access-log ``503`` with no traceback and no cause, and
-    finding out *why* meant reading source to locate the raise site. The
-    raised message already carries the underlying botocore error (see
+    says what to do. That is right for a caller and useless for whoever
+    has to fix it: before this log line, a storage outage appeared in the
+    journal as a bare access-log ``503`` with no traceback and no cause,
+    and finding out *why* meant reading source to locate the raise site.
+    The raised message already carries the underlying botocore error (see
     :func:`app.services.artifact_persistence._store_and_record`), which
     names the endpoint it failed to reach; the only thing missing was
-    somewhere to put it. Response shape is unchanged.
+    somewhere to put it.
+
+    "This has been recorded" is not a courtesy on the missing branch, and
+    it is not asserted from here. The route that reads stored bytes writes
+    the ``object_missing`` custody row *before* re-raising (ADR 0014), so
+    the sentence is true of every path that can reach this branch with a
+    request attached; a caller that reaches it opportunistically never
+    sees a response at all.
     """
+    if getattr(exc, "missing", False):
+        # A break in custody, so ``error`` and not ``warning`` — the same
+        # level ``_artifact_integrity_handler`` uses for the sibling break.
+        logger.error(
+            "ArtifactStorageUnavailable (object missing) on %s %s: %s",
+            request.method,
+            request.url.path,
+            exc,
+            exc_info=exc,
+        )
+        return JSONResponse(
+            status_code=502,
+            content={
+                "detail": (
+                    "The stored bytes for this artifact are not in the "
+                    "object store. This has been recorded; retrying will "
+                    "not clear it."
+                ),
+                "code": "artifact_object_missing",
+                "context": {},
+            },
+        )
     logger.warning(
         "ArtifactStorageUnavailable on %s %s: %s",
         request.method,

--- a/backend/app/api/routes/scientific/artifacts.py
+++ b/backend/app/api/routes/scientific/artifacts.py
@@ -271,11 +271,18 @@ def artifact_integrity_detail(
         404: {"description": "No approved artifact has this digest."},
         502: {
             "description": (
-                "Stored bytes failed integrity verification. Recorded "
-                "durably; retrying will not clear it."
+                "A recorded break in custody, and retrying will not clear "
+                "either: `artifact_integrity_failed` when stored bytes "
+                "failed verification, `artifact_object_missing` when the "
+                "store answered and the object is not at its key."
             )
         },
-        503: {"description": "Artifact storage is unavailable."},
+        503: {
+            "description": (
+                "`artifact_storage_unavailable` — the object store did "
+                "not answer. Transient; retry."
+            )
+        },
     },
 )
 def download_approved_artifact(
@@ -340,6 +347,13 @@ def download_approved_artifact(
         # be recorded as a custody break — but a store that answered and
         # said the object is *not there*, for a digest a row still
         # references, has told us something durable.
+        #
+        # The same discriminator decides the answer: the handler in
+        # app.api.errors reads ``exc.missing`` and mints
+        # ``artifact_object_missing`` (502) instead of
+        # ``artifact_storage_unavailable`` (503), because the two need
+        # opposite retry advice. Recorded here, before the re-raise, which
+        # is what makes the response's "this has been recorded" true.
         if getattr(exc, "missing", False):
             record_integrity_observation(
                 sha256=sha256,

--- a/backend/docs/specs/scientific_artifact_reads.md
+++ b/backend/docs/specs/scientific_artifact_reads.md
@@ -71,7 +71,31 @@ least one owning calculation has an explicit `approved` review state. It reads
 the content-addressed object and verifies both digest and persisted byte count
 before returning it. Unknown, under-review, rejected, deprecated, and otherwise
 non-approved digests all return the same 404 response so existence cannot be
-probed. Storage failure returns 503; integrity failure returns 502.
+probed.
+
+Failure to serve the bytes splits three ways, and the split is by what the
+object store said rather than by which check noticed:
+
+| Situation | Status | `code` | Retry? |
+|---|---|---|---|
+| The store did not answer | 503 | `artifact_storage_unavailable` | Yes — back off and retry |
+| The store answered, and the object is not at its key | 502 | `artifact_object_missing` | No — recorded as an `object_missing` custody event |
+| The bytes came back and failed digest/size verification | 502 | `artifact_integrity_failed` | No — recorded as a `digest_mismatch`/`size_mismatch` custody event |
+
+The second row was `503 artifact_storage_unavailable` until #226, which is
+the same answer as the first and the opposite advice: a store that reports
+"no such key" for a digest a committed row still points at will keep
+reporting it. Both non-retryable rows are breaks in custody and are written
+to `artifact_integrity_event` before the response is built, so the trust
+layer hard-fails the owning calculation for the *next* reader too — see
+[ADR 0014](../../../docs/adr/0014-custody-of-stored-evidence-is-recorded-not-logged.md).
+
+A missing object is deliberately **not** a 404 or a 410. The artifact record
+exists and is still published; what is gone are bytes TCKDB undertook to
+keep, so the failure is the server's and belongs in the 5xx band. A 404
+would additionally be indistinguishable from the anti-probing 404 above,
+and a 410 would tell a client to drop the reference that
+`restore_held_object` needs in order to put the object back.
 
 Successful downloads require cache revalidation so a later review-state change
 can take effect. They carry an ETag equal to the quoted SHA-256,

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -61175,10 +61175,10 @@
             "description": "Validation Error"
           },
           "502": {
-            "description": "Stored bytes failed integrity verification. Recorded durably; retrying will not clear it."
+            "description": "A recorded break in custody, and retrying will not clear either: `artifact_integrity_failed` when stored bytes failed verification, `artifact_object_missing` when the store answered and the object is not at its key."
           },
           "503": {
-            "description": "Artifact storage is unavailable."
+            "description": "`artifact_storage_unavailable` — the object store did not answer. Transient; retry."
           }
         },
         "summary": "Download Approved Artifact",

--- a/backend/tests/api/scientific/test_api_scientific_artifact_download.py
+++ b/backend/tests/api/scientific/test_api_scientific_artifact_download.py
@@ -321,7 +321,15 @@ def test_integrity_502_writes_a_durable_record_not_just_a_log(
 def test_store_reporting_no_such_key_is_recorded_as_a_missing_object(
     client, db_session, monkeypatch
 ) -> None:
-    """A row referencing an object the store says is gone is a custody break."""
+    """A row referencing an object the store says is gone is a custody break.
+
+    And it answers as one. Until #226 this case and the outage below both
+    came back ``(503, artifact_storage_unavailable)`` with "Retry later.",
+    which is a false instruction here: the store has answered, it will
+    keep answering the same way, and no amount of backing off puts the
+    bytes back. The pair is asserted, not the status alone — a status on
+    its own cannot distinguish this from its sibling break.
+    """
     artifact, _content = _downloadable_artifact(
         db_session, status=RecordReviewStatus.approved
     )
@@ -342,7 +350,18 @@ def test_store_reporting_no_such_key_is_recorded_as_a_missing_object(
         f"/api/v1/scientific/artifacts/{artifact.sha256}/download"
     )
 
-    assert response.status_code == 503
+    body = response.json()
+    assert (response.status_code, body["code"]) == (502, "artifact_object_missing"), (
+        response.text
+    )
+    assert body["detail"] == (
+        "The stored bytes for this artifact are not in the object store. "
+        "This has been recorded; retrying will not clear it."
+    )
+    # No database primary key in a user-facing body (DR-0028 Req 2).
+    assert body["context"] == {}, body
+    assert str(artifact.id) not in body["detail"], body
+
     (event,) = _events_for(db_session, artifact.sha256)
     assert event.finding is ArtifactIntegrityFinding.object_missing
     assert event.observed_sha256 is None
@@ -351,9 +370,11 @@ def test_store_reporting_no_such_key_is_recorded_as_a_missing_object(
 def test_unreachable_store_records_nothing(client, db_session, monkeypatch) -> None:
     """An endpoint that never answered says nothing about the object.
 
-    Same 503 to the client as the case above, and the opposite fact for
-    custody: recording a break here would manufacture a hard fail out of
-    a network blip.
+    The opposite fact for custody: recording a break here would
+    manufacture a hard fail out of a network blip. And, since #226, the
+    opposite answer too — this is the branch that keeps
+    ``artifact_storage_unavailable`` and its "retry later", because here
+    retrying is exactly right.
     """
     artifact, _content = _downloadable_artifact(
         db_session, status=RecordReviewStatus.approved
@@ -373,8 +394,62 @@ def test_unreachable_store_records_nothing(client, db_session, monkeypatch) -> N
         f"/api/v1/scientific/artifacts/{artifact.sha256}/download"
     )
 
-    assert response.status_code == 503
+    body = response.json()
+    assert (response.status_code, body["code"]) == (
+        503,
+        "artifact_storage_unavailable",
+    ), response.text
+    assert "Retry later." in body["detail"], body
     assert _events_for(db_session, artifact.sha256) == []
+
+
+def test_the_two_storage_failures_do_not_answer_the_same_way(
+    client, db_session, monkeypatch
+) -> None:
+    """The whole point of #226, asserted as a contrast in one test.
+
+    The two tests above can both pass while the route answers identically
+    if either is edited to match the other; what has to hold is that the
+    answers *differ*, and differ in the direction that carries the retry
+    advice. So both situations are provoked here, through the wire,
+    against the same artifact, and the two ``(status, code)`` pairs are
+    compared to each other rather than to a literal.
+
+    A test that asserted only "an error arrived" would pass against a
+    handler that fails on everything; a test that asserted only two
+    literals would pass against a handler that had lost the branch and
+    been re-pinned. Comparing the pairs is what neither can survive.
+    """
+    artifact, _content = _downloadable_artifact(
+        db_session, status=RecordReviewStatus.approved
+    )
+    _record_into(monkeypatch, db_session)
+    url = f"/api/v1/scientific/artifacts/{artifact.sha256}/download"
+
+    def raising(**kwargs):
+        def fake_load(*_args, **_kw):
+            raise ArtifactStorageUnavailable("Artifact storage read failed", **kwargs)
+
+        return fake_load
+
+    monkeypatch.setattr(
+        "app.api.routes.scientific.artifacts.load_artifact_bytes",
+        raising(missing=True),
+    )
+    gone = client.get(url)
+
+    monkeypatch.setattr(
+        "app.api.routes.scientific.artifacts.load_artifact_bytes", raising()
+    )
+    outage = client.get(url)
+
+    gone_pair = (gone.status_code, gone.json()["code"])
+    outage_pair = (outage.status_code, outage.json()["code"])
+    assert gone_pair != outage_pair, (gone.text, outage.text)
+    # And in the right direction: only one of them may say "retry".
+    assert outage_pair[0] == 503 and gone_pair[0] != 503, (gone_pair, outage_pair)
+    assert "Retry later." in outage.json()["detail"]
+    assert "will not clear it" in gone.json()["detail"]
 
 
 def test_a_failing_recorder_does_not_turn_the_502_into_a_500(

--- a/backend/tests/api/test_api_untested_refusals_tier_de.py
+++ b/backend/tests/api/test_api_untested_refusals_tier_de.py
@@ -914,6 +914,14 @@ def test_a_missing_object_names_the_storage_subsystem_too(
 
     Two typed exceptions, one function, one defect: fixing only the one
     with a task number would have left the other exactly as it was.
+
+    The code then moved once more. #226 found that naming the subsystem
+    was necessary and not sufficient: ``artifact_storage_unavailable``
+    was still carrying both "the store did not answer" and this — "the
+    store answered, and the object is not at its key" — which need
+    opposite retry advice. This case is now ``artifact_object_missing``
+    at 502. The provocation is unchanged and is the strong one: a real
+    empty store, reached through the wire, not a patched loader.
     """
     artifact = _an_approved_artifact(db_session)
 
@@ -922,8 +930,8 @@ def test_a_missing_object_names_the_storage_subsystem_too(
     _use_object_store(monkeypatch, db_session, _InMemoryObjectStore())
     body = _assert_code(
         client.get(f"/api/v1/scientific/artifacts/{_ARTIFACT_SHA256}/download"),
-        "artifact_storage_unavailable",
-        status=503,
+        "artifact_object_missing",
+        status=502,
     )
     assert body["context"] == {}, body
     assert str(artifact.id) not in str(body.get("detail")), body


### PR DESCRIPTION
## The defect

`GET /scientific/artifacts/{sha}/download` answered `503 artifact_storage_unavailable`
— "Artifact storage is temporarily unavailable. Retry later." — for two situations
whose retry advice is opposite:

1. the object store did not answer (network, endpoint down) — retrying is right;
2. the object store answered, and said the object is not at its key, for a digest a
   committed `calculation_artifact` row still points at — retrying can never succeed.

Case (2) had already been separated *internally*: #212's sweep gave
`ArtifactStorageUnavailable` a `missing` flag and made the route write an
`object_missing` row to `artifact_integrity_event` (ADR 0014). What it did not do —
correctly, since a sweep that also redesigns a contract is two changes in one PR — is
change what the caller is told. The custody break was recorded and then reported as a
transient outage.

## The investigation that came first: can (2) happen benignly?

No. A missing object under a live row is always a break in custody, by construction:

- **Object before row, always.** `artifact_persistence._store_and_record` calls
  `store_artifact` first and only then constructs the `CalculationArtifact`. A
  committed row therefore implies the bytes were written. The reverse orphan (object,
  no row) is the case that exists, and the reclaim sweep is what handles it.
- **Failure paths retain objects deliberately.** `_compensate_stored_objects` refuses
  to delete on rollback because a digest can be shared. So a partial upload leaves an
  orphan object, never an orphaned row.
- **One caller of `delete_artifact_object`**, measured: `hold_artifact_object`
  (`artifact_storage.py:614`), which copies before deleting and only for a digest
  nothing references.
- **The purge re-reads references and refuses any digest a row points at**
  (`verify_artifact_integrity.py`).
- **The one race is already classified as a break, on purpose.** An upload that
  deduplicated against an object between the reclaim's reference check and the move can
  commit its row afterwards. Migration `c8e2a7d41b96` states the position: the row is
  legitimate, the object is under `reclaimed/`, "every read of it records
  `object_missing`", and the repair is an automatic `reclaim_restore` plus a real
  re-read. So even the most benign-looking path is deliberately a recorded break.

So the answer is not "split into a lookup miss" and not "record it instead of
answering". It is: keep recording it — that part already works — and stop telling the
caller to retry.

## The change

`_artifact_storage_unavailable_handler` branches on `exc.missing`, the discriminator
set at the one place that can tell the two apart (`load_artifact_bytes`, from the S3
error code). The exception *type* is deliberately not split, so every opportunistic
`except ArtifactStorageUnavailable` in the archive, parameter-extraction and
reproducibility paths still catches both. This is the same shape as #197's
constraint-name split behind `username_taken`/`email_taken`.

| Situation | Before | After |
|---|---|---|
| Store did not answer | `503 artifact_storage_unavailable` | unchanged |
| Store said "no such key" | `503 artifact_storage_unavailable` | **`502 artifact_object_missing`** |
| Bytes came back corrupt | `502 artifact_integrity_failed` | unchanged |

### Why 502, and not 404 or 410

Under the 2026-08-16 rule (404 for a missing thing, 409 for a state conflict, 422 for a
malformed payload) the missing object looks like a 404, and because the *record* exists
while the *bytes* are gone it looks even more like a 410. Both are wrong here:

- **The caller did nothing wrong.** The request was well formed, authorised, and named
  an artifact TCKDB still publishes. `ApiCode.is_client_facing` already states the rule
  from the other end — a 5xx "is not a refusal of anything the caller did" — which is
  why neither this code nor `artifact_storage_unavailable` enters the client's
  `RejectionCode` enum.
- **404 would collide with the route's anti-probing 404.** Unknown, under-review,
  rejected and non-approved digests all deliberately answer the same
  `404 Approved artifact not found`. Putting "we lost the bytes" behind that same pair
  would recreate, one level up, exactly the ambiguity this PR removes — and it would let
  a broken deployment look like a normal not-found to every client and every monitor.
- **410 carries the right retry advice and the wrong instruction.** RFC 9110 frames 410
  as an intentional withdrawal and invites the client to remove references to the
  resource. That reference is precisely what `_restore_referenced_holds` needs in order
  to put the object back; a client that prunes on 410 destroys the repair path.
- **502 is what the sibling break already uses.** TCKDB is acting as a gateway to the
  object store, and "no such key for a key we committed to" is an invalid upstream
  response. `artifact_integrity_failed` sits at 502 for the same reason. The two differ
  in the recorded finding — `object_missing` vs `digest_mismatch`/`size_mismatch` — and
  therefore in what an operator does next, which is what a separate code buys.

## Client impact: none, and that is derived rather than decided

`ApiCode.is_client_facing` requires `400 <= status < 500`, so a 502 code is excluded
from the generated enum by construction. Running
`backend/scripts/generate_client_rejection_codes.py` produced a byte-identical
`clients/python/src/tckdb_client/rejection_codes.py`. There is therefore no client
change to test and no `pyproject.toml` version to bump — the package stays at 0.47.0.

### The honest counter-argument, and why it did not win

`tckdb_client.retry.DEFAULT_RETRY_STATUS_CODES` is `{429, 502, 503, 504}`, and
`Client.download_artifact` goes through it. So a 502 still gets bounded *transport*
replays before the caller ever sees the code — which is an argument for 410, the one
status that would stop them.

It does not win, for two reasons. `artifact_integrity_failed` already sits at 502 with
"retrying will not clear it" and is already replayed the same way, so 410 here would
make the two custody breaks behave differently for no reason a caller could name. And
the transport retry is bounded and then surfaces the real code, whereas the wrong things
about 404/410 — colliding with the anti-probing 404, and inviting a client to drop the
reference the repair needs — are permanent.

If the bounded replay is judged too expensive, the cleaner repair is on the client:
teach the retry layer not to replay a response whose `code` the catalogue marks
non-retryable. That fixes both breaks at once and needs no status to be wrong.

## Schema / migration impact

None. No model, schema or Alembic change; `artifact_integrity_event` and the
`object_missing` finding already exist and are already written on this path.

## Tests

- `test_store_reporting_no_such_key_is_recorded_as_a_missing_object` now asserts the
  `(status, code)` **pair**, the exact detail sentence, an empty `context` and no row id
  in the body (DR-0028 Req 2).
- `test_unreachable_store_records_nothing` now asserts its pair too, and that its detail
  still says "Retry later." — the branch that keeps the old contract.
- New `test_the_two_storage_failures_do_not_answer_the_same_way` provokes **both**
  situations through the wire against the same artifact and compares the two pairs to
  *each other*, not to literals. A handler that failed on everything, or one that had
  lost the branch and been re-pinned to one answer, fails it.
- `test_a_missing_object_names_the_storage_subsystem_too` (tier D/E) keeps the strongest
  provocation — a real empty in-memory object store reached through the wire, not a
  patched loader — and is re-pointed at the new pair.

## Verification actually run

- All three CI gates from the worktree, with `DB_TEST_NAME=tckdb_test_a9b32`:
  `test-scientific.sh` 2056 passed; `test-rest.sh` 4598 passed, 14 skipped;
  `test-api.sh` **failed first** on `test_openapi_snapshot.py::test_openapi_matches_golden`
  (the route's `responses=` descriptions changed), regenerated with
  `UPDATE_OPENAPI_GOLDEN=1` — the golden diff is exactly the two description lines —
  and re-ran green at 2890 passed.
- The client's `test_rejection_codes.py` is not affected (no enum change), and per the
  standing caveat a worktree imports the **main** checkout's `tckdb_schemas`; nothing
  here touches the wire package, so that gap is not load-bearing for this PR.
- Mutation 1: neutered the `exc.missing` branch in the handler → the two updated tests
  and the new contrast test went RED; restored, `__pycache__` cleared.
- Mutation 2: removed the `artifact_object_missing` catalogue entry → the runtime error
  code observer errored the download tests as an uncatalogued `(502, code)` pair;
  restored.

## Not fixed here, and worth a separate decision

`services/reproducibility_rubric.py` has the same conflation on a different surface: its
`except ArtifactStorageUnavailable` labels the snapshot
`ArtifactVerificationStatus.unavailable` and emits an `artifact_storage_unavailable`
warning for **both** cases, and — unlike the download route — it writes **no**
`object_missing` row when the store says the key is gone. So a reproducibility sweep can
discover a custody break and throw it away, which is the ADR 0014 defect. Fixing it
means deciding whether a missing object hard-fails a reproducibility assessment and
probably adding an `ArtifactVerificationStatus` member — a scientific-trust decision, not
a wire-contract one, so it is filed rather than smuggled in here.
