### PR TITLE
Refuse a row id in any error body, not one test at a time

### DIFF
--- a/backend/tests/api/test_error_body_id_gate.py
+++ b/backend/tests/api/test_error_body_id_gate.py
@@ -1,0 +1,214 @@
+"""The DR-0028 body sweep must catch the shape it exists to catch.
+
+``tests/error_body_observer.py`` is a passive observer: it inspects every
+4xx/5xx body the suite produces and fails the test that produced a
+leaking one. Nothing in the suite calls it, so if a refactor quietly
+stopped it matching anything, every gate would stay green and the file
+would be decoration. That is the failure mode this repository produces
+more often than any other, and ``all([])`` being ``True`` is how it
+usually looks.
+
+Three separate things have to be pinned, and the first two are the ones
+a passing suite cannot demonstrate on its own:
+
+* the extractor recognises a leak and does not invent one (below);
+* the plumbing is live -- a real refusal, over the wire, is seen by the
+  observer, and blinding the observer makes that assertion red;
+* the numeric ``context`` facts the API publishes today are *not* leaks,
+  stated as the measurement they came from, so a future tightening that
+  would break ``freq_mode_index_not_unique`` fails here first.
+
+The floor over the whole run lives in ``tests/conftest.py``
+(``BODY_SWEEP_FLOORS``); it is the coarse net for a blinding that leaves
+the extractor's entry intact. The per-test plumbing check is in
+``_check_error_bodies`` in the same file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests import error_body_observer
+from tests.error_body_observer import Observation, inspect
+
+
+def _leaks(status: int, content: dict) -> list[str]:
+    leaks, _fields = inspect(status, content)
+    return [leak.where for leak in leaks]
+
+
+def _fields(status: int, content: dict) -> int:
+    _leaks_found, fields = inspect(status, content)
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# The extractor
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_id_under_its_natural_name_is_a_leak() -> None:
+    """The shape the mistake has actually taken every time so far."""
+    body = {
+        "code": "calculation_not_owned",
+        "detail": "calculation is owned by another species entry",
+        "context": {"calculation_id": 412},
+    }
+    assert _leaks(422, body) == ["context.calculation_id"]
+
+
+@pytest.mark.parametrize(
+    "context, where",
+    [
+        ({"id": 7}, "context.id"),
+        ({"species_pk": 7}, "context.species_pk"),
+        # A list of ids, which is how a bulk refusal would carry them.
+        ({"calculation_ids": [3, 4]}, "context.calculation_ids"),
+        # A map keyed by the depositor's own local key, whose *values* are
+        # row ids. ``test_local_key_resolution.py`` and
+        # ``test_api_pdep_undeclared_local_keys.py`` each assert against
+        # this by hand; here it is caught wherever the map is id-named.
+        ({"resolved_ids": {"my_opt": 91}}, "context.resolved_ids"),
+        # Nested one level down, because ``context`` is not always flat.
+        ({"owner": {"species_entry_id": 3}}, "context.owner.species_entry_id"),
+    ],
+)
+def test_every_id_shaped_key_carrying_an_integer_is_a_leak(context, where) -> None:
+    body = {"code": "x", "detail": "refused", "context": context}
+    assert _leaks(422, body) == [where]
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        # The single worst leak the AST scan ever found, as a client sees it.
+        "ref resolves elsewhere (ref -> id=884)",
+        # The shape the AST scan catches only because ``calc_id`` is an
+        # id-shaped *name*. Here there is no name left, only the label.
+        "calculation not found (calculation_id=412)",
+        "species_entry_id: 9 is not owned by you",
+        "row was written (id: 7)",
+    ],
+)
+def test_prose_that_announces_an_id_and_then_gives_one_is_a_leak(detail) -> None:
+    """The rendered-string half of the AST scan's text rules.
+
+    ``test_no_row_ids_in_user_facing_text.py`` catches these at the raise
+    site when they are written as an f-string literal, and says in its own
+    docstring that it cannot when the message is ``%``-formatted, built
+    with ``str.format``, or bound to a local first. By the time the body
+    exists all three look the same, which is the whole reason to check
+    here as well as there.
+    """
+    body = {"code": "handle_conflict", "detail": detail, "context": {}}
+    assert _leaks(422, body) == ["detail"], detail
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        # The refusal named in DR-0028's own discussion. It must keep
+        # publishing both of these.
+        {"duplicate_mode_indices": [1], "mode_count": 2},
+        {"n_imag": 2, "imaginary_mode_count": 2},
+        {"molecularity": 3, "participant_index": 0},
+        {"charge": -1, "multiplicity": 2},
+        {"offset": 5000, "candidate_count": 12},
+        {"retry_after_seconds": 30},
+        {"min": 0.0, "max": 1.5},
+        # A formula map. Its keys are element symbols, which is why an
+        # allowlist of legitimate numeric key names cannot be written:
+        # the key space is the periodic table.
+        {"reactants": {"C": 2, "H": 6}, "products": {"C": 2, "H": 6}},
+        # An id-shaped key whose value is a public ref, not a row id. A
+        # misleading name is a naming problem; refusing it would teach
+        # authors to rename the key rather than to stop leaking.
+        {"species_entry_id": "spe_abcdefghijklmnopqrstuvwx"},
+        # ``isinstance(True, int)`` is True in Python.
+        {"is_valid_id": True},
+    ],
+)
+def test_the_numeric_context_the_api_publishes_today_is_not_a_leak(context) -> None:
+    """Measured, not assumed.
+
+    Every entry here was observed in a real 4xx body during a full run of
+    all three gates. The union across those gates was 29 distinct
+    numeric-valued ``context`` key names and **zero** id-shaped ones,
+    which is the measurement that chose a key-name rule over an
+    allowlist. If a future tightening makes one of these red, it is
+    taking a published scientific fact off the wire.
+    """
+    body = {"code": "x", "detail": "refused", "context": context}
+    assert _leaks(422, body) == []
+
+
+def test_prose_that_merely_contains_a_number_is_not_a_leak() -> None:
+    for detail in (
+        "grid=10 is too coarse",
+        "uuid=1 is not a uuid",
+        "valid=1 is not a boolean",
+        # Cantera really writes this into a warning during the rest gate.
+        "discontinuity in s/R detected at Tmid = 1000",
+        "matched 4 records, narrow the query",
+        "species_entry not found",
+        "invalid handle 'spe_zzz'",
+        # A quantity whose name merely ends in a digit-bearing suffix.
+        "pressure_bar=3 is out of range",
+    ):
+        body = {"code": "x", "detail": detail, "context": {}}
+        assert _leaks(422, body) == [], detail
+
+
+def test_a_clean_body_still_counts_as_examined() -> None:
+    """Why the floor counts fields and not only bodies.
+
+    Most error bodies carry ``context == {}``, so a walk of ``context``
+    alone visits nothing and a field floor would be near zero however
+    healthy the run. Counting the ``detail`` string too puts a hard
+    minimum of one field on every body, which is what makes a blinded
+    walk visibly different from a clean one.
+    """
+    assert _fields(404, {"code": "x", "detail": "not found", "context": {}}) == 1
+    assert _fields(422, {"code": "x", "detail": "no", "context": {"a": 1, "b": 2}}) == 3
+
+
+# ---------------------------------------------------------------------------
+# The plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_refusal_over_the_wire_reaches_the_observer(client) -> None:
+    """Both patches are live, proved against a request rather than a mock.
+
+    This is the assertion the per-test check in ``conftest.py`` makes for
+    every test in the suite; making it once, explicitly, is what turns
+    "no test ever complained" into evidence. ``drain()`` is called first
+    so the counts belong to this request and not to whatever the fixtures
+    did on the way in.
+    """
+    error_body_observer.drain()
+    response = client.get("/api/v1/scientific/reaction-entries/99999999/full")
+    assert response.status_code == 404, response.text
+
+    observed = error_body_observer.drain()
+    assert observed.bodies >= 1, "JSONResponse.__init__ is no longer patched"
+    assert observed.client_errors >= 1, "TestClient.request is no longer patched"
+    assert observed.leaks == [], observed.leaks
+    # The teardown hook must not then fail this test on a stale count.
+    assert error_body_observer.drain() == Observation()
+
+
+def test_the_session_totals_only_ever_grow(client) -> None:
+    """The floor reads these, and a drain must not reset them.
+
+    An early version cleared both counters together, which made the floor
+    a measure of the last test rather than of the run.
+    """
+    before_bodies, before_fields, before_client = error_body_observer.session_totals()
+    client.get("/api/v1/scientific/geometries/99999999")
+    error_body_observer.drain()
+    after_bodies, after_fields, after_client = error_body_observer.session_totals()
+
+    assert after_bodies > before_bodies
+    assert after_fields > before_fields
+    assert after_client > before_client

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,13 +26,51 @@ from app.api.rate_limit import reset_rate_limit_store
 from app.db.models.api_key import ApiKey
 from app.db.models.app_user import AppUser
 from app.db.models.common import AppUserRole
-from tests import error_code_observer
+from tests import error_body_observer, error_code_observer
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Installed at import so it is in place before the first request of the
 # session, in the controller and in every xdist worker alike.
 error_code_observer.install()
+error_body_observer.install()
+
+
+def _check_error_bodies(item) -> None:
+    """Fail the test whose error body carried a database row id.
+
+    Two failures, in the order they matter. The first is the rule --
+    DR-0028 Requirement 2, no primary key in a user-facing body. The
+    second is the guard on the guard: a sweep that examines nothing
+    passes trivially, so a test whose client *received* a JSON error
+    while the sweep examined *no* body means one of the two patches in
+    ``tests/error_body_observer.py`` is dead, and every other test's
+    silence means nothing. It is checked here, per test, because that
+    needs no constant and holds under any gate selection, any ``-k`` and
+    any worker count -- unlike the floor below, which is the coarser
+    second net.
+    """
+    observed = error_body_observer.drain()
+    if observed.leaks:
+        raise AssertionError(
+            f"{item.nodeid} produced an error body containing a database row "
+            "id (DR-0028 Requirement 2): "
+            + "; ".join(leak.explain() for leak in observed.leaks)
+            + ". A row id is an implementation detail of one database "
+            "instance -- it does not survive a restore and does not agree "
+            "between the hosted deployment and a lab self-host. Log it "
+            "server-side and name the field the depositor wrote, or the "
+            "public ref they supplied, instead."
+        )
+    if observed.client_errors and not observed.bodies:
+        raise AssertionError(
+            f"{item.nodeid} received {observed.client_errors} JSON error "
+            "response(s) and the DR-0028 body sweep examined none of them. "
+            "The observer patches JSONResponse.__init__ and "
+            "TestClient.request; one of them is no longer in place, which "
+            "makes the sweep silent rather than clean. See "
+            "backend/tests/error_body_observer.py."
+        )
 
 
 def pytest_runtest_teardown(item) -> None:
@@ -43,7 +81,12 @@ def pytest_runtest_teardown(item) -> None:
     ``backend/tests/error_code_observer.py`` for why a source scan alone
     cannot make the catalogue's completeness falsifiable, and why the
     comparison is on the pair rather than on the code alone.
+
+    The body sweep is drained here too, and for the same reason: a row id
+    in an error body is a defect of the request that produced it, not of
+    the run. See ``backend/tests/error_body_observer.py``.
     """
