### PR TITLE
Keep the database's own names off the wire

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -427,8 +427,14 @@ class Shape(str, Enum):
     #: between two or more things and names none of them, so ``context``
     #: is the only place the *which* can live. What goes in it is the
     #: things themselves — a field path, a public ref, a declared local
-    #: key, a constraint name, a count — and never a database primary key
-    #: (DR-0028 Requirement 2), which is logged instead.
+    #: key, a count — and never an internal identifier: not a database
+    #: primary key (DR-0028 Requirement 2), and since 2026-08-18 not a
+    #: raw database constraint name either. Both are logged instead, for
+    #: the same reason: they are ours, not the depositor's, they do not
+    #: survive a restore or a rename, and no public surface is keyed on
+    #: them. A constraint that deserves a public contract earns a code of
+    #: its own through the scientific check register — see
+    #: :func:`app.api.errors._integrity_error_handler`.
     relationship = "relationship"
 
 

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -229,20 +229,72 @@ def _no_result_found_handler(
 # constraint that the scientific check register names carries its own
 # code and sentence, looked up by name in ``_constraint_rejections``
 # below; everything else still falls back to the SQLSTATE bucket.
+#
+# What a bucket may say, settled 2026-08-18
+# -----------------------------------------
+# **A raw database constraint name never appears in a user-facing body.**
+# It is an internal identifier: meaningless to a depositor, unstable
+# across a rename, and a disclosure of schema layout — the same reasoning
+# that keeps row ids out of bodies under DR-0028 Requirement 2. The name
+# goes to the log below, where the operator is.
+#
+# So the sentence is what the bucket owes, and it is written to be acted
+# on rather than merely to be true. "Integrity constraint violation." is
+# true of every branch here and tells a depositor nothing; each message
+# below instead says which *kind* of rule refused the write and what
+# would make a second attempt succeed. That is the repair-shaped half of
+# the obligation these four ``Shape.relationship`` codes carry (see
+# :mod:`app.api.code_catalogue`) — the structured half, naming the things
+# that disagreed, stays open, because the only fact available here is the
+# constraint name and that is precisely what may not be disclosed.
+#
+# The sanctioned route from an internal name to a public contract is the
+# **register**: a constraint that matters enough to earn a specific code
+# declares one (``app.scientific_checks.declarations``) and gets a real
+# sentence, as ``uq_app_user_email`` does for ``email_taken`` in
+# :data:`app.api.routes.auth.REGISTRATION_CONFLICTS`. Putting the name in
+# the body is the unsanctioned shortcut around that.
 
 _SQLSTATE_TO_CATEGORY: dict[str, tuple[str, str]] = {
     # (category code, sanitized public message)
-    "23505": ("unique_conflict", "Resource conflicts with an existing record."),
+    "23505": (
+        "unique_conflict",
+        "A uniqueness rule was violated: a record with these values already "
+        "exists. Cite the existing record instead of creating a second one, "
+        "or change the values that have to be unique.",
+    ),
     "23503": (
         "reference_conflict",
-        "Request references an entity that does not exist or is still in use.",
+        "A referenced record does not exist, or is still referenced by "
+        "another record. Deposit or cite the record being referred to before "
+        "referring to it, and detach whatever depends on a record before "
+        "removing it.",
     ),
-    "23514": ("state_conflict", "Request violates a consistency rule."),
-    "23502": ("state_conflict", "Request is missing a required field."),
-    "23P01": ("state_conflict", "Request violates a consistency rule."),
+    "23514": (
+        "state_conflict",
+        "A consistency rule was violated: the submitted values contradict "
+        "one another. Re-check the fields this record constrains together.",
+    ),
+    "23502": (
+        "state_conflict",
+        "A required field was left empty. Supply every field this record "
+        "requires and resubmit.",
+    ),
+    "23P01": (
+        "state_conflict",
+        "An exclusion rule was violated: this record overlaps one that "
+        "already exists. Adjust the overlapping values or amend the existing "
+        "record instead.",
+    ),
 }
 
-_FALLBACK = ("integrity_conflict", "Integrity constraint violation.")
+_FALLBACK = (
+    "integrity_conflict",
+    "The database refused this write because it would have broken a "
+    "consistency rule. Nothing was stored; the rule that fired was logged "
+    "against this request, so quote the X-Request-ID response header when "
+    "reporting it.",
+)
 
 
 @lru_cache(maxsize=1)
@@ -298,34 +350,42 @@ def _integrity_error_handler(
     context: dict[str, Any] = {}
     # Named before classified. A constraint that encodes chemistry is a
     # stronger guarantee than any Python check -- no write path can get
-    # around it -- and until now it was the one a client was told least
-    # about, because every violation collapsed into its SQLSTATE bucket.
+    # around it -- and until the register began naming these constraints
+    # it was the one a client was told least about, because every
+    # violation collapsed into its SQLSTATE bucket.
     # Keyed on the constraint name rather than on the driver's message
     # text: parsing prose is what the typed envelope exists to replace.
     #
-    # Why the *unnamed* buckets below are left with an empty ``context``,
-    # although ``unique_conflict``, ``reference_conflict``,
+    # The name is the *key*, and it stays on this side of the wire. Until
+    # 2026-08-18 this branch also published it as
+    # ``context["constraint"]``, and the repository held three positions
+    # about whether that was allowed: this one said yes, the unregistered
+    # buckets said no in as many words ("Internal constraint name must not
+    # leak through the public body"), and the foreign-key bucket said
+    # nothing at all. Calvin settled it in the direction the majority
+    # already pointed -- a raw constraint name is an internal identifier
+    # and never appears in a user-facing body -- so what a registered
+    # constraint earns is a *code and a sentence of its own*, which is a
+    # public contract, rather than a schema object name, which is not.
+    # Looking the rule up in ``docs/guides/scientific_check_register.md``
+    # is done by that code; the name reaches the operator through the log
+    # line below.
+    #
+    # This leaves ``context`` empty on every branch here. That is a known
+    # gap and not a lie: ``unique_conflict``, ``reference_conflict``,
     # ``state_conflict`` and ``integrity_conflict`` are all
-    # ``Shape.relationship`` codes that owe a client the things that
-    # disagreed (see ``app.api.code_catalogue``): the only fact available
-    # here is the constraint name, and this repository holds two
-    # incompatible positions about whether that may be disclosed. The
-    # register path below reports it deliberately -- it is the key into
-    # ``docs/guides/scientific_check_register.md``, and
-    # ``test_api_database_constraint_codes.py`` asserts it reaches the
-    # body. ``test_api_integrity_error_handler.py`` asserts the opposite
-    # for the unregistered buckets, in as many words: "Internal
-    # constraint name must not leak through the public body." Widening
-    # disclosure is a decision for whoever owns that rule, not something
-    # to settle inside a tranche, so these four stay on the open list.
+    # ``Shape.relationship`` codes (see ``app.api.code_catalogue``) and so
+    # owe a client the things that disagreed, but the only fact this seam
+    # holds is the constraint name and that is exactly what may not be
+    # disclosed. Paying them needs a fact from the write path -- the field
+    # a depositor wrote, the local key they declared -- which means
+    # raising a coded exception there rather than letting the driver's
+    # error reach this handler. The messages above are the part that can
+    # be paid here: say which kind of rule refused, and what would make a
+    # second attempt succeed.
     rejection = _constraint_rejections().get(constraint) if constraint else None
     if rejection is not None:
         code, message = rejection
-        # The schema object name, not a row id. It is the key into
-        # ``docs/guides/scientific_check_register.md``, so a client (or a
-        # human reading a traceback) can look up which scientific position
-        # refused the write and what the escape hatch is.
-        context["constraint"] = constraint
     elif constraint == IDEMPOTENCY_UNIQUE_CONSTRAINT:
         code = "idempotency_conflict"
         message = (

--- a/backend/docs/specs/read_query_api_audit.md
+++ b/backend/docs/specs/read_query_api_audit.md
@@ -1258,14 +1258,33 @@ scientific surface — only metadata is exposed.
   `integrity_conflict`.
 - A constraint that the scientific check register names carries its own
   code and sentence instead — `atom_map_element_not_conserved` rather
-  than `state_conflict` — and echoes the **constraint name** in
-  `context.constraint`. That is a deliberate reversal of the earlier
-  position that the name is never echoed. A schema object name is not a
-  row id: it is stable across instances, it is the key into
-  `docs/guides/scientific_check_register.md`, and withholding it left
-  the client unable to tell which scientific rule refused the write when
-  the guarantee behind it is the strongest one TCKDB makes. See
-  `backend/tests/api/test_api_database_constraint_codes.py`.
+  than `state_conflict`. The **code** is the whole public contract, and
+  it is what a client branches on and what keys
+  `docs/guides/scientific_check_register.md`.
+- The **raw constraint name never appears in a body** (Calvin,
+  2026-08-18). Between #214 and that ruling this section described the
+  opposite — the registered path echoed the name in `context.constraint`,
+  argued as "a schema object name is not a row id, it is stable across
+  instances". The ruling rejects that premise: a constraint name is an
+  internal identifier on the same reasoning as DR-0028 Requirement 2 —
+  meaningless to a depositor, not stable across a migration that renames
+  it, and a disclosure of schema layout. The sanctioned route from an
+  internal name to a public contract is the register, which mints a code;
+  echoing the name was the shortcut around it. The name goes to the
+  handler's log line, where the operator is.
+- Enforced two ways: per-class in
+  `backend/tests/api/test_api_database_constraint_codes.py` and
+  `backend/tests/api/test_api_integrity_error_handler.py` (each absence
+  assertion sits beside the positive it guards, so it cannot pass against
+  an empty body), and for **every** error body the suite produces by the
+  sweep in `backend/tests/error_body_observer.py`.
+- The four SQLSTATE buckets therefore pay what they can pay: a
+  repair-shaped sentence saying which kind of rule refused and what would
+  make a second attempt succeed, rather than "Integrity constraint
+  violation." for all of them. Their `context` stays empty; they are
+  `Shape.relationship` codes and that half of the obligation is still
+  open, because the only fact this seam holds is the name it may not
+  disclose. Paying it needs a coded refusal raised on the write path.
 - `app.api.errors.not_found` is the single constructor for a 404: it
   logs the integer id server-side and returns a detail that names the
   resource kind, plus the public ref if the caller supplied one. A

--- a/backend/tests/api/test_api_database_constraint_codes.py
+++ b/backend/tests/api/test_api_database_constraint_codes.py
@@ -23,13 +23,35 @@ they are proved separately:
    constraint name at all, which is why ``DatabaseConstraint`` refuses to
    accept a rejection code for a kind PostgreSQL does not name.
 
-2. **The handler turns that name into the declared code, in the body.**
-   Proved by putting the real ``IntegrityError`` from (1) through the
-   real exception handlers -- ``register_exception_handlers`` is the
-   production wiring -- and asserting ``response.json()["code"]``, not
-   that the code appears somewhere in the prose. The assertion has to be
-   on the field, because matching the message is exactly what passes on
-   the broken system.
+2. **The handler turns that name into the declared code, in the body --
+   and leaves the name behind.** Proved by putting the real
+   ``IntegrityError`` from (1) through the real exception handlers --
+   ``register_exception_handlers`` is the production wiring -- and
+   asserting ``response.json()["code"]``, not that the code appears
+   somewhere in the prose. The assertion has to be on the field, because
+   matching the message is exactly what passes on the broken system.
+
+   The second half of that sentence is a **contract change made on
+   2026-08-18**, and this file is where it bites hardest. Until then this
+   test asserted ``body["context"]["constraint"] == name``: the register
+   path published the raw constraint name, on the argument that it is the
+   key into ``docs/guides/scientific_check_register.md``. Calvin ruled
+   the other way, and the ruling is about what an identifier *is* rather
+   than about how useful it would be -- a constraint name is internal,
+   meaningless to a depositor, unstable across a rename, and a disclosure
+   of schema layout, which is the same reasoning that keeps row ids out
+   of bodies under DR-0028 Requirement 2. What a registered constraint
+   earns is therefore a code and a sentence of its own, which is a public
+   contract; the name goes to the log, and the assertion below is now
+   that it is **absent**.
+
+   An absence assertion is worthless on its own -- it passes against a
+   handler that returns nothing at all -- so each one here sits beside
+   the positive it guards: the status, the declared code, the declared
+   sentence, and an empty ``context``. The absence is additionally
+   enforced for every body in the suite by
+   ``tests/error_body_observer.py``, which is what stops this rule
+   drifting back into three positions.
 
 Provoking a violation without a valid parent row
 ------------------------------------------------
@@ -233,10 +255,45 @@ def test_the_response_body_names_the_scientific_rule(name, db_session, envelope_
         "only that something conflicted."
     )
     assert body["detail"] == expected_detail
-    assert body["context"]["constraint"] == name
     # The sanitization the handler has always promised: no driver text.
     assert "psycopg" not in response.text
     assert "INSERT INTO" not in response.text
+
+
+@pytest.mark.parametrize("name", sorted(PROVOCATIONS))
+def test_the_response_body_does_not_disclose_the_constraint_name(
+    name, db_session, envelope_client
+):
+    """Fact 3, and a contract change: the name stays on this side.
+
+    Until 2026-08-18 this file asserted the opposite -- ``body["context"]
+    ["constraint"] == name`` -- and it was one of three positions the
+    repository held at once. See the module docstring for the ruling.
+
+    The positives are asserted first and deliberately: an assertion that
+    a string is missing from a body passes just as well against a handler
+    that produced no body, so the absence is only evidence when the thing
+    it is carved out of is known to be there.
+    """
+    expected_code, expected_detail = constraint_rejections()[name]
+    envelope_client.holder["exc"] = _provoke(db_session, name)
+
+    response = envelope_client.get("/boom")
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["code"] == expected_code
+    assert body["detail"] == expected_detail
+    assert isinstance(body["detail"], str) and body["detail"].strip()
+    # And now the absence, over the whole rendered body rather than one
+    # field, because a name moved to a differently-named key would still
+    # be a disclosure.
+    assert name not in response.text, (
+        f"the raw constraint name {name!r} reached the public body. It is an "
+        "internal identifier; the code above is what a client branches on and "
+        "the name belongs in the log."
+    )
+    assert body["context"] == {}
 
 
 def test_an_unregistered_constraint_still_falls_back_to_its_sqlstate(
@@ -268,5 +325,6 @@ def test_an_unregistered_constraint_still_falls_back_to_its_sqlstate(
     assert response.status_code == 409
     body = response.json()
     assert body["code"] == "state_conflict"
+    assert isinstance(body["detail"], str) and body["detail"].strip()
     assert body["context"] == {}
     assert "null value in column" not in response.text

--- a/backend/tests/api/test_api_integrity_error_handler.py
+++ b/backend/tests/api/test_api_integrity_error_handler.py
@@ -4,6 +4,18 @@ Exercises the public API integrity-error seam in ``app.api.errors`` to
 assert that raw DB/driver text is never exposed and that responses use
 a stable, application-facing envelope.
 
+Two things a generic 409 owes, and they are asserted together
+------------------------------------------------------------
+It owes a **sentence a depositor can act on** -- which kind of rule
+refused, and what would make a second attempt succeed -- and it owes the
+**absence of the constraint name**, which is an internal identifier
+(Calvin, 2026-08-18; the same reasoning as DR-0028 Requirement 2 for row
+ids). They are asserted together, in :func:`_assert_generic_conflict`,
+because an absence assertion on its own passes against a handler that
+returned nothing at all, and this repository has shipped that mistake
+before. The absence is additionally swept for every body in the suite by
+``tests/error_body_observer.py``.
+
 The tests mount the real exception handlers on a lightweight FastAPI app
 with a dedicated route that raises ``IntegrityError`` instances with
 controlled ``sqlstate`` values. This lets us exercise every classified
@@ -100,6 +112,41 @@ def _assert_sanitized(body: dict) -> None:
         )
 
 
+def _assert_generic_conflict(body: dict, code: str, constraint: str | None) -> None:
+    """The whole obligation of a generic 409, asserted in one place.
+
+    Three claims, and the order matters. The first two are positive --
+    the code a client branches on, and a sentence they can act on -- and
+    they are here because the third is an absence, and an absence
+    assertion passes just as happily against a handler that returned an
+    empty body. Asserting only that a name is missing is the vacuous-pass
+    shape this repository has produced more than once.
+
+    The third is Calvin's ruling of 2026-08-18: a raw database constraint
+    name never appears in a user-facing body. Before it, this file made
+    that assertion for unique and check violations, ``TestReferenceConflict``
+    made no assertion in either direction, and
+    ``test_api_database_constraint_codes.py`` asserted the opposite for
+    registered constraints. Three positions; now one, and the same one is
+    enforced for every body in the suite by ``tests/error_body_observer.py``.
+    """
+    assert body["code"] == code
+    detail = body["detail"]
+    assert isinstance(detail, str) and detail.strip(), (
+        "a generic 409 owes the client a sentence they can act on; the code "
+        "alone does not say which kind of rule refused the write"
+    )
+    _assert_sanitized(body)
+    if constraint is not None:
+        assert constraint not in repr(body), (
+            f"internal constraint name {constraint!r} leaked through the "
+            "public body. It is an internal identifier: meaningless to a "
+            "depositor, unstable across a rename, and a disclosure of schema "
+            "layout. It goes to the log; a constraint that deserves a public "
+            "contract is registered and earns a code of its own."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Category tests
 # ---------------------------------------------------------------------------
@@ -114,12 +161,7 @@ class TestUniqueConflict:
             params={"sqlstate": "23505", "constraint": "uq_species_smiles"},
         )
         assert resp.status_code == 409
-        body = resp.json()
-        assert body["code"] == "unique_conflict"
-        assert isinstance(body["detail"], str) and body["detail"]
-        _assert_sanitized(body)
-        # Internal constraint name must not leak through the public body.
-        assert "uq_species_smiles" not in repr(body)
+        _assert_generic_conflict(resp.json(), "unique_conflict", "uq_species_smiles")
 
 
 class TestCheckConflict:
@@ -131,14 +173,18 @@ class TestCheckConflict:
             params={"sqlstate": "23514", "constraint": "ck_owner_xor"},
         )
         assert resp.status_code == 409
-        body = resp.json()
-        assert body["code"] == "state_conflict"
-        _assert_sanitized(body)
-        assert "ck_owner_xor" not in repr(body)
+        _assert_generic_conflict(resp.json(), "state_conflict", "ck_owner_xor")
 
 
 class TestReferenceConflict:
-    """SQLSTATE 23503 -> reference_conflict."""
+    """SQLSTATE 23503 -> reference_conflict.
+
+    The gap this class used to be. It asserted the code and the absence
+    of driver text, and said nothing about the constraint name in either
+    direction -- so a foreign-key name could have been published without
+    a single test noticing, while the sibling classes forbade it. Closed
+    2026-08-18.
+    """
 
     def test_sanitized_envelope(self, handler_client):
         resp = handler_client.get(
@@ -146,13 +192,18 @@ class TestReferenceConflict:
             params={"sqlstate": "23503", "constraint": "fk_entry_species_id"},
         )
         assert resp.status_code == 409
-        body = resp.json()
-        assert body["code"] == "reference_conflict"
-        _assert_sanitized(body)
+        _assert_generic_conflict(
+            resp.json(), "reference_conflict", "fk_entry_species_id"
+        )
 
 
 class TestNotNullConflict:
-    """SQLSTATE 23502 -> state_conflict (missing required field)."""
+    """SQLSTATE 23502 -> state_conflict (missing required field).
+
+    PostgreSQL reports no constraint name for this one -- measured, and
+    pinned by ``test_api_database_constraint_codes.py`` -- so there is
+    nothing to hide here and the parameter is ``None``.
+    """
 
     def test_sanitized_envelope(self, handler_client):
         resp = handler_client.get(
@@ -160,9 +211,23 @@ class TestNotNullConflict:
             params={"sqlstate": "23502"},
         )
         assert resp.status_code == 409
-        body = resp.json()
-        assert body["code"] == "state_conflict"
-        _assert_sanitized(body)
+        _assert_generic_conflict(resp.json(), "state_conflict", None)
+
+
+class TestExclusionConflict:
+    """SQLSTATE 23P01 -> state_conflict, and it was never exercised.
+
+    The branch existed in ``_SQLSTATE_TO_CATEGORY`` from the start with
+    no test behind it, which meant its message could have said anything.
+    """
+
+    def test_sanitized_envelope(self, handler_client):
+        resp = handler_client.get(
+            "/raise-integrity",
+            params={"sqlstate": "23P01", "constraint": "ix_release_window"},
+        )
+        assert resp.status_code == 409
+        _assert_generic_conflict(resp.json(), "state_conflict", "ix_release_window")
 
 
 class TestFallback:
@@ -171,19 +236,64 @@ class TestFallback:
     def test_unknown_sqlstate(self, handler_client):
         resp = handler_client.get(
             "/raise-integrity",
-            params={"sqlstate": "99999"},
+            params={"sqlstate": "99999", "constraint": "uq_something_unmapped"},
         )
         assert resp.status_code == 409
-        body = resp.json()
-        assert body["code"] == "integrity_conflict"
-        _assert_sanitized(body)
+        _assert_generic_conflict(
+            resp.json(), "integrity_conflict", "uq_something_unmapped"
+        )
 
     def test_missing_sqlstate(self, handler_client):
         resp = handler_client.get("/raise-integrity")
         assert resp.status_code == 409
-        body = resp.json()
-        assert body["code"] == "integrity_conflict"
-        _assert_sanitized(body)
+        _assert_generic_conflict(resp.json(), "integrity_conflict", None)
+
+
+class TestEveryGenericMessageIsDistinctAndActionable:
+    """Six SQLSTATEs, six sentences, and not a constraint name among them.
+
+    Four codes carry them -- ``state_conflict`` answers three SQLSTATEs --
+    which is exactly why the sentence has to do work the code cannot: a
+    depositor who left a column empty and one who contradicted a CHECK
+    both receive ``state_conflict``, and the prose is the only thing that
+    tells them apart.
+
+    A repair-shaped description is the half of the ``Shape.relationship``
+    obligation this seam can actually pay: it holds no fact about the
+    request beyond the constraint name, and that is the one thing it may
+    not disclose. What it can do is stop saying "Integrity constraint
+    violation." to four different failures. This test is what makes that
+    a contract rather than a nicety -- it fails if a future edit
+    collapses them back onto one sentence.
+    """
+
+    CASES = (
+        ("23505", "unique_conflict"),
+        ("23503", "reference_conflict"),
+        ("23514", "state_conflict"),
+        ("23502", "state_conflict"),
+        ("23P01", "state_conflict"),
+        ("99999", "integrity_conflict"),
+    )
+
+    def test_each_sqlstate_gets_its_own_sentence(self, handler_client):
+        details = {}
+        for sqlstate, code in self.CASES:
+            resp = handler_client.get(
+                "/raise-integrity", params={"sqlstate": sqlstate}
+            )
+            body = resp.json()
+            assert body["code"] == code
+            details[sqlstate] = body["detail"]
+
+        assert len(set(details.values())) == len(self.CASES), (
+            "two SQLSTATEs share a sentence, so a depositor cannot tell a "
+            f"missing field from a broken rule: {details}"
+        )
+        for sqlstate, detail in details.items():
+            # Long enough to have said what to do, not merely what failed.
+            assert len(detail) > 60, (sqlstate, detail)
+            assert detail.endswith("."), (sqlstate, detail)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_error_body_id_gate.py
+++ b/backend/tests/api/test_error_body_id_gate.py
@@ -1,4 +1,10 @@
-"""The DR-0028 body sweep must catch the shape it exists to catch.
+"""The body sweep must catch the shapes it exists to catch.
+
+Two of them since 2026-08-18: a database primary key (DR-0028
+Requirement 2) and a raw database constraint name. Both are internal
+identifiers a depositor cannot act on, both go to the log instead, and
+the second is here because the repository had been asserting it one test
+at a time and had ended up holding three different positions at once.
 
 ``tests/error_body_observer.py`` is a passive observer: it inspects every
 4xx/5xx body the suite produces and fails the test that produced a
@@ -157,6 +163,99 @@ def test_prose_that_merely_contains_a_number_is_not_a_leak() -> None:
     ):
         body = {"code": "x", "detail": detail, "context": {}}
         assert _leaks(422, body) == [], detail
+
+
+@pytest.mark.parametrize(
+    "body, where",
+    [
+        # The disclosure the 2026-08-18 ruling removed: the registered
+        # constraint path published its own key.
+        (
+            {
+                "code": "atom_map_element_not_conserved",
+                "detail": "An atom map pairs two atoms of different elements.",
+                "context": {"constraint": "ck_reaction_atom_map_pair_element_matches"},
+            },
+            "context.constraint",
+        ),
+        # Renaming the key does not launder the value. The rule is about
+        # what is published, not what it is called.
+        (
+            {
+                "code": "unique_conflict",
+                "detail": "conflict",
+                "context": {"rule": "uq_software_name"},
+            },
+            "context.rule",
+        ),
+        # The foreign-key class, which had no assertion in either
+        # direction until this ruling.
+        (
+            {
+                "code": "reference_conflict",
+                "detail": "conflict",
+                "context": {"violated": ["fk_species_entry_species_id_species"]},
+            },
+            "context.violated[0]",
+        ),
+        # An index name, and a primary key's, because
+        # ``NAMING_CONVENTION`` mints five prefixes and not two.
+        (
+            {"code": "x", "detail": "no", "context": {"why": "ix_species_smiles"}},
+            "context.why",
+        ),
+        (
+            {"code": "x", "detail": "no", "context": {"why": "pk_species"}},
+            "context.why",
+        ),
+        # In prose, which is where it would land if somebody rendered the
+        # driver's own sentence instead of publishing a field.
+        (
+            {
+                "code": "state_conflict",
+                "detail": 'violates check constraint "ck_geometry_atom_element_canonical"',
+                "context": {},
+            },
+            "detail",
+        ),
+    ],
+)
+def test_a_database_constraint_name_in_a_body_is_a_leak(body, where) -> None:
+    """Calvin's ruling of 2026-08-18, as a shape the extractor refuses.
+
+    A raw constraint name is an internal identifier on exactly the DR-0028
+    reasoning: meaningless to a depositor, not stable across a migration
+    that renames it, and a disclosure of schema layout. The register is
+    the sanctioned route from such a name to a public contract -- the
+    constraint declares a rejection code and the *code* crosses the wire.
+    """
+    assert _leaks(409, body) == [where], body
+
+
+def test_prose_and_values_that_merely_look_technical_are_not_a_leak() -> None:
+    """The constraint rule must not swallow the codes it exists to protect.
+
+    Every registered rejection code, every public ref prefix and every
+    ordinary refusal sentence has to survive it, or the ruling would have
+    cost the contract it was meant to defend.
+    """
+    for context, detail in (
+        # The codes the register mints. These are the public contract.
+        ({}, "An atom map pairs two atoms of different elements."),
+        ({"code": "atom_map_not_a_bijection"}, "A map is a bijection or it is not."),
+        ({"code": "energy_transfer_scope_columns_disagree"}, "refused"),
+        # Public refs, which are what a body is allowed to name.
+        ({"species_entry_ref": "spe_abcdefghijklmnopqrstuvwx"}, "unknown entry"),
+        ({"ref": "nsolve_19ee5931311c4abe86a2d5b964"}, "unknown solve"),
+        # The new generic sentences, which must stay clean.
+        ({}, "A uniqueness rule was violated: a record with these values already exists."),
+        ({}, "A referenced record does not exist, or is still referenced by another record."),
+        # Words that merely begin with one of the five prefixes.
+        ({"field": "pkey_material"}, "ixion is not an element"),
+        ({"unit": "cm-1"}, "fk is not a recognised prefix here"),
+    ):
+        body = {"code": "x", "detail": detail, "context": context}
+        assert _leaks(422, body) == [], (context, detail)
 
 
 def test_a_clean_body_still_counts_as_examined() -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,10 +37,12 @@ error_body_observer.install()
 
 
 def _check_error_bodies(item) -> None:
-    """Fail the test whose error body carried a database row id.
+    """Fail the test whose error body carried an internal identifier.
 
-    Two failures, in the order they matter. The first is the rule --
-    DR-0028 Requirement 2, no primary key in a user-facing body. The
+    Two failures, in the order they matter. The first is the rule -- no
+    internal identifier in a user-facing body: not a primary key
+    (DR-0028 Requirement 2), and since 2026-08-18 not a raw database
+    constraint name either. Both go to the log. The
     second is the guard on the guard: a sweep that examines nothing
     passes trivially, so a test whose client *received* a JSON error
     while the sweep examined *no* body means one of the two patches in
@@ -53,12 +55,13 @@ def _check_error_bodies(item) -> None:
     observed = error_body_observer.drain()
     if observed.leaks:
         raise AssertionError(
-            f"{item.nodeid} produced an error body containing a database row "
-            "id (DR-0028 Requirement 2): "
+            f"{item.nodeid} produced an error body containing an internal "
+            "identifier: "
             + "; ".join(leak.explain() for leak in observed.leaks)
-            + ". A row id is an implementation detail of one database "
-            "instance -- it does not survive a restore and does not agree "
-            "between the hosted deployment and a lab self-host. Log it "
+            + ". A row id and a constraint name are both implementation "
+            "details of one database instance -- neither survives a restore, "
+            "neither agrees between the hosted deployment and a lab "
+            "self-host, and no public surface is keyed on either. Log it "
             "server-side and name the field the depositor wrote, or the "
             "public ref they supplied, instead."
         )
@@ -82,9 +85,10 @@ def pytest_runtest_teardown(item) -> None:
     cannot make the catalogue's completeness falsifiable, and why the
     comparison is on the pair rather than on the code alone.
 
-    The body sweep is drained here too, and for the same reason: a row id
-    in an error body is a defect of the request that produced it, not of
-    the run. See ``backend/tests/error_body_observer.py``.
+    The body sweep is drained here too, and for the same reason: an
+    internal identifier in an error body is a defect of the request that
+    produced it, not of the run. See
+    ``backend/tests/error_body_observer.py``.
     """
     _check_error_bodies(item)
     unlisted = error_code_observer.drain_unlisted()

--- a/backend/tests/error_body_observer.py
+++ b/backend/tests/error_body_observer.py
@@ -1,12 +1,28 @@
-"""Watch every error body the suite produces, and refuse a row id in one.
+"""Watch every error body the suite produces, and refuse an internal id.
 
-DR-0028 Requirement 2: a user-facing error body must never contain a
-database primary key. Row ids go to the log, where the operator is; the
-body names the field the depositor wrote, because that is the identifier
-they can act on. A row id is not secret, but it is not ours to give --
-it does not survive a restore into a fresh database, it does not agree
-between the hosted deployment and a lab self-host, and no public surface
-is keyed on it. ``public_ref`` is.
+Two identifiers, one argument. DR-0028 Requirement 2: a user-facing error
+body must never contain a database primary key. Row ids go to the log,
+where the operator is; the body names the field the depositor wrote,
+because that is the identifier they can act on. A row id is not secret,
+but it is not ours to give -- it does not survive a restore into a fresh
+database, it does not agree between the hosted deployment and a lab
+self-host, and no public surface is keyed on it. ``public_ref`` is.
+
+The second is a **raw database constraint name** -- ``uq_software_name``,
+``fk_species_entry_species_id_species`` -- and Calvin settled it on
+2026-08-18 on exactly the reasoning above: meaningless to a depositor,
+not stable across a migration that renames it, and a disclosure of schema
+layout. It reaches the operator through the handler's log line. The
+sanctioned route from an internal constraint name to a public contract is
+the scientific check register: a constraint that matters enough declares
+a rejection code, and the *code* is what crosses the wire. See
+:func:`app.api.errors._integrity_error_handler`.
+
+Before that ruling the repository held three positions at once -- one
+test asserting the name reached the body for registered constraints, one
+asserting it must not for unregistered ones, and a third silent about
+foreign keys. Three positions is what a per-test rule produces; this
+observer is the reason there can only be one from here on.
 
 Why a runtime observer, when a static scan already exists
 ---------------------------------------------------------
@@ -80,7 +96,27 @@ Three rules were considered. The measurement chose between them:
 
 So: rule 1, over ``context``. The blind spot is honest and stated below.
 
-The one text rule, and why it is not the AST scan again
+The constraint-name rule is the opposite case, and easy
+-------------------------------------------------------
+Where a row id is an integer indistinguishable from the useful integers
+beside it, a constraint name announces itself: ``NAMING_CONVENTION`` in
+``app/db/base.py`` gives every one of them a two-letter kind and an
+underscore, and nothing else in an error body is spelled that way. So
+this one *is* rule 3 -- refuse the shape, no enumeration, no allowlist --
+and it is applied to string **values** anywhere in ``context`` and to
+plain-string ``detail``. See :data:`CONSTRAINT_NAME`.
+
+Measured when it was added (2026-08-18). Exactly one body in the suite
+carried such a name -- the registered-constraint 409's
+``context["constraint"]`` -- and it was removed in the same change; with
+that gone, a full ``pytest backend/tests`` produces no match at all. So
+this rule lands green on a clean tree and every future match is a real
+finding rather than a backlog. Turning it off and putting the name back
+was run in both directions before it was believed: see the mutations
+recorded in the pull request, and the synthetic pair in
+``tests/api/test_error_body_id_gate.py``.
+
+The id text rule, and why it is not the AST scan again
 --------------------------------------------------------
 ``detail`` is also swept, but only where it is a plain string -- the
 ``NotFoundError`` / ``ValueError`` / ``HTTPException`` shape. It is
@@ -158,6 +194,32 @@ ID_IN_PROSE = re.compile(
     re.IGNORECASE,
 )
 
+#: A database constraint or index name, spelled the way
+#: ``NAMING_CONVENTION`` in ``app/db/base.py`` spells every one of them:
+#: a two-letter kind, an underscore, and the table it sits on. Those five
+#: prefixes are the whole vocabulary, which is why this is a shape check
+#: and not a list -- a constraint added tomorrow is caught without anyone
+#: adding it here, and that is the only version of this rule worth having.
+#:
+#: Applied to *values* and to prose, not to key names. The mistake this
+#: catches is publishing the name, and the name is the value; a
+#: ``context`` key literally called ``constraint`` is fine when what it
+#: carries is a code. Deliberately anchored on a non-word character so
+#: ``...uq_x`` inside a longer identifier is not matched, and it requires
+#: at least two characters after the prefix so a bare ``fk_`` in prose
+#: about the convention itself does not fire.
+#:
+#: The one false positive it can have: a depositor who names a *local key*
+#: ``fk_something`` and then triggers a refusal that echoes it back. That
+#: is the caller's own string, so it would not be a disclosure -- the same
+#: carve-out ``_integerish`` makes for ``existing_calculation_id``. It has
+#: not happened, and if it does the fix is a carve-out here rather than a
+#: weaker rule, because the alternative is an allowlist of every schema
+#: object name in the database.
+CONSTRAINT_NAME = re.compile(
+    r"(?:^|[^A-Za-z0-9_])((?:ck|uq|fk|ix|pk)_[a-z][a-z0-9_]*[a-z0-9])"
+)
+
 
 @dataclass(frozen=True)
 class Leak:
@@ -227,8 +289,19 @@ def _integerish(value: Any) -> str | None:
     return None
 
 
-def _sweep_context(node: Any, path: str, found: list[tuple[str, str]]) -> int:
-    """Walk *node*, appending ``(path, why)`` for each id-shaped key.
+def _sweep_context(
+    node: Any,
+    path: str,
+    found: list[tuple[str, str]],
+    named: list[tuple[str, str]],
+) -> int:
+    """Walk *node*, appending to *found* and *named*.
+
+    *found* collects ``(path, why)`` for each id-shaped key carrying an
+    integer; *named* collects ``(path, name)`` for each string value that
+    is spelled like a database constraint. Two lists rather than one
+    because the two findings need different sentences and a caller
+    reading a failure should not have to work out which rule fired.
 
     Returns the number of ``(key, value)`` pairs visited, which is what
     the floor counts: a blinded walk visits none of them.
@@ -242,10 +315,14 @@ def _sweep_context(node: Any, path: str, found: list[tuple[str, str]]) -> int:
                 why = _integerish(value)
                 if why is not None:
                     found.append((here, why))
-            visited += _sweep_context(value, here, found)
+            visited += _sweep_context(value, here, found, named)
     elif isinstance(node, (list, tuple)):
         for index, value in enumerate(node):
-            visited += _sweep_context(value, f"{path}[{index}]", found)
+            visited += _sweep_context(value, f"{path}[{index}]", found, named)
+    elif isinstance(node, str):
+        match = CONSTRAINT_NAME.search(node)
+        if match is not None:
+            named.append((path, match.group(1)))
     return visited
 
 
@@ -259,11 +336,25 @@ def inspect(status: int, content: dict[str, Any]) -> tuple[list[Leak], int]:
     code = code if isinstance(code, str) and code else "<no code>"
 
     found: list[tuple[str, str]] = []
-    visited = _sweep_context(content.get("context"), "context", found)
+    named: list[tuple[str, str]] = []
+    visited = _sweep_context(content.get("context"), "context", found, named)
     leaks = [
         Leak(status=status, code=code, where=where, detail=f"{why} under an id-shaped key")
         for where, why in found
     ]
+    leaks.extend(
+        Leak(
+            status=status,
+            code=code,
+            where=where,
+            detail=(
+                f"database constraint name {name!r} -- an internal "
+                "identifier; register the constraint for a code of its own "
+                "and let the name go to the log"
+            ),
+        )
+        for where, name in named
+    )
 
     detail = content.get("detail")
     if isinstance(detail, str):
@@ -276,6 +367,19 @@ def inspect(status: int, content: dict[str, Any]) -> tuple[list[Leak], int]:
                     code=code,
                     where="detail",
                     detail=f"prose discloses {match.group(0)!r}",
+                )
+            )
+        constraint = CONSTRAINT_NAME.search(detail)
+        if constraint is not None:
+            leaks.append(
+                Leak(
+                    status=status,
+                    code=code,
+                    where="detail",
+                    detail=(
+                        f"prose names database constraint "
+                        f"{constraint.group(1)!r}"
+                    ),
                 )
             )
     return leaks, visited


### PR DESCRIPTION
## In plain language

The database has rules with names — `uq_software_name` means "no two software
records may share a name". When you break one, PostgreSQL tells the application
which rule you broke, by that name. The question this PR settles is whether that
name should be repeated back to whoever made the request.

It should not. The name is ours, not theirs. It means nothing to a chemist
depositing data, it changes whenever we rename a rule in a migration, and it
quietly tells the outside world how our tables are laid out. So the name now
goes only into the server log, where an operator can read it, and the person who
made the request gets something they can act on instead: *"a uniqueness rule was
violated: a record with these values already exists — cite the existing record
instead of creating a second one."*

There is still a sanctioned way for a database rule to get a public name: put it
in the **scientific check register**, and it earns its own error code with its own
sentence — `atom_map_element_not_conserved` rather than a generic conflict. That
is a code we promise to keep stable. The raw rule name is not.

The awkward part, and it is stated plainly below: the repository was doing all
three things at once — one test said the name reaches the body, another said it
must not, a third said nothing — and on measurement it turned out the first was
publishing not a derived code but the **raw name itself**. One of those positions
had to be changed rather than tidied, and this PR changes it.

---

## The fact that decided the scope

The brief asked whether the registered-constraint path puts the *name itself* in
the body or only a code derived from it. **It is the name itself.** Measured by
provoking each registered constraint against the real schema and putting the real
`IntegrityError` through the production handlers:

```
REGISTERED ck_reaction_atom_map_pair_element_matches -> 409
{"detail": "An atom map pairs two atoms of different elements. An atom does not
 change element on the way across a reaction.",
 "code": "atom_map_element_not_conserved",
 "category": "integrity_error",
 "context": {"constraint": "ck_reaction_atom_map_pair_element_matches"}}
```

`backend/app/api/errors.py` set `context["constraint"] = constraint`, and
`backend/tests/api/test_api_database_constraint_codes.py` asserted
`body["context"]["constraint"] == name`. So this was a **fourth position**, it
contradicts the decision, and it is removed here. Scope is therefore larger than
the "small change" branch of the brief.

## The three (four) positions, and what changed

| Where | Was | Now |
|---|---|---|
| `test_api_database_constraint_codes.py` | asserted the raw name **is** in `context.constraint` | asserts the code and sentence are present and the name is **absent** — a deliberate contract change |
| `test_api_integrity_error_handler.py` — unique, check | asserted the name is absent | unchanged in direction; now asserts the positive beside it |
| `TestReferenceConflict` (foreign keys) | asserted **neither** direction | asserts the name is absent, plus the positive — **gap closed** |
| `backend/docs/specs/read_query_api_audit.md` §11.1 | argued in prose for echoing the name ("a schema object name is not a row id") | rewritten to the settled rule |

## What the generic 409s say now

`unique_conflict`, `reference_conflict`, `state_conflict` and `integrity_conflict`
are `Shape.relationship` codes, so they owe a client the things that disagreed.
The only fact this seam holds is the constraint name, and that is exactly what may
not be disclosed — so the structured half stays an open gap (paying it needs a
coded refusal raised on the write path, not in the driver's error handler). The
half that *can* be paid here is the sentence, and it now says which kind of rule
refused and what would make a second attempt succeed, instead of "Integrity
constraint violation." for four different failures.

`23P01` (exclusion violation) had a branch and no test; it has both now, and its
own sentence rather than a copy of `23514`'s.

## Enforcement: a sweep, not another per-test assertion

Three positions is what a per-test rule produces. The rule is now enforced for
**every** error body the suite emits, by extending the DR-0028 observer
(`backend/tests/error_body_observer.py`) with a second identifier class: a value
or a prose fragment spelled the way `NAMING_CONVENTION` spells every constraint
and index (`ck_`/`uq_`/`fk_`/`ix_`/`pk_` + table). This is a shape check, not a
list, so a constraint added tomorrow is covered without anyone remembering.

## The absence assertions, and the mutations proving each one bites

An absence assertion passes trivially against a handler that returns nothing, so
every one here sits beside its positive: status, declared code, a non-empty
`detail`, and `context == {}`. Each was then proved to fail by putting the name
back:

| Mutation to `app/api/errors.py` | Result |
|---|---|
| 1. restore `context["constraint"] = constraint` on the registered branch | `test_the_response_body_does_not_disclose_the_constraint_name` **FAILED** for every provoked constraint, and the observer failed each test at teardown |
| 2. `context["constraint"] = constraint` for **every** bucket | `TestUniqueConflict`, `TestCheckConflict`, **`TestReferenceConflict`**, `TestExclusionConflict`, `TestFallback::test_unknown_sqlstate` all **FAILED**; observer failed them at teardown too |
| 3. `message = f"{message} (constraint {constraint})"` — the name in prose | same set **FAILED**, via the observer's `detail` rule |

Mutation 2 is the one that matters for the foreign-key gap: on `main`,
`TestReferenceConflict` passes under that mutation. Here it fails.

The observer additionally has a synthetic detector pair in
`backend/tests/api/test_error_body_id_gate.py` — six leaking shapes it must catch
(including `context.violated[0]` in a list, an `ix_`/`pk_` name, and the driver's
own sentence in prose) and nine clean ones it must not (every registered rejection
code, public refs like `nsolve_…`, the new generic sentences, and words that
merely begin with one of the five prefixes).

## Provocations were real, not hand-built

Each of the three classes was provoked against the live schema, and the names
PostgreSQL actually reported were read off `orig.diag.constraint_name`:

- unique — duplicate `Software.name` → `23505`, `uq_software_name`
- foreign key — `species_entry.species_id` pointing at no species → `23503`,
  `fk_species_entry_species_id_species`
- check — `geometry_atom.element = 'xx'` → `23514`,
  `ck_geometry_atom_element_canonical`
- not-null → `23502`, and **no constraint name at all**, which is why
  `TestNotNullConflict` passes `None`

## Did any constraint deserve registering instead?

Yes, and deliberately not in this PR — registering is a different decision from
the one being settled, and it changes the generated client rejection-code module
(so a `clients/python` version bump). The candidates, all currently arriving as a
generic 409:

- `ck_reaction_atom_map_inferred_requires_note` — already in the register as a
  `DatabaseConstraint` with no `rejection_code`. A real scientific position
  ("an inferred map must say so in a note") reported as `state_conflict`.
- the three composite foreign keys on `reaction_atom_map_pair`
  (`fk_…_geometry_id_geometry_atom` and siblings) — ADR 0011's guarantee that a
  mapped atom really is that element at that index, reported as
  `reference_conflict`.
- `ck_geometry_atom_element_canonical` (`c5a1f8e3d074`) — not in the register at
  all; the element-symbol spelling invariant, reported as `state_conflict`.

## Schema / migration impact

None. No model, no migration, no new environment variable. No change under
`clients/` or `schemas/`, so no client version bump (checked against
`origin/main`, not the branch point).

## Files

- `backend/app/api/errors.py` — messages; `context["constraint"]` removed
- `backend/app/api/code_catalogue.py` — `Shape.relationship` no longer lists a
  constraint name as legitimate `context`
- `backend/tests/error_body_observer.py`, `backend/tests/conftest.py` — the sweep
- `backend/tests/api/test_api_database_constraint_codes.py`,
  `test_api_integrity_error_handler.py`, `test_error_body_id_gate.py`
- `backend/docs/specs/read_query_api_audit.md` §11.1

## Verification — exact commands run

From `backend/`, conda env `tckdb_env`, scratch DBs matching `tckdb_test*`:

```bash
# targeted, before and after each mutation
DB_TEST_NAME=tckdb_test_245 pytest tests/api/test_api_integrity_error_handler.py \
    tests/api/test_api_database_constraint_codes.py \
    tests/api/test_error_body_id_gate.py -q          # 61 passed

# the three CI gates, which cover backend/tests/ between them
DB_TEST_NAME=tckdb_test_245api  bash scripts/test-api.sh   # 3037 passed
DB_TEST_NAME=tckdb_test_245sci  bash scripts/test-scientific.sh  # 2079 passed
DB_TEST_NAME=tckdb_test_245rest bash scripts/test-rest.sh  # 4752 passed, 14 skipped

ruff check app tests scripts                         # clean
python scripts/check_runtime_ascii.py                # clean
mypy                                                 # no issues, 183 files
```
