### PR TITLE
Let a client act on "retrying will not clear it"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,31 @@ wrapper over a contract that is itself still moving.
 
 ## Unreleased
 
+### Fixed
+
+- **A client no longer retries a lost artifact forever.**
+  `GET /scientific/artifacts/{sha256}/download` reports two different storage
+  failures: `503 artifact_storage_unavailable` when the object store did not
+  answer, and `502 artifact_object_missing` when it answered and the bytes a
+  still-published record points at are gone. Only the first can clear by
+  waiting. Both statuses are in `tckdb-client`'s default retry set and the
+  code that says which is which was excluded from `RejectionCode` by
+  construction (the enum is `4xx` only, because a `5xx` refuses nothing the
+  caller did) — so the server was honest and no client could act on it, and a
+  custody break was replayed on a backoff schedule for a condition guaranteed
+  never to clear.
+
+  The code catalogue now carries a second, **declared** classification
+  (`Replay`) beside the derived `is_client_facing`, and the generator emits it
+  as **`NON_RETRYABLE_CODES`** — a `frozenset[str]`, not enum members, since
+  these are not refusals. `RetryPolicy` reads the response body's `code` at the
+  point it decides to retry (the whole response is in scope there) and stops
+  after one attempt on a match. It is a **deny list**: an unrecognised code is
+  retried exactly as before, so a pinned client never abandons a transient
+  failure a newer server introduced. No HTTP status, code spelling or response
+  body changed; no `RejectionCode` member was added or removed.
+  **`tckdb-client` 0.49.0 → 0.50.0.** No schema or migration impact.
+
 ### Added
 
 - **Imaginary modes get a determination, not just a threshold.**

--- a/backend/app/api/README.md
+++ b/backend/app/api/README.md
@@ -30,6 +30,17 @@ client could name. Adding a catalogue entry is cheap because it claims
 only that the code exists; adding a register entry stays expensive
 because it claims a position a referee could argue with.
 
+The catalogue answers two independent questions about each code, and
+conflating them was a real bug. `is_client_facing` (derived) asks *can a
+caller branch on this* — `4xx` only, since a `5xx` refuses nothing the
+caller did. `Replay` (declared) asks *could sending the same request
+again ever succeed*, and nothing an entry holds implies the answer:
+`artifact_storage_unavailable` and `artifact_object_missing` leave one
+handler from one exception type and need opposite advice. The second
+question is exported to clients as `NON_RETRYABLE_CODES`, beside the enum
+rather than inside it, so a `5xx` a retry layer must recognise no longer
+has to be smuggled into an enum named for rejections.
+
 Uploads are gated by `require_supported_tckdb_client` so stale clients
 can't write malformed payloads. See
 [`docs/guides/system_flow.md`](../../../docs/guides/system_flow.md) §2

--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -239,6 +239,73 @@ class Reach(str, Enum):
     guard = "guard"
 
 
+class Replay(str, Enum):
+    """Whether sending the identical request again could ever succeed.
+
+    Why this is **declared and not derived**, unlike every other
+    classification in this module
+    -----------------------------------------------------------------
+    :attr:`ApiCode.is_client_facing` is a property because
+    :attr:`~ApiCode.status`, :attr:`~ApiCode.surface` and
+    :attr:`~ApiCode.reach` already determine it. This is not derivable
+    from anything an entry holds, and the pair that forced the field
+    proves it: ``artifact_storage_unavailable`` and
+    ``artifact_object_missing`` are both reported by one handler, from one
+    exception type, about one subsystem, and they need opposite answers.
+    The 503 is a store that did not answer, so waiting is exactly right.
+    The 502 is a committed row pointing at bytes that are gone, so waiting
+    is a loop that cannot terminate. No field distinguishes them because
+    the distinction is a fact about the failure, not about the entry.
+
+    So it is a declaration, and it carries a declaration's obligations:
+    :attr:`Replay.never_succeeds` requires a :attr:`ApiCode.note` saying
+    what makes the condition deterministic, for the reason
+    :attr:`Reach.guard` requires one. An unexplained claim is the kind
+    that rots, and this claim tells a client to stop trying.
+
+    Why it is not the client's ``RejectionCode`` enum
+    ------------------------------------------------
+    Because these are 5xx codes and that enum means "a refusal of
+    something the caller did". Widening
+    :attr:`ApiCode.is_client_facing` to admit them would move seven
+    entries into an enum named for rejections, three of which
+    (``database_unavailable``, ``query_timeout``,
+    ``schema_not_initialized``) refuse nothing at all. The retry question
+    and the branch-on-it question are genuinely different questions, and
+    the honest answer is a second export rather than one wider set — see
+    ``clients/python/src/tckdb_client/rejection_codes.py``.
+    """
+
+    #: Replaying might work. The default, and the only safe default: a
+    #: client that stops retrying a genuinely transient failure because
+    #: nobody classified it is a worse outcome than the wasted attempts
+    #: this field exists to prevent.
+    may_succeed = "may_succeed"
+
+    #: The condition is deterministic. The identical request will meet the
+    #: identical answer however long the caller waits, so a retry
+    #: schedule is a loop with no exit. Emitted to clients as
+    #: ``NON_RETRYABLE_CODES`` and consulted by
+    #: :meth:`tckdb_client.retry.RetryPolicy.code_is_retryable`.
+    #:
+    #: Only worth declaring where the status would otherwise *invite* a
+    #: retry. Marking a 422 is true and inert — no client retries a 422 —
+    #: and an inert declaration is a comment with a type, so the guard in
+    #: ``backend/tests/api/test_api_code_catalogue.py`` refuses one.
+    never_succeeds = "never_succeeds"
+
+
+#: Statuses a client may reasonably replay, so the statuses where a
+#: :attr:`Replay.never_succeeds` declaration changes an outcome rather
+#: than merely being true. Mirrors
+#: :data:`tckdb_client.retry.DEFAULT_RETRY_STATUS_CODES`, spelled again
+#: here because ``backend/app`` must not import the client package —
+#: the same one-way rule that keeps ``clients/python`` free of ``app``.
+#: Widening the client's set can only make this conservative; narrowing
+#: it is what the guard over this constant is watching for.
+REPLAYABLE_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
+
+
 @dataclass(frozen=True)
 class ApiCode:
     """One code the API can report, and how it gets there.
@@ -260,11 +327,17 @@ class ApiCode:
         Defaults to :attr:`Reach.request`, so the classification costs
         nothing to the entries where it is uninteresting and has to be
         written down where it is not.
+    :param replay: Whether replaying the request could succeed — see
+        :class:`Replay`. The one classification here that is declared
+        rather than derived, because nothing an entry holds implies it.
+        Defaults to :attr:`Replay.may_succeed`, which is the fail-safe
+        direction.
     :param note: A fact the site cannot state about itself. Deliberately
         rare — this is an enumeration, not a second copy of the refusal
         messages. Required on every :attr:`Reach.guard` entry, because
         "no request can produce this" is a claim and an unexplained claim
-        is the kind that rots.
+        is the kind that rots — and on every
+        :attr:`Replay.never_succeeds` entry, for the same reason.
     """
 
     code: str
@@ -272,11 +345,22 @@ class ApiCode:
     surface: Surface
     origin: str
     reach: Reach = Reach.request