+    _check_error_bodies(item)
     unlisted = error_code_observer.drain_unlisted()
     if unlisted:
         raise AssertionError(
@@ -808,6 +851,169 @@ def pytest_terminal_summary(terminalreporter) -> None:
         "defect in the code under test. Re-run serially before believing a "
         "red result."
     )
+
+
+# ---------------------------------------------------------------------------
+# DR-0028 body sweep: the floor
+# ---------------------------------------------------------------------------
+# The per-test check in ``_check_error_bodies`` is the strong net and needs no
+# numbers. This is the coarse second one, and it exists for the blinding the
+# first cannot see: an extractor whose *entry* still runs -- so every body is
+# still counted -- but whose walk visits nothing. Then no test ever notices,
+# because the sweep is examining bodies and simply finding nothing in them.
+#
+# The floor is per gate, because the three gates produce wildly different
+# numbers and one figure for all of them would be the smallest, which is 1.
+# Selection is read from the invocation's own arguments and matched against
+# what the gate scripts pass; anything else -- a ``-k``, a single file, a node
+# id -- is not a gate run and gets no floor, which is said out loud in the
+# summary rather than passing quietly.
+
+#: pytest options that consume the following token, so its value is not
+#: mistaken for a test path. Only the ones the gate scripts and CI use.
+_OPTIONS_TAKING_A_VALUE = frozenset({"-c", "-n", "-o", "-p", "-W", "--ignore", "--tb"})
+
+#: Options that narrow a selection. Their presence means this is not a whole
+#: gate, so no floor applies.
+_FILTERING_OPTIONS = ("-k", "-m", "--deselect", "--lf", "--last-failed", "--ff")
+
+#: ``(bodies swept, body fields examined)`` each selection must reach.
+#:
+#: Measured at seed 424242 with 8 workers, then rounded down by ~10% so that
+#: adding or removing a handful of refusal tests does not fail a run. The
+#: three gates were measured at ``38766219``; the whole-suite row at
+#: ``6d614cb1``, two commits earlier, which is why it is the smaller number:
+#:
+#:     whole suite   935 bodies / 1236 fields   (8,038 tests)
+#:     rest gate       1 body   /    1 field    (4,673 tests)
+#:     api gate      933 bodies / 1234 fields   (2,940 tests)
+#:     scientific    389 bodies /  401 fields   (2,056 tests)
+#:
+#: Re-measure rather than trust these: every run prints its own tally beside
+#: the floor it was held to.
+#:
+#: A drop below these is not "fewer tests"; it is the sweep having stopped
+#: looking. The rest gate's 1 is not a typo -- 4,630 tests there produce a
+#: single error body between them, and 96% of the suite's error bodies come
+#: from ``tests/api``. That lopsidedness is exactly why the per-test check
+#: in ``_check_error_bodies``, and not this table, is what the non-vacuity
+#: argument rests on: a floor of 1 forbids almost nothing.
+BODY_SWEEP_FLOORS: dict[tuple[str, ...], tuple[int, int]] = {
+    ("tests",): (830, 1_080),
+    ("tests", "!tests/api", "!tests/services/scientific_read"): (1, 1),
+    ("tests/api",): (830, 1_080),
+    ("tests/api/scientific", "tests/services/scientific_read"): (350, 360),
+}
+
+
+def _selection_key(config) -> tuple[str, ...] | None:
+    """The invocation reduced to "which subtree", or ``None`` if narrowed.
+
+    Positional paths and ``--ignore`` values only, normalised the way
+    ``tests/scripts/test_gate_coverage.py`` normalises them -- the scripts
+    and the workflows disagree about the trailing slash and that must not
+    change the answer. An ignore is spelled ``!path`` so one tuple can
+    carry both halves of the complement gate's subtraction.
+    """
+    paths: list[str] = []
+    ignored: list[str] = []
+    arguments = list(config.invocation_params.args)
+    skip_next = False
+    for index, argument in enumerate(arguments):
+        if skip_next:
+            skip_next = False
+            continue
+        if any(argument.startswith(option) for option in _FILTERING_OPTIONS):
+            return None
+        if argument == "--ignore":
+            if index + 1 < len(arguments):
+                ignored.append(arguments[index + 1])
+            skip_next = True
+            continue
+        if argument.startswith("--ignore="):
+            ignored.append(argument.split("=", 1)[1])
+            continue
+        if argument in _OPTIONS_TAKING_A_VALUE:
+            skip_next = True
+            continue
+        if argument.startswith("-"):
+            continue
+        paths.append(argument)
+    if not paths:
+        return None
+    return tuple(
+        sorted(path.rstrip("/") for path in paths)
+        + sorted("!" + path.rstrip("/") for path in ignored)
+    )
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    """Hand this worker's sweep totals up, or check them on the controller.
+
+    Under xdist the counters live in eight separate processes and the
+    controller's own are zero, so a floor asserted anywhere but here, after
+    the sum, would be asserting against a fraction that varies with how
+    ``--dist load`` happened to split the run.
+    """
+    totals = error_body_observer.session_totals()
+    workeroutput = getattr(session.config, "workeroutput", None)
+    if workeroutput is not None:
+        workeroutput["tckdb_body_sweep"] = totals
+        return
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return
+
+    bodies, fields, client_errors = totals
+    for worker_bodies, worker_fields, worker_client_errors in getattr(
+        session.config, "_tckdb_worker_sweeps", []
+    ):
+        bodies += worker_bodies
+        fields += worker_fields
+        client_errors += worker_client_errors
+
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    selection = _selection_key(session.config)
+    floor = BODY_SWEEP_FLOORS.get(selection) if selection is not None else None
+
+    def say(line: str) -> None:
+        if reporter is not None:
+            reporter.write_line(line)
+        else:  # pragma: no cover - only when -p no:terminal
+            print(line)
+
+    tally = (
+        f"tckdb: DR-0028 body sweep examined {bodies} error body/bodies, "
+        f"{fields} fields within them; {client_errors} JSON error responses "
+        "reached a client."
+    )
+    if floor is None:
+        say(f"{tally} No floor: this selection is not one of the gate scripts.")
+        return
+
+    say(f"{tally} Floor for this selection is {floor[0]}/{floor[1]}.")
+    if bodies >= floor[0] and fields >= floor[1]:
+        return
+    say(
+        f"ERROR: the DR-0028 body sweep fell below its floor for {selection}. "
+        f"Expected at least {floor[0]} bodies and {floor[1]} fields; saw "
+        f"{bodies} and {fields}. Either the sweep in "
+        "backend/tests/error_body_observer.py stopped examining what it "
+        "claims to, or this gate's selection genuinely shrank -- in which "
+        "case lower BODY_SWEEP_FLOORS in the same change that says why."
+    )
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+def pytest_testnodedown(node, error) -> None:
+    """Collect a finished xdist worker's sweep totals on the controller."""
+    totals = getattr(node, "workeroutput", {}).get("tckdb_body_sweep")
+    if totals is None:
+        return
+    sweeps = getattr(node.config, "_tckdb_worker_sweeps", None)
+    if sweeps is None:
+        sweeps = []
+        node.config._tckdb_worker_sweeps = sweeps  # type: ignore[attr-defined]
+    sweeps.append(tuple(totals))
 
 
 #: Scratch-database names built by individual tests must be reclaimable by

