### PR TITLE
Withhold the facts when the code is withheld

### DIFF
--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -314,6 +314,14 @@ def _declared_errors(detail: object) -> list[CodedValidationError]:
     return found
 
 
+#: Handed to :func:`validation_detail_code` by
+#: :func:`validation_detail_context` so that "did it promote anything?"
+#: can be asked without a second copy of the promotion rule. Spelled with
+#: NULs because a code is ``snake_case``: no real code can equal this, so
+#: a fallback is never mistaken for a promotion.
+_NO_CODE_PROMOTED = "\x00no code promoted\x00"
+
+
 def validation_detail_context(detail: object) -> dict[str, Any]:
     """Structured facts from the coded error behind a validation failure.
 
@@ -325,18 +333,43 @@ def validation_detail_context(detail: object) -> dict[str, Any]:
     place, which is what makes "read ``context``, never ``detail``"
     advice a client can actually follow.
 
-    Empty unless exactly one code was promoted, for the same reason
-    :func:`validation_detail_code` falls back there: facts attached to a
-    code the envelope is not reporting would be facts about nothing.
+    Empty unless :func:`validation_detail_code` promoted a code *and*
+    exactly one declared error carries it: facts attached to a code the
+    envelope is not reporting would be facts about nothing.
+
+    That rule is not restated here, it is *asked* -- this function calls
+    :func:`validation_detail_code` rather than reimplementing its test.
+    The two used to spell the question differently: the code fell back on
+    more than one *failure*, the context only on more than one distinct
+    *code*. Two failures carrying the same code therefore produced the
+    generic ``request_validation_error`` beside a populated ``context``,
+    describing one of the failures the envelope had just declined to
+    name. #219 moves ~24 refusals into ``model_validator(mode="after")``,
+    which accumulates failures instead of stopping at the first, so that
+    combination stops being rare. One expression, one caller, no drift.
+
+    There is deliberately no merge. Two contexts for one promoted code
+    would have to be combined, and the loop that did it was
+    ``merged.update(...)``, where an overlapping key means the last error
+    silently wins and the earlier fact is gone with nothing said. Raising
+    on the collision instead is worse: this runs *inside* the 422
+    handler, so it would turn a malformed request into a 500. Reporting
+    no facts is the only honest third answer, and ``detail`` still
+    carries every failure in full.
     """
 
-    errors = _declared_errors(detail)
-    if len({error.code for error in errors}) != 1:
+    promoted = validation_detail_code(detail, fallback=_NO_CODE_PROMOTED)
+    carrying = [
+        error.context for error in _declared_errors(detail) if error.code == promoted
+    ]
+    if len(carrying) != 1:
+        # Empty in the two cases that are not one declared error's facts:
+        # nothing was promoted (``promoted`` is the sentinel, which no
+        # declared code equals), or the code came from a message and
+        # there are no structured facts to lift. More than one is the
+        # no-merge case in the docstring.
         return {}
-    merged: dict[str, Any] = {}
-    for error in errors:
-        merged.update(error.context)
-    return merged
+    return dict(carrying[0])
 
 
 def validation_detail_code(detail: object, *, fallback: str) -> str:
@@ -355,6 +388,11 @@ def validation_detail_code(detail: object, *, fallback: str) -> str:
     # outer list. Even if two failures happen to carry the same embedded
     # code, promoting that code would hide the fact that the request failed
     # in more than one place.
+    #
+    # ``validation_detail_context`` asks this function rather than
+    # repeating the test, so changing this line changes what ``context``
+    # reports too -- that coupling is deliberate. They were two separate
+    # conditions once, and the pair disagreed about exactly this case.
     if isinstance(detail, (list, tuple)) and len(detail) != 1:
         return fallback
 

--- a/backend/tests/api/test_api_freq_mode_index_uniqueness.py
+++ b/backend/tests/api/test_api_freq_mode_index_uniqueness.py
@@ -139,6 +139,98 @@ def test_a_correctly_numbered_frequency_list_is_still_accepted(client) -> None:
     assert resp.json()["warnings"] == [], resp.text[:800]
 
 
