### PR TITLE
Let mypy see the wire package it was shrugging off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,52 @@ wrapper over a contract that is itself still moving.
 
 ### Fixed
 
+- **The `mypy` gate could not see the wire-contract package, and said
+  "Success" anyway.** `tckdb-schemas` is a first-party package that lives in
+  this repository and is installed *editable*. `mypy` does not read an
+  editable install's import hook, so it could not find the package by name and
+  reported `import-not-found` on all **38** of its imports from
+  `backend/app/schemas` — which `ignore_missing_imports = true` then absorbed
+  silently. The gate reported `Success: no issues found in 149 source files`
+  while every type error *inside* the wire package, and every type error in
+  backend code arising from how it uses the wire package, was invisible to it.
+
+  Made resolvable and made a check target: `mypy_path` points at the package,
+  the package is listed in `files`, and `ignore_missing_imports` is now
+  **off**. All three are necessary and none substitutes for another.
+  `follow_imports = "silent"` means a merely-*imported* module is analysed but
+  its own errors are suppressed, so `mypy_path` alone would still have said
+  nothing about a broken annotation inside the package; and
+  `ignore_missing_imports` cannot distinguish "third-party package with no
+  stubs" from "first-party package we failed to point mypy at", which is what
+  made the original failure silent by construction. Measured at the time of
+  the change: nothing in scope needed the setting — all 38 suppressed errors
+  were `tckdb_schemas`. A stubless third-party dependency now needs a narrow
+  per-module override, the way `rdkit` already has one.
+
+  **12 findings** the gate had been missing, all in code that merged green.
+  Eleven are fixed here; one is a documented suppression with its argument on
+  the line. The one that was a live defect rather than an annotation
+  infelicity: `EnergyTransferIn.model` on the pressure-dependent network
+  upload is a **required** `str`, but its normalizer was
+  `normalize_optional_text`, which collapses a blank string to `None`. A
+  whitespace-only energy-transfer model name passes `min_length=1` and then
+  left the field holding `None`. It is now `normalize_required_text`, which
+  refuses the blank with a 422 — which is what `min_length=1` was already
+  promising. The rest: two `float | None` comparisons in the NASA polynomial
+  temperature-bound validator that were guarded by a `None`-count the checker
+  could not read; two loop variables reused across loops over differently
+  shaped payloads; and one dict annotated with the ORM `CalculationType` while
+  holding the wire `CalculationType` — two distinct classes with identical
+  members, whose every comparison worked only because both subclass `str`.
+
+  Gate scope went from 149 to 183 source files. Proven by mutation, because a
+  configuration change that silently still ignores the package looks identical
+  to one that works: a deliberate `return 12345` from a `-> str` function
+  inside the wire package, a deliberate misuse of a `tckdb_schemas` symbol
+  from `backend/app`, and a deliberately unresolvable `mypy_path` each fail
+  the gate now and each passed it green before.
+
 - **A full artifact store is no longer reported as "retry later", and no
   longer reports itself as healthy.** Two halves of one defect.
 

--- a/backend/app/schemas/workflows/network_pdep_upload.py
+++ b/backend/app/schemas/workflows/network_pdep_upload.py
@@ -53,6 +53,7 @@ from app.schemas.reaction_family import find_canonical_reaction_family
 # Re-exported for backwards compatibility — ArtifactIn now lives in
 # app/schemas/fragments/artifact.py.
 __all__ = ("ArtifactIn",)
+from tckdb_schemas.enums import CalculationType as PayloadCalculationType
 from tckdb_schemas.fragments.ts_validation_evidence import (
     TransitionStateValidationEvidenceIn,
     validate_ts_evidence_set,
@@ -82,7 +83,7 @@ from tckdb_schemas.stationary_point import (
 )
 from tckdb_schemas.workflows.computed_species_upload import StatmechInBundle
 
-from app.schemas.utils import normalize_optional_text
+from app.schemas.utils import normalize_optional_text, normalize_required_text
 from app.schemas.workflows.literature_upload import LiteratureUploadRequest
 from app.schemas.workflows.transport_upload import TransportUploadPayload
 
@@ -590,7 +591,13 @@ class EnergyTransferIn(SchemaBase):
 
     @model_validator(mode="after")
     def normalize_text(self) -> Self:
-        self.model = normalize_optional_text(self.model)
+        # `normalize_required_text`, not `normalize_optional_text`. `model`
+        # is a required `str`, and the optional helper collapses a blank
+        # string to None -- so a whitespace-only model name (which passes
+        # `min_length=1`) left this field holding None on a non-optional
+        # column-bound value. The required helper refuses the blank with a
+        # 422 instead, which is what `min_length=1` was already promising.
+        self.model = normalize_required_text(self.model)
         self.note = normalize_optional_text(self.note)
         return self
 
@@ -1394,7 +1401,15 @@ class NetworkPDepUploadRequest(SchemaBase):
         for sp in self.species:
             if sp.statmech is None:
                 continue
-            own_calc_types: dict[str, CalculationType] = {}
+            # Annotated with the *payload* enum, not the ORM one. `calc.type`
+            # comes off a wire-package `CalculationIn`, so it is a
+            # `tckdb_schemas.enums.CalculationType`; this module's bare
+            # `CalculationType` is `app.db.models.common.CalculationType`.
+            # The two are distinct classes with identical members, and every
+            # comparison between them happens to work only because both are
+            # `str` subclasses -- so the mismatch was invisible until mypy
+            # could see the wire package's types at all.
+            own_calc_types: dict[str, PayloadCalculationType] = {}
             for conf in sp.conformers:
                 own_calc_types[conf.calculation.key] = conf.calculation.type
             for calc in sp.calculations:
@@ -1458,18 +1473,21 @@ class NetworkPDepUploadRequest(SchemaBase):
                         declared=species_keys,
                     )
 
