### PR TITLE
Say when a bent molecule has a linear molecule's mode count

### DIFF
--- a/backend/app/api/routes/uploads.py
+++ b/backend/app/api/routes/uploads.py
@@ -38,6 +38,13 @@ from app.schemas.workflows.transition_state_upload import (
     TransitionStateUploadRequest,
 )
 from app.schemas.workflows.transport_upload import TransportUploadRequest
+from app.services.frequency_geometry_linearity import (
+    computed_reaction_linearity_warnings,
+    computed_species_linearity_warnings,
+    inline_calculation_linearity_warnings,
+    network_pdep_linearity_warnings,
+    transition_state_upload_linearity_warnings,
+)
 from app.services.provenance_warnings import (
     collect_kinetics_content_warnings,
     collect_kinetics_provenance_warnings,
@@ -396,6 +403,7 @@ def upload_network_pdep(
     pdep_warnings: list[UploadWarning] = stationary_point_warnings(
         request.stationary_point_findings()
     )
+    pdep_warnings.extend(network_pdep_linearity_warnings(request))
     network = persist_network_pdep_upload(
         session,
         request,
@@ -439,6 +447,7 @@ def upload_statmech(
         return replay
     warnings = reconcile_species_entry(request.species_entry)
     warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
+    warnings.extend(inline_calculation_linearity_warnings(request.calculations))
     warnings.extend(collect_statmech_provenance_warnings(request))
     warnings.extend(
         collect_statmech_content_warnings(
@@ -482,6 +491,7 @@ def upload_thermo(
         return replay
     warnings = reconcile_species_entry(request.species_entry)
     warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
+    warnings.extend(inline_calculation_linearity_warnings(request.calculations))
     warnings.extend(collect_thermo_provenance_warnings(request))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.thermo
@@ -524,6 +534,7 @@ def upload_transition_state(
         for w in ws:
             warnings.append(w.model_copy(update={"field": f"reaction.products[{i}].{w.field}"}))
     warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
+    warnings.extend(transition_state_upload_linearity_warnings(request))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.transition_state
     )
@@ -569,6 +580,7 @@ def upload_transport(
         return replay
     warnings = reconcile_species_entry(request.species_entry)
     warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
+    warnings.extend(inline_calculation_linearity_warnings(request.calculations))
     warnings.extend(collect_transport_provenance_warnings(request))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.transport
@@ -605,6 +617,10 @@ def upload_computed_species(
         return replay
     warnings = reconcile_species_entry(request.species_entry)
     warnings.extend(stationary_point_warnings(request.stationary_point_findings()))
+    # The sharper half of the completeness question, which needs the
+    # geometry's coordinates and a collinearity tolerance and therefore
+    # cannot live in the wire package alongside the ``3N - 6`` floor.
+    warnings.extend(computed_species_linearity_warnings(request))
     sub = open_upload_submission(
         session, created_by=current_user.id, kind=SubmissionKind.computed_species
     )
@@ -688,6 +704,7 @@ def upload_computed_reaction(
     # reported rather than being produced inside it.
     result_dict["warnings"] = [
         *stationary_point_warnings(request.stationary_point_findings()),
+        *computed_reaction_linearity_warnings(request),
         *result_dict.get("warnings", []),
     ]
     result = ComputedReactionUploadResult(

--- a/backend/app/scientific_checks/declarations.py
+++ b/backend/app/scientific_checks/declarations.py
@@ -82,6 +82,7 @@ from app.scientific_checks import (
 from app.services import (
     calculation_geometry_composition,
     charge_multiplicity_reconciliation,
+    frequency_geometry_linearity,
     reaction_resolution,
     species_resolution,
     transition_state_validation,
@@ -1300,6 +1301,7 @@ DECLARING_MODULES: tuple[ModuleType, ...] = (
     chemistry_species,
     chemistry_units,
     charge_multiplicity_reconciliation,
+    frequency_geometry_linearity,
     geometry_validation_service,
     reaction_atom_map_service,
     reaction_resolution,

--- a/backend/app/services/frequency_geometry_linearity.py
+++ b/backend/app/services/frequency_geometry_linearity.py
@@ -1,0 +1,738 @@
+"""The sharper half of the frequency-completeness question: is it linear?
+
+``tckdb_schemas.frequency_completeness`` measures a deposited frequency
+list against the *weakest certainly-true* floor, ``3N - 6`` for
+``N >= 3``. That bound is deliberately loose, and its own docstring says
+why: a collinear molecule has ``3N - 5`` modes, one **more** than
+``3N - 6``, so comparing against ``3N - 6`` accepts every linear molecule
+without ever having to decide whether a given geometry is linear —
+a decision that needs a collinearity tolerance, which the wire package
+has no business carrying (it is chemistry-free, imports no numerics, and
+is forbidden from importing ``app`` by an AST scan *and* a runtime
+``sys.modules`` check).
+
+The residue that leaves
+-----------------------
+A **non-linear** molecule depositing exactly ``3N - 5`` modes sits
+inside the accepted band and passes silently. Water with four
+frequencies, methanol with thirteen: one mode too many for a bent
+molecule, and exactly the count a linear molecule of the same atom count
+would have. The two ways that happens in practice are both worth
+telling a depositor about:
+
+* the frequency job — or the script that read it — treated the molecule
+  as linear and printed ``3N - 5`` modes, dropping one real vibration
+  and keeping one rigid-body eigenvalue in its place; or
+* one rigid-body translation/rotation leaked into an otherwise complete
+  ``3N - 6`` list.
+
+Neither is visible to the floor check, because ``3N - 5 > 3N - 6``.
+
+Why this is a *second* check and not a tighter first one
+--------------------------------------------------------
+The wire-package bound keeps exactly the strength it can prove from an
+atom count alone, and this module adds the strength that needs
+coordinates. That split is the point. It is not a tightening of
+``minimum_complete_mode_count``: that function still answers "what is
+certainly true of any geometry with this many atoms", and it is still
+called on every path, unchanged. This module answers a narrower question
+about one specific set of coordinates, and only ever when the wire check
+was already satisfied.
+
+The alternative — moving a collinearity tolerance into the wire package
+so both sides could share it — was considered and **not** done. It would
+put a numerical judgement, and a numpy dependency, inside a package whose
+whole contract is that it carries neither.
+
+Tier: advisory, never blocking
+------------------------------
+`ADR 0008 <../../../docs/adr/0008-validation-tiers-definitions-block-expectations-warn.md>`_
+lets a check block only when it asserts a definition or a contract, never
+an expectation. "This molecule looks bent, so it should have ``3N - 6``
+modes" rests on a *tolerance* — on where the line between bent and
+straight is drawn — and a rule whose answer moves when a constant moves
+is an expectation by construction. It is also, unlike the ``3N`` ceiling,
+a rule a correct deposit can trip: a genuinely quasi-linear molecule, or
+a producer who deposited ``3N - 6`` vibrations plus one designated
+rigid-body eigenvalue on purpose, is depositing something true. So the
+record is accepted and annotated, and a depositor who disagrees needs no
+escape hatch — the warning costs them nothing but an explanation.
+
+Where the tolerance comes from, and why not the existing one
+------------------------------------------------------------
+:data:`app.chemistry.normal_modes.LINEARITY_SINGULAR_VALUE_TOLERANCE`
+already exists and already answers "is this geometry collinear" — but it
+answers it for a *different purpose* and cannot be reused here. It is an
+exact-rank test on the six rigid-body vectors, with a relative cutoff of
+``1e-6``, used to decide how many directions to project out of a Hessian.
+There, admitting a nearly-zero direction into the basis would corrupt the
+projection, so the tolerance is set as tight as floating point allows.
+
+Measured against real coordinates, that tightness is wrong for this
+question: a CO2 geometry bent by one *thousandth* of a degree —
+179.999°, which is ordinary optimiser noise and rounding in a deposited
+XYZ — comes out at a relative singular value of ``4.5e-6`` and is
+classified **not linear**. Reusing that constant here would therefore
+have fired this warning on real, correct, linear molecules, which is the
+one outcome an advisory check must not produce.
+
+So this module carries its own pair of thresholds and its own three-way
+answer. See :data:`COLLINEAR_MAX_TRANSVERSE_RATIO` and
+:data:`BENT_MIN_TRANSVERSE_RATIO`.
+
+What the check does *not* do
+----------------------------
+It does not report the mirror case — a geometry determined **linear**
+whose list is ``3N - 6``, one mode short of the ``3N - 5`` a linear
+molecule has. That is the same size of slack in the other direction and
+is a reasonable follow-up, but the short-list warning already has an
+owner (``freq_list_incomplete_for_geometry``) whose message and tier were
+argued from partial Hessians, frozen-atom regions and lumped
+participants; extending it to a case those arguments do not cover is its
+own decision, not a rider on this one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+import numpy as np
+
+from app.chemistry.geometry import parse_xyz
+from app.schemas.fragments.geometry import GeometryPayload
+from app.schemas.upload_warning import UploadWarning
+from app.scientific_checks import (
+    CheckTier,
+    CodeChannel,
+    ConstantThreshold,
+    DesignPosition,
+    PythonCheck,
+    ScientificCheck,
+)
+
+#: The deposited frequency list has exactly the mode count a **linear**
+#: molecule of this size would have, but the geometry it is attached to
+#: is not linear. Advisory: the record is accepted and annotated.
+W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY = (
+    "freq_list_linear_mode_count_for_bent_geometry"
+)
+
+#: At or below this, the geometry is treated as **linear** and the check
+#: says nothing.
+#:
+#: The measure is scale-free: the second singular value of the centred
+#: coordinate matrix divided by the first — the molecule's spread
+#: *across* its long axis divided by its spread *along* it. Exactly
+#: collinear gives zero, and no unit, bond length or molecule size enters.
+#:
+#: ``1e-3`` is roughly 0.2° of bend for a symmetric triatomic. Measured
+#: on CO2 at a 1.16 Å bond length: 180.000° → 3.5e-17, 179.999° → 5.0e-6,
+#: 179.99° → 5.0e-5, 179.9° → 5.0e-4. So every deposit of a linear
+#: molecule that is straight to within a tenth of a degree — which covers
+#: optimiser convergence noise and XYZ rounding by three orders of
+#: magnitude — lands on the silent side.
+COLLINEAR_MAX_TRANSVERSE_RATIO = 1e-3
+
+#: At or above this, the geometry is treated as **bent** and the warning
+#: may fire. Same measure as above.
+#:
+#: ``3e-2`` is roughly 6° of bend for a symmetric triatomic (CO2 at 175°
+#: → 2.5e-2; at 170° → 5.1e-2), and water sits at 4.5e-1 — fifteen times
+#: over. A molecule that is genuinely bent is bent by tens of degrees, so
+#: the threshold is nowhere near anything real, which is what a threshold
+#: on an advisory check should look like.
+BENT_MIN_TRANSVERSE_RATIO = 3e-2
+
+#: Below three atoms linearity is a fact rather than a measurement — one
+#: atom has no vibrations, two are collinear by definition — and
+#: ``minimum_complete_mode_count`` already gives those cases their exact
+#: counts. Nothing here applies.
+_MIN_ATOMS_FOR_LINEARITY_QUESTION = 3
+
+
+class GeometryLinearity(str, Enum):
+    """Three answers, because two would be a lie.
+
+    The gap between :data:`COLLINEAR_MAX_TRANSVERSE_RATIO` and
+    :data:`BENT_MIN_TRANSVERSE_RATIO` is deliberate and is the whole
+    reason this is not a boolean. A molecule with a bond angle of 178° is
+    genuinely ambiguous — quasi-linear molecules exist, their
+    equilibrium structures are basin-dependent and method-dependent, and
+    any single cutoff mis-sorts some of them. A check that had to answer
+    "linear or bent" for such a geometry would answer confidently and
+    sometimes wrongly, in a *message telling the depositor their record
+    is wrong*.
+
+    :cvar linear: Collinear to well within deposit noise. Say nothing:
+        ``3N - 5`` is exactly right for it.
+    :cvar bent: Bent by far more than any tolerance argument could
+        explain away. This is the only value that lets a warning fire.
+    :cvar undetermined: In between, or unmeasurable (fewer than three
+        atoms, an unparseable or absent geometry, a degenerate coordinate
+        set). Say nothing.
+    """
+
+    linear = "linear"
+    bent = "bent"
+    undetermined = "undetermined"
+
+
+@dataclass(frozen=True)
+class LinearityAssessment:
+    """A linearity verdict and the number it was reached from.
+
+    :param verdict: The three-way answer.
+    :param transverse_ratio: ``sigma_2 / sigma_1`` of the centred
+        coordinate matrix, or ``None`` when it could not be computed.
+    """
+
+    verdict: GeometryLinearity
+    transverse_ratio: float | None
+
+
+def transverse_extent_ratio(coordinates: np.ndarray) -> float | None:
+    """How far the atoms spread *across* their long axis, relative to along it.
+
+    Singular values of the centred ``(N, 3)`` coordinate matrix are the
+    RMS extents along the three principal geometric axes. Their ratio
+    ``sigma_2 / sigma_1`` is zero for a collinear set of points and grows
+    with the bend, is invariant under translation, rotation and choice of
+    length unit, and needs no masses — collinearity is a property of the
+    positions alone, and weighting them by mass would make the answer
+    depend on isotopic labelling, which moves no nucleus.
+
+    :param coordinates: ``(N, 3)`` atomic positions.
+    :returns: The ratio, or ``None`` for a degenerate set (all atoms on
+        one point) where the question has no answer.
+    """
+
+    centred = np.asarray(coordinates, dtype=float)
+    if centred.ndim != 2 or centred.shape[1] != 3 or centred.shape[0] == 0:
+        return None
+    centred = centred - centred.mean(axis=0)
+    singular_values = np.linalg.svd(centred, compute_uv=False)
+    if singular_values.size < 2 or singular_values[0] <= 0.0:
+        return None
+    return float(singular_values[1] / singular_values[0])
+
+
+def classify_linearity(coordinates: np.ndarray) -> LinearityAssessment:
+    """Sort a coordinate set into linear / bent / undetermined.
+
+    :param coordinates: ``(N, 3)`` atomic positions.
+    :returns: The verdict and the ratio behind it. Fewer than three atoms
+        is :attr:`GeometryLinearity.undetermined` here rather than
+        "linear": two atoms *are* collinear, but this module is only ever
+        asked about geometries whose exact mode count the floor check has
+        already pinned down, and answering a question nobody asks invites
+        a caller to rely on it.
+    """
+
+    array = np.asarray(coordinates, dtype=float)
+    if array.ndim != 2 or array.shape[0] < _MIN_ATOMS_FOR_LINEARITY_QUESTION:
+        return LinearityAssessment(GeometryLinearity.undetermined, None)
+
+    ratio = transverse_extent_ratio(array)
+    if ratio is None:
+        return LinearityAssessment(GeometryLinearity.undetermined, None)
+    if ratio <= COLLINEAR_MAX_TRANSVERSE_RATIO:
+        return LinearityAssessment(GeometryLinearity.linear, ratio)
+    if ratio >= BENT_MIN_TRANSVERSE_RATIO:
+        return LinearityAssessment(GeometryLinearity.bent, ratio)
+    return LinearityAssessment(GeometryLinearity.undetermined, ratio)
+
+
+def classify_xyz_linearity(xyz_text: str | None) -> LinearityAssessment:
+    """:func:`classify_linearity` for an XYZ block.
+
+    An unparseable geometry is refused by the fragment that owns that
+    contract, so this declines to speak rather than reporting the same
+    defect a second time in different words — the same rule
+    ``atom_count_of_xyz`` follows on the wire side.
+    """
+
+    if xyz_text is None:
+        return LinearityAssessment(GeometryLinearity.undetermined, None)
+    try:
+        parsed = parse_xyz(GeometryPayload(xyz_text=xyz_text))
+    except (ValueError, TypeError):
+        return LinearityAssessment(GeometryLinearity.undetermined, None)
+    if not parsed.atoms:
+        return LinearityAssessment(GeometryLinearity.undetermined, None)
+    coordinates = np.array([[x, y, z] for _element, x, y, z in parsed.atoms])
+    return classify_linearity(coordinates)
+
+
+def evaluate_frequency_list_linearity(
+    n_modes: int | None,
+    xyz_text: str | None,
+    *,
+    location: str,
+) -> list[UploadWarning]:
+    """Judge one deposited frequency list against its geometry's shape.
+
+    Fires on exactly one configuration: ``n_modes == 3N - 5`` for a
+    geometry classified :attr:`GeometryLinearity.bent`. Everything else
+    is silent, including every list the wire-side floor and ceiling
+    already speak about — this check never reports a length those bounds
+    reach, so a payload cannot collect two warnings for one list.
+
+    :param n_modes: Length of the deposited frequency list. ``None``
+        means no list was deposited; nothing is reported.
+    :param xyz_text: The geometry the frequency job ran on, already
+        resolved by the caller.
+    :param location: Path to the payload element, used verbatim.
+    :returns: Zero or one warning. Never raises, and never blocks.
+    """
+
+    if n_modes is None or xyz_text is None:
+        return []
+
+    assessment = classify_xyz_linearity(xyz_text)
+    if assessment.verdict is not GeometryLinearity.bent:
+        return []
+
+    try:
+        n_atoms = parse_xyz(GeometryPayload(xyz_text=xyz_text)).natoms
+    except (ValueError, TypeError):  # pragma: no cover - classify already parsed
+        return []
+
+    linear_count = 3 * n_atoms - 5
+    bent_count = 3 * n_atoms - 6
+    if n_modes != linear_count:
+        return []
+
+    ratio = assessment.transverse_ratio
+    return [
+        UploadWarning(
+            field=location,
+            code=W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY,
+            message=(
+                f"{location}: the frequency list carries {n_modes} modes, "
+                f"which is 3N-5 for this {n_atoms}-atom geometry — the "
+                f"vibrational count of a *linear* molecule "
+                f"({W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY}). This "
+                f"geometry is not linear: its atoms spread across their long "
+                f"axis by {ratio:.2g} of their spread along it, against a "
+                f"threshold of {BENT_MIN_TRANSVERSE_RATIO:g} for calling a "
+                f"geometry bent (exactly collinear is 0). A non-linear "
+                f"{n_atoms}-atom molecule has 3N-6 = {bent_count} "
+                f"vibrations, so one mode here is either spurious or is a "
+                f"rigid-body translation/rotation left in the list — the "
+                f"usual cause being a frequency job, or a script reading "
+                f"one, that treated the molecule as linear. The record is "
+                f"accepted and flagged, not refused: the boundary between "
+                f"linear and bent is a tolerance rather than a definition, "
+                f"and near-linear geometries are deliberately left "
+                f"unreported. Deposit every mode the job printed, or the "
+                f"geometry the job actually ran on."
+            ),
+        )
+    ]
+
+
+def evaluate_deposited_frequency_list_linearity(
+    n_modes: int | None,
+    *,
+    input_geometry_xyz_text: str | None,
+    fallback_xyz_text: str | None,
+    location: str,
+) -> list[UploadWarning]:
+    """Judge a list against whichever geometry it will be bound to.
+
+    Resolves the geometry the same way
+    ``tckdb_schemas.frequency_completeness.evaluate_deposited_frequency_list``
+    does — the calculation's own first input geometry when the producer
+    named one, otherwise the enclosing conformer's or transition state's
+    reference geometry, which is the fallback the persistence workflow
+    itself applies for ``freq``. The two checks must count the same atoms
+    to be talking about the same record, so the rule is restated here
+    rather than approximated.
+    """
+
+    xyz_text = (
+        input_geometry_xyz_text
+        if input_geometry_xyz_text is not None
+        else fallback_xyz_text
+    )
+    return evaluate_frequency_list_linearity(n_modes, xyz_text, location=location)
+
+
+def calculation_linearity_warnings(
+    calc: object,
+    *,
+    location: str,
+    fallback_xyz_text: str | None = None,
+) -> list[UploadWarning]:
+    """Judge one calculation payload's frequency list, if it has one.
+
+    The backend twin of
+    ``CalculationWithResultsPayload.frequency_completeness_findings``.
+    ``calc`` is read structurally rather than by type: the bundle
+    calculation payloads re-declare the primitive payload's fields rather
+    than inheriting them, so there is no single class to annotate, and
+    every shape that reaches here carries ``freq_result`` and
+    ``input_geometries`` under those names.
+
+    :param calc: A calculation upload payload.
+    :param location: Path to the payload element, used verbatim.
+    :param fallback_xyz_text: The enclosing conformer's or transition
+        state's reference geometry.
+    """
+
+    freq_result = getattr(calc, "freq_result", None)
+    if freq_result is None:
+        return []
+    modes = getattr(freq_result, "modes", None)
+    if modes is None:
+        return []
+    input_geometries = getattr(calc, "input_geometries", None) or ()
+    return evaluate_deposited_frequency_list_linearity(
+        len(modes),
+        input_geometry_xyz_text=(
+            input_geometries[0].xyz_text if input_geometries else None
+        ),
+        fallback_xyz_text=fallback_xyz_text,
+        location=location,
+    )
+
+
+def calculation_in_linearity_warnings(
+    calc_in: object,
+    *,
+    location: str,
+    xyz_text: str | None,
+) -> list[UploadWarning]:
+    """The bundle-local twin of :func:`calculation_linearity_warnings`.
+
+    A bundle's ``CalculationIn`` carries flat ``freq_*`` fields rather
+    than a ``freq_result`` block, and only some of them become a stored
+    result. It is read through ``freq_result_of`` for the same reason the
+    wire-side completeness check does: judging the raw field would judge
+    something the database will never hold.
+
+    :param xyz_text: The geometry this calculation ran on, already
+        resolved from ``geometry_key`` by the caller — a bundle-local
+        calculation cannot see its own bundle's geometry namespace.
+    """
+
+    from tckdb_schemas.shared.calculation_in import freq_result_of
+
+    freq_result = freq_result_of(calc_in)
+    if freq_result is None or freq_result.modes is None:
+        return []
+    inline = getattr(calc_in, "input_geometries", None) or ()
+    return evaluate_deposited_frequency_list_linearity(
+        len(freq_result.modes),
+        input_geometry_xyz_text=inline[0].xyz_text if inline else None,
+        fallback_xyz_text=xyz_text,
+        location=location,
+    )
+
+
+def computed_species_linearity_warnings(request: object) -> list[UploadWarning]:
+    """Walk a computed-species bundle for bent geometries counted as linear.
+
+    Mirrors ``ComputedSpeciesUploadRequest.stationary_point_findings``
+    exactly, including the ``location`` strings, so a depositor who gets
+    both warnings on one calculation sees one path rather than two
+    spellings of it. The walk is repeated here rather than shared with
+    the wire package because the wire package cannot reach a
+    collinearity tolerance and this check cannot work without one; a test
+    pins the two location formats together.
+    """
+
+    warnings: list[UploadWarning] = []
+    for conformer in request.conformers:
+        for calc in (
+            conformer.primary_calculation,
+            *conformer.additional_calculations,
+        ):
+            warnings.extend(
+                calculation_linearity_warnings(
+                    calc,
+                    location=(
+                        f"conformers['{conformer.key}'].calculations"
+                        f"['{calc.key}'].freq_result.modes"
+                    ),
+                    fallback_xyz_text=conformer.geometry.xyz_text,
+                )
+            )
+    return warnings
+
+
+def computed_reaction_linearity_warnings(request: object) -> list[UploadWarning]:
+    """Walk a computed-reaction bundle for bent geometries counted as linear.
+
+    Mirrors the ``stationary_point_findings`` walks on ``BundleSpeciesIn``
+    and ``BundleTransitionStateIn``, including their ``location``
+    strings. A species-level calculation's geometry comes from its
+    ``geometry_key``; an unresolvable key means the calculation named no
+    geometry, and the check declines to speak rather than guessing one.
+    """
+
+    warnings: list[UploadWarning] = []
+    for species in request.species:
+        xyz_by_geometry_key = {
+            conformer.geometry.key: conformer.geometry.xyz_text
+            for conformer in species.conformers
+        }
+        for conformer in species.conformers:
+            warnings.extend(
+                calculation_in_linearity_warnings(
+                    conformer.calculation,
+                    location=(
+                        f"species['{species.key}'].conformers"
+                        f"['{conformer.key}'].calculation"
+                        f".freq_frequencies_cm1"
+                    ),
+                    xyz_text=conformer.geometry.xyz_text,
+                )
+            )
+        for calc in species.calculations:
+            warnings.extend(
+                calculation_in_linearity_warnings(
+                    calc,
+                    location=(
+                        f"species['{species.key}'].calculations"
+                        f"['{calc.key}'].freq_frequencies_cm1"
+                    ),
+                    xyz_text=xyz_by_geometry_key.get(calc.geometry_key or ""),
+                )
+            )
+
+    transition_state = request.transition_state
+    if transition_state is not None:
+        for calc in (transition_state.calculation, *transition_state.calculations):
+            warnings.extend(
+                calculation_in_linearity_warnings(
+                    calc,
+                    location=(
+                        f"transition_state.calculations['{calc.key}']"
+                        f".freq_frequencies_cm1"
+                    ),
+                    xyz_text=transition_state.geometry.xyz_text,
+                )
+            )
+    return warnings
+
+
+def transition_state_upload_linearity_warnings(
+    request: object,
+) -> list[UploadWarning]:
+    """Walk a standalone transition-state upload. Mirrors its findings walk."""
+
+    warnings: list[UploadWarning] = []
+    for label, calc in [
+        ("primary_opt", request.primary_opt),
+        *(
+            (f"additional_calculations[{index}]", calc)
+            for index, calc in enumerate(request.additional_calculations)
+        ),
+    ]:
+        warnings.extend(
+            calculation_linearity_warnings(
+                calc,
+                location=f"{label}.freq_result.modes",
+                fallback_xyz_text=request.geometry.xyz_text,
+            )
+        )
+    return warnings
+
+
+def inline_calculation_linearity_warnings(
+    calculations: object,
+) -> list[UploadWarning]:
+    """Walk the inline calculations of a statmech/thermo/transport upload.
+
+    The backend twin of
+    :func:`app.schemas.workflows.stationary_point_seam.inline_calculation_findings`,
+    and silent for the same reason it is: these three requests carry a
+    product and its evidence, never a conformer, so there is no reference
+    geometry to fall back to and the question is answerable only for a
+    calculation that named the geometry it ran on.
+    """
+
+    warnings: list[UploadWarning] = []
+    for item in calculations:
+        warnings.extend(
+            calculation_linearity_warnings(
+                item.calculation,
+                location=f"calculations['{item.key}'].freq_result.modes",
+            )
+        )
+    return warnings
+
+
+def network_pdep_linearity_warnings(request: object) -> list[UploadWarning]:
+    """Walk a pressure-dependent network upload. Mirrors its findings walks."""
+
+    warnings: list[UploadWarning] = []
+    for species in request.species:
+        xyz_by_geometry_key = {
+            conformer.geometry.key: conformer.geometry.xyz_text
+            for conformer in species.conformers
+        }
+        for conformer in species.conformers:
+            warnings.extend(
+                calculation_in_linearity_warnings(
+                    conformer.calculation,
+                    location=(
+                        f"species['{species.key}'].conformers"
+                        f"['{conformer.key}'].calculation"
+                        f"['{conformer.calculation.key}'].freq_frequencies_cm1"
+                    ),
+                    xyz_text=conformer.geometry.xyz_text,
+                )
+            )
+        for calc in species.calculations:
+            warnings.extend(
+                calculation_in_linearity_warnings(
+                    calc,
+                    location=(
+                        f"species['{species.key}'].calculations"
+                        f"['{calc.key}'].freq_frequencies_cm1"
+                    ),
+                    xyz_text=xyz_by_geometry_key.get(calc.geometry_key or ""),
+                )
+            )
+    for transition_state in request.transition_states:
+        for calc in (transition_state.calculation, *transition_state.calculations):
+            warnings.extend(
+                calculation_in_linearity_warnings(
+                    calc,
+                    location=(
+                        f"transition_states['{transition_state.key}']"
+                        f".calculations['{calc.key}'].freq_frequencies_cm1"
+                    ),
+                    xyz_text=transition_state.geometry.xyz_text,
+                )
+            )
+    return warnings
+
+
+CHECK_FREQ_LIST_MODE_COUNT_MATCHES_GEOMETRY_SHAPE = ScientificCheck(
+    group="Stationary points",
+    sort_key=9,
+    code=W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY,
+    asserts=(
+        "A frequency list carrying exactly ``3N - 5`` modes should be "
+        "attached to a collinear geometry, because ``3N - 5`` is the "
+        "vibrational count of a linear molecule and a non-linear one has "
+        "``3N - 6``."
+    ),
+    tier=CheckTier.warn,
+    channel=CodeChannel.upload_warning,
+    tier_rationale=(
+        "An expectation, not a definition, and ADR 0008 is explicit that only "
+        "the latter may block. The verdict rests on a *tolerance* — on where "
+        "the line between collinear and bent is drawn — and a rule whose "
+        "answer moves when a constant moves is an expectation by "
+        "construction. Unlike the ``3N`` ceiling, which no correct deposit "
+        "can trip, this one can: a genuinely quasi-linear molecule sits on "
+        "no side of the line, and a producer who deposited ``3N - 6`` "
+        "vibrations plus one rigid-body eigenvalue on purpose deposited "
+        "something true. So the check declines to answer in the ambiguous "
+        "band and annotates rather than refuses outside it. It is also the "
+        "*second* judgement on one list: the wire package's "
+        "``freq_list_incomplete_for_geometry`` floor keeps exactly the "
+        "strength an atom count can prove, and this adds only the strength "
+        "coordinates can."
+    ),
+    adr="0008",
+    enforced_by=(
+        PythonCheck(
+            evaluate_frequency_list_linearity,
+            note=(
+                "Owns the arithmetic and the verdict; the payload walks that "
+                "resolve which geometry each frequency list is measured "
+                "against live in the same module, one per upload shape, and "
+                "restate the wire-side rule — the calculation's own first "
+                "input geometry where the producer named one, otherwise the "
+                "enclosing conformer's or transition state's reference "
+                "geometry. The two checks must count the same atoms to be "
+                "talking about the same record."
+            ),
+        ),
+        DesignPosition(
+            "The collinearity tolerance stays backend-side. "
+            "``tckdb_schemas`` is forbidden from importing ``app`` by an AST "
+            "scan and a runtime ``sys.modules`` check, and it carries no "
+            "numerics; moving a tolerance into it to share one constant "
+            "would put a numerical judgement inside a package whose contract "
+            "is that it holds none. So the wire package keeps the bound it "
+            "can prove from an atom count and the backend adds the sharper "
+            "one where the coordinates are."
+        ),
+        DesignPosition(
+            "``LINEARITY_SINGULAR_VALUE_TOLERANCE`` in "
+            "``app.chemistry.normal_modes`` is *not* reused, though it "
+            "answers the same question. It is an exact-rank test at 1e-6 "
+            "relative, set that tight because admitting a nearly-zero "
+            "direction into a projection basis corrupts the projection. "
+            "Measured on real coordinates, CO2 bent by one thousandth of a "
+            "degree — ordinary optimiser noise — comes out at 4.5e-6 and "
+            "classifies as *not linear*, so reusing it would have fired this "
+            "warning on correct linear molecules."
+        ),
+    ),
+    thresholds=(
+        ConstantThreshold(
+            name="COLLINEAR_MAX_TRANSVERSE_RATIO",
+            value=COLLINEAR_MAX_TRANSVERSE_RATIO,
+            unit="dimensionless (sigma_2 / sigma_1 of the centred coordinates)",
+            rationale=(
+                "At or below this the geometry is treated as linear and "
+                "nothing is reported. Roughly 0.2 degrees of bend for a "
+                "symmetric triatomic — three orders of magnitude looser than "
+                "optimiser convergence noise, so a real linear molecule "
+                "cannot be flagged. Loosening it would silence the check for "
+                "genuinely bent molecules; tightening it risks warning about "
+                "correct ones, which is the failure an advisory check must "
+                "not have."
+            ),
+        ),
+        ConstantThreshold(
+            name="BENT_MIN_TRANSVERSE_RATIO",
+            value=BENT_MIN_TRANSVERSE_RATIO,
+            unit="dimensionless (sigma_2 / sigma_1 of the centred coordinates)",
+            rationale=(
+                "At or above this the geometry is treated as bent and the "
+                "warning may fire. Roughly 6 degrees of bend for a symmetric "
+                "triatomic; water sits fifteen times over it. Between the two "
+                "thresholds the check answers 'undetermined' and says "
+                "nothing, which is what keeps a quasi-linear molecule from "
+                "receiving a confident claim two degrees cannot support."
+            ),
+        ),
+    ),
+    escape_hatch=(
+        "None needed — the warning is the accommodation, and the record is "
+        "stored either way. A depositor whose molecule is genuinely "
+        "quasi-linear will usually not see the warning at all, because the "
+        "band between the two thresholds is deliberately silent."
+    ),
+)
+
+
+__all__ = [
+    "BENT_MIN_TRANSVERSE_RATIO",
+    "CHECK_FREQ_LIST_MODE_COUNT_MATCHES_GEOMETRY_SHAPE",
+    "COLLINEAR_MAX_TRANSVERSE_RATIO",
+    "W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY",
+    "GeometryLinearity",
+    "LinearityAssessment",
+    "calculation_in_linearity_warnings",
+    "calculation_linearity_warnings",
+    "classify_linearity",
+    "classify_xyz_linearity",
+    "computed_reaction_linearity_warnings",
+    "computed_species_linearity_warnings",
+    "evaluate_deposited_frequency_list_linearity",
+    "evaluate_frequency_list_linearity",
+    "inline_calculation_linearity_warnings",
+    "network_pdep_linearity_warnings",
+    "transition_state_upload_linearity_warnings",
+    "transverse_extent_ratio",
+]

--- a/backend/app/services/frequency_geometry_linearity.py
+++ b/backend/app/services/frequency_geometry_linearity.py
@@ -310,7 +310,7 @@ def evaluate_frequency_list_linearity(
             code=W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY,
             message=(
                 f"{location}: the frequency list carries {n_modes} modes, "
-                f"which is 3N-5 for this {n_atoms}-atom geometry — the "
+                f"which is 3N-5 for this {n_atoms}-atom geometry -- the "
                 f"vibrational count of a *linear* molecule "
                 f"({W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY}). This "
                 f"geometry is not linear: its atoms spread across their long "
@@ -319,7 +319,7 @@ def evaluate_frequency_list_linearity(
                 f"geometry bent (exactly collinear is 0). A non-linear "
                 f"{n_atoms}-atom molecule has 3N-6 = {bent_count} "
                 f"vibrations, so one mode here is either spurious or is a "
-                f"rigid-body translation/rotation left in the list — the "
+                f"rigid-body translation/rotation left in the list -- the "
                 f"usual cause being a frequency job, or a script reading "
                 f"one, that treated the molecule as linear. The record is "
                 f"accepted and flagged, not refused: the boundary between "

--- a/backend/app/services/upload_reconciliation.py
+++ b/backend/app/services/upload_reconciliation.py
@@ -39,6 +39,9 @@ from app.services.ess_result import (
     ESSSymmetry,
 )
 from app.services.ess_species_deduction import Deduction, deduce_all
+from app.services.frequency_geometry_linearity import (
+    calculation_linearity_warnings,
+)
 
 # ---------------------------------------------------------------------------
 # Warning codes
@@ -462,16 +465,31 @@ def reconcile_species_entry_full(
     # computes the completeness findings, so there is no such duplication
     # to avoid for them, and routing them through here is what puts them
     # on the one upload path that skips the schema-side collection.
+    #
+    # Layer 1d, immediately below, is the sharper half of the same
+    # question and runs on the same list for the same reason. The two
+    # never both fire on one frequency list: the completeness floor
+    # speaks only below ``3N - 6`` and the linearity check only at
+    # exactly ``3N - 5``.
     if primary_calc is not None:
         for index, calc in enumerate([primary_calc, *additional]):
+            location = f"calculations[{index}].freq_result.modes"
             warnings.extend(
                 stationary_point_warnings(
                     calc.frequency_completeness_findings(
-                        location=(
-                            f"calculations[{index}].freq_result.modes"
-                        ),
+                        location=location,
                         fallback_xyz_text=reference_xyz_text,
                     )
+                )
+            )
+            # Layer 1d: does the *count* say linear while the *shape*
+            # says bent? Needs coordinates and a collinearity tolerance,
+            # so it cannot live where Layer 1c's rule does.
+            warnings.extend(
+                calculation_linearity_warnings(
+                    calc,
+                    location=location,
+                    fallback_xyz_text=reference_xyz_text,
                 )
             )
 

--- a/backend/tests/api/test_api_frequency_linearity.py
+++ b/backend/tests/api/test_api_frequency_linearity.py
@@ -1,0 +1,278 @@
+"""A depositor must actually *receive* the linear-count warning.
+
+The unit tests in ``tests/services/test_frequency_geometry_linearity.py``
+prove the judgement. This file proves the wiring: that the judgement
+reaches the ``warnings`` array of a real 201, on the real routes, for a
+real molecule — because a check that is *computed* and a warning a
+depositor *sees* are different claims, and only the second is the point.
+
+Every case is run twice, once with a genuinely bent molecule and once
+with a genuinely linear one depositing the *same mode count*. A test
+using only one geometry kind cannot distinguish this check from the
+``3N - 6`` floor it sits on top of: the floor accepts both, and a rule
+that flagged every ``3N - 5`` deposit would pass a bent-only file while
+being wrong about every linear molecule in the database.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.services.frequency_geometry_linearity import (
+    W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY,
+)
+
+_SOFTWARE = {"name": "Gaussian", "version": "16"}
+_LOT = {"method": "B3LYP", "basis": "6-31G(d)"}
+
+#: Water: bent, 3 atoms. 3N-6 = 3 vibrations, so a four-mode list is one
+#: mode too many — and is exactly the count a linear triatomic has.
+_WATER_XYZ = (
+    "3\nwater\n"
+    "O  0.000000  0.000000  0.117300\n"
+    "H  0.000000  0.757200 -0.469200\n"
+    "H  0.000000 -0.757200 -0.469200"
+)
+
+#: Carbon dioxide: linear, 3 atoms. 3N-5 = 4 vibrations, so a four-mode
+#: list is complete and correct. Same atom count, same mode count,
+#: opposite verdict.
+_CO2_XYZ = (
+    "3\ncarbon dioxide\n"
+    "C  0.000000  0.000000  0.000000\n"
+    "O  0.000000  0.000000  1.162000\n"
+    "O  0.000000  0.000000 -1.162000"
+)
+
+#: One rigid-body eigenvalue left in an otherwise complete water
+#: spectrum. Four entries.
+_WATER_PLUS_ONE = [12.0, 1595.0, 3657.0, 3756.0]
+#: CO2's four genuine vibrations: the bend is doubly degenerate.
+_CO2_SPECTRUM = [667.0, 667.0, 1333.0, 2349.0]
+
+
+def _freq_calc(frequencies: list[float], *, key: str | None = None) -> dict:
+    calc: dict = {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "freq_result": {
+            "n_imag": 0,
+            "modes": [
+                {
+                    "mode_index": index + 1,
+                    "frequency_cm1": value,
+                    "is_imaginary": False,
+                }
+                for index, value in enumerate(frequencies)
+            ],
+        },
+    }
+    if key is not None:
+        calc["key"] = key
+    return calc
+
+
+def _linearity_warnings(resp) -> list[dict]:
+    return [
+        w
+        for w in resp.json()["warnings"]
+        if w["code"] == W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY
+    ]
+
+
+# ---------------------------------------------------------------------------
+# /uploads/conformers — the reconciliation path
+# ---------------------------------------------------------------------------
+
+
+def _conformer_payload(
+    *, smiles: str, xyz_text: str, frequencies: list[float], label: str
+) -> dict:
+    return {
+        "species_entry": {"smiles": smiles, "charge": 0, "multiplicity": 1},
+        "geometry": {"xyz_text": xyz_text},
+        "calculation": {
+            "type": "opt",
+            "software_release": _SOFTWARE,
+            "level_of_theory": _LOT,
+        },
+        "additional_calculations": [_freq_calc(frequencies)],
+        "label": label,
+    }
+
+
+def test_bent_water_depositing_the_linear_count_is_flagged(client: TestClient):
+    """The residue PR #162 left open, closed and visible on the response.
+
+    Four modes clears the ``3N - 6`` floor of three and sits far below
+    the ``3N`` ceiling of nine, so nothing said anything before this.
+    """
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_conformer_payload(
+            smiles="O",
+            xyz_text=_WATER_XYZ,
+            frequencies=_WATER_PLUS_ONE,
+            label="water-linear-count",
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    warnings = _linearity_warnings(resp)
+    assert len(warnings) == 1, resp.json()["warnings"]
+    assert warnings[0]["field"] == "calculations[1].freq_result.modes"
+    assert "3N-6 = 3" in warnings[0]["message"]
+
+
+def test_linear_carbon_dioxide_depositing_the_same_count_is_not(client: TestClient):
+    """The control that makes the test above mean anything.
+
+    Identical atom count, identical mode count, and the record is
+    correct — CO2 really does have four vibrations. A check that
+    classified every geometry as bent, or that keyed on ``3N - 5``
+    alone, would flag this one.
+    """
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_conformer_payload(
+            smiles="O=C=O",
+            xyz_text=_CO2_XYZ,
+            frequencies=_CO2_SPECTRUM,
+            label="co2-linear-count",
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert _linearity_warnings(resp) == []
+
+
+def test_water_depositing_its_own_three_modes_is_not_flagged(client: TestClient):
+    """The complete record for a bent molecule stays silent."""
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_conformer_payload(
+            smiles="O",
+            xyz_text=_WATER_XYZ,
+            frequencies=[1595.0, 3657.0, 3756.0],
+            label="water-complete",
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert _linearity_warnings(resp) == []
+
+
+def test_the_warning_never_refuses_the_deposit(client: TestClient):
+    """ADR 0008: this asserts an expectation, so it may only annotate.
+
+    The boundary between linear and bent is a tolerance, and a rule whose
+    answer moves when a constant moves cannot block. The record is
+    stored — the response carries the ids to prove it — and flagged.
+    """
+    resp = client.post(
+        "/api/v1/uploads/conformers",
+        json=_conformer_payload(
+            smiles="O",
+            xyz_text=_WATER_XYZ,
+            frequencies=_WATER_PLUS_ONE,
+            label="water-still-stored",
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert resp.json()["id"] > 0
+    assert resp.json()["species_entry_id"] > 0
+    assert _linearity_warnings(resp) != []
+
+
+# ---------------------------------------------------------------------------
+# /uploads/computed-species — the bundle route the ARC adapter uses
+# ---------------------------------------------------------------------------
+
+
+def _species_bundle(*, smiles: str, xyz_text: str, frequencies: list[float]) -> dict:
+    return {
+        "species_entry": {"smiles": smiles, "charge": 0, "multiplicity": 1},
+        "conformers": [
+            {
+                "key": "c0",
+                "geometry": {"xyz_text": xyz_text},
+                "primary_calculation": {
+                    "key": "opt0",
+                    "type": "opt",
+                    "software_release": _SOFTWARE,
+                    "level_of_theory": _LOT,
+                    "opt_result": {"converged": True},
+                },
+                "additional_calculations": [_freq_calc(frequencies, key="freq0")],
+            }
+        ],
+    }
+
+
+def test_the_bundle_route_reports_it_too(client: TestClient):
+    resp = client.post(
+        "/api/v1/uploads/computed-species",
+        json=_species_bundle(
+            smiles="O", xyz_text=_WATER_XYZ, frequencies=_WATER_PLUS_ONE
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    warnings = _linearity_warnings(resp)
+    assert len(warnings) == 1, resp.json()["warnings"]
+    assert (
+        warnings[0]["field"]
+        == "conformers['c0'].calculations['freq0'].freq_result.modes"
+    )
+
+
+def test_the_bundle_route_stays_silent_for_a_linear_molecule(client: TestClient):
+    resp = client.post(
+        "/api/v1/uploads/computed-species",
+        json=_species_bundle(
+            smiles="O=C=O", xyz_text=_CO2_XYZ, frequencies=_CO2_SPECTRUM
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert _linearity_warnings(resp) == []
+
+
+# ---------------------------------------------------------------------------
+# /uploads/statmech — a product upload, where the calculation must name
+# its own geometry because there is no conformer to fall back to
+# ---------------------------------------------------------------------------
+
+
+def _statmech_payload(*, smiles: str, xyz_text: str, frequencies: list[float]) -> dict:
+    calc = _freq_calc(frequencies)
+    calc["input_geometries"] = [{"xyz_text": xyz_text}]
+    return {
+        "species_entry": {"smiles": smiles, "charge": 0, "multiplicity": 1},
+        "scientific_origin": "computed",
+        "statmech_treatment": "rrho",
+        "external_symmetry": 2,
+        "calculations": [{"key": "freq0", "calculation": calc}],
+    }
+
+
+def test_a_product_upload_reports_it_from_the_calculations_own_geometry(
+    client: TestClient,
+):
+    resp = client.post(
+        "/api/v1/uploads/statmech",
+        json=_statmech_payload(
+            smiles="O", xyz_text=_WATER_XYZ, frequencies=_WATER_PLUS_ONE
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    warnings = _linearity_warnings(resp)
+    assert len(warnings) == 1, resp.json()["warnings"]
+    assert warnings[0]["field"] == "calculations['freq0'].freq_result.modes"
+
+
+def test_a_product_upload_stays_silent_for_a_linear_molecule(client: TestClient):
+    resp = client.post(
+        "/api/v1/uploads/statmech",
+        json=_statmech_payload(
+            smiles="O=C=O", xyz_text=_CO2_XYZ, frequencies=_CO2_SPECTRUM
+        ),
+    )
+    assert resp.status_code == 201, resp.text[:800]
+    assert _linearity_warnings(resp) == []

--- a/backend/tests/services/test_frequency_geometry_linearity.py
+++ b/backend/tests/services/test_frequency_geometry_linearity.py
@@ -1,0 +1,398 @@
+"""The proof that "3N-5 modes" is judged against the geometry's *shape*.
+
+``tckdb_schemas.frequency_completeness`` compares a deposited frequency
+list against ``3N - 6``, the weakest bound that is certainly true for any
+geometry with that many atoms. It has to be: linearity is never
+determined in the wire package, and since ``3N - 5 > 3N - 6`` a linear
+molecule clears a ``3N - 6`` floor without anyone having to choose a
+collinearity tolerance.
+
+The residue that leaves is one mode wide, and it is what this file is
+about: a **non-linear** molecule depositing exactly ``3N - 5`` modes —
+one spurious extra, or one rigid-body mode left in the list — sits inside
+the accepted band and passes silently.
+
+Every test here uses a real molecule, and both kinds are present on
+purpose. A file testing only bent geometries could not tell this check
+from a rule that flags every ``3N - 5`` deposit; a file testing only
+linear ones could not tell it from today's behaviour, which flags
+nothing. The pair is the test.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.frequency_geometry_linearity import (
+    BENT_MIN_TRANSVERSE_RATIO,
+    COLLINEAR_MAX_TRANSVERSE_RATIO,
+    W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY,
+    GeometryLinearity,
+    calculation_linearity_warnings,
+    classify_xyz_linearity,
+    evaluate_deposited_frequency_list_linearity,
+    evaluate_frequency_list_linearity,
+    transverse_extent_ratio,
+)
+
+# ---------------------------------------------------------------------------
+# Real geometries, both kinds
+# ---------------------------------------------------------------------------
+
+#: Water. Bent, 104.5°. 3 atoms: 3N-6 = 3 vibrations, 3N-5 = 4.
+WATER_XYZ = (
+    "3\nwater\n"
+    "O  0.000000  0.000000  0.117300\n"
+    "H  0.000000  0.757200 -0.469200\n"
+    "H  0.000000 -0.757200 -0.469200"
+)
+
+#: Carbon dioxide. Linear. 3 atoms: 3N-5 = 4 vibrations, one *more*
+#: than water's three despite the identical atom count.
+CO2_XYZ = (
+    "3\ncarbon dioxide\n"
+    "C  0.000000  0.000000  0.000000\n"
+    "O  0.000000  0.000000  1.162000\n"
+    "O  0.000000  0.000000 -1.162000"
+)
+
+#: Hydrogen cyanide. Linear, and unlike CO2 not symmetric — so a check
+#: that accidentally keyed on symmetry rather than collinearity would
+#: part company with reality here.
+HCN_XYZ = (
+    "3\nhydrogen cyanide\n"
+    "H  0.000000  0.000000 -1.064000\n"
+    "C  0.000000  0.000000  0.000000\n"
+    "N  0.000000  0.000000  1.156000"
+)
+
+#: Acetylene. Linear, 4 atoms: 3N-5 = 7 vibrations. Four atoms rather
+#: than three, so the arithmetic is exercised away from the smallest case.
+ACETYLENE_XYZ = (
+    "4\nacetylene\n"
+    "C  0.000000  0.000000  0.601000\n"
+    "C  0.000000  0.000000 -0.601000\n"
+    "H  0.000000  0.000000  1.663000\n"
+    "H  0.000000  0.000000 -1.663000"
+)
+
+#: Methanol. Bent and three-dimensional, 6 atoms: 3N-6 = 12 vibrations,
+#: 3N-5 = 13.
+METHANOL_XYZ = (
+    "6\nmethanol\n"
+    "C  -0.047130   0.664390   0.000000\n"
+    "O  -0.047130  -0.758550   0.000000\n"
+    "H  -1.093000   0.969790   0.000000\n"
+    "H   0.437050   1.064220   0.890410\n"
+    "H   0.437050   1.064220  -0.890410\n"
+    "H   0.863080  -1.049960   0.000000"
+)
+
+
+def _bent_co2_xyz(x: float, y: float) -> str:
+    """CO2 with its two oxygens pulled off the axis by ``y``."""
+    return (
+        "3\nbent carbon dioxide\n"
+        "C  0.000000  0.000000  0.000000\n"
+        f"O  {x:.6f}  {y:.6f}  0.000000\n"
+        f"O  {-x:.6f}  {y:.6f}  0.000000"
+    )
+
+
+#: CO2 bent by a thousandth of a degree — ordinary optimiser convergence
+#: noise, and the case that rules out reusing
+#: ``LINEARITY_SINGULAR_VALUE_TOLERANCE``.
+CO2_179_999_XYZ = _bent_co2_xyz(1.161000, 0.000010)
+
+#: CO2 at 179°: genuinely between the two thresholds.
+CO2_179_XYZ = _bent_co2_xyz(1.161956, 0.010140)
+
+#: CO2 at 178° — the brief's example of a genuinely ambiguous geometry.
+CO2_178_XYZ = _bent_co2_xyz(1.161823, 0.020280)
+
+#: CO2 at 170°: bent past any tolerance argument.
+CO2_170_XYZ = _bent_co2_xyz(1.157578, 0.101275)
+
+
+class TestTheGeometricMeasure:
+    def test_an_exactly_collinear_set_has_no_transverse_extent(self):
+        coordinates = np.array([[0.0, 0.0, -1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+        assert transverse_extent_ratio(coordinates) == pytest.approx(0.0, abs=1e-12)
+
+    def test_the_measure_is_invariant_under_rotation_and_translation(self):
+        """Collinearity is a property of the shape, not of the frame.
+
+        A geometry deposited in a rotated or shifted frame is the same
+        molecule, so a check that answered differently for the two would
+        be reporting the file's orientation, not the chemistry.
+        """
+        parsed = classify_xyz_linearity(WATER_XYZ)
+        angle = 0.7
+        rotation = np.array(
+            [
+                [np.cos(angle), -np.sin(angle), 0.0],
+                [np.sin(angle), np.cos(angle), 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        water = np.array(
+            [
+                [0.0, 0.0, 0.1173],
+                [0.0, 0.7572, -0.4692],
+                [0.0, -0.7572, -0.4692],
+            ]
+        )
+        moved = water @ rotation.T + np.array([3.0, -4.0, 5.0])
+        assert transverse_extent_ratio(moved) == pytest.approx(
+            parsed.transverse_ratio, rel=1e-9
+        )
+
+    def test_a_single_point_has_no_answer(self):
+        coordinates = np.array([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
+        assert transverse_extent_ratio(coordinates) is None
+
+
+class TestClassification:
+    @pytest.mark.parametrize(
+        "name,xyz",
+        [
+            ("co2", CO2_XYZ),
+            ("hcn", HCN_XYZ),
+            ("acetylene", ACETYLENE_XYZ),
+            ("co2 bent by 0.001 degrees", CO2_179_999_XYZ),
+        ],
+    )
+    def test_linear_molecules_are_classified_linear(self, name, xyz):
+        assert classify_xyz_linearity(xyz).verdict is GeometryLinearity.linear, name
+
+    @pytest.mark.parametrize(
+        "name,xyz",
+        [
+            ("water", WATER_XYZ),
+            ("methanol", METHANOL_XYZ),
+            ("co2 bent to 170 degrees", CO2_170_XYZ),
+        ],
+    )
+    def test_bent_molecules_are_classified_bent(self, name, xyz):
+        assert classify_xyz_linearity(xyz).verdict is GeometryLinearity.bent, name
+
+    @pytest.mark.parametrize(
+        "name,xyz",
+        [("co2 at 179 degrees", CO2_179_XYZ), ("co2 at 178 degrees", CO2_178_XYZ)],
+    )
+    def test_near_linear_molecules_are_left_undetermined(self, name, xyz):
+        """The band between the thresholds, and why it exists.
+
+        A bond angle of 178° is genuinely ambiguous — quasi-linear
+        molecules are real, and any single cutoff mis-sorts some of them.
+        The check answers "undetermined" rather than picking a side, so
+        no depositor is told confidently that their record is wrong on
+        the strength of two degrees.
+        """
+        assert (
+            classify_xyz_linearity(xyz).verdict is GeometryLinearity.undetermined
+        ), name
+
+    def test_the_thresholds_leave_a_band_between_them(self):
+        assert COLLINEAR_MAX_TRANSVERSE_RATIO < BENT_MIN_TRANSVERSE_RATIO
+
+    def test_water_is_bent_by_an_order_of_magnitude_more_than_the_threshold(self):
+        """The threshold is nowhere near anything real, which is the point."""
+        ratio = classify_xyz_linearity(WATER_XYZ).transverse_ratio
+        assert ratio > 10 * BENT_MIN_TRANSVERSE_RATIO
+
+    def test_an_unparseable_geometry_is_not_spoken_about(self):
+        assert (
+            classify_xyz_linearity("not an xyz block").verdict
+            is GeometryLinearity.undetermined
+        )
+
+    def test_a_diatomic_is_not_answered_here(self):
+        """Two atoms are collinear by definition and already have an exact
+        count from ``minimum_complete_mode_count``. Answering a question
+        nobody asks would invite a caller to rely on it."""
+        diatomic = "2\nHF\nH 0.0 0.0 0.0\nF 0.0 0.0 0.917"
+        assert (
+            classify_xyz_linearity(diatomic).verdict
+            is GeometryLinearity.undetermined
+        )
+
+
+class TestTheWarningFiresOnlyForBentGeometries:
+    def test_water_with_four_modes_is_flagged(self):
+        """Four modes is 3N-5: the count a *linear* triatomic has.
+
+        The whole residue in one case. The wire-side floor is ``3N - 6``
+        = 3 and the ceiling ``3N`` = 9, so four sits comfortably inside
+        the accepted band and nothing said anything before this check.
+        """
+        warnings = evaluate_frequency_list_linearity(4, WATER_XYZ, location="x")
+        assert [w.code for w in warnings] == [
+            W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY
+        ]
+
+    def test_carbon_dioxide_with_four_modes_is_not_flagged(self):
+        """The same atom count, the same mode count, the opposite verdict.
+
+        This is the test that separates the new check from a rule that
+        simply flags ``3N - 5``: CO2 genuinely has four vibrations.
+        """
+        assert evaluate_frequency_list_linearity(4, CO2_XYZ, location="x") == []
+
+    def test_hydrogen_cyanide_with_four_modes_is_not_flagged(self):
+        assert evaluate_frequency_list_linearity(4, HCN_XYZ, location="x") == []
+
+    def test_acetylene_with_seven_modes_is_not_flagged(self):
+        assert evaluate_frequency_list_linearity(7, ACETYLENE_XYZ, location="x") == []
+
+    def test_methanol_with_thirteen_modes_is_flagged(self):
+        warnings = evaluate_frequency_list_linearity(13, METHANOL_XYZ, location="x")
+        assert [w.code for w in warnings] == [
+            W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY
+        ]
+
+    def test_methanol_with_its_twelve_modes_is_not_flagged(self):
+        assert evaluate_frequency_list_linearity(12, METHANOL_XYZ, location="x") == []
+
+    def test_a_near_linear_geometry_is_never_flagged(self):
+        """178° with four modes: silent, because the verdict is silent.
+
+        A warning here would be a confident-sounding claim resting on a
+        two-degree bend, which no tolerance can support.
+        """
+        assert evaluate_frequency_list_linearity(4, CO2_178_XYZ, location="x") == []
+
+
+class TestItStaysOutOfTheOtherChecksWay:
+    @pytest.mark.parametrize("n_modes", [0, 1, 2, 3, 5, 6, 7, 8, 9, 10])
+    def test_only_the_linear_count_is_ever_reported(self, n_modes):
+        """Every other length belongs to the floor, the ceiling, or nobody.
+
+        A payload cannot collect this warning *and* a completeness one
+        for the same list: water's floor is 3 and its ceiling 9, and this
+        check speaks only at 4.
+        """
+        assert evaluate_frequency_list_linearity(n_modes, WATER_XYZ, location="x") == []
+
+    def test_no_list_is_not_a_wrong_list(self):
+        assert evaluate_frequency_list_linearity(None, WATER_XYZ, location="x") == []
+
+    def test_no_geometry_means_no_opinion(self):
+        assert evaluate_frequency_list_linearity(4, None, location="x") == []
+
+
+class TestTheMessage:
+    def test_it_names_the_code_the_counts_and_the_measure(self):
+        warning = evaluate_frequency_list_linearity(
+            4, WATER_XYZ, location="calculations[0].freq_result.modes"
+        )[0]
+        assert warning.field == "calculations[0].freq_result.modes"
+        assert W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY in warning.message
+        assert "4 modes" in warning.message
+        assert "3N-6 = 3" in warning.message
+        assert "accepted and flagged" in warning.message
+
+    def test_it_carries_no_database_identifiers(self):
+        """DR-0028 Requirement 2: nothing a depositor cannot act on."""
+        warning = evaluate_frequency_list_linearity(
+            4, WATER_XYZ, location="calculations[0].freq_result.modes"
+        )[0]
+        assert "_id" not in warning.message
+        assert "id=" not in warning.message
+
+
+class TestGeometryResolution:
+    def test_the_calculations_own_geometry_wins_over_the_fallback(self):
+        """Same rule as the wire-side completeness check, restated.
+
+        The two must count the same atoms to be talking about the same
+        record. Here the calculation names a bent geometry while the
+        enclosing conformer's reference is linear: the calculation's own
+        is the one the frequency job ran on.
+        """
+        warnings = evaluate_deposited_frequency_list_linearity(
+            4,
+            input_geometry_xyz_text=WATER_XYZ,
+            fallback_xyz_text=CO2_XYZ,
+            location="x",
+        )
+        assert [w.code for w in warnings] == [
+            W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY
+        ]
+
+    def test_the_fallback_is_used_when_the_calculation_names_none(self):
+        warnings = evaluate_deposited_frequency_list_linearity(
+            4,
+            input_geometry_xyz_text=None,
+            fallback_xyz_text=WATER_XYZ,
+            location="x",
+        )
+        assert [w.code for w in warnings] == [
+            W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY
+        ]
+
+    def test_the_linear_fallback_keeps_a_linear_deposit_silent(self):
+        assert (
+            evaluate_deposited_frequency_list_linearity(
+                4,
+                input_geometry_xyz_text=None,
+                fallback_xyz_text=CO2_XYZ,
+                location="x",
+            )
+            == []
+        )
+
+
+class TestThePayloadAdapter:
+    def _calc(self, frequencies: list[float] | None):
+        from app.schemas.fragments.calculation import CalculationWithResultsPayload
+
+        freq_result: dict = {"n_imag": 0}
+        if frequencies is not None:
+            freq_result["modes"] = [
+                {
+                    "mode_index": index + 1,
+                    "frequency_cm1": value,
+                    "is_imaginary": False,
+                }
+                for index, value in enumerate(frequencies)
+            ]
+        return CalculationWithResultsPayload.model_validate(
+            {
+                "type": "freq",
+                "software_release": {"name": "Gaussian", "version": "16"},
+                "level_of_theory": {"method": "B3LYP", "basis": "6-31G(d)"},
+                "freq_result": freq_result,
+            }
+        )
+
+    def test_a_bent_conformer_geometry_flags_its_freq_calculation(self):
+        warnings = calculation_linearity_warnings(
+            self._calc([1595.0, 3657.0, 3756.0, 12.0]),
+            location="calculations[1].freq_result.modes",
+            fallback_xyz_text=WATER_XYZ,
+        )
+        assert [w.code for w in warnings] == [
+            W_FREQ_LIST_LINEAR_COUNT_FOR_BENT_GEOMETRY
+        ]
+
+    def test_a_linear_conformer_geometry_does_not(self):
+        assert (
+            calculation_linearity_warnings(
+                self._calc([667.0, 667.0, 1333.0, 2349.0]),
+                location="calculations[1].freq_result.modes",
+                fallback_xyz_text=CO2_XYZ,
+            )
+            == []
+        )
+
+    def test_a_calculation_with_no_frequency_list_is_silent(self):
+        assert (
+            calculation_linearity_warnings(
+                self._calc(None),
+                location="calculations[1].freq_result.modes",
+                fallback_xyz_text=WATER_XYZ,
+            )
+            == []
+        )

--- a/docs/guides/scientific_check_register.md
+++ b/docs/guides/scientific_check_register.md
@@ -85,22 +85,22 @@ disagree, this one is right by construction.
 | Tier | Entries | Meaning |
 | --- | --- | --- |
 | `block` | 20 | Refuses the payload. ADR 0008 permits this only for a definition or a contract — a record no correct calculation could produce. |
-| `warn` | 8 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
+| `warn` | 9 | Accepts the payload and records a machine-readable warning. The tier for expectations (which could fire on a correct novel result) and for absences (an incomplete record is still a true one). |
 | `label` | 1 | Labels a stored record at read time without refusing anything — a `HardFailReason` in the trust evaluator. For facts TCKDB observes about a record after it was accepted, which no upload-time check could have refused because they did not exist yet. |
 | `review` | 0 | Referred to `machine_review` under a versioned rubric. ADR 0008 puts every cross-check against external reference data here. |
 | `structural` | 5 | Not an ADR 0008 consequence tier. The position is enforced by the shape of the schema, so a record violating it cannot be represented. |
-| **total** | **34** | |
+| **total** | **35** | |
 
 ## Where a check's code reaches a client
 
 | Channel | Entries | What a consumer can do with it |
 | --- | --- | --- |
 | `error_envelope` | 21 | the `code` field of the 422 error body — a client can branch on it |
-| `upload_warning` | 9 | the `code` field of an `UploadWarning` returned alongside the accepted upload |
+| `upload_warning` | 10 | the `code` field of an `UploadWarning` returned alongside the accepted upload |
 | `trust_label` | 1 | a read-time trust label (`HardFailReason`), not any refusal |
 | `database_constraint` | 1 | PostgreSQL only, so the refusal is a 409 rather than a 422 — named, where the constraint declares a rejection code |
 | `none` | 2 | *nothing carries a code* |
-| **total** | **34** | |
+| **total** | **35** | |
 
 ## Recorded divergences
 
@@ -110,7 +110,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 - **[9]** Every geometry linked to a calculation is made of the atoms of the subject that calculation is filed under -- the species entry's own formula, or, for a transition state, the sum of its reaction's reactants.
 - **[12]** An optimisation's output geometry still describes the species it was declared for — the optimiser handed back the molecule it was given.
 - **[16]** A transition state's imaginary modes other than the reaction coordinate are judged by magnitude against a tolerance read from the protocol that produced them, not by counting them.
-- **[31]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+- **[32]** A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 ## Entries
 
@@ -525,9 +525,36 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** **None, and that absence is the argument for blocking rather than a gap in it.** Every other entry in this group needs a door because a correct record can trip it: a genuine higher-order saddle is deposited by designating its reaction coordinate, a van der Waals complex by declaring `molecule_kind`, a contradictory `n_imag` by omitting `modes`. There is no counterpart here because there is nothing to let through — no calculation, honest or otherwise, produces more modes than the geometry has degrees of freedom, so a hatch would exist only to admit a record whose own two halves disagree. What looks like a hatch and is not: omitting `modes` still avoids the refusal, but it is not a door onto legitimate chemistry the check would have refused — it deposits a different, weaker record, and the thing it drops is a frequency list this check has already determined does not belong to the geometry beside it. The repair is to attach the calculation to the geometry it ran on, or to deposit that geometry.
 
+### 21. A frequency list carrying exactly `3N - 5` modes should be attached to a collinear geometry, because `3N - 5` is the vibrational count of a linear molecule and a non-linear one has `3N - 6`.
+
+| Field | Value |
+| --- | --- |
+| **Tier** | `warn` |
+| **Code** | `freq_list_linear_mode_count_for_bent_geometry` |
+| **Code reaches a client via** | the `code` field of an `UploadWarning` returned alongside the accepted upload |
+| **Governing ADR** | 0008 |
+
+**Why this tier.** An expectation, not a definition, and ADR 0008 is explicit that only the latter may block. The verdict rests on a *tolerance* — on where the line between collinear and bent is drawn — and a rule whose answer moves when a constant moves is an expectation by construction. Unlike the `3N` ceiling, which no correct deposit can trip, this one can: a genuinely quasi-linear molecule sits on no side of the line, and a producer who deposited `3N - 6` vibrations plus one rigid-body eigenvalue on purpose deposited something true. So the check declines to answer in the ambiguous band and annotates rather than refuses outside it. It is also the *second* judgement on one list: the wire package's `freq_list_incomplete_for_geometry` floor keeps exactly the strength an atom count can prove, and this adds only the strength coordinates can.
+
+**Enforced at.**
+
+- `evaluate_frequency_list_linearity` — `backend/app/services/frequency_geometry_linearity.py::evaluate_frequency_list_linearity`
+  *Owns the arithmetic and the verdict; the payload walks that resolve which geometry each frequency list is measured against live in the same module, one per upload shape, and restate the wire-side rule — the calculation's own first input geometry where the producer named one, otherwise the enclosing conformer's or transition state's reference geometry. The two checks must count the same atoms to be talking about the same record.*
+- The collinearity tolerance stays backend-side. `tckdb_schemas` is forbidden from importing `app` by an AST scan and a runtime `sys.modules` check, and it carries no numerics; moving a tolerance into it to share one constant would put a numerical judgement inside a package whose contract is that it holds none. So the wire package keeps the bound it can prove from an atom count and the backend adds the sharper one where the coordinates are.
+- `LINEARITY_SINGULAR_VALUE_TOLERANCE` in `app.chemistry.normal_modes` is *not* reused, though it answers the same question. It is an exact-rank test at 1e-6 relative, set that tight because admitting a nearly-zero direction into a projection basis corrupts the projection. Measured on real coordinates, CO2 bent by one thousandth of a degree — ordinary optimiser noise — comes out at 4.5e-6 and classifies as *not linear*, so reusing it would have fired this warning on correct linear molecules.
+
+**Thresholds.**
+
+- `COLLINEAR_MAX_TRANSVERSE_RATIO` = **0.001 dimensionless (sigma_2 / sigma_1 of the centred coordinates)** — a constant fixed in code.
+  At or below this the geometry is treated as linear and nothing is reported. Roughly 0.2 degrees of bend for a symmetric triatomic — three orders of magnitude looser than optimiser convergence noise, so a real linear molecule cannot be flagged. Loosening it would silence the check for genuinely bent molecules; tightening it risks warning about correct ones, which is the failure an advisory check must not have.
+- `BENT_MIN_TRANSVERSE_RATIO` = **0.03 dimensionless (sigma_2 / sigma_1 of the centred coordinates)** — a constant fixed in code.
+  At or above this the geometry is treated as bent and the warning may fire. Roughly 6 degrees of bend for a symmetric triatomic; water sits fifteen times over it. Between the two thresholds the check answers 'undetermined' and says nothing, which is what keeps a quasi-linear molecule from receiving a confident claim two degrees cannot support.
+
+**Escape hatch.** None needed — the warning is the accommodation, and the record is stored either way. A depositor whose molecule is genuinely quasi-linear will usually not see the warning at all, because the band between the two thresholds is deliberately silent.
+
 ## Atom mapping across a reaction
 
-### 21. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
+### 22. An atom does not change element on the way across a reaction: carbon does not map onto nitrogen.
 
 | Field | Value |
 | --- | --- |
@@ -548,7 +575,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Case is not load-bearing, and no longer needs a special provision to stop it becoming so. The comparison used to be case-insensitive on both sides, because the two ends quote two different geometries and nothing guaranteed they spelled an element the same way — carbon becoming nitrogen is a contradiction, while `Cl` becoming `CL` is one program shouting where another did not, and refusing the second would have refused correct chemistry. `b4e7c1d20f83` canonicalised the symbol on the way into `geometry_atom.element` and `c5a1f8e3d074` made that a CHECK, so one element now has one spelling in every state the database can be in and both the constraint and the service compare the stored values directly. Isotope mass number is deliberately *not* carried across the same way, because a NULL disables a MATCH SIMPLE foreign key; isotope consistency is checked in the service layer instead.
 
-### 22. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
+### 23. One saddle-point atom is claimed by exactly one atom of each leg, and one participant atom maps to exactly one saddle-point atom.
 
 | Field | Value |
 | --- | --- |
@@ -572,7 +599,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Per leg, not globally: the reactant and product legs each claim the whole saddle point, which is the point of storing two maps both pointing at it. A `side` column exists on the pair row purely so this can be a unique constraint, because SQL cannot dereference the participant to find its role.
 
-### 23. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
+### 24. Every atom index in a map is counted against a named geometry that the participant actually owns, and names an atom that geometry actually has.
 
 | Field | Value |
 | --- | --- |
@@ -596,7 +623,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None, and the cost is stated in ADR 0011: the map is welded to the geometries it names, so depositing a second conformer or re-optimising at another level of theory does not carry it across. Canonical-order-relative indexing would be portable, and was rejected because its failure mode is a map that looks fine and refers to a different atom order than the depositor intended. Portability can be added later as a derived view; correctness cannot be retrofitted onto records nobody can verify.
 
-### 24. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
+### 25. When a map covers every declared participant of an atom-balanced reaction, both legs claim the same saddle-point atoms and no saddle-point atom is left unclaimed.
 
 | Field | Value |
 | --- | --- |
@@ -614,7 +641,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Leave the map incomplete, or deposit an unbalanced reaction — either drops the rule to the warning tier by design rather than by accident.
 
-### 25. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
+### 26. Where a deposit carries both an atom map and an IRC participant mapping for the same saddle point, they agree about which saddle-point atoms each participant is made of.
 
 | Field | Value |
 | --- | --- |
@@ -632,7 +659,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** Omit one surface, or correct whichever is wrong — the mappings are optional on every path and a partial atom map is always accepted. Three absences are deliberately *not* disagreements: an atom map that omits a participant or leaves atoms unmapped is compared only over what it does claim, a transition state with no passing IRC mapping is not compared at all, and a barrierless channel has neither surface. Two participants on one side that are the same species entry are interchangeable, so a disagreement a permutation within that group would resolve is treated as arbitrary labelling rather than contradiction. A participant with no atoms is not an absence: both surfaces can say it has none -- an empty atom list -- so a reaction releasing a free electron carries a complete partition on both and is compared like any other, with the electron contributing no atoms to either side of the comparison.
 
-### 26. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
+### 27. A reaction that has a transition state should say which atom of the reactants is which atom of the saddle point and of the products.
 
 | Field | Value |
 | --- | --- |
@@ -650,7 +677,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None is needed — the warning *is* the accommodation. TCKDB deliberately will not infer a map: several chemically distinct maps are usually consistent with the same reactants and products, so choosing one by algorithm would manufacture provenance.
 
-### 27. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
+### 28. A supplied atom map should cover every declared participant molecule, every atom of each mapped participant, and every atom of the saddle point.
 
 | Field | Value |
 | --- | --- |
@@ -668,7 +695,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Escape hatch.** None.
 
-### 28. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
+### 29. An atom map records whether a human asserted it or an algorithm produced it, an inferred map names the algorithm, and neither attribution can be relabelled afterwards.
 
 | Field | Value |
 | --- | --- |
@@ -692,7 +719,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Rate coefficients
 
-### 29. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
+### 30. An Arrhenius pre-exponential factor carries units of the dimensionality its reaction order requires — per-second for unimolecular, concentration^-1 time^-1 for bimolecular, concentration^-2 time^-1 for termolecular.
 
 | Field | Value |
 | --- | --- |
@@ -712,7 +739,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Statistical mechanics
 
-### 30. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
+### 31. A partition function belongs to exactly one subject — a species entry or a transition-state entry, never both and never neither.
 
 | Field | Value |
 | --- | --- |
@@ -733,7 +760,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Pressure-dependent networks
 
-### 31. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
+### 32. A set of phenomenological k(T,P) declares whether this database holds the master-equation derivation behind it; a `computed` solve must actually carry master-equation evidence, and a `reported` one must cite the publication it was transcribed from.
 
 | Field | Value |
 | --- | --- |
@@ -756,7 +783,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 **Recorded divergence.** Existence, not coverage — and the trigger must not be read as the whole contract. The database guarantees a computed solve carries nonzero evidence of each applicable class; the three coverage rules (one energy per state, one energy-transfer model per (well, collider) pair or a network-wide declaration, one barrier per saddle-point path) remain properties of the single wired upload path. A computed solve with four energies out of five passes the database and fails the validator. ADR 0010's amendment states this deliberately: a computed solve with *zero* energies is a contradiction and may block, while an incomplete one is a true record to be graded by the trust and reproducibility layers. Separately, `kind` cannot surface in CHEMKIN export, which has no provenance field; a tripwire test guards the moment network kinetics first reach mechanism output.
 
-### 32. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
+### 33. A collisional energy-transfer model records whether its ⟨ΔE⟩down was determined per (well, collider) pair or declared once for the whole network.
 
 | Field | Value |
 | --- | --- |
@@ -777,7 +804,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Custody of the evidence
 
-### 33. The bytes TCKDB serves for a stored artifact are the bytes it stored, and a record whose evidence is known not to be is labelled as such at read time rather than graded as if it were intact.
+### 34. The bytes TCKDB serves for a stored artifact are the bytes it stored, and a record whose evidence is known not to be is labelled as such at read time rather than graded as if it were intact.
 
 | Field | Value |
 | --- | --- |
@@ -805,7 +832,7 @@ Where a check's documentation and its behaviour disagree, or where a guarantee i
 
 ## Reproducibility
 
-### 34. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
+### 35. Whether a record's preserved evidence is sufficient to understand, audit or repeat it is assessed separately from how far its evidence is trusted and from whether a curator approved it, and the three may disagree.
 
 | Field | Value |
 | --- | --- |


### PR DESCRIPTION
## In plain language

A molecule made of *N* atoms needs 3*N* numbers to say where its atoms are. Six of
those only say where the molecule *sits* and which way it *points* — they stretch
no bond and bend no angle — so a bent molecule has **3N − 6** genuine vibrations.
A *linear* molecule is the exception: spinning it about its own axis moves nothing,
so it has one rotation fewer and therefore one vibration more, **3N − 5**.

TCKDB already checked that a deposited list of vibrational frequencies is not
obviously too short. But the check ran in the **wire package** — the small,
dependency-free library that describes what an upload looks like, shared between
the server and the clients — and that package deliberately contains no chemistry
maths, so it cannot work out whether a molecule is straight. It therefore used the
loosest bound that is true either way: at least `3N − 6`. A linear molecule's
`3N − 5` clears that easily, which is exactly why the loose bound was the right
call.

The gap that left is one mode wide. A **bent** molecule that deposits exactly
`3N − 5` frequencies — water with four, methanol with thirteen — has one mode too
many, and nothing said so, because `3N − 5` is above the `3N − 6` floor. In
practice that happens when the frequency program (or a script reading its output)
treated the molecule as linear, or when one of the six "where it sits" modes got
left in the list by mistake.

This PR adds a **second, sharper check on the server side**, where the atom
coordinates and the numerical tools are both available. It measures how far the
atoms deviate from a straight line, and if the molecule is clearly bent while its
frequency count is the linear one, the upload is **accepted** and a warning is
attached to the response. It never refuses a deposit, and if the molecule is only
*nearly* straight — a bond angle of 178°, say — it says nothing at all, because at
that point no threshold can honestly tell straight from bent.

Some vocabulary used below: a **warning** here is a machine-readable entry in the
`warnings` array of a successful (201) upload response — the record is stored, the
depositor is told. A **wire package** is `tckdb-schemas`, the shared payload
definitions. A **register entry** is a row in `docs/guides/scientific_check_register.md`,
the generated document that lists every scientific judgement TCKDB makes and why
it blocks or merely warns.

---

## Which option, and why

The brief offered three. **I took (c): a second check backend-side.**

- **(a) a declared `statmech.is_linear`** — not taken, for the reason the previous
  agent gave: it would make the rule fire or not depending on whether a statmech
  block happens to be present, which is a worse shape than a slightly loose bound.
- **(b) move the tolerance into the wire package** — **not taken, deliberately.**
  `tckdb_schemas` is forbidden from importing `app`, enforced by an AST scan *and*
  a runtime `sys.modules` check in a subprocess. That boundary is not weakened
  here by one line. Beyond the import rule, the package carries no numerics at all;
  the check needs an SVD. Putting a numerical judgement inside a package whose
  whole contract is that it holds none would be paying a permanent architectural
  price for a one-mode advisory. **No wire-package file is touched by this PR**, so
  `clients/python/pyproject.toml` is not bumped and nothing here is CI-only —
  every claim below was verified locally.
- **(c) backend-side, after resolution** — taken. The wire package keeps exactly
  the strength an atom count can prove; the backend adds the strength coordinates
  can. `minimum_complete_mode_count` is unchanged and still runs on every path.

## Does the backend have the frequency list at a usable point? Yes.

Confirmed before building, and this was the load-bearing question.

The upload routes hold the fully-parsed request object *and* already assemble the
`warnings` array from it — `stationary_point_warnings(request.stationary_point_findings())`
at `backend/app/api/routes/uploads.py`, and the "Layer 1c" walk at
`backend/app/services/upload_reconciliation.py`, which is the existing exemplar:
it already takes `reference_xyz_text` and calls the wire-side completeness check
per calculation. So both the frequency lists and the geometries are in hand at a
point where a warning still reaches the response body.

Two placements were considered and rejected, with reasons, because the obvious
guesses do not work:

- **`persist_calculation_result`** has the mode list but not the *fallback*
  geometry — a `freq` calculation that names no input geometry of its own inherits
  the enclosing conformer's, and that is supplied separately by the callers,
  after this function returns.
- **`attach_calculation_input_geometries`** is the one function that decides which
  geometry the database binds, which made it look like the single choke point.
  It is not: only 5 of the 9 sites that persist a calculation call it. The
  statmech/thermo/transport, standalone transition-state and PDep paths persist
  calculations without it.

So the check is wired at the route/reconciliation seams, alongside the sibling
completeness check, on **every** upload path that can carry a frequency list:

| Route | Wiring point |
| --- | --- |
| `/uploads/conformers` | `upload_reconciliation.py` "Layer 1d", beside Layer 1c |
| `/uploads/computed-species` | `uploads.py`, beside `stationary_point_findings()` |
| `/uploads/computed-reaction` | same |
| `/uploads/transition-states` | same |
| `/uploads/statmech`, `/thermo`, `/transport` | same |
| `/uploads/network-pdep` | same |

The per-shape walks restate the wire-side geometry rule (the calculation's own
first input geometry where the producer named one, otherwise the enclosing
conformer's or transition state's reference geometry) and reuse its `location`
strings verbatim, so a depositor who trips both checks sees one path, not two
spellings of it.

## What the tolerance does at the boundary

**It refuses to answer.** The classification is three-way — `linear`, `bent`,
`undetermined` — not a boolean, and the gap between the two thresholds is the
whole point.

The measure is scale-free and needs no masses: σ₂/σ₁ of the centred coordinate
matrix, i.e. how far the atoms spread *across* their long axis relative to *along*
it. Exactly collinear is 0.

| Geometry | σ₂/σ₁ | Verdict |
| --- | --- | --- |
| CO₂ at 180.000° | 3.5e-17 | linear — silent |
| CO₂ at 179.999° | 5.0e-06 | linear — silent |
| CO₂ at 179.9° | 5.0e-04 | linear — silent |
| CO₂ at 179° | 5.0e-03 | **undetermined — silent** |
| CO₂ at 178° | 1.0e-02 | **undetermined — silent** |
| CO₂ at 170° | 5.1e-02 | bent — may warn |
| water (104.5°) | 4.5e-01 | bent — may warn |

`COLLINEAR_MAX_TRANSVERSE_RATIO = 1e-3` (~0.2° of bend for a symmetric triatomic)
and `BENT_MIN_TRANSVERSE_RATIO = 3e-2` (~6°). **The brief's 178° case lands in the
silent band by design**: a quasi-linear molecule receives no confident-sounding
warning, because no tolerance could support one.

### Why the existing tolerance is not reused

`LINEARITY_SINGULAR_VALUE_TOLERANCE = 1e-6` in `app/chemistry/normal_modes.py`
answers the same question for a different purpose — an exact-rank test used to
decide how many directions to project out of a Hessian, where admitting a
nearly-zero direction corrupts the projection, so it is set as tight as floating
point allows.

**Measured, not assumed:** a CO₂ geometry bent by one *thousandth* of a degree —
ordinary optimiser convergence noise and XYZ rounding — gives a relative singular
value of 4.5e-6 and is classified **not linear** by that constant. Reusing it
would have fired this warning on real, correct, linear molecules, which is the one
failure an advisory check must not have. The new module carries its own pair of
thresholds and documents this in the register entry.

## Tier: warn, never block

ADR 0008 permits blocking only for a definition or a contract. "This molecule looks
bent, so it should have `3N − 6` modes" rests on a *tolerance*, and a rule whose
answer moves when a constant moves is an expectation by construction. Unlike the
`3N` ceiling — which no correct deposit can trip — this one can: a genuinely
quasi-linear molecule, or a producer who deposited `3N − 6` vibrations plus one
designated rigid-body eigenvalue on purpose, is depositing something true. So the
record is stored and annotated. A test asserts the 201 and reads the record ids
back off it.

The two checks are disjoint by construction: the completeness floor speaks only
*below* `3N − 6` and this one only *at exactly* `3N − 5`, so one frequency list can
never collect both. A parametrised test pins that across every other length.

## Scope deliberately not taken

The mirror case — a geometry determined **linear** whose list is `3N − 6`, one mode
short — is the same slack in the other direction and is a reasonable follow-up. It
is not done here: the short-list warning already has an owner
(`freq_list_incomplete_for_geometry`) whose message and tier were argued from
partial Hessians, frozen-atom regions and lumped participants, and extending it to
a case those arguments do not cover is its own decision.

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no column, no enum. Nothing is
persisted — the judgement is computed at upload time and returned in the response
body. No new environment variable.

The only generated artefact touched is `docs/guides/scientific_check_register.md`,
regenerated by `backend/scripts/generate_scientific_check_register.py` after adding
the register entry (34 → 35 entries; `warn` 8 → 9, `upload_warning` 9 → 10). The
register guard test verifies the document is in sync.

## The mutation, landed and confirmed RED

Per the brief: a check that silently classifies everything as linear reproduces
exactly today's behaviour and would otherwise pass unnoticed.

`classify_linearity` was edited to return `GeometryLinearity.linear` unconditionally
and the suite re-run. **17 tests failed**, including every one that matters:

- `test_bent_water_depositing_the_linear_count_is_flagged` (API, `/uploads/conformers`)
- `test_the_bundle_route_reports_it_too` (API, `/uploads/computed-species`)
- `test_water_with_four_modes_is_flagged`, `test_methanol_with_thirteen_modes_is_flagged`
- `test_bent_molecules_are_classified_bent[water]`, `[methanol]`, `[co2 bent to 170 degrees]`
- `test_near_linear_molecules_are_left_undetermined[co2 at 179 degrees]`, `[178 degrees]`

The mutation was then reverted and the same tests re-run green (49 passed).

Both geometry kinds are tested throughout, which is the property that makes the
suite mean anything: **CO₂, HCN and acetylene depositing `3N − 5` must not warn;
water and methanol depositing `3N − 5` must warn.** A file using only one kind
could not tell this check from the old behaviour in one direction, or from a rule
that flags every `3N − 5` deposit in the other.

## One thing the first full run caught

`backend/tests/scripts/test_check_runtime_ascii.py` refuses a non-ASCII character
in a string that reaches a database, a client or a log. The first draft of the
warning message used two em dashes and the gate went red on all three of its
tests. Fixed in the second commit — the message is ASCII (`--`), and the prose in
docstrings and register rationales, which the gate does not police, is unchanged.

Noting it because a reviewer will see two commits and because it is the kind of
gate that is easy to discover only in a 43-minute full run.

## Exact commands run

```
# Full suite, from backend/ (the cwd backend/pytest.ini is the inifile for):
#   8014 passed, 14 skipped, 27 warnings in 2704.69s (45:04)
cd backend && conda run -n tckdb_env python -m pytest tests/ -q
conda run -n tckdb_env python -m pytest backend/tests/services/test_frequency_geometry_linearity.py \
                                       backend/tests/api/test_api_frequency_linearity.py -q
conda run -n tckdb_env python -m pytest backend/tests/db/test_scientific_check_register.py -q
conda run -n tckdb_env python backend/scripts/generate_scientific_check_register.py
cd backend && conda run -n tckdb_env ruff check app tests scripts    # All checks passed
cd backend && conda run -n tckdb_env mypy                            # no issues, 149 files
git diff   # from the repository root
```

A note on cwd, since the earlier run of this suite from the repository root
reported one extra failure:
`backend/tests/services/test_calculation_geometry_composition.py::test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key`
resolves its fixture with a **relative** `glob.glob("tests/fixtures/...")`, so it
raises `IndexError` when pytest is invoked from the repository root and passes
from `backend/`. That file is not touched by this branch and the failure is
pre-existing and unrelated. Mentioned rather than silently dropped.

## Files

- **new** `backend/app/services/frequency_geometry_linearity.py` — the measure, the
  three-way classification, the warning, the per-shape walks, and the register entry
- **new** `backend/tests/services/test_frequency_geometry_linearity.py` (43 tests)
- **new** `backend/tests/api/test_api_frequency_linearity.py` (8 tests, three routes)
- `backend/app/api/routes/uploads.py` — wiring
- `backend/app/services/upload_reconciliation.py` — Layer 1d
- `backend/app/scientific_checks/declarations.py` — one declaring module registered
- `docs/guides/scientific_check_register.md` — regenerated
