### PR TITLE
Refuse a version number two packages could claim

### DIFF
--- a/.github/workflows/repo-gate.yml
+++ b/.github/workflows/repo-gate.yml
@@ -47,6 +47,22 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Full history, not the depth-1 default. The package version guard
+          # below compares against the *merge base* of this branch and the
+          # base branch, and a shallow clone has no merge base to compute --
+          # git would fail rather than quietly find nothing, but only
+          # because check_package_version_bump.py refuses that case
+          # explicitly. test_the_gate_has_the_history_it_needs pins this.
+          fetch-depth: 0
+          # And tags, which fetch-depth: 0 does NOT bring on its own -- the
+          # action passes --no-tags unless asked for them. Without this the
+          # guard's third check ("is this version already pinned by a
+          # <name>-v<version> tag?") would see an empty tag list, find no
+          # conflict, and sit there inert while reporting green. That is the
+          # exact shape of failure this whole gate exists to prevent, so it
+          # would be a poor one to build into it.
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -58,6 +74,52 @@ jobs:
 
       - name: Every test file is run by a required job
         run: python -m pytest --noconftest -q backend/tests/scripts/test_gate_coverage.py
+
+      # WHY THE VERSION GUARD IS HERE AND NOT IN python-client-ci.yml
+      #   Two agents branched from tckdb-client 0.46.0 on 2026-08-16, both
+      #   correctly bumped to 0.47.0, and git merged the byte-identical
+      #   version line with no conflict and no entry in the merge stat. One
+      #   number, two packages. The same thing has already happened five
+      #   times to tckdb-schemas -- run the script with --audit to see them.
+      #
+      #   It lives in the unfiltered workflow because the packages it covers
+      #   include integrations/mcp, which python-client-ci.yml's paths:
+      #   filter does not match: a pull request touching only that package
+      #   would start no job that could notice. The guard's own tests run
+      #   here too, for the reason given above about the aggregator -- a
+      #   defect in a guard is a defect in the gate.
+      - name: The guard against two packages claiming one version works
+        run: python -m pytest --noconftest -q backend/tests/scripts/test_check_package_version_bump.py
+
+      # THE TWO REFS ARE DIFFERENT ON PURPOSE.
+      #
+      #   --base-ref is the base branch's tip *as the pull request event saw
+      #   it*, a concrete sha that always exists in the checkout. The script
+      #   takes merge-base(base, head) from it, which is the only ref that
+      #   asks the author the question they can answer: "did you raise the
+      #   number from where you branched?" Comparing against the current tip
+      #   instead would fail a branch that is merely behind, blaming it for
+      #   someone else's merge.
+      #
+      #   --main-ref is the base branch as fetched *now*, which is fresher
+      #   than base.sha and therefore includes a sibling branch that merged
+      #   after this pull request last ran. That is the whole point: the
+      #   colliding version is never on the merge base's history -- it
+      #   arrives on main after the branch point, which is what makes the
+      #   collision possible.
+      #
+      # RESIDUAL GAP, STATED RATHER THAN HIDDEN
+      #   If this job last ran before the sibling merged and is never re-run,
+      #   its green is stale. No CI check can close that from inside the run;
+      #   it needs "Require branches to be up to date before merging" in
+      #   branch protection. The guard narrows the window to the interval
+      #   between the last run and the merge, instead of leaving it open.
+      - name: A changed package carries an unused, strictly greater version
+        run: >-
+          python backend/scripts/check_package_version_bump.py
+          --base-ref "${{ github.event.pull_request.base.sha || github.sha }}"
+          --head-ref "${{ github.event.pull_request.head.sha || github.sha }}"
+          --main-ref "origin/${{ github.base_ref || github.event.repository.default_branch }}"
 
       # Runs here too, and not only in the backend complement gate, because
       # this file is the mechanism by which the *other* workflows become