-            # Solve source calculations must reference defined calculation keys
-            for sc_index, sc in enumerate(self.solve.source_calculations):
-                if sc.calculation_key not in calculation_keys:
+            # Solve source calculations must reference defined calculation keys.
+            # Named `solve_sc`, not `sc`: the statmech loop earlier in this
+            # same function binds `sc` to a `StatmechSourceCalcIn`, so reusing
+            # the name gave the solve entry the statmech entry's static type.
+            for sc_index, solve_sc in enumerate(self.solve.source_calculations):
+                if solve_sc.calculation_key not in calculation_keys:
                     raise undeclared_key_error(
                         W_CALCULATION_KEY_UNDECLARED,
                         f"Solve source_calculations references undefined "
-                        f"calculation_key '{sc.calculation_key}'.",
+                        f"calculation_key '{solve_sc.calculation_key}'.",
                         field=(
                             f"solve.source_calculations[{sc_index}]."
                             f"calculation_key"
                         ),
-                        key=sc.calculation_key,
+                        key=solve_sc.calculation_key,
                         declared=calculation_keys,
                     )
 

--- a/backend/app/schemas/workflows/statmech_upload.py
+++ b/backend/app/schemas/workflows/statmech_upload.py
@@ -148,7 +148,32 @@ class StatmechSourceCalculationIn(StatmechSourceCalcIn):
     :param role: Scientific role the calculation plays for this statmech.
     """
 
-    calculation_key: str | None = Field(default=None, min_length=1)
+    # Widening a base class's mutable attribute is a Liskov violation, and
+    # mypy is right to say so. It is nonetheless the declared design here,
+    # and the suppression is narrowed to this one line and this one error
+    # code rather than the module.
+    #
+    # The subclass relationship is load-bearing at *runtime*, not just
+    # cosmetic: ``ConformerUploadStatmechPayload.source_calculations`` is
+    # annotated with the key-only base, and Pydantic v2's
+    # ``revalidate_instances="never"`` is what lets an instance of this
+    # subclass pass through that field with ``existing_calculation_id``
+    # intact. Break the inheritance and Pydantic revalidates into the base,
+    # silently dropping the chained id -- the exact failure
+    # ``test_statmech_upload_chained_id_survives_payload_handover`` exists
+    # to pin. So the fix mypy would want is the one thing that must not
+    # happen.
+    #
+    # The reason it is safe is a runtime invariant, not a type: the
+    # ``validate_exactly_one_reference`` validator below guarantees that
+    # whenever ``calculation_key`` is None, ``existing_calculation_id`` is
+    # not -- and the only consumer that reads ``calculation_key`` as a
+    # non-optional ``str``
+    # (``app.services.statmech_resolution._resolve_calculation_key``) is
+    # reached only on the branch where the chained id was absent.
+    calculation_key: str | None = Field(  # type: ignore[assignment]
+        default=None, min_length=1
+    )
     existing_calculation_id: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="after")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -306,15 +306,65 @@ ignore = [
 # mypy configuration. Scoped adoption: strict-ish on the layers with the
 # highest annotation quality (models, schemas, chemistry); widen the
 # `files` list per-package as layers are brought up to standard.
+#
+# Paths here are resolved against the current working directory, so this
+# whole block assumes mypy is run from `backend/` — which is what CI does
+# (`working-directory: backend`) and what the documented local command
+# does. Running it from the repository root checks nothing and is not
+# supported.
+#
+# The wire package is in `files` and on `mypy_path`, and
+# `ignore_missing_imports` is off. All three are load-bearing; see the
+# block below.
 [tool.mypy]
 python_version = "3.13"
-files = ["app/db", "app/schemas", "app/chemistry"]
+files = [
+    "app/db",
+    "app/schemas",
+    "app/chemistry",
+    "../schemas/python/tckdb-schemas/tckdb_schemas",
+]
+mypy_path = "../schemas/python/tckdb-schemas"
 follow_imports = "silent"
-ignore_missing_imports = true
+ignore_missing_imports = false
 check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = false
 no_implicit_optional = true
+
+# Why the three settings above are the way they are.
+#
+# `tckdb_schemas` is a first-party package that lives in this repository
+# and is installed *editable*. mypy does not read an editable install's
+# import hook, so it could not find the package by name and reported
+# `import-not-found` on all 38 of its imports from `app/schemas` --
+# which `ignore_missing_imports = true` then absorbed silently. The gate
+# said "Success: no issues found in 149 source files" while every type
+# error inside the wire package, and every type error arising from how
+# the backend uses it, was invisible to it. Measured when this was fixed:
+# 12 real findings, in code that had merged green.
+#
+# `mypy_path` makes the package resolvable, so backend code is checked
+# against the wire package's *actual* types instead of `Any`.
+#
+# The `files` entry is separate and equally necessary. `follow_imports =
+# "silent"` means a merely-imported module is analysed but its own errors
+# are suppressed, so `mypy_path` alone would still have said nothing
+# about a broken annotation inside the wire package. Listing it as a
+# check target is what makes its own errors reportable. The two settings
+# catch different halves and neither substitutes for the other; a
+# mutation test for each is the only way to tell a working config from
+# one that silently still ignores the package.
+#
+# `ignore_missing_imports = false` is what stops this recurring. That
+# setting cannot distinguish "third-party package with no stubs" from
+# "first-party package in this repository that we failed to point mypy
+# at", so with it on, the second failure is silent by construction. Off,
+# an unresolvable module is an error. Measured at the time of the change:
+# nothing in scope needed it -- all 38 suppressed errors were
+# `tckdb_schemas`. If a genuinely stubless third-party dependency arrives,
+# add a narrow `[[tool.mypy.overrides]]` naming that module, the way the
+# rdkit block below does. Do not turn this back on.
 
 # Some rdkit-stubs releases ship a syntactically-broken .pyi
 # (rdchem.pyi: "parameter without a default follows parameter with a default"),

--- a/backend/tests/scripts/test_mypy_sees_the_wire_package.py
+++ b/backend/tests/scripts/test_mypy_sees_the_wire_package.py
@@ -1,0 +1,310 @@
+"""The ``mypy`` gate must actually type-check the wire-contract package.
+
+``tckdb-schemas`` is a first-party package that lives in this repository
+and is installed *editable*. ``mypy`` does not read an editable install's
+import hook, so for as long as nothing pointed it at the source tree it
+could not find the package by name: all 38 ``import tckdb_schemas...``
+statements in ``app/schemas`` reported ``import-not-found``, and
+``ignore_missing_imports = true`` absorbed every one of them. The gate
+printed ``Success: no issues found in 149 source files`` while every type
+error inside the wire package -- and every type error in backend code
+arising from how it uses the wire package -- was invisible to it.
+Measured when it was fixed: 12 real findings in code that had merged
+green, one of them a live defect (a required ``str`` field left holding
+``None``).
+
+Three settings make the gate bite, and this file pins all three because
+each covers a different half and none substitutes for another:
+
+* ``mypy_path`` makes the package *resolvable*, so backend code is
+  checked against its real types instead of ``Any``.
+* the ``files`` entry makes it a *check target*. ``follow_imports =
+  "silent"`` analyses a merely-imported module but suppresses its own
+  errors, so ``mypy_path`` alone would still say nothing about a broken
+  annotation inside the package.
+* ``ignore_missing_imports = false`` is what stops the whole thing
+  recurring. That setting cannot tell "third-party package with no
+  stubs" from "first-party package we failed to point mypy at", so with
+  it on the second failure is silent by construction.
+
+A configuration that silently ignores the package looks *identical* to
+one that works -- same exit code, same reassuring summary line. So the
+last test here does not read configuration at all: it runs the gate's
+own ``mypy`` over a module that misuses a real ``tckdb_schemas`` symbol
+and asserts the misuse is reported. That is the only assertion in this
+file that could not pass vacuously.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_DIR.parent
+PYPROJECT = BACKEND_DIR / "pyproject.toml"
+
+
+def _config_only_env() -> dict[str, str]:
+    """The subprocess environment with every *ambient* import path removed.
+
+    Measured, and it cost a false pass: mypy's module search path includes
+    the target interpreter's ``sys.path``, so a ``PYTHONPATH`` naming the
+    wire package makes ``tckdb_schemas`` resolve **regardless** of the
+    configuration -- which is exactly how a developer running the suite
+    with the package on ``PYTHONPATH`` (the documented way to test a
+    worktree copy) would watch this file pass against a configuration
+    that fixes nothing. ``MYPYPATH`` does the same thing more directly.
+
+    Stripping both makes ``backend/pyproject.toml`` the only thing that
+    can make the package resolvable, which is the property under test.
+    """
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env.pop("MYPYPATH", None)
+    return env
+
+#: Where the wire package's import root and its top-level package sit,
+#: as absolute paths. Derived from the repository layout rather than from
+#: the configuration, so a configuration that names the wrong place fails
+#: instead of agreeing with itself.
+WIRE_IMPORT_ROOT = REPO_ROOT / "schemas" / "python" / "tckdb-schemas"
+WIRE_PACKAGE_DIR = WIRE_IMPORT_ROOT / "tckdb_schemas"
+
+#: Floor on the module count, so "the target expands to nothing" cannot
+#: read as "the target is covered". 34 modules at the time of writing.
+MIN_WIRE_MODULES = 25
+
+
+def _mypy_config() -> dict:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"]["mypy"]
+
+
+def _mypy_overrides() -> list[dict]:
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"]["mypy"]
+    return list(config.get("overrides", []))
+
+
+def _wire_modules() -> list[Path]:
+    return sorted(WIRE_PACKAGE_DIR.rglob("*.py"))
+
+
+def test_the_wire_package_is_actually_on_disk_where_configured() -> None:
+    """Guard the guard: every other test here is vacuous if this is wrong."""
+    assert WIRE_PACKAGE_DIR.is_dir(), WIRE_PACKAGE_DIR
+    assert (WIRE_PACKAGE_DIR / "__init__.py").is_file()
+    modules = _wire_modules()
+    assert len(modules) >= MIN_WIRE_MODULES, (
+        f"only {len(modules)} module(s) under {WIRE_PACKAGE_DIR}; either the "
+        f"package moved or MIN_WIRE_MODULES is now wrong"
+    )
+
+
+def test_every_configured_check_target_exists() -> None:
+    """A moved package must fail the gate, not silently empty it.
+
+    ``files`` entries are resolved against the working directory, which
+    for both CI (``working-directory: backend``) and the documented local
+    command is ``backend/``. An entry that no longer names anything is
+    the failure mode that turns a gate into a no-op.
+    """
+    targets = _mypy_config()["files"]
+    assert targets, "[tool.mypy] declares no files to check"
+    for target in targets:
+        resolved = (BACKEND_DIR / target).resolve()
+        assert resolved.exists(), f"mypy check target does not exist: {target}"
+
+
+def test_the_wire_package_is_a_check_target_not_merely_an_import() -> None:
+    """``follow_imports = "silent"`` is why being importable is not enough."""
+    config = _mypy_config()
+    targets = [(BACKEND_DIR / entry).resolve() for entry in config["files"]]
+    assert WIRE_PACKAGE_DIR.resolve() in targets, (
+        f"{WIRE_PACKAGE_DIR} is not in [tool.mypy] files={config['files']}; "
+        f"with follow_imports='silent' its own errors would be suppressed"
+    )
+    # The setting that makes the distinction matter. If someone turns
+    # follow_imports up to "normal" this assertion is the thing that
+    # should be revisited -- not deleted.
+    assert config.get("follow_imports") == "silent", config.get("follow_imports")
+
+
+def test_the_wire_package_import_root_is_on_mypy_path() -> None:
+    """Resolvable by *name*, so backend code sees real types, not ``Any``."""
+    raw = _mypy_config().get("mypy_path")
+    assert raw, "[tool.mypy] sets no mypy_path; tckdb_schemas cannot resolve"
+    entries = [raw] if isinstance(raw, str) else list(raw)
+    resolved = [(BACKEND_DIR / entry).resolve() for entry in entries]
+    assert WIRE_IMPORT_ROOT.resolve() in resolved, resolved
+    # An import root is the directory *containing* the package, not the
+    # package. Pointing one level too deep resolves nothing and looks fine.
+    assert (WIRE_IMPORT_ROOT / "tckdb_schemas" / "__init__.py").is_file()
+
+
+def test_missing_imports_are_errors_not_shrugs() -> None:
+    """The recurrence guard.
+
+    With ``ignore_missing_imports = true`` a first-party package that
+    stops resolving is indistinguishable from a third-party package with
+    no stubs, and the gate reports success. Off, it is an error.
+    """
+    assert _mypy_config().get("ignore_missing_imports") is not True, (
+        "ignore_missing_imports must stay off: it is what made the "
+        "unresolvable wire package a silent success. Add a narrow "
+        "[[tool.mypy.overrides]] for a specific stubless third-party "
+        "module instead, the way the rdkit block does."
+    )
+
+
+def test_no_override_re_enables_the_shrug_for_first_party_code() -> None:
+    """A per-module escape hatch must not be aimed at our own package."""
+    for override in _mypy_overrides():
+        modules = override.get("module")
+        modules = [modules] if isinstance(modules, str) else list(modules or [])
+        for module in modules:
+            first_party = module.split(".")[0] in {"tckdb_schemas", "app"}
+            if first_party:
+                assert override.get("ignore_missing_imports") is not True, (
+                    f"override for {module!r} re-enables "
+                    f"ignore_missing_imports on first-party code"
+                )
+                assert override.get("follow_imports") != "skip", (
+                    f"override for {module!r} skips first-party code, which "
+                    f"makes it Any everywhere it is used"
+                )
+
+
+def test_every_wire_module_falls_under_a_check_target() -> None:
+    """A new subpackage joins the gate the day it is added, not later.
+
+    Asserted against the modules on disk rather than a written-down list,
+    for the same reason ``test_gate_coverage.py`` enumerates real test
+    files: a list is a thing somebody forgets to extend.
+    """
+    targets = [(BACKEND_DIR / entry).resolve() for entry in _mypy_config()["files"]]
+    uncovered = [
+        module
+        for module in _wire_modules()
+        if not any(module.resolve().is_relative_to(target) for target in targets)
+    ]
+    assert uncovered == [], uncovered
+
+
+def test_mypy_reports_a_misuse_of_a_wire_package_symbol(tmp_path: Path) -> None:
+    """End-to-end: run the gate's own mypy and watch it catch a real misuse.
+
+    Everything above reads configuration, and configuration can agree
+    with itself while checking nothing. This runs
+    ``mypy --config-file backend/pyproject.toml`` -- the settings CI
+    uses, from the directory CI uses -- over a module that calls
+    ``GeometryIn.to_payload`` with an argument it does not take and
+    assigns its result to an ``int``. Both are errors only if the wire
+    package resolved; if it did not, ``GeometryIn`` is ``Any`` and mypy
+    finds nothing.
+    """
+    mypy = shutil.which("mypy")
+    if mypy is None:  # pragma: no cover - depends on the local environment
+        pytest.skip("mypy is not installed in this environment")
+
+    probe = tmp_path / "wire_misuse_probe.py"
+    probe.write_text(
+        "from tckdb_schemas.shared.calculation_in import GeometryIn\n"
+        "\n"
+        "\n"
+        "def probe() -> int:\n"
+        '    return GeometryIn(key="k", xyz_text="x").to_payload(99)\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            mypy,
+            "--config-file",
+            str(PYPROJECT),
+            "--no-incremental",
+            str(probe),
+        ],
+        cwd=BACKEND_DIR,
+        env=_config_only_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode != 0, (
+        f"mypy accepted a misuse of a tckdb_schemas symbol, which means the "
+        f"package resolved to Any:\n{combined}"
+    )
+    # Name the codes, so "it failed" cannot be satisfied by an unrelated
+    # failure such as a bad config path or a missing interpreter.
+    assert "call-arg" in combined, combined
+    assert "GeometryIn" in combined, combined
+    # And prove the reason is not that the import was unresolvable.
+    assert "import-not-found" not in combined, combined
+
+
+def test_the_probe_would_pass_if_the_package_were_unresolvable(
+    tmp_path: Path,
+) -> None:
+    """The control for the test above -- otherwise it proves nothing.
+
+    Same probe, same mypy, but ``ignore_missing_imports`` on and no
+    ``mypy_path``: the pre-fix configuration. It must report the import
+    as missing rather than the misuse, which is exactly how a blatant
+    error merged green.
+    """
+    mypy = shutil.which("mypy")
+    if mypy is None:  # pragma: no cover - depends on the local environment
+        pytest.skip("mypy is not installed in this environment")
+
+    probe = tmp_path / "wire_misuse_probe.py"
+    probe.write_text(
+        "from tckdb_schemas.shared.calculation_in import GeometryIn\n"
+        "\n"
+        "\n"
+        "def probe() -> int:\n"
+        '    return GeometryIn(key="k", xyz_text="x").to_payload(99)\n',
+        encoding="utf-8",
+    )
+    # An empty config file: no mypy_path, and mypy's own default for
+    # ignore_missing_imports, which the flag below then forces on.
+    empty_config = tmp_path / "no_mypy_path.toml"
+    empty_config.write_text("[tool.mypy]\npython_version = \"3.13\"\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            mypy,
+            "--config-file",
+            str(empty_config),
+            "--ignore-missing-imports",
+            "--no-site-packages",
+            "--no-incremental",
+            str(probe),
+        ],
+        cwd=BACKEND_DIR,
+        env=_config_only_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        "the control is supposed to pass -- if it fails, this test is no "
+        f"longer measuring what it claims:\n{combined}"
+    )
+    assert "call-arg" not in combined, combined
+
+
+def test_python_version_pin_matches_the_interpreter_family() -> None:
+    """A stale ``python_version`` silently changes what the gate checks."""
+    pinned = _mypy_config()["python_version"]
+    major, minor = (int(part) for part in pinned.split("."))
+    assert (major, minor) >= (3, 11), pinned
+    assert major == sys.version_info.major, (pinned, sys.version)

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.52.0"
+version = "0.52.1"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/python/tckdb-schemas/pyproject.toml
+++ b/schemas/python/tckdb-schemas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-schemas"
-version = "0.35.0"
+version = "0.35.1"
 description = "Pure Pydantic wire-contract schemas for TCKDB upload payloads."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/python/tckdb-schemas/tckdb_schemas/thermo.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/thermo.py