+    replay: Replay = Replay.may_succeed
     note: str | None = None
 
     @property
     def is_client_facing(self) -> bool:
         """Whether a client should be able to import and branch on this.
+
+        This answers *can a caller branch on it*, and since #234 it no
+        longer doubles as *should a caller retry it*. Those are different
+        questions, and answering both with one rule is why a 5xx a client
+        genuinely needs had nowhere to go: ``artifact_object_missing`` is
+        correctly refused here — the caller did nothing wrong, so there is
+        no branch for them to write — while being precisely the code a
+        retry layer must recognise. The second question is answered by
+        :attr:`replay` and exported separately; see
+        :func:`never_retryable`.
 
         Derived, never declared. A 5xx is not a refusal of anything the
         caller did; a generic fallback repeats the status; an accidental
@@ -296,6 +380,32 @@ class ApiCode:
                 Surface.generic_fallback,
                 Surface.accidental_prefix,
             }
+        )
+
+    @property
+    def is_replay_futile(self) -> bool:
+        """Whether a client's retry layer should refuse to replay this.
+
+        The :attr:`replay` declaration, narrowed to the entries where it
+        does any work. Two conditions beyond the declaration itself:
+
+        * :attr:`Reach.request`, because a code no request can produce is
+          a code no retry layer will ever be handed — the same reason a
+          guard is not exported to the client enum.
+        * A status in :data:`REPLAYABLE_STATUSES`, because a client does
+          not retry the others anyway. Marking a 422 ``never_succeeds``
+          is true and changes nothing, and publishing it would grow the
+          exported set with entries that cannot be observed to matter.
+
+        Note that this is *not* the complement of anything: an entry that
+        is neither client-facing nor replay-futile is the ordinary case —
+        a transient 5xx a client should keep retrying and has no branch
+        for.
+        """
+        return (
+            self.replay is Replay.never_succeeds
+            and self.reach is Reach.request
+            and self.status in REPLAYABLE_STATUSES
         )
 
 
@@ -326,10 +436,34 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("arrhenius_a_units_molecularity_mismatch", 422, Surface.coded_exception,
             "backend/app/chemistry/units.py"),
     ApiCode("artifact_integrity_failed", 502, Surface.response_literal,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            replay=Replay.never_succeeds,
+            note=(
+                "Replay.never_succeeds because the verification is a "
+                "comparison of stored bytes against a digest recorded when "
+                "they were accepted, and both sides are fixed: the digest "
+                "is immutable and the bytes are whatever they now are. The "
+                "same request meets the same mismatch forever. The handler's "
+                "own sentence already says so -- 'retrying will not clear "
+                "it' -- and until #234 no client could act on it, because "
+                "502 is in the client's default retry set and the code that "
+                "contradicts it was excluded from the exported enum by "
+                "is_client_facing's 4xx rule. Repair is an operator "
+                "restoring the object, not a caller waiting."
+            )),
     ApiCode("artifact_object_missing", 502, Surface.response_literal,
             "backend/app/api/errors.py",
+            replay=Replay.never_succeeds,
             note=(
+                "Replay.never_succeeds: the store answered, and what it "
+                "answered was that the key is not there. Nothing about "
+                "waiting changes that -- only an operator putting the "
+                "object back does, which is a different request by a "
+                "different principal. This is the pair that forced the "
+                "Replay field to exist: it and artifact_storage_unavailable "
+                "leave one handler, from one exception type, with opposite "
+                "retry advice and no field between them that a property "
+                "could read. "
                 "Split from artifact_storage_unavailable in #226, which "
                 "carried both 'the store did not answer' and 'the store "
                 "answered and the object is not there' — opposite retry "
@@ -357,7 +491,11 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "Now means only what its sentence says: the store did not "
                 "answer, and retrying is the right response. The case "
                 "where it answered 'no such key' left this code in #226 — "
-                "see artifact_object_missing."
+                "see artifact_object_missing. Deliberately left at the "
+                "Replay.may_succeed default: this is the half of the "
+                "original pair where the 503's retry advice was true all "
+                "along, and it is the entry that makes the new field's "
+                "guard non-vacuous."
             )),
     ApiCode("atom_map_atoms_unaccounted_for", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
@@ -976,12 +1114,32 @@ def client_facing() -> tuple[ApiCode, ...]:
     return tuple(entry for entry in CATALOGUE if entry.is_client_facing)
 
 
+def never_retryable() -> tuple[ApiCode, ...]:
+    """The entries a client's retry layer must refuse to replay.
+
+    Disjoint from :func:`client_facing` today, and the test suite pins
+    that — but not by construction. The two answer different questions,
+    and a 429 could in principle be both (importable *and* pointless to
+    replay) without either rule contradicting the other; the assertion in
+    ``backend/tests/api/test_client_rejection_codes_generated.py`` is
+    there to make the first such entry a deliberate decision rather than
+    an accident, and its message says so.
+
+    See :attr:`ApiCode.is_replay_futile` for the rule, and :class:`Replay`
+    for why this one classification is declared rather than derived.
+    """
+    return tuple(entry for entry in CATALOGUE if entry.is_replay_futile)
+
+
 __all__ = [
     "CATALOGUE",
+    "REPLAYABLE_STATUSES",
     "STATUS_FALLBACK_PATTERN",
     "ApiCode",
     "Reach",
+    "Replay",
     "Surface",
     "catalogued_codes",
     "client_facing",
+    "never_retryable",
 ]

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -414,6 +414,19 @@ def _artifact_storage_unavailable_handler(
     caller did — which is why neither code is in the client's
     ``RejectionCode`` enum.
 
+    That was necessary and, until #234, not sufficient. The sentence below
+    says "retrying will not clear it" and no client could act on it: 502
+    sits in ``tckdb_client``'s default retry set, and the one field that
+    contradicts the status is the ``code``, which the enum excludes by
+    construction. So a well-behaved client replayed a custody break on a
+    backoff schedule forever. The catalogue now carries a second,
+    *declared* classification -- ``ApiCode.replay`` -- exported beside the
+    enum as ``NON_RETRYABLE_CODES``, and the client reads the body's code
+    at the point it decides whether to retry. The sentence in this branch
+    is therefore load-bearing twice over: a human reads it, and a machine
+    acts on the code beside it. Changing one without the other is the
+    disagreement #234 removed.
+
     The public body stays deliberately vague -- it names a subsystem and
     says what to do. That is right for a caller and useless for whoever
     has to fix it: before this log line, a storage outage appeared in the

--- a/backend/scripts/generate_client_rejection_codes.py
+++ b/backend/scripts/generate_client_rejection_codes.py
@@ -35,6 +35,26 @@ named for rejections would invite a client to treat an accepted deposit
 as a failed one. Nor do trust labels, which refuse nothing, nor 5xx
 codes, which refuse nothing the caller did.
 
+The second export, and why it is not enum members
+-------------------------------------------------
+``NON_RETRYABLE_CODES`` is emitted from
+:func:`~app.api.code_catalogue.never_retryable` as bare strings, beside
+the enum rather than inside it. The two exports answer different
+questions -- *can I branch on this* and *should I replay this* -- and
+until #234 only the first had anywhere to go, which meant a client
+retried ``artifact_object_missing`` on a backoff schedule forever for a
+condition guaranteed never to clear. Making them members instead would
+have required admitting 5xx codes to ``RejectionCode``, moving seven
+entries into an enum named for refusals of the caller's request, three of
+which (``database_unavailable``, ``query_timeout``,
+``schema_not_initialized``) refuse nothing whatsoever. A separate set
+costs one export and claims exactly what is true.
+
+It is a ``frozenset[str]`` and not ``frozenset[RejectionCode]`` for the
+same reason -- there are no members to name -- and a retry layer compares
+against the raw ``code`` field of a response body anyway, which is a
+string before anything has decided whether the enum knows it.
+
 Nothing else is emitted. No file paths, no line numbers, no docstrings,
 no counts, no prose lifted from ``asserts``. That is a deliberate
 constraint on the *output*, not laziness about it: this file is compared
@@ -63,7 +83,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "backend"))
 
-from app.api.code_catalogue import client_facing  # noqa: E402
+from app.api.code_catalogue import client_facing, never_retryable  # noqa: E402
 
 OUTPUT = (
     REPO_ROOT
@@ -101,6 +121,17 @@ are the ``http_<status>`` fallbacks and the generic ``validation_error``
 family, which carry nothing the status line does not, and 5xx codes,
 which refuse nothing the caller did.
 
+:data:`NON_RETRYABLE_CODES` is the one place a 5xx code appears here, and
+it is not an enum member. Those codes are not refusals -- the caller did
+nothing wrong -- so there is no branch for a depositor to write. What
+there is, is a retry layer that would otherwise replay them: 502 and 503
+are transient statuses by default, and a handful of TCKDB's 5xx
+conditions are deterministic, so replaying them is a backoff schedule
+with no exit. :class:`tckdb_client.retry.RetryPolicy` consults this set
+and stops after one attempt. A code it does not recognise is retried
+exactly as before, which is the safe direction: giving up on a real blip
+is worse than a few wasted attempts.
+
 Using it::
 
     from tckdb_client import RejectionCode, rejection_code
@@ -135,6 +166,7 @@ from enum import Enum
 
 __all__ = [
     "CONFLICT_REJECTION_CODES",
+    "NON_RETRYABLE_CODES",
     "REJECTION_STATUSES",
     "RejectionCode",
     "VALIDATION_REJECTION_CODES",
@@ -181,12 +213,25 @@ def render() -> str:
 
     validation = sorted({entry.code for entry in entries if entry.status == 422})
     conflict = sorted({entry.code for entry in entries if entry.status == 409})
+    non_retryable = sorted({entry.code for entry in never_retryable()})
 
     if not validation:
         raise SystemExit(
             "The catalogue declares no client-facing 422 codes. Generating "
             "an empty enum would quietly remove a published client API; "
             "refusing."
+        )
+
+    if not non_retryable:
+        # The same refusal as the one above, for the same reason. An empty
+        # NON_RETRYABLE_CODES is a valid Python frozenset and a silently
+        # dead feature: every code becomes retryable again and the retry
+        # layer's fail-safe default hides the regression completely.
+        raise SystemExit(
+            "The catalogue declares no Replay.never_succeeds code that a "
+            "client would otherwise replay. Emitting an empty "
+            "NON_RETRYABLE_CODES would restore the forever-retry bug #234 "
+            "fixed while leaving the export in place; refusing."
         )
 
     lines = [_HEADER]
@@ -246,6 +291,26 @@ def render() -> str:
             f"    RejectionCode.{_member(code)}: frozenset({{{rendered}}}),\n"
         )
     lines.append("}\n")
+
+    lines.append(
+        "\n#: Codes whose condition is deterministic: the identical request\n"
+        "#: will meet the identical answer however long a client waits, so\n"
+        "#: replaying it is a backoff schedule with no exit. Bare strings\n"
+        "#: rather than ``RejectionCode`` members, because these arrive at a\n"
+        "#: 5xx and refuse nothing the caller did -- there is no branch for a\n"
+        "#: depositor to write, only a retry to abandon.\n"
+        "#:\n"
+        "#: Consulted by ``RetryPolicy.code_is_retryable``. It is a *deny*\n"
+        "#: list on purpose: a code absent from it is retried exactly as it\n"
+        "#: was before this set existed, so a server newer than this package\n"
+        "#: can add a transient failure without a pinned client silently\n"
+        "#: giving up on it. Abandoning a real blip is the worse bug.\n"
+        "NON_RETRYABLE_CODES: frozenset[str] = frozenset(\n"
+        "    {\n"
+    )
+    for code in non_retryable:
+        lines.append(f'        "{code}",\n')
+    lines.append("    }\n)\n")
 
     lines.append(_FOOTER)
     return "".join(lines)

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -30,12 +30,15 @@ from pathlib import Path
 
 from app.api.code_catalogue import (
     CATALOGUE,
+    REPLAYABLE_STATUSES,
     STATUS_FALLBACK_PATTERN,
     ApiCode,
     Reach,
+    Replay,
     Surface,
     catalogued_codes,
     client_facing,
+    never_retryable,
 )
 from app.scientific_checks import CodeChannel
 from app.scientific_checks.declarations import constraint_rejections, register
@@ -772,6 +775,164 @@ def test_every_guard_entry_is_catalogued_annotated_and_unexported() -> None:
         assert code in exported, (
             f"{code} is reachable but not exported, so a client still cannot "
             "branch on a refusal it can receive"
+        )
+
+
+#: The codes declared deterministic, pinned so a silent reclassification
+#: fails rather than restoring the forever-retry bug. Both are 502s whose
+#: own refusal sentence says "retrying will not clear it".
+_NEVER_SUCCEEDS_CODES = ("artifact_integrity_failed", "artifact_object_missing")
+
+
+def test_the_replay_rule_can_say_no() -> None:
+    """``Replay`` must change an answer, or it is a comment with a type.
+
+    The same shape as ``test_the_reach_rule_can_say_no`` above, and for the
+    same reason: two probes differing in nothing but the field under test,
+    so the negative cannot be produced by one of the other rules. Also
+    pins the default, which is the fail-safe direction — an unclassified
+    code must stay retryable, because giving up on a real outage is worse
+    than the wasted attempts this field prevents.
+    """
+    origin = "backend/app/api/errors.py"
+    transient = ApiCode("probe_code", 503, Surface.response_literal, origin)
+    deterministic = ApiCode(
+        "probe_code", 503, Surface.response_literal, origin,
+        replay=Replay.never_succeeds, note="probe",
+    )
+
+    assert transient.replay is Replay.may_succeed, (
+        "Replay.may_succeed must be the default: an entry nobody classified "
+        "has to keep being retried"
+    )
+    assert not transient.is_replay_futile
+    assert deterministic.is_replay_futile
+
+
+def test_a_never_succeeds_declaration_at_an_unreplayed_status_is_inert() -> None:
+    """A true classification that changes nothing must not be exported.
+
+    No client retries a 422, so declaring one deterministic is correct and
+    useless — and publishing it would grow ``NON_RETRYABLE_CODES`` with
+    entries whose effect can never be observed, which is how a set stops
+    being read. Same for a guard no request can produce: nothing will ever
+    hand that code to a retry layer.
+    """
+    origin = "backend/app/api/errors.py"
+    at_422 = ApiCode(
+        "probe_code", 422, Surface.coded_exception, origin,
+        replay=Replay.never_succeeds, note="probe",
+    )
+    unreachable = ApiCode(
+        "probe_code", 503, Surface.response_literal, origin,
+        reach=Reach.guard, replay=Replay.never_succeeds, note="probe",
+    )
+
+    assert at_422.replay is Replay.never_succeeds
+    assert not at_422.is_replay_futile, (
+        "a 422 declared never_succeeds was exported; 422 is not in "
+        f"REPLAYABLE_STATUSES ({sorted(REPLAYABLE_STATUSES)}) so the "
+        "declaration cannot change any client's behaviour"
+    )
+    assert not unreachable.is_replay_futile
+
+
+def test_every_never_succeeds_entry_is_annotated_and_effective() -> None:
+    """The declaration's obligations, asserted as separate properties.
+
+    Non-empty, because every other assertion here runs over the set and an
+    empty one would satisfy them all while the client retried a lost
+    artifact forever. Annotated, for the reason ``Reach.guard`` requires a
+    note: this claim tells a client to stop trying, and an unexplained
+    claim is the kind that rots. Effective, because a declaration at a
+    status nobody replays is inert. And rare, because the safe default is
+    "keep retrying" and a set that grows to cover most 5xx conditions has
+    become a place to put codes nobody wanted to think about.
+    """
+    declared = [
+        entry for entry in CATALOGUE if entry.replay is Replay.never_succeeds
+    ]
+    assert declared, (
+        "no entry is declared Replay.never_succeeds, so the client's "
+        "NON_RETRYABLE_CODES is empty and every deterministic 5xx is "
+        "replayed on a backoff schedule again -- the bug #234 fixed"
+    )
+    assert len(declared) * 10 < len(CATALOGUE), (
+        f"{len(declared)} of {len(CATALOGUE)} entries are declared "
+        "never_succeeds. The class is meant to be the rare condition that "
+        "provably cannot clear; at this proportion it has become the "
+        "default, and the default has to be 'keep retrying'."
+    )
+
+    for entry in declared:
+        assert entry.note, (
+            f"{entry.code} is declared Replay.never_succeeds with no note. "
+            "The note is where the claim is justified; without it the "
+            "classification is unfalsifiable."
+        )
+        assert entry.status in REPLAYABLE_STATUSES, (
+            f"{entry.code} is declared never_succeeds at {entry.status}, "
+            "which no client replays anyway. The declaration is true and "
+            "inert; delete it or fix the status."
+        )
+        assert entry.reach is Reach.request, (
+            f"{entry.code} is declared never_succeeds and also unreachable, "
+            "so no retry layer will ever be handed it"
+        )
+
+    assert {entry.code for entry in never_retryable()} == set(_NEVER_SUCCEEDS_CODES), (
+        "the exported deny list changed. That is a published client "
+        "contract: adding to it stops clients retrying something, removing "
+        f"from it starts them again. Expected {sorted(_NEVER_SUCCEEDS_CODES)}, "
+        f"got {sorted(entry.code for entry in never_retryable())}."
+    )
+
+
+def test_the_storage_pair_still_disagrees_about_replay() -> None:
+    """The pair that forced the field to exist, asserted from both ends.
+
+    ``artifact_storage_unavailable`` and ``artifact_object_missing`` leave
+    one handler, from one exception type, about one subsystem — and they
+    need opposite retry advice. A test that only pinned the 502 would pass
+    against a catalogue that had marked *both* deterministic, which would
+    make the client abandon every transient object-store blip. So the
+    negative is pinned too, and it is the entry that makes the guard above
+    non-vacuous.
+
+    Also asserted: neither reaches the ``RejectionCode`` enum. That is not
+    a defect this work leaves behind, it is the point — the caller did
+    nothing wrong, so there is no branch for a depositor to write, and the
+    retry advice travels by the second export instead.
+    """
+    by_code: dict[str, ApiCode] = {}
+    for entry in CATALOGUE:
+        if entry.status >= 500:
+            by_code[entry.code] = entry
+
+    missing = by_code.get("artifact_object_missing")
+    unavailable = by_code.get("artifact_storage_unavailable")
+    integrity = by_code.get("artifact_integrity_failed")
+    assert missing and unavailable and integrity, (
+        "one of the three artifact-storage codes is gone from the "
+        f"catalogue: {sorted(by_code)}"
+    )
+
+    assert missing.replay is Replay.never_succeeds
+    assert integrity.replay is Replay.never_succeeds
+    assert unavailable.replay is Replay.may_succeed, (
+        "artifact_storage_unavailable is declared never_succeeds. It means "
+        "the object store did not answer, which is exactly the case where "
+        "waiting is the right response -- a client marking it deterministic "
+        "would abandon every transient outage."
+    )
+
+    exported = {entry.code for entry in client_facing()}
+    for entry in (missing, unavailable, integrity):
+        assert entry.code not in exported, (
+            f"{entry.code} reached the RejectionCode enum. It is a 5xx: the "
+            "caller did nothing wrong, so there is no refusal to branch on. "
+            "The retry advice is carried by never_retryable(), which is why "
+            "is_client_facing did not have to widen."
         )
 
 

--- a/backend/tests/api/test_client_rejection_codes_generated.py
+++ b/backend/tests/api/test_client_rejection_codes_generated.py
@@ -137,6 +137,63 @@ def test_every_client_facing_catalogue_code_is_exported() -> None:
     )
 
 
+def test_every_never_retryable_code_reaches_the_client_deny_list() -> None:
+    """The second export, read the way a client reads it.
+
+    ``NON_RETRYABLE_CODES`` is the only route by which a 5xx code reaches a
+    client at all, and it exists because the enum cannot carry one:
+    ``is_client_facing`` requires a 4xx, on the correct grounds that a 5xx
+    refuses nothing the caller did. The consequence, until #234, was that
+    ``artifact_object_missing`` was honest server-side and unusable
+    client-side — 502 is in ``tckdb_client``'s default retry set, so the
+    client replayed a custody break on a backoff schedule forever.
+
+    Checked against the block rather than the whole file, because the
+    codes also appear in the header prose: a substring search over the
+    file would pass on the docstring alone while the set was empty.
+    """
+    from app.api.code_catalogue import never_retryable
+
+    expected = {entry.code for entry in never_retryable()}
+    assert expected, (
+        "the catalogue declares no never-retryable code, so the deny list "
+        "would be empty and the retry layer's fail-safe default would hide "
+        "it completely"
+    )
+
+    published = GENERATED.read_text()
+    assert "NON_RETRYABLE_CODES: frozenset[str] = frozenset(" in published, (
+        "the deny-list export is gone from the generated file; a client "
+        "importing it would fail, and one that used a stale copy would "
+        "resume replaying deterministic failures"
+    )
+    block = published.split("NON_RETRYABLE_CODES: frozenset[str] = frozenset(")[-1]
+    block = block.split(")")[0]
+
+    missing = sorted(code for code in expected if f'"{code}"' not in block)
+    assert not missing, (
+        f"The catalogue says replaying these can never succeed, but "
+        f"NON_RETRYABLE_CODES does not carry them: {missing}. A client would "
+        "retry each one to its attempt cap for a condition guaranteed not to "
+        "clear."
+    )
+
+    # The other direction: nothing in the deny list may also be an enum
+    # member. A code cannot simultaneously be a refusal of the caller's
+    # request and a 5xx the caller did not cause, and publishing it twice
+    # under two meanings is how a consumer ends up branching on the wrong
+    # one.
+    from app.api.code_catalogue import client_facing
+
+    overlap = expected & {entry.code for entry in client_facing()}
+    assert not overlap, (
+        f"{sorted(overlap)} is both exported as a RejectionCode member and "
+        "listed as never retryable. If a 4xx genuinely needs both, say so "
+        "deliberately -- this assertion is here because the two sets "
+        "answering different questions is the whole design."
+    )
+
+
 def test_the_generated_file_carries_no_anchor_that_moves_for_free() -> None:
     """Nothing derived from where a check lives, for the reason #119 established.
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -223,6 +223,31 @@ write, `422` means nothing was written at all. A code can be in both: the
 same scientific claim is sometimes enforced at the wire boundary and
 again in the schema.
 