--- a/backend/scripts/check_package_version_bump.py
+++ b/backend/scripts/check_package_version_bump.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Refuse a distributed package version that two different packages could claim.
+
+WHY
+    On 2026-08-16 two agents branched from ``clients/python/pyproject.toml``
+    at ``0.46.0``. Both followed the standing rule that a change to
+    ``tckdb-client`` bumps the version, and both chose ``0.47.0``. The first
+    merged. The second still carried ``-0.46.0 / +0.47.0``.
+
+    Git did not notice. Both sides of the merge held the byte-identical line
+    ``version = "0.47.0"``, so there was no conflict, no entry in the merge
+    stat, and nothing for a reviewer scanning the diff to catch. One version
+    number then described two different packages.
+
+    That is not hypothetical here. Walking the first-parent history of
+    ``main`` (this file's ``--audit`` mode does it) finds five versions of
+    ``tckdb-schemas`` that have *already* shipped with two or three
+    different distributed contents each: ``0.2.0``, ``0.8.0``, ``0.14.0``,
+    ``0.30.0`` and ``0.33.0``. The ``0.2.0`` and ``0.8.0`` collisions are
+    substantive -- new enum members and changed upload-schema fields, not
+    typography. And ``0.8.0`` is the version the annotated tag
+    ``tckdb-schemas-v0.8.0`` pins "for tckdb-adapters/tckdb_arc (Phase 1)",
+    so an ARC-side pin of ``tckdb-schemas==0.8.0`` resolves to one of two
+    genuinely different packages depending on when it was fetched.
+
+WHAT IS CHECKED
+    For each covered package (see ``PACKAGES``), given a base ref and a head
+    ref:
+
+    1. **Monotonicity, against the merge base.** If the package's
+       distributed content changed between the merge base and the head, the
+       head's version must be *strictly greater* than the merge base's.
+       This catches "changed the package, forgot to bump" and "bumped
+       downwards".
+
+    2. **Novelty, against the whole of main's history.** The head's version
+       must not already be claimed, anywhere on ``--main-ref``'s first-parent
+       history, by a *different* content. This is the check that catches the
+       collision above, and it is the reason (2) cannot be folded into (1) --
+       see MERGE BASE VERSUS TIP.
+
+    3. **Novelty, against release tags.** If a tag ``<name>-v<version>``
+       exists and its content differs from the head's, the head is trying to
+       reuse a number something has already been pinned to.
+
+MERGE BASE VERSUS TIP, AND WHY BOTH REFS ARE NEEDED
+    These two comparisons genuinely need different references, and getting
+    that wrong is the whole subtlety.
+
+    Monotonicity must use the **merge base**, not main's tip. Against the
+    tip, a branch that is merely *behind* main gets failed for a bump it
+    made correctly from where it started, and the message blames the author
+    for someone else's merge. The merge base is the only ref that answers
+    the question actually being asked of the author: "did *you* raise the
+    number from where *you* branched?"
+
+    Novelty must use main's **tip history**, not the merge base. In the
+    incident, the colliding ``0.47.0`` was not on the merge base's history
+    at all -- it arrived on main *after* the branch point, which is exactly
+    what made the collision possible. A check confined to the merge base
+    cannot see it. So: monotonicity asks "did you bump?", novelty asks "is
+    the number you chose taken?", and only the pair is complete.
+
+WHAT COUNTS AS "THE PACKAGE CHANGED"
+    The importable tree that goes into the wheel (``Package.dist_paths``,
+    derived from each project's ``[tool.setuptools.packages.find]``), plus
+    ``pyproject.toml`` with the ``version =`` line removed -- so a bump on
+    its own is not self-justifying, and a dependency-pin change is.
+
+    Deliberately *out* of scope: ``tests/``, ``docs/``, ``README.md``,
+    notebooks and examples. None of them is importable from the installed
+    distribution. A README typo does technically change the sdist's
+    long_description, and a checker that demands a version bump for a typo
+    is a checker that gets switched off within a week -- at which point it
+    is not guarding the enum members either. The same reasoning is written
+    out at more length in ``check_runtime_ascii.py``; this file draws the
+    line in the same place and for the same reason.
+
+WHY NOT BUMP AT MERGE TIME INSTEAD
+    Deciding the number when the merge happens would remove the race
+    outright: there is only one merge at a time, so there is no second
+    author to collide with. It is rejected here for three reasons, and the
+    trade is real rather than obvious.
+
+    It contradicts the standing rule that every change to the client bumps
+    the version, which is a rule contributors already follow and which
+    keeps the number reviewable *in the diff that earns it*. It moves the
+    decision to a moment when nobody is looking at the change -- the number
+    would be chosen by whoever presses merge, or by a bot, and a wrong one
+    would land unreviewed. And it needs write access from CI to the
+    protected branch, which is a much larger permission than this check's
+    ``contents: read``.
+
+    Monotonicity plus novelty gets the same guarantee while leaving the
+    number where an author and a reviewer can both see it. If the volume of
+    concurrent client changes ever makes the rebase-and-renumber loop the
+    dominant cost, merge-time assignment is the right thing to revisit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Package:
+    """A distribution whose version number must not be reused."""
+
+    name: str
+    pyproject: str
+    # The importable trees that land in the wheel. A tuple because a layout
+    # can change (``tckdb-schemas`` was flat, ``tckdb-client`` is src/) and
+    # the history walk has to recognise the package on both sides of such a
+    # move; every path that exists at a given commit contributes.
+    dist_paths: tuple[str, ...]
+
+
+PACKAGES: tuple[Package, ...] = (
+    Package(
+        name="tckdb-client",
+        pyproject="clients/python/pyproject.toml",
+        dist_paths=("clients/python/src",),
+    ),
+    Package(
+        name="tckdb-schemas",
+        pyproject="schemas/python/tckdb-schemas/pyproject.toml",
+        # Flat layout today (``where = ["."]``, ``include =
+        # ["tckdb_schemas*"]``); ``src/`` is listed because the history walk
+        # reaches commits from before the package settled, and a path that
+        # does not exist at a commit is simply skipped.
+        dist_paths=(
+            "schemas/python/tckdb-schemas/tckdb_schemas",
+            "schemas/python/tckdb-schemas/src",
+        ),
+    ),
+    Package(
+        name="tckdb-chemkin",
+        pyproject="clients/python/adapters/chemkin/pyproject.toml",
+        dist_paths=("clients/python/adapters/chemkin/tckdb_chemkin",),
+    ),
+    Package(
+        name="tckdb-mcp",
+        pyproject="integrations/mcp/pyproject.toml",
+        dist_paths=("integrations/mcp/src/tckdb_mcp",),
+    ),
+)
+
+# Every ``pyproject.toml`` in the repository is either covered above or named
+# here with a reason. ``test_every_pyproject_is_covered_or_excluded`` fails if
+# a new one appears in neither list, because the recurring defect in this
+# repository's checkers is not being wrong -- it is being aimed at fewer
+# places than they should have been, and nobody noticing for months.
+EXCLUDED_PYPROJECTS: dict[str, str] = {
+    "backend/pyproject.toml": (
+        "The application, not a distribution. Nothing installs tckdb-backend "
+        "from an index, so no third party can hold a pin that two different "
+        "trees could satisfy; its version has been an inert 0.1.0 since it "
+        "was written. If the backend is ever published as a wheel, move it "
+        "into PACKAGES."
+    ),
+}
+
+
+class VersionError(ValueError):
+    """A version string this checker will not rank."""
+
+
+# PEP 440, minus epochs and local versions: a release segment, then an
+# optional pre-release, post-release and dev-release. Anything outside this
+# is refused by name rather than ranked on a guess -- mis-ordering a version
+# is worse than declining to order it, because a wrong order silently
+# *passes* the branch it should have stopped.
+_VERSION_RE = re.compile(
+    r"""^\s*v?
+    (?P<release>\d+(?:\.\d+)*)
+    (?:[-_.]?(?P<pre_l>a|b|c|rc|alpha|beta|pre|preview)[-_.]?(?P<pre_n>\d+)?)?
+    (?:[-_.]?post[-_.]?(?P<post_n>\d+)?)?
+    (?:[-_.]?dev[-_.]?(?P<dev_n>\d+)?)?
+    \s*$""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+_PRE_RANK = {"a": 0, "alpha": 0, "b": 1, "beta": 1, "c": 2, "rc": 2, "pre": 2, "preview": 2}
+
+# Sorts after any real pre-release number, so a final release outranks its
+# own pre-releases. Sorts before nothing else, so it is only ever compared
+# inside the same release segment.
+_FINAL = (1, 0, 0)
+_DEV_ONLY = (-1, 0, 0)
+_NO_DEV = float("inf")
+
+
+def version_key(raw: str) -> tuple:
+    """Return a sortable key for ``raw``.
+
+    Semantic, not lexical: ``0.10.0`` must outrank ``0.9.0`` even though it
+    sorts before it as a string. That trap is the reason this function
+    exists rather than a ``>`` on two strings.
+    """
+    if not isinstance(raw, str):
+        raise VersionError(f"version must be a string, got {type(raw).__name__}")
+    match = _VERSION_RE.match(raw)
+    if match is None:
+        raise VersionError(
+            f"cannot rank the version {raw!r}. This checker accepts a PEP 440 "
+            f"release with optional pre/post/dev segments and nothing else. "
+            f"It refuses rather than guessing an order, because a guessed "
+            f"order passes the change it should have refused. Extend "
+            f"_VERSION_RE and its tests if this spelling is intended."
+        )
+    release = tuple(int(part) for part in match.group("release").split("."))
+    # Pad so 0.9 and 0.9.0 rank equal instead of by length.
+    release = release + (0,) * (8 - len(release)) if len(release) < 8 else release
+
+    pre_l, pre_n = match.group("pre_l"), match.group("pre_n")
+    post_n, dev_n = match.group("post_n"), match.group("dev_n")
+
+    if pre_l is not None:
+        pre = (0, _PRE_RANK[pre_l.lower()], int(pre_n or 0))
+    elif post_n is None and dev_n is not None:
+        # 1.0.dev1 precedes 1.0a1, which precedes 1.0.
+        pre = _DEV_ONLY
+    else:
+        pre = _FINAL
+
+    post = -1 if post_n is None else int(post_n)
+    dev = _NO_DEV if dev_n is None else int(dev_n)
+    return (release, pre, post, dev)
+
+
+def compare_versions(left: str, right: str) -> int:
+    """-1, 0 or 1 as ``left`` is less than, equal to or greater than ``right``."""
+    a, b = version_key(left), version_key(right)
+    return (a > b) - (a < b)
+
+
+class Git:
+    """The handful of git queries this checker makes, against one repo."""
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    def run(self, *args: str, allow_fail: bool = False) -> str | None:
+        proc = subprocess.run(
+            ["git", "-C", self.repo, *args],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            if allow_fail:
+                return None
+            raise RuntimeError(
+                f"git {' '.join(args)} failed in {self.repo}: {proc.stderr.strip()}"
+            )
+        return proc.stdout
+
+    def rev_parse(self, rev: str) -> str | None:
+        out = self.run("rev-parse", "--verify", "--quiet", rev, allow_fail=True)
+        return out.strip() if out else None
+
+    def merge_base(self, a: str, b: str) -> str | None:
+        out = self.run("merge-base", a, b, allow_fail=True)
+        return out.strip() if out else None
+
+    def show(self, commit: str, path: str) -> str | None:
+        return self.run("show", f"{commit}:{path}", allow_fail=True)
+
+    def tree_id(self, commit: str, path: str) -> str | None:
+        out = self.run("rev-parse", "--verify", "--quiet", f"{commit}:{path}", allow_fail=True)
+        return out.strip() if out else None
+
+    def touching_commits(self, ref: str, paths: tuple[str, ...]) -> list[str]:
+        """First-parent commits on ``ref`` that touched any of ``paths``.
+
+        First-parent because that is what "shipped on main" means under a
+        squash/merge workflow: the sequence of states main actually held.
+        Only commits that touched the package can change its (version,
+        content) pair, so walking these instead of all of history keeps the
+        novelty scan to tens of commits rather than hundreds.
+        """
+        out = self.run("log", "--first-parent", "--format=%H", ref, "--", *paths, allow_fail=True)
+        return out.split() if out else []
+
+    def subject(self, commit: str) -> str:
+        out = self.run("log", "-1", "--format=%s", commit, allow_fail=True)
+        return (out or "").strip()
+
+    def tags(self) -> list[str]:
+        out = self.run("tag", "-l", allow_fail=True)
+        return out.split() if out else []
+
+
+_VERSION_LINE_RE = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class State:
+    """A package's version and distributed content at one commit."""
+
+    version: str
+    digest: str
+
+
+def read_state(git: Git, commit: str, package: Package) -> State | None:
+    """The package's (version, content-digest) at ``commit``, or None if absent."""
+    blob = git.show(commit, package.pyproject)
+    if blob is None:
+        return None
+    match = _VERSION_LINE_RE.search(blob)
+    if match is None:
+        return None
+    version = match.group(1)
+
+    parts = []
+    for path in package.dist_paths:
+        tree = git.tree_id(commit, path)
+        if tree is not None:
+            parts.append(f"{path}={tree}")
+    # A version bump must not count as a content change on its own, or every
+    # bump would justify itself and check (1) would be vacuous.
+    parts.append("pyproject=" + _VERSION_LINE_RE.sub("", blob))
+    digest = hashlib.sha1("\n".join(parts).encode("utf-8")).hexdigest()
+    return State(version=version, digest=digest)
+
+
+@dataclass
+class Finding:
+    package: str
+    code: str
+    message: str
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+    # Packages whose distributed content changed between merge base and head.
+    changed: list[str] = field(default_factory=list)
+    # Packages present at the head and therefore actually examined. A guard
+    # that examined nothing passes trivially, so callers assert on this.
+    examined: list[str] = field(default_factory=list)
+    merge_base: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+
+def check(
+    git: Git,
+    base_ref: str,
+    head_ref: str,
+    main_ref: str | None = None,
+    packages: tuple[Package, ...] = PACKAGES,
+) -> Report:
+    """Run all three checks for every package present at ``head_ref``."""
+    report = Report()
+
+    head = git.rev_parse(head_ref)
+    if head is None:
+        raise RuntimeError(f"cannot resolve head ref {head_ref!r}")
+    base = git.rev_parse(base_ref)
+    if base is None:
+        raise RuntimeError(f"cannot resolve base ref {base_ref!r}")
+
+    merge_base = git.merge_base(base, head)
+    if merge_base is None:
+        raise RuntimeError(
+            f"no merge base between {base_ref!r} and {head_ref!r}. A shallow "
+            f"clone is the usual cause: this check needs fetch-depth: 0."
+        )
+    report.merge_base = merge_base
+
+    novelty_ref = main_ref or base_ref
+    # Resolved here, loudly, rather than inside the per-package scan. If an
+    # unresolvable ref made the novelty scan quietly return "no conflict",
+    # the collision this whole file exists to catch would report a pass --
+    # a gate that verified nothing while looking green.
+    if git.rev_parse(novelty_ref) is None:
+        raise RuntimeError(
+            f"cannot resolve the novelty ref {novelty_ref!r}. This is the ref "
+            f"whose history must not already claim the head's version, so the "
+            f"check cannot be skipped: refusing rather than passing. In CI, "
+            f"fetch-depth: 0 is what makes the remote-tracking branch exist."
+        )
+
+    for package in packages:
+        head_state = read_state(git, head, package)
+        if head_state is None:
+            continue
+        report.examined.append(package.name)
+        base_state = read_state(git, merge_base, package)
+        findings_before = len(report.findings)
+
+        content_changed = base_state is None or base_state.digest != head_state.digest
+        if content_changed:
+            report.changed.append(package.name)
+
+        # (1) Monotonicity against the merge base.
+        if base_state is not None:
+            try:
+                order = compare_versions(head_state.version, base_state.version)
+            except VersionError as exc:
+                report.findings.append(
+                    Finding(package.name, "unrankable-version", str(exc))
+                )
+                continue
+            if content_changed and order <= 0:
+                verb = (
+                    "is unchanged from"
+                    if order == 0
+                    else "is LOWER than"
+                )
+                report.findings.append(
+                    Finding(
+                        package.name,
+                        "not-bumped" if order == 0 else "lowered",
+                        f"{package.name}: the distributed package changed, but "
+                        f"the version {head_state.version} {verb} the version "
+                        f"{base_state.version} at the merge base "
+                        f"({merge_base[:9]}). Raise it.",
+                    )
+                )
+            elif not content_changed and order < 0:
+                report.findings.append(
+                    Finding(
+                        package.name,
+                        "lowered",
+                        f"{package.name}: the version was lowered from "
+                        f"{base_state.version} at the merge base "
+                        f"({merge_base[:9]}) to {head_state.version}, and the "
+                        f"package's contents did not change. A version number "
+                        f"must never go backwards.",
+                    )
+                )
+
+        # (2) and (3) police *this* change, so they only run for a package
+        # this change actually touched. Two reasons, and the second is what
+        # makes the guard usable at all.
+        #
+        # It is the honest scope: a pull request that does not touch
+        # tckdb-mcp has not made tckdb-mcp's history any worse, and failing
+        # it for a collision someone else shipped tells the author to fix
+        # something they cannot fix from their branch.
+        #
+        # And the baseline is already dirty. ``--audit`` on origin/main finds
+        # five colliding tckdb-schemas versions plus tckdb-mcp 0.1.0 with
+        # four distinct contents (it has never been bumped). Unscoped, this
+        # check would fail on an untouched main, which means it would fail on
+        # every pull request -- and a gate that is red for everybody is a
+        # gate that gets switched off or marked non-required within a week.
+        # Recording those collisions is ``--audit``'s job; this is the gate.
+        if not content_changed:
+            continue
+
+        # One finding per package, and monotonicity is the one that names the
+        # fix. When a change did not bump at all, the old number is
+        # necessarily also "already claimed with different contents" and
+        # probably also tagged -- three findings describing one mistake, of
+        # which only the first tells the author what to do. Report that one.
+        if len(report.findings) > findings_before:
+            continue
+
+        # (2) Novelty against main's first-parent history.
+        claimed_by = _find_conflicting_claim(git, novelty_ref, package, head_state)
+        if claimed_by is not None:
+            commit, subject = claimed_by
+            report.findings.append(
+                Finding(
+                    package.name,
+                    "version-already-claimed",
+                    f"{package.name}: version {head_state.version} is already "
+                    f"on {novelty_ref}'s history at {commit[:9]} "
+                    f"({subject!r}) with DIFFERENT contents. Two packages "
+                    f"would claim one number, and git will not conflict on "
+                    f"it because both sides spell the version line "
+                    f"identically. Pick the next unused version.",
+                )
+            )
+
+        # (3) Novelty against release tags.
+        tag_conflict = _find_conflicting_tag(git, package, head_state)
+        if tag_conflict is not None:
+            tag = tag_conflict
+            report.findings.append(
+                Finding(
+                    package.name,
+                    "version-already-tagged",
+                    f"{package.name}: the tag {tag} already pins version "
+                    f"{head_state.version} to different contents. Something "
+                    f"downstream may hold that pin. Pick the next unused "
+                    f"version.",
+                )
+            )
+
+    return report
+
+
+def _find_conflicting_claim(
+    git: Git,
+    ref: str,
+    package: Package,
+    head_state: State,
+) -> tuple[str, str] | None:
+    """A commit on ``ref`` claiming head's version with a different digest.
+
+    ``ref`` is resolved by the caller, which raises if it cannot be. Do not
+    add a "return None if unresolvable" shortcut here: that turns a broken
+    checkout into a silent pass.
+    """
+    paths = (package.pyproject, *package.dist_paths)
+    for commit in git.touching_commits(ref, paths):
+        state = read_state(git, commit, package)
+        if state is None:
+            continue
+        if state.version != head_state.version:
+            continue
+        if state.digest != head_state.digest:
+            return commit, git.subject(commit)
+    return None
+
+
+def _find_conflicting_tag(git: Git, package: Package, head_state: State) -> str | None:
+    """A ``<name>-v<version>`` tag pinning head's version to other contents."""
+    wanted = f"{package.name}-v{head_state.version}"
+    if wanted not in git.tags():
+        return None
+    commit = git.rev_parse(wanted + "^{commit}")
+    if commit is None:
+        return None
+    state = read_state(git, commit, package)
+    if state is None or state.digest == head_state.digest:
+        return None
+    return wanted
+
+
+def audit(git: Git, ref: str, packages: tuple[Package, ...] = PACKAGES) -> dict:
+    """Report versions already shipped with more than one content on ``ref``.
+
+    Read-only history archaeology. This is what found the five
+    ``tckdb-schemas`` collisions named in the module docstring; it does not
+    repair them, because a version number that has already been fetched
+    cannot be recalled.
+    """
+    results: dict[str, dict[str, list[tuple[str, str]]]] = {}
+    for package in packages:
+        paths = (package.pyproject, *package.dist_paths)
+        commits = list(reversed(git.touching_commits(ref, paths)))
+        by_version: dict[str, dict[str, list[str]]] = {}
+        for commit in commits:
+            state = read_state(git, commit, package)
+            if state is None:
+                continue
+            by_version.setdefault(state.version, {}).setdefault(state.digest, []).append(commit)
+        collisions = {
+            version: [(digest, commits_[0]) for digest, commits_ in digests.items()]
+            for version, digests in by_version.items()
+            if len(digests) > 1
+        }
+        if collisions:
+            results[package.name] = collisions
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=".", help="repository to inspect")
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="the pull request's base. The merge base of this and --head-ref "
+        "is what monotonicity is measured against.",
+    )
+    parser.add_argument("--head-ref", default="HEAD", help="the pull request's head")
+    parser.add_argument(
+        "--main-ref",
+        default=None,
+        help="the branch whose whole history must not already claim the "
+        "head's version. Defaults to --base-ref. This is deliberately not "
+        "the merge base; see MERGE BASE VERSUS TIP in the module docstring.",
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="report versions already shipped with more than one content, and "
+        "exit 0 regardless. History archaeology, not a gate.",
+    )
+    args = parser.parse_args(argv)
+
+    git = Git(args.repo)
+
+    if args.audit:
+        ref = args.main_ref or args.base_ref
+        collisions = audit(git, ref)
+        if not collisions:
+            print(f"audit: no version on {ref} shipped with two contents.")
+            return 0
+        for name, versions in collisions.items():
+            print(f"{name}: {len(versions)} version(s) shipped with >1 content")
+            for version, states in versions.items():
+                print(f"  {version}: {len(states)} distinct contents")
+                for digest, commit in states:
+                    print(f"    {digest[:8]}  first at {commit[:9]}  {git.subject(commit)[:60]}")
+        return 0
+
+    report = check(git, args.base_ref, args.head_ref, args.main_ref)
+
+    if not report.examined:
+        print(
+            "check_package_version_bump: no covered package was present at "
+            f"{args.head_ref}. Nothing was verified.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if report.ok:
+        if report.changed:
+            print(
+                "Version bump OK for: "
+                + ", ".join(report.changed)
+                + f" (merge base {report.merge_base[:9]})"
+            )
+        else:
+            print(
+                f"No covered package changed since the merge base "
+                f"({report.merge_base[:9]}); "
+                f"{len(report.examined)} package(s) examined."
+            )
+        return 0
+
+    print("", file=sys.stderr)
+    print("Package version check FAILED.", file=sys.stderr)
+    print("", file=sys.stderr)
+    for finding in report.findings:
+        print(f"  [{finding.code}] {finding.message}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Why this exists: two branches can bump to the same number from the "
+        "same starting point, and git merges the identical version line "
+        "without a conflict and without listing the file in the merge stat. "
+        "See the module docstring of backend/scripts/check_package_version_bump.py.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/tests/scripts/test_check_package_version_bump.py
+++ b/backend/tests/scripts/test_check_package_version_bump.py
@@ -1,0 +1,749 @@
+"""The version guard has to fire on the case git merges silently.
+
+THE CASE THAT MATTERS
+    Two branches start from ``version = "0.46.0"``. Both bump to
+    ``0.47.0``. The first merges. When the second merges, both sides hold
+    the byte-identical version line, so git reports no conflict and does
+    not list the file in the merge stat -- and one version number now
+    describes two different packages.
+
+    ``test_equal_version_already_claimed_on_main_fails`` is that case, and
+    it is the reason this file exists. Note what it costs the naive design:
+    the second branch's bump *is* monotonic against its own merge base
+    (0.47.0 > 0.46.0), so a check that only compares against the merge base
+    passes it. Catching it needs the separate novelty scan over main's
+    history. ``test_the_collision_case_survives_a_merge_base_only_check``
+    pins that distinction, so nobody simplifies the guard back into the
+    hole it was written to close.
+
+WHY THESE TESTS BUILD REAL GIT REPOSITORIES
+    The subject is git's own behaviour across a merge base, and a mocked
+    ``git`` would be a mock of the exact thing in doubt. Each test creates a
+    throwaway repository under ``tmp_path`` with the real package layout,
+    commits, branches, and runs the checker against it. Nothing here reads
+    or depends on the state of the repository it ships in, except the
+    wiring tests at the bottom, which read the workflow file on purpose.
+
+VACUITY
+    A guard is maximally exposed to passing without checking anything, so
+    the assertions below are on the *verdict and the reason*, never on the
+    mere absence of a failure: every negative case asserts the specific
+    finding code, and every positive case asserts the package was actually
+    examined and seen to change. ``test_main_refuses_when_nothing_was_examined``
+    covers the degenerate case directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_ROOT.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "repo-gate.yml"
+
+
+def _load_module(name: str, path: Path):
+    """Import by path.
+
+    This file is run by the repo gate with ``--noconftest`` from the
+    repository root, where ``from scripts import ...`` is unavailable, and
+    also by the backend complement gate with ``backend/`` as the rootdir.
+    Importing by path is the only spelling that works in both. Same
+    reasoning, and same helper, as ``test_gate_coverage.py``.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution because ``@dataclass`` resolves its own
+    # module out of ``sys.modules`` while the class body is being processed,
+    # and raises AttributeError on None if it is not there yet.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_module(
+    "check_package_version_bump",
+    BACKEND_ROOT / "scripts" / "check_package_version_bump.py",
+)
+
+
+# ---------------------------------------------------------------------------
+# Semantic version ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("lower", "higher"),
+    [
+        # The lexical trap, stated first because it is the one that would
+        # silently pass a downgrade: "0.10.0" < "0.9.0" as strings.
+        pytest.param("0.9.0", "0.10.0", id="lexical-trap-minor"),
+        pytest.param("0.9.9", "0.10.0", id="lexical-trap-carry"),
+        pytest.param("0.46.0", "0.47.0", id="the-incident"),
+        pytest.param("1.9.0", "1.10.0", id="lexical-trap-in-1x"),
+        pytest.param("0.2.0", "0.2.1", id="patch"),
+        pytest.param("0.2.9", "0.3.0", id="minor-over-patch"),
+        pytest.param("0.99.0", "1.0.0", id="major"),
+        pytest.param("1.0.0", "1.0.0.post1", id="post-outranks-final"),
+        pytest.param("1.0.0rc1", "1.0.0", id="final-outranks-rc"),
+        pytest.param("1.0.0a1", "1.0.0b1", id="beta-outranks-alpha"),
+        pytest.param("1.0.0b1", "1.0.0rc1", id="rc-outranks-beta"),
+        pytest.param("1.0.0.dev1", "1.0.0a1", id="dev-precedes-pre"),
+        pytest.param("1.0.0a1", "1.0.0a2", id="pre-number"),
+    ],
+)
+def test_version_ordering_is_semantic_not_lexical(lower: str, higher: str) -> None:
+    assert checker.compare_versions(higher, lower) == 1, (lower, higher)
+    assert checker.compare_versions(lower, higher) == -1, (lower, higher)
+
+
+@pytest.mark.parametrize(
+    ("a", "b"),
+    [
+        pytest.param("0.9", "0.9.0", id="padded-equal"),
+        pytest.param("1.0.0", "1.0.0", id="identical"),
+        pytest.param("1.2.3", "v1.2.3", id="v-prefix-ignored"),
+    ],
+)
+def test_equivalent_spellings_rank_equal(a: str, b: str) -> None:
+    assert checker.compare_versions(a, b) == 0
+
+
+def test_lexical_comparison_would_have_got_this_wrong() -> None:
+    """Pin the trap itself, so the semantic key is not 'simplified' away."""
+    assert "0.10.0" < "0.9.0"  # string comparison, the wrong answer
+    assert checker.compare_versions("0.10.0", "0.9.0") == 1  # the right one
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "latest", "1.0.0-alpha+deadbeef+x", "not.a.version", "0.1.x", "1..0"],
+)
+def test_unrankable_versions_are_refused_not_guessed(bad: str) -> None:
+    with pytest.raises(checker.VersionError):
+        checker.version_key(bad)
+
+
+# ---------------------------------------------------------------------------
+# A throwaway repository with the real package layout
+# ---------------------------------------------------------------------------
+
+PKG = checker.PACKAGES[0]  # tckdb-client
+assert PKG.name == "tckdb-client"
+PYPROJECT = PKG.pyproject
+MODULE = PKG.dist_paths[0] + "/tckdb_client/__init__.py"
+
+
+def _pyproject(version: str) -> str:
+    return (
+        "[project]\n"
+        'name = "tckdb-client"\n'
+        f'version = "{version}"\n'
+        'requires-python = ">=3.10"\n'
+    )
+
+
+class Repo:
+    """A real git repository, built commit by commit."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        root.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", ".")
+        self._git("config", "user.email", "gate@example.invalid")
+        self._git("config", "user.name", "gate")
+        self._git("config", "commit.gpgsign", "false")
+
+    def _git(self, *args: str) -> str:
+        proc = subprocess.run(
+            ["git", "-C", str(self.root), *args],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, f"git {args}: {proc.stderr}"
+        return proc.stdout
+
+    def write(self, rel: str, text: str) -> None:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def commit(self, message: str, *, version: str | None = None, body: str | None = None):
+        """Commit a package state. ``version`` and ``body`` are independent."""
+        if version is not None:
+            self.write(PYPROJECT, _pyproject(version))
+        if body is not None:
+            self.write(MODULE, body)
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", message)
+        return self._git("rev-parse", "HEAD").strip()
+
+    def branch(self, name: str) -> None:
+        self._git("checkout", "-q", "-b", name)
+
+    def checkout(self, name: str) -> None:
+        self._git("checkout", "-q", name)
+
+    def tag(self, name: str, message: str = "pinned") -> None:
+        self._git("tag", "-a", name, "-m", message)
+
+    @property
+    def git(self):
+        return checker.Git(str(self.root))
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Repo:
+    """A repository whose main branch holds tckdb-client 0.46.0."""
+    r = Repo(tmp_path / "repo")
+    r.commit("baseline", version="0.46.0", body="VALUE = 1\n")
+    return r
+
+
+def _check(repo: Repo, head: str = "feat", base: str = "main", main: str | None = None):
+    return checker.check(repo.git, base_ref=base, head_ref=head, main_ref=main or base)
+
+
+def _codes(report) -> set[str]:
+    return {f.code for f in report.findings}
+
+
+# ---------------------------------------------------------------------------
+# The four cases the brief requires, each with its verdict
+# ---------------------------------------------------------------------------
+
+
+def test_case_1_version_raised_passes(repo: Repo) -> None:
+    """Package changed, version raised. PASS."""
+    repo.branch("feat")
+    repo.commit("feature", version="0.47.0", body="VALUE = 2\n")
+
+    report = _check(repo)
+
+    # Prove the check actually looked at something. A report with an empty
+    # `examined` would pass `ok` trivially.
+    assert PKG.name in report.examined
+    assert PKG.name in report.changed, "the guard did not notice the package changed"
+    assert report.findings == []
+    assert report.ok
+
+
+def test_case_2_version_unchanged_while_package_changed_fails(repo: Repo) -> None:
+    """Package changed, version left alone. FAIL -- the standing rule."""
+    repo.branch("feat")
+    repo.commit("feature without a bump", body="VALUE = 2\n")
+
+    report = _check(repo)
+
+    assert PKG.name in report.changed
+    assert _codes(report) == {"not-bumped"}
+    assert not report.ok
+    message = report.findings[0].message
+    assert "0.46.0" in message
+    assert "Raise it" in message
+
+
+def test_case_3_version_lowered_fails(repo: Repo) -> None:
+    """Package changed, version moved backwards. FAIL."""
+    repo.branch("feat")
+    repo.commit("feature with a downgrade", version="0.45.0", body="VALUE = 2\n")
+
+    report = _check(repo)
+
+    assert PKG.name in report.changed
+    assert _codes(report) == {"lowered"}
+    assert not report.ok
+    assert "LOWER" in report.findings[0].message
+
+
+def test_case_3b_version_lowered_with_no_content_change_fails(repo: Repo) -> None:
+    """A number must never go backwards, bump or no bump. FAIL."""
+    repo.branch("feat")
+    repo.commit("gratuitous downgrade", version="0.45.0")
+
+    report = _check(repo)
+
+    assert PKG.name not in report.changed  # content genuinely identical
+    assert _codes(report) == {"lowered"}
+    assert not report.ok
+
+
+def test_case_4_equal_version_already_claimed_on_main_fails(repo: Repo) -> None:
+    """THE case that slipped through.
+
+    Both branches bump 0.46.0 -> 0.47.0 from the same starting point. The
+    first has already merged. The second is still monotonic against its own
+    merge base, so only the novelty scan can catch it.
+    """
+    base = repo._git("rev-parse", "HEAD").strip()
+
+    # Agent B branches, bumps to 0.47.0 with its own contents.
+    repo.branch("feat")
+    repo.commit("agent B feature", version="0.47.0", body="VALUE = 'B'\n")
+
+    # Agent A merged first: main now also holds 0.47.0, different contents.
+    repo.checkout("main")
+    repo.commit("agent A feature (merged first)", version="0.47.0", body="VALUE = 'A'\n")
+
+    report = _check(repo, head="feat", base="main", main="main")
+
+    assert report.merge_base == base, "monotonicity must be measured from the branch point"
+    assert PKG.name in report.changed
+    assert _codes(report) == {"version-already-claimed"}
+    assert not report.ok
+    message = report.findings[0].message
+    assert "0.47.0" in message
+    assert "DIFFERENT contents" in message
+
+
+def test_the_collision_case_survives_a_merge_base_only_check(repo: Repo) -> None:
+    """A merge-base-only guard passes the collision. Pin why both refs exist.
+
+    If someone ever 'simplifies' the checker by dropping the novelty scan,
+    this test is the one that explains what was lost: the bump in case 4 is
+    perfectly monotonic against the merge base.
+    """
+    repo.branch("feat")
+    repo.commit("agent B feature", version="0.47.0", body="VALUE = 'B'\n")
+    repo.checkout("main")
+    repo.commit("agent A feature", version="0.47.0", body="VALUE = 'A'\n")
+
+    git = repo.git
+    merge_base = git.merge_base("main", "feat")
+    at_base = checker.read_state(git, merge_base, PKG)
+    at_head = checker.read_state(git, git.rev_parse("feat"), PKG)
+
+    # Monotonicity alone says this branch is fine...
+    assert checker.compare_versions(at_head.version, at_base.version) == 1
+    # ...and it is not.
+    assert not _check(repo, head="feat", base="main", main="main").ok
+
+
+# ---------------------------------------------------------------------------
+# Merge base, not main's tip
+# ---------------------------------------------------------------------------
+
+
+def test_a_branch_merely_behind_main_is_not_failed(repo: Repo) -> None:
+    """Main moving on must not fail a correct bump made from the branch point.
+
+    This is why monotonicity uses the merge base. Against main's tip, this
+    branch's 0.47.0 would be compared with 0.48.0 and refused for something
+    its author did not do.
+    """
+    repo.branch("feat")
+    repo.commit("a correct bump from the branch point", version="0.47.0", body="VALUE = 2\n")
+
+    repo.checkout("main")
+    # Main advances, in a way that does not collide: different version.
+    repo.commit("unrelated work", version="0.48.0", body="OTHER = 1\n")
+
+    report = _check(repo, head="feat", base="main", main="main")
+
+    assert PKG.name in report.changed
+    assert report.findings == [], "a branch that is merely behind must not be failed"
+    assert report.ok
+
+
+def test_novelty_scan_sees_main_beyond_the_merge_base(repo: Repo) -> None:
+    """And this is why novelty does NOT use the merge base.
+
+    The colliding version is not on the merge base's history at all; it
+    arrived on main afterwards, which is what made the collision possible.
+    """
+    repo.branch("feat")
+    repo.commit("feature", version="0.47.0", body="VALUE = 'B'\n")
+    repo.checkout("main")
+    repo.commit("collides", version="0.47.0", body="VALUE = 'A'\n")
+
+    git = repo.git
+    merge_base = git.merge_base("main", "feat")
+
+    # Confirm the premise: 0.47.0 is genuinely absent from the merge base's
+    # own history, so a scan rooted there could not have found it.
+    history = git.touching_commits(merge_base, (PKG.pyproject, *PKG.dist_paths))
+    versions = {checker.read_state(git, c, PKG).version for c in history}
+    assert "0.47.0" not in versions
+
+    assert _codes(_check(repo, head="feat", base="main", main="main")) == {
+        "version-already-claimed"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tags
+# ---------------------------------------------------------------------------
+
+
+def test_reusing_a_tagged_version_fails(tmp_path: Path) -> None:
+    """A tag is a pin something downstream may hold. Reusing it is refused.
+
+    This is the real ``tckdb-schemas-v0.8.0`` shape: the tag pins 0.8.0
+    "for tckdb-adapters/tckdb_arc (Phase 1)", and a later change shipped
+    different contents under the same number. Constructed so that
+    monotonicity *passes* -- otherwise this would be testing the bump check
+    again rather than the tag check.
+    """
+    r = Repo(tmp_path / "tagged")
+    r.commit("baseline", version="0.45.0", body="VALUE = 1\n")
+
+    # A release branch cut 0.46.0 and pinned it.
+    r.branch("rel")
+    r.commit("the release that was pinned", version="0.46.0", body="VALUE = 'TAGGED'\n")
+    r.tag("tckdb-client-v0.46.0", "pinned for a downstream adapter")
+
+    # main never saw 0.46.0, so the novelty scan over main cannot catch this.
+    r.checkout("main")
+    r.branch("feat")
+    r.commit("different contents, same number", version="0.46.0", body="VALUE = 'NEW'\n")
+
+    report = checker.check(r.git, base_ref="main", head_ref="feat", main_ref="main")
+
+    # Monotonicity is satisfied: 0.46.0 > 0.45.0 at the merge base.
+    assert checker.compare_versions("0.46.0", "0.45.0") == 1
+    assert _codes(report) == {"version-already-tagged"}
+    assert not report.ok
+    assert "tckdb-client-v0.46.0" in report.findings[0].message
+
+
+def test_an_untouched_package_is_not_failed_for_history_it_did_not_make(
+    repo: Repo,
+) -> None:
+    """Scope: the gate polices this change, not the baseline.
+
+    ``--audit`` on the real origin/main finds five colliding tckdb-schemas
+    versions and a tckdb-mcp that has never been bumped. If the novelty scan
+    ran for packages a pull request did not touch, the gate would be red on
+    an untouched main -- red for everybody, which is how a gate stops being
+    required.
+    """
+    # main already contains a collision: 0.46.0 with two different contents.
+    repo.commit("silently changed under the same number", body="VALUE = 999\n")
+    repo.branch("feat")
+    # The branch touches nothing in the package.
+    repo.write("README.md", "unrelated\n")
+    repo._git("add", "-A")
+    repo._git("commit", "-q", "-m", "docs only")
+
+    report = _check(repo, head="feat", base="main", main="main")
+
+    assert PKG.name in report.examined, "the package must still be examined"
+    assert PKG.name not in report.changed
+    assert report.findings == []
+    assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# What counts as a change
+# ---------------------------------------------------------------------------
+
+
+def test_a_bump_alone_does_not_justify_itself(repo: Repo) -> None:
+    """The version line is excluded from the content digest.
+
+    If it were not, every bump would register as a content change and the
+    monotonicity check would be vacuous -- satisfied by the very edit it is
+    supposed to be judging.
+    """
+    repo.branch("feat")
+    repo.commit("bump only", version="0.47.0")
+
+    report = _check(repo)
+
+    assert PKG.name not in report.changed
+    assert report.ok
+
+
+def test_a_dependency_change_counts_as_a_change(repo: Repo) -> None:
+    """pyproject minus the version line is in scope: a pin change ships."""
+    repo.branch("feat")
+    repo.write(
+        PYPROJECT,
+        _pyproject("0.46.0") + 'dependencies = ["tckdb-schemas>=0.35.0"]\n',
+    )
+    repo._git("add", "-A")
+    repo._git("commit", "-q", "-m", "raise the schemas floor")
+
+    report = _check(repo)
+
+    assert PKG.name in report.changed
+    assert _codes(report) == {"not-bumped"}
+
+
+def test_a_readme_change_does_not_demand_a_bump(repo: Repo) -> None:
+    """The line is drawn at the importable tree, on purpose.
+
+    A checker that demands a version bump for a README typo is a checker
+    that gets switched off, and then it is not guarding the enum members
+    either. Same reasoning as check_runtime_ascii.py's docstring/prose
+    carve-out.
+    """
+    repo.branch("feat")
+    repo.write("clients/python/README.md", "a typo fix\n")
+    repo._git("add", "-A")
+    repo._git("commit", "-q", "-m", "fix a typo")
+
+    report = _check(repo)
+
+    assert PKG.name not in report.changed
+    assert report.ok
+
+
+def test_a_test_only_change_does_not_demand_a_bump(repo: Repo) -> None:
+    """tests/ is not in the wheel."""
+    repo.branch("feat")
+    repo.write("clients/python/tests/test_thing.py", "def test_x():\n    pass\n")
+    repo._git("add", "-A")
+    repo._git("commit", "-q", "-m", "add a test")
+
+    report = _check(repo)
+
+    assert PKG.name not in report.changed
+    assert report.ok
+
+
+def test_a_new_package_is_examined_and_novelty_checked(repo: Repo) -> None:
+    """A package absent at the merge base still gets its number checked."""
+    repo.branch("feat")
+    repo.write(
+        checker.PACKAGES[1].pyproject,
+        '[project]\nname = "tckdb-schemas"\nversion = "0.1.0"\n',
+    )
+    repo.write(
+        checker.PACKAGES[1].dist_paths[0] + "/__init__.py",
+        "VALUE = 1\n",
+    )
+    repo._git("add", "-A")
+    repo._git("commit", "-q", "-m", "add the schemas package")
+
+    report = _check(repo)
+
+    assert "tckdb-schemas" in report.examined
+    assert "tckdb-schemas" in report.changed
+    assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# Vacuity: the guard must refuse to pass having checked nothing
+# ---------------------------------------------------------------------------
+
+
+def test_main_refuses_when_nothing_was_examined(tmp_path: Path, capsys) -> None:
+    """A repository with no covered package must not report success.
+
+    This is the trivial-pass shape the guard is most exposed to: walk an
+    empty list, find no violations, exit 0.
+    """
+    r = Repo(tmp_path / "empty")
+    r.write("unrelated.txt", "hello\n")
+    r._git("add", "-A")
+    r._git("commit", "-q", "-m", "nothing to do with any package")
+
+    exit_code = checker.main(
+        ["--repo", str(r.root), "--base-ref", "main", "--head-ref", "main"]
+    )
+
+    assert exit_code == 1, "a check that examined nothing must not pass"
+    assert "Nothing was verified" in capsys.readouterr().err
+
+
+def test_main_exits_nonzero_on_a_violation(repo: Repo, capsys) -> None:
+    """The gate's exit status, not just the report object, must fail."""
+    repo.branch("feat")
+    repo.commit("no bump", body="VALUE = 2\n")
+
+    exit_code = checker.main(
+        ["--repo", str(repo.root), "--base-ref", "main", "--head-ref", "feat"]
+    )
+
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "not-bumped" in err
+    assert "without a conflict" in err, "the failure must explain why it exists"
+
+
+def test_main_exits_zero_on_a_correct_bump(repo: Repo, capsys) -> None:
+    repo.branch("feat")
+    repo.commit("correct", version="0.47.0", body="VALUE = 2\n")
+
+    exit_code = checker.main(
+        ["--repo", str(repo.root), "--base-ref", "main", "--head-ref", "feat"]
+    )
+
+    assert exit_code == 0
+    assert "tckdb-client" in capsys.readouterr().out
+
+
+def test_an_unresolvable_novelty_ref_fails_instead_of_passing(repo: Repo) -> None:
+    """The novelty scan must never be silently skipped.
+
+    If a missing remote-tracking branch made the scan return "no conflict",
+    the one case this guard exists for would report a pass. Refusing is the
+    only safe direction.
+    """
+    repo.branch("feat")
+    repo.commit("feature", version="0.47.0", body="VALUE = 2\n")
+
+    with pytest.raises(RuntimeError, match="cannot resolve the novelty ref"):
+        checker.check(
+            repo.git,
+            base_ref="main",
+            head_ref="feat",
+            main_ref="origin/does-not-exist",
+        )
+
+
+def test_a_shallow_clone_fails_loudly(tmp_path: Path) -> None:
+    """No merge base means the check cannot run, and must say so.
+
+    ``actions/checkout@v4`` defaults to ``fetch-depth: 1``. If that default
+    ever comes back, this check must fail rather than silently find nothing.
+    """
+    a = Repo(tmp_path / "a")
+    a.commit("a", version="0.1.0", body="A = 1\n")
+    a._git("checkout", "-q", "--orphan", "unrelated")
+    a.commit("b", version="0.2.0", body="B = 1\n")
+
+    with pytest.raises(RuntimeError, match="no merge base"):
+        checker.check(a.git, base_ref="main", head_ref="unrelated")
+
+
+# ---------------------------------------------------------------------------
+# Coverage: aimed at every package, not at fewer than it should be
+# ---------------------------------------------------------------------------
+
+
+def test_every_pyproject_is_covered_or_excluded() -> None:
+    """The recurring defect here is a correct check aimed too narrowly.
+
+    ``check_runtime_ascii.py`` records four separate occasions on which one
+    of this repository's checkers was pointed at fewer trees than it should
+    have been, each found by a person noticing months later. This test is
+    the cheap way not to repeat it.
+    """
+    covered = {p.pyproject for p in checker.PACKAGES}
+    excluded = set(checker.EXCLUDED_PYPROJECTS)
+
+    # Relative parts, not absolute: a git worktree of this repository lives
+    # under .claude/worktrees/, so filtering on path.parts silently excluded
+    # every file in the tree and left this test asserting over an empty set.
+    # That is the house defect -- a check that passes having verified nothing
+    # -- and it happened while writing this very test.
+    ignored = {".git", "node_modules", "build", "dist", ".venv", ".claude", ".tox"}
+    found = set()
+    for path in REPO_ROOT.rglob("pyproject.toml"):
+        rel_parts = path.relative_to(REPO_ROOT).parts
+        if any(part in ignored for part in rel_parts):
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel.endswith(".egg-info/pyproject.toml"):
+            continue
+        found.add(rel)
+
+    # Guard the guard: if the walk finds nothing, the two assertions below
+    # are both vacuously true.
+    assert len(found) >= len(covered), (
+        f"the pyproject walk found only {sorted(found)}, fewer than the "
+        f"{len(covered)} packages already known to be covered. The walk is "
+        f"broken, and this test would pass having checked nothing."
+    )
+
+    unaccounted = found - covered - excluded
+    assert not unaccounted, (
+        "these pyproject.toml files are neither covered by PACKAGES nor "
+        "listed in EXCLUDED_PYPROJECTS with a reason, so a version collision "
+        "in them would go unnoticed:\n  " + "\n  ".join(sorted(unaccounted))
+    )
+
+    stale = (covered | excluded) - found
+    assert not stale, (
+        "these are declared but do not exist; the registry has drifted:\n  "
+        + "\n  ".join(sorted(stale))
+    )
+
+
+def test_every_excluded_pyproject_states_a_reason() -> None:
+    for path, reason in checker.EXCLUDED_PYPROJECTS.items():
+        assert len(reason) > 40, f"{path} needs a real reason, not {reason!r}"
+
+
+def test_covered_dist_paths_exist_for_the_current_layout() -> None:
+    """Each covered package must have at least one real importable tree.
+
+    A typo in ``dist_paths`` would make the content digest depend on the
+    pyproject alone, and the guard would stop noticing code changes -- while
+    still passing.
+    """
+    for package in checker.PACKAGES:
+        assert (REPO_ROOT / package.pyproject).is_file(), package.pyproject
+        present = [p for p in package.dist_paths if (REPO_ROOT / p).is_dir()]
+        assert present, (
+            f"{package.name}: none of dist_paths={package.dist_paths} exists, "
+            f"so the guard would not see a code change in it"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the gate has to actually run, with enough history to run on
+# ---------------------------------------------------------------------------
+
+
+def test_the_gate_runs_in_the_unfiltered_workflow() -> None:
+    """The guard must run on every pull request.
+
+    It cannot live in a path-filtered workflow: a pull request that changes
+    only ``integrations/mcp/`` would not start ``python-client-ci.yml``, and
+    the collision it is guarding against would sail through unexamined.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "backend/scripts/check_package_version_bump.py" in text, (
+        "the version guard is not invoked by repo-gate.yml, the one workflow "
+        "with no path filter"
+    )
+    assert "backend/tests/scripts/test_check_package_version_bump.py" in text, (
+        "the guard's own tests must run in the unfiltered workflow too; a "
+        "defect in the guard is a defect in the gate"
+    )
+
+
+def test_the_gate_has_the_history_it_needs() -> None:
+    """A merge base needs full history, and checkout defaults to depth 1."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "fetch-depth: 0" in text, (
+        "repo-gate.yml must check out full history, or git merge-base has "
+        "nothing to compute against and the guard cannot run"
+    )
+    assert "fetch-tags: true" in text, (
+        "fetch-depth: 0 does not fetch tags -- actions/checkout passes "
+        "--no-tags unless asked. Without tags the guard's tag check sees an "
+        "empty list, reports no conflict, and is silently inert"
+    )
+
+
+def test_the_gate_passes_a_base_and_a_separate_novelty_ref() -> None:
+    """The two refs answer different questions and must not be collapsed.
+
+    A single ref cannot do both jobs: monotonicity needs the branch point
+    (or a branch that is merely behind gets blamed for someone else's merge)
+    and novelty needs the current tip (or the colliding version, which lands
+    after the branch point, is invisible). If a future edit passes only one,
+    the guard silently loses one of its two halves.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    invocation = text.split("check_package_version_bump.py", 1)[1]
+    # The gate step, not the pytest step: take the text after the script name.
+    assert "--base-ref" in invocation, "the merge-base comparison has no base"
+    assert "--main-ref" in invocation, (
+        "no --main-ref is passed, so the novelty scan falls back to the base "
+        "sha and cannot see a sibling that merged after this branch ran"
+    )
+    assert "pull_request.base.sha" in invocation, (
+        "--base-ref should be the event's base sha; merge-base is computed "
+        "from it inside the script"
+    )


### PR DESCRIPTION
## Plain language first

Two of our Python packages get installed by other people: `tckdb-client`, which
talks to the API, and `tckdb-schemas`, which defines the shape of an upload.
Each carries a **version number** — a label like `0.47.0` meaning "this exact
set of files". The standing rule is that changing one of those packages raises
its number, so anyone who installed `0.47.0` knows what they got.

The problem: two people can raise the number to *the same* new value at the same
time. Both start at `0.46.0`, both write `0.47.0`, and when the second merges,
**git does not complain** — both sides of the merge contain the identical line
`version = "0.47.0"`, so there is nothing to conflict about. Git does not even
list the file as changed. Now one label describes two different sets of files,
and someone installing "`0.47.0`" gets one or the other depending on the day.

This PR adds a check that runs on every pull request and refuses that situation.
It also **measured whether it has already happened** — and it has, five times,
though not to the package we were worried about.

---

## 1. Has a duplicate already shipped? Yes — five times, to `tckdb-schemas`

Measured before any prevention work, twice, with two independently written
scripts that agree.

`tckdb-schemas` has shipped **five versions that each carry two or three
different sets of files**:

| version | distinct contents | commits | severity |
|---|---|---|---|
| `0.2.0` | 3 | `aa478e3d6`, `daf381405`, `3bc86f3fa` | **substantive** — 167 insertions across 8 modules |
| `0.8.0` | 2 | `1dd7651d0`, `7ad5cb99a` (#50) | **substantive** — 9 new enum lines + 15 in `computed_reaction_upload.py` |
| `0.14.0` | 2 | `ee7377f53` (#66), `01d557093` | cosmetic — a `__version__` dunder catching up from `0.10.0` |
| `0.30.0` | 2 | `9c332e89a` (#163), `0815d99af` | consumer-visible — warning strings changed (`cm^-1` spelling) |
| `0.33.0` | 2 | `d1de9d16d` (#177), `aee41adba` (#181) | docstring only |

To make "substantive" concrete rather than a label: across the two `0.2.0`
states, one lacks `HessianSource` and `TunnelingModel` entirely, along with the
falloff members `lindemann`, `troe`, `sri`, `plog` and `chebyshev`. Two clients
both believing they run `tckdb-schemas 0.2.0` would disagree about which upload
payloads are even *valid* — one rejects what the other accepts.

**The most serious is `0.8.0`, because it is tagged.** The annotated tag
`tckdb-schemas-v0.8.0` reads *"tckdb-schemas 0.8.0 — pinned for
tckdb-adapters/tckdb_arc (Phase 1)"*. That tag's commit contains the **first**
`0.8.0`; `7ad5cb99a` (#50, 2026-07-22) later changed `enums.py` and
`workflows/computed_reaction_upload.py` and left the number at `0.8.0`:

```
git merge-base --is-ancestor 1dd7651d0 tckdb-schemas-v0.8.0   -> YES  (first 0.8.0 is in the tag)
git merge-base --is-ancestor 7ad5cb99a tckdb-schemas-v0.8.0   -> NO   (second 0.8.0 is not)
```

So `tckdb-schemas 0.8.0` fetched from the tag and the same version fetched from
`main` after 2026-07-22 are **different packages with different accepted upload
fields**. That is the "installed pin resolves to one of two packages" harm, and
it is real rather than projected.

Scope limit, stated honestly: `tckdb-adapters/tckdb_arc` is a separate
repository I cannot inspect from here, so I can confirm the tag *declares* a
downstream pin but not what that consumer does with it. In-tree the declared
constraints are floors, not exact pins — `backend/pyproject.toml:102`
`tckdb-schemas>=0.10` and `clients/python/pyproject.toml:52`
`tckdb-schemas>=0.33.0` — and a floor resolves to the newest available, so
in-tree exposure is limited. (Note `0.33.0`, the floor the client declares, is
itself one of the collided versions.)

Two further findings from the same measurement:

- **`tckdb-client` is clean** — zero collisions across 402 commits carrying it.
  The package the brief was worried about is the one that has *not* been
  damaged; the damage is all in `tckdb-schemas`. The near-miss was caught; the
  systematic failure was somewhere nobody was looking.
- **`tckdb-mcp` has never been bumped at all** — `0.1.0` carries four distinct
  sets of files. A different defect (an unmaintained version, not a race) with
  the same consequence. The guard covers it going forward.

### Two corrections to the brief's framing

The brief says the client went `0.46.0` → `0.52.0` "in a single day". Measured,
`2026-08-16 14:02` → `2026-08-17 16:54` — about 27 hours over two calendar days.
The substance (six bumps in barely more than a day, hence high exposure) holds.

And **two of those six bumps changed nothing that ships**: `0.48.0` → `0.49.0`
and `0.51.0` → `0.52.0` each touched only the `version =` line.

```
git diff --stat 1a198bc9a 34845f26c -- clients/python/src clients/python/pyproject.toml
 clients/python/pyproject.toml | 2 +-
```

The guard permits that — a spare number is harmless, unlike a reused one — but
part of the churn raising collision risk is bumps that were not needed. It also
confirms the content digest excludes the version line; without that exclusion
every bump would justify itself and the monotonicity check would be vacuous.

These are recorded, not repaired: a version number already fetched cannot be
recalled. `--audit` reproduces the whole table on demand:

```
python backend/scripts/check_package_version_bump.py --main-ref origin/main --audit
```

## 2. The guard

`backend/scripts/check_package_version_bump.py`, wired into
`.github/workflows/repo-gate.yml` — the **one workflow with no path filter**, so
it runs on every pull request. It could not live in `python-client-ci.yml`:
that workflow's `paths:` filter does not match `integrations/mcp/**`, so a PR
touching only that package would start no job able to notice.

Three checks, and it takes **two different refs** to make them. This is the part
of the brief that is subtly wrong, and it matters:

**(1) Monotonicity — against the merge base.** If the package's shipped content
changed, the version must be *strictly greater* than at the merge base. The
merge base is right here, exactly as the brief says: against `main`'s tip, a
branch that is merely behind gets failed for a bump it made correctly, and the
message blames the author for someone else's merge.

**(2) Novelty — against `main`'s current tip history.** The version must not
already be claimed anywhere on `main`'s first-parent history by *different*
content.

**The brief says the colliding version is "already on the merge base's history".
It is not — and a guard built to that description would not have caught the
incident.** In the real event the colliding `0.47.0` arrived on `main` *after*
the branch point; that is precisely what made the collision possible. A scan
rooted at the merge base cannot see it. Monotonicity asks "did *you* bump?";
novelty asks "is the number you chose taken?" Only the pair is complete, and
they need different refs. `test_novelty_scan_sees_main_beyond_the_merge_base`
and `test_the_collision_case_survives_a_merge_base_only_check` pin both halves
so a later "simplification" cannot quietly reopen the hole.

**(3) Novelty — against release tags.** A `<name>-v<version>` tag pinning that
number to different content fails. This is the `tckdb-schemas-v0.8.0` shape.

### How the merge base is obtained

`actions/checkout@v4` with **`fetch-depth: 0`** (added; the default is depth 1,
which has no merge base at all) **and `fetch-tags: true`** — `fetch-depth: 0`
does *not* bring tags, because the action passes `--no-tags` unless asked, and
without them the tag check would see an empty list, find no conflict, and sit
inert while reporting green. Both are pinned by
`test_the_gate_has_the_history_it_needs`. Then, inside the script,
`git merge-base <base> <head>`. The workflow passes:

- `--base-ref ${{ github.event.pull_request.base.sha }}` — a concrete sha that
  always exists in the checkout, so no remote-ref resolution can fail. The
  script derives `merge-base(base, head)` from it. **Not `main`'s tip.**
- `--main-ref origin/<base_ref>` — the base branch **as fetched at job runtime**,
  fresher than `base.sha` and therefore including a sibling that merged after
  this PR last ran. Deliberately *not* the merge base.

If `--main-ref` cannot be resolved the script **raises** rather than reporting no
conflict; an unresolvable ref silently returning "clean" would be a gate that
verified nothing while looking green
(`test_an_unresolvable_novelty_ref_fails_instead_of_passing`).

### Residual gap, stated rather than hidden

If this job last ran *before* the sibling merged and is never re-run, its green
is stale. No check can close that from inside its own run — it needs **"Require
branches to be up to date before merging"** in branch protection. The guard
narrows the window from "the life of the branch" to "between the last run and the
merge"; it does not eliminate it. That is a settings change, not something this
PR can do.

### What records published versions: almost nothing

Asked and answered rather than assumed.

- **No registry.** No `twine`, no `pypa/gh-action-pypi-publish`, no PyPI
  reference in any workflow. Neither package is published to an index at all.
  (`build-api-image.yml` publishes a Docker image of the backend — unrelated.)
- **Tags: a partial, abandoned ledger.** Exactly two release tags exist,
  `tckdb-client-v0.27.1` and `tckdb-schemas-v0.8.0`, and **both point at the same
  commit** `911df469c` (2026-07-20). The client is now `0.52.0` and schemas
  `0.35.0`, so the `<name>-v<version>` convention existed and was dropped.

The tag check is therefore real but thin, and the guard's weight rests on
monotonicity plus the history scan. I did not invent a release ledger.

### Which packages are covered

All four distributed packages, not just the two named:

| package | pyproject | shipped tree |
|---|---|---|
| `tckdb-client` | `clients/python/pyproject.toml` | `clients/python/src` |
| `tckdb-schemas` | `schemas/python/tckdb-schemas/pyproject.toml` | `.../tckdb_schemas` |
| `tckdb-chemkin` | `clients/python/adapters/chemkin/pyproject.toml` | `.../tckdb_chemkin` |
| `tckdb-mcp` | `integrations/mcp/pyproject.toml` | `integrations/mcp/src/tckdb_mcp` |

`backend/pyproject.toml` is excluded **with a reason in the code**
(`EXCLUDED_PYPROJECTS`): it is the application, nobody installs it from an index,
and its version has been an inert `0.1.0` since it was written.
`test_every_pyproject_is_covered_or_excluded` fails if a new `pyproject.toml`
appears in neither list — because per `check_runtime_ascii.py`'s own history, the
recurring defect in this repo's checkers is not being wrong, it is being **aimed
at fewer places than they should be**, found months late.

Covering all four is a deliberate widening beyond the brief, easy to dial back:
move entries from `PACKAGES` into `EXCLUDED_PYPROJECTS`. It is **not**
retroactive — novelty and tag checks run only for a package whose content the PR
actually changed, so the dirty baseline (`tckdb-schemas`' five, `tckdb-mcp`'s
one) does not turn every PR red. Without that scoping the gate would be red for
everybody, which is how a gate stops being required.

### Version comparison is semantic, not lexical

`0.10.0` > `0.9.0`, the opposite of string order. Implemented as a PEP 440 sort
key (release + optional pre/post/dev, zero-padded so `0.9` and `0.9.0` rank
equal). Anything unparseable is **refused by name** rather than ranked on a
guess, since a guessed order silently *passes* the change it should have stopped.
16 ordering cases are parametrized, including
`test_lexical_comparison_would_have_got_this_wrong`, which asserts the trap
itself (`"0.10.0" < "0.9.0"`) so the semantic key cannot be "simplified" away.

## 3. The alternative: bumping at merge time

Weighed and rejected, with the reasoning written into the script's docstring so
it outlives this PR. It would remove the race outright — one merge at a time, no
second author to collide with — but it contradicts the standing rule that every
client change bumps the version; it moves the decision to a moment when nobody is
reviewing the change, so a wrong number lands unreviewed; and it needs CI write
access to a protected branch, far more than this check's `contents: read`.
Monotonicity + novelty gets the same guarantee with the number still visible in
the diff that earns it. If the rebase-and-renumber loop ever becomes the dominant
cost, that is the moment to revisit.

## 4. The four cases, replayed against real repository history

Not only synthetic fixtures. `703d04574` is the commit that set the client to
`0.46.0` (#195); `4bdcfd3ef` is the one that set `0.47.0` (#197) and merged
first. I cloned the repo, branched from `703d04574`, and replayed each case with
`--main-ref 4bdcfd3ef`:

| case | verdict | finding code |
|---|---|---|
| 1. version raised (`0.46.0` → `0.48.0`), package changed | **PASS** | — |
| 2. package changed, version left at `0.46.0` | **FAIL** | `not-bumped` |
| 3. version lowered (`0.46.0` → `0.45.0`) | **FAIL** | `lowered` |
| 4. **the incident** — `0.47.0`, already merged by a sibling | **FAIL** | `version-already-claimed` |

Case 4's actual message:

```
tckdb-client: version 0.47.0 is already on 4bdcfd3ef's history at 4bdcfd3ef
('Say which field registration refused, not that one was (#197)') with
DIFFERENT contents. Two packages would claim one number, and git will not
conflict on it because both sides spell the version line identically.
Pick the next unused version.
```

Every case reported `examined=['tckdb-client', 'tckdb-schemas', 'tckdb-chemkin',
'tckdb-mcp']` and `changed=['tckdb-client']` — the guard is asserted to have
actually looked at four packages and *noticed* the one that changed, so none of
these is a pass over an empty list. `test_main_refuses_when_nothing_was_examined`
covers the degenerate case directly: a repo with no covered package **exits 1**,
it does not report success. The same four cases are covered again as unit tests
on throwaway git repositories built per test.

## 5. The mutation

Two, because the guard has two independent halves and one mutation would have
left the other unproven.

- `compare_versions` forced to always return `1` ("greater") → **21 tests RED**,
  including cases 2, 3, 3b and every lexical-trap case. Case 4 stayed green,
  correctly: it does not depend on the comparator.
- `_find_conflicting_claim` forced to always return `None` ("no conflict") →
  **3 tests RED**: `test_case_4_equal_version_already_claimed_on_main_fails`,
  `test_the_collision_case_survives_a_merge_base_only_check`,
  `test_novelty_scan_sees_main_beyond_the_merge_base`.

Both reverted. The split confirms the collision case is guarded by the novelty
scan specifically, not incidentally by the version comparison.

One real vacuity bug was caught *while writing these tests*:
`test_every_pyproject_is_covered_or_excluded` filtered on `path.parts`, and
because a git worktree of this repo lives under `.claude/worktrees/`, every path
matched the `.claude` exclusion — the walk found **zero** files and the test
passed having checked nothing. Fixed to use the repo-relative path, plus an added
assertion that the walk finds at least as many files as are already covered.

## 6. Schema and migration impact

**None.** No ORM model, no Pydantic schema, no Alembic revision, no database
access. The check reads git history and text files. No new environment variable.
No package version bump was needed because this PR changes no covered package —
confirmed by running the guard on this very branch:

```
No covered package changed since the merge base (c3424b217); 4 package(s) examined.
```

## 7. Exact commands run

```bash
# Measurement, twice, with two independently written scripts (they agree)
python backend/scripts/check_package_version_bump.py --repo . --main-ref origin/main --audit

# Tag/duplicate relationship
git merge-base --is-ancestor 1dd7651d0 tckdb-schemas-v0.8.0    # YES
git merge-base --is-ancestor 7ad5cb99a tckdb-schemas-v0.8.0    # NO
git for-each-ref --format='%(refname:short) %(objecttype) %(contents:subject)' refs/tags/

# The guard's own tests, as repo-gate runs them (stock python, no DB)
python3 -m pytest --noconftest -q backend/tests/scripts/test_check_package_version_bump.py
#   -> 49 passed

# The gate-coverage machinery still accepts the new file
python3 -m pytest --noconftest -q backend/tests/scripts/test_gate_coverage.py \
                                  backend/tests/scripts/test_aggregate_pr_gates.py
#   -> 67 passed

# The guard against this branch
python backend/scripts/check_package_version_bump.py --repo . \
    --base-ref origin/main --head-ref HEAD --main-ref origin/main
#   -> exit 0, "No covered package changed since the merge base (c3424b217); 4 package(s) examined."

# House lint gates
cd backend && conda run -n tckdb_env ruff check scripts/check_package_version_bump.py \
                       tests/scripts/test_check_package_version_bump.py   # All checks passed!
cd backend && conda run -n tckdb_env python scripts/check_runtime_ascii.py --audit  # clean
cd backend && conda run -n tckdb_env python scripts/check_runtime_ascii.py          # clean

# Under the real conda env WITH backend/tests/conftest.py loaded (the other
# environment this file must survive), isolated DB since siblings share the server
cd backend && DB_TEST_NAME=tckdb_test_verbump conda run -n tckdb_env pytest \
    tests/scripts/ tests/test_test_package_layout.py tests/test_release_metadata.py -q
#   -> 542 passed

# Required full suite, from backend/ as the cwd-relative fixture glob needs.
# Isolated DB name because sibling agents share this PostgreSQL server.
cd backend && DB_TEST_NAME=tckdb_test_vg3 conda run -n tckdb_env \
    pytest tests/ -q -n 4 -p no:cacheprovider
#   -> 8209 passed, 14 skipped, 27 warnings in 1025.88s (0:17:05)
#      zero FAILED, zero ERROR

# The collected total for the committed tree, as a cross-check on the above
cd backend && conda run -n tckdb_env pytest tests/ --collect-only -q | tail -1
#   -> 8223 tests collected          (= 8209 passed + 14 skipped)

# Proof the new tests are inside that number rather than beside it
cd backend && conda run -n tckdb_env pytest tests/ --collect-only -q \
    | grep -c test_check_package_version_bump
#   -> 49
```

`ruff format` is intentionally a no-op in this repo
(`[tool.ruff.format] exclude = ["**"]`, guarded by
`test_ruff_format_is_not_a_trap.py`), so only `ruff check` applies — it passes.

**Full suite: green.** `8209 passed, 14 skipped` in 17m05s, zero `FAILED` and
zero `ERROR`, from `backend/` against an isolated database. That matches the
committed tree's collected total of `8223` exactly (`8209 + 14`). The fixture
reported concurrent sibling runs on the same PostgreSQL server, which is why an
isolated `DB_TEST_NAME` was used; the result is not a shared-database artefact.

<details>
<summary>Why an earlier run of this branch reported 8170 instead, and why local
totals here are not fully reproducible</summary>

I ran the suite twice. An earlier run reported `8170 passed, 14 skipped` — also
green, also zero failures, but 39 tests short. Rather than pick the number I
liked, here is the cause.

The editable installs in `tckdb_env` resolve to the **main checkout**, not to
this worktree:

```
tckdb_schemas -> /home/calvin/code/TCKDB_v2/schemas/python/tckdb-schemas/tckdb_schemas/__init__.py
tckdb_client  -> /home/calvin/code/TCKDB_v2/clients/python/src/tckdb_client/__init__.py
```

So a local `backend/tests/` run imports whatever wire package the main checkout
currently holds, and sibling agents were editing it between my two runs. Tests
parametrized over the wire contract therefore change count run to run, through
no action of this branch.

Two consequences worth stating plainly. Local full-suite *totals* on a worktree
branch are not reproducible while other agents are active — only the
pass/fail verdict and the counts that come from the worktree itself are.
And **CI is the authoritative signal**, because the runner checks out this branch
alone and installs the wire package from it; CI is green. Neither run had a
single `FAILED` or `ERROR`, so the verdict was never in question — but the
number I first quoted was measured against a tree that was partly somebody
else's, and it should not be presented as this branch's.

This branch changes neither wire package, so it cannot be the cause of the
drift; the note is here because a reviewer re-running the suite will get a third
number and deserves to know why.
</details>

The `--collect-only` count above matters more than the total: it shows the 49 new
tests are *inside* that 8170 rather than sitting in a file the suite never
reaches. A new test file that no job collects is the failure mode
`test_gate_coverage.py` exists to catch, and it is the one this PR is most
exposed to.

### Confirmed in the real runner, not just locally

The one thing I could not test on a laptop is whether the workflow's refs resolve
inside a GitHub Actions `pull_request` checkout. They do. From the `CI gate
coverage` job on this PR (21s, green):

```
Run python backend/scripts/check_package_version_bump.py
  --base-ref "c3424b217320666886c326a19ab42dc7733c1075"
  --head-ref "6ccd088f8cbf66fd2b2a4c406edbd1425ddc24fb"
  --main-ref "origin/main"

No covered package changed since the merge base (c3424b217); 4 package(s) examined.
```

Read that verdict line carefully, because it is what distinguishes a real pass
from a green that checked nothing:

- `origin/main` **resolved** — an unresolvable novelty ref raises, so a pass
  proves the remote-tracking branch is there under `fetch-depth: 0`.
- **`4 package(s) examined`** — non-empty. The script exits 1 when it examines
  zero packages, so this number is the guard reporting that it actually looked.
- the merge base was computed as `c3424b217`, from the base sha rather than from
  `main`'s tip.

And the guard's own suite ran in the same job: `49 passed in 3.31s`.

All three workflows on this PR are green: `CI gate coverage` (21s), `Backend CI`,
`CodeQL`. The `Required gates` job also passed, so the aggregate gate still
recognises the workflow after the edit.

## 8. Files

- `backend/scripts/check_package_version_bump.py` (new) — the guard, plus
  `--audit` history archaeology.
- `backend/tests/scripts/test_check_package_version_bump.py` (new) — 49 tests,
  building real throwaway git repositories rather than mocking git, since git's
  own merge-base behaviour across a merge is the subject.
- `.github/workflows/repo-gate.yml` — `fetch-depth: 0` and `fetch-tags: true` on
  the checkout, and two steps added to the existing `CI gate coverage` job.
  **No job renamed and no new job added**, so the required branch-protection
  contexts (`CI gate coverage`, `Required gates`) are untouched.

### Possible positional conflict

A sibling agent is working on CI mypy configuration and another on a test-gate
anchor conversion, so `.github/workflows/` may conflict positionally. Per the
brief I have **not** rebased pre-emptively. Nothing here renames a job or edits
`REQUIRED_WORKFLOWS` / `AGGREGATED_WORKFLOWS`, so any conflict should be textual
rather than semantic.

### A live demonstration, for free

While this PR was being written, a sibling agent overwrote my draft PR
description: we had both chosen the filename `pr_body.md` in a shared scratch
directory, and the second write silently replaced the first with no warning and
no conflict. Same failure as the one this PR guards against, in a different
medium — two writers, one name, last-write-wins, no signal. It cost a rewrite
rather than a bad release, but it is a fair illustration of why the guard is
worth having.