@@ -80,16 +80,22 @@ class ThermoNASABase(BaseModel):
 
     @model_validator(mode="after")
     def validate_temperature_bounds(self) -> Self:
-        temps = [self.t_low, self.t_mid, self.t_high]
-        nones = sum(t is None for t in temps)
-        if nones not in (0, 3):
+        # Bound to locals and compared through explicit `is not None`
+        # guards rather than a `nones == 0` count. The count is the same
+        # fact, but it is a fact about a list rather than about the three
+        # attributes, so no reader -- human or type checker -- can tell
+        # from the comparison below that all three are floats there. The
+        # ordering rules are unchanged.
+        t_low, t_mid, t_high = self.t_low, self.t_mid, self.t_high
+        supplied = [t for t in (t_low, t_mid, t_high) if t is not None]
+        if len(supplied) not in (0, 3):
             raise ValueError(
                 "Temperature bounds must be all provided or all omitted."
             )
-        if nones == 0:
-            if self.t_mid <= self.t_low:
+        if t_low is not None and t_mid is not None and t_high is not None:
+            if t_mid <= t_low:
                 raise ValueError("t_mid must be greater than t_low.")
-            if self.t_high <= self.t_mid:
+            if t_high <= t_mid:
                 raise ValueError("t_high must be greater than t_mid.")
         return self
 

