### PR TITLE
Say which error codes owe a client structured facts, and pay four of them

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -57,6 +57,64 @@ Nor any line numbers or rendered paths in the generated client file. See
 ``backend/scripts/generate_client_rejection_codes.py`` for why a gate that
 fires on cosmetic movement is worse than no gate.
 
+Which codes owe a client structured facts
+-----------------------------------------
+Every entry also carries a :class:`Shape`: whether the code names a
+*thing* or a *relationship between things*, and therefore whether the
+envelope's ``context`` owes a client anything. The rule and its reasoning
+live on that class. What belongs here is the part a reader of *this list*
+needs -- the borderline calls -- because a classification whose hard cases
+are undocumented is one the next person re-litigates from scratch.
+
+Measured on this file: 64 entries (62 distinct codes) are relationships,
+104 are things.
+
+The groups where the call was genuinely arguable, and the argument:
+
+* **Caps are things.** ``limit_too_large``, ``offset_too_large``,
+  ``geometry_too_large``, ``smiles_too_long``, ``export_all_cap_exceeded``,
+  ``ml_export_all_cap_exceeded``, ``query_too_expensive`` and
+  ``composed_search_candidate_limit_exceeded`` each compare a supplied
+  value against a server-side limit, so by the letter of the rule they
+  assert something about two things. They are classified as things because
+  the rule's discriminator is *conflict, mismatch, ambiguity* and a cap
+  breach is none of those: the code names one field and states a predicate
+  about it, and the field is the whole repair. This is the largest
+  borderline group and the one most likely to be revisited -- a client
+  retrying with a legal page size does want the cap, and on a deployment
+  that lowers ``public_max_limit`` the cap is not guessable from the docs.
+* **A code that names both its fields is a thing.**
+  ``parameter_value_requires_key``,
+  ``canonical_parameter_value_requires_key`` and
+  ``unsupported_ranking_for_calculation_type`` are each about two fields
+  and each *names* both, so a ``context`` would be the code spelled a
+  second way.
+* **"Taken" is a thing.** ``email_taken``, ``username_taken`` and
+  ``release_tag_taken`` imply a second claimant, but only one party is
+  identifiable and the code says which field it is -- which was the point
+  of splitting the first two in #225. The other claimant is another
+  principal's row and is not ours to disclose.
+* **``artifact_integrity_failed`` is a thing**, although it is a digest
+  comparison. Its name states a property of one artifact, and the two
+  digests are custody evidence for an operator -- recorded in
+  ``artifact_integrity_event``, not handed to a caller who can act on
+  neither. Its response body is pinned empty for exactly that reason.
+* **``invalid_structure_query`` is a thing** because only one of its two
+  conditions has a second thing (``mode`` not accepting a query kind); the
+  other is an unparseable SMILES. A code that owes facts on one path and
+  not the other should be split, which is a bigger decision than a
+  classification.
+* **``supersedes_same_record`` is a relationship** although it fires
+  because two things are the *same* rather than different. The test the
+  rule applies is whether the code asserts something about two things and
+  names neither, and it does.
+* **``tckdb_client_version_unsupported`` is a relationship that is
+  deliberately not populated.** Its two facts are already
+  machine-readable, in a ``detail`` that is a dict rather than a sentence
+  -- see :attr:`Surface.detail_object`. That is why
+  :attr:`ApiCode.owes_context` is a property and not a bare comparison
+  against :attr:`Shape.relationship`.
+
 Why completeness is checked, not claimed
 ----------------------------------------
 A catalogue that asserts it is complete and is not would be exactly the
@@ -295,6 +353,107 @@ class Replay(str, Enum):
     never_succeeds = "never_succeeds"
 
 
+class Shape(str, Enum):
+    """Whether the code names a *thing* or a *relationship between things*.
+
+    Why this classification and not "does it have ``context`` yet"
+    -------------------------------------------------------------
+    The error contract tells clients to branch on :attr:`ApiCode.code` and
+    read the envelope's structured ``context``, never the prose ``detail``
+    — see :mod:`app.api.error_contract`. That advice is right, and for a
+    large part of this catalogue ``context`` is an empty object, so the
+    advice reduced to "read this empty dict" and the only place the reason
+    lived was the prose a client was told not to parse.
+
+    The obvious repair — populate ``context`` everywhere — is wrong. Most
+    refusals have nothing to put there. Calvin's rule (2026-08-17) says
+    which do:
+
+        A code naming a **relationship** — conflict, mismatch, ambiguity —
+        needs ``context``, because it asserts something about two or more
+        things and names none of them. A code naming a **thing** —
+        ``unknown_X``, ``missing_Y`` — does not, because the name is the
+        whole message.
+
+    ``unknown_release`` is complete as it stands: a client that reads the
+    code knows exactly what happened and what to fix. ``state_conflict``
+    is not: it says two things disagreed and names neither, so without
+    ``context`` the only way to find out which is to read English.
+
+    What this field is, and what it is not
+    --------------------------------------
+    It is a statement about the **code**, in the same way :class:`Surface`
+    is a statement about mechanism: a fact that does not change when the
+    implementation does. It is deliberately *not* a record of whether the
+    obligation has been met — that is measured from the response body by
+    the per-code wire tests, not declared here, because a declaration
+    would go stale in the direction that hides work rather than the
+    direction that fails.
+
+    So a :attr:`relationship` entry with an empty ``context`` today is a
+    known gap, not a lie: the classification is what makes the gap
+    countable, and nothing in the test suite asserts that any such
+    ``context`` *stays* empty. Pinning the empty object would make every
+    future improvement cost a red test, which is why the suite carefully
+    does not do it.
+
+    Why the default is :attr:`thing`, and why that is safe
+    -----------------------------------------------------
+    Because most codes are things (measured: roughly five in eight), so
+    declaring the majority case would be noise of the kind
+    :attr:`Reach.request` and :attr:`Replay.may_succeed` also avoid. The
+    risk a default carries is the opposite of theirs, though: an
+    unclassified *relationship* would read as a thing and quietly excuse
+    itself from the obligation.
+
+    That is closed by :data:`RELATIONSHIP_WORDS` and its guard in
+    ``backend/tests/api/test_api_code_catalogue.py``. A code whose *name*
+    contains a word that can only describe a relation between two things
+    must declare :attr:`relationship`; the guard covers the spellings the
+    codes here actually use, and it is the reason a new ``*_mismatch``
+    cannot arrive classified as a thing by omission. The converse is not
+    guarded and cannot be: plenty of relationships are spelled without
+    one of those words — ``atom_map_not_a_bijection``,
+    ``selection_already_stands``, ``multiple_structure_queries`` — so
+    those are declared by hand and the declaration is the judgement.
+    """
+
+    #: The name is the whole message. A client that reads the code knows
+    #: what happened; ``context`` would repeat it in a second spelling.
+    #: The default.
+    thing = "thing"
+
+    #: The code asserts a disagreement, a collision or an ambiguity
+    #: between two or more things and names none of them, so ``context``
+    #: is the only place the *which* can live. What goes in it is the
+    #: things themselves — a field path, a public ref, a declared local
+    #: key, a constraint name, a count — and never a database primary key
+    #: (DR-0028 Requirement 2), which is logged instead.
+    relationship = "relationship"
+
+
+#: Words that can only describe a relation between two or more things.
+#: A code whose name contains one of these must declare
+#: :attr:`Shape.relationship`; the guard over this constant lives in
+#: ``backend/tests/api/test_api_code_catalogue.py``.
+#:
+#: Deliberately short, and deliberately not "every word that hints at a
+#: comparison". ``too_large``, ``exceeds`` and ``requires`` were all
+#: considered and left out: each compares a supplied value against a
+#: server-side limit or a sibling field that the *code itself already
+#: names*, so the name is the whole message and forcing them into
+#: :attr:`Shape.relationship` would turn a judgement into an accident of
+#: vocabulary. See the borderline notes in the module docstring.
+RELATIONSHIP_WORDS: tuple[str, ...] = (
+    "ambiguous",
+    "conflict",
+    "contradicts",
+    "disagree",
+    "mismatch",
+    "not_conserved",
+)
+
+
 #: Statuses a client may reasonably replay, so the statuses where a
 #: :attr:`Replay.never_succeeds` declaration changes an outcome rather
 #: than merely being true. Mirrors
@@ -332,6 +491,11 @@ class ApiCode:
         rather than derived, because nothing an entry holds implies it.
         Defaults to :attr:`Replay.may_succeed`, which is the fail-safe
         direction.
+    :param shape: Whether the code names a thing or a relationship
+        between things, and therefore whether it owes a client a populated
+        ``context`` — see :class:`Shape`. Declared, because no other field
+        implies it; defaults to :attr:`Shape.thing` with
+        :data:`RELATIONSHIP_WORDS` guarding the omission that would matter.
     :param note: A fact the site cannot state about itself. Deliberately
         rare — this is an enumeration, not a second copy of the refusal
         messages. Required on every :attr:`Reach.guard` entry, because
@@ -346,7 +510,22 @@ class ApiCode:
     origin: str
     reach: Reach = Reach.request
     replay: Replay = Replay.may_succeed
+    shape: Shape = Shape.thing
     note: str | None = None
+
+    @property
+    def owes_context(self) -> bool:
+        """Whether a client is owed structured facts beside this code.
+
+        True exactly for :attr:`Shape.relationship`. A separate property
+        rather than a bare comparison so the obligation has a name the
+        tests and the client-facing docs can both cite, and so that
+        narrowing it later — should a relationship code turn out to state
+        its things in a structured ``detail`` instead, as
+        ``tckdb_client_version_unsupported`` does — is one edit here rather
+        than a search for ``is Shape.relationship``.
+        """
+        return self.shape is Shape.relationship
 
     @property
     def is_client_facing(self) -> bool:
@@ -418,6 +597,7 @@ class ApiCode:
 CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("applied_energy_correction_source_calculation_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship,
             note=(
                 "Reach.guard until #195, and the note it carried named the "
                 "repair that ended it: /uploads/computed-reaction resolves "
@@ -434,7 +614,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("applied_energy_correction_source_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
     ApiCode("arrhenius_a_units_molecularity_mismatch", 422, Surface.coded_exception,
-            "backend/app/chemistry/units.py"),
+            "backend/app/chemistry/units.py",
+            shape=Shape.relationship),
     ApiCode("artifact_integrity_failed", 502, Surface.response_literal,
             "backend/app/api/errors.py",
             replay=Replay.never_succeeds,
@@ -534,13 +715,17 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "guard non-vacuous."
             )),
     ApiCode("atom_map_atoms_unaccounted_for", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py",
+            shape=Shape.relationship),
     ApiCode("atom_map_contradicts_irc_mapping", 422, Surface.coded_exception,
-            "backend/app/services/reaction_atom_map.py"),
+            "backend/app/services/reaction_atom_map.py",
+            shape=Shape.relationship),
     ApiCode("atom_map_element_not_conserved", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py",
+            shape=Shape.relationship),
     ApiCode("atom_map_element_not_conserved", 409, Surface.database_constraint,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py",
+            shape=Shape.relationship,
             note=(
                 "Two entries, and both are real. The claim is stated once at "
                 "the wire boundary and again as a check constraint, so which "
@@ -553,19 +738,23 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("atom_map_geometry_unparseable", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
     ApiCode("atom_map_indices_not_geometry_relative", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py",
+            shape=Shape.relationship),
     ApiCode("atom_map_inferred_requires_note", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
     ApiCode("atom_map_not_a_bijection", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py",
+            shape=Shape.relationship),
     ApiCode("atom_map_not_a_bijection", 409, Surface.database_constraint,
-            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py",
+            shape=Shape.relationship),
     ApiCode("atom_map_participant_not_declared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
     ApiCode("atom_map_without_transition_state", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/reaction_atom_map.py"),
     ApiCode("calculation_geometry_composition_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_geometry_composition.py",
+            shape=Shape.relationship,
             note=(
                 "A geometry linked to a calculation is not made of the atoms "
                 "of the subject the calculation is filed under. One code "
@@ -581,7 +770,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "payload's identity block, this one on a calculation."
             )),
     ApiCode("calculation_handle_conflict", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship),
     ApiCode("calculation_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py",
             note=(
@@ -605,13 +795,17 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("composed_search_candidate_limit_exceeded", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py"),
     ApiCode("composed_search_invalid_page", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/common.py"),
+            "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship),
     ApiCode("composed_search_pagination_changed", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/common.py"),
+            "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship),
     ApiCode("composed_search_pagination_stalled", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/common.py"),
+            "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship),
     ApiCode("curation_policy_version_conflict", 409, Surface.message_prefix,
             "backend/app/services/release/curation.py",
+            shape=Shape.relationship,
             note=(
                 "409, not the 422 a bare ReleaseCurationError would reach. "
                 "It was recorded wrong for a long time because the status "
@@ -625,9 +819,11 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("curator_task_not_found", 404, Surface.coded_exception,
             "backend/app/services/machine_review/curator_task_lifecycle.py"),
     ApiCode("cursor_offset_conflict", 422, Surface.coded_exception,
-            "backend/app/services/scientific_read/analytics.py"),
+            "backend/app/services/scientific_read/analytics.py",
+            shape=Shape.relationship),
     ApiCode("cursor_query_mismatch", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/keyset.py"),
+            "backend/app/services/scientific_read/keyset.py",
+            shape=Shape.relationship),
     ApiCode("data_integrity_error", 500, Surface.generic_fallback,
             "backend/app/api/errors.py"),
     ApiCode("database_error", 503, Surface.generic_fallback,
@@ -647,6 +843,7 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/api/errors.py"),
     ApiCode("doi_already_recorded", 409, Surface.message_prefix,
             "backend/app/services/release/curation.py",
+            shape=Shape.relationship,
             note=(
                 "409 since #211. Recording the DOI the release already cites "
                 "succeeds; only a *different* one refuses, and it refuses "
@@ -672,7 +869,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "all -- and that argument covers this endpoint only."
             )),
     ApiCode("energy_transfer_scope_columns_disagree", 409, Surface.database_constraint,
-            "backend/app/scientific_checks/declarations.py"),
+            "backend/app/scientific_checks/declarations.py",
+            shape=Shape.relationship),
     ApiCode("export_all_cap_exceeded", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/export.py"),
     ApiCode("export_seed_empty", 422, Surface.message_prefix,
@@ -681,6 +879,7 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/export.py"),
     ApiCode("freq_list_exceeds_geometry_degrees_of_freedom", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/frequency_completeness.py",
+            shape=Shape.relationship,
             note=(
                 "One of two codes that module reports, and the only one that "
                 "refuses. Its sibling freq_list_incomplete_for_geometry is an "
@@ -692,6 +891,7 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("freq_mode_index_not_unique", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py",
+            shape=Shape.relationship,
             note=(
                 "Catalogued but deliberately absent from the scientific "
                 "check register, unlike its file neighbour "
@@ -703,7 +903,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "code a client must branch on, about no chemistry at all."
             )),
     ApiCode("freq_n_imag_disagrees_with_modes", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/fragments/calculation.py",
+            shape=Shape.relationship),
     ApiCode("geometry_key_unresolved", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py",
             note=(
@@ -719,12 +920,36 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/geometry.py"),
     ApiCode("handle_not_found", 404, Surface.coded_exception,
             "backend/app/services/scientific_read/calculation_paths.py"),
-    ApiCode("handle_type_mismatch", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+    ApiCode("handle_type_mismatch", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship,
+            note=(
+                "Surface.coded_exception since #210, and the detail did not "
+                "move a byte. It was message_prefix -- two "
+                "ValueError(f'handle_type_mismatch: ...') sites -- which is "
+                "the surface with nowhere to put context, and this code "
+                "names a relationship: two ref prefixes that are not the "
+                "same one, neither of them named. Both sites now raise "
+                "CodedValueError with message_prefix=True, so str(exc) is "
+                "unchanged and only the route into `code` differs: declared "
+                "on the exception rather than promoted out of the sentence. "
+                "It leaves MESSAGE_PREFIX_CODES as a consequence, which is "
+                "correct -- the envelope no longer needs to read English to "
+                "find this code. Its six *_handle_conflict neighbours in the "
+                "same module have the same defect and are *not* converted "
+                "here: their code is minted from reconcile_id_ref's "
+                "conflict_code parameter, and test_error_contract_catalogue_"
+                "gate.py's TestTheShapeTheRaiseSiteScanCannotRead is written "
+                "over exactly that spelling, so moving them means "
+                "re-pointing that gate at the new shape rather than "
+                "deleting it."
+            )),
     ApiCode("idempotency_conflict", 409, Surface.response_literal,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            shape=Shape.relationship),
     ApiCode("idempotency_in_progress", 409, Surface.response_literal,
             "backend/app/api/errors.py",
+            shape=Shape.relationship,
             reach=Reach.guard,
             note=(
                 "The ternary that mints it has one live arm. "
@@ -741,7 +966,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("include_not_implemented_yet", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/calculations.py"),
     ApiCode("integrity_conflict", 409, Surface.generic_fallback,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            shape=Shape.relationship),
     ApiCode("invalid_cursor", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/keyset.py"),
     ApiCode("invalid_handle", 422, Surface.message_prefix,
@@ -751,17 +977,31 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("invalid_pagination", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py"),
     ApiCode("invalid_range", 422, Surface.coded_exception,
-            "backend/app/services/scientific_read/analytics.py"),
+            "backend/app/services/scientific_read/analytics.py",
+            shape=Shape.relationship),
     ApiCode("invalid_structure_query", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/structure_search.py"),
-    ApiCode("invalid_temperature_range", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/common.py"),
+    ApiCode("invalid_temperature_range", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship,
+            note=(
+                "Surface.coded_exception since #210, with the detail "
+                "byte-identical: the raise moved to CodedValueError with "
+                "message_prefix=True so it could carry the two bounds in "
+                "context. Its sibling invalid_range in "
+                "scientific_read/analytics.py was already coded_exception "
+                "and already carried them, which is what made this one's "
+                "empty context visible as an inconsistency rather than a "
+                "policy."
+            )),
     ApiCode("irc_result_not_found", 404, Surface.coded_exception,
             "backend/app/services/scientific_read/calculation_paths.py"),
     ApiCode("kinetics_interpretation_conformer_selection_owner_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/calculation_ownership.py"),
+            "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship),
     ApiCode("kinetics_interpretation_statmech_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship,
             note=(
                 "One code, two comparisons: a reactant/product assignment "
                 "is held to the participant's species entry and a "
@@ -771,7 +1011,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "which owner disagreed is already in context['owner_kind']."
             )),
     ApiCode("level_of_theory_handle_conflict", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship),
     ApiCode("limit_too_large", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py",
             note=(
@@ -819,10 +1060,20 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/ml_dataset.py"),
     ApiCode("micro_reaction_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
-    ApiCode("multiple_structure_queries", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/structure_search.py"),
+    ApiCode("multiple_structure_queries", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/structure_search.py",
+            shape=Shape.relationship,
+            note=(
+                "Surface.coded_exception since #210, detail unchanged. An "
+                "ambiguity code that named none of the fields it was "
+                "ambiguous between; context['supplied'] now does. Its "
+                "neighbour missing_structure_query stays message_prefix "
+                "and stays empty on purpose: it names a thing (no query "
+                "was supplied) and the code is the whole message."
+            )),
     ApiCode("n_imag_contradicts_minimum", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py",
+            shape=Shape.relationship),
     ApiCode("network_channel_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
     ApiCode("network_solve_reported_requires_literature", 409, Surface.database_constraint,
@@ -850,7 +1101,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("post_search_fields_must_be_in_body", 422, Surface.message_prefix,
             "backend/app/api/routes/scientific/artifacts.py"),
     ApiCode("pressure_alias_conflict", 422, Surface.message_prefix,
-            "backend/app/schemas/reads/scientific_kinetics.py"),
+            "backend/app/schemas/reads/scientific_kinetics.py",
+            shape=Shape.relationship),
     ApiCode("query_timeout", 503, Surface.response_literal,
             "backend/app/api/errors.py"),
     ApiCode("query_too_expensive", 422, Surface.message_prefix,
@@ -860,9 +1112,11 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("rationale_required", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
     ApiCode("reaction_charge_not_conserved", 422, Surface.coded_exception,
-            "backend/app/services/reaction_resolution.py"),
+            "backend/app/services/reaction_resolution.py",
+            shape=Shape.relationship),
     ApiCode("reaction_mass_balance_failed", 422, Surface.coded_exception,
-            "backend/app/services/reaction_resolution.py"),
+            "backend/app/services/reaction_resolution.py",
+            shape=Shape.relationship),
     ApiCode("record_has_no_subject", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
     ApiCode("record_not_approved", 422, Surface.message_prefix,
@@ -870,15 +1124,19 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("record_ref_not_selectable", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
     ApiCode("record_subject_mismatch", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+            "backend/app/services/release/curation.py",
+            shape=Shape.relationship),
     ApiCode("record_type_not_selectable", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
     ApiCode("reaction_entry_handle_conflict", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship),
     ApiCode("reaction_handle_conflict", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship),
     ApiCode("reference_conflict", 409, Surface.sqlstate_category,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            shape=Shape.relationship),
     ApiCode("release_artifact_corrupt", 500, Surface.message_prefix,
             "backend/app/api/routes/scientific/releases.py"),
     ApiCode("release_not_draft", 409, Surface.message_prefix,
@@ -923,6 +1181,7 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/api/routes/health.py"),
     ApiCode("selection_already_stands", 409, Surface.message_prefix,
             "backend/app/services/release/curation.py",
+            shape=Shape.relationship,
             note=(
                 "409 since #211, and it moved with its sibling rather than "
                 "after it: this and selection_already_superseded are the same "
@@ -932,6 +1191,7 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("selection_already_superseded", 409, Surface.message_prefix,
             "backend/app/services/release/curation.py",
+            shape=Shape.relationship,
             note=(
                 "409 since #211. Supersession chains stay linear, so the row "
                 "to replace is the one that currently stands -- a different "
@@ -942,49 +1202,65 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("smiles_too_long", 422, Surface.message_prefix,
             "backend/app/schemas/reads/scientific_kinetics_search.py"),
     ApiCode("species_entry_handle_conflict", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship),
     ApiCode("species_geometry_composition_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/species_resolution.py"),
+            "backend/app/services/species_resolution.py",
+            shape=Shape.relationship),
     ApiCode("species_geometry_isotope_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/species_resolution.py"),
+            "backend/app/services/species_resolution.py",
+            shape=Shape.relationship),
     ApiCode("species_handle_conflict", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/handles.py"),
+            "backend/app/services/scientific_read/handles.py",
+            shape=Shape.relationship),
     ApiCode("species_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
     ApiCode("species_kind_conflict", 422, Surface.coded_exception,
-            "backend/app/services/species_resolution.py"),
+            "backend/app/services/species_resolution.py",
+            shape=Shape.relationship),
     ApiCode("species_smiles_charge_mismatch", 422, Surface.coded_exception,
-            "backend/app/chemistry/species.py"),
+            "backend/app/chemistry/species.py",
+            shape=Shape.relationship),
     ApiCode("state_conflict", 409, Surface.sqlstate_category,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            shape=Shape.relationship),
     ApiCode("statmech_calculation_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
     ApiCode("statmech_source_calculation_owner_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/calculation_ownership.py"),
+            "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship),
     ApiCode("statmech_source_role_type_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/statmech_resolution.py"),
+            "backend/app/services/statmech_resolution.py",
+            shape=Shape.relationship),
     ApiCode("statmech_subject_not_exactly_one", 409, Surface.database_constraint,
             "backend/app/scientific_checks/declarations.py"),
     ApiCode("statmech_torsion_scan_calculation_owner_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/calculation_ownership.py"),
+            "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship),
     ApiCode("stored_species_smiles_unparseable", 422, Surface.coded_exception,
             "backend/app/services/reaction_resolution.py"),
     ApiCode("subject_type_mismatch", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+            "backend/app/services/release/curation.py",
+            shape=Shape.relationship),
     ApiCode("supersedes_same_record", 422, Surface.message_prefix,
-            "backend/app/services/release/curation.py"),
+            "backend/app/services/release/curation.py",
+            shape=Shape.relationship),
     ApiCode("tckdb_client_version_invalid", 426, Surface.detail_object,
             "backend/app/api/client_version.py"),
     ApiCode("tckdb_client_version_missing", 426, Surface.detail_object,
             "backend/app/api/client_version.py"),
     ApiCode("tckdb_client_version_unsupported", 426, Surface.detail_object,
-            "backend/app/api/client_version.py"),
+            "backend/app/api/client_version.py",
+            shape=Shape.relationship),
     ApiCode("thermo_source_calculation_owner_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/calculation_ownership.py"),
+            "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship),
     ApiCode("thermo_source_role_type_mismatch", 422, Surface.coded_exception,
-            "backend/app/workflows/thermo.py"),
+            "backend/app/workflows/thermo.py",
+            shape=Shape.relationship),
     ApiCode("thermo_statmech_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship,
             note=(
                 "The ownership family's first code over a cited row that "
                 "is not a calculation. Distinct from "
@@ -994,21 +1270,26 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "repairs them in different places."
             )),
     ApiCode("transition_state_charge_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/reaction_resolution.py"),
+            "backend/app/services/reaction_resolution.py",
+            shape=Shape.relationship),
     ApiCode("transition_state_composition_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/reaction_resolution.py"),
+            "backend/app/services/reaction_resolution.py",
+            shape=Shape.relationship),
     ApiCode("transition_state_irc_mapping_element_mismatch", 422, Surface.coded_exception,
-            "backend/app/services/reaction_resolution.py"),
+            "backend/app/services/reaction_resolution.py",
+            shape=Shape.relationship),
     ApiCode("transition_state_key_undeclared", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
     ApiCode("transition_state_no_imaginary_mode", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
     ApiCode("transition_state_reaction_coordinate_ambiguous", 422, Surface.coded_exception,
-            "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
+            "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py",
+            shape=Shape.relationship),
     ApiCode("transition_state_reaction_coordinate_not_designated", 422, Surface.coded_exception,
             "schemas/python/tckdb-schemas/tckdb_schemas/stationary_point.py"),
     ApiCode("transport_source_calculation_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
+            shape=Shape.relationship,
             reach=Reach.guard,
             note=(
                 "No request produces it, and unlike its four siblings no "
@@ -1024,7 +1305,8 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "does."
             )),
     ApiCode("unique_conflict", 409, Surface.sqlstate_category,
-            "backend/app/api/errors.py"),
+            "backend/app/api/errors.py",
+            shape=Shape.relationship),
     ApiCode("unknown_calculation_artifact_ref", 404, Surface.coded_exception,
             "backend/app/services/upload_reference.py",
             note=(
@@ -1169,11 +1451,13 @@ def never_retryable() -> tuple[ApiCode, ...]:
 
 __all__ = [
     "CATALOGUE",
+    "RELATIONSHIP_WORDS",
     "REPLAYABLE_STATUSES",
     "STATUS_FALLBACK_PATTERN",
     "ApiCode",
     "Reach",
     "Replay",
+    "Shape",
     "Surface",
     "catalogued_codes",
     "client_facing",

--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -597,7 +597,20 @@ class ApiCode:
 CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("ambiguous_conformer_selection_locator", 422, Surface.coded_exception,
             "backend/app/services/conformer_selection_locator.py",
+            shape=Shape.relationship,
             note=(
+                "Shape.relationship, and it was already meeting the "
+                "obligation before there was a field to name it: the code "
+                "says several rows matched and names none of them, while "
+                "Discrimination.as_context reports match_count, differs_by, "
+                "discriminator, discriminator_values and locator_can_express "
+                "-- the things that differ, never their ids. So this entry "
+                "needed a declaration, not a repair. It is also the first "
+                "code to arrive after RELATIONSHIP_WORDS existed, and it "
+                "arrived misclassified by omission: written before Shape "
+                "was, it took the Shape.thing default and the word guard "
+                "refused it on the merge. Nothing else would have -- the "
+                "merge was textually clean. "
                 "The 'several matched' half of a split; unknown_conformer_"
                 "selection is the 'none matched' half, at 404. Both used to "
                 "be one bare ValueError reading 'must resolve exactly one "

--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -137,6 +137,52 @@ the count 73 are gone: they were reworded, not reclassified. So the set of
 error-reachable prefixes the catalogue does not cover is presently empty —
 measured, and re-measurable, rather than asserted.
 
+What ``context`` promises, and what it does not
+----------------------------------------------
+"Branch on ``code``, read ``context``, never parse ``detail``" is the
+published advice and it is right. It was also, until #210, an
+over-promise: ``context`` is populated by the raiser, and a large part of
+the catalogue has no raiser that can populate it. Measured on the entry
+count as this was written, 76 of 168 entries arrive by
+:data:`~app.api.code_catalogue.Surface.message_prefix` — that is,
+``raise ValueError(f"code: prose")`` — and a plain ``ValueError`` has
+nowhere to put structured facts, so :func:`error_envelope` renders
+``"context": {}`` for every one of them. Several hand-built
+``JSONResponse`` bodies in :mod:`app.api.errors` do the same.
+
+The repair is not "populate everything". Most refusals have nothing to
+put there, and a ``context`` that restates the code in a second spelling
+is drift with extra steps. What a client is owed depends on what the code
+names, which is what
+:class:`~app.api.code_catalogue.Shape` classifies and
+:attr:`~app.api.code_catalogue.ApiCode.owes_context` answers:
+
+* A code naming a **thing** — ``unknown_release``, ``missing_filter``,
+  ``limit_too_large`` — is complete on its own. ``context`` may be empty
+  and that is not a gap.
+* A code naming a **relationship** — ``state_conflict``,
+  ``handle_type_mismatch``, ``atom_map_element_not_conserved`` — asserts
+  something about two or more things and names none of them. There
+  ``context`` is the only machine-readable place the *which* can live,
+  and an empty one leaves the reason reachable only through the prose a
+  client was told not to read.
+
+So the honest promise is narrower than the old one: **where a code names
+a relationship, the facts are in ``context``; where it names a thing, the
+code is the fact.** Not every relationship entry has been populated yet —
+they are being worked through in tranches, and the classification is what
+makes the remainder countable. Nothing asserts that any of those
+``context`` objects stays empty, deliberately: pinning the empty object
+would make each improvement cost a red test.
+
+One exception is worth naming because it looks like a violation and is
+not. ``tckdb_client_version_unsupported`` and its two siblings arrive by
+:data:`~app.api.code_catalogue.Surface.detail_object`, where ``detail``
+is a *dict* rather than prose. Their facts — the version sent and the
+minimum supported — are already machine-readable; they are simply in
+``detail``. "Never parse ``detail``" still holds, because parsing is what
+a sentence needs and a dict does not.
+
 One of those five was itself repaired rather than merely recorded. Only
 ``geometry_validation`` contained an underscore, so it was the only logger
 prefix ``_CODE_POSITION_PATTERN`` could match — a string carrying the
@@ -456,6 +502,12 @@ def error_envelope(
 
     The envelope is deep-sanitised so any non-finite float echoed from the
     offending request cannot break JSON rendering (see :func:`_json_safe`).
+
+    ``context`` is whatever the caller passed, and ``{}`` when it passed
+    nothing. That empty object is not a promise unmet for most codes — see
+    "What ``context`` promises, and what it does not" in the module
+    docstring for which codes owe a client facts here and which are
+    complete without them.
     """
 
     return _json_safe(

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -302,6 +302,22 @@ def _integrity_error_handler(
     # about, because every violation collapsed into its SQLSTATE bucket.
     # Keyed on the constraint name rather than on the driver's message
     # text: parsing prose is what the typed envelope exists to replace.
+    #
+    # Why the *unnamed* buckets below are left with an empty ``context``,
+    # although ``unique_conflict``, ``reference_conflict``,
+    # ``state_conflict`` and ``integrity_conflict`` are all
+    # ``Shape.relationship`` codes that owe a client the things that
+    # disagreed (see ``app.api.code_catalogue``): the only fact available
+    # here is the constraint name, and this repository holds two
+    # incompatible positions about whether that may be disclosed. The
+    # register path below reports it deliberately -- it is the key into
+    # ``docs/guides/scientific_check_register.md``, and
+    # ``test_api_database_constraint_codes.py`` asserts it reaches the
+    # body. ``test_api_integrity_error_handler.py`` asserts the opposite
+    # for the unregistered buckets, in as many words: "Internal
+    # constraint name must not leak through the public body." Widening
+    # disclosure is a decision for whoever owns that rule, not something
+    # to settle inside a tranche, so these four stay on the open list.
     rejection = _constraint_rejections().get(constraint) if constraint else None
     if rejection is not None:
         code, message = rejection

--- a/backend/app/services/reaction_resolution.py
+++ b/backend/app/services/reaction_resolution.py
@@ -817,7 +817,32 @@ def validate_ts_evidence_participant_composition(
                         "participant, so a participant cannot be made of atoms it "
                         "does not contain. The identical claim written as an "
                         "atom_map is already refused; correct the mapping per "
-                        "atom, not per count."
+                        "atom, not per count.",
+                        # The two compositions that disagree, and the two
+                        # things they belong to. A ``*_mismatch`` code names
+                        # neither side by construction (``Shape.relationship``
+                        # in ``app.api.code_catalogue``), so without this the
+                        # only machine-readable fact is that *something* did
+                        # not match -- and the sentence a client was told not
+                        # to parse is where the rest lived. Its sibling
+                        # ``atom_map_element_not_conserved``, which refuses
+                        # the same claim written per atom, has carried its
+                        # context since it was written.
+                        #
+                        # No row ids: ``participant_key`` and
+                        # ``participant_index`` are the depositor's own
+                        # payload coordinates and ``smiles`` is what they
+                        # wrote (DR-0028 Requirement 2).
+                        context={
+                            "field": field_path,
+                            "participant_key": participant_key,
+                            "role": role.value,
+                            "participant_index": participant_index,
+                            "ts_atom_indices": sorted(atom_indices),
+                            "assigned_composition": dict(sorted(assigned.items())),
+                            "declared_composition": dict(sorted(declared.items())),
+                            "declared_smiles": species.smiles,
+                        },
                     )
 
 

--- a/backend/app/services/scientific_read/common.py
+++ b/backend/app/services/scientific_read/common.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.config import settings
+from app.api.error_contract import CodedValueError
 from app.db.models.common import RecordReviewStatus, SubmissionRecordType
 from app.db.models.record_review import RecordReview
 from app.schemas.reads.scientific_common import (
@@ -237,8 +238,27 @@ def validate_temperature_range(
         and temperature_max is not None
         and temperature_min > temperature_max
     ):
-        raise ValueError(
-            "invalid_temperature_range: temperature_min must be <= temperature_max"
+        # ``invalid_temperature_range`` names a relationship -- two bounds
+        # that are the wrong way round -- and names neither value, which is
+        # the case ``Shape.relationship`` in ``app.api.code_catalogue`` is
+        # about. Its sibling ``invalid_range`` in ``scientific_read/
+        # analytics.py`` has carried its two bounds in ``context`` since it
+        # was written; this one is the same shape and had nothing.
+        #
+        # ``message_prefix=True`` keeps ``str(exc)`` -- and so the
+        # response's ``detail`` -- byte-identical to the plain
+        # ``ValueError`` this replaced. Only the route into ``code``
+        # changes, from promoted-out-of-the-sentence to declared on the
+        # exception, which is why the catalogue entry moves to
+        # ``Surface.coded_exception``. Both values are the caller's own
+        # query parameters, so nothing here is a row id.
+        raise CodedValueError(
+            "invalid_temperature_range",
+            "temperature_min must be <= temperature_max",
+            context={
+                "temperature_min_k": temperature_min,
+                "temperature_max_k": temperature_max,
+            },
         )
 
 

--- a/backend/app/services/scientific_read/handles.py
+++ b/backend/app/services/scientific_read/handles.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.api.errors import not_found
 from app.db.models.calculation import Calculation
 from app.db.models.common import RecordReviewStatus, SubmissionRecordType
@@ -96,6 +97,47 @@ def parse_handle(value: str) -> tuple[str, Any]:
     raise ValueError(
         f"invalid_handle: {stripped!r} is neither an integer id nor a "
         "<prefix>_<body> public ref"
+    )
+
+
+def _handle_type_mismatch(
+    kind_label: str,
+    expected_prefix: str,
+    prefix: str,
+    *,
+    noun: str,
+) -> CodedValueError:
+    """The 422 for a public ref carrying the wrong resource's prefix.
+
+    ``handle_type_mismatch`` names a relationship — two prefixes that are
+    not the same one — and names neither of them, which is the case
+    :class:`~app.api.code_catalogue.Shape.relationship` is about. The two
+    prefixes and the resource expected therefore go in ``context``, where
+    a client can read them without parsing the sentence. Nothing here is a
+    database id: a prefix is a schema-level constant and the supplied ref
+    is the caller's own input.
+
+    ``message_prefix=True`` keeps ``str(exc)`` -- and so the response's
+    ``detail`` -- byte-identical to the ``ValueError(f"handle_type_mismatch:
+    ...")`` this replaced. Only the *route* into ``code`` changes: it is
+    now declared on the exception instead of promoted out of the sentence,
+    which is why the catalogue entry moved from
+    :attr:`~app.api.code_catalogue.Surface.message_prefix` to
+    :attr:`~app.api.code_catalogue.Surface.coded_exception`.
+
+    :param noun: ``"handle"`` on a path lookup, ``"ref"`` on a filter --
+        the two call sites word it differently and the published prose is
+        preserved exactly, prefix included.
+    """
+    return CodedValueError(
+        "handle_type_mismatch",
+        f"expected a {kind_label} {noun} "
+        f"(prefix {expected_prefix!r}) but got prefix {prefix!r}",
+        context={
+            "expected_kind": kind_label,
+            "expected_prefix": expected_prefix,
+            "supplied_prefix": prefix,
+        },
     )
 
 
@@ -304,9 +346,8 @@ def resolve_path_handle(
     ref = parsed
     prefix = ref.split("_", 1)[0]
     if prefix != expected_prefix:
-        raise ValueError(
-            f"handle_type_mismatch: expected a {kind_label} handle "
-            f"(prefix {expected_prefix!r}) but got prefix {prefix!r}"
+        raise _handle_type_mismatch(
+            kind_label, expected_prefix, prefix, noun="handle"
         )
     row_id = session.scalar(
         select(model_cls.id).where(model_cls.public_ref == ref)
@@ -359,9 +400,8 @@ def resolve_filter_ref(
     expected_prefix = prefix_for(model_cls)
     prefix = ref.split("_", 1)[0]
     if prefix != expected_prefix:
-        raise ValueError(
-            f"handle_type_mismatch: expected a {kind_label} ref "
-            f"(prefix {expected_prefix!r}) but got prefix {prefix!r}"
+        raise _handle_type_mismatch(
+            kind_label, expected_prefix, prefix, noun="ref"
         )
     return session.scalar(
         select(model_cls.id).where(model_cls.public_ref == ref)

--- a/backend/app/services/scientific_read/structure_search.py
+++ b/backend/app/services/scientific_read/structure_search.py
@@ -44,6 +44,7 @@ from rdkit.Chem import inchi as _inchi
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.db.models.common import (
     RecordReviewStatus,
     SubmissionRecordType,
@@ -273,9 +274,24 @@ def _select_structure_query(
         )
     if len(supplied) > 1:
         names = sorted(k.value for k, _ in supplied)
-        raise ValueError(
-            "multiple_structure_queries: exactly one structure query "
-            f"field is allowed; got {names!r}."
+        # An *ambiguity*, which is one of the three shapes
+        # ``Shape.relationship`` in ``app.api.code_catalogue`` names: the
+        # request supplied more than one structure query and the code says
+        # which of none. ``context['supplied']`` carries the field names --
+        # the depositor's own query keys, so no row id is involved -- and
+        # the query *values* are deliberately not echoed: a SMARTS pattern
+        # is the caller's, but repeating it adds nothing the field name
+        # does not and grows the body without bound.
+        #
+        # ``message_prefix=True``, so ``detail`` is byte-identical to the
+        # plain ``ValueError`` this replaced; the catalogue entry moves to
+        # ``Surface.coded_exception`` because ``code`` is now declared on
+        # the exception rather than promoted out of the sentence.
+        raise CodedValueError(
+            "multiple_structure_queries",
+            "exactly one structure query "
+            f"field is allowed; got {names!r}.",
+            context={"supplied": [f"query_{name}" for name in names]},
         )
     return supplied[0]
 

--- a/backend/tests/api/scientific/test_api_integer_handle_oracle.py
+++ b/backend/tests/api/scientific/test_api_integer_handle_oracle.py
@@ -98,6 +98,46 @@ def test_wrong_prefix_ref_returns_422_handle_type_mismatch(client):
     assert "handle_type_mismatch" in r.json()["detail"]
 
 
+def test_a_wrong_prefix_names_both_prefixes_in_context(client):
+    """The relationship refusal says *which two* prefixes disagreed.
+
+    ``handle_type_mismatch`` asserts that the prefix on the supplied ref and
+    the prefix the route expects are not the same one, and the code names
+    neither -- the case ``Shape.relationship`` in ``app.api.code_catalogue``
+    is about. Until #210 the only place the two lived was the sentence,
+    which the error contract tells clients not to parse.
+
+    Asserted on the ``(status, code)`` pair *and* the individual keys. "the
+    context is non-empty" would pass against a handler that stuffed in a
+    constant, and asserting the whole dict by equality would make an added
+    fact a red test for no reason -- so each key is named and its value
+    checked.
+    """
+    r = client.get(
+        "/api/v1/scientific/reaction-entries/"
+        "spe_abcdefghijklmnopqrstuvwxyz/full"
+    )
+
+    assert r.status_code == 422, r.text
+    body = r.json()
+    assert body["code"] == "handle_type_mismatch", body
+    context = body["context"]
+    assert context["expected_kind"] == "reaction_entry", context
+    assert context["expected_prefix"] == "rxe", context
+    assert context["supplied_prefix"] == "spe", context
+
+    # The published prose did not move: the code is now declared on the
+    # exception instead of promoted out of the sentence, and the sentence is
+    # byte-for-byte what it was.
+    assert body["detail"].startswith("handle_type_mismatch: expected a "), body
+
+    # A prefix is a schema-level constant and the supplied one is the
+    # caller's own input, so no row id is disclosed (DR-0028 Requirement 2).
+    assert not any(
+        key.endswith("_id") or key == "id" for key in context
+    ), context
+
+
 def test_malformed_handle_returns_422_invalid_handle(client):
     r = client.get("/api/v1/scientific/geometries/!!notarealhandle!!")
     assert r.status_code == 422

--- a/backend/tests/api/scientific/test_api_scientific_structure_search.py
+++ b/backend/tests/api/scientific/test_api_scientific_structure_search.py
@@ -87,6 +87,46 @@ def test_post_multiple_structure_queries_returns_422(client, db_session):
     assert "multiple_structure_queries" in resp.text
 
 
+def test_an_ambiguous_structure_query_names_the_fields_it_got(
+    client, db_session
+):
+    """The ambiguity code names which fields were ambiguous between.
+
+    ``multiple_structure_queries`` is a relationship code in the sense
+    ``Shape.relationship`` means it -- an *ambiguity* asserted about two or
+    more things, naming none of them. ``context['supplied']`` now names
+    them. The query values are deliberately not echoed: the field names are
+    the whole repair.
+
+    Asserted on the ``(status, code)`` pair and on the exact list, not on
+    "context is non-empty".
+    """
+    resp = client.post(
+        SEARCH_URL,
+        json={
+            "query_smiles": "CCO",
+            "query_smarts": "[#6]O",
+            "mode": "substructure",
+        },
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "multiple_structure_queries", body
+    assert body["context"]["supplied"] == ["query_smarts", "query_smiles"], (
+        body["context"]
+    )
+    # Neither query value is echoed, and no row id is disclosed.
+    assert "CCO" not in repr(body["context"]), body["context"]
+    assert not any(
+        key == "id" or key.endswith(("_id", "_ids")) for key in body["context"]
+    ), body["context"]
+    # The published prose did not move.
+    assert body["detail"].startswith(
+        "multiple_structure_queries: exactly one structure query field is allowed;"
+    ), body["detail"]
+
+
 def test_invalid_smiles_returns_422(client, db_session):
     resp = client.get(
         SEARCH_URL + "?query_smiles=NOT_A_REAL_MOLECULE&mode=substructure"

--- a/backend/tests/api/scientific/test_api_thermo_search.py
+++ b/backend/tests/api/scientific/test_api_thermo_search.py
@@ -65,6 +65,37 @@ def test_invalid_temperature_range_returns_422(client, db_session):
     assert "invalid_temperature_range" in resp.text
 
 
+def test_an_inverted_temperature_range_names_both_bounds_in_context(
+    client, db_session
+):
+    """The two bounds that are the wrong way round, structured.
+
+    ``invalid_temperature_range`` is a relationship code -- it says two
+    values are in the wrong order and names neither -- and its ``context``
+    was empty because the raise was a plain ``ValueError``, which has
+    nowhere to put facts. Its sibling ``invalid_range`` in
+    ``scientific_read/analytics.py`` has always carried its bounds.
+
+    Asserted key by key on the ``(status, code)`` pair. "``context`` is
+    non-empty" would pass against a handler that stuffed in a constant.
+    """
+    _seed(db_session, smiles="TRC")
+    resp = client.get(
+        "/api/v1/scientific/thermo/search"
+        "?smiles=TRC&temperature_min=3000&temperature_max=300"
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "invalid_temperature_range", body
+    assert body["context"]["temperature_min_k"] == 3000.0, body["context"]
+    assert body["context"]["temperature_max_k"] == 300.0, body["context"]
+    # The published prose did not move: only the route into ``code`` did.
+    assert body["detail"] == (
+        "invalid_temperature_range: temperature_min must be <= temperature_max"
+    ), body["detail"]
+
+
 def test_invalid_include_token_returns_422(client, db_session):
     _seed(db_session, smiles="II")
     resp = client.get(

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -30,11 +30,13 @@ from pathlib import Path
 
 from app.api.code_catalogue import (
     CATALOGUE,
+    RELATIONSHIP_WORDS,
     REPLAYABLE_STATUSES,
     STATUS_FALLBACK_PATTERN,
     ApiCode,
     Reach,
     Replay,
+    Shape,
     Surface,
     catalogued_codes,
     client_facing,
@@ -1008,3 +1010,181 @@ def test_the_ownership_guards_are_guards_because_of_a_schema_shape() -> None:
     exported = {entry.code for entry in client_facing()}
     assert "applied_energy_correction_source_calculation_owner_mismatch" in exported
     assert "transport_source_calculation_owner_mismatch" not in exported
+
+
+# ---------------------------------------------------------------------------
+# Shape: does the code owe a client structured facts?
+# ---------------------------------------------------------------------------
+#
+# ``Shape`` classifies every entry by Calvin's rule (2026-08-17): a code
+# naming a relationship -- conflict, mismatch, ambiguity -- owes a client a
+# populated ``context``, because it asserts something about two or more
+# things and names none of them; a code naming a thing does not, because the
+# name is the whole message.
+#
+# What is deliberately *not* asserted here, and must stay that way: that
+# any entry's ``context`` is empty. Pinning the empty object would make
+# every future improvement cost a red test, so the gap is left countable
+# and unfrozen. The obligation in the other direction -- that a populated
+# ``context`` keeps its keys -- is asserted per code on the wire, where a
+# response body can be looked at, not here.
+
+
+#: Entries whose ``context`` this repository has already populated *and*
+#: which a wire test pins by key. Pinned here so that unpopulating one is a
+#: deliberate edit in two places rather than a silent regression in one --
+#: and pinned as a *floor*, never as the whole set, so the tranche that
+#: populates the next relationship code does not have to edit this list.
+_POPULATED_RELATIONSHIP_CODES = (
+    "handle_type_mismatch",
+    "invalid_temperature_range",
+    "multiple_structure_queries",
+    "transition_state_irc_mapping_element_mismatch",
+)
+
+
+def test_the_shape_rule_can_say_no() -> None:
+    """``Shape`` must change an answer, or it is a comment with a type.
+
+    The same shape as ``test_the_reach_rule_can_say_no`` and
+    ``test_the_replay_rule_can_say_no``: two probes differing in nothing
+    but the field under test, so the negative cannot be produced by one of
+    the other rules. Also pins the default, and the default is the one that
+    needs pinning -- an unclassified code reads as a thing and therefore
+    excuses itself from the obligation, which is the failure the word guard
+    below exists to close.
+    """
+    origin = "backend/app/api/errors.py"
+    named = ApiCode("probe_code", 409, Surface.sqlstate_category, origin)
+    relating = ApiCode(
+        "probe_code", 409, Surface.sqlstate_category, origin,
+        shape=Shape.relationship,
+    )
+
+    assert named.shape is Shape.thing, "Shape.thing must be the default"
+    assert not named.owes_context
+    assert relating.owes_context
+
+
+def test_the_classification_splits_the_catalogue_both_ways() -> None:
+    """Both classes are populated, and neither swallowed the catalogue.
+
+    A classification where every entry landed on one side is a field that
+    was added and not applied -- it would satisfy every other assertion
+    below while saying nothing. The bounds are deliberately loose: the
+    point is that both answers are given, not that the ratio is any
+    particular number.
+    """
+    relationships = [entry for entry in CATALOGUE if entry.shape is Shape.relationship]
+    things = [entry for entry in CATALOGUE if entry.shape is Shape.thing]
+
+    assert len(relationships) + len(things) == len(CATALOGUE), (
+        "an entry carries neither shape, which the enum should have made "
+        "impossible"
+    )
+    assert len(relationships) > 20, (
+        f"only {len(relationships)} of {len(CATALOGUE)} entries are "
+        "classified as relationships. The catalogue is full of *_mismatch "
+        "and *_conflict codes; a number this low means the field was added "
+        "and not applied."
+    )
+    assert len(things) > 20, (
+        f"only {len(things)} of {len(CATALOGUE)} entries are classified as "
+        "things. Most refusals name a thing -- unknown_X, missing_Y -- so a "
+        "number this low means the rule was read as 'populate everything', "
+        "which is the answer it exists to refuse."
+    )
+    assert {entry.code for entry in CATALOGUE if entry.owes_context} == {
+        entry.code for entry in relationships
+    }, "ApiCode.owes_context has drifted from Shape.relationship"
+
+
+def test_no_entry_named_like_a_relationship_is_classified_as_a_thing() -> None:
+    """The word guard, and proof it has something to guard.
+
+    ``Shape`` defaults to ``thing``, so the classification a new code gets
+    for free is the one that excuses it from the obligation. This is what
+    stops that being silent for the spellings the codes here actually use:
+    a name containing ``mismatch``, ``conflict``, ``contradicts``,
+    ``disagree``, ``ambiguous`` or ``not_conserved`` cannot describe one
+    thing, so it must be declared.
+
+    The converse is not checked and cannot be -- ``atom_map_not_a_bijection``
+    and ``selection_already_stands`` are relationships spelled without any
+    of those words -- so a ``Shape.relationship`` declaration on a code
+    with none of them is a judgement, not an error.
+    """
+    matched = [
+        entry
+        for entry in CATALOGUE
+        if any(word in entry.code for word in RELATIONSHIP_WORDS)
+    ]
+    assert len(matched) > 25, (
+        f"only {len(matched)} entries carry a relationship word, so this "
+        "guard is nearly vacuous. Either RELATIONSHIP_WORDS lost a word or "
+        "the catalogue was renamed out from under it."
+    )
+    misclassified = [
+        entry.code for entry in matched if entry.shape is not Shape.relationship
+    ]
+    assert not misclassified, (
+        f"{sorted(set(misclassified))} are named for a relation between two "
+        "things but classified Shape.thing. A code whose name contains "
+        f"{list(RELATIONSHIP_WORDS)} asserts something about two or more "
+        "things and names neither, so it owes a client a populated context "
+        "-- see Shape in app/api/code_catalogue.py. If one of these really "
+        "is complete under its own name, rename the code; do not reclassify "
+        "it."
+    )
+
+
+def test_the_word_guard_would_notice_a_misclassification() -> None:
+    """The detector above must be able to fail, not merely to pass.
+
+    Measured, not reasoned about: the real catalogue satisfies the guard,
+    so a bug that made the word test match nothing would be invisible. A
+    synthetic entry named for a relation and classified as a thing has to
+    be caught by the same expression the assertion uses.
+    """
+    origin = "backend/app/api/errors.py"
+    bait = ApiCode("probe_owner_mismatch", 422, Surface.coded_exception, origin)
+    honest = ApiCode(
+        "probe_owner_mismatch", 422, Surface.coded_exception, origin,
+        shape=Shape.relationship,
+    )
+    clean = ApiCode("probe_unknown_thing", 404, Surface.coded_exception, origin)
+
+    def caught(entry: ApiCode) -> bool:
+        return (
+            any(word in entry.code for word in RELATIONSHIP_WORDS)
+            and entry.shape is not Shape.relationship
+        )
+
+    assert caught(bait), "the word guard cannot see a misclassified *_mismatch"
+    assert not caught(honest)
+    assert not caught(clean), (
+        "the word guard fires on a code that names no relation, so it would "
+        "force a classification by accident of vocabulary"
+    )
+
+
+def test_every_populated_relationship_code_is_still_a_relationship() -> None:
+    """The codes with wire tests over their ``context`` keep the claim.
+
+    One direction only. A code moving *out* of ``Shape.relationship`` while
+    a wire test still pins its context keys is a contradiction: the entry
+    would say the code names a thing while the response names two. The
+    other direction -- a relationship entry whose context is still empty --
+    is the open work and is deliberately not asserted anywhere, because
+    pinning it either way costs a red test for the next improvement.
+    """
+    by_code = {entry.code: entry for entry in CATALOGUE}
+    for code in _POPULATED_RELATIONSHIP_CODES:
+        entry = by_code.get(code)
+        assert entry is not None, f"{code} left the catalogue"
+        assert entry.shape is Shape.relationship, (
+            f"{code} is classified Shape.thing, but a wire test asserts its "
+            "response context names the two things that disagreed. One of "
+            "the two is wrong."
+        )
+        assert entry.owes_context

--- a/backend/tests/api/test_api_code_catalogue.py
+++ b/backend/tests/api/test_api_code_catalogue.py
@@ -1036,6 +1036,13 @@ def test_the_ownership_guards_are_guards_because_of_a_schema_shape() -> None:
 #: and pinned as a *floor*, never as the whole set, so the tranche that
 #: populates the next relationship code does not have to edit this list.
 _POPULATED_RELATIONSHIP_CODES = (
+    # Not populated by this pass -- it arrived already carrying its
+    # context, from ``Tell "no such selection" from "which selection?"``,
+    # and ``test_api_conformer_selection_locator_codes.py`` pins its keys
+    # on the wire. Listed for the same reason as the rest: a later edit
+    # moving it to ``Shape.thing`` while those assertions stand would be a
+    # contradiction, and this is what says so.
+    "ambiguous_conformer_selection_locator",
     "handle_type_mismatch",
     "invalid_temperature_range",
     "multiple_structure_queries",

--- a/backend/tests/api/test_api_scientific_rejection_codes.py
+++ b/backend/tests/api/test_api_scientific_rejection_codes.py
@@ -1066,3 +1066,28 @@ class TestTheAtomMapAgainstTheIrcPartition:
         assert "transition_state_irc_mapping_element_mismatch" in str(
             body["detail"]
         )
+
+        # The two compositions that disagree, and the two things they belong
+        # to. A ``*_mismatch`` names neither side by construction
+        # (``Shape.relationship`` in ``app.api.code_catalogue``), so before
+        # #210 the only machine-readable fact here was that *something* did
+        # not match. Asserted key by key, not as "context is non-empty" --
+        # that would pass against a handler stuffing in a constant.
+        context = body["context"]
+        # ``reactant:1`` is CH3 and the partition hands it the saddle
+        # point's four hydrogens, so it is the first slot to disagree.
+        assert context["role"] == "reactant", context
+        assert context["participant_key"] == "reactant:1", context
+        assert context["participant_index"] == 1, context
+        assert context["ts_atom_indices"] == [2, 3, 4, 5], context
+        assert context["assigned_composition"] == {"H": 4}, context
+        assert context["declared_composition"] == {"C": 1, "H": 3}, context
+        assert context["declared_smiles"] == "[CH3]", context
+        assert context["field"] == "transition_state.validation_evidence", context
+
+        # No row ids reach a client (DR-0028 Requirement 2): every fact here
+        # is either the depositor's own payload coordinate or an element
+        # count.
+        assert not any(
+            key == "id" or key.endswith(("_id", "_ids")) for key in context
+        ), context

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -209,8 +209,18 @@ except TCKDBHTTPError as exc:
         case None:
             raise                               # not a code this client knows
     print(exc.detail)                           # prose, for a human
-    print(exc.response_json["context"])         # the same facts, structured
+    print(exc.response_json["context"])         # structured facts, or {}
 ```
+
+`context` is not populated for every code, and `{}` is often the correct
+answer rather than a gap. The server's rule: a code that names a
+**relationship** — `*_conflict`, `*_mismatch`, anything asserting that
+two things disagree — puts the *which* in `context` (a field path, a
+public ref, a local key, a constraint name, a count; never a database row
+id). A code that names a **thing** — `unknown_release`, `missing_filter`
+— is already the whole message and has no second fact to report. Branch
+on `code` first and enrich from `context` if it is there; never make a
+non-empty `context` a precondition for handling a refusal.
 
 Use `rejection_code(exc.code)` rather than `RejectionCode(exc.code)`: a
 server is routinely newer than the client pinned against it, and a code

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.52.1"
+version = "0.52.2"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/docs/clients/generic-client-targeting.md
+++ b/docs/clients/generic-client-targeting.md
@@ -456,9 +456,43 @@ The distinction worth building on is what a client should *do*:
 | `arrhenius_a_units_molecularity_mismatch` | `a_units` do not have the dimensionality the reaction order requires | fix the unit token |
 | `validation_error` | a refusal that carries no more specific code | read `detail`; and please report it, because a scientific refusal reaching you as this is a gap |
 
-`context` carries the same facts in structured form — the two element
-counts that disagreed, the two charges, the disputed atom indices — so a
-client can render a useful message without parsing the sentence.
+### What `context` carries, and when it is empty
+
+`context` is where a refusal's facts go in structured form — the two
+element counts that disagreed, the two charges, the disputed atom indices
+— so a client can render a useful message without parsing the sentence.
+
+It is **not populated for every code**, and the rule for which is worth
+knowing before you write a branch that reads it:
+
+- A code that names a **relationship** — `state_conflict`,
+  `handle_type_mismatch`, `atom_map_element_not_conserved`, anything
+  spelled `*_conflict` or `*_mismatch` — asserts that two or more things
+  disagree and names none of them. There `context` is where the *which*
+  lives: a field path, a public ref, a local key you declared, the
+  database constraint that refused, a count. Never a database row id —
+  TCKDB does not put row ids in error bodies, because a row id is not
+  stable across a restore or between two deployments and no public
+  surface is keyed on one.
+- A code that names a **thing** — `unknown_release`, `missing_filter`,
+  `limit_too_large` — is already the whole message. `context` may be `{}`
+  and that is the honest answer, not a gap: there is no second fact to
+  report.
+
+So: read `context` where the code names a relationship, and treat `{}`
+as normal everywhere else. Do not make a populated `context` a
+precondition for handling a refusal — branch on `code` first, then
+enrich from `context` if it is there. Some relationship codes have not
+been populated yet; that work is in progress, and the server's own
+catalogue (`backend/app/api/code_catalogue.py`) records the
+classification per code if you need to know where things stand.
+
+One special case that looks like an exception and is not: the `426`
+client-version refusals (`tckdb_client_version_unsupported` and
+siblings) put their facts — the version you sent, the minimum this
+server accepts — in `detail`, which for these three is a JSON object
+rather than a sentence. "Never parse `detail`" still holds: parsing is
+what a sentence needs, and these are already structured.
 
 A warning is not a refusal: an accepted upload returns `201` with a
 `warnings` list whose entries carry their own `code`. The register's


### PR DESCRIPTION
## Plain language first

TCKDB refuses a bad request with a small JSON object: a machine-readable
`code`, a sentence of `detail` for a human, and a `context` object meant to
hold the structured facts. We tell client software to *switch on `code` and
read `context`*, and never to pattern-match the sentence — because the
sentence gets reworded and, for schema-level failures, it echoes back
whatever the caller sent.

The problem: `context` was empty for most refusals. So on a large part of
the API the advice reduced to "read this empty object", and the only place
that said *why* the request was refused was the prose we had told clients
not to read.

The wrong fix is to fill `context` in everywhere. Most refusals have
nothing to put there. If the code is `unknown_release`, that *is* the whole
message — a `context` restating it would be a second copy of the same fact
to keep in step. But if the code is `state_conflict`, the code says "two
things could not both be true" and names *neither of them*, and there the
structured facts are the only machine-readable answer.

So this PR does three things:

1. **Classifies every one of the 168 catalogue entries** as naming a
   *thing* or naming a *relationship*, per Calvin's rule of 2026-08-17.
   The classification is the main artefact — it is a declared field on
   each entry, so it can be argued with, guarded, and counted.
2. **Populates `context` for a first tranche of six relationship codes**,
   naming the things that disagree — never a database row id.
3. **Fixes the documentation that over-promised**, in three places: the
   backend's own error-contract module, the generic-client guide, and the
   Python client's README. That mismatch — docs promising something a
   large surface does not provide — is worse than either answer on its
   own, and is the part that usually gets skipped.

Software terms used below: an *envelope* is the JSON error body's fixed
shape; a *surface* is the mechanism by which a code reaches that body (the
raiser attached it to an exception, or wrote it in front of a colon in a
sentence, or a handler looked it up from a PostgreSQL constraint name); a
*SQLSTATE* is PostgreSQL's five-character class for what kind of rule
refused a write.
---

## Re-derived surface counts

Measured on this branch over `app.api.code_catalogue.CATALOGUE`. The
catalogue has grown since the brief's figures: **168 entries / 166 distinct
codes**, not 162.

| surface | entries (branch point) | entries (this PR) | share |
|---|---|---|---|
| `message_prefix` | 76 | **73** | 43 % |
| `coded_exception` | 63 | **66** | 39 % |
| `response_literal` | 11 | 11 | 7 % |
| `generic_fallback` | 7 | 7 | 4 % |
| `database_constraint` | 5 | 5 | 3 % |
| `sqlstate_category` | 3 | 3 | 2 % |
| `detail_object` | 3 | 3 | 2 % |
| `accidental_prefix` | 0 | 0 | 0 % |

Three codes move `message_prefix` → `coded_exception` in this PR (see
below); their published `detail` does not change by a byte.

Two rows in the brief's table were **wrong**, not merely stale:

- **`accidental_prefix` is 0, not 1.** No entry has used it since #178
  reworded the two messages that did — the catalogue's own docstring says
  so in as many words.
- **`generic_fallback` is 7, not 8.**

The thesis behind the brief holds, and it explains exactly where the gap
is: a `message_prefix` code is raised as `ValueError(f"code: prose")`, and
a plain `ValueError` **has no channel for structured facts at all**.
`error_envelope` therefore renders `"context": {}` for every one of the 73,
and no care at the raise site changes that without changing the exception
type.

---

## The classification — the main artefact

`Shape` is a new declared field on `ApiCode`, applied to all 168 entries.

| | entries | distinct codes |
|---|---|---|
| `Shape.relationship` | 64 | 62 |
| `Shape.thing` | 104 | 104 |

(64 vs 62 because `atom_map_element_not_conserved` and
`atom_map_not_a_bijection` each have two entries — 422 at the wire boundary
and 409 as a check constraint.)

`ApiCode.owes_context` is the property that answers the obligation, so a
future narrowing is one edit rather than a search for
`is Shape.relationship`.

The default is `Shape.thing`, for the same reason `Reach.request` and
`Replay.may_succeed` are defaults. Here the default is the *dangerous*
direction — an unclassified relationship would silently excuse itself — so
`RELATIONSHIP_WORDS` closes it: a code whose **name** contains
`ambiguous`, `conflict`, `contradicts`, `disagree`, `mismatch` or
`not_conserved` cannot describe one thing and must declare
`Shape.relationship`. 40 entries match, so the guard is not vacuous, and
`test_the_word_guard_would_notice_a_misclassification` proves the detector
can fail as well as pass.

The converse is deliberately unguarded and cannot be guarded: plenty of
relationships are spelled without any of those words —
`atom_map_not_a_bijection`, `selection_already_stands`,
`multiple_structure_queries`, `composed_search_pagination_changed` — so
those are declared by hand, and the declaration *is* the judgement.

### Borderline calls, and the argument for each

These are also recorded in the catalogue's module docstring, so they do not
live only in a PR description.

**1. Caps are `thing` — the largest borderline group, and the one I am
least sure of.** `limit_too_large`, `offset_too_large`, `geometry_too_large`,
`smiles_too_long`, `export_all_cap_exceeded`, `ml_export_all_cap_exceeded`,
`query_too_expensive`, `composed_search_candidate_limit_exceeded`.

By the *letter* of the rule these are relationships: each compares a
supplied value against a server-side cap and the cap is not in the name. A
client that receives `limit_too_large` genuinely wants the cap in order to
retry with a legal value, and on a deployment that lowers
`public_max_limit` the cap is not guessable from the docs.

I classified them `thing` because the rule's discriminator is *conflict,
mismatch, ambiguity* and a cap breach is none of those: the code names one
field and states a predicate about it, and the field is the whole repair.
**This is the group where "populate everything" and "populate
relationships" visibly diverge, so it is the one worth overruling me on.**
Moving them is one line per entry plus a
`context={"cap": …, "supplied": …}` at eight raise sites.

**2. A code that names both its fields is `thing`.**
`parameter_value_requires_key`, `canonical_parameter_value_requires_key`,
`unsupported_ranking_for_calculation_type`. Each is about two fields and
each *names* both; the message is a constant. A `context` would be the code
spelled a second way.

**3. "Taken" is `thing`.** `email_taken`, `username_taken`,
`release_tag_taken`. "Taken" implies a second claimant, but only one party
is identifiable and the code says which field it is — which was the entire
point of splitting `email_taken` from `username_taken` in #225 (so a
sign-up form can highlight the input at fault). The other claimant is
another principal's row and is not ours to disclose.

**4. `artifact_integrity_failed` is `thing`,** although it is a digest
comparison and so by shape a relationship. Its name states a property of
one artifact; and the two digests are custody evidence for an *operator*,
recorded in `artifact_integrity_event`, not facts a caller can act on.
`test_api_untested_refusals_tier_de.py:733` pins its `context` empty for
exactly that reason, and reclassifying it would put that test and this
field in contradiction for no gain.

**5. `invalid_structure_query` is `thing`** because only one of its two
conditions has a second thing (`mode` not accepting a query kind); the other
is an unparseable SMILES. A code that owes facts on one path and not the
other should be *split*, which is a bigger decision than a classification.

**6. `record_not_approved` is `thing`.** "at or above X review status; this
one is Y" is a threshold comparison, classified consistently with the caps
above rather than against them.

**7. `supersedes_same_record` is `relationship`** although it fires because
two things are *the same* rather than different. The test the rule applies
is whether the code asserts something about two things and names neither,
and it does.

**8. `tckdb_client_version_unsupported` is `relationship` and deliberately
not populated.** Its facts — the version sent, the minimum accepted — are
already machine-readable: they are in `detail`, which for the three
`detail_object` codes is a JSON object rather than a sentence. "Never parse
`detail`" still holds, because parsing is what a sentence needs and a dict
does not.

The full 168-entry table is at the end of this description.

---

## What this PR populates: four codes

Chosen so the diff stays reviewable and no disclosure policy is touched.

| code | status | `context` keys now |
|---|---|---|
| `handle_type_mismatch` | 422 | `expected_kind`, `expected_prefix`, `supplied_prefix` |
| `invalid_temperature_range` | 422 | `temperature_min_k`, `temperature_max_k` |
| `multiple_structure_queries` | 422 | `supplied` (the query field names) |
| `transition_state_irc_mapping_element_mismatch` | 422 | `field`, `participant_key`, `role`, `participant_index`, `ts_atom_indices`, `assigned_composition`, `declared_composition`, `declared_smiles` |

The first three were `message_prefix`, so each raise moves from
`ValueError(f"code: prose")` to `CodedValueError(code, prose,
context={...}, message_prefix=True)`. **`str(exc)` — and therefore the
response's `detail` — stays byte-identical**; only the route into `code`
changes, from promoted-out-of-the-sentence to declared on the exception.
The catalogue entries move to `Surface.coded_exception` accordingly, which
is what shrinks `MESSAGE_PREFIX_CODES` from 76 to 73. The fourth was
already a `CodedValueError` and simply had no `context`.

Each was picked because *nothing is written over its old spelling*: none of
the three is named by `test_error_contract_catalogue_gate.py`, and none was
pinned to an empty `context` anywhere.

No `context` value is a database primary key. `expected_prefix` /
`supplied_prefix` are schema-level constants; `supplied`, `field`,
`participant_key`, `participant_index`, `declared_smiles` and the
temperature bounds are all the depositor's own payload or query values; the
compositions are element-count maps of exactly the `{"C": 2, "H": 6}` shape
`error_body_observer.py` documents as legitimate. Two of the new tests
assert no `*_id`-shaped key is present, on top of PR #202's observer.

### Two consistency arguments worth noting

- `invalid_range` (in `scientific_read/analytics.py`) has carried its two
  bounds in `context` since it was written. `invalid_temperature_range` is
  the same shape and carried nothing — so the fix here is removing an
  inconsistency, not inventing a policy.
- `atom_map_element_not_conserved`, which refuses the same claim as
  `transition_state_irc_mapping_element_mismatch` written per atom rather
  than per count, has always carried its context. The IRC form did not.

---

## What remains: 25 of 62 relationship codes

Measured by a helper-aware static scan (`context=` at the call, or a callee
that supplies one — `unknown_reference`, `raise_for_blocking_findings` and
the ownership guards all do), then corrected by hand for the three places a
*handler* writes the context instead of the raiser.

Before this PR, 33 of the 62 relationship codes answered a client
adequately. **37 do now.** The 25 that do not, and why each is not in this
tranche:

**(a) 18 are `message_prefix` and need the same conversion.**

`calculation_handle_conflict`, `composed_search_invalid_page`,
`composed_search_pagination_changed`, `composed_search_pagination_stalled`,
`curation_policy_version_conflict`, `cursor_query_mismatch`,
`doi_already_recorded`, `level_of_theory_handle_conflict`,
`pressure_alias_conflict`, `reaction_entry_handle_conflict`,
`reaction_handle_conflict`, `record_subject_mismatch`,
`selection_already_stands`, `selection_already_superseded`,
`species_entry_handle_conflict`, `species_handle_conflict`,
`subject_type_mismatch`, `supersedes_same_record`.

Mostly mechanical, with **two known obstacles**:

- **The six `*_handle_conflict` codes are not mechanical.** Their code is
  minted from `reconcile_id_ref`'s `conflict_code` *parameter*, and
  `test_error_contract_catalogue_gate.py::TestTheShapeTheRaiseSiteScanCannotRead`
  is written over exactly that spelling: it asserts the helper raises
  `f"{conflict_code}: …"` and that those six are in `MESSAGE_PREFIX_CODES`.
  Converting them means **re-pointing that gate at the new shape** — the
  blind spot it covers still exists, since the first argument would still
  be a variable — and that is a change to a carefully-reasoned gate that
  deserves its own review rather than being buried in a tranche.
  `handle_type_mismatch` was taken instead because it is a plain literal at
  both of its sites and no gate is written over it.
- **`pressure_alias_conflict` is pinned to an empty `context`** at
  `backend/tests/api/scientific/test_api_kinetics_search.py:96`. See the
  falsity section below.

**(b) 4 are blocked on a disclosure question this PR will not settle.**
`unique_conflict`, `reference_conflict`, `state_conflict`,
`integrity_conflict`.

These four were my *first* choice of tranche and I reverted them, which is
worth explaining because the code is the highest-value item on the list.
Today an unregistered constraint violation answers "Request violates a
consistency rule." with `context == {}`, while the handler already *knows*
the constraint name and logs it. Reporting it looked like a four-line win.

It is not, because the repository holds two incompatible positions:

- `test_api_database_constraint_codes.py::test_the_response_body_names_the_scientific_rule`
  asserts `body["context"]["constraint"] == name` for constraints the
  scientific check register claims, on the stated grounds that a constraint
  name is a schema object name and the key into
  `docs/guides/scientific_check_register.md`.
- `test_api_integrity_error_handler.py` asserts the **opposite** for the
  unregistered buckets, in as many words: *"Internal constraint name must
  not leak through the public body."* Two tests
  (`TestUniqueConflict::test_sanitized_envelope`,
  `TestCheckConflict::test_sanitized_envelope`) went red on my change and
  are the reason it is reverted.

Widening disclosure is a decision for whoever owns that rule, not something
to slip into a tranche, and the brief forbids weakening a test. So the
handler keeps its behaviour and gains a comment recording the conflict and
pointing at both tests. **A follow-up needs a decision from Calvin: may an
unregistered constraint name appear in a 409 body?** Worth noting that the
existing position is already inconsistent —
`TestReferenceConflict::test_sanitized_envelope` has no such assertion, so
foreign-key names are unguarded either way.

**(c) 3 are `coded_exception` and are *partially* populated.**
`freq_list_exceeds_geometry_degrees_of_freedom`,
`n_imag_contradicts_minimum`,
`transition_state_reaction_coordinate_ambiguous`. All three leave
`raise_for_blocking_findings`, which supplies
`context={"locations": [...]}` — so they say *where* but not *which two
values disagreed*. Sharpening them is a change inside `tckdb_schemas` and
carries a wire-package bump; not in this tranche.

---

## The documentation fix

Three places promised what the surface does not provide. All three now
state the narrower, true promise: **where a code names a relationship the
facts are in `context`; where it names a thing the code is the fact.**

1. **`backend/app/api/error_contract.py`** — a new module-docstring
   section, *"What `context` promises, and what it does not"*, carrying the
   measured 73-of-168 figure, the reason (`ValueError` has nowhere to put
   facts), the thing/relationship rule, the honest statement that the
   relationship set is being worked through in tranches, and the
   `detail_object` exception. `error_envelope`'s own docstring now says
   `{}` is not a promise unmet for most codes and points at it.
2. **`docs/clients/generic-client-targeting.md`** — the sentence
   "`context` carries the same facts in structured form" was the
   over-promise. Replaced with a section that gives clients the rule, tells
   them to treat `{}` as normal, tells them **never to make a populated
   `context` a precondition** for handling a refusal, and states the
   no-row-ids rule so a client does not go looking for an id.
3. **`clients/python/README.md`** — `# the same facts, structured` becomes
   `# structured facts, or {}`, with the rule spelled out beneath the
   example.

---

## Mutations run

Each landed in the working tree, the named test run, then restored;
`git diff --stat` verified unchanged afterwards.

| # | mutation | expected | observed |
|---|---|---|---|
| M1 | drop `context=` from `_handle_type_mismatch` | its wire test red | **1 failed** |
| M2 | drop `context=` from the IRC-mapping raise | its wire test red | **1 failed** |
| M3 | drop `context=` from `invalid_temperature_range` | its wire test red | **1 failed** |
| M4 | drop `context=` from `multiple_structure_queries` | its wire test red | **1 failed** |
| M5 | flip `species_geometry_isotope_mismatch` to `Shape.thing` | word guard red | **1 failed, 1 passed** |
| M6 | blank `RELATIONSHIP_WORDS` | word guard + its non-vacuity floor red | **2 failed** |
| M7 | strip `shape=` from every entry (field added, not applied) | the split guard, the word guard and the populated-codes guard all red | **3 failed** |

M7 is the one that matters most: it is the "the field was added and nobody
applied it" failure, and three separate assertions catch it.

**And the check in the other direction, which the brief asked for
explicitly:** no code left alone is asserted empty by anything this PR
adds. Verified mechanically —
`git diff -U0 -- backend/tests | grep '^+' | grep -c 'context"] == {}'`
returns **0**. The 20 pre-existing such assertions are untouched (and their
count is not zero — see below).

---

## Commands run

```bash
# from backend/
conda run -n tckdb_env pytest tests/ -q                  # 8234 passed, 14 skipped
conda run -n tckdb_env ruff check app tests scripts      # All checks passed
conda run -n tckdb_env mypy                              # no issues, 183 files
conda run -n tckdb_env python scripts/check_runtime_ascii.py
# from clients/python/
conda run -n tckdb_env pytest -q                         # 1371 passed
# from schemas/python/tckdb-schemas/
conda run -n tckdb_env pytest -q                         # 38 passed
# mutations
bash <scratch>/mutate.sh                                 # M1-M7, all red as intended
```

`git diff` was read from the repository root throughout.

---

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no column, no enum in
`app/db/models/common.py`. `Shape` is an enum in `app/api/`, not a database
type.

## Environment variables

**None added.**

## Client version

`clients/python/pyproject.toml` 0.52.1 → **0.52.2** (the README changed).
Checked against `origin/main`, not the branch point: `origin/main` is
0.52.1, so 0.52.2 is unclaimed.

The generated `clients/python/src/tckdb_client/rejection_codes.py` is
**not** regenerated and does not need to be: the generator reads only
`client_facing()` codes/statuses and `never_retryable()` codes, and this PR
changes no code string, no status, no `reach` and no `replay`, and moves no
surface to or from `generic_fallback`/`accidental_prefix`. Verified —
`test_client_rejection_codes_generated.py` passes with `--check`.

---

## Things in the brief I found to be false

1. **"An earlier agent deliberately did not assert `context == {}`
   anywhere."** There are **20** such assertions in `backend/tests`, across
   15 files. The judgement the brief describes is real —
   `test_api_untested_refusals_tier_a.py:66` explicitly says it *declines*
   to pin `context == {}` — but it was applied in one place, not
   everywhere. Most of the 20 are harmless because they concern `thing`
   codes (`curator_task_not_found`, `unknown_include_token`,
   `username_taken`, `email_taken`, the artifact `5xx`s) or the
   two-failures request-validation path.
   **One is not harmless:**
   `backend/tests/api/scientific/test_api_kinetics_search.py:96` pins
   `pressure_alias_conflict`'s `context` empty, and that is a
   `Shape.relationship` code. Populating it will cost exactly the red test
   the brief warned about. I left it alone rather than weaken it; the next
   tranche must tighten that assertion to the new keys in the same commit.
2. **The surface table was stale in two rows and wrong in one.**
   `accidental_prefix` is 0, not 1 (the catalogue's own docstring says so),
   and `generic_fallback` is 7, not 8.
3. **"`CoderValueError`"** — the class is `CodedValueError`
   (`app.api.error_contract`), subclassing
   `tckdb_schemas.coded_error.CodedValidationError`. Cosmetic, noted only
   because grepping the wrong spelling finds nothing.
4. **The `#210` in this repository's git log is a real GitHub PR number**
   ("Let mypy see the wire package it was shrugging off", `1274bc21`),
   which collides with this task id. I have cited task ids as bare `#NNN`
   inside code comments only where the surrounding file already does so,
   and used no `Closes #210`.

---

<details>
<summary>The full 168-entry classification</summary>

### RELATIONSHIP

| code | status | surface |
|---|---|---|
| `applied_energy_correction_source_calculation_owner_mismatch` | 422 | `coded_exception` |
| `arrhenius_a_units_molecularity_mismatch` | 422 | `coded_exception` |
| `atom_map_atoms_unaccounted_for` | 422 | `coded_exception` |
| `atom_map_contradicts_irc_mapping` | 422 | `coded_exception` |
| `atom_map_element_not_conserved` | 422 | `coded_exception` |
| `atom_map_element_not_conserved` | 409 | `database_constraint` |
| `atom_map_indices_not_geometry_relative` | 422 | `coded_exception` |
| `atom_map_not_a_bijection` | 422 | `coded_exception` |
| `atom_map_not_a_bijection` | 409 | `database_constraint` |
| `calculation_geometry_composition_mismatch` | 422 | `coded_exception` |
| `calculation_handle_conflict` | 422 | `message_prefix` |
| `composed_search_invalid_page` | 422 | `message_prefix` |
| `composed_search_pagination_changed` | 422 | `message_prefix` |
| `composed_search_pagination_stalled` | 422 | `message_prefix` |
| `curation_policy_version_conflict` | 409 | `message_prefix` |
| `cursor_offset_conflict` | 422 | `coded_exception` |
| `cursor_query_mismatch` | 422 | `message_prefix` |
| `doi_already_recorded` | 409 | `message_prefix` |
| `energy_transfer_scope_columns_disagree` | 409 | `database_constraint` |
| `freq_list_exceeds_geometry_degrees_of_freedom` | 422 | `coded_exception` |
| `freq_mode_index_not_unique` | 422 | `coded_exception` |
| `freq_n_imag_disagrees_with_modes` | 422 | `coded_exception` |
| `handle_type_mismatch` | 422 | `coded_exception` |
| `idempotency_conflict` | 409 | `response_literal` |
| `idempotency_in_progress` | 409 | `response_literal` |
| `integrity_conflict` | 409 | `generic_fallback` |
| `invalid_range` | 422 | `coded_exception` |
| `invalid_temperature_range` | 422 | `coded_exception` |
| `kinetics_interpretation_conformer_selection_owner_mismatch` | 422 | `coded_exception` |
| `kinetics_interpretation_statmech_owner_mismatch` | 422 | `coded_exception` |
| `level_of_theory_handle_conflict` | 422 | `message_prefix` |
| `multiple_structure_queries` | 422 | `coded_exception` |
| `n_imag_contradicts_minimum` | 422 | `coded_exception` |
| `pressure_alias_conflict` | 422 | `message_prefix` |
| `reaction_charge_not_conserved` | 422 | `coded_exception` |
| `reaction_mass_balance_failed` | 422 | `coded_exception` |
| `record_subject_mismatch` | 422 | `message_prefix` |
| `reaction_entry_handle_conflict` | 422 | `message_prefix` |
| `reaction_handle_conflict` | 422 | `message_prefix` |
| `reference_conflict` | 409 | `sqlstate_category` |
| `selection_already_stands` | 409 | `message_prefix` |
| `selection_already_superseded` | 409 | `message_prefix` |
| `species_entry_handle_conflict` | 422 | `message_prefix` |
| `species_geometry_composition_mismatch` | 422 | `coded_exception` |
| `species_geometry_isotope_mismatch` | 422 | `coded_exception` |
| `species_handle_conflict` | 422 | `message_prefix` |
| `species_kind_conflict` | 422 | `coded_exception` |
| `species_smiles_charge_mismatch` | 422 | `coded_exception` |
| `state_conflict` | 409 | `sqlstate_category` |
| `statmech_source_calculation_owner_mismatch` | 422 | `coded_exception` |
| `statmech_source_role_type_mismatch` | 422 | `coded_exception` |
| `statmech_torsion_scan_calculation_owner_mismatch` | 422 | `coded_exception` |
| `subject_type_mismatch` | 422 | `message_prefix` |
| `supersedes_same_record` | 422 | `message_prefix` |
| `tckdb_client_version_unsupported` | 426 | `detail_object` |
| `thermo_source_calculation_owner_mismatch` | 422 | `coded_exception` |
| `thermo_source_role_type_mismatch` | 422 | `coded_exception` |
| `thermo_statmech_owner_mismatch` | 422 | `coded_exception` |
| `transition_state_charge_mismatch` | 422 | `coded_exception` |
| `transition_state_composition_mismatch` | 422 | `coded_exception` |
| `transition_state_irc_mapping_element_mismatch` | 422 | `coded_exception` |
| `transition_state_reaction_coordinate_ambiguous` | 422 | `coded_exception` |
| `transport_source_calculation_owner_mismatch` | 422 | `coded_exception` |
| `unique_conflict` | 409 | `sqlstate_category` |

### THING

| code | status | surface |
|---|---|---|
| `applied_energy_correction_source_key_undeclared` | 422 | `coded_exception` |
| `artifact_integrity_failed` | 502 | `response_literal` |
| `artifact_object_missing` | 502 | `response_literal` |
| `artifact_storage_full` | 507 | `response_literal` |
| `artifact_storage_unavailable` | 503 | `response_literal` |
| `atom_map_geometry_unparseable` | 422 | `coded_exception` |
| `atom_map_inferred_requires_note` | 422 | `coded_exception` |
| `atom_map_participant_not_declared` | 422 | `coded_exception` |
| `atom_map_without_transition_state` | 422 | `coded_exception` |
| `calculation_key_undeclared` | 422 | `coded_exception` |
| `canonical_parameter_value_requires_key` | 422 | `message_prefix` |
| `client_sort_not_supported` | 422 | `message_prefix` |
| `composed_search_candidate_limit_exceeded` | 422 | `message_prefix` |
| `curator_task_not_found` | 404 | `coded_exception` |
| `data_integrity_error` | 500 | `generic_fallback` |
| `database_error` | 503 | `generic_fallback` |
| `database_unavailable` | 503 | `response_literal` |
| `domain_error` | 400 | `generic_fallback` |
| `email_taken` | 409 | `message_prefix` |
| `export_all_cap_exceeded` | 422 | `message_prefix` |
| `export_seed_empty` | 422 | `message_prefix` |
| `export_seed_unresolved` | 422 | `message_prefix` |
| `geometry_key_unresolved` | 422 | `coded_exception` |
| `geometry_too_large` | 422 | `message_prefix` |
| `handle_not_found` | 404 | `coded_exception` |
| `include_not_implemented_yet` | 422 | `message_prefix` |
| `invalid_cursor` | 422 | `message_prefix` |
| `invalid_handle` | 422 | `message_prefix` |
| `invalid_idempotency_key` | 400 | `response_literal` |
| `invalid_pagination` | 422 | `message_prefix` |
| `invalid_structure_query` | 422 | `message_prefix` |
| `irc_result_not_found` | 404 | `coded_exception` |
| `limit_too_large` | 422 | `message_prefix` |
| `lowest_energy_unavailable` | 422 | `coded_exception` |
| `manifest_already_frozen` | 409 | `message_prefix` |
| `manifest_not_frozen` | 404 | `message_prefix` |
| `missing_filter` | 422 | `message_prefix` |
| `missing_identifier` | 422 | `message_prefix` |
| `missing_reaction_search_filter` | 422 | `message_prefix` |
| `missing_structure_query` | 422 | `message_prefix` |
| `ml_export_all_cap_exceeded` | 422 | `message_prefix` |
| `ml_export_lot_unresolved` | 422 | `message_prefix` |
| `ml_export_seed_empty` | 422 | `message_prefix` |
| `ml_export_seed_unresolved` | 422 | `message_prefix` |
| `micro_reaction_key_undeclared` | 422 | `coded_exception` |
| `network_channel_key_undeclared` | 422 | `coded_exception` |
| `network_solve_reported_requires_literature` | 409 | `database_constraint` |
| `network_state_key_undeclared` | 422 | `coded_exception` |
| `non_finite_value` | 422 | `message_prefix` |
| `offset_too_large` | 422 | `message_prefix` |
| `owner_missing` | 404 | `coded_exception` |
| `parameter_value_requires_key` | 422 | `message_prefix` |
| `path_search_result_not_found` | 404 | `coded_exception` |
| `post_search_fields_must_be_in_body` | 422 | `message_prefix` |
| `query_timeout` | 503 | `response_literal` |
| `query_too_expensive` | 422 | `message_prefix` |
| `rate_limit_exceeded` | 429 | `response_literal` |
| `rationale_required` | 422 | `message_prefix` |
| `record_has_no_subject` | 422 | `message_prefix` |
| `record_not_approved` | 422 | `message_prefix` |
| `record_ref_not_selectable` | 422 | `message_prefix` |
| `record_type_not_selectable` | 422 | `message_prefix` |
| `release_artifact_corrupt` | 500 | `message_prefix` |
| `release_not_draft` | 409 | `message_prefix` |
| `release_not_published` | 409 | `message_prefix` |
| `release_scoping_not_implemented` | 422 | `message_prefix` |
| `release_selects_nothing` | 422 | `message_prefix` |
| `release_tag_taken` | 409 | `message_prefix` |
| `request_validation_error` | 422 | `generic_fallback` |
| `resource_not_found` | 404 | `generic_fallback` |
| `scan_result_not_found` | 404 | `coded_exception` |
| `schema_not_initialized` | 503 | `response_literal` |
| `selection_no_longer_approved` | 422 | `message_prefix` |
| `smiles_too_long` | 422 | `message_prefix` |
| `species_key_undeclared` | 422 | `coded_exception` |
| `statmech_calculation_key_undeclared` | 422 | `coded_exception` |
| `statmech_subject_not_exactly_one` | 409 | `database_constraint` |
| `stored_species_smiles_unparseable` | 422 | `coded_exception` |
| `tckdb_client_version_invalid` | 426 | `detail_object` |
| `tckdb_client_version_missing` | 426 | `detail_object` |
| `transition_state_key_undeclared` | 422 | `coded_exception` |
| `transition_state_no_imaginary_mode` | 422 | `coded_exception` |
| `transition_state_reaction_coordinate_not_designated` | 422 | `coded_exception` |
| `unknown_calculation_artifact_ref` | 404 | `coded_exception` |
| `unknown_calculation_ref` | 404 | `coded_exception` |
| `unknown_curation_policy` | 404 | `message_prefix` |
| `unknown_include_token` | 422 | `message_prefix` |
| `unknown_network_kinetics_ref` | 404 | `coded_exception` |
| `unknown_record` | 404 | `message_prefix` |
| `unknown_record_type` | 422 | `message_prefix` |
| `unknown_release` | 404 | `message_prefix` |
| `unknown_release_artifact` | 404 | `message_prefix` |
| `unknown_selection` | 404 | `message_prefix` |
| `unknown_statmech_ref` | 404 | `coded_exception` |
| `unknown_transition_state_entry_ref` | 404 | `coded_exception` |
| `unsafe_lowest_energy_comparison` | 422 | `message_prefix` |
| `unsupported_direction` | 422 | `message_prefix` |
| `unsupported_filter` | 422 | `coded_exception` |
| `unsupported_ranking_for_calculation_type` | 422 | `message_prefix` |
| `unsupported_reaction_molecularity` | 422 | `coded_exception` |
| `unsupported_release_record_type` | 422 | `message_prefix` |
| `username_taken` | 409 | `message_prefix` |
| `validation_error` | 422 | `generic_fallback` |
| `withdraw_reason_required` | 422 | `message_prefix` |

</details>
---

## Update after merging `main`: the guard caught a real code on its first contact

`Tell "no such selection" from "which selection?"` (#213) merged while this
branch was in review and added two catalogue entries:

- `unknown_conformer_selection` — 404
- `ambiguous_conformer_selection_locator` — 422

The merge was **textually clean** — the two entries and this branch's
`shape=` declarations touch different lines — so nothing about the merge
itself flagged anything. The `Backend API gate` went red on exactly one
assertion:

```
FAILED tests/api/test_api_code_catalogue.py::
    test_no_entry_named_like_a_relationship_is_classified_as_a_thing
AssertionError: ['ambiguous_conformer_selection_locator'] are named for a
relation between two things but classified Shape.thing.
```

That is the guard doing precisely the job it was built for, on the first
new code to arrive after it existed. `ambiguous_conformer_selection_locator`
was written before `Shape` did, so it took the `Shape.thing` default — the
"classified wrong by omission" case the `RELATIONSHIP_WORDS` list exists to
make impossible to do quietly. **This is better evidence for the guard than
any of the seven mutations below**, because nothing was staged: a real
sibling PR, a clean merge, and the only thing that noticed was the word
list.

### What was done about it

**Declared, not repaired.** The failing entry gains
`shape=Shape.relationship` and a note; nothing else about the sibling's code
is touched.

`unknown_conformer_selection` is a `thing` by the same rule — `unknown_X`,
the name is the whole message — and takes the `Shape.thing` default, which
in this design *is* its declaration. No edit.

### It did not join the remaining backlog

Checked rather than assumed. `ambiguous_conformer_selection_locator`
**already satisfied `owes_context` before there was a field to name the
obligation**: `Discrimination.as_context` reports `field`, `kind`,
`match_count`, `differs_by`, `discriminator`, `discriminator_values` and
`locator_can_express` — the things that differ across the candidates, and
no row ids. `test_api_conformer_selection_locator_codes.py` already pins
those keys on the wire, to the same standard this PR's four use
(`(status, code)` plus named keys, never "context is non-empty").

So it is added to `_POPULATED_RELATIONSHIP_CODES` — not because this pass
populated it, but because a later edit moving it to `Shape.thing` while
those assertions stand would be a contradiction, and that floor is what
says so.

### Revised counts

| | before merge | after merge |
|---|---|---|
| entries / distinct codes | 168 / 166 | **170 / 168** |
| `Shape.relationship` | 64 entries / 62 codes | **65 entries / 63 codes** |
| `Shape.thing` | 104 | **105** |
| relationship codes answered adequately | 37 of 62 | **38 of 63** |
| remaining | 25 | **25** (unchanged) |

The remaining 25 are unchanged: 18 `message_prefix`, 4 blocked on the
unregistered-constraint disclosure question, 3 carrying `locations` only.

### Re-verified after the merge

- `pytest backend/tests/ -q` from `backend/`
- `ruff check app tests scripts`, `mypy`, `scripts/check_runtime_ascii.py` —
  all clean.

### Still open for Calvin, unchanged

- **The cap family.** Left classified as `thing`, as it stands. The
  invitation to overrule is in the borderline section above and is not
  pre-empted here.
- **May an unregistered constraint name appear in a 409 body?** Still the
  blocker on `unique_conflict`, `reference_conflict`, `state_conflict` and
  `integrity_conflict`.