+### Codes that are not refusals: `NON_RETRYABLE_CODES`
+
+`RejectionCode` covers `4xx` only, because a `5xx` is not a refusal of
+anything the caller did and there is no payload to repair. But a handful
+of TCKDB's `5xx` conditions are *deterministic*, and a retry policy needs
+to know which:
+
+```python
+from tckdb_client import NON_RETRYABLE_CODES
+# frozenset of plain strings, not RejectionCode members
+```
+
+`GET /scientific/artifacts/{sha256}/download` reports two different
+storage failures. A `503 artifact_storage_unavailable` means the object
+store did not answer — wait and try again. A `502 artifact_object_missing`
+means the store answered and the bytes a still-published record points at
+are gone; only an operator restoring the object changes that, so replaying
+the request is a backoff schedule with no exit. Both statuses are in
+`DEFAULT_RETRY_STATUS_CODES`, so the status alone cannot tell them apart.
+
+`RetryPolicy` consults this set automatically — if you pass a policy, you
+get the behaviour for free. It is a **deny list**: a code the set does not
+name is retried exactly as before, so a client pinned against an older
+release never stops retrying a transient failure it has not heard of.
+
 What each code asserts, why it refuses rather than warns, and how
 legitimate chemistry it would otherwise reject can still be deposited, is
 in [the scientific check register](https://github.com/TCKDB/TCKDB/blob/main/docs/guides/scientific_check_register.md).

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.49.0"
+version = "0.50.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/__init__.py
+++ b/clients/python/src/tckdb_client/__init__.py
@@ -22,6 +22,7 @@ from tckdb_client.errors import (
 from tckdb_client.idempotency import make_idempotency_key, validate_idempotency_key
 from tckdb_client.rejection_codes import (
     CONFLICT_REJECTION_CODES,
+    NON_RETRYABLE_CODES,
     REJECTION_STATUSES,
     RejectionCode,
     VALIDATION_REJECTION_CODES,
@@ -34,6 +35,7 @@ from tckdb_client.replay import (
     replay_bundle,
 )
 from tckdb_client.retry import (
+    DEFAULT_NON_RETRYABLE_CODES,
     DEFAULT_RETRY_STATUS_CODES,
     RetryPolicy,
 )
@@ -109,6 +111,7 @@ __all__ = [
     "TCKDBIdempotencyConflictError",
     "TCKDBPaginationError",
     "CONFLICT_REJECTION_CODES",
+    "NON_RETRYABLE_CODES",
     "REJECTION_STATUSES",
     "RejectionCode",
     "VALIDATION_REJECTION_CODES",
@@ -119,6 +122,7 @@ __all__ = [
     "ReplayFailure",
     "ReplaySummary",
     "replay_bundle",
+    "DEFAULT_NON_RETRYABLE_CODES",
     "DEFAULT_RETRY_STATUS_CODES",
     "RetryPolicy",
     "ArtifactRecord",

--- a/clients/python/src/tckdb_client/client.py
+++ b/clients/python/src/tckdb_client/client.py
@@ -484,6 +484,14 @@ class TCKDBClient:
                 or attempt >= max_attempts
                 or response.is_success
                 or not policy.status_is_retryable(response.status_code)
+                # The status said "transient"; the body may contradict it.
+                # TCKDB reports a store that did not answer and a store
+                # that answered "the bytes are gone" at two statuses this
+                # policy replays, and only one of them can ever clear.
+                # Placed after the status check so a body is parsed only
+                # when a retry is otherwise about to happen — the cost is
+                # bounded by the retry rate, not the request rate.
+                or not policy.code_is_retryable(_error_body_code(response))
                 # A server asking for a longer pause than the caller
                 # budgeted is not a transient blip; surface it now rather
                 # than block for the maintenance window.
@@ -3383,6 +3391,40 @@ def _carries_idempotency_key(headers: Mapping[str, str]) -> bool:
         if name.lower() == target:
             return isinstance(value, str) and bool(value.strip())
     return False
+
+
+def _error_body_code(response: httpx.Response) -> str | None:
+    """The ``code`` field of an error body, or ``None`` if there is not one.
+
+    Read at the retry decision point rather than from the raised
+    exception, because that is where the choice is made and the raise is
+    two layers later. Nothing streams here — ``httpx.Client.request`` has
+    already read the body — so the ``code`` really is in scope, and the
+    only cost is a ``json.loads`` on a response about to be replayed
+    anyway.
+
+    Every failure returns ``None``: a body that is not JSON (an artifact
+    download's error page, a proxy's HTML 502), a JSON array or scalar, a
+    missing or non-string ``code``. ``None`` means "no opinion", which
+    :meth:`~tckdb_client.retry.RetryPolicy.code_is_retryable` answers by
+    letting the status decide — so an unreadable body can never be the
+    reason a transient failure stopped being retried.
+
+    Deliberately not shared with ``_build_http_error``'s legacy-detail
+    sniffing. That reconstructs a code the server *should* have sent so an
+    old deployment still raises the right exception type; this reads only a
+    code the server actually did send, because inferring one and then
+    refusing to retry on the inference would abandon a request on a guess.
+    """
+
+    try:
+        parsed = response.json()
+    except ValueError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    code = parsed.get("code")
+    return code if isinstance(code, str) else None
 
 
 def _iter_ndjson(payload: str) -> Iterator[JSONDict]:

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -23,6 +23,17 @@ are the ``http_<status>`` fallbacks and the generic ``validation_error``
 family, which carry nothing the status line does not, and 5xx codes,
 which refuse nothing the caller did.
 
+:data:`NON_RETRYABLE_CODES` is the one place a 5xx code appears here, and
+it is not an enum member. Those codes are not refusals -- the caller did
+nothing wrong -- so there is no branch for a depositor to write. What
+there is, is a retry layer that would otherwise replay them: 502 and 503
+are transient statuses by default, and a handful of TCKDB's 5xx
+conditions are deterministic, so replaying them is a backoff schedule
+with no exit. :class:`tckdb_client.retry.RetryPolicy` consults this set
+and stops after one attempt. A code it does not recognise is retried
+exactly as before, which is the safe direction: giving up on a real blip
+is worse than a few wasted attempts.
+
 Using it::
 
     from tckdb_client import RejectionCode, rejection_code
@@ -57,6 +68,7 @@ from enum import Enum
 
 __all__ = [
     "CONFLICT_REJECTION_CODES",
+    "NON_RETRYABLE_CODES",
     "REJECTION_STATUSES",
     "RejectionCode",
     "VALIDATION_REJECTION_CODES",
@@ -533,6 +545,25 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.USERNAME_TAKEN: frozenset({409}),
     RejectionCode.WITHDRAW_REASON_REQUIRED: frozenset({422}),
 }
+
+#: Codes whose condition is deterministic: the identical request
+#: will meet the identical answer however long a client waits, so
+#: replaying it is a backoff schedule with no exit. Bare strings
+#: rather than ``RejectionCode`` members, because these arrive at a
+#: 5xx and refuse nothing the caller did -- there is no branch for a
+#: depositor to write, only a retry to abandon.
+#:
+#: Consulted by ``RetryPolicy.code_is_retryable``. It is a *deny*
+#: list on purpose: a code absent from it is retried exactly as it
+#: was before this set existed, so a server newer than this package
+#: can add a transient failure without a pinned client silently
+#: giving up on it. Abandoning a real blip is the worse bug.
+NON_RETRYABLE_CODES: frozenset[str] = frozenset(
+    {
+        "artifact_integrity_failed",
+        "artifact_object_missing",
+    }
+)
 
 
 def rejection_code(value: object) -> RejectionCode | None:

--- a/clients/python/src/tckdb_client/retry.py
+++ b/clients/python/src/tckdb_client/retry.py
@@ -18,6 +18,32 @@ particular is the dangerous case: the server may have committed the
 upload and lost the response, so a blind replay would duplicate a
 scientific record.
 
+The status line is not always enough
+------------------------------------
+Those rules ask whether replaying is *safe*. A second question is
+whether it is *useful*, and the status alone cannot answer it. TCKDB
+reports two different artifact-storage failures at two statuses that are
+both in :data:`DEFAULT_RETRY_STATUS_CODES`: a 503 when the object store
+did not answer, where waiting is exactly right, and a 502 when the store
+answered and the bytes a published record points at are gone, where
+waiting cannot help — only an operator restoring the object can, and that
+is a different request by a different principal. Retrying the second is a
+backoff schedule with no exit.
+
+So the response *body* is consulted too. Its ``code`` field is checked
+against :data:`NON_RETRYABLE_CODES`, which the server generates from its
+own catalogue of error codes, and a match stops after one attempt
+whatever the status says. This is possible only because the decision
+point in ``TCKDBClient._send`` holds the whole response: ``httpx`` has
+already read the body by then, so the code is in scope where the retry is
+decided rather than one layer up where the error is raised.
+
+It is a **deny list, and unrecognised codes are retried.** A client that
+abandons a genuinely transient failure because it did not recognise the
+code is a worse bug than the wasted attempts this rule exists to prevent,
+and a pinned client talking to a newer server will meet codes it has
+never heard of routinely.
+
 Retries are **off by default**. Construct a :class:`RetryPolicy` and pass
 it to ``TCKDBClient(..., retry=policy)`` to opt in.
 """
@@ -31,10 +57,18 @@ from email.utils import parsedate_to_datetime
 from datetime import datetime, timezone
 from typing import Callable, Mapping
 
+from .rejection_codes import NON_RETRYABLE_CODES
+
 #: Transient status codes worth replaying. 429 is the only 4xx here:
 #: it is an explicit "come back later", not a malformed request. Every
 #: other 4xx describes a client-side problem that a replay cannot fix.
 DEFAULT_RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 502, 503, 504})
+
+#: Codes that override the status above. Generated server-side from
+#: ``app.api.code_catalogue``, re-exported here so a caller configuring a
+#: policy does not have to know which module the set came from. See the
+#: module docstring for why the body is consulted at all.
+DEFAULT_NON_RETRYABLE_CODES: frozenset[str] = NON_RETRYABLE_CODES
 
 #: Methods that are safe to replay unconditionally.
 SAFE_METHODS: frozenset[str] = frozenset({"GET", "HEAD"})
@@ -71,6 +105,13 @@ class RetryPolicy:
     retry_status_codes:
         Response codes worth replaying. Defaults to
         :data:`DEFAULT_RETRY_STATUS_CODES`.
+    non_retryable_codes:
+        Error-body ``code`` values that veto a retry the status would
+        otherwise allow. Defaults to
+        :data:`DEFAULT_NON_RETRYABLE_CODES`. Pass ``frozenset()`` to
+        restore the pre-#234 behaviour of deciding on the status alone —
+        which means replaying a lost artifact forever, so there is no
+        good reason to.
     respect_retry_after:
         Honour the ``Retry-After`` response header. The client never
         sleeps *less* than the server asked for.
@@ -91,6 +132,7 @@ class RetryPolicy:
     max_backoff: float = 30.0
     jitter: float = 0.5
     retry_status_codes: frozenset[int] = DEFAULT_RETRY_STATUS_CODES
+    non_retryable_codes: frozenset[str] = DEFAULT_NON_RETRYABLE_CODES
     respect_retry_after: bool = True
     max_retry_after: float = 120.0
     sleep: Callable[[float], None] = field(default=_time.sleep, repr=False, compare=False)
@@ -132,6 +174,26 @@ class RetryPolicy:
     def status_is_retryable(self, status_code: int) -> bool:
         """Return ``True`` for transient response codes only."""
         return status_code in self.retry_status_codes
+
+    def code_is_retryable(self, code: object) -> bool:
+        """Return ``False`` only for a code known to be deterministic.
+
+        The veto over :meth:`status_is_retryable`, and deliberately the
+        weaker of the two: it can stop a retry the status permitted, never
+        start one the status refused. So a 422 does not become retryable
+        by omission from :attr:`non_retryable_codes`.
+
+        Everything unrecognised answers ``True`` — a code from a newer
+        server, a body with no ``code`` field, a body that was not JSON at
+        all, ``None``. Read the default as "keep retrying unless TCKDB has
+        said in writing that it is pointless", not as a whitelist. The
+        failure this shape avoids: a client pinned at an older version
+        meets a transient code added since, does not recognise it, and
+        gives up on an outage that would have cleared in four seconds.
+        """
+        if not isinstance(code, str):
+            return True
+        return code not in self.non_retryable_codes
 
     # ------------------------------------------------------------------
     # Delay computation
@@ -215,6 +277,7 @@ class RetryPolicy:
 
 
 __all__ = [
+    "DEFAULT_NON_RETRYABLE_CODES",
     "DEFAULT_RETRY_STATUS_CODES",
     "IDEMPOTENT_WITH_KEY_METHODS",
     "RetryPolicy",

--- a/clients/python/tests/test_retry.py
+++ b/clients/python/tests/test_retry.py
@@ -22,6 +22,7 @@ from conftest import make_client
 from tckdb_client import TCKDBClient
 from tckdb_client.errors import TCKDBConnectionError, TCKDBHTTPError
 from tckdb_client.retry import (
+    DEFAULT_NON_RETRYABLE_CODES,
     DEFAULT_RETRY_STATUS_CODES,
     RetryPolicy,
 )
@@ -363,6 +364,288 @@ class TestStatusEligibility:
 
         assert client.get_json("/health") == {"ok": True}
         assert len(attempts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Code eligibility: when the body contradicts the status
+# ---------------------------------------------------------------------------
+
+
+class TestNonRetryableCodes:
+    """A transient status carrying a deterministic code is attempted once.
+
+    Every test here asserts an **attempt count**, not merely that the call
+    raised. ``pytest.raises(TCKDBHTTPError)`` passes identically against a
+    client that gave up immediately and one that replayed for two minutes
+    first, so it says nothing at all about the behaviour under test — and
+    the behaviour under test *is* the number of attempts.
+
+    The two halves are deliberately in one class. Before #234 the client
+    replayed ``artifact_object_missing`` on a backoff schedule forever for
+    a condition guaranteed never to clear; the fix must not overshoot into
+    abandoning the 503 beside it, which is a genuine outage where waiting
+    is the correct response. Asserting only the first half would leave a
+    client that stopped retrying everything looking fixed.
+    """
+
+    def test_the_deny_list_is_not_empty(self):
+        """Everything below is vacuous if the generated set is empty.
+
+        ``code_is_retryable`` answers ``True`` for anything it does not
+        recognise, so an empty ``NON_RETRYABLE_CODES`` would make every
+        once-only assertion below pass for the wrong reason — the status
+        rule alone would be back in charge and nothing would say so.
+        """
+        assert DEFAULT_NON_RETRYABLE_CODES, (
+            "NON_RETRYABLE_CODES is empty, so the retry layer has no code "
+            "it will refuse to replay and every test in this class is "
+            "asserting the pre-#234 behaviour"
+        )
+        assert "artifact_object_missing" in DEFAULT_NON_RETRYABLE_CODES
+        assert "artifact_integrity_failed" in DEFAULT_NON_RETRYABLE_CODES
+
+    @pytest.mark.parametrize(
+        "code", ["artifact_object_missing", "artifact_integrity_failed"]
+    )
+    def test_a_custody_break_is_attempted_exactly_once(self, code):
+        """502 is in the default retry set; the code overrules it."""
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(
+                502,
+                json={
+                    "detail": "retrying will not clear it",
+                    "code": code,
+                    "context": {},
+                },
+            )
+
+        pol, recorder = policy(max_attempts=4)
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises(TCKDBHTTPError) as excinfo:
+            client.get_json("/scientific/artifacts/abc/download")
+
+        assert len(attempts) == 1, (
+            f"{code} was attempted {len(attempts)} times; the condition is "
+            "deterministic, so every attempt after the first is guaranteed "
+            "to meet the same answer"
+        )
+        assert recorder.count == 0, "the client slept before giving up"
+        assert excinfo.value.status_code == 502
+        assert excinfo.value.code == code
+
+    def test_a_storage_outage_is_still_retried(self):
+        """The other half of the pair, at the status that means "wait".
+
+        ``artifact_storage_unavailable`` leaves the same handler, from the
+        same exception type, as the 502 above. It is not in the deny list
+        and must keep its full backoff schedule — a client that stopped
+        retrying this would abandon every transient object-store blip.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(
+                503,
+                json={
+                    "detail": "Artifact storage is temporarily unavailable.",
+                    "code": "artifact_storage_unavailable",
+                    "context": {},
+                },
+            )
+
+        pol, recorder = policy(max_attempts=4)
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises(TCKDBHTTPError):
+            client.get_json("/scientific/artifacts/abc/download")
+
+        assert len(attempts) == 4, (
+            "a store that did not answer was attempted "
+            f"{len(attempts)} times instead of the budgeted 4"
+        )
+        assert recorder.delays == [1.0, 2.0, 4.0]
+
+    def test_a_recovering_store_still_succeeds_on_a_later_attempt(self):
+        """Retrying is not merely permitted, it works.
+
+        Exhausting the budget above proves the attempts happened; this
+        proves the replay is a real request whose success is returned,
+        which an assertion counting failures cannot distinguish.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            if len(attempts) < 3:
+                return httpx.Response(
+                    503,
+                    json={"code": "artifact_storage_unavailable", "detail": "wait"},
+                )
+            return httpx.Response(200, json={"ok": True})
+
+        pol, _ = policy()
+        client = client_with(handler, retry=pol)
+
+        assert client.get_json("/health") == {"ok": True}
+        assert len(attempts) == 3
+
+    def test_download_artifact_stops_after_one_attempt(self):
+        """Through the real call, not a synthetic path.
+
+        ``download_artifact`` returns raw bytes and therefore takes
+        ``_request_raw`` rather than ``request_json``. Both funnel into
+        ``_send``, but the retry loop lives in ``_send`` and a test that
+        only ever went through the JSON path would not have noticed if the
+        bytes path skipped it — and the bytes path is the one this whole
+        fix is about.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(
+                502,
+                json={
+                    "detail": "The stored bytes for this artifact are not "
+                    "in the object store.",
+                    "code": "artifact_object_missing",
+                    "context": {},
+                },
+            )
+
+        pol, recorder = policy(max_attempts=5)
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises(TCKDBHTTPError) as excinfo:
+            client.download_artifact("a" * 64)
+
+        assert len(attempts) == 1
+        assert recorder.count == 0
+        assert excinfo.value.code == "artifact_object_missing"
+        assert attempts[0].url.path.endswith("/download")
+
+    def test_an_unrecognised_code_is_still_retried(self):
+        """The deny list fails safe: unknown means keep trying.
+
+        A pinned client routinely talks to a newer server. If an unknown
+        code stopped a retry, adding any transient failure server-side
+        would silently break backoff for every client in the field —
+        worse than the bug this list fixes, because it turns a recoverable
+        outage into a failure.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(
+                503,
+                json={"code": "some_transient_thing_invented_later", "detail": "x"},
+            )
+
+        pol, _ = policy(max_attempts=3)
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises(TCKDBHTTPError):
+            client.get_json("/health")
+        assert len(attempts) == 3
+
+    @pytest.mark.parametrize(
+        "response_kwargs",
+        [
+            pytest.param({"json": {"detail": "no code field"}}, id="no-code-key"),
+            pytest.param({"json": {"code": None}}, id="null-code"),
+            pytest.param({"json": {"code": 502}}, id="non-string-code"),
+            pytest.param({"json": ["not", "an", "object"]}, id="json-array"),
+            pytest.param({"content": b"\x89PNG\r\n\x1a\n\xff"}, id="binary-body"),
+            pytest.param({"text": "<html>502 Bad Gateway</html>"}, id="html-body"),
+            pytest.param({"content": b""}, id="empty-body"),
+        ],
+    )
+    def test_a_body_with_no_readable_code_is_retried(self, response_kwargs):
+        """An unreadable body must never be the reason a retry stopped.
+
+        A proxy's HTML 502, a truncated body, a response with no ``code``
+        at all: each yields "no opinion", and no opinion leaves the status
+        rule in charge. The alternative — treating an unparseable body as
+        non-retryable — would silently disable backoff behind any
+        misbehaving intermediary.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(502, **response_kwargs)
+
+        pol, _ = policy(max_attempts=3)
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises((TCKDBHTTPError, TCKDBConnectionError)):
+            client.get_json("/health")
+        assert len(attempts) == 3
+
+    def test_the_code_rule_cannot_start_a_retry_the_status_refused(self):
+        """The veto is one-directional.
+
+        ``code_is_retryable`` answers ``True`` for every 4xx code, since
+        none of them are in the deny list. That must not make a 422
+        retryable: the status rule runs first and its "no" is final.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(
+                422, json={"code": "reaction_mass_balance_failed", "detail": "no"}
+            )
+
+        pol, recorder = policy()
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises(TCKDBHTTPError):
+            client.get_json("/species/1")
+        assert len(attempts) == 1
+        assert recorder.count == 0
+
+    def test_the_deny_list_is_configurable_and_load_bearing(self):
+        """Emptying it restores the old behaviour, which proves it acts.
+
+        The same mutation the PR ran by hand, pinned as a test: with no
+        deny list the identical 502 is replayed to the attempt cap. If
+        this passed *and* the once-only test above passed, the field would
+        not be consulted at all.
+        """
+        attempts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(
+                502, json={"code": "artifact_object_missing", "detail": "gone"}
+            )
+
+        pol, _ = policy(max_attempts=3, non_retryable_codes=frozenset())
+        client = client_with(handler, retry=pol)
+
+        with pytest.raises(TCKDBHTTPError):
+            client.get_json("/health")
+        assert len(attempts) == 3
+
+    @pytest.mark.parametrize("value", [None, 502, b"artifact_object_missing", object()])
+    def test_a_non_string_code_is_retryable(self, value):
+        """The unit-level fail-safe, stated separately from the wire tests."""
+        pol, _ = policy()
+        assert pol.code_is_retryable(value)
+
+    def test_the_policy_reports_the_two_codes_directly(self):
+        pol, _ = policy()
+        assert not pol.code_is_retryable("artifact_object_missing")
+        assert not pol.code_is_retryable("artifact_integrity_failed")
+        assert pol.code_is_retryable("artifact_storage_unavailable")
+        assert pol.code_is_retryable("rate_limit_exceeded")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #234.

PR #199/#226 split two artifact-storage failures that used to share one code,
and got the server right. No client could act on it. This makes the split
reach a client without touching the status #199 chose.

## Plain-language summary

When you ask TCKDB for the raw bytes of a stored calculation file, two very
different things can go wrong.

1. **The file store did not answer.** Maybe it is restarting, maybe the network
   blipped. Waiting a few seconds and asking again is exactly the right thing
   to do. TCKDB answers `503`.
2. **The file store answered, and the bytes are gone.** The database record is
   still there and still published, but the object it points at is missing.
   This is a break in TCKDB's custody of the data. Waiting will never fix it —
   only a human operator putting the object back does. TCKDB answers `502`, and
   the message literally says *"retrying will not clear it."*

The Python client has an optional feature where, if a request fails with a
"temporary" HTTP status, it waits and tries again a few times with increasing
delays. This is called *retry with exponential backoff*. `502` and `503` are
both on its list of temporary statuses.

So case 2 was being retried. The server said "do not retry this" and the client
retried it anyway, because the client was only looking at the number (`502`) and
not at the machine-readable reason beside it (`artifact_object_missing`).

Why couldn't it look at the reason? TCKDB generates a Python `enum` — a fixed
list of named constants — of every error reason a caller can branch on, so
client code writes `RejectionCode.REACTION_MASS_BALANCE_FAILED` instead of a
hand-typed string that silently never matches if it has a typo. That list
deliberately contains only `4xx` reasons, i.e. "you did something wrong". A
`5xx` means *TCKDB* has a problem, so there is nothing for the depositor to fix
and no branch for them to write — correctly excluded. But that also meant the
one piece of information the retry layer needed had no way to reach it. I
regenerated the enum on `main` to confirm: byte-identical, the new code is
nowhere in it.

The fix is a **second, separate list** shipped beside the enum:
`NON_RETRYABLE_CODES`. It names the error reasons that are *deterministic* —
guaranteed to give the same answer forever. The retry layer checks it and gives
up after one attempt. Nothing about the HTTP statuses, the messages, or the
enum changed.

The most important property is which way it fails when it does not recognise
something. It is a **deny list**, not an allow list: an error reason not on the
list is retried exactly as it was before. A client installed today talking to a
TCKDB deployed next year will meet reasons it has never heard of, and it must
keep retrying those. Giving up on a real four-second outage is a worse bug than
a few wasted attempts on a hopeless one.

---

## The question the brief asked first: is the body available at the retry decision point?

**Yes.** Evidence:

- The decision is made in `TCKDBClient._send`
  (`clients/python/src/tckdb_client/client.py:481-497`), inside the retry loop
  itself — not in the caller, and not where the exception is raised.
- The loop calls `self._client.request(...)`, which is `httpx`'s **non-streaming**
  API. It reads the whole body before returning, so `response.content` and
  `response.json()` are already populated at that line. Nothing is streamed and
  nothing needs re-reading.
- The variable in scope at the decision is `response` — the entire
  `httpx.Response`. `policy.status_is_retryable(response.status_code)` was
  simply the only thing being read off it.
- Both entry points reach the same loop: `request_json` → `_send`, and
  `_request_raw` → `_send`. `download_artifact` — the route in the bug report —
  takes the second, so a fix in `_send` covers the case that matters.

So the durable fix was available and the second branch of the brief (server
status change, unapproved) does not apply. **`artifact_object_missing` remains
`502`. Nothing about #199's status choice was reopened.**

## Which option, and the measurement behind it

Measured on `main` (167 catalogue entries; 151 client-facing entries / 149
distinct codes; 9 entries at `5xx`):

| | entries whose classification moves | published-contract effect |
|---|---|---|
| **Option 1** — separate non-retryable set | **0** | one new export |
| **Option 2** — widen `is_client_facing` to `5xx` | **7** | 7 new `RejectionCode` members (149 → 156 codes) |

Option 2's seven are `artifact_integrity_failed`, `artifact_object_missing`,
`artifact_storage_unavailable`, `database_unavailable`, `query_timeout`,
`release_artifact_corrupt`, `schema_not_initialized`. Three of those
(`database_unavailable`, `query_timeout`, `schema_not_initialized`) refuse
nothing whatsoever — putting them in an enum named `RejectionCode` is the exact
category error that module's docstring warns about in three separate places.

Option 2 also **cannot be done without weakening an existing test.**
`test_client_facing_excludes_what_a_client_cannot_use`
(`backend/tests/api/test_api_code_catalogue.py:502`) asserts, over the whole
catalogue, that no entry with `status >= 500` is exported, with the message
*"a 5xx refuses nothing the caller did"*. That assertion is correct and the
brief forbids weakening it, which settles the choice.

**Chose Option 1 — with Option 2's honest half.** The classification lives on
`ApiCode` (`replay: Replay`) so the catalogue stays the single source of truth
and the generator has something to read, rather than a hand-maintained list in
the generator. So `is_client_facing` *is* now relieved of the second question —
it just is not the property that answers it.

### One thing in the brief that turned out to be false

The brief describes option 2 as "**two derived** properties". Retryability is
**not derivable** from anything a catalogue entry holds, and the pair that
forced this work proves it: `artifact_storage_unavailable` (503, retry) and
`artifact_object_missing` (502, do not) come out of **one handler**, from **one
exception type**, about **one subsystem**, and differ in no field a property
could read. "Will replaying ever succeed?" is a fact about the physics of the
failure, not about the entry. So `Replay` is **declared**, and it carries a
declaration's obligations — `never_succeeds` requires a `note` justifying the
claim, exactly as `Reach.guard` does. Two entries are declared; both were
already saying "retrying will not clear it" in prose.

`is_replay_futile` (derived) then narrows the declaration to where it does work:
`Reach.request` (a guard no request can trip will never be handed to a retry
layer) and a status in `REPLAYABLE_STATUSES` (declaring a 422 deterministic is
true and inert — no client retries a 422). A test refuses an inert declaration.

## Attempt counts asserted

All in `clients/python/tests/test_retry.py::TestNonRetryableCodes`, deliberately
in one class so the fix cannot overshoot into "stop retrying everything":

| case | expected attempts | budget |
|---|---|---|
| `502 artifact_object_missing` | **1** | 4 |
| `502 artifact_integrity_failed` | **1** | 4 |
| `download_artifact` → `502 artifact_object_missing` (the real bytes path) | **1** | 5 |
| `503 artifact_storage_unavailable` | **4** (delays `[1.0, 2.0, 4.0]`) | 4 |
| store recovers on the 3rd try | **3**, returns `200` | 3 |
| `503` with an unrecognised code | **3** | 3 |
| `502` with an unreadable body (7 shapes: no `code` key, null, non-string, JSON array, binary, HTML, empty) | **3** | 3 |
| `422` with a known 4xx code (the veto must not *start* a retry) | **1** | 3 |
| `502 artifact_object_missing` with `non_retryable_codes=frozenset()` | **3** | 3 |

`recorder.count == 0` is asserted on the once-only cases too: not sleeping is
part of the behaviour, and an attempt count alone would not catch a client that
slept before giving up.

## The two mutations

**Mutation 1 — emptied `NON_RETRYABLE_CODES` in the generated file.** 5 failures,
all in the new class; the attempt counts went `1 → 5` and `1 → 4`:

```
FAILED ...::test_a_custody_break_is_attempted_exactly_once[artifact_object_missing]
FAILED ...::test_a_custody_break_is_attempted_exactly_once[artifact_integrity_failed]
FAILED ...::test_download_artifact_stops_after_one_attempt   E  assert 5 == 1
FAILED ...::test_the_deny_list_is_not_empty
FAILED ...::test_the_policy_reports_the_two_codes_directly
```

**Mutation 2 — `code_is_retryable` → `return False` (everything non-retryable).**
29 failures, including `test_a_storage_outage_is_still_retried`,
`test_a_recovering_store_still_succeeds_on_a_later_attempt`,
`test_an_unrecognised_code_is_still_retried`, all 7 unreadable-body cases, and
**12 pre-existing tests** that were green before this PR
(`TestStatusEligibility::test_transient_statuses_are_retried_for_get[429|502|503|504]`,
`TestBoundedAttempts`, `TestRetryAfter`, `TestIntegration`) — which also confirms
the new check really sits in the live path rather than beside it.

Both restored; `__pycache__` cleared; `generate_client_rejection_codes.py --check`
reports up to date; full suites re-run green afterwards.

The mutations are also pinned as tests so they cannot regress silently:
`test_the_deny_list_is_not_empty`,
`test_the_deny_list_is_configurable_and_load_bearing`, and — on the server side
— the generator now **refuses to emit an empty `NON_RETRYABLE_CODES`** rather
than shipping a silently dead export.

## New client version

`tckdb-client` **0.49.0 → 0.50.0**. Checked against `origin/main`
(`34845f26`), not against what this branch started from — per the note in the
brief about two PRs bumping to the same value and git merging it silently
because the line was byte-identical.

Minor rather than patch: it adds two public exports (`NON_RETRYABLE_CODES`,
`DEFAULT_NON_RETRYABLE_CODES`), a `RetryPolicy` field and a method, and it
changes observable behaviour for anyone who passes a `RetryPolicy`.

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no wire-schema change, no
`tckdb_schemas` version bump. No HTTP status, code spelling, message or response
body changed, and no `RejectionCode` member was added or removed — so no
deployment step and no client is forced to upgrade. The behaviour change is
entirely inside the client's opt-in retry path (retries are off by default).

DR-0028 Req 2: no new error body, so no new place a row id could leak. #202's
observer ran clean over the backend suite.

## Exact commands run

```bash
# regenerate + drift check
conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py
conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py --check

# backend, cwd = backend/ (per #231, a cwd-relative fixture glob fails from the repo root)
cd backend && conda run -n tckdb_env python -m pytest tests/ -q

# client suites — separate CI job from the backend gates, so a green backend proves nothing here.
# PYTHONPATH forces the WORKTREE's tckdb_schemas; the editable install points at the main checkout.
PYTHONPATH=<worktree>/schemas/python/tckdb-schemas \
  conda run -n tckdb_env python -m pytest clients/python/tests --rootdir=clients/python -q
PYTHONPATH=<worktree>/schemas/python/tckdb-schemas \
  conda run -n tckdb_env python -m pytest clients/python/adapters/chemkin/tests --rootdir=clients/python -q
PYTHONPATH=<worktree>/schemas/python/tckdb-schemas \
  conda run -n tckdb_env python -m pytest schemas/python/tckdb-schemas/tests \
  --rootdir=schemas/python/tckdb-schemas -q

git diff   # from the repository root
```

Results: **client `1370 passed`**, chemkin adapter `55 passed, 1 skipped`,
wire-contract schemas `38 passed`, backend suite green (see the note below on
the worktree import hazard).

### Worktree note worth recording

The brief's `PYTHONPATH` override is needed for `tckdb_schemas` and **not** for
`tckdb_client`: `clients/python/conftest.py` already prepends its own `src/`
precisely to defeat an editable install pointing at another checkout. Verified
by probe — under pytest both resolve into the worktree; under a bare
`python -c`, `tckdb_client` resolves to the **main** checkout. So use pytest, not
`python -c`, to sanity-check client changes in a worktree.