--- a/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
+++ b/schemas/python/tckdb-schemas/tckdb_schemas/workflows/computed_reaction_upload.py
@@ -1579,18 +1579,24 @@ class ComputedReactionUploadRequest(SchemaBase):
         for sp in self.species:
             if sp.statmech is None:
                 continue
-            for i, sc in enumerate(sp.statmech.source_calculations):
-                if sc.calculation_key not in all_calc_keys:
+            # Named `msc`, not `sc`: the thermo loop above binds `sc` to a
+            # `ThermoSourceCalcInBundle` in this same function scope, and
+            # reusing the name here made the statmech entry's static type
+            # the thermo one. Nothing broke, because both happen to carry
+            # `calculation_key` -- which is exactly why it would keep not
+            # breaking until the two shapes diverged.
+            for i, msc in enumerate(sp.statmech.source_calculations):
+                if msc.calculation_key not in all_calc_keys:
                     raise undeclared_key_error(
                         W_CALCULATION_KEY_UNDECLARED,
                         f"species[{sp.key!r}].statmech.source_calculations[{i}]."
                         f"calculation_key references undefined "
-                        f"calculation_key '{sc.calculation_key}'.",
+                        f"calculation_key '{msc.calculation_key}'.",
                         field=(
                             f"species['{sp.key}'].statmech.source_calculations"
                             f"[{i}].calculation_key"
                         ),
-                        key=sc.calculation_key,
+                        key=msc.calculation_key,
                         declared=all_calc_keys,
                     )
             for i, t in enumerate(sp.statmech.torsions):


