### PR TITLE
Tell "no such selection" from "which selection?"

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -416,6 +416,28 @@ class ApiCode:
 #: this from :mod:`app.scientific_checks`, whose entries claim something a
 #: referee could argue with and must stay expensive.
 CATALOGUE: tuple[ApiCode, ...] = (
+    ApiCode("ambiguous_conformer_selection_locator", 422, Surface.coded_exception,
+            "backend/app/services/conformer_selection_locator.py",
+            note=(
+                "The 'several matched' half of a split; unknown_conformer_"
+                "selection is the 'none matched' half, at 404. Both used to "
+                "be one bare ValueError reading 'must resolve exactly one "
+                "selection', so 422 validation_error with an empty context "
+                "covered two opposite repairs -- deposit the missing row, "
+                "versus say more about which row you meant. 422 and not 409 "
+                "because every candidate exists: the world is consistent and "
+                "the request is under-determined. context reports what "
+                "actually differs across the candidates (discriminator, "
+                "discriminator_values) and whether the locator has a field "
+                "for it (locator_can_express), because 'be more specific' is "
+                "only advice if there is something to add -- and here there "
+                "is not: the lookup filters on all three locator fields, so "
+                "candidates agree on all three and can only differ by the "
+                "conformer group, which the locator cannot name. Every "
+                "observed refusal therefore reports "
+                "locator_can_express=false, which is the evidence the "
+                "locator needs widening."
+            )),
     ApiCode("applied_energy_correction_source_calculation_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
             note=(
@@ -1049,6 +1071,23 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "status. context['field'] separates them; context['ref'] is "
                 "present for the public-ref spelling only, because a row id "
                 "is logged and never echoed (DR-0028 Requirement 2)."
+            )),
+    ApiCode("unknown_conformer_selection", 404, Surface.coded_exception,
+            "backend/app/services/conformer_selection_locator.py",
+            note=(
+                "The one unknown_* on /uploads/kinetics not built by "
+                "upload_reference.unknown_reference, and the reason is that "
+                "helper's own rule: it takes exactly one of ref= (echoed) or "
+                "row_id= (logged only), because the spelling chooses the "
+                "disclosure rule. A conformer_selection content locator is a "
+                "third spelling -- a description, not a name -- so there is "
+                "no caller-written string to quote back and context carries "
+                "the locator's own fields (selection_kind, and "
+                "assignment_scheme_ref when set) instead. The field/kind "
+                "pair is kept identical to unknown_reference's so a client "
+                "reads one body layout. Paired with "
+                "ambiguous_conformer_selection_locator at 422, which is the "
+                "same locator matching too many rows rather than none."
             )),
     ApiCode("unknown_curation_policy", 404, Surface.message_prefix,
             "backend/app/api/routes/releases_admin.py"),

--- a/backend/app/services/conformer_selection_locator.py
+++ b/backend/app/services/conformer_selection_locator.py
@@ -1,0 +1,355 @@
+"""Refusing a conformer-selection *content locator* that names nothing, or too much.
+
+The locator
+-----------
+``ConformerSelectionContentRef`` is how a depositor cites a stored
+conformer selection when they hold no handle for it. Instead of a ref they
+*describe* the row — ``{species_entry, selection_kind,
+assignment_scheme_ref}``, read as "the lowest-energy selection for this
+species entry under this scheme" — and the workflow expects the
+description to pick out exactly one row.
+
+Two conditions, two repairs, and one sentence
+---------------------------------------------
+Until this module, both failures raised one bare ``ValueError``:
+
+    conformer_selection content locator must resolve exactly one selection.
+
+so both arrived as ``422 validation_error`` with an empty ``context``.
+They are opposite repairs. **Zero** matched means the described row is not
+in the database, and no corrected body conjures it — the depositor must
+deposit the selection, or they named the wrong species entry. **Several**
+matched means every row the description could mean exists; the world is
+fine and the *request* is under-determined. A client receiving one string
+for both cannot tell which, and the two calls to action share no step.
+
+So: zero is :data:`W_UNKNOWN_CONFORMER_SELECTION` at **404**, which is
+where :mod:`app.services.upload_reference` already puts "you named a row
+that is not there" for every other spelling on this route. Several is
+:data:`W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR` at **422** — not 409,
+because nothing about the stored data is inconsistent; the payload simply
+did not say enough.
+
+Why the 404 is built here and not by ``unknown_reference``
+----------------------------------------------------------
+:func:`app.services.upload_reference.unknown_reference` takes exactly one
+of ``ref=`` (a public ref, echoed) or ``row_id=`` (a database id, logged
+only), because the choice of spelling *is* the choice of disclosure rule.
+A content locator is a third spelling and neither of those: there is no
+single string the caller wrote for us to quote back. What there is, is the
+locator's own describable fields, so those are what ``context`` carries.
+The 404 keeps ``unknown_reference``'s body shape — ``context['field']``
+and ``context['kind']`` — deliberately, so a client reading a
+``field``/``kind`` pair does not have to learn a second layout depending
+on how the row was named.
+
+Why the 422 has to say what *differs*
+-------------------------------------
+"Be more specific" is only advice if there is something to add. The
+locator has three fields and the lookup filters on all three, so **every
+candidate agrees on all three by construction** — and the axis that
+actually separates them is the conformer group, which the locator cannot
+name at all. ``conformer_group`` is unique on ``(species_entry_id,
+label)`` with NULLs distinct, so one species entry may own many groups,
+each able to carry a ``lowest_energy`` selection with a NULL scheme, and
+the locator joins on ``species_entry_id`` alone.
+
+Told only "be more specific", that depositor is being sent to look for a
+field that does not exist. An error whose advice cannot be followed is
+worse than a vague one, because it teaches people to stop reading the
+advice. :func:`discriminate` therefore computes what varies across the
+candidate set and the refusal says it, with
+``context['locator_can_express']`` stating outright whether the difference
+is one the payload could have expressed.
+
+The three outcomes, and which of them a request can reach
+--------------------------------------------------------
+:func:`discriminate` classifies a candidate set three ways, and only one
+of them is reachable through a route today. That is recorded here rather
+than pruned, because the *unreachable* ones are what the classification
+exists to prove:
+
+1. **Differs by a locator field** (``selection_kind``,
+   ``assignment_scheme_ref``). Actionable: add the field. Structurally
+   unreachable — those are the two fields the ``WHERE`` clause pins.
+2. **Differs by something the locator cannot express** (the conformer
+   group's ``label``, or failing that its ``public_ref``). The only
+   outcome a request reaches, and the evidence that the locator is too
+   narrow.
+3. **Differs by nothing reportable.** A duplicate curation row rather
+   than an under-determined request, and worth saying so rather than
+   dressing it up as ambiguity. Unreachable while
+   ``uq_conformer_selection_conformer_group_id`` holds: it permits at most
+   one selection per ``(group, scheme, kind)``, and candidates share
+   scheme and kind, so two candidates always sit in two groups and always
+   differ by ``conformer_group_ref``.
+
+:func:`discriminate` is a pure function over
+:class:`SelectionCandidate` values precisely so that all three are
+exercised by unit tests rather than asserted about in prose. A branch that
+no test can enter is the failure mode this repository produces most.
+
+What ``context`` may carry
+--------------------------
+No database primary key (DR-0028 Requirement 2), which rules out the
+selection ids and the group ids — the obvious way to disambiguate and the
+one that is not available. Every discriminator here is a public-surface
+value instead: a group **label**, a group **public ref**, an assignment
+scheme **public ref**, a ``selection_kind``, and a count. ``match_count``
+follows ``freq_mode_index_not_unique``'s ``{"duplicate_mode_indices":
+[...], "mode_count": N}`` — the house shape for "several of a thing".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from app.api.error_contract import CodedValueError
+from app.api.errors import NotFoundError
+
+#: A conformer-selection content locator describes no stored selection.
+#: 404 rather than 422 for the reason
+#: :mod:`app.services.upload_reference` gives at length: the namespace is
+#: the whole database, and no corrected body can conjure the row.
+W_UNKNOWN_CONFORMER_SELECTION = "unknown_conformer_selection"
+
+#: A conformer-selection content locator describes more than one stored
+#: selection. 422 and not 409: every row it could mean exists, so nothing
+#: about the world is wrong — the request is under-determined, which is
+#: what a 422 says.
+W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR = "ambiguous_conformer_selection_locator"
+
+#: The record kind, in the API's own vocabulary. Shared by both refusals
+#: so a client keys off one spelling.
+_KIND = "conformer_selection"
+
+
+@dataclass(frozen=True)
+class SelectionCandidate:
+    """One stored selection a content locator could have meant.
+
+    Deliberately not the ORM row. The refusal may publish only
+    public-surface values, so the candidate carries exactly those plus the
+    ``selection_id`` the caller needs on the success path — and the id is
+    never an axis, which is what makes it impossible for
+    :func:`discriminate` to put one in ``context``.
+    """
+
+    selection_id: int
+    selection_kind: str
+    conformer_group_label: str | None
+    conformer_group_ref: str
+    assignment_scheme_ref: str | None
+
+
+#: The axes a candidate set can differ along, **ordered so that the ones
+#: the locator can express come first**. :func:`discriminate` reports the
+#: first axis that varies, so the ordering is what makes it prefer advice
+#: the depositor can act on over advice they cannot.
+_AXES: tuple[str, ...] = (
+    "selection_kind",
+    "assignment_scheme_ref",
+    "conformer_group_label",
+    "conformer_group_ref",
+)
+
+#: The subset of :data:`_AXES` that ``ConformerSelectionContentRef``
+#: actually has a field for. ``species_entry`` is not here because it is
+#: not an axis: the lookup joins on it, so it cannot vary.
+_LOCATOR_AXES: frozenset[str] = frozenset({"selection_kind", "assignment_scheme_ref"})
+
+
+@dataclass(frozen=True)
+class Discrimination:
+    """What separates the candidates a locator matched.
+
+    :param match_count: How many selections the locator described.
+    :param differs_by: Every axis that varies, in :data:`_AXES` order.
+    :param discriminator: The axis the refusal names — the first entry of
+        ``differs_by``, so a locator-expressible axis wins if one varies.
+        ``None`` when nothing varies.
+    :param discriminator_values: The distinct values of ``discriminator``,
+        in candidate order — which the caller is responsible for making
+        deterministic, since this is a published list. Not sorted here:
+        ``None`` is a legitimate group label and sorting a list containing
+        it raises.
+    :param locator_can_express: Whether ``discriminator`` is a field the
+        payload could have set. The half a client branches on, and the
+        half that decides whether the advice is followable.
+    """
+
+    match_count: int
+    differs_by: tuple[str, ...]
+    discriminator: str | None
+    discriminator_values: tuple[str | None, ...]
+    locator_can_express: bool
+
+    def as_context(self, *, field: str) -> dict[str, object]:
+        """The refusal's ``context``. Public-surface values only."""
+        return {
+            "field": field,
+            "kind": _KIND,
+            "match_count": self.match_count,
+            "differs_by": list(self.differs_by),
+            "discriminator": self.discriminator,
+            "discriminator_values": list(self.discriminator_values),
+            "locator_can_express": self.locator_can_express,
+        }
+
+
+def _distinct(values: list[str | None]) -> tuple[str | None, ...]:
+    """The distinct entries of *values*, in first-seen order."""
+    seen: list[str | None] = []
+    for value in values:
+        if value not in seen:
+            seen.append(value)
+    return tuple(seen)
+
+
+def discriminate(candidates: list[SelectionCandidate]) -> Discrimination:
+    """Work out what separates *candidates*, and whether the payload could say it.
+
+    Pure, and the reason this module has a function rather than an inline
+    block: the three outcomes it distinguishes are not all reachable
+    through a route (see the module docstring), so unit tests over
+    hand-built candidates are the only honest way to hold the
+    classification.
+
+    :param candidates: Two or more selections one locator matched.
+        Calling it with fewer is not wrong — it answers ``differs_by=()``
+        — but the caller has a better refusal available in that case.
+    """
+    differs = tuple(
+        axis
+        for axis in _AXES
+        if len({getattr(candidate, axis) for candidate in candidates}) > 1
+    )
+    discriminator = differs[0] if differs else None
+    values: tuple[str | None, ...] = ()
+    if discriminator is not None:
+        values = _distinct([getattr(c, discriminator) for c in candidates])
+    return Discrimination(
+        match_count=len(candidates),
+        differs_by=differs,
+        discriminator=discriminator,
+        discriminator_values=values,
+        locator_can_express=discriminator in _LOCATOR_AXES,
+    )
+
+
+def unknown_conformer_selection(
+    *,
+    field: str,
+    selection_kind: str,
+    assignment_scheme_ref: str | None,
+) -> NotFoundError:
+    """Build the 404 for a locator that describes no stored selection.
+
+    :param field: The payload path, e.g.
+        ``"interpretation_assignments[0].conformer_selection"``. Carried in
+        ``context['field']`` as well as the sentence, because one payload
+        can hold several locators.
+    :param selection_kind: The kind the locator asked for. Echoed: the
+        caller wrote it.
+    :param assignment_scheme_ref: The scheme public ref the locator asked
+        for, if any. Omitted from ``context`` when absent, matching
+        ``unknown_reference``'s treatment of ``ref``.
+    """
+    described = f"selection_kind={selection_kind!r}"
+    if assignment_scheme_ref is not None:
+        described += f", assignment_scheme_ref={assignment_scheme_ref!r}"
+    else:
+        described += ", no assignment scheme"
+    context: dict[str, object] = {
+        "field": field,
+        "kind": _KIND,
+        "selection_kind": selection_kind,
+    }
+    if assignment_scheme_ref is not None:
+        context["assignment_scheme_ref"] = assignment_scheme_ref
+    # No ``"code: "`` prefix in the prose: the exception carries the code
+    # as an attribute and the handler passes it through unparsed.
+    return NotFoundError(
+        f"{field} ({described}) describes no conformer selection for that "
+        "species entry in this database. Deposit the conformer selection "
+        "first, or correct the species entry the locator names.",
+        code=W_UNKNOWN_CONFORMER_SELECTION,
+        context=context,
+    )
+
+
+def ambiguous_conformer_selection_locator(
+    *,
+    field: str,
+    candidates: list[SelectionCandidate],
+) -> CodedValueError:
+    """Build the 422 for a locator that describes more than one selection.
+
+    The sentence changes with the outcome :func:`discriminate` reports,
+    because the three outcomes have three different calls to action — and
+    one of them has none, which is the case worth saying out loud rather
+    than papering over with "be more specific".
+    """
+    found = discriminate(candidates)
+    listed = ", ".join(
+        "unlabelled" if value is None else repr(value)
+        for value in found.discriminator_values
+    )
+    head = (
+        f"{found.match_count} conformer selections match {field}, so the "
+        "content locator does not name one"
+    )
+    if found.discriminator is None:
+        # Unreachable through a route while
+        # ``uq_conformer_selection_conformer_group_id`` holds; see the
+        # module docstring. Reported as what it would be if it happened --
+        # duplicate curation rows -- rather than as ambiguity, because
+        # "be more specific" would be false here in a second way.
+        detail = (
+            f"{head}. They differ in nothing this API can report, which "
+            "makes them duplicate curation rows rather than an "
+            "under-determined request. Please report this: no locator can "
+            "separate them."
+        )
+    elif found.locator_can_express:
+        detail = (
+            f"{head}. They differ by {found.discriminator}: {listed}. Set "
+            f"{found.discriminator} on the locator to name exactly one."
+        )
+    else:
+        detail = (
+            f"{head}. They differ by {found.discriminator} ({listed}), "
+            "which the content locator has no field for -- so no corrected "
+            "locator resolves this. Give the selections distinct assignment "
+            "schemes, or report that the locator needs widening."
+        )
+    return CodedValueError(
+        W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR,
+        detail,
+        context=found.as_context(field=field),
+        message_prefix=False,
+    )
+
+
+def selection_kind_token(value: str | Enum) -> str:
+    """The wire token for a ``selection_kind`` read back from the database.
+
+    ``ConformerSelectionKind`` is a ``str`` subclass, so it survives a
+    JSON encoder unnoticed -- but ``str()`` of it is ``"ConformerSelectionKind.
+    lowest_energy"`` on Python 3.11+, which is what would land in
+    ``context`` if this normalisation were skipped.
+    """
+    return value.value if isinstance(value, Enum) else value
+
+
+__all__ = [
+    "W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR",
+    "W_UNKNOWN_CONFORMER_SELECTION",
+    "Discrimination",
+    "SelectionCandidate",
+    "ambiguous_conformer_selection_locator",
+    "discriminate",
+    "selection_kind_token",
+    "unknown_conformer_selection",
+]

--- a/backend/app/workflows/kinetics.py
+++ b/backend/app/workflows/kinetics.py
@@ -48,6 +48,12 @@ from app.services.calculation_ownership import (
     assert_statmech_owned_by,
 )
 from app.services.calculation_resolution import resolve_level_of_theory_ref
+from app.services.conformer_selection_locator import (
+    SelectionCandidate,
+    ambiguous_conformer_selection_locator,
+    selection_kind_token,
+    unknown_conformer_selection,
+)
 from app.services.kinetics_resolution import persist_kinetics, resolve_kinetics_upload
 from app.services.record_review import (
     RecordRef,
@@ -298,25 +304,76 @@ def _resolve_interpretation_assignments(
             selection_species_entry = resolve_species_entry(
                 session, locator.species_entry, created_by=created_by
             )
+            # The scheme join is an OUTER join and was an inner one: the
+            # refusal below has to be able to report the scheme each
+            # candidate carries, including the NULL-scheme case, and an
+            # inner join cannot see a row that has none. The ``WHERE``
+            # clauses are unchanged, and a predicate on an outer-joined
+            # column filters exactly as the inner join did.
             stmt = (
-                select(ConformerSelection.id)
+                select(
+                    ConformerSelection.id,
+                    ConformerSelection.selection_kind,
+                    ConformerGroup.label,
+                    ConformerGroup.public_ref,
+                    ConformerAssignmentScheme.public_ref,
+                )
                 .join(ConformerGroup, ConformerGroup.id == ConformerSelection.conformer_group_id)
+                .outerjoin(
+                    ConformerAssignmentScheme,
+                    ConformerAssignmentScheme.id == ConformerSelection.assignment_scheme_id,
+                )
                 .where(
                     ConformerGroup.species_entry_id == selection_species_entry.id,
                     ConformerSelection.selection_kind == locator.selection_kind,
                 )
+                # Label first so the values the refusal prints come out in
+                # an order a human can scan, and ``public_ref`` after it so
+                # unlabelled groups -- of which one species entry may have
+                # many, the constraint treating NULL labels as distinct --
+                # still order deterministically. A published list whose
+                # order shifts between two identical requests is a
+                # contract nobody can write a test against.
+                .order_by(ConformerGroup.label, ConformerGroup.public_ref)
             )
             if locator.assignment_scheme_ref is None:
                 stmt = stmt.where(ConformerSelection.assignment_scheme_id.is_(None))
             else:
-                stmt = stmt.join(
-                    ConformerAssignmentScheme,
-                    ConformerAssignmentScheme.id == ConformerSelection.assignment_scheme_id,
-                ).where(ConformerAssignmentScheme.public_ref == locator.assignment_scheme_ref)
-            selection_ids = session.scalars(stmt.limit(2)).all()
-            if len(selection_ids) != 1:
-                raise ValueError("conformer_selection content locator must resolve exactly one selection.")
-            selection_id = selection_ids[0]
+                stmt = stmt.where(
+                    ConformerAssignmentScheme.public_ref == locator.assignment_scheme_ref
+                )
+            # Unbounded on purpose, where the old lookup took ``limit(2)``:
+            # the 422 has to publish an honest ``match_count`` and the
+            # values that separate the candidates, and a capped fetch would
+            # report a count that is not the count. The set is small by
+            # construction -- one species entry, one selection kind, one
+            # scheme, and ``uq_conformer_selection_conformer_group_id``
+            # permits at most one row per conformer group of that entry.
+            candidates = [
+                SelectionCandidate(
+                    selection_id=row[0],
+                    selection_kind=selection_kind_token(row[1]),
+                    conformer_group_label=row[2],
+                    conformer_group_ref=row[3],
+                    assignment_scheme_ref=row[4],
+                )
+                for row in session.execute(stmt).all()
+            ]
+            # Zero and several are opposite repairs and used to share one
+            # sentence at 422 with an empty context. See
+            # :mod:`app.services.conformer_selection_locator`.
+            if not candidates:
+                raise unknown_conformer_selection(
+                    field=f"{field}.conformer_selection",
+                    selection_kind=locator.selection_kind,
+                    assignment_scheme_ref=locator.assignment_scheme_ref,
+                )
+            if len(candidates) > 1:
+                raise ambiguous_conformer_selection_locator(
+                    field=f"{field}.conformer_selection",
+                    candidates=candidates,
+                )
+            selection_id = candidates[0].selection_id
             # The role test is defence in depth, not a live branch:
             # ``validate_role_shape`` already refuses a conformer_selection
             # on a transition-state assignment, so nothing reaching here

--- a/backend/tests/api/test_api_conformer_selection_locator_codes.py
+++ b/backend/tests/api/test_api_conformer_selection_locator_codes.py
@@ -1,0 +1,297 @@
+"""Two opposite repairs that used to share one sentence, on the wire.
+
+What was wrong
+--------------
+``/uploads/kinetics`` lets an interpretation assignment cite a stored
+conformer selection by *describing* it —
+``{species_entry, selection_kind, assignment_scheme_ref}`` — and expects
+the description to pick out exactly one row. Both ways that can fail
+raised one bare ``ValueError``:
+
+    conformer_selection content locator must resolve exactly one selection.
+
+Measured before the change, both arrived byte-identically as
+``422 {"code": "validation_error", "context": {}}``. They are opposite
+repairs. **Zero** matched means the row is not there: deposit it, or fix
+the species entry named. **Several** matched means every row the
+description could mean exists and the description was under-determined. A
+client got one string and could not tell which.
+
+Now: zero is ``404 unknown_conformer_selection``, several is
+``422 ambiguous_conformer_selection_locator``.
+
+Why these are on the wire
+-------------------------
+The classification itself is unit-tested in
+``tests/services/test_conformer_selection_locator.py``, which is the only
+place two of its three outcomes can be reached at all. Only a request can
+establish that the envelope carries the code and the context out to a
+client, and that the split did not come at the cost of the accepting path
+— so the exactly-one case is asserted here too. A test that only checks an
+error arrived passes against a resolver that refuses everything.
+
+Assertions are on ``(status, code)`` and on ``context`` keys, never on
+substrings of ``detail``.
+"""
+
+from __future__ import annotations
+
+from tests.api.test_api_statmech_citation_ownership import (
+    _KINETICS,
+    _assignments,
+    _rate,
+    _seed_participants,
+)
+from tests.services.scientific_read._factories import (
+    attach_conformer_selection,
+    make_conformer_group,
+)
+
+_UNKNOWN = "unknown_conformer_selection"
+_AMBIGUOUS = "ambiguous_conformer_selection_locator"
+
+#: ``CH3``, the first reactant of the reaction the shared fixture declares.
+_CH3 = {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}
+
+
+def _payload(statmechs, *, species_entry=None, selection_kind="lowest_energy"):
+    """A correct rate whose first reactant also cites a conformer selection.
+
+    Everything but the locator is valid: the statmechs are the right ones
+    for the right participants and the interpretation set is complete. That
+    is what makes a refusal here attributable to the locator rather than to
+    one of the four guards above it.
+    """
+    return _rate(
+        _assignments(
+            statmechs,
+            **{
+                "reactant:1": {
+                    "conformer_selection": {
+                        "species_entry": species_entry or _CH3,
+                        "selection_kind": selection_kind,
+                    }
+                }
+            },
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Zero matched -> 404
+# ---------------------------------------------------------------------------
+
+
+def test_a_locator_matching_nothing_is_a_404_with_its_own_code(
+    client, db_session
+) -> None:
+    """No conformer selection exists for CH3 at all."""
+    _entries, statmechs = _seed_participants(db_session)
+
+    resp = client.post(_KINETICS, json=_payload(statmechs))
+
+    assert resp.status_code == 404, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _UNKNOWN, body
+    assert body["context"]["field"] == (
+        "interpretation_assignments[0].conformer_selection"
+    ), body
+    assert body["context"]["kind"] == "conformer_selection", body
+    assert body["context"]["selection_kind"] == "lowest_energy", body
+    # The locator named no scheme, so there is no scheme to echo.
+    assert "assignment_scheme_ref" not in body["context"], body
+
+
+def test_a_selection_of_the_wrong_kind_still_matches_nothing(
+    client, db_session
+) -> None:
+    """The species entry has a selection; the locator asks for another kind.
+
+    The distinction that matters: this is not "no conformer data for this
+    species", it is "nothing answering this description", and the same 404
+    covers both because the same deposit repairs both.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    attach_conformer_selection(
+        db_session, conformer_group=make_conformer_group(db_session, entries["ch3"])
+    )
+
+    resp = client.post(
+        _KINETICS, json=_payload(statmechs, selection_kind="curator_pick")
+    )
+
+    assert resp.status_code == 404, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _UNKNOWN, body
+    assert body["context"]["selection_kind"] == "curator_pick", body
+
+
+# ---------------------------------------------------------------------------
+# Several matched -> 422, reporting what differs
+# ---------------------------------------------------------------------------
+
+
+def test_two_labelled_groups_make_the_locator_ambiguous(client, db_session) -> None:
+    """One species entry, two conformer groups, one selection each.
+
+    ``conformer_group`` is unique on ``(species_entry_id, label)`` and the
+    locator joins on ``species_entry_id`` alone, which is what makes this
+    reachable: two distinct basins, each with a ``lowest_energy`` selection
+    under no assignment scheme.
+
+    The discriminating axis is the group *label*, which the locator has no
+    field for — so ``locator_can_express`` is ``False`` and the refusal
+    says the difference cannot be expressed rather than telling the
+    depositor to add something that does not exist.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    for label in ("basin-A", "basin-B"):
+        attach_conformer_selection(
+            db_session,
+            conformer_group=make_conformer_group(
+                db_session, entries["ch3"], label=label
+            ),
+        )
+
+    resp = client.post(_KINETICS, json=_payload(statmechs))
+
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _AMBIGUOUS, body
+    context = body["context"]
+    assert context["field"] == (
+        "interpretation_assignments[0].conformer_selection"
+    ), body
+    assert context["kind"] == "conformer_selection", body
+    assert context["match_count"] == 2, body
+    assert context["discriminator"] == "conformer_group_label", body
+    assert context["discriminator_values"] == ["basin-A", "basin-B"], body
+    assert context["differs_by"] == [
+        "conformer_group_label",
+        "conformer_group_ref",
+    ], body
+    assert context["locator_can_express"] is False, body
+
+
+def test_two_unlabelled_groups_fall_back_to_the_group_ref(client, db_session) -> None:
+    """The same ambiguity with nothing to print but the group's public ref.
+
+    ``uq_conformer_group_species_entry_id`` does not declare
+    ``postgresql_nulls_not_distinct``, so a species entry may own several
+    groups with no label — and then the label separates nothing. Reporting
+    the public refs keeps this out of the "differ by nothing" outcome,
+    which would have called two real curation rows a duplicate.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    groups = [
+        make_conformer_group(db_session, entries["ch3"], label=None) for _ in range(2)
+    ]
+    for group in groups:
+        attach_conformer_selection(db_session, conformer_group=group)
+
+    resp = client.post(_KINETICS, json=_payload(statmechs))
+
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _AMBIGUOUS, body
+    context = body["context"]
+    assert context["match_count"] == 2, body
+    assert context["differs_by"] == ["conformer_group_ref"], body
+    assert context["discriminator"] == "conformer_group_ref", body
+    assert sorted(context["discriminator_values"]) == sorted(
+        group.public_ref for group in groups
+    ), body
+    assert context["locator_can_express"] is False, body
+
+
+def test_a_third_group_is_counted_and_listed(client, db_session) -> None:
+    """``match_count`` is the real count, not the old ``limit(2)`` fetch.
+
+    The lookup used to stop at two rows because it only needed to know
+    whether the answer was exactly one. A refusal that says how many
+    matched has to actually count them, and "2" for three matches is the
+    shape of wrong that reads as right.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    for label in ("basin-A", "basin-B", "basin-C"):
+        attach_conformer_selection(
+            db_session,
+            conformer_group=make_conformer_group(
+                db_session, entries["ch3"], label=label
+            ),
+        )
+
+    resp = client.post(_KINETICS, json=_payload(statmechs))
+
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _AMBIGUOUS, body
+    assert body["context"]["match_count"] == 3, body
+    assert body["context"]["discriminator_values"] == [
+        "basin-A",
+        "basin-B",
+        "basin-C",
+    ], body
+
+
+# ---------------------------------------------------------------------------
+# Exactly one -> still accepted
+# ---------------------------------------------------------------------------
+
+
+def test_a_locator_matching_exactly_one_selection_is_still_accepted(
+    client, db_session
+) -> None:
+    """The half that fails against a resolver which refuses everything.
+
+    Same route, same field, same locator shape as both refusals above --
+    the only difference is how many selections the database holds.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    attach_conformer_selection(
+        db_session, conformer_group=make_conformer_group(db_session, entries["ch3"])
+    )
+
+    resp = client.post(_KINETICS, json=_payload(statmechs))
+
+    assert resp.status_code == 201, resp.text[:800]
+
+
+# ---------------------------------------------------------------------------
+# The two are distinguishable, which is the whole point
+# ---------------------------------------------------------------------------
+
+
+def test_the_two_halves_no_longer_share_a_status_or_a_code(
+    client, db_session
+) -> None:
+    """One assertion over both, so collapsing them cannot pass.
+
+    Before this change both bodies were byte-identical:
+    ``422 {"code": "validation_error", "detail": "conformer_selection
+    content locator must resolve exactly one selection.", "context": {}}``.
+    Asserting each half separately would still pass if a later edit gave
+    them one code again, provided each assertion were updated on its own;
+    comparing the pair is what refuses that.
+    """
+    entries, statmechs = _seed_participants(db_session)
+
+    zero = client.post(_KINETICS, json=_payload(statmechs))
+
+    for label in ("basin-A", "basin-B"):
+        attach_conformer_selection(
+            db_session,
+            conformer_group=make_conformer_group(
+                db_session, entries["ch3"], label=label
+            ),
+        )
+    several = client.post(_KINETICS, json=_payload(statmechs))
+
+    assert (zero.status_code, zero.json()["code"]) == (404, _UNKNOWN), zero.text[:400]
+    assert (several.status_code, several.json()["code"]) == (
+        422,
+        _AMBIGUOUS,
+    ), several.text[:400]
+    assert zero.status_code != several.status_code
+    assert zero.json()["code"] != several.json()["code"]
+    assert zero.json()["context"] != several.json()["context"]

--- a/backend/tests/services/test_conformer_selection_locator.py
+++ b/backend/tests/services/test_conformer_selection_locator.py
@@ -1,0 +1,288 @@
+"""The discriminator behind ``ambiguous_conformer_selection_locator``.
+
+Why a unit test and not only a wire test
+----------------------------------------
+:func:`app.services.conformer_selection_locator.discriminate` classifies a
+candidate set three ways, and **only one of the three is reachable through
+a route**:
+
+* *differs by a locator field* cannot happen, because the lookup filters on
+  every field the locator has, so candidates agree on all of them;
+* *differs by nothing reportable* cannot happen while
+  ``uq_conformer_selection_conformer_group_id`` holds — it permits one
+  selection per ``(group, scheme, kind)`` and candidates share scheme and
+  kind, so two candidates always sit in two groups and always differ by
+  ``conformer_group_ref``.
+
+Both are worth *reporting distinctly* anyway: the first is the outcome
+that would tell a depositor what to add, and its unreachability is the
+finding that the locator is too narrow; the second would be a duplicate
+curation row, which is a different bug and one the depositor should hear
+about rather than be told to be more specific. A branch no test can enter
+is how this repository's recurring defect looks, so the function is pure
+and the classification is pinned here, over hand-built candidates.
+
+The wire half — that the two codes, statuses and context keys reach a
+client, and that a locator matching exactly one selection still succeeds —
+is ``tests/api/test_api_conformer_selection_locator_codes.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.models.common import ConformerSelectionKind
+from app.services.conformer_selection_locator import (
+    W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR,
+    W_UNKNOWN_CONFORMER_SELECTION,
+    SelectionCandidate,
+    ambiguous_conformer_selection_locator,
+    discriminate,
+    selection_kind_token,
+    unknown_conformer_selection,
+)
+
+_FIELD = "interpretation_assignments[0].conformer_selection"
+
+
+def test_the_two_codes_are_two_distinct_published_strings() -> None:
+    """Spelled out, not compared to the constants they came from.
+
+    Every other assertion in this file reads ``error.code ==
+    W_UNKNOWN_CONFORMER_SELECTION``, which is satisfied by whatever the
+    constant happens to say -- including by both constants saying the same
+    thing, which is precisely the collapse this work undid.
+    """
+    assert W_UNKNOWN_CONFORMER_SELECTION == "unknown_conformer_selection"
+    assert (
+        W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR
+        == "ambiguous_conformer_selection_locator"
+    )
+    assert W_UNKNOWN_CONFORMER_SELECTION != W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR
+
+
+def _candidate(
+    selection_id: int,
+    *,
+    selection_kind: str = "lowest_energy",
+    label: str | None = None,
+    group_ref: str = "cgrp_aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    scheme_ref: str | None = None,
+) -> SelectionCandidate:
+    return SelectionCandidate(
+        selection_id=selection_id,
+        selection_kind=selection_kind,
+        conformer_group_label=label,
+        conformer_group_ref=group_ref,
+        assignment_scheme_ref=scheme_ref,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outcome 1: differs by something the locator can express
+# ---------------------------------------------------------------------------
+
+
+def test_a_differing_selection_kind_is_reported_as_actionable() -> None:
+    found = discriminate(
+        [
+            _candidate(1, selection_kind="lowest_energy", group_ref="cgrp_a"),
+            _candidate(2, selection_kind="curator_pick", group_ref="cgrp_b"),
+        ]
+    )
+    assert found.discriminator == "selection_kind", found
+    assert found.locator_can_express is True, found
+    assert found.discriminator_values == ("lowest_energy", "curator_pick"), found
+
+
+def test_a_differing_assignment_scheme_is_reported_as_actionable() -> None:
+    found = discriminate(
+        [
+            _candidate(1, scheme_ref="cas_one", group_ref="cgrp_a"),
+            _candidate(2, scheme_ref="cas_two", group_ref="cgrp_b"),
+        ]
+    )
+    assert found.discriminator == "assignment_scheme_ref", found
+    assert found.locator_can_express is True, found
+
+
+def test_a_locator_field_wins_over_a_group_difference() -> None:
+    """Both axes vary; the one the depositor can act on is the one named.
+
+    This is what the ordering of ``_AXES`` buys, and the assertion that
+    would fail if the axes were reordered or collected into a set.
+    """
+    found = discriminate(
+        [
+            _candidate(1, selection_kind="lowest_energy", label="A", group_ref="cgrp_a"),
+            _candidate(2, selection_kind="curator_pick", label="B", group_ref="cgrp_b"),
+        ]
+    )
+    assert found.differs_by == (
+        "selection_kind",
+        "conformer_group_label",
+        "conformer_group_ref",
+    ), found
+    assert found.discriminator == "selection_kind", found
+    assert found.locator_can_express is True, found
+
+
+# ---------------------------------------------------------------------------
+# Outcome 2: differs only by something the locator cannot express
+# ---------------------------------------------------------------------------
+
+
+def test_a_group_label_difference_is_reported_as_unactionable() -> None:
+    found = discriminate(
+        [
+            _candidate(1, label="basin-A", group_ref="cgrp_a"),
+            _candidate(2, label="basin-B", group_ref="cgrp_b"),
+        ]
+    )
+    assert found.discriminator == "conformer_group_label", found
+    assert found.locator_can_express is False, found
+    assert found.discriminator_values == ("basin-A", "basin-B"), found
+
+
+def test_unlabelled_groups_fall_back_to_the_group_ref() -> None:
+    """Two groups with no label at all.
+
+    ``uq_conformer_group_species_entry_id`` does not declare
+    ``postgresql_nulls_not_distinct``, so one species entry may own many
+    unlabelled groups — and then the *label* discriminates nothing and the
+    public ref is the only handle left. Without this fallback the refusal
+    would land in outcome 3 and call two genuinely different curation rows
+    a duplicate.
+    """
+    found = discriminate(
+        [_candidate(1, group_ref="cgrp_a"), _candidate(2, group_ref="cgrp_b")]
+    )
+    assert found.differs_by == ("conformer_group_ref",), found
+    assert found.discriminator == "conformer_group_ref", found
+    assert found.locator_can_express is False, found
+    assert found.discriminator_values == ("cgrp_a", "cgrp_b"), found
+
+
+def test_one_labelled_and_one_unlabelled_group_still_discriminate() -> None:
+    found = discriminate(
+        [
+            _candidate(1, label=None, group_ref="cgrp_a"),
+            _candidate(2, label="basin-B", group_ref="cgrp_b"),
+        ]
+    )
+    assert found.discriminator == "conformer_group_label", found
+    assert found.discriminator_values == (None, "basin-B"), found
+    # A ``None`` in the published list must not crash the sentence, which
+    # is the one thing sorting or ``", ".join`` would have done.
+    assert "unlabelled" in str(
+        ambiguous_conformer_selection_locator(
+            field=_FIELD,
+            candidates=[
+                _candidate(1, label=None, group_ref="cgrp_a"),
+                _candidate(2, label="basin-B", group_ref="cgrp_b"),
+            ],
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outcome 3: differs by nothing reportable
+# ---------------------------------------------------------------------------
+
+
+def test_indistinguishable_candidates_are_reported_as_duplicates() -> None:
+    """Not reachable through a route; see the module docstring.
+
+    Reported as a duplicate curation row rather than as ambiguity, because
+    "be more specific" would be false twice over here: there is nothing to
+    add *and* nothing that separates them.
+    """
+    found = discriminate([_candidate(1), _candidate(2)])
+    assert found.differs_by == (), found
+    assert found.discriminator is None, found
+    assert found.discriminator_values == (), found
+    assert found.locator_can_express is False, found
+
+    error = ambiguous_conformer_selection_locator(
+        field=_FIELD, candidates=[_candidate(1), _candidate(2)]
+    )
+    assert "duplicate curation rows" in str(error), str(error)
+    assert "be more specific" not in str(error), str(error)
+
+
+# ---------------------------------------------------------------------------
+# The two refusals themselves
+# ---------------------------------------------------------------------------
+
+
+def test_the_ambiguity_refusal_publishes_the_documented_context() -> None:
+    error = ambiguous_conformer_selection_locator(
+        field=_FIELD,
+        candidates=[
+            _candidate(1, label="basin-A", group_ref="cgrp_a"),
+            _candidate(2, label="basin-B", group_ref="cgrp_b"),
+            _candidate(3, label="basin-C", group_ref="cgrp_c"),
+        ],
+    )
+    assert error.code == W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR
+    assert error.context == {
+        "field": _FIELD,
+        "kind": "conformer_selection",
+        "match_count": 3,
+        "differs_by": ["conformer_group_label", "conformer_group_ref"],
+        "discriminator": "conformer_group_label",
+        "discriminator_values": ["basin-A", "basin-B", "basin-C"],
+        "locator_can_express": False,
+    }, error.context
+    # ``message_prefix=False``: the code is an attribute, and repeating it
+    # in the prose puts a second copy where a reword can drop it.
+    assert not str(error).startswith(W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR)
+
+
+def test_no_context_value_is_a_row_id() -> None:
+    """The selection ids are the obvious discriminator and the banned one.
+
+    DR-0028 Requirement 2. ``SelectionCandidate`` carries the id because
+    the success path needs it, so the guard that matters is that no axis
+    names it.
+    """
+    error = ambiguous_conformer_selection_locator(
+        field=_FIELD,
+        candidates=[
+            _candidate(918, label="basin-A", group_ref="cgrp_a"),
+            _candidate(919, label="basin-B", group_ref="cgrp_b"),
+        ],
+    )
+    rendered = str(error) + str(error.context)
+    for token in ("918", "919", "selection_id", "conformer_group_id"):
+        assert token not in rendered, (token, rendered)
+
+
+@pytest.mark.parametrize("scheme_ref", [None, "cas_aaaaaaaaaaaaaaaaaaaaaaaaaa"])
+def test_the_unknown_refusal_echoes_only_what_the_caller_wrote(scheme_ref) -> None:
+    error = unknown_conformer_selection(
+        field=_FIELD,
+        selection_kind="lowest_energy",
+        assignment_scheme_ref=scheme_ref,
+    )
+    assert error.code == W_UNKNOWN_CONFORMER_SELECTION
+    assert error.context["field"] == _FIELD
+    assert error.context["kind"] == "conformer_selection"
+    assert error.context["selection_kind"] == "lowest_energy"
+    if scheme_ref is None:
+        # Omitted rather than published as null, matching
+        # ``unknown_reference``'s treatment of an absent ``ref``.
+        assert "assignment_scheme_ref" not in error.context, error.context
+    else:
+        assert error.context["assignment_scheme_ref"] == scheme_ref, error.context
+
+
+def test_a_selection_kind_read_back_from_the_database_is_a_token() -> None:
+    """``str()`` of a ``str``-Enum is ``"ClassName.member"`` on 3.11+.
+
+    Which is what would have reached ``context`` and the client's branch.
+    """
+    assert (
+        selection_kind_token(ConformerSelectionKind.lowest_energy) == "lowest_energy"
+    )
+    assert selection_kind_token("curator_pick") == "curator_pick"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.52.1"
+version = "0.52.2"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -83,6 +83,7 @@ class RejectionCode(str, Enum):
     can be used wherever the raw code was.
     """
 
+    AMBIGUOUS_CONFORMER_SELECTION_LOCATOR = "ambiguous_conformer_selection_locator"
     APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH = "applied_energy_correction_source_calculation_owner_mismatch"
     APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED = "applied_energy_correction_source_key_undeclared"
     ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH = "arrhenius_a_units_molecularity_mismatch"
@@ -214,6 +215,7 @@ class RejectionCode(str, Enum):
     UNIQUE_CONFLICT = "unique_conflict"
     UNKNOWN_CALCULATION_ARTIFACT_REF = "unknown_calculation_artifact_ref"
     UNKNOWN_CALCULATION_REF = "unknown_calculation_ref"
+    UNKNOWN_CONFORMER_SELECTION = "unknown_conformer_selection"
     UNKNOWN_CURATION_POLICY = "unknown_curation_policy"
     UNKNOWN_INCLUDE_TOKEN = "unknown_include_token"
     UNKNOWN_NETWORK_KINETICS_REF = "unknown_network_kinetics_ref"
@@ -239,6 +241,7 @@ class RejectionCode(str, Enum):
 #: payload may be sent again under the same idempotency key.
 VALIDATION_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
     {
+        RejectionCode.AMBIGUOUS_CONFORMER_SELECTION_LOCATOR,
         RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH,
         RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED,
         RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH,
@@ -395,6 +398,7 @@ CONFLICT_REJECTION_CODES: frozenset[RejectionCode] = frozenset(
 #: wire boundary and again in the schema reports the same code from
 #: both, at two different statuses.
 REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
+    RejectionCode.AMBIGUOUS_CONFORMER_SELECTION_LOCATOR: frozenset({422}),
     RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_CALCULATION_OWNER_MISMATCH: frozenset({422}),
     RejectionCode.APPLIED_ENERGY_CORRECTION_SOURCE_KEY_UNDECLARED: frozenset({422}),
     RejectionCode.ARRHENIUS_A_UNITS_MOLECULARITY_MISMATCH: frozenset({422}),
@@ -526,6 +530,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.UNIQUE_CONFLICT: frozenset({409}),
     RejectionCode.UNKNOWN_CALCULATION_ARTIFACT_REF: frozenset({404}),
     RejectionCode.UNKNOWN_CALCULATION_REF: frozenset({404}),
+    RejectionCode.UNKNOWN_CONFORMER_SELECTION: frozenset({404}),
     RejectionCode.UNKNOWN_CURATION_POLICY: frozenset({404}),
     RejectionCode.UNKNOWN_INCLUDE_TOKEN: frozenset({422}),
     RejectionCode.UNKNOWN_NETWORK_KINETICS_REF: frozenset({404}),


### PR DESCRIPTION
## Plain-language summary

A depositor uploading a rate coefficient can point at a stored *conformer
selection* — the curator's record of "this basin is the lowest-energy one for
this species" — without holding a handle for it. Instead of a name they send a
*description*: `{species_entry, selection_kind, assignment_scheme_ref}`, read as
"the lowest-energy selection for this species entry under this scheme". The
server insists the description picks out exactly one stored row.

Two completely different things can go wrong, and until this change the server
said the same thing for both: *"conformer_selection content locator must resolve
exactly one selection."* Either **nothing** matched the description — the row is
simply not in the database — or **several** did, because the description was too
vague. Those need opposite responses. For "nothing matched" the depositor has to
go and deposit the record first; no amount of rewording the request will help.
For "several matched" everything they named exists and they only need to say
more about which one they meant. One sentence for both meant a program on the
other end could not tell which situation it was in, so it could not decide what
to do next.

Some software terms used below:

* **HTTP status** — the three-digit number a web request comes back with. `404`
  conventionally means "the thing you named does not exist"; `422` means "your
  message was malformed or incomplete — fix it and resend"; `409` means "your
  message is fine but the world is not how you assumed".
* **error code** — a short fixed machine-readable string (`unknown_statmech_ref`)
  in the response body. A program branches on this; the English sentence beside
  it is for humans and is not a contract.
* **context** — the structured half of an error body: a small set of named facts
  a program can read without parsing English.
* **row id / primary key** — the internal integer a database uses to identify a
  row. TCKDB never publishes these (DR-0028 Requirement 2), because they are an
  implementation detail of one database instance and a client that learns to read
  one is building against something we never promised to keep stable. Everything
  published here is a *public ref* or a human label instead.

So this change splits one message into two answers, and — the interesting half —
makes the "several matched" answer say **what actually differs between the
candidates**, rather than just "be more specific". That distinction matters
because "be more specific" is only advice if there is something to add, and here
there provably is not: see the finding below.

---

## The site

One line, `backend/app/workflows/kinetics.py`, on `/uploads/kinetics`:

```
raise ValueError("conformer_selection content locator must resolve exactly one selection.")
```

Confirmed the single instance in the repository by grep, and
`git log -S` over `backend/app` returns exactly one commit —
*Close scientific integrity blockers (Stage 2)* (`ee7377f5`) — so it has never
lived anywhere else. Earlier task notes described this and "the group 3 locator
site" as two separate things; they are the same line, and this PR owns it.

## Wire reproduction — before

Both halves, through a real request against a real database, byte-identical:

```
ZERO    -> 422 {"code": "validation_error",
                "detail": "conformer_selection content locator must resolve exactly one selection.",
                "context": {}}
SEVERAL -> 422 {"code": "validation_error",
                "detail": "conformer_selection content locator must resolve exactly one selection.",
                "context": {}}
ONE     -> 201
```

The premise holds: identical status, identical code, identical detail, empty
context.

## Wire reproduction — after

```
ZERO -> 404 {
  "code": "unknown_conformer_selection",
  "detail": "interpretation_assignments[0].conformer_selection (selection_kind='lowest_energy',
             no assignment scheme) describes no conformer selection for that species entry in
             this database. Deposit the conformer selection first, or correct the species entry
             the locator names.",
  "context": {"field": "interpretation_assignments[0].conformer_selection",
              "kind": "conformer_selection",
              "selection_kind": "lowest_energy"}
}

SEVERAL -> 422 {
  "code": "ambiguous_conformer_selection_locator",
  "detail": "2 conformer selections match interpretation_assignments[0].conformer_selection, so
             the content locator does not name one. They differ by conformer_group_label
             ('basin-A', 'basin-B'), which the content locator has no field for -- so no
             corrected locator resolves this. Give the selections distinct assignment schemes,
             or report that the locator needs widening.",
  "context": {"field": "interpretation_assignments[0].conformer_selection",
              "kind": "conformer_selection",
              "match_count": 2,
              "differs_by": ["conformer_group_label", "conformer_group_ref"],
              "discriminator": "conformer_group_label",
              "discriminator_values": ["basin-A", "basin-B"],
              "locator_can_express": false}
}

ONE -> 201   (unchanged)
```

## The two codes

| code | status | surface | why that status |
|---|---|---|---|
| `unknown_conformer_selection` | 404 | coded exception | The depositor named a curation-overlay row that is not there. No corrected body conjures it. Keeps "you named a thing that is not there" at one status across every locator spelling on this route, consistent with *Name which citation the 404 was about, on thermo and statmech* (#200) and *Say which kind of wrong a refusal was* (#195). |
| `ambiguous_conformer_selection_locator` | 422 | coded exception | Every row it could mean exists, so the stored data is consistent and 409 would be a false claim about the world. The *request* is under-determined, which is what a published 422 says. |

Context keys, and what a client branches on:

* 404: `field`, `kind`, `selection_kind`, and `assignment_scheme_ref` **only when
  the locator set one** — matching `unknown_reference`'s treatment of an absent
  `ref`. The `field`/`kind` pair is deliberately identical to the shape #195/#200
  publish, so a client does not learn a second body layout depending on how the
  row was named.
* 422: `field`, `kind`, `match_count`, `differs_by`, `discriminator`,
  `discriminator_values`, `locator_can_express`. `match_count` follows the
  `freq_mode_index_not_unique` precedent (`{"duplicate_mode_indices": [...],
  "mode_count": N}`) — the house shape for "several of a thing".

No context value is a database primary key (DR-0028 Requirement 2). Every
discriminator is a public-surface value: a conformer group **label**, a conformer
group **public ref**, an assignment scheme **public ref**, a `selection_kind`, or
a count. The selection ids the query fetches are carried on the candidate
dataclass for the success path and are never an axis, so the discriminator
computation structurally cannot put one in `context`. The runtime body observer
from *Watch every error body for a row id* (#202) saw both new bodies during the
run and passed.

## Which discriminator outcome was observed, and whether the locator must widen

**Outcome 2, always — and it is structural, not incidental. The locator must
widen.**

The brief anticipated that "be more specific" would usually mean "add an
`assignment_scheme_ref`". It never can. The lookup filters on **every field the
locator has**: it joins on `species_entry_id`, tests
`selection_kind = <locator value>`, and either tests
`assignment_scheme_id IS NULL` or joins the scheme and tests its unique
`public_ref`. So every candidate agrees on all three locator fields *by
construction*, and the axis that separates them can never be a locator field.
Adding a scheme ref does not narrow an ambiguous NULL-scheme match; it selects a
different, empty set.

What actually separates them is the **conformer group**, which the locator cannot
name at all. `conformer_group` is unique on `(species_entry_id, label)` and the
locator joins on `species_entry_id` alone, so one species entry may own many
groups, each able to carry a `lowest_energy` selection under no scheme. Every
refusal a request can provoke therefore reports `locator_can_express: false`.

The natural widening is a **conformer group public ref** field on
`ConformerSelectionContentRef`, not a label: `uq_conformer_group_species_entry_id`
does not declare `postgresql_nulls_not_distinct`, so a species entry may own
several *unlabelled* groups and the label discriminates nothing in that case.
That is why the discriminator falls back to the group's public ref, and why the
error still has something true to print when it does.

**Not done in this PR**, per the brief: adding a field to an upload schema is a
contract change of its own. The finding is that it is warranted, and a follow-up
task is justified.

The two outcomes a request cannot reach are still computed and reported
distinctly, because their unreachability is the finding:

1. **Differs by a locator field** — actionable, and structurally impossible for
   the reason above.
3. **Differs by nothing reportable** — would be a duplicate curation row rather
   than an under-determined request, and the refusal says exactly that instead of
   dressing it up as ambiguity. Unreachable while
   `uq_conformer_selection_conformer_group_id` holds: it permits at most one
   selection per `(group, scheme, kind)`, candidates share scheme and kind, so
   two candidates always sit in two groups and always differ by their group's
   public ref.

Both are held by unit tests over hand-built candidates rather than asserted about
in prose, which is why the classification is a pure function
(`discriminate()`) and not an inline block. A branch no test can enter is this
repository's recurring defect.

## How the several-matched case was built

One species entry (`CH3`), two `conformer_group` rows with labels `basin-A` and
`basin-B`, one `lowest_energy` `conformer_selection` on each with a NULL
assignment scheme. Reachable through the ordinary factories with no fixture
surgery, and the second wire test builds the *unlabelled* variant (two groups
with `label=None`) to exercise the public-ref fallback. A third test seeds three
groups, because the lookup used to fetch `limit(2)` and a `match_count` of 2 for
three matches is the shape of wrong that reads as right.

## Mutations

Both landed and both reddened; both reverted.

1. **Collapse the two codes into one** — pointed
   `W_UNKNOWN_CONFORMER_SELECTION` at the ambiguity code. Reddened the wire
   tests for both halves (`test_a_locator_matching_nothing_is_a_404_with_its_own_code`,
   `test_a_selection_of_the_wrong_kind_still_matches_nothing`,
   `test_the_two_halves_no_longer_share_a_status_or_a_code`) *and* the #202
   runtime catalogue observer, which reported `HTTP 404
   'ambiguous_conformer_selection_locator': catalogued only at 422`.

   This mutation also exposed a hole and closed it: the unit tests compared
   `error.code` against the constants they came from, so a constant edit was
   invisible to them. `test_the_two_codes_are_two_distinct_published_strings`
   now spells both strings out and asserts they differ.

2. **Blind the discriminator** — made `discriminate()` return no differing axis
   (`differs = ()`). Reddened 10 tests: 7 unit tests across all three outcomes
   and 3 wire tests (`test_two_labelled_groups_make_the_locator_ambiguous`,
   `test_two_unlabelled_groups_fall_back_to_the_group_ref`,
   `test_a_third_group_is_counted_and_listed`).

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no new environment variable. Read
paths and write paths are untouched apart from the one lookup, and the accepting
path is asserted unchanged (`201`) by
`test_a_locator_matching_exactly_one_selection_is_still_accepted`.

Two mechanical changes inside that lookup, both behaviour-preserving on the
success path:

* the assignment-scheme join became an **OUTER** join, so the refusal can report
  the scheme a NULL-scheme candidate carries. The `WHERE` clauses are unchanged,
  and a predicate on an outer-joined column filters exactly as the inner join
  did;
* the `limit(2)` is gone, because a refusal that publishes `match_count` has to
  actually count. The set is small by construction — one species entry, one
  selection kind, one scheme, and the unique constraint permits at most one row
  per conformer group of that entry.

## Wire package / client

`clients/python/src/tckdb_client/rejection_codes.py` regenerated from the
catalogue (both codes are 4xx and request-reachable, so both are client-facing),
and `clients/python/pyproject.toml` bumped **0.52.1 → 0.52.2** — checked against
`origin/main`, not the branch point. No change to `tckdb_schemas`.

## Noted, deliberately not touched

* `backend/app/workflows/kinetics.py` `_find_sp_for_species` **already** splits
  zero from multiple into two distinct sentences — but both are bare
  `ValueError`s arriving as `422 validation_error` with no code and no context.
  That is the ideal precedent for the remaining group-3 work: the split exists in
  prose and was never given codes. Left alone.
* `kinetics.py`'s `len(ts_refs) != 1` is **not** the same shape — `if not
  ts_refs: return None` sits above it, so `!= 1` can only mean "more than one".
  One condition, one repair. Untouched.

## Commands run

From `backend/` (a pre-existing cwd-relative fixture glob fails from the
repository root):

```
conda run -n tckdb_env pytest tests/ -q
conda run -n tckdb_env pytest tests/services/test_conformer_selection_locator.py \
    tests/api/test_api_conformer_selection_locator_codes.py \
    tests/workflows/test_kinetics_upload.py \
    tests/api/test_api_statmech_citation_ownership.py -q
conda run -n tckdb_env pytest tests/api/test_api_code_catalogue.py \
    tests/api/test_client_rejection_codes_generated.py -q
conda run -n tckdb_env ruff check app tests scripts
conda run -n tckdb_env python scripts/check_runtime_ascii.py
conda run -n tckdb_env mypy
```

From the repository root:

```
conda run -n tckdb_env python backend/scripts/generate_client_rejection_codes.py
git diff
```

Blast radius before editing: `impact({target: "_resolve_interpretation_assignments",
direction: "upstream"})` — **LOW**, 1 direct caller (`persist_kinetics_upload`),
one execution flow (`upload_kinetics`).