--- a/backend/tests/error_body_observer.py
+++ b/backend/tests/error_body_observer.py
@@ -1,0 +1,348 @@
+"""Watch every error body the suite produces, and refuse a row id in one.
+
+DR-0028 Requirement 2: a user-facing error body must never contain a
+database primary key. Row ids go to the log, where the operator is; the
+body names the field the depositor wrote, because that is the identifier
+they can act on. A row id is not secret, but it is not ours to give --
+it does not survive a restore into a fresh database, it does not agree
+between the hosted deployment and a lab self-host, and no public surface
+is keyed on it. ``public_ref`` is.
+
+Why a runtime observer, when a static scan already exists
+---------------------------------------------------------
+``backend/tests/api/test_no_row_ids_in_user_facing_text.py`` reads the
+AST of ``backend/app`` and fails an f-string that interpolates an
+id-shaped name into a refusal. It is a good check and it stays. It also
+says, in its own words, what it cannot see: a message bound to a local
+before being raised, ``%``-formatting and ``str.format``, and anything
+that is not a literal at the raise site.
+
+It has a fourth blind spot it does not name, and that one is the reason
+this file exists: **it only looks at text.** The envelope a client
+receives is ``{"code", "detail", "context"}``, and ``context`` is the
+half the envelope tells clients to read. It is assembled as a ``dict``
+-- ``CodedValueError(..., context={...})`` -- so no f-string is involved
+and there is nothing for an AST text scan to match. A row id put there
+reaches every client and no check in the repository sees it.
+
+Until now that half was covered the way the error codes were before
+#185: per test, one body at a time, wherever an author remembered.
+Twenty-one test files cite DR-0028 Requirement 2 between them, in 36
+places; exactly one of them
+(``test_api_untested_refusals_tier_bc.py::_refusal``) wrapped the check
+in something reusable, and it is reused nowhere else. So this is the
+same answer #185 gave for codes -- a passive, total observer that
+inspects what the suite already produces, rather than a rule each new
+test must opt into.
+
+Every 4xx/5xx JSON body is recorded as it is built, and the test that
+produced a leaking one fails -- attributing the leak to the request that
+caused it rather than to a suite-wide tally nobody can debug. That is
+:mod:`tests.error_code_observer`'s shape, deliberately.
+
+What counts as a leak, and why not "an integer"
+-----------------------------------------------
+A bare integer in a body is not a row id. It is usually the point of the
+refusal. Measured across all three gates on the commit this was written
+against, ``context`` carries **29 distinct numeric-valued key names**:
+``mode_count``, ``n_imag``, ``duplicate_mode_indices``, ``molecularity``,
+``charge``, ``multiplicity``, ``offset``, ``retry_after_seconds``,
+``min``/``max``, ``participant_index``, ``ts_atom_index`` and the rest.
+``freq_mode_index_not_unique`` publishes ``{"duplicate_mode_indices":
+[1], "mode_count": 2}`` and must keep doing so. "No integers" would
+delete the useful half of the contract.
+
+Three rules were considered. The measurement chose between them:
+
+1. **Key name.** Refuse a ``context`` key named like a database key --
+   ``id``, ``*_id``, ``*_ids``, ``*_pk`` -- carrying an integer. Cheap,
+   and it is the shape the mistake has actually taken: somebody passes a
+   row id under its natural name. **Measured: zero such keys exist
+   today**, in any of the three gates, so the rule lands green and every
+   future one is a real finding.
+2. **Value correlation** -- compare body integers against primary keys
+   created in the same transaction. Precise in principle. The
+   measurement argues against it: the only id-shaped values in any body
+   today are ``detail[].input.existing_calculation_id``, which is
+   Pydantic echoing back *the caller's own* programmatic-chaining field.
+   A correlator would flag it, and it is not a disclosure -- the client
+   sent that number.
+3. **Allowlist the legitimate numeric keys, refuse the rest.** Inverting
+   the burden is the shape that has worked repeatedly in this codebase,
+   and it was the front-runner. It is not tractable here, and not merely
+   because 29 is a lot to maintain. Two of the 29 are ``C`` and ``H`` --
+   element symbols, keys of the formula map in ``{"reactants": {"C": 2,
+   "H": 6}}``. The key space is the periodic table crossed with whatever
+   a depositor uploads, so no enumeration can be complete, and the
+   remaining 27 grow with every new coded refusal that carries a count.
+   An allowlist would turn "this refusal now says how many modes
+   disagreed" into a red gate.
+
+So: rule 1, over ``context``. The blind spot is honest and stated below.
+
+The one text rule, and why it is not the AST scan again
+--------------------------------------------------------
+``detail`` is also swept, but only where it is a plain string -- the
+``NotFoundError`` / ``ValueError`` / ``HTTPException`` shape. It is
+scanned for the *label* form, ``id=123`` or ``(pk: 4)``: prose that
+announces an id and then discloses one. This is the same rule as
+``ID_LABEL`` in the AST scan, applied at the other end of the pipeline,
+and that is the point -- here it sees the rendered string, so it catches
+the ``%``-format, the ``.format``, and the message-bound-to-a-local
+cases the AST scan lists as out of reach.
+
+A structured ``detail`` (Pydantic's list of failures) is **not** swept.
+It is the caller's own request echoed back, ints and all -- including
+the caller's own ``existing_calculation_id``. Sweeping it would refuse a
+number the client itself sent.
+
+What this cannot catch
+----------------------
+An id under a name that does not look like one -- ``{"winner": 12}`` --
+and an id in prose that does not announce itself. Rule 2 is what would
+catch those, and the measurement above is why it is not here. This is a
+floor, like the AST scan is a floor: it makes the obvious way to write
+the mistake fail, and the obvious way is the way it has been written
+every time so far.
+
+Non-vacuity
+-----------
+A sweep that inspects zero bodies passes trivially, which is the failure
+mode this repository produces most often. Three separate things make
+that impossible here, and none of them is ``> 0``:
+
+* **A second, independent witness.** ``TestClient.request`` is patched
+  as well as ``JSONResponse.__init__``. They sit at opposite ends of the
+  request: one records what the application *built*, the other what a
+  client *received*. If either patch dies, or the extractor is blinded
+  at its entry, a test whose client received a JSON error while the
+  sweep examined nothing fails -- immediately, and attributed. This
+  needs no constant and holds under any selection, any ``-k``, any
+  worker count.
+* **A measured floor** on the two counters, per gate, in
+  ``conftest.py``. It catches a blinding that leaves the entry intact
+  but walks nothing.
+* **A detector test** (``tests/api/test_error_body_id_gate.py``) that
+  runs the extractor over a synthetic leaking body and a synthetic clean
+  one, so a refactor that quietly stopped matching is red on its own.
+
+Cost is one ``isinstance`` and a small dict walk per error response, and
+nothing at all for 2xx.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+#: A ``context`` key named the way a database key is named. Deliberately
+#: about the name: an id-valued expression called something else is out of
+#: reach of a shape check, and pretending otherwise would oversell this.
+ID_KEY = re.compile(r"^(?:id|ids|pk|pks)$|_id$|_ids$|_pk$|_pks$")
+
+#: Prose that announces an id and then discloses one --
+#: ``calculation_id=412``, ``(id: 7)``. This is
+#: ``tests/api/test_no_row_ids_in_user_facing_text.py``'s ``ID_LABEL``
+#: rule and its ``ID_NAME`` rule collapsed into one, because by the time
+#: the body exists the label and the interpolated name are the same
+#: characters.
+#:
+#: The optional prefix must end in ``_``, and a bare ``id`` must be
+#: preceded by a non-alphanumeric. Together those keep out the words that
+#: merely end in the letters: ``uuid=3``, ``grid=10``, ``valid=1``, and
+#: -- measured, it really occurs in this suite's output --
+#: Cantera's ``Tmid = 1000``.
+ID_IN_PROSE = re.compile(
+    r"(?:^|[^A-Za-z0-9])(?:[A-Za-z0-9]*_)?(?:id|ids|pk|pks|rowid)\s*[=:]\s*-?\d+",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Leak:
+    """One id-shaped fact found in one error body."""
+
+    status: int
+    code: str
+    where: str
+    detail: str
+
+    def explain(self) -> str:
+        return f"HTTP {self.status} {self.code!r}: {self.where} -- {self.detail}"
+
+
+@dataclass
+class Observation:
+    """What happened between two drains, i.e. during one test."""
+
+    leaks: list[Leak] = field(default_factory=list)
+    #: Error bodies the extractor entered.
+    bodies: int = 0
+    #: JSON 4xx/5xx responses a ``TestClient`` handed back.
+    client_errors: int = 0
+
+
+#: Cleared by :func:`drain`, so a failure names the test that caused it.
+_PENDING = Observation()
+
+#: Never cleared. The floor in ``conftest.py`` reads these.
+_TOTAL_BODIES = 0
+_TOTAL_FIELDS = 0
+_TOTAL_CLIENT_ERRORS = 0
+
+_INSTALLED = False
+
+
+def _is_int(value: Any) -> bool:
+    """An integer that is not a ``bool``.
+
+    ``isinstance(True, int)`` is ``True`` in Python, and a flag named
+    ``is_valid_id`` carrying ``True`` is not a row id.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _integerish(value: Any) -> str | None:
+    """How *value* carries an integer, or ``None``.
+
+    A row id put under an id-shaped key arrives three ways: bare, in a
+    list (``{"calculation_ids": [3, 4]}``), or as the *values* of a map
+    keyed by something the caller supplied (``{"resolved_ids": {"my_key":
+    7}}``). The third is the shape ``test_local_key_resolution.py`` and
+    ``test_api_pdep_undeclared_local_keys.py`` each assert against by
+    hand; it is caught here whenever the map's own name is id-shaped.
+
+    A *string* value is not flagged. ``{"species_entry_id": "spc_abc"}``
+    is a public ref under a misleading name -- a naming problem, not a
+    disclosure, and refusing it would push authors to rename the key
+    rather than to stop leaking.
+    """
+    if _is_int(value):
+        return repr(value)
+    if isinstance(value, (list, tuple)) and any(_is_int(item) for item in value):
+        return f"list containing {[i for i in value if _is_int(i)][:5]!r}"
+    if isinstance(value, dict) and any(_is_int(item) for item in value.values()):
+        return f"map whose values include {[i for i in value.values() if _is_int(i)][:5]!r}"
+    return None
+
+
+def _sweep_context(node: Any, path: str, found: list[tuple[str, str]]) -> int:
+    """Walk *node*, appending ``(path, why)`` for each id-shaped key.
+
+    Returns the number of ``(key, value)`` pairs visited, which is what
+    the floor counts: a blinded walk visits none of them.
+    """
+    visited = 0
+    if isinstance(node, dict):
+        for key, value in node.items():
+            visited += 1
+            here = f"{path}.{key}"
+            if isinstance(key, str) and ID_KEY.search(key):
+                why = _integerish(value)
+                if why is not None:
+                    found.append((here, why))
+            visited += _sweep_context(value, here, found)
+    elif isinstance(node, (list, tuple)):
+        for index, value in enumerate(node):
+            visited += _sweep_context(value, f"{path}[{index}]", found)
+    return visited
+
+
+def inspect(status: int, content: dict[str, Any]) -> tuple[list[Leak], int]:
+    """The leaks in one error envelope, and how many keys were examined.
+
+    The public seam of this module: the detector test drives it directly
+    with synthetic bodies, and blinding it is what the floor detects.
+    """
+    code = content.get("code")
+    code = code if isinstance(code, str) and code else "<no code>"
+
+    found: list[tuple[str, str]] = []
+    visited = _sweep_context(content.get("context"), "context", found)
+    leaks = [
+        Leak(status=status, code=code, where=where, detail=f"{why} under an id-shaped key")
+        for where, why in found
+    ]
+
+    detail = content.get("detail")
+    if isinstance(detail, str):
+        visited += 1
+        match = ID_IN_PROSE.search(detail)
+        if match is not None:
+            leaks.append(
+                Leak(
+                    status=status,
+                    code=code,
+                    where="detail",
+                    detail=f"prose discloses {match.group(0)!r}",
+                )
+            )
+    return leaks, visited
+
+
+def install() -> None:
+    """Patch the two ends of a request: what was built, what was received.
+
+    Idempotent, for the same reason :func:`tests.error_code_observer.install`
+    is: pytest imports conftest once per process, but a plugin reload or a
+    nested session must not stack wrappers.
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    from starlette.responses import JSONResponse
+    from starlette.testclient import TestClient
+
+    original_response = JSONResponse.__init__
+
+    def recording_init(self, content=None, status_code=200, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(status_code, int) and status_code >= 400 and isinstance(content, dict):
+            global _TOTAL_BODIES, _TOTAL_FIELDS
+            leaks, visited = inspect(status_code, content)
+            _PENDING.bodies += 1
+            _TOTAL_BODIES += 1
+            _TOTAL_FIELDS += visited
+            _PENDING.leaks.extend(leaks)
+        return original_response(self, content, status_code, *args, **kwargs)
+
+    original_request = TestClient.request
+
+    def recording_request(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        response = original_request(self, *args, **kwargs)
+        status = getattr(response, "status_code", 0)
+        media = (response.headers.get("content-type") or "").split(";")[0].strip()
+        if status >= 400 and media == "application/json":
+            global _TOTAL_CLIENT_ERRORS
+            _PENDING.client_errors += 1
+            _TOTAL_CLIENT_ERRORS += 1
+        return response
+
+    JSONResponse.__init__ = recording_init  # type: ignore[method-assign]
+    TestClient.request = recording_request  # type: ignore[method-assign]
+    _INSTALLED = True
+
+
+def drain() -> Observation:
+    """Return, and forget, what this test produced.
+
+    Draining rather than accumulating is what keeps a failure attached to
+    the request that caused it: without it the first leaking body would
+    fail every subsequent test in the process, and the culprit would be
+    whichever test happened to run first.
+    """
+    global _PENDING
+    observed = _PENDING
+    _PENDING = Observation()
+    return observed
+
+
+def session_totals() -> tuple[int, int, int]:
+    """``(bodies swept, body fields examined, client errors seen)`` so far.
+
+    Cumulative and never reset -- this is what the floor in ``conftest.py``
+    is asserted against, and under xdist what each worker hands back to the
+    controller to be summed.
+    """
+    return _TOTAL_BODIES, _TOTAL_FIELDS, _TOTAL_CLIENT_ERRORS


### PR DESCRIPTION
Task #227. DR-0028 Requirement 2 — *a user-facing error body must never contain a database primary key* — now has a runtime gate over every error body the suite produces, instead of 36 hand-written assertions in 21 files.

## In plain language, first

When TCKDB refuses something, it sends back a small JSON object called the **error envelope**. It has three fields: `code` (a short machine-readable token like `offset_too_large`, which client programs branch on), `detail` (a sentence for a human), and `context` (structured facts about what went wrong — for example "there were 2 vibrational modes and modes 1 and 1 were duplicates").

A **row id** is the number a database gives each record internally — record 412, record 413. It is meaningless to a depositor: it does not survive a restore into a fresh database, it does not agree between the hosted deployment and a lab self-host, and no public part of TCKDB is keyed on it (public refs like `spe_abc…` are). Putting one in an error message tells the depositor nothing they can act on, and quietly exposes how the store is laid out. So the rule is: the row id goes to the **server log**, where the operator is; the body names the field the depositor actually wrote.

A **gate** here means an automated check that fails the build. An **observer** is a gate that watches what the test suite already does rather than asking each test to call it — you cannot forget to opt in, because there is nothing to opt into.

This PR adds one observer, one test file that proves the observer works, and a tally with a floor. It changes nothing that a client receives.

## The known problem, corrected

The brief said "nothing enforces this globally". That is **half true, and the half that is false is worth recording**: `backend/tests/api/test_no_row_ids_in_user_facing_text.py` already scans the AST of every module under `backend/app` and fails an f-string that interpolates an id-shaped name into a refusal. It is a real global gate and it stays.

It has a blind spot it does not name, and that is the gap this PR fills: **it only looks at text.** `context` is assembled as a `dict` — `CodedValueError(..., context={...})` — so no f-string is involved and there is nothing for a text scan to match. A row id put in `context` reaches every client, and no check in the repository sees it.

So the two are complementary, not duplicative: the AST scan covers `detail` at the raise site; this observer covers `context` at the wire, plus the `detail` shapes the AST scan lists as out of its reach (`%`-formatting, `str.format`, a message bound to a local before being raised).

## Which option, and the measurement behind it

**Option 1 — key-name based**, scoped to `context`. Refuse a key matching `id`, `ids`, `pk`, `*_id`, `*_ids`, `*_pk` whose value carries an integer.

The measurement that chose it. I instrumented `JSONResponse.__init__`, ran all three gate scripts on `396165f1`, and recorded the shape of every 4xx/5xx body:

| gate | tests | 4xx/5xx bodies | distinct numeric-valued `context` key names |
|---|---|---|---|
| `test-rest.sh` | 4,630 | **1** | 0 |
| `test-api.sh` | 2,901 | **924** | 29 |
| `test-scientific.sh` | 2,056 | **389** | 4 (a subset) |
| union | — | — | **29** |

The 29, in full:

```
C  H  atom_index  candidate_count  charge  coordinate_lines  declared_atoms
declared_charge  disputed_ts_atoms  duplicate_mode_indices  geometry_atom_count
imaginary_mode_count  max  min  mode_count  molecularity  multiplicity  n_imag
offset  participant_index  product_charge  product_leg_only  reactant_charge
reactant_leg_only  retry_after_seconds  smiles_charge  transition_state_charge
ts_atom_index  unclaimed_ts_atoms
```

Three findings decided the choice:

1. **Zero id-shaped `context` keys exist today**, in any gate. Option 1 therefore lands green, and every future hit is a real finding rather than a backlog.
2. **Option 3 (allowlist the legitimate numeric keys) is not tractable, and not merely burdensome.** Two of the 29 are `C` and `H` — they are *element symbols*, the keys of the formula map in `{"reactants": {"C": 2, "H": 6}}`. The key space is the periodic table crossed with whatever formula a depositor uploads, so no enumeration can ever be complete. The other 27 grow with every new coded refusal that carries a count; an allowlist would turn "this refusal now says how many modes disagreed" into a red gate, which is exactly what `test_api_untested_refusals_tier_a.py` declined to do when it refused to pin `context == {}`.
3. **Option 2 (value correlation) would misfire on the evidence.** The only id-shaped values anywhere in any body today are `detail[].input.existing_calculation_id` (4 occurrences) and `detail[].input.parameters_json.tckdb_origin.existing_calculation_id` (1) — Pydantic echoing back *the caller's own* programmatic-chaining field. A correlator would flag a number the client itself sent.

`freq_mode_index_not_unique`'s `{"duplicate_mode_indices": [1], "mode_count": 2}` keeps working, and is pinned as a test.

### What the rule also catches, beyond a bare key

- `{"calculation_ids": [3, 4]}` — a list of ids.
- `{"resolved_ids": {"my_opt": 91}}` — a map whose *values* are row ids. This is the shape `test_local_key_resolution.py` and `test_api_pdep_undeclared_local_keys.py` each assert against by hand.
- Nested `context`, at any depth.
- A **string** value under an id-shaped key is *not* flagged: `{"species_entry_id": "spe_abc…"}` is a public ref under a misleading name. That is a naming problem, and refusing it would teach authors to rename the key rather than to stop leaking.
- One text rule on `detail`, applied only where `detail` is a plain string: prose that announces an id and then discloses one (`calculation_id=412`, `(ref -> id=884)`, `(id: 7)`). A structured `detail` — Pydantic's list of failures — is deliberately **not** swept, because it is the caller's own request echoed back, including their own `existing_calculation_id`.

### What it cannot catch, honestly

An id under a name that does not look like one (`{"winner": 12}`), and an id in prose that does not announce itself. Option 2 is what would catch those, and the measurement above is why it is not here. This is a floor, exactly as the AST scan is a floor.

## The vacuity trap

Non-vacuity does **not** rest on the floor, because on the evidence a floor cannot carry it: the rest gate produces **one** error body across 4,630 tests, so its floor is 1, and a floor of 1 forbids almost nothing. Three separate things carry it instead.

**1. A second, independent witness (the strong net, constant-free).** `starlette.testclient.TestClient.request` is patched alongside `JSONResponse.__init__`. They sit at opposite ends of the request: one records what the application *built*, the other what a client *received*. Per test, in `pytest_runtest_teardown`:

> if the client received ≥1 JSON 4xx/5xx and the sweep examined 0 bodies → **fail, naming that test**.

This needs no constant and holds under any gate selection, any `-k`, any worker count. It is what the floor cannot be.

**2. A measured floor**, in `BODY_SWEEP_FLOORS` in `backend/tests/conftest.py`, on two counters — bodies swept and fields examined within them. It exists for the one blinding the witness cannot see: an extractor whose *entry* still runs (so bodies are still counted) but whose walk visits nothing.

Measured at seed 424242, 8 workers, then rounded down ~10%:

| selection | measured | floor |
|---|---|---|
| whole suite (`tests/`) | 935 bodies / 1236 fields (8,038 tests) | 830 / 1080 |
| `test-rest.sh` | 1 / 1 (4,673 tests) | 1 / 1 |
| `test-api.sh` | 933 / 1234 (2,940 tests) | 830 / 1080 |
| `test-scientific.sh` | 389 / 401 (2,056 tests) | 350 / 360 |

The three gate rows are measured at `38766219` (this PR's base); the whole-suite row at `6d614cb1`, two commits earlier, which is why it is slightly smaller. Every run prints its own tally beside the floor it was held to, so these are re-measurable rather than asserted.

The counters are summed across xdist workers on the controller (`pytest_testnodedown` → `pytest_sessionfinish`); asserting them anywhere else would be asserting against whatever fraction `--dist load` happened to hand one worker. Every run prints its tally whether or not a floor applies, and a selection that is not one of the gate scripts (a `-k`, a single file, a node id) says out loud that it has no floor rather than passing quietly.

`fields` counts the `detail` string as one field even when `context` is `{}`, which is deliberate: 761 of the 924 api-gate bodies carry an empty `context`, so a floor over `context` keys alone would be near zero however healthy the run.

**3. A detector test file** — `backend/tests/api/test_error_body_id_gate.py`, 24 tests — driving the extractor over synthetic leaking and synthetic clean bodies, plus a live-plumbing test that issues a real 404 over the wire and asserts both patches saw it.

### The two mutations, both shown RED

**Blinding the extractor** — `inspect()` made to `return [], 0` at its first line, `__pycache__` cleared, `bash backend/scripts/test-api.sh`:

```
ERROR: the DR-0028 body sweep fell below its floor for ('tests/api',).
Expected at least 830 bodies and 1130 fields; saw 927 and 0.
9 failed, 2913 passed in 233.43s
exit=1
```

The floor fails **on the fields count while the body count is untouched** — which is precisely the blinding the per-test witness cannot see, and precisely what the floor is there for. Restored.

**A real leak** — one line added to a real refusal, `"geometry_id": geometry_id` in the `calculation_geometry_composition_mismatch` context in `backend/app/services/calculation_geometry_composition.py` (the row id was already at hand there; it goes to the log, as DR-0028 asks). `__pycache__` cleared, `bash backend/scripts/test-api.sh`:

```
E   AssertionError: tests/api/test_api_scientific_rejection_codes.py::
    TestAStructureAgainstItsOwnLabel::
    test_a_calculation_geometry_of_another_molecule_names_its_own_code
    produced an error body containing a database row id (DR-0028 Requirement 2):
    HTTP 422 'calculation_geometry_composition_mismatch':
    context.geometry_id -- 38 under an id-shaped key. …

E   AssertionError: tests/api/test_api_pdep_undeclared_local_keys.py::
    test_resolving_a_geometry_key_does_not_bypass_the_composition_rule
    … context.geometry_id -- 130 under an id-shaped key. …

2920 passed, 1 warning, 4 errors in 233.72s
exit=1
```

Four tests, each naming its own request, the key, and the value. Restored; `__pycache__` cleared; `git status` clean apart from the three intended files.

**A third, free demonstration** that the floor is genuinely wired to the gate scripts and not to a key that never matches: `bash backend/scripts/test-rest.sh --collect-only -q` collects without running, so the sweep sees nothing, and the rest gate's floor of 1/1 fires:

```
ERROR: the DR-0028 body sweep fell below its floor for
('tests', '!tests/api', '!tests/services/scientific_read').
Expected at least 1 bodies and 1 fields; saw 0 and 0.
exit=1
```

## Pre-existing leaks found

**None.** All three gates and the full suite are green with the sweep live and no allowance list — `ALLOWED`-style escape hatches were not needed and none was added. The one id-shaped thing in any body is the caller's own `existing_calculation_id` echoed by Pydantic inside a structured `detail`, which is not swept and is not a disclosure.

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no Pydantic schema, no API behaviour. Three test-tree files: one new observer module, one new test file, and `conftest.py` wiring. No new environment variable.

## Commands actually run

All from the repository root unless stated; `git diff` from the root, gates as CI runs them.

```bash
# baseline, before any change (396165f1) — all three gates green
conda run -n tckdb_env bash backend/scripts/test-rest.sh        # 4630 passed, 14 skipped
conda run -n tckdb_env bash backend/scripts/test-api.sh         # 2901 passed
conda run -n tckdb_env bash backend/scripts/test-scientific.sh  # 2056 passed

# the measurement (temporary instrumentation, since removed)
# recorded every 4xx/5xx JSONResponse content dict across the three gates

# after the change, on this PR's base (38766219) -- all three gates green
conda run -n tckdb_env bash backend/scripts/test-rest.sh        # 4673 passed, 14 skipped
conda run -n tckdb_env bash backend/scripts/test-api.sh         # 2940 passed
conda run -n tckdb_env bash backend/scripts/test-scientific.sh  # 2056 passed
# api gate:        933 bodies / 1234 fields; 930 reached a client. Floor 830/1080.
# scientific gate: 389 bodies /  401 fields; 389 reached a client. Floor 350/360.

# the full suite, cwd backend/, as the task asked (at 6d614cb1)
cd backend && conda run -n tckdb_env python -m pytest tests/ -q --randomly-seed=424242 -n 8
# 8038 passed, 14 skipped, 27 warnings in 428.67s
# tckdb: DR-0028 body sweep examined 935 error body/bodies, 1236 fields within
#        them; 931 JSON error responses reached a client. Floor 830/1080.

# the mutations
#   inspect() -> return [], 0     ; bash backend/scripts/test-api.sh  -> exit 1
#   context["geometry_id"]        ; bash backend/scripts/test-api.sh  -> exit 1
#   bash backend/scripts/test-rest.sh --collect-only -q               -> exit 1

conda run -n tckdb_env ruff check backend/tests/error_body_observer.py \
    backend/tests/conftest.py backend/tests/api/test_error_body_id_gate.py
# All checks passed!
```

Rebased twice while this was in flight: onto `6d614cb1` (#200, *Name which citation the 404 was about*) and then onto `38766219` (#201, *Say when a bent molecule has a linear molecule's mode count*). #200 is DR-0028 Requirement 2 work on the same surface — it logs `row_id` and keeps it out of the body — and the sweep is green over both.

## Files

- `backend/tests/error_body_observer.py` — new. The observer, the extractor, and the argument for the rule.
- `backend/tests/api/test_error_body_id_gate.py` — new. 24 tests: the detector, the measured-clean inventory, the live plumbing.
- `backend/tests/conftest.py` — install the observer, drain it per test, and the floor with its xdist aggregation.