### PR DESCRIPTION
## Plain language first

CI runs a program called **mypy**, which reads the code and looks for
mistakes of *kind* — handing a text string to something that expects a
number, calling a function with an argument it does not take. It never
runs anything, so it is cheap and it catches errors before a deposit ever
touches the database.

The upload payload definitions that TCKDB and every client agree on
(species, calculations, thermo, kinetics — "the wire contract") live in
their own small package in this repository, `tckdb-schemas`. It is
installed in *editable* mode, meaning the installed package is a pointer
to the source folder rather than a copy, so an edit takes effect
immediately.

**mypy does not follow that kind of pointer.** So it could not find
`tckdb_schemas` at all. And because the configuration told it "if you
cannot find a package, don't worry about it" — reasonable advice for a
third-party library nobody here maintains — it did not complain. It just
treated every wire-contract type as "could be anything", and anything is
compatible with anything.

The result: the gate printed **`Success: no issues found in 149 source
files`**, and that sentence was true and useless. Every mistake inside
the wire package, and every mistake in backend code about how it uses the
wire package, was outside what it looked at. This is the same failure
shape as a test that passes because it asserts nothing.

Pointed at the package, mypy immediately found **12 real problems** in
code that had already merged with a green gate. One was a live defect: a
field that is *required* to be text could end up holding "nothing" if a
depositor sent only spaces. The rest were the kind of thing that is
harmless today and becomes a bug the first time somebody edits nearby.

