### PR TITLE
Anchor a judged handler by name, not by line

### DIFF
--- a/backend/tests/api/test_coded_exception_reraise_gate.py
+++ b/backend/tests/api/test_coded_exception_reraise_gate.py
@@ -58,11 +58,21 @@ asserted:
 
 * a **new** catch-and-replace site fails :meth:`test_every_site_that_
   replaces_the_message_is_accounted_for`, and the failure names it;
-* a listed site that has been fixed, moved or deleted fails
+* a listed site that has been fixed, renamed or deleted fails
   :meth:`test_no_entry_describes_a_site_that_is_gone`, so the list cannot
   outlive what it describes;
 * and the scan itself is provoked against a site known to exist, so a
   scan that silently matches nothing cannot pass as a clean sweep.
+
+How an entry names its site
+---------------------------
+Both exemption lists here -- :data:`JUDGED_SITES` and
+:data:`JUDGED_ABSORBING_HANDLERS` -- key on
+``"<path>::<enclosing qualname>"``. Neither keys on a line number, and one
+of them used to: the drift that retired the form is written up on
+:data:`JUDGED_SITES`, along with the two tests that hold the qualname form
+honest, since an anchor is only worth having if the day it stops resolving
+is a red build rather than a quiet skip.
 
 The second rule: a handler that can *absorb* a coded refusal
 ------------------------------------------------------------
@@ -152,14 +162,33 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 API_ROOT = REPO_ROOT / "backend" / "app" / "api"
 
 #: Sites that catch an exception and raise an ``HTTPException`` carrying a
-#: *new* message, keyed ``"<path>:<except lineno>"``. Each value says why
-#: that is not a lost code. Anything not here must pass ``str(exc)``
+#: *new* message, keyed ``"<path>::<enclosing qualname>"``. Each value says
+#: why that is not a lost code. Anything not here must pass ``str(exc)``
 #: through so a ``message_prefix`` code survives.
 #:
 #: Keep this small. An entry is a standing claim that a client loses
 #: nothing, and every one of them should name the test that checked it.