+def _two_bad_freq_calculations() -> dict:
+    """A conformer whose *two* freq results each repeat a mode index.
+
+    Deliberately different in both facts they report — ``[2]`` in a
+    three-mode list against ``[7]`` in a two-mode one — so that a context
+    built by merging the two is not merely wrong but says which of them
+    it kept.
+    """
+    payload = _payload(indices=[1, 2, 2], label="two-dup-index")
+    second = {
+        "type": "freq",
+        "software_release": _SOFTWARE,
+        "level_of_theory": _LOT,
+        "freq_result": {
+            "n_imag": 0,
+            "zpe_hartree": 0.02,
+            "modes": [
+                {"mode_index": 7, "frequency_cm1": 1595.0, "is_imaginary": False},
+                {"mode_index": 7, "frequency_cm1": 3657.0, "is_imaginary": False},
+            ],
+        },
+    }
+    payload["additional_calculations"].append(second)
+    return payload
+
+
+def test_two_repeated_mode_indices_report_no_single_code_and_no_facts(
+    client,
+) -> None:
+    """#236, on the wire: ``code`` and ``context`` must agree.
+
+    A request that fails twice is two things to fix, so the envelope
+    declines to name one — ``validation_detail_code`` has always fallen
+    back on more than one failure, whatever codes they carry.
+    ``validation_detail_context`` used to fall back only on more than one
+    *distinct* code, so these two failures (same code, twice) produced
+    the generic code beside a populated ``context``: the facts of the
+    second freq result, ``{"duplicate_mode_indices": [7], "mode_count":
+    2}``, attached to a code naming neither result, with the first
+    result's ``[2]``/``3`` silently overwritten by ``merged.update()``
+    and reported nowhere.
+
+    ``detail`` still carries both failures in full — only the
+    single-failure summary is withheld, which is the whole of the
+    decision.
+    """
+    resp = client.post(_ROUTE, json=_two_bad_freq_calculations())
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+
+    assert body["code"] == "request_validation_error", body
+    assert body["context"] == {}, (
+        "facts about one failure reached a client under a code naming "
+        f"neither failure: {body['context']}"
+    )
+    # The premise: this really is the two-failure case, not a payload
+    # that happened to be refused once. Without it the assertions above
+    # would also pass on a single-failure request.
+    assert len(body["detail"]) == 2, body["detail"]
+    assert all(
+        "mode_index values must be unique within a freq result." in str(entry)
+        for entry in body["detail"]
+    ), body["detail"]
+
+
+def test_one_repeated_mode_index_still_names_the_code_and_the_facts(
+    client,
+) -> None:
+    """The other direction of the test above, one failure instead of two.
+
+    Same route, same builder, same refusal. Without this, a
+    ``validation_detail_context`` that returned ``{}`` unconditionally --
+    or a route that stopped promoting codes at all -- would leave the
+    two-failure assertions green while the envelope told a client
+    nothing.
+    """
+    payload = _two_bad_freq_calculations()
+    payload["additional_calculations"] = payload["additional_calculations"][:1]
+
+    resp = client.post(_ROUTE, json=payload)
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+
+    assert body["code"] == W_FREQ_MODE_INDEX_NOT_UNIQUE, body
+    assert body["context"] == {
+        "field": "modes",
+        "duplicate_mode_indices": [2],
+        "mode_count": 3,
+    }, body
+    assert len(body["detail"]) == 1, body["detail"]
+
+
 def test_out_of_order_indices_are_not_duplicates(client) -> None:
     """Order is not the rule; uniqueness is.
 

--- a/backend/tests/api/test_error_contract_coded_promotion.py
+++ b/backend/tests/api/test_error_contract_coded_promotion.py
@@ -3,8 +3,11 @@
 The end-to-end proofs in ``test_api_scientific_rejection_codes.py`` show
 that twenty specific codes arrive. These pin the *rules* they arrive by,
 including the two that are decisions rather than plumbing: a refusal may
-attach a code without moving its message, and a failure carrying two
-different codes reports neither.
+attach a code without moving its message, and a request that failed more
+than once reports no single code — whether the failures carry two
+different codes or the same one twice. ``context`` follows that decision
+rather than making its own, because for a while it made its own and the
+two disagreed (#236).
 """
 
 from __future__ import annotations