The fix is three configuration lines and eleven small code corrections.
The part worth reviewing carefully is not the fix — it is the proof that
the fix does anything, because a configuration that silently still
ignores the package produces *exactly the same reassuring output* as one
that works. So three deliberate errors were introduced and each was
watched to fail.

---

## CI's mypy invocation

**Unchanged**, before and after:

```yaml
- name: Type check (mypy, scoped)
  if: matrix.gate == 'api'
  working-directory: backend
  run: conda run -n tckdb_env mypy
```

That is deliberate. The whole change is in `backend/pyproject.toml`, so a
local `cd backend && mypy` and the CI step now check **the same set of
files with the same settings**. Putting `MYPYPATH` in the workflow
instead (option 1 in the brief) would have made CI and a local run
disagree about what is checked, which is the divergence class this repo
already has one open complaint about.

**What it reported before:** `Success: no issues found in 149 source files`
**What it reports now:** `Success: no issues found in 183 source files`

## Reproduction

`ignore_missing_imports = true` hides the symptom, so the first step was
to turn it off *while leaving the package unresolvable*:

```
$ cd backend && mypy --config-file <copy of pyproject with ignore_missing_imports = false>
app/schemas/utils.py:3: error: Cannot find implementation or library stub for module named "tckdb_schemas.utils"  [import-not-found]
...
Found 38 errors in 28 files (checked 149 source files)
```

**38** `import-not-found` errors across **28** files, and — measured, not
assumed — **all 38 were `tckdb_schemas`**. Nothing else in the checked
scope needed `ignore_missing_imports` at all. That number is what made
option 3 cheap enough to take (below).

## The measured count: 12

Running the same scope with the package resolvable *and* listed as a
check target:

```
Found 12 errors in 4 files (checked 183 source files)
```

| # | Location | Finding |
|---|---|---|
| 6 | `tckdb_schemas/thermo.py:90,92` | `Unsupported operand types for <=/>= ("float" and "None")` ×3 per line |
| 1 | `tckdb_schemas/workflows/computed_reaction_upload.py:1582` | `StatmechSourceCalcIn` assigned to a `ThermoSourceCalcInBundle` variable |
| 1 | `app/schemas/workflows/statmech_upload.py:151` | `str \| None` where the base class declared `str` |
| 1 | `app/schemas/workflows/network_pdep_upload.py:593` | `str \| None` assigned to a `str` |
| 2 | `app/schemas/workflows/network_pdep_upload.py:1399,1401` | wire `CalculationType` assigned into a dict of ORM `CalculationType` |
| 1 | `app/schemas/workflows/network_pdep_upload.py:1462` | `SolveSourceCalculationIn` assigned to a `StatmechSourceCalcIn` variable |

Twelve is a handful, so all twelve are dealt with here rather than
staged: **eleven fixed, one a documented suppression** (argued below).

### The one that was a live defect

`network_pdep_upload.py:593`. `EnergyTransferIn.model` is a **required**
`str` with `min_length=1`, but its normalizer was
`normalize_optional_text`, which trims and then **collapses a blank
string to `None`**. A whitespace-only model name passes `min_length=1`
(one character), and the validator then wrote `None` into a
non-optional field.

Reproduced before fixing, with `pytest`:

```python
et = EnergyTransferIn(state_key="w1", collider_species_key="he",
                      model="   ", alpha0_cm_inv=1.0)
assert et.model is None          # passed: model repr: None
```

Now `normalize_required_text`, which refuses the blank with a 422 — which
is what `min_length=1` was already promising the caller.

### The rest, and why none is cosmetic

- **`thermo.py:90,92`** — the NASA polynomial temperature-bound validator
  guarded `t_mid <= t_low` behind `if nones == 0`, where `nones` counts
  `None`s in a *list*. Correct, and unreadable to a checker (or a human
  skimming) as a statement about the three attributes. Rewritten with
  explicit `is not None` guards on locals. **Ordering rules unchanged.**
- **`computed_reaction_upload.py:1582`** and
  **`network_pdep_upload.py:1462`** — a loop variable named `sc` reused
  across loops over differently shaped payloads in the same function
  scope, so the second loop's entries carried the first loop's static
  type. Nothing broke, because both shapes happen to carry
  `calculation_key` — which is precisely why it would keep not breaking
  until they diverged. Renamed (`msc`, `solve_sc`).
- **`network_pdep_upload.py:1399,1401`** — a dict annotated
  `dict[str, CalculationType]` using the **ORM** enum, filled from
  wire-package payloads carrying the **wire** enum. Two distinct classes
  with identical members; every comparison between them works only
  because both subclass `str`. Annotated with the payload enum, imported
  as `PayloadCalculationType` so the distinction is visible at the point
  of use. No runtime behaviour change.

### The one suppression, and the argument

`statmech_upload.py:151`. `StatmechSourceCalculationIn` widens the wire
base's `calculation_key: str` to `str | None` (because this one contract
also accepts `existing_calculation_id`). Widening a base class's mutable
attribute is a Liskov violation and **mypy is right**. It is *not* a
false positive.