+#:
+#: Anchored on the enclosing function rather than the ``except`` line
+#: number, matching :data:`JUDGED_ABSORBING_HANDLERS`. The line-number form
+#: was measured failing: "Say which field registration refused, not that
+#: one was" (#197) added a helper above this handler, which moved the
+#: ``except`` from line 181 to line 256 and turned two tests below red --
+#: :meth:`~TestTheSweepIsComplete.test_every_site_that_replaces_the_message
+#: _is_accounted_for` saw an unlisted site at 256 and
+#: :meth:`~TestTheSweepIsComplete.test_no_entry_describes_a_site_that_is_
+#: gone` saw a listed site gone from 181. The handler had not changed; the
+#: coordinate had. A qualname survives every edit except a rename, and a
+#: rename is a change worth re-reading the judgement for.
+#:
+#: The anchor form is load-bearing, not cosmetic, so it is itself held:
+#: :meth:`~TestTheSweepIsComplete.test_every_anchor_names_an_enclosing_
+#: function` fails if a site appears at module scope (nothing to name), and
+#: :meth:`~TestTheSweepIsComplete.test_no_two_judged_sites_share_an_anchor`
+#: fails if two such handlers land in one function, where one entry would
+#: silently exempt both.
 JUDGED_SITES: dict[str, str] = {
-    "backend/app/api/routes/auth.py:256": (
+    "backend/app/api/routes/auth.py::register": (
         "Registration catches IntegrityError to roll back before answering, "
         "and this entry is the *completed* half of the one it replaces. "
         "That entry said letting the exception through would publish "
@@ -185,16 +214,27 @@ JUDGED_SITES: dict[str, str] = {
 }
 
 #: A site the scan must find, so a scan that matches nothing cannot pass.
-#: It is the ``ReleaseCurationError`` handler on the release-publish route
+#: It is the ``ReleaseCurationError`` handlers on the release-admin routes
 #: -- the canonical *correct* shape, ``detail=str(exc)``.
+#:
+#: A **file**, not a qualname, and deliberately so: nine handlers in this
+#: module share the idiom, and the claim being made is about the idiom, not
+#: about any one route keeping its name. Naming a single function here would
+#: only add a way for the assertion to fail without the idiom changing.
 _A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH = "backend/app/api/routes/releases_admin.py"
 
-#: Measured 2026-08-16, after the repairs: 13 handlers in
-#: ``backend/app/api`` raise an ``HTTPException``, of which 12 pass the
-#: caught message through and one is judged below. The floor is well under
-#: 13 and exists only to catch a scan that has stopped seeing the tree,
-#: not to police the count.
+#: Measured 2026-08-17: 13 handlers in ``backend/app/api`` raise an
+#: ``HTTPException``, of which 12 pass the caught message through and one is
+#: judged above. The floor is well under 13 and exists only to catch a scan
+#: that has stopped seeing the tree, not to police the count. Counted per
+#: handler rather than per anchor, so two in one function still count twice.
 _MINIMUM_SITES_THE_SCAN_MUST_SEE = 8
+
+#: How many of those 13 replace the caught message: exactly one, the
+#: registration conflict handler judged above. A floor rather than an
+#: equality so that repairing a site does not require editing two places,
+#: but not zero -- at zero, both directions of the sweep pass vacuously.
+_REPLACING_SITES_THE_SCAN_MUST_SEE = 1
 
 
 def _raised_http_exceptions(node: ast.AST) -> list[ast.Call]:
@@ -234,46 +274,103 @@ def _passes_the_message_through(call: ast.Call, bound: str | None) -> bool:
     return False
 
 
-def _scan() -> dict[str, str]:
-    """``"<path>:<lineno>" -> caught type(s)`` for catch-and-replace sites."""
-    replaced: dict[str, str] = {}
+def _qualnames(tree: ast.Module) -> dict[int, str]:
+    """``id(node) -> "outer.inner"`` for every node, by enclosing scope.
+
+    Shared by both rules: each anchors its exemption list on the enclosing
+    function rather than on a line number.
+    """
+    resolved: dict[int, str] = {}
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                inner = f"{prefix}.{child.name}" if prefix else child.name
+                resolved[id(child)] = inner
+                walk(child, inner)
+            else:
+                resolved[id(child)] = prefix
+                walk(child, prefix)
+
+    walk(tree, "")
+    return resolved
+
+
+def _http_raising_handlers() -> list[dict]:
+    """One record per ``except`` in the API layer raising an ``HTTPException``.
+
+    A list, not a dict: the count of *handlers* is asserted below, and
+    collapsing onto anchors first would let two handlers in one function
+    read as one and quietly lower that count.
+    """
+    records: list[dict] = []
     for path in sorted(API_ROOT.rglob("*.py")):
         tree = ast.parse(path.read_text())
         relative = str(path.relative_to(REPO_ROOT))
+        qualnames = _qualnames(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.ExceptHandler):
                 continue
             raises = _raised_http_exceptions(node)
             if not raises:
                 continue
-            if all(_passes_the_message_through(call, node.name) for call in raises):
-                continue
-            replaced[f"{relative}:{node.lineno}"] = ast.unparse(node.type or ast.Name("BaseException"))
-    return replaced
+            qualname = qualnames.get(id(node)) or "<module>"
+            records.append(
+                {
+                    "key": f"{relative}::{qualname}",
+                    "path": relative,
+                    "qualname": qualname,
+                    "lineno": node.lineno,
+                    "caught": ast.unparse(node.type or ast.Name("BaseException")),
+                    "replaces_message": not all(
+                        _passes_the_message_through(call, node.name)
+                        for call in raises
+                    ),
+                }
+            )
+    return records
 
 
-def _all_sites() -> dict[str, str]:
+def _by_anchor(records: list[dict]) -> dict[str, dict]:
+    """Collapse records onto ``"<path>::<qualname>"``, flagging collisions.
+
+    Two handlers in one function share an anchor, so one would vanish from
+    the sweep and a single entry would exempt both. The merge is recorded
+    rather than hidden, for the test that fails on it.
+    """
+    merged: dict[str, dict] = {}
+    for record in records:
+        previous = merged.get(record["key"])
+        if previous is None:
+            merged[record["key"]] = dict(record, collided=False)
+            continue
+        previous["collided"] = True
+    return merged
+
+
+def _scan() -> dict[str, dict]:
+    """``"<path>::<qualname>" -> record`` for catch-and-replace sites."""
+    return _by_anchor(
+        [record for record in _http_raising_handlers() if record["replaces_message"]]
+    )
+
+
+def _all_sites() -> dict[str, dict]:
     """Every ``except`` in the API layer that raises an ``HTTPException``."""
-    sites: dict[str, str] = {}
-    for path in sorted(API_ROOT.rglob("*.py")):
-        tree = ast.parse(path.read_text())
-        relative = str(path.relative_to(REPO_ROOT))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ExceptHandler) and _raised_http_exceptions(node):
-                sites[f"{relative}:{node.lineno}"] = ast.unparse(
-                    node.type or ast.Name("BaseException")
-                )
-    return sites
+    return _by_anchor(_http_raising_handlers())
 
 
 class TestTheScanSeesTheCodeItIsWrittenOver:
     """A survey that checked nothing passes; these say what it checked."""
 
     def test_it_finds_more_than_a_handful_of_handlers(self):
-        sites = _all_sites()
-        assert len(sites) >= _MINIMUM_SITES_THE_SCAN_MUST_SEE, (
-            f"only {len(sites)} except-and-raise sites found under {API_ROOT}; "
-            "the scan has probably stopped walking the tree"
+        """Counted per handler, not per anchor, so a merge cannot hide one."""
+        handlers = _http_raising_handlers()
+        assert len(handlers) >= _MINIMUM_SITES_THE_SCAN_MUST_SEE, (
+            f"only {len(handlers)} except-and-raise sites found under "
+            f"{API_ROOT}; the scan has probably stopped walking the tree"
         )
 
     def test_it_recognises_the_message_passthrough_idiom(self):
@@ -281,8 +378,8 @@ class TestTheScanSeesTheCodeItIsWrittenOver:
         sites = _all_sites()
         passthrough = {
             site
-            for site in sites
-            if site.startswith(_A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH)
+            for site, info in sites.items()
+            if info["path"] == _A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH
         }
         assert passthrough, (
             f"no handler found in {_A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH}; "
@@ -314,8 +411,8 @@ class TestTheSweepIsComplete:
 
     def test_every_site_that_replaces_the_message_is_accounted_for(self):
         unlisted = {
-            site: caught
-            for site, caught in _scan().items()
+            site: f"{info['caught']} (line {info['lineno']})"
+            for site, info in _scan().items()
             if site not in JUDGED_SITES
         }
         assert not unlisted, (
@@ -327,13 +424,91 @@ class TestTheSweepIsComplete:
         )
 
     def test_no_entry_describes_a_site_that_is_gone(self):
-        """A list nothing re-checks is how a stale survey stays believed."""
+        """A list nothing re-checks is how a stale survey stays believed.
+
+        This is also what stops an anchor from resolving to nothing. An
+        entry naming a function that no longer exists -- renamed, moved to
+        another module, deleted -- is not quietly skipped: it appears here
+        as stale and fails.
+        """
         found = _scan()
         stale = sorted(set(JUDGED_SITES) - set(found))
         assert not stale, (
             f"JUDGED_SITES describes sites that no longer replace the caught "
             f"exception's message: {stale}. If they were repaired, delete the "
-            "entry; if they moved, re-anchor it."
+            "entry; if the enclosing function was renamed or the handler "
+            f"moved to another one, re-anchor it. Found: {sorted(found)}"
+        )
+
+    def test_the_judged_list_is_not_empty_and_is_exactly_the_scan(self):
+        """The count, derived the way the gate derives it.
+
+        A sweep over an empty list satisfies both directions above
+        vacuously: nothing is unlisted and nothing is stale. Pinning a
+        floor on what the scan classifies as catch-and-replace means an
+        ``ast`` walk that has stopped matching cannot read as a clean
+        sweep, and the set equality then says the list is neither short
+        nor long.
+        """
+        replacing = _scan()
+        assert len(replacing) >= _REPLACING_SITES_THE_SCAN_MUST_SEE, (
+            f"the scan classifies only {len(replacing)} handlers as replacing "
+            f"the caught message, below the floor of "
+            f"{_REPLACING_SITES_THE_SCAN_MUST_SEE} measured 2026-08-17. Either "
+            "a judged site was genuinely repaired -- lower the floor and say "
+            "so -- or the classifier has stopped recognising the shape, in "
+            "which case every assertion in this class passes having checked "
+            "nothing"
+        )
+        assert set(JUDGED_SITES) == set(replacing), (
+            "JUDGED_SITES and the scan disagree; "
+            f"listed-not-found={sorted(set(JUDGED_SITES) - set(replacing))}, "
+            f"found-not-listed={sorted(set(replacing) - set(JUDGED_SITES))}"
+        )
+
+    def test_every_anchor_names_an_enclosing_function(self):
+        """A module-level handler has no name to anchor an entry on.
+
+        There are none today (measured 2026-08-17: all 13 sites sit inside
+        a named function), which is why the qualname form is a clean sweep
+        rather than a hybrid. Should one appear at module scope, its anchor
+        would degrade to ``"<path>::<module>"`` -- file-level precision
+        wearing a function-level spelling, and shared with every other
+        module-level handler in the same file. Fail here instead, where the
+        message can say what to do about it.
+        """
+        unanchorable = sorted(
+            f"{record['path']}:{record['lineno']}"
+            for record in _http_raising_handlers()
+            if record["qualname"] == "<module>"
+        )
+        assert not unanchorable, (
+            "these handlers raise an HTTPException at module scope, so there "
+            f"is no enclosing function for an entry to name: {unanchorable}. "
+            "Move the handler into a named function, or re-key both this scan "
+            "and JUDGED_SITES on the line number as well -- and record why the "
+            "anchor form had to change"
+        )
+
+    def test_no_two_judged_sites_share_an_anchor(self):
+        """Two in one function would merge, and one entry would exempt both.
+
+        The ambiguity a line number does not have, and a real cost of this
+        anchor form rather than a hypothetical one. The sibling scan carries
+        the same guard, and two of the four defects repaired by "Re-raise a
+        caught coded exception, not a bare 404/502" were *in the same
+        function* -- the download route's ``ArtifactIntegrityError`` and
+        ``ArtifactStorageUnavailable`` clauses.
+        """
+        collided = sorted(
+            key for key, info in _all_sites().items() if info["collided"]
+        )
+        assert not collided, (
+            "these functions hold more than one `except` that raises an "
+            "HTTPException, so JUDGED_SITES cannot address them separately "
+            f"and one entry would exempt both: {collided}. Split the "
+            "function, or key this scan on the handler's line number as well "
+            "as its qualname"
         )
 
     def test_the_artifact_routes_did_not_regrow_their_handlers(self):
@@ -359,7 +534,7 @@ class TestTheSweepIsComplete:
         ``test_every_curator_task_route_names_a_missing_task_the_same_way``,
         verified by mutation: reinstating the private guard turns it red.
         """
-        replaced_by_file = {site.split(":")[0] for site in _scan()}
+        replaced_by_file = {info["path"] for info in _scan().values()}
         path = "backend/app/api/routes/scientific/artifacts.py"
         assert path not in replaced_by_file, (
             f"{path} has regrown a handler that catches an exception and "
@@ -388,7 +563,9 @@ CODED_CATCHES = frozenset({"CodedValidationError", "CodedValueError"})
 #: ``"<path>::<enclosing qualname>"``. Anchored on the function rather than
 #: a line number so that reformatting the module above them does not fail
 #: this gate -- the lesson ``test_the_artifact_routes_did_not_regrow_their_
-#: handlers`` records, applied to a list eight entries long instead of one.
+#: handlers`` records. :data:`JUDGED_SITES` uses the same form; it was
+#: line-numbered until the drift documented there was measured, and this
+#: file now has one anchor convention rather than two.
 #:
 #: Every value must say what a client loses and why that is right. Adding
 #: an entry is the expensive path on purpose: re-raising (``raise``) or an
@@ -514,26 +691,6 @@ def _reraises_the_original(handler: ast.ExceptHandler) -> bool:
     return search(handler)
 
 
-def _qualnames(tree: ast.Module) -> dict[int, str]:
-    """``id(node) -> "outer.inner"`` for every node, by enclosing scope."""
-    resolved: dict[int, str] = {}
-
-    def walk(node: ast.AST, prefix: str) -> None:
-        for child in ast.iter_child_nodes(node):
-            if isinstance(
-                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
-            ):
-                inner = f"{prefix}.{child.name}" if prefix else child.name
-                resolved[id(child)] = inner
-                walk(child, inner)
-            else:
-                resolved[id(child)] = prefix
-                walk(child, prefix)
-
-    walk(tree, "")
-    return resolved
-
-
 def _absorbing_handlers() -> dict[str, dict]:
     """``"<path>::<qualname>" -> {caught, safe, lineno}`` for the API layer.
 
@@ -557,7 +714,9 @@ def _absorbing_handlers() -> dict[str, dict]:
                     continue
                 if not (caught & ABSORBING_CATCHES):
                     continue
-                key = f"{relative}::{qualnames.get(id(node), '<module>')}"
+                # ``or``, not a ``.get`` default: every node is in the map,
+                # and module scope is recorded as the empty string.
+                key = f"{relative}::{qualnames.get(id(node)) or '<module>'}"
                 safe = coded_taken_first or _reraises_the_original(handler)
                 previous = found.get(key)
                 if previous is not None:


### PR DESCRIPTION
## Plain language first

This repository has a **gate** — an automated test whose job is not to check that a
feature works, but to check that a *rule* is still obeyed everywhere in the codebase. This
one guards error codes. When the API refuses something, it answers with a machine-readable
code like `username_taken`, so a client program can branch on it instead of pattern-matching
English prose. There is a way to accidentally throw that code away: catch the error deep in
the code and re-raise a generic one, at which point the client sees only `http_409`. The
gate walks the source of every API route looking for that shape.

A handful of places do it on purpose and for good reasons. Those are written down in an
**exemption list** in the test file: one entry per place, each carrying a paragraph
explaining why nothing is lost there.

The problem was **how those entries named the place they exempt**. There are two such lists
in the file, and they used two different naming schemes:

- one said *"file X, line 256"* — a coordinate;
- the other said *"file X, function `register`"* — a name.

A coordinate goes stale the moment anybody inserts code higher up the file, even code that
has nothing to do with the exempted place. That is not hypothetical — it happened, and the
evidence is below. A name survives any edit except renaming the function, and a rename is
exactly the moment somebody *should* re-read the exemption.

This PR converts the coordinate-keyed list to names, so the file has one scheme. It touches
only the test tree; no API behaviour changes.

---

## The re-derived split

The brief described this as two conventions added to one list by two PRs. Re-derived at
`c3424b21`, that is not quite the shape. The two conventions belong to **two separate
registries**, each serving one of the file's two rules, and neither registry was internally
mixed:

| registry | rule it exempts from | key form before | entries |
|---|---|---|---|
| `JUDGED_SITES` | rule 1: a handler that raises `HTTPException` with a *new* message | `"<path>:<except lineno>"` | **1** |
| `JUDGED_ABSORBING_HANDLERS` | rule 2: a handler that can *absorb* a coded refusal | `"<path>::<enclosing qualname>"` | **8** |

So the conversion is one entry, not a sweep of many — but the constant it is compared
against is derived by a scan over all 13 sites, and that scan is what changed shape.

There is also a **third, coarser anchor form** in the file that the brief did not mention
and that I deliberately left alone: `_A_SITE_THAT_PASSES_THE_MESSAGE_THROUGH` is a **bare
file path**, no line and no function. It anchors the assertion "the scan classifies the
*correct* idiom correctly", and nine handlers in `releases_admin.py` share that idiom. The
claim is about the idiom, not about any one route keeping its name, so narrowing it to a
qualname would only add a way for it to fail without the idiom changing. Documented in
place rather than converted.

Provenance of the drift, since the brief asked it be re-derived rather than trusted:
`git show 4bdcfd3e` — "Say which field registration refused, not that one was" (#197) —
contains exactly `-"backend/app/api/routes/auth.py:181"` / `+"...auth.py:256"`. The handler
did not move for a reason of its own; a 75-line helper was added above it.

## Feasibility, measured before assuming this was mechanical

The brief asked three questions before treating the conversion as safe. All three were
answered by enumerating the tree, not by inspection:

**1. Does every judged site sit inside a named function?** Yes — **0 of 13** sites are at
module scope. A module-level handler or a lambda would have no name to anchor to, which
would have forced a hybrid. It did not, so this is a **clean sweep**.

Rather than leave that as a fact true today, it is now asserted:
`test_every_anchor_names_an_enclosing_function`. A module-scope handler would otherwise key
`"<path>::<module>"` — file-level precision wearing function-level spelling, and shared with
every other module-level handler in the same file. It fails instead, with a message saying
what to do.

**2. Are any two judged sites in the same function?** No — **0 collisions** across all 13
sites on `"<path>::<qualname>"`. (`_release` occurs twice as a function name, but in two
different modules, and the key carries the path.)

This is the real cost of a name over a coordinate, and the brief was right to flag that it
may be why the line form existed. It is now guarded:
`test_no_two_judged_sites_share_an_anchor`. The concern is concrete rather than theoretical
— the sibling registry already carries the same guard, and two of the four defects this gate
was written for were **two handlers in the same function**. Mutation 4 below shows what
happens without it.

**3. Does the scan still resolve each anchor to a real site?** Yes, and an anchor that
resolves to nothing **fails rather than skipping** — that is `test_no_entry_describes_a_site_
that_is_gone`, which subtracts the scan's keys from the registry's. Mutation 2 below proves
it fires. Its message now also prints what the scan *did* find, so a re-anchoring does not
require re-running the scan by hand.

## The asserted site count

The brief asked for the count of judged sites, derived the way the gate derives it — because
a sweep over an empty list satisfies both directions vacuously (nothing unlisted, nothing
stale). Added `test_the_judged_list_is_not_empty_and_is_exactly_the_scan`:

- `len(_scan()) >= _REPLACING_SITES_THE_SCAN_MUST_SEE`, floor **1**;
- `set(JUDGED_SITES) == set(_scan())`, printing both differences on failure.

The pre-existing floor on all except-and-raise handlers (`_MINIMUM_SITES_THE_SCAN_MUST_SEE
= 8`, against 13 measured) is kept, but is now counted **per handler rather than per anchor**
— `_http_raising_handlers()` returns a list. Collapsing onto anchors first would let two
handlers in one function read as one and quietly lower the number the floor is checking.

## Both mutations, shown going RED

Every mutation was reverted; `git diff` against `backend/app/` is empty (shown below).

**Mutation 1 — rename an anchored function without updating its entry.** The non-negotiable
one: if this stays green the anchor is decorative.

`app/api/routes/auth.py`: `def register(` → `def register_account(`

```
FAILED ...::test_no_entry_describes_a_site_that_is_gone
FAILED ...::test_every_site_that_replaces_the_message_is_accounted_for
FAILED ...::test_the_judged_list_is_not_empty_and_is_exactly_the_scan
3 failed, 18 passed

E  AssertionError: JUDGED_SITES and the scan disagree;
   listed-not-found=['backend/app/api/routes/auth.py::register'],
   found-not-listed=['backend/app/api/routes/auth.py::register_account']
```

**Mutation 2 — point an entry at a function that does not exist.** The other direction:
confirm the gate fails rather than quietly skipping the entry.

`JUDGED_SITES` key → `"backend/app/api/routes/auth.py::no_such_function"`

```
FAILED ...::test_the_judged_list_is_not_empty_and_is_exactly_the_scan
FAILED ...::test_no_entry_describes_a_site_that_is_gone
FAILED ...::test_every_site_that_replaces_the_message_is_accounted_for
3 failed, 18 passed

E  AssertionError: these handlers catch an exception and raise an HTTPException with a
   new message, so the caught exception's handler never mints its code:
   {'backend/app/api/routes/auth.py::register': 'IntegrityError (line 256)'} ...
```

Two further mutations, because the two guards this PR *adds* would otherwise be unproven —
a check that cannot fail is the recurring defect in this repo:

**Mutation 3 — a handler at module scope.** Appended a module-level
`try/except ValueError -> raise HTTPException` to `app/api/routes/health.py`.

```
FAILED ...::test_every_anchor_names_an_enclosing_function
E  AssertionError: these handlers raise an HTTPException at module scope, so there is no
   enclosing function for an entry to name: ['backend/app/api/routes/health.py:545'] ...
```

This also exercised the dead-default fix described below: the sibling scan reported
`health.py::<module>` rather than `health.py::`.

**Mutation 4 — two catch-and-replace handlers in one function.** Added a second
`except IntegrityError -> HTTPException(409, "second handler")` inside `register`.

```
FAILED ...::test_no_two_judged_sites_share_an_anchor
1 failed, 20 passed
E  AssertionError: these functions hold more than one `except` that raises an
   HTTPException, so JUDGED_SITES cannot address them separately and one entry would
   exempt both: ['backend/app/api/routes/auth.py::register'] ...
```

**Read the second line of that result carefully: 20 passed.** Every other test in the file
stayed green while a brand-new, unjudged catch-and-replace handler sat in the tree — the
existing `register` entry silently exempted it. That is precisely the ambiguity the brief
predicted, it is the one genuine advantage the line-number form had, and the collision guard
is what buys it back. Without that guard the conversion would have been a net loss.

## Incidental fix in the sibling scan

`_absorbing_handlers` computed its key as `qualnames.get(id(node), '<module>')`. That
default is unreachable: `_qualnames` maps **every** node, and records module scope as the
empty string. Module-scope absorbing handlers were therefore keyed `"<path>::"`. There are
none today, so no verdict changes — but a dead default in a gate is the same class of
problem as a vacuous assertion, and now that both registries depend on this key form it is
worth being correct. Changed to `or '<module>'`, and mutation 3 demonstrates the difference.

## Schema / migration impact

**None.** No ORM model, Pydantic schema, or Alembic revision is touched. No new environment
variable. No production file of any kind changes — the diff is one file under
`backend/tests/`:

```
$ git diff --stat c3424b21..HEAD          # from the repository root
 backend/tests/api/test_coded_exception_reraise_gate.py | 279 ++++++++++++++-----
 1 file changed, 218 insertions(+), 61 deletions(-)

$ git diff c3424b21..HEAD -- backend/app/ backend/alembic/ clients/
(empty)
```

No test was weakened, skipped, xfailed or deleted; the file goes from 18 tests to 21.

## Verification — exact commands run, with results

```bash
# the gate file itself (cwd backend/, per the pre-existing cwd-relative fixture glob)
conda run -n tckdb_env python -m pytest tests/api/test_coded_exception_reraise_gate.py -q
#   -> 21 passed        (18 before this PR)

# the four mutations above, each applied, run, and reverted; results quoted above

conda run -n tckdb_env ruff check tests/api/test_coded_exception_reraise_gate.py
#   -> All checks passed!
conda run -n tckdb_env mypy
#   -> Success: no issues found in 149 source files
git diff --check c3424b21..HEAD
#   -> clean

# the CI-shaped gate covering tests/api/, run on the exact committed tree
DB_TEST_NAME=tckdb_test_a6ba conda run -n tckdb_env bash backend/scripts/test-api.sh
#   -> 3007 passed in 419.64s

# the full backend suite
DB_TEST_NAME=tckdb_test_a6ba conda run -n tckdb_env bash backend/scripts/test-full.sh
#   -> 8163 passed, 14 skipped in 787.56s
```

Two notes on how those runs were taken, since a green result taken carelessly is the thing
this file exists to prevent:

- **`DB_TEST_NAME` was overridden to an isolated `tckdb_test*` database.** Sibling agents
  were running suites concurrently on this machine — each run's own banner named three
  other live runs sharing the server. Local Postgres is `max_connections=200`, and
  concurrent runs produce connection failures that read like real breakage.
- **`test-full.sh` started before a final docstring-only amend**, so `test-api.sh` was run
  again afterwards against the committed tree (`git status` clean) and is the authoritative
  result for the changed file. The amend replaced a bare task id in one docstring with the
  merged PR title it refers to.

## One correction to the premise

The brief described `JUDGED_SITES` as internally mixed — "keys its entries two different
ways". Re-derived, that is not the shape: `JUDGED_SITES` was uniformly line-numbered and
held a single entry, and the qualname form lived in the *other* registry, added by "Refuse a
route handler that can swallow a coded refusal" (#196). Both forms were live in one file,
but no one list was inconsistent with itself. The conversion is therefore one key plus the
scan behind it, not a sweep — and the interesting work turned out to be the two guards that
make the name-based anchor trustworthy, not the rename.

Also measured: the file has been touched by **three** PRs (all on 2026-08-16), not four.