@@ -255,3 +258,160 @@ class TestTwoCodesReportNeither:
             == "a_code"
         )
         assert validation_detail_context(failures) == {"field": "alpha"}
+
+
+class TestTwoFailuresWithOneCodeReportNeither:
+    """#236: the two functions used to ask *different* questions.
+
+    ``validation_detail_code`` falls back on more than one **failure**;
+    ``validation_detail_context`` used to fall back only on more than one
+    distinct **code**. Two failures carrying the same code slipped
+    between them: the envelope reported the generic
+    ``request_validation_error`` beside a populated ``context``
+    describing one of the failures it had just declined to name — and
+    ``merged.update()`` meant that for any key both errors set, the last
+    one silently won and the first fact was gone with nothing said.
+
+    ``TestTwoCodesReportNeither`` above never caught it because its two
+    failures carry *different* codes, which trips the old condition too.
+    The distinguishing case is the same code twice, and it is only rare
+    until #219 moves ~24 refusals into ``model_validator(mode="after")``,
+    which accumulates failures rather than stopping at the first.
+    """
+
+    def test_two_failures_sharing_a_code_report_no_context(self):
+        """The code falls back, so the facts must go with it.
+
+        Asserting emptiness alone would be satisfied by a
+        ``validation_detail_context`` that always returned ``{}``, so
+        every assertion here is paired with
+        :meth:`test_a_single_failure_still_carries_its_facts` below,
+        which uses the same ``_failure`` builder and the same code.
+        """
+        failures = [_failure("a_code", "alpha"), _failure("a_code", "beta")]
+        assert {
+            error["ctx"]["error"].code for error in failures
+        } == {"a_code"}, "the premise: one distinct code across two failures"
+        assert (
+            validation_detail_code(failures, fallback="request_validation_error")
+            == "request_validation_error"
+        )
+        assert validation_detail_context(failures) == {}
+
+    def test_a_single_failure_still_carries_its_facts(self):
+        """The other direction, with the identical code and builder.
+
+        This is what makes the assertion above a statement about *two
+        failures* rather than about ``a_code`` or about the function
+        having been emptied out.
+        """
+        failures = [_failure("a_code", "alpha")]
+        assert (
+            validation_detail_code(failures, fallback="request_validation_error")
+            == "a_code"
+        )
+        assert validation_detail_context(failures) == {"field": "alpha"}
+
+    def test_the_later_failures_facts_are_not_smuggled_through(self):
+        """Named separately, because the old behaviour was *specifically*
+        this: ``merged.update()`` left the second failure's ``field`` in
+        place of the first's. A reinstated merge fails here reporting the
+        value it kept, rather than only failing an ``== {}`` whose
+        message says nothing about which fact leaked.
+
+        Only the merge can produce a non-empty result in this shape --
+        the code falls back before any context is looked at -- so this
+        does not also guard "picks a winner".
+        ``TestOneCodeCarriedByTwoDeclaredErrors`` below does, on the one
+        shape where picking a winner is reachable.
+        """
+        failures = [_failure("a_code", "alpha"), _failure("a_code", "beta")]
+        context = validation_detail_context(failures)
+        assert context.get("field") != "beta", (
+            "the later failure's facts reached the envelope under a code "
+            "naming neither failure — this is the #236 defect"
+        )
+
+    def test_the_envelope_a_client_reads_is_consistent(self):
+        """Assembled the way ``errors.py`` assembles it.
+
+        The two functions are only ever read together, through
+        ``error_envelope``. Pinning the pair at the seam catches a future
+        change that keeps each function defensible alone while making the
+        body they build disagree with itself.
+        """
+        failures = [_failure("a_code", "alpha"), _failure("a_code", "beta")]
+        envelope = error_envelope(
+            failures,
+            code=validation_detail_code(
+                failures, fallback="request_validation_error"
+            ),
+            context=validation_detail_context(failures),
+            fallback_code="request_validation_error",
+        )
+        assert envelope["code"] == "request_validation_error"
+        assert envelope["context"] == {}
+        assert len(envelope["detail"]) == 2, (
+            "both failures must still be reported in full; withholding the "
+            "summary is not the same as hiding a failure"
+        )
+
+
+class TestOneCodeCarriedByTwoDeclaredErrors:
+    """A code *is* promoted, and two declared errors claim it.
+
+    This is the only shape in which the no-merge decision is reachable,
+    and it is deliberately contrived: Pydantic puts one exception in one
+    ``ctx["error"]``, so through ``ValidationError.errors()`` the number
+    of declared errors equals the number of failures, and two failures
+    make :func:`validation_detail_code` fall back before any context is
+    consulted. Nesting the two under a single outer entry is what gets
+    past the fallback.
+
+    It is tested rather than deleted because the branch is what stops a
+    silent winner from reappearing. #219 changes how failures accumulate,
+    and a defensive branch nothing exercises is a branch that quietly
+    stops working — which is the same defect one layer down as the one
+    this file is about.
+    """
+
+    @staticmethod
+    def _two_errors_under_one_entry() -> list:
+        return [[_failure("a_code", "alpha"), _failure("a_code", "beta")]]
+
+    def test_the_code_is_promoted_here(self):
+        """The premise. Without it the context assertion proves nothing.
+
+        If this ever falls back, the test below passes for the wrong
+        reason -- the early ``{}`` return -- and stops guarding the
+        merge at all.
+        """
+        assert (
+            validation_detail_code(
+                self._two_errors_under_one_entry(),
+                fallback="request_validation_error",
+            )
+            == "a_code"
+        )
+
+    def test_two_contexts_for_one_code_report_neither(self):
+        """No merge, and no winner picked from the two."""
+        context = validation_detail_context(self._two_errors_under_one_entry())
+        assert context == {}, (
+            "one of two declared errors' facts was reported as though it "
+            f"were the whole story: {context}"
+        )
+
+    def test_one_context_for_one_code_is_still_reported(self):
+        """The other direction, in the same nested shape.
+
+        Same nesting, same code, one declared error instead of two — so
+        the assertion above is about the *count*, not about the nesting
+        defeating :func:`_declared_errors`.
+        """
+        nested = [[_failure("a_code", "alpha")]]
+        assert (
+            validation_detail_code(nested, fallback="request_validation_error")
+            == "a_code"
+        )
+        assert validation_detail_context(nested) == {"field": "alpha"}