It is also not fixable in the direction mypy wants, and that is the
whole argument: the subclass relationship is load-bearing **at runtime**.
`ConformerUploadStatmechPayload.source_calculations` is annotated with
the key-only base, and Pydantic v2's `revalidate_instances="never"` is
what lets a subclass instance pass through that field with
`existing_calculation_id` intact. Break the inheritance and Pydantic
revalidates into the base and **silently drops the chained id** — no
error, no link row, a deposit that looks successful and cites nothing.
`test_statmech_upload_chained_id_survives_payload_handover` exists
specifically to pin that. So the refactor that would satisfy mypy is the
one thing that must not happen.

What makes it safe is a runtime invariant rather than a type: the
`validate_exactly_one_reference` validator guarantees that when
`calculation_key` is `None`, `existing_calculation_id` is not — and the
only consumer that reads `calculation_key` as a non-optional `str`
(`statmech_resolution._resolve_calculation_key`) is reached only on the
branch where the chained id was absent.

So: `# type: ignore[assignment]`, scoped to **one line and one error
code** (not the module, not the file), with that argument written above
it. `warn_unused_ignores` is already `false`, so it does not become noise
if the situation changes.

## Which options were taken, and why

The brief offered three. **Options 2 and 3, plus a fourth the brief did
not name but which turns out to be necessary.**

| Option | Taken | Why |
|---|---|---|
| 1. `MYPYPATH` in the CI invocation | No | Makes CI and a local run disagree about what is checked. |
| 2. `mypy_path` in the config | **Yes** | Checked in, applies to local runs, one source of truth. |
| 3. Narrow `ignore_missing_imports` | **Yes** — set to `false` outright | Measured first: **all 38** suppressed errors were `tckdb_schemas`, so nothing in scope needed the setting. Zero unrelated noise, so there was nothing to narrow *to*. |
| 4. The package in `files` | **Yes** | Not in the brief, and `mypy_path` alone is not enough — see below. |

**Why option 4 is not optional.** `follow_imports = "silent"` means a
merely-*imported* module is analysed but its own errors are **suppressed**.
With `mypy_path` alone, backend code would be checked against the wire
package's real types (catching misuse), but a broken annotation *inside*
the wire package would still be invisible. The `files` entry is what makes
it a check target. The two settings catch different halves; that is why
there are two mutations below and not one.

**Why `ignore_missing_imports = false` rather than a per-module list.**
It is the recurrence guard. The setting cannot distinguish "third-party
package with no stubs" from "first-party package in this repository that
we forgot to point mypy at", so with it on, the *next* instance of this
failure is silent by construction. Off, an unresolvable module is an
error. A genuinely stubless third-party dependency now needs a narrow
`[[tool.mypy.overrides]]` naming it, the way `rdkit` already has one; the
config comment says so.

**Scope of the gate**: 149 → 183 source files (the wire package's 34
modules). `backend-ci.yml` already triggers on
`schemas/python/tckdb-schemas/**`, so a change to the wire package
reaches the gate that now checks it. No workflow file is touched.

## Do local and CI now agree about what is checked?

Yes, and that is why option 2 was preferred over option 1. Both run
`mypy` with no arguments from `backend/`, and every setting lives in
`backend/pyproject.toml`. Paths in that block are resolved against the
working directory, so it is now stated explicitly in the file that the
block assumes `backend/` as cwd — running it from the repository root
checks nothing.

One caveat found while writing the guard test, worth knowing: **mypy's
module search path includes the target interpreter's `sys.path`, so
`PYTHONPATH` silently affects resolution.** A developer who follows the
worktree convention (`PYTHONPATH=<worktree>/schemas/python/tckdb-schemas
pytest ...`) makes the package resolve regardless of configuration. That
briefly produced a false pass in the new test, which now scrubs
`PYTHONPATH` and `MYPYPATH` from the mypy subprocess so only the config
can decide. All measurements quoted in this PR were taken without
`PYTHONPATH` set.

## Proof that the gate now bites

A configuration change that silently still ignores the package looks
**identical** to one that works — same exit code, same reassuring summary
line. So each half was mutated and watched to fail, and the same mutation
was run against the pre-change config as a control.

| Mutation | New config | Old config (control) |
|---|---|---|
| **1. Type error *inside* the wire package.** `return 12345` from `normalize_required_text() -> str` in `tckdb_schemas/utils.py` | **FAILS.** `utils.py:20: error: Incompatible return value type (got "int", expected "str")  [return-value]` — exit 1 | **PASSES.** `Success: no issues found in 149 source files` — exit 0 |
| **2. Misuse of a wire symbol from `backend/app`.** `_mutation: int = GeometryIn(...).to_payload(99)` in `network_pdep_upload.py` | **FAILS.** `[call-arg] Too many arguments for "to_payload" of "GeometryIn"` + `[assignment] GeometryPayload → int` — exit 1 | **PASSES.** `Success: no issues found in 149 source files` — exit 0 |
| **3. The recurrence itself.** `mypy_path` pointed at a directory that does not exist, wire package dropped from `files` | **FAILS.** `Found 39 errors in 28 files` — all `import-not-found` | **PASSES.** exit 0 |

Both mutations were reverted; `git diff` confirms neither remains.

Mutation 3 is the one that matters for the future. Under the old config a
package that moves, or a `mypy_path` someone deletes while tidying, is a
silent no-op. It is now 39 errors.

## New test: the guard for the guard

`backend/tests/scripts/test_mypy_sees_the_wire_package.py`, 10 tests,
alongside the existing repo-checks in `tests/scripts/`. Nothing here
weakens, skips or xfails anything.

