### PR TITLE
Name which citation the 404 was about, on thermo and statmech

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -795,7 +795,20 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "digest. context carries both halves."
             )),
     ApiCode("unknown_calculation_ref", 404, Surface.coded_exception,
-            "backend/app/services/upload_reference.py"),
+            "backend/app/services/upload_reference.py",
+            note=(
+                "Three roots since #230, and two spellings. "
+                "/uploads/kinetics names the job by public ref; "
+                "/uploads/thermo and /uploads/statmech name it by row id in "
+                "source_calculations[i].existing_calculation_id, which "
+                "answered the generic resource_not_found with an empty "
+                "context until #230. One code because the missing row and "
+                "its repair are identical and only the spelling differs -- "
+                "splitting on spelling is the defect #195 removed from the "
+                "status. context['field'] separates them; context['ref'] is "
+                "present for the public-ref spelling only, because a row id "
+                "is logged and never echoed (DR-0028 Requirement 2)."
+            )),
     ApiCode("unknown_curation_policy", 404, Surface.message_prefix,
             "backend/app/api/routes/releases_admin.py"),
     ApiCode("unknown_include_token", 422, Surface.message_prefix,
@@ -830,7 +843,12 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "status matched neither the condition nor the sibling roots: "
                 "/uploads/thermo and /uploads/statmech already answered 404 "
                 "when a caller-supplied existing_*_id named no row, so the "
-                "status depended on how the caller spelled the name."
+                "status depended on how the caller spelled the name. Those "
+                "sibling roots answered it with no code and no context, "
+                "which #230 fixed by pointing thermo's existing_statmech_id "
+                "at this same code -- same missing row, same repair, and a "
+                "code that differed by spelling would have rebuilt one "
+                "field down what #195 removed from the status."
             )),
     ApiCode("unknown_transition_state_entry_ref", 404, Surface.coded_exception,
             "backend/app/services/upload_reference.py",

--- a/backend/app/services/statmech_resolution.py
+++ b/backend/app/services/statmech_resolution.py
@@ -30,7 +30,6 @@ from collections.abc import Mapping
 from sqlalchemy.orm import Session
 
 from app.api.error_contract import CodedValueError
-from app.api.errors import NotFoundError
 from app.db.models.calculation import Calculation
 from app.db.models.common import CalculationType, StatmechCalculationRole
 from app.db.models.statmech import (
@@ -50,6 +49,10 @@ from app.services.energy_correction_resolution import resolve_or_create_freq_sca
 from app.services.literature_resolution import resolve_or_create_literature
 from app.services.local_key_resolution import resolve_calculation_key
 from app.services.software_resolution import resolve_software_release_ref
+from app.services.upload_reference import (
+    W_UNKNOWN_CALCULATION_REF,
+    unknown_reference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,11 +165,29 @@ def _resolve_existing_calculation(
     Returning the row rather than its id is deliberate: the caller needs
     it for :func:`assert_statmech_role_compatible`, and re-fetching would
     invite the two checks to run against different rows.
+
+    Since #230 the 404 carries ``unknown_calculation_ref`` and a
+    ``context`` naming this field, instead of the generic
+    ``resource_not_found`` with an empty one. It is the same code
+    ``/uploads/kinetics`` uses for a ``source_calculation_ref`` that names
+    nothing: the same kind of row is missing and the repair is the same,
+    so a code that differed by spelling would recreate one field down the
+    defect #195 removed from the status. The id is logged, not echoed —
+    the sentence above about not disclosing it is now enforced by the seam
+    rather than by this function remembering to omit it.
     """
     calculation = session.get(Calculation, calculation_id)
     if calculation is None:
-        raise NotFoundError(
-            f"{context} refers to a calculation that does not exist."
+        raise unknown_reference(
+            code=W_UNKNOWN_CALCULATION_REF,
+            field=context,
+            kind="calculation",
+            row_id=calculation_id,
+            remedy=(
+                "Declare the job inline in this request with a "
+                "calculation_key, or deposit it first and cite the id "
+                "this API returned for it."
+            ),
         )
     assert_calculation_owned_by(
         calculation,

--- a/backend/app/services/upload_reference.py
+++ b/backend/app/services/upload_reference.py
@@ -45,11 +45,46 @@ depositing three different things through three different endpoints. Two
 fields needing two different right answers is what earns two codes.
 ``context['field']`` still says which ref asked, because a payload can
 cite several of the same kind.
+
+Two ways of naming a row, one code per kind
+-------------------------------------------
+``/uploads/kinetics`` names an already-stored record by **public ref**.
+``/uploads/thermo`` and ``/uploads/statmech`` name one by **row id**, in
+an ``existing_*_id`` field — programmatic chaining, a client quoting back
+an id this API issued it (see the schema rules' one sanctioned
+exception). Since #230 both spellings arrive here.
+
+They share a code per kind of row, and that is the point rather than an
+economy. #195 landed because the *status* used to depend on how the
+caller spelled the name — 404 for an id, 422 for a ref, for one condition
+— and "which spelling did you use" is not a distinction a depositor can
+act on. Splitting the *code* on the same axis would rebuild that defect
+one field down: a missing statmech is repaired by depositing a statmech,
+whether the payload asked for it by ``statmech_ref`` or by
+``existing_statmech_id``. ``context['field']`` says which field asked,
+which is the part a client actually branches on.
+
+What the two spellings do **not** share is disclosure. A public ref is
+echoed back, because the caller wrote it and quoting it is what makes the
+refusal diagnosable. A row id is **not**: DR-0028 Requirement 2 and
+:func:`app.api.errors.not_found` both refuse it, on the grounds that a row
+id is an implementation detail of one database instance which no public
+surface is keyed on, and a client that learns to read one builds against
+something TCKDB never promised to keep stable. Whoever needs it is the
+operator reading the log, so ``row_id=`` logs it and returns a body that
+does not contain it. That is why one function takes both parameters and
+insists on exactly one: the choice of spelling *is* the choice of
+disclosure rule, and separating them into two helpers would let a caller
+pick the wrong pair.
 """
 
 from __future__ import annotations
 
+import logging
+
 from app.api.errors import NotFoundError
+
+logger = logging.getLogger(__name__)
 
 #: An interpretation assignment's ``statmech_ref`` names no statmech row.
 W_UNKNOWN_STATMECH_REF = "unknown_statmech_ref"
@@ -86,11 +121,16 @@ def unknown_reference(
     code: str,
     field: str,
     kind: str,
-    ref: str,
+    ref: str | None = None,
+    row_id: int | None = None,
     remedy: str,
     **extra: object,
 ) -> NotFoundError:
-    """Build the 404 for a payload ref that resolves to nothing.
+    """Build the 404 for a payload reference that resolves to nothing.
+
+    Exactly one of ``ref`` and ``row_id`` must be given: they are the two
+    ways a payload can name an already-stored row, and they carry
+    different disclosure rules (see the module docstring).
 
     :param code: One of the ``W_UNKNOWN_*`` constants above.
     :param field: The payload path the depositor must look at, e.g.
@@ -99,21 +139,49 @@ def unknown_reference(
         can cite several refs of the same kind and "statmech not found"
         does not say which one.
     :param kind: The record kind, in the API's own vocabulary.
-    :param ref: The ref the caller supplied, echoed back — the caller
-        wrote it, so quoting it is what makes the refusal diagnosable.
+    :param ref: A **public ref** the caller supplied. Echoed into the
+        message and into ``context['ref']`` — the caller wrote it, so
+        quoting it is what makes the refusal diagnosable.
+    :param row_id: A **database row id** the caller supplied in an
+        ``existing_*_id`` field. Logged and never returned, because a row
+        id is not a public surface (DR-0028 Requirement 2). ``field``
+        already says which citation failed, which is the half a client
+        can act on.
     :param remedy: What to do about it, in one sentence.
     :param extra: Further structured context. Never a database primary
         key (DR-0028 Requirement 2); a public ref or a digest is fine.
+    :raises TypeError: If neither or both of ``ref`` and ``row_id`` are
+        given. A programming error rather than a refusal, so it is not a
+        coded 4xx: silently guessing which disclosure rule was meant is
+        how a row id ends up on the wire.
     """
+    if (ref is None) == (row_id is None):
+        raise TypeError(
+            "unknown_reference() takes exactly one of ref= (a public ref, "
+            "echoed) or row_id= (a database id, logged only)."
+        )
+    if row_id is not None:
+        # The operator's copy. Deliberately the only place the id appears:
+        # the returned body must be safe to hand a client verbatim.
+        logger.info(
+            "404 upload reference not found: code=%s field=%s kind=%s row_id=%s",
+            code,
+            field,
+            kind,
+            row_id,
+        )
+        named = f"{field} does not name a {kind} in this database."
+    else:
+        named = f"{field} {ref!r} does not name a {kind} in this database."
+    context: dict[str, object] = {"field": field, "kind": kind}
+    if ref is not None:
+        context["ref"] = ref
+    context.update(extra)
     # No ``"code: "`` prefix on the message: the exception carries the code
     # as an attribute and the handler passes it through unparsed, which is
     # the surface every new refusal should use. Writing it in the prose as
     # well would put a second copy where a reword can silently drop it.
-    return NotFoundError(
-        f"{field} {ref!r} does not name a {kind} in this database. {remedy}",
-        code=code,
-        context={"field": field, "kind": kind, "ref": ref, **extra},
-    )
+    return NotFoundError(f"{named} {remedy}", code=code, context=context)
 
 
 __all__ = [

--- a/backend/app/workflows/statmech.py
+++ b/backend/app/workflows/statmech.py
@@ -67,7 +67,10 @@ def persist_statmech_upload(
     :raises ValueError: If a resolved supporting calculation does not
         belong to the statmech target's species entry.
     :raises NotFoundError: If an ``existing_calculation_id`` names a
-        calculation row that does not exist.
+        calculation row that does not exist. 404 carrying
+        ``unknown_calculation_ref`` since #230 — the same code the
+        public-ref spelling on ``/uploads/kinetics`` uses, since the
+        missing row and its repair are the same.
     """
     species_entry = resolve_species_entry(
         session, request.species_entry, created_by=created_by

--- a/backend/app/workflows/thermo.py
+++ b/backend/app/workflows/thermo.py
@@ -7,7 +7,6 @@ import logging
 from sqlalchemy.orm import Session
 
 from app.api.error_contract import CodedValueError
-from app.api.errors import NotFoundError
 from app.db.models.calculation import Calculation
 from app.db.models.common import (
     CalculationType,
@@ -42,6 +41,11 @@ from app.services.record_review import (
 from app.services.species_resolution import resolve_species_entry
 from app.services.statmech_resolution import accepted_types_phrase
 from app.services.thermo_resolution import persist_thermo, resolve_thermo_upload
+from app.services.upload_reference import (
+    W_UNKNOWN_CALCULATION_REF,
+    W_UNKNOWN_STATMECH_REF,
+    unknown_reference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +157,15 @@ def _resolve_source_calculation(
     map of just-persisted calculations. Existing ids are loaded from the
     database; missing rows produce 404, cross-species or role/type
     mismatches produce 422 (DR-0028 Requirement 2).
+
+    Since #230 the 404 carries ``unknown_calculation_ref`` and a
+    ``context`` naming this field, rather than the generic
+    ``resource_not_found`` with nothing in it. Same code as the public-ref
+    spelling on ``/uploads/kinetics``, on purpose: the row that is missing
+    is the same kind of row and the repair is the same, so making the code
+    depend on the spelling would rebuild the defect #195 removed from the
+    status. The id the caller supplied is *not* echoed — it goes to the
+    log, per :func:`app.services.upload_reference.unknown_reference`.
     """
     field_path = f"source_calculations[{index}]"
     if entry.calculation_key is not None:
@@ -163,13 +176,20 @@ def _resolve_source_calculation(
         )
         context = f"{field_path}.calculation_key='{entry.calculation_key}'"
     else:
+        context = f"{field_path}.existing_calculation_id"
         calc_row = session.get(Calculation, entry.existing_calculation_id)
         if calc_row is None:
-            raise NotFoundError(
-                f"{field_path}.existing_calculation_id refers to a "
-                f"calculation that does not exist."
+            raise unknown_reference(
+                code=W_UNKNOWN_CALCULATION_REF,
+                field=context,
+                kind="calculation",
+                row_id=entry.existing_calculation_id,
+                remedy=(
+                    "Declare the job inline in this request with a "
+                    "calculation_key, or deposit it first and cite the id "
+                    "this API returned for it."
+                ),
             )
-        context = f"{field_path}.existing_calculation_id"
         assert_calculation_owned_by(
             calc_row,
             code=W_THERMO_SOURCE_CALCULATION_OWNER_MISMATCH,
@@ -199,6 +219,11 @@ def _resolve_statmech_id(
     different species entry produces 422. The error detail names the field
     but does not leak internal identifiers.
 
+    The 404 carries ``unknown_statmech_ref`` since #230 — the same code
+    ``/uploads/kinetics`` uses for a ``statmech_ref`` that names nothing,
+    because the missing row and its repair are identical and only the
+    spelling differs. ``context['field']`` is what tells the two apart.
+
     The 422 goes through the shared ownership guard rather than an inline
     comparison, which is what gives it
     ``thermo_statmech_owner_mismatch`` instead of the generic
@@ -211,9 +236,15 @@ def _resolve_statmech_id(
         return None
     statmech = session.get(Statmech, existing_statmech_id)
     if statmech is None:
-        raise NotFoundError(
-            "existing_statmech_id refers to a statmech record that does "
-            "not exist."
+        raise unknown_reference(
+            code=W_UNKNOWN_STATMECH_REF,
+            field="existing_statmech_id",
+            kind="statmech",
+            row_id=existing_statmech_id,
+            remedy=(
+                "Deposit the partition function through /uploads/statmech "
+                "first, then cite the id this API returned for it."
+            ),
         )
     assert_statmech_owned_by(
         statmech,

--- a/backend/tests/api/test_api_kinetics_unknown_reference_codes.py
+++ b/backend/tests/api/test_api_kinetics_unknown_reference_codes.py
@@ -413,11 +413,13 @@ def test_the_thermo_root_already_answered_404_for_the_same_condition(
     holds the half that did *not* change, so a later edit cannot restore
     the split by moving thermo instead of kinetics.
 
-    It also records what is still owed: this 404 carries the generic
-    ``resource_not_found`` rather than a code of its own, so a client can
-    read the status but not branch on the field. Giving the ``existing_*_id``
-    404s real codes is a separate pass — asserting the current answer here
-    is what keeps it from being forgotten.
+    What this test used to record as still owed is now paid. #230 gave the
+    ``existing_*_id`` 404s the same codes their public-ref counterparts
+    carry — the *status* is untouched, only the code and ``context`` — so
+    the code asserted here is ``unknown_statmech_ref`` and not the generic
+    ``resource_not_found``. The full assertions for that root live in
+    ``test_api_upload_existing_id_reference_codes.py``; this one keeps the
+    cross-root agreement pinned from the kinetics side.
     """
     refused = client.post(
         _THERMO,
@@ -429,7 +431,9 @@ def test_the_thermo_root_already_answered_404_for_the_same_condition(
         },
     )
     assert refused.status_code == 404, refused.text[:800]
-    assert refused.json()["code"] == "resource_not_found", refused.json()
+    body = refused.json()
+    assert body["code"] == "unknown_statmech_ref", body
+    assert body["context"]["field"] == "existing_statmech_id", body
 
     accepted = client.post(
         _THERMO,

--- a/backend/tests/api/test_api_upload_existing_id_reference_codes.py
+++ b/backend/tests/api/test_api_upload_existing_id_reference_codes.py
@@ -1,0 +1,366 @@
+"""Every ``existing_*_id`` that names no row, asserted on the wire.
+
+What changed, and what deliberately did not
+--------------------------------------------
+``/uploads/thermo`` and ``/uploads/statmech`` let a client cite a record
+this API already stored, by quoting back the row id it was issued —
+``existing_statmech_id``, ``source_calculations[i].existing_calculation_id``.
+When the id named nothing they answered **404**, which is correct and is
+unchanged here: nothing the depositor can retype makes a missing statmech
+exist, so the honest answer is "the thing you named is not there" and the
+repair is to deposit it first (see
+:mod:`app.services.upload_reference` for why not 422).
+
+What they did *not* do was say anything else. The body carried the generic
+``resource_not_found`` and an **empty** ``context``, so a depositor whose
+payload cited a statmech and three calculations learned only that one of
+the four was missing. Since #230 each refusal carries the same code its
+public-ref counterpart on ``/uploads/kinetics`` carries, plus a ``context``
+naming the field and the kind of row.
+
+Why the same code and not a new one
+------------------------------------
+#195 landed because the *status* used to depend on how a caller spelled
+the name — 404 for a row id, 422 for a public ref, for one condition — and
+"which spelling did you use" is not a distinction a depositor can act on.
+Minting ``unknown_statmech_id`` alongside ``unknown_statmech_ref`` would
+rebuild that defect one field down: the missing row is the same kind of
+row and the repair is the same deposit through the same endpoint.
+``context['field']`` is what separates the two, and it is the half a
+client branches on. The cross-root agreement is pinned from the kinetics
+side in ``test_api_kinetics_unknown_reference_codes.py`` and from this side
+below, so neither can drift without the other failing.
+
+The one thing the two spellings do not share
+---------------------------------------------
+Disclosure. A public ref is echoed into ``context['ref']``; a row id is
+**not** echoed anywhere (DR-0028 Requirement 2 — a row id is an
+implementation detail of one database instance, no public surface is keyed
+on it, and a client that learns to read one builds against something TCKDB
+never promised to keep stable). It goes to the log instead.
+:func:`test_no_refusal_here_echoes_the_row_id` is the assertion, and it
+checks the *whole serialised body* rather than ``context`` alone, because
+the id would most plausibly leak back through the prose.
+
+The shape of every test here
+----------------------------
+* the **exact status and code**, plus the structured ``context`` — never a
+  substring of ``detail``;
+* a **neighbouring request that must still be accepted**, because a test
+  asserting only "a 404 arrived" passes against a handler that 404s on
+  everything;
+* no database primary key anywhere in the body.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.models.common import CalculationType
+from app.db.models.statmech import Statmech
+from app.services.upload_reference import (
+    W_UNKNOWN_CALCULATION_REF,
+    unknown_reference,
+)
+from tests.services.scientific_read._factories import (
+    make_calculation,
+    make_species,
+    make_species_entry,
+    next_inchi_key,
+)
+
+_THERMO = "/api/v1/uploads/thermo"
+_STATMECH = "/api/v1/uploads/statmech"
+
+#: Comfortably past any row this suite creates, and never a real id.
+_ABSENT = 2_000_000_000
+
+
+@pytest.fixture
+def methyl(db_session):
+    """One species entry, and an ``opt`` calculation that belongs to it.
+
+    The calculation is real and correctly owned so that the *accepted*
+    half of each test is refused by nothing: an id that names a row owned
+    by another species entry is a different (422) refusal, and one that
+    names a job of the wrong type is a third, either of which would fire
+    first and make a green assertion here mean nothing.
+    """
+    entry = make_species_entry(
+        db_session,
+        make_species(
+            db_session, smiles="[CH3]", multiplicity=2,
+            inchi_key=next_inchi_key("EXID"),
+        ),
+    )
+    calculation = make_calculation(
+        db_session, type=CalculationType.opt, species_entry_id=entry.id
+    )
+    statmech = Statmech(species_entry_id=entry.id, scientific_origin="computed")
+    db_session.add(statmech)
+    db_session.flush()
+    return entry, calculation, statmech
+
+
+_SPECIES = {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}
+
+
+def _thermo(**overrides) -> dict:
+    body: dict = {
+        "species_entry": _SPECIES,
+        "scientific_origin": "computed",
+        "h298_kj_mol": 146.7,
+    }
+    body.update(overrides)
+    return body
+
+
+def _statmech(**overrides) -> dict:
+    body: dict = {
+        "species_entry": _SPECIES,
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 1,
+    }
+    body.update(overrides)
+    return body
+
+
+def _missing(response, *, code: str, field: str, kind: str) -> dict:
+    """Assert the 404 a client branches on, and return the body.
+
+    ``detail`` is deliberately not matched: asserting the code and the
+    structured ``context`` is what a client can act on, and a substring of
+    the prose is not a contract.
+    """
+    assert response.status_code == 404, response.text[:800]
+    body = response.json()
+    assert body["code"] == code, body
+    context = body["context"]
+    assert context["field"] == field, body
+    assert context["kind"] == kind, body
+    # No row id, under any key: not the one the caller sent, not any other.
+    leaked = [key for key in context if key == "id" or key.endswith("_id")]
+    assert not leaked, f"{code} leaked database ids into context: {leaked}"
+    assert str(_ABSENT) not in str(body), body
+    return body
+
+
+# ---------------------------------------------------------------------------
+# /uploads/thermo -- existing_statmech_id
+# ---------------------------------------------------------------------------
+
+
+def test_a_thermo_citing_a_statmech_that_is_not_there_is_a_coded_404(
+    client, methyl
+):
+    """An enthalpy cannot be anchored to a partition function that is absent.
+
+    The repair is to deposit the statmech, which is a different request to
+    a different endpoint — so the depositor is told the row is missing and
+    which field named it, not that their payload is malformed.
+    """
+    _entry, _calc, statmech = methyl
+
+    refused = client.post(_THERMO, json=_thermo(existing_statmech_id=_ABSENT))
+    _missing(
+        refused,
+        code="unknown_statmech_ref",
+        field="existing_statmech_id",
+        kind="statmech",
+    )
+
+    accepted = client.post(
+        _THERMO, json=_thermo(existing_statmech_id=statmech.id)
+    )
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# /uploads/thermo -- source_calculations[i].existing_calculation_id
+# ---------------------------------------------------------------------------
+
+
+def test_a_thermo_source_link_naming_no_calculation_is_a_coded_404(
+    client, methyl
+):
+    """``context['field']`` carries the index, because a payload cites many.
+
+    A thermo record may link several supporting jobs. "calculation not
+    found" would not say which of them, which is the whole reason the
+    index is in the field path rather than only in the prose.
+    """
+    _entry, calculation, _row = methyl
+
+    refused = client.post(
+        _THERMO,
+        json=_thermo(
+            source_calculations=[{"existing_calculation_id": _ABSENT, "role": "sp"}]
+        ),
+    )
+    _missing(
+        refused,
+        code="unknown_calculation_ref",
+        field="source_calculations[0].existing_calculation_id",
+        kind="calculation",
+    )
+
+    accepted = client.post(
+        _THERMO,
+        json=_thermo(
+            source_calculations=[
+                {"existing_calculation_id": calculation.id, "role": "sp"}
+            ]
+        ),
+    )
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+def test_the_second_thermo_source_link_reports_its_own_index(client, methyl):
+    """The index is read off the loop, not hard-coded to zero.
+
+    Without this the field path would be right by accident for every
+    payload that cites exactly one calculation, which is most of them.
+    """
+    _entry, calculation, _row = methyl
+
+    refused = client.post(
+        _THERMO,
+        json=_thermo(
+            source_calculations=[
+                {"existing_calculation_id": calculation.id, "role": "sp"},
+                {"existing_calculation_id": _ABSENT, "role": "freq"},
+            ]
+        ),
+    )
+    _missing(
+        refused,
+        code="unknown_calculation_ref",
+        field="source_calculations[1].existing_calculation_id",
+        kind="calculation",
+    )
+
+
+# ---------------------------------------------------------------------------
+# /uploads/statmech -- source_calculations[i].existing_calculation_id
+# ---------------------------------------------------------------------------
+
+
+def test_a_statmech_source_link_naming_no_calculation_is_a_coded_404(
+    client, methyl
+):
+    """The sibling root, whose field path is namespaced ``statmech.``.
+
+    Same code as thermo's and as the kinetics public-ref spelling: one
+    kind of missing row, one repair. The field path is what differs, and
+    it is the field path a client reads.
+    """
+    _entry, calculation, _row = methyl
+
+    refused = client.post(
+        _STATMECH,
+        json=_statmech(
+            source_calculations=[{"existing_calculation_id": _ABSENT, "role": "sp"}]
+        ),
+    )
+    _missing(
+        refused,
+        code="unknown_calculation_ref",
+        field="statmech.source_calculations[0].existing_calculation_id",
+        kind="calculation",
+    )
+
+    accepted = client.post(
+        _STATMECH,
+        json=_statmech(
+            source_calculations=[
+                {"existing_calculation_id": calculation.id, "role": "sp"}
+            ]
+        ),
+    )
+    assert accepted.status_code == 201, accepted.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# The disclosure rule, checked across every root at once
+# ---------------------------------------------------------------------------
+
+
+def test_no_refusal_here_echoes_the_row_id(client, methyl):
+    """The id the caller sent appears in no part of the body.
+
+    Checked over the whole serialised response rather than over
+    ``context``, because the likeliest way for it to come back is inside
+    the sentence — which is exactly how the thirty ``f"... ({kind}_id=
+    {row_id})"`` 404s :func:`app.api.errors.not_found` replaced were
+    written.
+    """
+    bodies = [
+        client.post(_THERMO, json=_thermo(existing_statmech_id=_ABSENT)),
+        client.post(
+            _THERMO,
+            json=_thermo(
+                source_calculations=[
+                    {"existing_calculation_id": _ABSENT, "role": "sp"}
+                ]
+            ),
+        ),
+        client.post(
+            _STATMECH,
+            json=_statmech(
+                source_calculations=[
+                    {"existing_calculation_id": _ABSENT, "role": "sp"}
+                ]
+            ),
+        ),
+    ]
+    for response in bodies:
+        assert response.status_code == 404, response.text[:400]
+        assert str(_ABSENT) not in response.text, response.text[:400]
+
+
+# ---------------------------------------------------------------------------
+# The seam's own guard
+# ---------------------------------------------------------------------------
+
+
+def test_the_seam_refuses_to_guess_which_disclosure_rule_was_meant():
+    """``ref=`` echoes and ``row_id=`` does not, so exactly one is required.
+
+    A ``TypeError`` and not a coded 4xx: this is a caller of the seam
+    getting it wrong, not a depositor. Defaulting either way is how a row
+    id reaches the wire — passing an id as ``ref=`` would echo it, and
+    silently dropping both would produce a refusal naming nothing.
+    """
+    with pytest.raises(TypeError):
+        unknown_reference(
+            code=W_UNKNOWN_CALCULATION_REF,
+            field="f",
+            kind="calculation",
+            remedy="r",
+        )
+    with pytest.raises(TypeError):
+        unknown_reference(
+            code=W_UNKNOWN_CALCULATION_REF,
+            field="f",
+            kind="calculation",
+            ref="calc_abc",
+            row_id=7,
+            remedy="r",
+        )
+
+
+def test_the_row_id_form_keeps_the_id_out_of_the_exception_it_builds():
+    """The unit-level statement of the rule the wire tests check end to end."""
+    error = unknown_reference(
+        code=W_UNKNOWN_CALCULATION_REF,
+        field="source_calculations[0].existing_calculation_id",
+        kind="calculation",
+        row_id=987_654_321,
+        remedy="Deposit it first.",
+    )
+    assert error.code == W_UNKNOWN_CALCULATION_REF
+    assert "987654321" not in str(error)
+    assert "987654321" not in str(error.context)
+    assert "ref" not in error.context
+    assert error.context["kind"] == "calculation"

--- a/backend/tests/api/test_api_upload_key_and_role_contracts.py
+++ b/backend/tests/api/test_api_upload_key_and_role_contracts.py
@@ -851,7 +851,13 @@ class TestChainedCitationPassesEveryCheckALocalOneDoes:
         assert body["context"]["accepted_calculation_types"] == ["opt"]
 
     def test_an_id_that_does_not_exist_is_a_clean_404(self, client):
-        """Not a 500, and not a foreign-key error leaking out of psycopg."""
+        """Not a 500, and not a foreign-key error leaking out of psycopg.
+
+        The status has not moved. What moved (#230) is the code: this used
+        to answer the generic ``resource_not_found`` with an empty
+        ``context``, so a depositor learned that *something* was missing
+        and had to read English prose to find out which citation named it.
+        """
         resp = client.post(
             "/api/v1/uploads/statmech",
             json=_standalone_statmech_payload(
@@ -864,10 +870,14 @@ class TestChainedCitationPassesEveryCheckALocalOneDoes:
         assert resp.status_code == 404, resp.text
         body = resp.json()
         assert set(body) >= {"code", "detail"}, body
-        assert body["code"] == "resource_not_found", body
-        assert "does not exist" in body["detail"]
+        assert body["code"] == "unknown_calculation_ref", body
+        assert body["context"]["kind"] == "calculation", body
         # The field the depositor wrote is named; nothing else is.
-        assert "existing_calculation_id" in body["detail"]
+        assert (
+            body["context"]["field"]
+            == "statmech.source_calculations[0].existing_calculation_id"
+        ), body
+        assert "999999999" not in str(body), body
 
     def test_a_calculation_owned_by_another_species_entry_is_refused(
         self, client

--- a/backend/tests/api/test_api_uploads.py
+++ b/backend/tests/api/test_api_uploads.py
@@ -541,6 +541,12 @@ class TestThermoUpload:
         assert data["species_entry_id"] == species_entry_id
 
     def test_existing_calculation_id_not_found_returns_404(self, client):
+        """The status is unchanged; the code and context are new in #230.
+
+        This used to assert a substring of ``detail``, which was all there
+        was to assert while the refusal carried the generic
+        ``resource_not_found`` with an empty ``context``.
+        """
         payload = {
             "species_entry": {"smiles": "[H]", "charge": 0, "multiplicity": 2},
             "scientific_origin": "computed",
@@ -551,7 +557,13 @@ class TestThermoUpload:
         }
         resp = client.post("/api/v1/uploads/thermo", json=payload)
         assert resp.status_code == 404, resp.text
-        assert "does not exist" in resp.json()["detail"]
+        body = resp.json()
+        assert body["code"] == "unknown_calculation_ref", body
+        assert body["context"] == {
+            "field": "source_calculations[0].existing_calculation_id",
+            "kind": "calculation",
+        }, body
+        assert "999999999" not in str(body), body
 
     def test_existing_calc_wrong_species_entry_returns_422(self, client):
         """A cross-owner chained citation is refused, under a real code.

--- a/backend/tests/workflows/test_statmech_upload.py
+++ b/backend/tests/workflows/test_statmech_upload.py
@@ -963,7 +963,15 @@ def test_statmech_upload_links_existing_calculation_without_duplicating_it(
 def test_statmech_upload_chained_id_that_does_not_exist_raises_not_found(
     db_conn,
 ) -> None:
-    """A missing row is a named 404, never a ``KeyError`` or a raw FK error."""
+    """A missing row is a named 404, never a ``KeyError`` or a raw FK error.
+
+    Asserted on the ``code`` since #230, not on a substring of the
+    sentence. The prose was the only thing this could check while the
+    refusal carried the generic ``resource_not_found``; now that it
+    declares ``unknown_calculation_ref`` there is a real contract to hold,
+    and the id the caller supplied must stay out of the message
+    (DR-0028 Requirement 2).
+    """
     request = StatmechUploadRequest(
         species_entry={"smiles": "CCOCCC", "charge": 0, "multiplicity": 1},
         scientific_origin="computed",
@@ -972,9 +980,15 @@ def test_statmech_upload_chained_id_that_does_not_exist_raises_not_found(
             {"existing_calculation_id": 999_999_999, "role": "sp"}
         ],
     )
-    with pytest.raises(NotFoundError, match="does not exist"):
+    with pytest.raises(NotFoundError) as excinfo:
         with Session(db_conn) as session, session.begin():
             persist_statmech_upload(session, request)
+    assert excinfo.value.code == "unknown_calculation_ref"
+    assert excinfo.value.context == {
+        "field": "statmech.source_calculations[0].existing_calculation_id",
+        "kind": "calculation",
+    }
+    assert "999999999" not in str(excinfo.value)
 
 
 def test_statmech_upload_chained_id_from_another_species_entry_raises(

--- a/backend/tests/workflows/test_thermo_upload.py
+++ b/backend/tests/workflows/test_thermo_upload.py
@@ -1215,7 +1215,12 @@ def test_thermo_upload_existing_calc_id_not_found_raises_not_found(
     db_conn,
 ) -> None:
     """DR-0028 Req 2: a missing existing_calculation_id must surface as 404
-    via NotFoundError (mapped to HTTP 404 by the API exception handler)."""
+    via NotFoundError (mapped to HTTP 404 by the API exception handler).
+
+    Since #230 the 404 also declares ``unknown_calculation_ref`` and names
+    the field in ``context``, so this asserts the contract rather than a
+    substring of the sentence. The status is unchanged.
+    """
     from app.api.errors import NotFoundError
 
     distinct = {"smiles": "CN", "charge": 0, "multiplicity": 1}
@@ -1228,9 +1233,15 @@ def test_thermo_upload_existing_calc_id_not_found_raises_not_found(
         ],
     )
 
-    with pytest.raises(NotFoundError, match="does not exist"):
+    with pytest.raises(NotFoundError) as excinfo:
         with Session(db_conn) as session, session.begin():
             persist_thermo_upload(session, request)
+    assert excinfo.value.code == "unknown_calculation_ref"
+    assert excinfo.value.context == {
+        "field": "source_calculations[0].existing_calculation_id",
+        "kind": "calculation",
+    }
+    assert "999999999" not in str(excinfo.value)
 
 
 def test_thermo_upload_existing_calc_id_wrong_species_entry_raises_422(
@@ -1615,11 +1626,16 @@ def test_thermo_upload_links_existing_statmech(db_conn) -> None:
 
 
 def test_thermo_upload_statmech_not_found_raises_not_found(db_conn) -> None:
-    """A missing existing_statmech_id surfaces as 404 (NotFoundError)."""
+    """A missing existing_statmech_id surfaces as 404 (NotFoundError).
+
+    Carrying ``unknown_statmech_ref`` since #230 — the same code the
+    public-ref spelling on ``/uploads/kinetics`` uses, because the missing
+    row and its repair are the same. The status did not move.
+    """
     from app.api.errors import NotFoundError
 
     distinct = {"smiles": "CCCCCCCCCC", "charge": 0, "multiplicity": 1}
-    with pytest.raises(NotFoundError, match="does not exist"):
+    with pytest.raises(NotFoundError) as excinfo:
         with Session(db_conn) as session, session.begin():
             persist_thermo_upload(
                 session,
@@ -1630,6 +1646,12 @@ def test_thermo_upload_statmech_not_found_raises_not_found(db_conn) -> None:
                     existing_statmech_id=999_999_999,
                 ),
             )
+    assert excinfo.value.code == "unknown_statmech_ref"
+    assert excinfo.value.context == {
+        "field": "existing_statmech_id",
+        "kind": "statmech",
+    }
+    assert "999999999" not in str(excinfo.value)
 
 
 def test_thermo_upload_statmech_wrong_species_entry_raises_422(db_conn) -> None:


### PR DESCRIPTION
## In plain language

When you upload a thermodynamics or partition-function record, you can point at
something TCKDB already stored by quoting back the id it gave you —
`existing_statmech_id`, `existing_calculation_id`. If that id names nothing, the
server said **404** ("not found"), which is the right answer and has not changed.

What it did *not* say was **which** of your citations was the bad one. The reply
carried the catch-all label `resource_not_found` and an empty `context` — the
structured, machine-readable half of an error body, as opposed to `detail`, which
is an English sentence written for a human. A payload citing one partition
function and three jobs got back "something you named is missing" and nothing
else, so any program wanting to react had to pattern-match on the prose.

This PR gives those refusals the same labels their siblings already carry, plus a
`context` naming the exact field — `source_calculations[1].existing_calculation_id`
— and the kind of record expected. **No status code anywhere changed**: it was
404 before and it is 404 now.

A "code" here is the short stable string in the `code` field of an error body,
the thing client software is meant to branch on instead of reading the sentence.
"Context" is the accompanying dictionary of structured facts. "The seam" is the
one small module every refusal of this shape is built through, so the decision
about what an error may disclose is made once rather than at each `raise`.

## What changed

Adopts the `upload_reference.py` seam from #195 on the two sibling upload roots.
Three raise sites, all previously a bare `NotFoundError`:

| site | field | now |
|---|---|---|
| `backend/app/workflows/thermo.py` | `existing_statmech_id` | 404 `unknown_statmech_ref` |
| `backend/app/workflows/thermo.py` | `source_calculations[i].existing_calculation_id` | 404 `unknown_calculation_ref` |
| `backend/app/services/statmech_resolution.py` | `statmech.source_calculations[i].existing_calculation_id` | 404 `unknown_calculation_ref` |

### No status changed — confirmed, not assumed

Reproduced through the wire before and after. Before, all three answered
`404 {"code": "resource_not_found", "context": {}}`. After, all three answer `404`
with a real code and a populated `context`. Every neighbouring valid payload still
returns `201`. The full backend suite is green, so nothing elsewhere moved either.

This is therefore **non-breaking for a client branching on status**, unlike #195
which moved a 422 to a 404. It is also non-breaking for a client branching on the
published `RejectionCode` enum: `resource_not_found` is `Surface.generic_fallback`
and has never been exported to clients (`ApiCode.is_client_facing`). A client
hard-coding the literal `"resource_not_found"` for these two roots would see the
value change — that is the point of the change, and it is the case the generated
enum exists to make unnecessary.

### Why the same codes and not new ones

`unknown_statmech_ref` and `unknown_calculation_ref` are reused rather than
`unknown_statmech_id` / `unknown_calculation_id` being minted.

#195 landed because the *status* used to depend on how the caller spelled the
name: 404 for a row id, 422 for a public ref, for one condition. "Which spelling
did you use" is not a distinction a depositor can act on. Splitting the *code* on
that same axis would rebuild the defect one field down — a missing statmech is
repaired by depositing a statmech through `/uploads/statmech`, whether the payload
asked for it by `statmech_ref` or by `existing_statmech_id`. `context['field']` is
what separates them, and it is the half a client branches on.

Consequence: **no new codes, so no wire-package change and no client version bump.**

### What the two spellings do not share: disclosure

A public ref is echoed back into `context['ref']`. A row id is **not** echoed
anywhere — DR-0028 Requirement 2, and the same reasoning `app.api.errors.not_found`
already gives: a row id is an implementation detail of one database instance, no
public surface is keyed on it, and a client that learns to read one builds against
something TCKDB never promised to keep stable. It goes to the log instead.

`unknown_reference()` therefore takes `ref=` **or** `row_id=` and raises `TypeError`
on neither/both. One function rather than two helpers, because the choice of
spelling *is* the choice of disclosure rule and two helpers would let a caller pick
the wrong pair; a `TypeError` rather than a coded 4xx, because getting this wrong
is a bug in a caller of the seam, not something a depositor did.

## Schema / migration impact

**None.** No ORM model, no Pydantic schema, no Alembic revision, no new
environment variable. Error-envelope contents only.

## Wire package

**Untouched.** No new code reaches `RejectionCode`, so `clients/python/pyproject.toml`
is not bumped and `rejection_codes.py` is not regenerated. (Had it needed one: tests
in a worktree silently import the *main* checkout's `tckdb_schemas`, so a
wire-package edit would have been CI-verified rather than locally verified.)

## Commands actually run

From `backend/`, with an isolated scratch database so the four other agent
suites running concurrently on this box could not contaminate the result:

```
DB_TEST_NAME=tckdb_test_ae6ed conda run -n tckdb_env python -m pytest tests/ -q -p no:randomly
conda run -n tckdb_env ruff check app tests scripts        # All checks passed!
conda run -n tckdb_env mypy                                # Success: no issues found in 149 source files
conda run -n tckdb_env python scripts/check_runtime_ascii.py
conda run -n tckdb_env pytest tests/api/test_openapi_snapshot.py -q    # 3 passed
conda run -n tckdb_env pytest tests/api/test_api_code_catalogue.py -q  # 14 passed
```

The first full-suite run was `4 failed, 7937 passed, 14 skipped` — the four
prose-substring tests listed below. After updating them the suite is green.

Both premises were reproduced first, through `TestClient`, before any edit.

## Mutations landed (each confirmed RED, then reverted, `__pycache__` cleared)

| # | mutation | test that went red |
|---|---|---|
| 1 | thermo statmech 404 raised with the wrong code | `test_a_thermo_citing_a_statmech_that_is_not_there_is_a_coded_404` + the kinetics-side cross-root pin |
| 2 | `field_path` hard-coded to `source_calculations[0]` | `test_the_second_thermo_source_link_reports_its_own_index` |
| 3 | seam echoes `row_id` into the message and `context['ref']` | `test_no_refusal_here_echoes_the_row_id`, `test_the_row_id_form_keeps_the_id_out_of_the_exception_it_builds` (+2 more) |
| 4 | seam's exactly-one guard deleted | `test_the_seam_refuses_to_guess_which_disclosure_rule_was_meant` |
| 5 | statmech site reverted to the bare `NotFoundError` | `test_a_statmech_source_link_naming_no_calculation_is_a_coded_404`, `test_an_id_that_does_not_exist_is_a_clean_404` |
| 6 | thermo guard changed to `if True` (refuse every citation) | `test_a_thermo_citing_a_statmech_that_is_not_there_is_a_coded_404` — the paired-201 half |

Mutation 6 is the one that matters most: it proves the "a test asserting only
*a 404 arrived* passes against a handler that 404s on everything" failure mode is
actually closed here, rather than merely warned about.

## Six tests updated rather than added

None is weakened; every one asserts strictly more than before. Each swaps a
substring of the English `detail` for the machine-readable `code` and `context`,
and gains a check that the id the caller supplied is absent from the whole body.

* `test_api_kinetics_unknown_reference_codes.py::test_the_thermo_root_already_answered_404_for_the_same_condition`
  explicitly recorded the generic code as *still owed* ("Giving the `existing_*_id`
  404s real codes is a separate pass"). That pass is this PR, so the assertion moves
  from `resource_not_found` to `unknown_statmech_ref` and gains a `context` check.
* `test_api_upload_key_and_role_contracts.py::test_an_id_that_does_not_exist_is_a_clean_404`
* `test_api_uploads.py::TestThermoUpload::test_existing_calculation_id_not_found_returns_404`
* `test_workflows/test_thermo_upload.py::test_thermo_upload_existing_calc_id_not_found_raises_not_found`
* `test_workflows/test_thermo_upload.py::test_thermo_upload_statmech_not_found_raises_not_found`
* `test_workflows/test_statmech_upload.py::test_statmech_upload_chained_id_that_does_not_exist_raises_not_found`

The last four were **found by the full suite, not by grep** — they keyed on the
substring `"does not exist"` rather than on `resource_not_found`, so a search for
the old code missed them entirely. Worth recording: the reason they were invisible
is precisely the reason this PR exists. A test that can only assert a fragment of
prose is a test written against an error body that had no contract to assert.

## Part 2 was NOT done, because the brief contradicts itself — please read

The task asked me to split `conformer_selection content locator must resolve
exactly one selection` into a none-matched and a several-matched refusal, and
separately said there is "a third instance of this same shape" at
`backend/app/workflows/kinetics.py:318` which I must **not** fix here (task #204
group 3).

There is exactly **one** instance of that message in the entire repository, and it
is `kinetics.py:318`. `git log -S` shows it has lived there since #66 and has never
existed anywhere else. The site Part 2 asks me to change and the site Part 2
forbids me to change are the same line, so I stopped rather than pick one.

Both halves of the condition *are* real — reproduced on the wire, both
`422 validation_error` with identical prose and empty context. Several-matched is
genuinely reachable: `conformer_group` is unique on `(species_entry_id, label)`, so
a species entry may own several groups, each carrying its own `lowest_energy`
selection with a NULL scheme, and the locator's query joins on `species_entry_id`
rather than on a group.

What I would do, ready to drop into #204 group 3:

* **none matched → 404 `unknown_conformer_selection`.** The depositor named a
  curation-overlay row that is not there; no corrected body conjures it. Same
  argument the seam's docstring already makes, and it keeps "you named a thing that
  is not there" at one status across every locator spelling.
* **several matched → 422 `ambiguous_conformer_selection_locator`**, with
  `context['match_count']` (and never the candidate row ids). Every row the locator
  could mean exists, so the world is fine and 409 would be wrong; the *request* is
  under-determined, and 422's published meaning is "fix it and resend".

One caveat that argues for doing the split and a locator widening together rather
than the split alone: `ConformerSelectionContentRef` carries only
`{species_entry, selection_kind, assignment_scheme_ref}`. A depositor told "be more
specific" has nothing but `assignment_scheme_ref` to add, and when both matching
selections carry a NULL scheme there is nothing they *can* add. A 422 whose remedy
sentence is un-actionable is barely better than the shared message it replaces.

## Proposed rule for the error-contract module docstring

Not written into any file — proposing it here first, as asked. Reacting to the
suggested wording: it is right but only half a rule, and the missing half is the
one this PR needed. Stating only "different repairs get different codes" invites
the opposite error — a code per raise site — which is how a catalogue rots.

> **One code per repair.** If two conditions send a client to do different
> things next, they get different codes — even when they share a raise site,
> even when they share a status, and even when the same `if` produced both.
> The test is not "is this the same check?" but "would a caller's next action
> be the same?". A username already taken and an email already taken are one
> uniqueness violation and two different forms to re-fill.
>
> The converse binds equally. One repair earns **one** code across as many
> raise sites, fields and spellings as it takes: `unknown_calculation_ref`
> covers a public ref on one root and a row id on two others, because the
> missing row is the same row and the fix is the same deposit. A code that
> varies with how the caller spelled a name reports our implementation back
> at them.

## Files

* `backend/app/services/upload_reference.py` — seam extended with `row_id=`
* `backend/app/workflows/thermo.py` — two sites
* `backend/app/services/statmech_resolution.py` — one site
* `backend/app/workflows/statmech.py` — docstring
* `backend/app/api/code_catalogue.py` — notes on the two reused codes
* `backend/tests/api/test_api_upload_existing_id_reference_codes.py` — new, 7 tests
* six existing tests updated across five files, as described above