### PR DESCRIPTION
Closes #236. Blocks #219.

## Plain-language summary

When the API refuses a request, it sends back three things: a `code` (a short
machine-readable label saying *what kind* of thing was wrong, e.g.
`freq_mode_index_not_unique`), a `detail` (the human-readable list of every
individual failure), and a `context` (structured facts about the failure —
which field, which numbers disagreed).

There was a long-standing rule: **if a request failed in more than one way, the
API refuses to name a single `code`**, because naming one of two problems tells
the depositor to fix one and stay ignorant of the other. It reports the generic
`request_validation_error` instead, and `detail` still lists everything.

The bug is that `context` did not follow that rule. It used a *different* test.
The `code` backed off when there was more than one **failure**; the `context`
backed off only when there was more than one **distinct code**. So if a request
failed twice *in the same way* — two frequency lists that each repeat a mode
index, say — the two disagreed. The response said "something generic went
wrong" while `context` confidently reported facts about one specific failure.
Worse, the two failures' facts were merged with a plain dictionary update, so
where they used the same key the second one silently overwrote the first: the
first failure's facts were not just unlabelled, they were *gone*.

For a depositor, that means: you upload two bad frequency lists, and the error
tells you about one of them under a heading that names neither. You fix that one
and re-upload, and only then discover the second.

This is currently rare, because most checks stop at the first problem. #219
changes ~24 refusals to collect *all* problems before reporting, which is
exactly what makes two-failures-one-code the normal case. Hence fixing it first.

The fix: `context` now *asks* the code-promotion function whether it promoted
anything, instead of keeping its own copy of the rule. One rule, one place, so
they cannot drift apart again.

## The defect reproduced, on the wire

Route `POST /api/v1/uploads/conformers`, one conformer carrying two `freq`
calculations that each repeat a `mode_index` — two failures, both
`freq_mode_index_not_unique`.

**Before:**