Nine tests read the configuration; but configuration can agree with
itself while checking nothing, so the tenth **runs the gate's own mypy**
over a module that calls `GeometryIn.to_payload(99)` and assigns the
result to an `int`, and asserts the misuse is reported by error code —
both errors exist only if the wire package resolved. It is paired with a
control that runs the *same* probe under the pre-fix settings and asserts
it passes, so neither can pass vacuously.

The config assertions are deliberately derived rather than written down:
`test_every_wire_module_falls_under_a_check_target` enumerates the real
`.py` files on disk, so a new subpackage joins the gate the day it is
added; `test_every_configured_check_target_exists` fails if a target
stops naming anything, because "the package moved" must fail the gate
rather than silently empty it; and `MIN_WIRE_MODULES = 25` is a floor so
"the target expands to nothing" cannot read as "the target is covered".

**Mutation-tested too.** With the config reverted to its pre-fix state,
**5 of the 10 fail** (`..._is_a_check_target_not_merely_an_import`,
`..._import_root_is_on_mypy_path`, `test_missing_imports_are_errors_not_shrugs`,
`..._every_wire_module_falls_under_a_check_target`, and the end-to-end
`test_mypy_reports_a_misuse_of_a_wire_package_symbol`). Restored: 10 pass.

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no database schema change,
no migration. No new environment variable.

No **wire contract** change either: no field added, removed, retyped or
renamed, and no JSON-schema-visible change, so `openapi.json` is
untouched and the golden-contract tests pass unchanged. The wire-package
edits are a validator rewritten with the same rules and a loop variable
renamed. The one **behaviour** change anywhere is intentional and
narrow: a whitespace-only `solve.energy_transfer[].model` on
`/uploads/network-pdep` is now refused with a 422 instead of being
silently stored as `None`.

Versions bumped: `tckdb-schemas` 0.35.0 → **0.35.1**, `tckdb-client`
0.52.0 → **0.52.1** (checked against `origin/main`, both were at those
values). `CHANGELOG.md` gains an Unreleased → Fixed entry.

## Exact commands run

```bash
# --- reproduction and measurement (no PYTHONPATH set) ---
cd backend && conda run -n tckdb_env mypy
#   -> Success: no issues found in 149 source files   (the vacuous pass)
conda run -n tckdb_env mypy --config-file <pyproject, ignore_missing_imports=false>
#   -> Found 38 errors in 28 files (checked 149 source files); all tckdb_schemas
conda run -n tckdb_env mypy --config-file <+ mypy_path + files entry>
#   -> Found 12 errors in 4 files (checked 183 source files)   <-- the measure

# --- after the change: CI's exact invocation ---
cd backend && conda run -n tckdb_env mypy
#   -> Success: no issues found in 183 source files

# --- mutations (each reverted; controls run against origin/main's config) ---
#   1. return 12345 from normalize_required_text() -> str   => 1 error, exit 1
#   2. GeometryIn(...).to_payload(99) assigned to int       => 2 errors, exit 1
#   3. mypy_path -> nonexistent dir, files entry removed    => 39 errors, exit 1
git show origin/main:backend/pyproject.toml > /tmp/old_pyproject.toml
cd backend && conda run -n tckdb_env mypy --config-file /tmp/old_pyproject.toml
#   -> Success: no issues found in 149 source files, for mutations 1 and 2

# --- the other gate steps, as CI runs them ---
cd backend && conda run -n tckdb_env ruff check app tests scripts
#   -> All checks passed!
cd backend && conda run -n tckdb_env python scripts/check_runtime_ascii.py --audit
#   -> audit: every source file is scanned or declared out of scope
cd backend && conda run -n tckdb_env python scripts/check_runtime_ascii.py
#   -> clean

# --- tests (cwd backend/, isolated scratch DB, worktree wire package pinned) ---
DB_TEST_NAME=tckdb_test_mypygate PYTHONPATH=<worktree>/schemas/python/tckdb-schemas \
  conda run -n tckdb_env pytest tests/ -q -n 8
#   -> see result below
conda run -n tckdb_env pytest tests/scripts/ -q          # 487 passed
conda run -n tckdb_env pytest tests/scripts/test_mypy_sees_the_wire_package.py -q
#   -> 10 passed  (5 failed with the config reverted)

# --- the three python-client-ci steps ---
cd clients/python && conda run -n tckdb_env python -m pytest -q
#   -> 1371 passed
cd clients/python && conda run -n tckdb_env python -m pytest adapters/chemkin/tests -q
#   -> 55 passed, 1 skipped
cd schemas/python/tckdb-schemas && conda run -n tckdb_env python -m pytest -q
#   -> 38 passed
```

Test databases were `tckdb_test_mypygate*` throughout. Nothing touched
the Pi, `.env.pi`, or any deployed database.

## Anything in the brief that was false

Two things, both minor:

- The brief describes options 1–3 and says "(2) plus (3) prevents
  recurrence". Measured, that is **not sufficient**: with
  `follow_imports = "silent"`, `mypy_path` makes the package resolvable
  but leaves its *own* errors suppressed, so a deliberate type error
  inside `tckdb_schemas` would still have merged green. A fourth change —
  listing the package in `files` — is required, and mutation 1 is what
  distinguishes the two.
- The brief's suggested local verification
  (`PYTHONPATH=<worktree>/schemas/python/tckdb-schemas pytest ...`) is
  correct for pytest but is an active hazard for anything measuring mypy:
  mypy takes the interpreter's `sys.path` into its module search path, so
  that `PYTHONPATH` makes the package resolve independently of the
  configuration. It produced one false pass here before being caught.
