### PR TITLE
Find the fixture from the test, not from the cwd

### DIFF
--- a/backend/tests/services/test_calculation_geometry_composition.py
+++ b/backend/tests/services/test_calculation_geometry_composition.py
@@ -365,17 +365,27 @@ def test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key(
     have left it open.
     """
 
-    import glob
     import json
+    from pathlib import Path
 
     from app.schemas.workflows.computed_reaction_upload import (
         ComputedReactionUploadRequest,
     )
     from app.workflows.computed_reaction import persist_computed_reaction_upload
 
-    fixture = glob.glob(
-        "tests/fixtures/arc_runs/reaction_1/tckdb_payloads/computed_reaction/*.json"
-    )[0]
+    # Anchored to this file, not to the process's working directory: globbing a
+    # relative path found nothing when pytest was run from the repository root,
+    # and the empty list then failed as an ``IndexError`` on the subscript below
+    # rather than as the missing fixture it actually was.
+    fixture_dir = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures/arc_runs/reaction_1/tckdb_payloads/computed_reaction"
+    )
+    # ``*.payload.json`` and not ``*.json``: the directory also holds a
+    # ``.meta.json`` sidecar, which is upload bookkeeping and not a payload.
+    fixtures = sorted(fixture_dir.glob("*.payload.json"))
+    assert fixtures, f"no computed-reaction payload fixture under {fixture_dir}"
+    fixture = fixtures[0]
     with open(fixture) as handle:
         doc = json.load(handle)
 


### PR DESCRIPTION
## Plain language

This test reads a sample upload file from disk. It asked for that file by a
path spelled relative to *wherever you happened to be standing* when you
started the test run — `tests/fixtures/...`. That only resolves if you are
standing inside `backend/`. Run the suite the obvious way from the top of the
repository and the pattern matches nothing.

Matching nothing is not, by itself, the confusing part. The confusing part is
what happened next: the code took "the first item" of a list that had no items,
so Python complained about a *subscript* — `IndexError: list index out of
range` — pointing at square brackets rather than at the missing file. Someone
hitting this learns that a list was empty, not that a fixture was not found.

Two changes. The path is now worked out from the test file's own location, so
it resolves from anywhere. And the test now checks the file list is non-empty
*before* indexing it, so if the fixture ever goes missing the message names the
directory it looked in.

That second change is the more useful one, and it is the familiar
empty-collection trap seen from its other side. Usually an empty collection
makes a check pass while verifying nothing. Here it made a check fail while
explaining nothing. Both come from indexing or iterating a collection without
first establishing it has contents.

## Detail

`backend/tests/services/test_calculation_geometry_composition.py`, in
`test_a_ts_calculation_may_not_borrow_a_reactants_geometry_by_key`:

```python
fixture = glob.glob(
    "tests/fixtures/arc_runs/reaction_1/tckdb_payloads/computed_reaction/*.json"
)[0]
```

CI never saw it: all three gate scripts `cd backend` first. It only bites a
human or an agent running `pytest backend/tests/` from the root.

The path is now anchored to `Path(__file__).resolve().parents[1]`, and the
result is asserted non-empty before it is indexed.

### A third thing found while fixing it

The glob was `*.json`, but that directory holds two files:

```
CHO-CH4-CH2O-CH3.payload.json
CHO-CH4-CH2O-CH3.meta.json
```

`.meta.json` is upload bookkeeping (`base_url`, `idempotency_key`,
`payload_file`, ...) and is not a payload — feeding it to
`ComputedReactionUploadRequest` would not work. `glob.glob` does not sort, so
which of the two `[0]` returned was left to filesystem order; it happens to
return the payload on this machine today. The pattern is now
`*.payload.json` and the result is sorted, so the selection is determined by
the code rather than by directory order. One character of pattern, same
expression, no new helper.

Both halves of this fix just restore the convention the fixture tree already
documents. `backend/tests/api/test_api_arc_run_fixtures.py` is the other
consumer of `tests/fixtures/arc_runs/`, and it independently does the same two
things this test was not doing:

```python
ARC_RUNS_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "arc_runs"
...
for payload_file in sorted(payloads_root.rglob("*.payload.json")):
```

with a module docstring spelling out that `<name>.payload.json` is "what we
POST" and `<name>.meta.json` is the companion. The site fixed here was the
outlier, not the precedent.

### Not done, deliberately

Re-grepped `backend/tests/` for other cwd-relative fixture reads. This is still
the only one. The other relative paths found are either string literals
compared against, never opened (`test_api_code_catalogue.py`,
`test_coded_exception_reraise_gate.py`), or subprocess arguments already
passed with `cwd=conftest.REPO_ROOT` (`test_concurrent_run_detection.py`). So
no shared fixture-path helper for a single site.

## Verification

**From the repository root** — the case that was broken. Before:

```
>       fixture = glob.glob(
            "tests/fixtures/arc_runs/reaction_1/tckdb_payloads/computed_reaction/*.json"
        )[0]
E       IndexError: list index out of range
1 failed in 3.01s
```

After:

```
$ conda run -n tckdb_env python -m pytest \
    backend/tests/services/test_calculation_geometry_composition.py -q
12 passed in 4.21s
```

**From `backend/`** — the case that already worked, confirmed still working:

```
$ cd backend && conda run -n tckdb_env python -m pytest \
    tests/services/test_calculation_geometry_composition.py -q
12 passed in 4.19s
```

**Mutation.** Pointed the fixture directory at one that does not exist
(`reaction_1` -> `reaction_NOPE`) and re-ran from the root:

```
>       assert fixtures, f"no computed-reaction payload fixture under {fixture_dir}"
E       AssertionError: no computed-reaction payload fixture under
E         /.../backend/tests/fixtures/arc_runs/reaction_NOPE/tckdb_payloads/computed_reaction
E       assert []
1 failed in 3.66s
```

The failure now names the missing fixtures and the directory searched, instead
of `IndexError` on a subscript. Mutation reverted; `NOPE` appears nowhere in
the diff.

`ruff check` passes. `ruff format --check` reports this file as unformatted,
but it did so before this change too — seven pre-existing hunks, none of them
mine; the new lines match the file's prevailing wrapping. Left alone rather
than smuggling a whole-file reformat into a two-line fix.

## Impact

Schema impact: none. Migration impact: none. New environment variables: none.
Test-only change, one function, one file.