```
STATUS : 422
CODE   : request_validation_error        <- the fallback: two failures
CONTEXT: {'field': 'modes', 'duplicate_mode_indices': [7], 'mode_count': 2}
N DETAIL ENTRIES: 2
   loc: ['body', 'additional_calculations', 0, 'freq_result']
   loc: ['body', 'additional_calculations', 1, 'freq_result']
```

`context` describes only `additional_calculations[1]`. The first result's
`{'duplicate_mode_indices': [2], 'mode_count': 3}` was overwritten by
`merged.update()` and appears nowhere in the body.

**After:**

```
STATUS : 422
CODE   : request_validation_error
CONTEXT: {}
N DETAIL ENTRIES: 2   (both failures still reported in full)
```

The single-failure case is unchanged: `code = freq_mode_index_not_unique`,
`context = {'field': 'modes', 'duplicate_mode_indices': [2], 'mode_count': 3}`.

## Which intent, and why

The brief offered two options. **Chose option 1: empty `context` when the code
falls back.**

Option 2 (fallback code plus a list of per-failure contexts) is rejected on
evidence, not taste — `context` being a flat object is a *published, typed*
contract in three places:

- `backend/docs/specs/machine_consumer_query_contract.md:15` — "top-level
  `code`, `detail`, and **object-valued `context`**";
- `clients/python/src/tckdb_client/scientific_types.py:59` — `context: dict[str, Any]`;
- `backend/app/api/error_contract.py` `error_envelope()` coerces `dict(context or {})`,
  and `backend/docs/specs/scientific_analytics_surface.md:276` documents the shape.

Making the envelope's shape depend on the failure count would break the shipped
client's type at exactly the moment #219 makes multi-failure the common path —
the worst possible timing. If per-failure facts are wanted later, the honest
place is a new field (`context_by_failure`), added additively, not a shape change
to `context`.

Option 1 is also right on its own terms: facts attached to a code the envelope
is not reporting are facts about nothing, and `detail` already carries every
failure in full. Only the single-failure *summary* is withheld — nothing is
hidden.

## What I did about `merged.update()`

**Removed the merge entirely.** There is now no combining step at all: `context`
is the context of the one declared error carrying the promoted code, or `{}`.

The brief offered "merge without collision — failing loudly on a duplicate key".
Rejected, and this is the one place I'd push back on the brief: this function
runs *inside* the HTTP 422 handler. Raising there converts a client's malformed
request into a 500 — a bug report against the server for what is actually a bad
upload, and an alert page for an operator. Refusing to report facts is the only
honest third answer, and it is what the code does.

Note this branch is now reachable only in one shape (a single failure entry
nesting two coded errors). Through Pydantic, `ctx["error"]` holds one exception,
so failures and declared errors are 1:1 and two failures fall back before any
context is read. The branch is kept because it is what stops a silent winner
from reappearing as #219 changes how failures accumulate — and it is
*tested* rather than left as unexercised decoration
(`TestOneCodeCarriedByTwoDeclaredErrors`), because a defensive branch nothing
exercises is the same defect one layer down.

## The corrected docstring

The old text asserted a symmetry the code did not implement, so a reader
checking the pair *by reading rather than running* concluded it was correct:

> Empty unless exactly one code was promoted, for the same reason
> `validation_detail_code` falls back there…

It now states the rule the code implements, records why the two functions are
coupled, and says why there is no merge. A pointer was also added at
`validation_detail_code`'s own fallback test, so a reader editing *that* line
learns it now governs `context` too.

## Catalogue question: does the guard see the positional raise shape?

**Yes — established by mutation, not by reading.** The #219 investigation's
worry is unfounded; new codes raised this way will *not* ship uncatalogued.

Dropped a probe module into a scanned root raising both spellings:

```python
W_ZZ_POSITIONAL = "zz_probe_positional_constant_code"
raise CodedValidationError(W_ZZ_POSITIONAL, "...")            # module constant
raise CodedValidationError("zz_probe_positional_literal_code", "...")  # bare literal
```

`test_every_raise_site_code_is_catalogued` failed, naming **both**:

```
AssertionError: These codes are raised but not catalogued ...:
{'zz_probe_positional_constant_code': 'backend/app/api/_zz_probe.py',
 'zz_probe_positional_literal_code': 'backend/app/api/_zz_probe.py'}
```

The mechanism, for the record: `backend/tests/api/test_api_code_catalogue.py:213-216`
reads `call.args[0]` at any `raise` of a name in `_CODED_EXCEPTIONS` (line 56:
`CodedValueError`, `CodedValidationError`), resolving a `Name` through
`_module_constants` — which is gathered across *all* scanned sources, so a
constant imported from another module resolves too. The position it records,
`_CODED_FIRST_ARG` (line 63), is in `_WRITTEN_AS_A_REFUSAL` (line 71), which is
the set the closure scan uses. The probe was removed; no repo file was left
changed by it. **No fix needed, and no follow-up task.**

## Schema / migration impact

**None.** No ORM model, Pydantic schema, Alembic revision, or database object is
touched. Three backend files, all under `backend/app/api/` and `backend/tests/`.
No new environment variable. The wire package (`clients/python`,
`schemas/python`) is untouched, so no version bump is required — `git diff --stat`
against `main` confirms.

DR-0028 Requirement 2 (no database primary keys in user-facing error detail) is
unaffected and marginally better served: the change only ever makes `context`
*smaller*, never larger. It rebases cleanly onto #202's new global error-body
observer, which explicitly whitelists this refusal's `mode_count` and
`duplicate_mode_indices` keys. That observer ran over this branch and stayed
within its floor:

```
DR-0028 body sweep examined 937 error body/bodies, 1239 fields within them;
933 JSON error responses reached a client. Floor for this selection is 830/1080.
```

## Exact commands run

Rebased onto `main` at `7a1085b8` (moved from `38766219` mid-task; #202 landed).

```bash
# all pytest runs from cwd backend/, per the task brief
export DB_USER=tckdb DB_PASSWORD=tckdb DB_HOST=127.0.0.1 DB_PORT=5432

conda run -n tckdb_env pytest tests/ -q
#   -> 8098 passed, 14 skipped, 28 warnings in 2586.33s (0:43:06)
conda run -n tckdb_env pytest tests/api/test_error_contract_coded_promotion.py \
    tests/api/test_api_freq_mode_index_uniqueness.py \
    tests/api/test_error_contract_catalogue_gate.py \
    tests/api/test_api_code_catalogue.py -q                   # 64 passed
conda run -n tckdb_env ruff check app/api/error_contract.py \
    tests/api/test_error_contract_coded_promotion.py \
    tests/api/test_api_freq_mode_index_uniqueness.py          # All checks passed
```

`git diff` was read from the repository root throughout.

## Mutations landed (every one confirmed RED, then reverted)

A test asserting only "context is empty" passes against a function that always
returns `{}`, so each direction was mutated separately.

| # | Mutation | Result |
|---|---|---|
| A | Restore the original body (`len({codes}) != 1` + `merged.update`) | **5 RED** — 4 unit + the wire test |
| B | `return {}` unconditionally | **6 RED** — every single-failure test, unit and wire, incl. two pre-existing ones |
| C | Pick a winner: `if carrying: return dict(carrying[0])` | **1 RED** — `test_two_contexts_for_one_code_report_neither` |

Mutation C is why `TestOneCodeCarriedByTwoDeclaredErrors` exists. On the first
attempt I asserted "no winner is picked" against the two-*failure* shape and the
mutation **survived** — the code falls back before any context is read there, so
that assertion could never have caught it. The guard was moved to the one shape
where the branch is reachable, and the original test's docstring now says
explicitly what it does *not* cover.

## Tests added

`backend/tests/api/test_error_contract_coded_promotion.py`
- `TestTwoFailuresWithOneCodeReportNeither` — the defect (two failures, one
  code) with the single-failure counter-direction beside it using the same
  builder and the same code; a named assertion that the *later* failure's facts
  are not smuggled through; and the assembled `error_envelope` pinned at the
  seam `errors.py` reads it through.
- `TestOneCodeCarriedByTwoDeclaredErrors` — the no-merge branch, with its
  premise (`the code really is promoted here`) asserted separately so the
  emptiness assertion cannot pass for the wrong reason.

`backend/tests/api/test_api_freq_mode_index_uniqueness.py`
- The wire reproduction, and its one-failure counter-direction on the same route
  with the same builder.
