### PR TITLE
Say what the cap is, without saying how much is behind it

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -66,23 +66,38 @@ live on that class. What belongs here is the part a reader of *this list*
 needs -- the borderline calls -- because a classification whose hard cases
 are undocumented is one the next person re-litigates from scratch.
 
-Measured on this file: 64 entries (62 distinct codes) are relationships,
-104 are things.
+Measured on this file: 73 entries (71 distinct codes) are relationships,
+97 are things. The cap family moved eight of them across on 2026-08-18 --
+see the first borderline group below.
 
 The groups where the call was genuinely arguable, and the argument:
 
-* **Caps are things.** ``limit_too_large``, ``offset_too_large``,
-  ``geometry_too_large``, ``smiles_too_long``, ``export_all_cap_exceeded``,
-  ``ml_export_all_cap_exceeded``, ``query_too_expensive`` and
-  ``composed_search_candidate_limit_exceeded`` each compare a supplied
-  value against a server-side limit, so by the letter of the rule they
-  assert something about two things. They are classified as things because
-  the rule's discriminator is *conflict, mismatch, ambiguity* and a cap
-  breach is none of those: the code names one field and states a predicate
-  about it, and the field is the whole repair. This is the largest
-  borderline group and the one most likely to be revisited -- a client
-  retrying with a legal page size does want the cap, and on a deployment
-  that lowers ``public_max_limit`` the cap is not guessable from the docs.
+* **Caps are relationships. Overruled 2026-08-18.** ``limit_too_large``,
+  ``offset_too_large``, ``geometry_too_large``, ``smiles_too_long``,
+  ``export_all_cap_exceeded``, ``ml_export_all_cap_exceeded``,
+  ``query_too_expensive`` and
+  ``composed_search_candidate_limit_exceeded`` were classified as things
+  when :class:`Shape` was introduced, on the ground that the rule's
+  discriminator is *conflict, mismatch, ambiguity* and a cap breach is
+  none of those. That reading was invited to be overruled and was.
+
+  The argument that won: **a limit refusal that does not state the limit
+  is un-actionable.** A client that wants to retry must guess, or a human
+  must go and read documentation -- and every one of these caps is a
+  *setting* or a module constant, so on a deployment that lowers
+  ``public_max_limit`` there is no document that has the right number in
+  it. That is the same defect diagnosed in "Tell 'no such selection' from
+  'which selection?'": advice that cannot be followed teaches people to
+  stop reading advice.
+
+  Publishing a cap is not a security concern. It is discoverable in about
+  three requests by halving the value; the control is the cap being
+  *enforced*, not the cap being secret; and it describes TCKDB's own
+  configuration rather than anybody's data.
+
+  What may **not** be published is the other number, and the rule for
+  that is on :class:`Shape` -- see "The disclosure line". Four of the
+  eight publish a threshold and deliberately publish nothing else.
 * **A code that names both its fields is a thing.**
   ``parameter_value_requires_key``,
   ``canonical_parameter_value_requires_key`` and
@@ -399,7 +414,8 @@ class Shape(str, Enum):
 
     Why the default is :attr:`thing`, and why that is safe
     -----------------------------------------------------
-    Because most codes are things (measured: roughly five in eight), so
+    Because most codes are things (measured: roughly four in seven, and
+    it was five in eight before the cap family moved), so
     declaring the majority case would be noise of the kind
     :attr:`Reach.request` and :attr:`Replay.may_succeed` also avoid. The
     risk a default carries is the opposite of theirs, though: an
@@ -416,6 +432,59 @@ class Shape(str, Enum):
     one of those words — ``atom_map_not_a_bijection``,
     ``selection_already_stands``, ``multiple_structure_queries`` — so
     those are declared by hand and the declaration is the judgement.
+
+    The disclosure line
+    -------------------
+    Deciding a code is a relationship settles that it owes ``context``.
+    It does not settle *what goes in it*, and for the cap family the two
+    questions come apart, because a cap refusal compares two numbers of
+    different kinds. Calvin's rule of 2026-08-18:
+
+        **Publish the THRESHOLD. Never publish the MEASURED VALUE that
+        crossed it, where that value describes the corpus rather than the
+        caller's own request.**
+
+    A configured cap is a fact about TCKDB, and one a client must have to
+    retry. A measured count is a fact about **how much data exists** —
+    precisely the enumeration exposure
+    ``docs/specs/public_identifier_policy.md`` argues against when it
+    rejects sequential integer primary keys (§"Why this matters now",
+    item 3: they "leak the total count of objects (and roughly the upload
+    schedule) of every table"). A refusal that reports an exact match
+    count turns any filter into a free census endpoint, which is worse
+    than a primary key: a key leaks the count once, a countable refusal
+    leaks it per query, forever, and cheaply.
+
+    Three categories, and only the third is withheld:
+
+    * **The threshold** — ``limit_max``, ``offset_max``, ``max_atoms``,
+      ``max_length``, ``cap``, ``max_traversable``. TCKDB's own
+      configuration. Always published.
+    * **The caller's own request echoed back** — the ``limit`` they sent,
+      the ``offset`` they sent, the length of the SMILES they sent.
+      Telling someone they asked for 5000 discloses nothing they did not
+      already know. Published.
+    * **A server-side measurement of the corpus** — how many records
+      matched, how many rows exist, how many entries a table holds.
+      Logged, never published, and absent from ``detail`` as well as
+      ``context``: ``detail`` is published too, so omitting it from one
+      and not the other would be decorative.
+
+    The discriminator between the second and third categories is not
+    "did the server compute it" — the server computes the second as well.
+    It is **what the number is about**. A geometry's atom count is
+    chemistry: a property of one molecule the caller named, and strictly
+    less than the same endpoint returns for any request under the cap. A
+    ``len(...)`` over rows TCKDB stores is holdings. The first is
+    published; the second is not.
+
+    Four codes sit on the withheld side and carry the threshold alone:
+    ``export_all_cap_exceeded``, ``ml_export_all_cap_exceeded``,
+    ``query_too_expensive`` and
+    ``composed_search_candidate_limit_exceeded``. That the count is
+    *absent* is asserted per code in
+    ``backend/tests/api/test_api_query_caps.py``, because an omission is
+    the one property no other test notices when it is lost.
     """
 
     #: The name is the whole message. A client that reads the code knows
@@ -827,8 +896,20 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/calculations_search.py"),
     ApiCode("client_sort_not_supported", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py"),
-    ApiCode("composed_search_candidate_limit_exceeded", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/common.py"),
+    ApiCode("composed_search_candidate_limit_exceeded", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship,
+            note=(
+                "Two raise sites in collect_bounded_pages, and they are not "
+                "the same disclosure question. The first compares the "
+                "*match count* against public_max_offset + page_size: the "
+                "bound is published as context['max_traversable'] and the "
+                "match count is logged, because a filter that can be turned "
+                "into an exact row count is a census endpoint TCKDB does "
+                "not offer. The second simply ran past the offset bound and "
+                "measures nothing, so it publishes offset_max. Both carry "
+                "resource."
+            )),
     ApiCode("composed_search_invalid_page", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/common.py",
             shape=Shape.relationship),
@@ -906,8 +987,18 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("energy_transfer_scope_columns_disagree", 409, Surface.database_constraint,
             "backend/app/scientific_checks/declarations.py",
             shape=Shape.relationship),
-    ApiCode("export_all_cap_exceeded", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/export.py"),
+    ApiCode("export_all_cap_exceeded", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/export.py",
+            shape=Shape.relationship,
+            note=(
+                "Shape.relationship since 2026-08-18, and one of the four "
+                "codes that publish the threshold and withhold the "
+                "measurement. context carries cap and record_type; the "
+                "count that crossed it is an unfiltered row count over "
+                "reaction_entry -- the corpus total -- so it is logged and "
+                "appears in neither context nor detail. See the disclosure "
+                "line on Shape."
+            )),
     ApiCode("export_seed_empty", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/export.py"),
     ApiCode("export_seed_unresolved", 422, Surface.message_prefix,
@@ -951,8 +1042,17 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "workflow really cannot resolve -- calling that undeclared "
                 "would be false."
             )),
-    ApiCode("geometry_too_large", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/geometry.py"),
+    ApiCode("geometry_too_large", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/geometry.py",
+            shape=Shape.relationship,
+            note=(
+                "Shape.relationship since 2026-08-18. context carries "
+                "max_atoms (settings.max_geometry_atoms_public) and atoms "
+                "(the requested geometry's own atom count). The second is "
+                "not the withheld kind of measurement: it is a property of "
+                "one record the caller named, and strictly less than this "
+                "endpoint returns for any request under the cap."
+            )),
     ApiCode("handle_not_found", 404, Surface.coded_exception,
             "backend/app/services/scientific_read/calculation_paths.py"),
     ApiCode("handle_type_mismatch", 422, Surface.coded_exception,
@@ -1048,8 +1148,9 @@ CATALOGUE: tuple[ApiCode, ...] = (
     ApiCode("level_of_theory_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py",
             shape=Shape.relationship),
-    ApiCode("limit_too_large", 422, Surface.message_prefix,
+    ApiCode("limit_too_large", 422, Surface.coded_exception,
             "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship,
             note=(
                 "Split out of invalid_pagination, which covered four "
                 "conditions with three different remedies. A limit above the "
@@ -1059,7 +1160,11 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "configuration, where MAX_LIMIT and public_max_limit are "
                 "both 200 and Query(le=200) refuses anything larger first -- "
                 "reachable through a POST search body, and through any GET "
-                "on a deployment that lowers public_max_limit."
+                "on a deployment that lowers public_max_limit. "
+                "Shape.relationship since Calvin's overrule of 2026-08-18; "
+                "context carries limit_max (a setting) and limit (the "
+                "caller's own value). Surface.coded_exception from the same "
+                "change, and detail did not move a byte."
             )),
     ApiCode("lowest_energy_unavailable", 422, Surface.coded_exception,
             "backend/app/services/scientific_read/species_calculations_search.py"),
@@ -1085,8 +1190,15 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/reactions.py"),
     ApiCode("missing_structure_query", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/structure_search.py"),
-    ApiCode("ml_export_all_cap_exceeded", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/ml_dataset.py"),
+    ApiCode("ml_export_all_cap_exceeded", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/ml_dataset.py",
+            shape=Shape.relationship,
+            note=(
+                "The ML surface's own cap, and the same call as its native "
+                "sibling export_all_cap_exceeded: context carries cap and "
+                "record_type, and the species_entry row count that crossed "
+                "it is logged rather than published."
+            )),
     ApiCode("ml_export_lot_unresolved", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/ml_dataset.py"),
     ApiCode("ml_export_seed_empty", 422, Surface.message_prefix,
@@ -1117,15 +1229,18 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "schemas/python/tckdb-schemas/tckdb_schemas/local_key_codes.py"),
     ApiCode("non_finite_value", 422, Surface.message_prefix,
             "backend/app/services/release/artifacts.py"),
-    ApiCode("offset_too_large", 422, Surface.message_prefix,
+    ApiCode("offset_too_large", 422, Surface.coded_exception,
             "backend/app/services/scientific_read/common.py",
+            shape=Shape.relationship,
             note=(
                 "The sibling of limit_too_large, and the reason they are two "
                 "codes rather than one: retrying with a smaller offset "
                 "returns different rows, so this one is not recoverable by "
                 "resending. Reachable on any paginated read against the "
                 "shipped configuration -- offset carries no upper bound at "
-                "the route, so settings.public_max_offset is the only one."
+                "the route, so settings.public_max_offset is the only one. "
+                "Shape.relationship since 2026-08-18; context carries "
+                "offset_max (a setting) and offset (the caller's own)."
             )),
     ApiCode("owner_missing", 404, Surface.coded_exception,
             "backend/app/services/scientific_read/calculations.py"),
@@ -1140,8 +1255,19 @@ CATALOGUE: tuple[ApiCode, ...] = (
             shape=Shape.relationship),
     ApiCode("query_timeout", 503, Surface.response_literal,
             "backend/app/api/errors.py"),
-    ApiCode("query_too_expensive", 422, Surface.message_prefix,
-            "backend/app/services/scientific_read/provenance.py"),
+    ApiCode("query_too_expensive", 422, Surface.coded_exception,
+            "backend/app/services/scientific_read/provenance.py",
+            shape=Shape.relationship,
+            note=(
+                "Shape.relationship since 2026-08-18, published "
+                "threshold-only. context carries section (which sub-array "
+                "was the offender) and cap. len(block) -- how many "
+                "calculations, geometries, artifacts, conformer groups or "
+                "atom-map pairs TCKDB holds for the requested record -- is "
+                "a count of the corpus, not a property of the caller's "
+                "request, so it is logged. A caller who could read it off a "
+                "cheap refusal would have a row-counting oracle."
+            )),
     ApiCode("rate_limit_exceeded", 429, Surface.response_literal,
             "backend/app/api/rate_limit.py"),
     ApiCode("rationale_required", 422, Surface.message_prefix,
@@ -1234,8 +1360,17 @@ CATALOGUE: tuple[ApiCode, ...] = (
             )),
     ApiCode("selection_no_longer_approved", 422, Surface.message_prefix,
             "backend/app/services/release/curation.py"),
-    ApiCode("smiles_too_long", 422, Surface.message_prefix,
-            "backend/app/schemas/reads/scientific_kinetics_search.py"),
+    ApiCode("smiles_too_long", 422, Surface.coded_exception,
+            "backend/app/schemas/reads/scientific_kinetics_search.py",
+            shape=Shape.relationship,
+            note=(
+                "Shape.relationship since 2026-08-18. Two sites -- this one "
+                "and the reaction-search twin -- raise the wire package's "
+                "CodedValidationError rather than the backend's subclass, "
+                "because app.schemas.reads sits on the wire side. context "
+                "carries max_length (a module constant) and length (the "
+                "caller's own string, measured). The string is not echoed."
+            )),
     ApiCode("species_entry_handle_conflict", 422, Surface.message_prefix,
             "backend/app/services/scientific_read/handles.py",
             shape=Shape.relationship),

--- a/backend/app/api/error_contract.py
+++ b/backend/app/api/error_contract.py
@@ -143,7 +143,7 @@ What ``context`` promises, and what it does not
 published advice and it is right. It was also, until #210, an
 over-promise: ``context`` is populated by the raiser, and a large part of
 the catalogue has no raiser that can populate it. Measured on the entry
-count as this was written, 76 of 168 entries arrive by
+count as this was written, 65 of 170 entries arrive by
 :data:`~app.api.code_catalogue.Surface.message_prefix` — that is,
 ``raise ValueError(f"code: prose")`` — and a plain ``ValueError`` has
 nowhere to put structured facts, so :func:`error_envelope` renders
@@ -158,14 +158,23 @@ names, which is what
 :attr:`~app.api.code_catalogue.ApiCode.owes_context` answers:
 
 * A code naming a **thing** — ``unknown_release``, ``missing_filter``,
-  ``limit_too_large`` — is complete on its own. ``context`` may be empty
-  and that is not a gap.
+  ``unknown_include_token`` — is complete on its own. ``context`` may be
+  empty and that is not a gap.
 * A code naming a **relationship** — ``state_conflict``,
   ``handle_type_mismatch``, ``atom_map_element_not_conserved`` — asserts
   something about two or more things and names none of them. There
   ``context`` is the only machine-readable place the *which* can live,
   and an empty one leaves the reason reachable only through the prose a
   client was told not to read.
+
+``limit_too_large`` was the example in the first bullet until 2026-08-18
+and is now in the second, which is worth saying out loud rather than
+quietly editing: a cap refusal that does not state the cap is
+un-actionable, so the whole cap family became relationships and now
+carries the limit. What such a code may put in ``context`` is bounded by
+the disclosure line on :class:`~app.api.code_catalogue.Shape` — the
+threshold and the caller's own value, never a server-side measurement of
+how much data exists.
 
 So the honest promise is narrower than the old one: **where a code names
 a relationship, the facts are in ``context``; where it names a thing, the

--- a/backend/app/schemas/reads/scientific_kinetics_search.py
+++ b/backend/app/schemas/reads/scientific_kinetics_search.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from tckdb_schemas.coded_error import CodedValidationError
 
 from app.db.models.common import KineticsModelKind, RecordReviewStatus
 from app.schemas.reads._field_bounds import (
@@ -109,11 +110,21 @@ class KineticsSearchRequest(BaseModel):
     @field_validator("reactants", "products")
     @classmethod
     def _bound_participant_lengths(cls, value: list[str]) -> list[str]:
+        """The kinetics-search twin of the reaction-search bound.
+
+        See ``app.schemas.reads.scientific_reactions`` for why this
+        carries the cap and the supplied length and not the string.
+        """
         for item in value:
             if len(item) > _MAX_SMILES_LENGTH:
-                raise ValueError(
-                    "smiles_too_long: participant SMILES exceeds "
-                    f"the maximum length of {_MAX_SMILES_LENGTH}."
+                raise CodedValidationError(
+                    "smiles_too_long",
+                    "participant SMILES exceeds "
+                    f"the maximum length of {_MAX_SMILES_LENGTH}.",
+                    context={
+                        "max_length": _MAX_SMILES_LENGTH,
+                        "length": len(item),
+                    },
                 )
         return value
 

--- a/backend/app/schemas/reads/scientific_reactions.py
+++ b/backend/app/schemas/reads/scientific_reactions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from enum import Enum
 
 from pydantic import BaseModel, Field, field_validator
+from tckdb_schemas.coded_error import CodedValidationError
 
 from app.db.models.common import RecordReviewStatus
 from app.schemas.reads._field_bounds import (
@@ -82,12 +83,31 @@ class ReactionSearchRequest(BaseModel):
     @field_validator("reactants", "products")
     @classmethod
     def _bound_participant_lengths(cls, value: list[str]) -> list[str]:
-        """Reject participant SMILES that exceed the public free-text cap."""
+        """Reject participant SMILES that exceed the public free-text cap.
+
+        ``smiles_too_long`` is a relationship code as of 2026-08-18: a
+        supplied length against a configured maximum, neither named by
+        the code. ``context`` carries both, and both are safe under the
+        disclosure line in ``app.api.code_catalogue.Shape`` — the
+        maximum is TCKDB's own constant, and the length is the caller's
+        own string measured back to them. The string itself is *not*
+        echoed: it adds nothing the length does not and would grow the
+        body by up to the cap.
+
+        ``CodedValidationError`` rather than the backend's
+        ``CodedValueError`` because ``app.schemas.reads`` is on the wire
+        side of the schema layer; both are caught by the same handler.
+        """
         for item in value:
             if len(item) > _MAX_SMILES_LENGTH:
-                raise ValueError(
-                    "smiles_too_long: participant SMILES exceeds "
-                    f"the maximum length of {_MAX_SMILES_LENGTH}."
+                raise CodedValidationError(
+                    "smiles_too_long",
+                    "participant SMILES exceeds "
+                    f"the maximum length of {_MAX_SMILES_LENGTH}.",
+                    context={
+                        "max_length": _MAX_SMILES_LENGTH,
+                        "length": len(item),
+                    },
                 )
         return value
 

--- a/backend/app/services/scientific_read/common.py
+++ b/backend/app/services/scientific_read/common.py
@@ -13,6 +13,7 @@ Each service module imports from here so the rules are defined once.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -37,6 +38,8 @@ from app.services.scientific_read.profile import current_read_profile
 
 if TYPE_CHECKING:
     pass
+
+logger = logging.getLogger(__name__)
 
 
 class PaginatedResponse(Protocol):
@@ -99,6 +102,28 @@ def validate_pagination(offset: int, limit: int) -> tuple[int, int]:
     — the code was catalogued, exported, and unreachable on these two
     paths. One token per message is now checked statically by
     ``tests/api/test_error_contract_catalogue_gate.py``.
+
+    Both caps are published in ``context``
+    --------------------------------------
+    ``limit_too_large`` and ``offset_too_large`` are
+    :attr:`~app.api.code_catalogue.Shape.relationship` codes as of
+    Calvin's overrule of 2026-08-18: each asserts that a supplied value
+    and a server-side cap are in the wrong order, and the code names
+    neither. A refusal that does not state the limit cannot be acted on
+    without guessing, and both caps are *settings* — a deployment that
+    lowers ``public_max_limit`` is not documented anywhere the client can
+    read.
+
+    Both values are safe to publish under the disclosure line in
+    :class:`~app.api.code_catalogue.Shape`: the cap is TCKDB's own
+    configuration, and the supplied value is the caller's own request
+    echoed back. Neither measures the corpus.
+
+    ``message_prefix=True`` keeps ``str(exc)`` byte-identical to the
+    plain ``ValueError`` these replaced, so the published ``detail`` does
+    not move; only the route into ``code`` changes, which is why the
+    catalogue entries move to
+    :attr:`~app.api.code_catalogue.Surface.coded_exception`.
     """
     if offset < 0:
         raise ValueError("invalid_pagination: offset must be >= 0")
@@ -106,14 +131,19 @@ def validate_pagination(offset: int, limit: int) -> tuple[int, int]:
         raise ValueError("invalid_pagination: limit must be >= 1")
     effective_limit_cap = min(MAX_LIMIT, settings.public_max_limit)
     if limit > effective_limit_cap:
-        raise ValueError(
-            f"limit_too_large: limit must be <= {effective_limit_cap} "
-            f"(got {limit})"
+        raise CodedValueError(
+            "limit_too_large",
+            f"limit must be <= {effective_limit_cap} (got {limit})",
+            context={"limit_max": effective_limit_cap, "limit": limit},
         )
     if offset > settings.public_max_offset:
-        raise ValueError(
-            f"offset_too_large: offset must be <= {settings.public_max_offset} "
-            f"(got {offset})"
+        raise CodedValueError(
+            "offset_too_large",
+            f"offset must be <= {settings.public_max_offset} (got {offset})",
+            context={
+                "offset_max": settings.public_max_offset,
+                "offset": offset,
+            },
         )
     return offset, limit
 
@@ -128,6 +158,32 @@ def collect_bounded_pages(
     Composed endpoints must not silently treat the first 200 rows as the
     complete set. Walk all pages within the hosted offset bound and fail
     explicitly when the complete result is not reachable.
+
+    ``composed_search_candidate_limit_exceeded`` publishes the bound and
+    not the match count
+    -------------------------------------------------------------------
+    This is the sharp case for the disclosure line in
+    :class:`~app.api.code_catalogue.Shape`. The refusal compares two
+    numbers and they are not the same kind of number:
+
+    * ``max_traversable`` — ``public_max_offset + page_size`` — is
+      TCKDB's own configuration. Publishing it is what makes the refusal
+      actionable, and a caller can derive it in about three requests by
+      halving a page size anyway.
+    * ``expected_total`` is **how many records in the corpus matched the
+      query**. That is a measurement of TCKDB's holdings, not of the
+      request, and it is exactly the enumeration signal
+      ``docs/specs/public_identifier_policy.md`` (§"Why this matters
+      now", item 3) rejects sequential integer primary keys for: it
+      leaks the total count of objects and roughly the upload schedule.
+      A caller who can turn any filter into an exact row count has a
+      free census endpoint that no route offers.
+
+    So the count is logged and not published — neither in ``context``
+    nor in ``detail``, because ``detail`` is published too and putting it
+    there would make the ``context`` omission decorative.
+    ``tests/api/test_api_query_caps.py`` asserts its absence from the
+    whole body.
     """
     page_size = min(MAX_LIMIT, settings.public_max_limit)
     max_reachable = settings.public_max_offset + page_size
@@ -143,10 +199,26 @@ def collect_bounded_pages(
         if expected_total is None:
             expected_total = page_total
             if expected_total > max_reachable:
-                raise ValueError(
-                    "composed_search_candidate_limit_exceeded: "
-                    f"{resource_name} matched {expected_total} records, but at most "
-                    f"{max_reachable} can be traversed; narrow the query."
+                # Phrased so the code is not in the code position: a log
+                # line declares nothing, and a snake_case token in front
+                # of a colon is how this codebase declares an error code.
+                # See TestNoLoggerFormatStringSitsInTheCodePosition.
+                logger.info(
+                    "composed search refused as "
+                    "composed_search_candidate_limit_exceeded; %s matched %d "
+                    "records against a traversable bound of %d",
+                    resource_name,
+                    expected_total,
+                    max_reachable,
+                )
+                raise CodedValueError(
+                    "composed_search_candidate_limit_exceeded",
+                    f"{resource_name} matched more records than the "
+                    f"{max_reachable} that can be traversed; narrow the query.",
+                    context={
+                        "resource": resource_name,
+                        "max_traversable": max_reachable,
+                    },
                 )
         elif page_total != expected_total:
             raise ValueError(
@@ -172,10 +244,17 @@ def collect_bounded_pages(
 
         offset += len(page_records)
         if offset > settings.public_max_offset:
-            raise ValueError(
-                "composed_search_candidate_limit_exceeded: "
+            # The second site of the same code. Nothing here measures the
+            # corpus: the traversal simply ran past a configured offset
+            # bound, so the bound is the whole fact and it is published.
+            raise CodedValueError(
+                "composed_search_candidate_limit_exceeded",
                 f"{resource_name} requires an offset beyond "
-                f"{settings.public_max_offset}; narrow the query."
+                f"{settings.public_max_offset}; narrow the query.",
+                context={
+                    "resource": resource_name,
+                    "offset_max": settings.public_max_offset,
+                },
             )
 
 

--- a/backend/app/services/scientific_read/export.py
+++ b/backend/app/services/scientific_read/export.py
@@ -32,6 +32,7 @@ line without materializing the full mechanism.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -39,6 +40,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
+from app.api.error_contract import CodedValueError
 from app.db.models.common import (
     ReactionRole,
     RecordReviewStatus,
@@ -75,6 +77,8 @@ from app.services.scientific_read.profile import (
     ResolvedReadProfile,
     current_read_profile,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Schema tag for the selected scientific projection.  This is intentionally
 #: distinct from the future ``tckdb.archive.v1`` lossless archive contract.
@@ -578,9 +582,36 @@ def resolve_seed(
     if seed.all_reactions:
         all_ids = session.scalars(select(ReactionEntry.id)).all()
         if len(all_ids) > all_cap:
-            raise ValueError(
-                "export_all_cap_exceeded: refusing to export "
-                f"{len(all_ids)} reaction entries (cap {all_cap})"
+            # A relationship code as of 2026-08-18, published cap-only.
+            #
+            # ``len(all_ids)`` is an unfiltered ``SELECT`` over
+            # ``reaction_entry``: it is the total number of reaction
+            # entries TCKDB holds. That is the enumeration signal
+            # ``docs/specs/public_identifier_policy.md`` (§"Why this
+            # matters now", item 3) rejects sequential integer primary
+            # keys for -- the total count of objects, and, polled over
+            # time, roughly the upload schedule. ``all=true`` is by
+            # construction the one request whose size the caller did not
+            # state, so echoing the count back is not echoing their own
+            # request: it is answering a census question nothing else
+            # answers.
+            #
+            # The cap is TCKDB's own configuration and is published, so
+            # a client still learns what would have to change. The count
+            # is logged and appears in neither ``context`` nor
+            # ``detail`` -- ``detail`` is published too, and leaving it
+            # there would make the ``context`` omission decorative.
+            logger.info(
+                "export refused as export_all_cap_exceeded; %d reaction "
+                "entries against a cap of %d",
+                len(all_ids),
+                all_cap,
+            )
+            raise CodedValueError(
+                "export_all_cap_exceeded",
+                "refusing to export every reaction entry: the corpus is "
+                f"larger than the export cap of {all_cap}",
+                context={"cap": all_cap, "record_type": "reaction_entry"},
             )
         reaction_entry_ids.update(all_ids)
 

--- a/backend/app/services/scientific_read/geometry.py
+++ b/backend/app/services/scientific_read/geometry.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.config import settings
+from app.api.error_contract import CodedValueError
 from app.api.errors import NotFoundError
 from app.db.models.calculation import (
     Calculation,
@@ -92,10 +93,23 @@ def get_geometry(
     # ``docs/specs/public_read_abuse_controls.md``.
     cap = settings.max_geometry_atoms_public
     if cap and geometry.natoms is not None and geometry.natoms > cap:
-        raise ValueError(
-            "geometry_too_large: geometry has "
-            f"{geometry.natoms} atoms which exceeds the public cap "
-            f"of {cap}. Contact a curator for bulk access."
+        # A relationship code as of 2026-08-18: a supplied geometry's
+        # size and a configured cap, neither named by the code. Both
+        # numbers are publishable.
+        #
+        # ``max_atoms`` is TCKDB's own configuration. ``atoms`` looks at
+        # first like the measured value the disclosure line in
+        # ``app.api.code_catalogue.Shape`` withholds, and it is not: it
+        # is the atom count of *one* record the caller named by handle —
+        # chemistry, not a count of TCKDB's holdings. It carries no
+        # enumeration signal, and it is strictly less than this endpoint
+        # discloses for any request that succeeds, since a geometry
+        # under the cap returns every atom individually.
+        raise CodedValueError(
+            "geometry_too_large",
+            f"geometry has {geometry.natoms} atoms which exceeds the "
+            f"public cap of {cap}. Contact a curator for bulk access.",
+            context={"max_atoms": cap, "atoms": geometry.natoms},
         )
 
     atoms = _load_atoms(session, geometry_id)

--- a/backend/app/services/scientific_read/ml_dataset.py
+++ b/backend/app/services/scientific_read/ml_dataset.py
@@ -52,6 +52,7 @@ selection/trust machinery this reuses):
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -59,6 +60,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.error_contract import CodedValueError
 from app.chemistry.geometry import resolve_element_symbol
 from app.db.models.calculation import (
     Calculation,
@@ -101,6 +103,8 @@ from app.services.scientific_read.profile import (
     ResolvedReadProfile,
     current_read_profile,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Schema tag stamped on every ML record so a consumer can branch on format.
 ML_EXPORT_SCHEMA = "tckdb.ml.v0"
@@ -473,9 +477,24 @@ def _resolve_species_entry_ids(
             select(SpeciesEntry.id).order_by(SpeciesEntry.id)
         ).all()
         if len(all_ids) > all_cap:
-            raise ValueError(
-                "ml_export_all_cap_exceeded: refusing to export "
-                f"{len(all_ids)} species entries (cap {all_cap})"
+            # The ML surface's own cap, and the same disclosure call as
+            # its native sibling ``export_all_cap_exceeded``: publish the
+            # configured cap, log the count. ``len(all_ids)`` is an
+            # unfiltered ``SELECT`` over ``species_entry`` -- the total
+            # number of species entries TCKDB holds, which is the
+            # enumeration signal ``docs/specs/public_identifier_policy.md``
+            # rejects sequential integer primary keys for.
+            logger.info(
+                "ML export refused as ml_export_all_cap_exceeded; %d "
+                "species entries against a cap of %d",
+                len(all_ids),
+                all_cap,
+            )
+            raise CodedValueError(
+                "ml_export_all_cap_exceeded",
+                "refusing to export every species entry: the corpus is "
+                f"larger than the export cap of {all_cap}",
+                context={"cap": all_cap, "record_type": "species_entry"},
             )
         ids.extend(all_ids)
 

--- a/backend/app/services/scientific_read/provenance.py
+++ b/backend/app/services/scientific_read/provenance.py
@@ -6,10 +6,13 @@ review summary into a single response. See docs/specs/read_api_mvp.md §Endpoint
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api.config import settings
+from app.api.error_contract import CodedValueError
 from app.api.errors import not_found
 from app.db.models.calculation import (
     Calculation,
@@ -98,6 +101,8 @@ from app.services.scientific_read.transition_states import (
     _build_evidence_summary_for_entries,
     build_transition_state_entry_trust_fragment,
 )
+
+logger = logging.getLogger(__name__)
 
 _LEGAL_INCLUDE_TOKENS: set[str] = {
     "species",
@@ -1334,6 +1339,28 @@ def _enforce_full_expansion_caps(
     ``atom_map_pairs`` is likewise flattened across the reaction's maps:
     a reaction has few maps and each holds one row per atom per leg, so
     the pairs are the leaf rows and the maps are the grouping ones.
+
+    What the refusal publishes, and what it withholds
+    -------------------------------------------------
+    ``query_too_expensive`` is a
+    :attr:`~app.api.code_catalogue.Shape.relationship` code as of
+    2026-08-18 — it says a sub-array and a cap are the wrong way round
+    and names neither — so it owes a client ``context``. It carries the
+    offending ``section`` and that section's ``cap``, which is the whole
+    repair: narrow ``include=``, or request the section directly with
+    pagination.
+
+    It deliberately does **not** carry ``len(block)``. That number is how
+    many rows TCKDB *holds* for the requested record — how many
+    calculations, geometries, artifacts, conformer groups or atom-map
+    pairs exist. Unlike a geometry's atom count, which is a property of
+    the molecule, this is a count of the corpus, and a caller who can
+    read it off a cheap refusal has a row-counting oracle: set the cap
+    low, sweep records, and recover the holdings profile and roughly the
+    upload schedule that ``docs/specs/public_identifier_policy.md``
+    (§"Why this matters now", item 3) refuses to leak through primary
+    keys. The count is logged instead, and is absent from ``detail`` as
+    well as ``context`` — ``detail`` is published too.
     """
     pairs: list[tuple[str, list | None, int]] = [
         ("calculations", calculations, settings.max_full_calculations_public),
@@ -1354,11 +1381,19 @@ def _enforce_full_expansion_caps(
         if block is None or cap <= 0:
             continue
         if len(block) > cap:
-            raise ValueError(
-                "query_too_expensive: /full expansion for section "
-                f"{section_name!r} would return {len(block)} rows "
-                f"which exceeds the public cap of {cap}. Narrow the "
-                "include= set or request specific sections directly."
+            logger.info(
+                "full expansion refused as query_too_expensive; section %r "
+                "would return %d rows against a cap of %d",
+                section_name,
+                len(block),
+                cap,
+            )
+            raise CodedValueError(
+                "query_too_expensive",
+                f"/full expansion for section {section_name!r} would "
+                f"return more rows than the public cap of {cap}. Narrow "
+                "the include= set or request specific sections directly.",
+                context={"section": section_name, "cap": cap},
             )
 
 

--- a/backend/tests/api/test_api_query_caps.py
+++ b/backend/tests/api/test_api_query_caps.py
@@ -2,11 +2,45 @@
 
 Covers the limit/offset/geometry/full caps defined in
 ``docs/specs/public_read_abuse_controls.md``.
+
+What the cap family publishes, and what it must not
+---------------------------------------------------
+Since 2026-08-18 every cap code is a
+``app.api.code_catalogue.Shape.relationship``: a refusal that does not
+state the limit cannot be acted on without guessing, and these caps are
+settings, so no document a client can read has the right number in it.
+The tests below therefore assert the **specific key and its value**, not
+that ``context`` is non-empty -- the latter is satisfied by a handler
+stuffing in a constant.
+
+The other half is an *absence*, and it is the half nothing else in the
+suite would notice if it were lost. The rule on ``Shape`` is:
+
+    Publish the THRESHOLD. Never publish the MEASURED VALUE that crossed
+    it, where that value describes the corpus rather than the caller's
+    own request.
+
+``query_too_expensive`` is the case in this file. Its measured value is
+how many calculation / geometry / artifact rows TCKDB holds for the
+requested record, and a caller who can read that off a cheap refusal has
+a row-counting oracle -- the enumeration exposure
+``docs/specs/public_identifier_policy.md`` rejects integer primary keys
+for. So the count is logged, and its absence is asserted **over the
+whole body**, not only ``context``: ``detail`` is published too, and an
+omission from one and not the other is decorative. Its three siblings
+(``export_all_cap_exceeded``, ``ml_export_all_cap_exceeded``,
+``composed_search_candidate_limit_exceeded``) are asserted the same way
+in ``test_api_untested_refusals_tier_de.py``, next to their own accept
+halves.
 """
 
 from __future__ import annotations
 
+import json
+import re
+
 from app.api.config import settings
+from app.schemas.reads._field_bounds import MAX_SMILES_LENGTH
 
 # ---------------------------------------------------------------------------
 # Pagination caps
@@ -205,3 +239,222 @@ def test_include_all_does_not_bypass_caps(client, db_session, monkeypatch):
     )
     assert resp.status_code == 422
     assert "query_too_expensive" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# The caps now say what the cap is (2026-08-18)
+# ---------------------------------------------------------------------------
+
+
+def test_limit_too_large_publishes_the_cap_and_the_supplied_limit(
+    client, monkeypatch
+):
+    """The whole point of the reclassification: a retryable number.
+
+    ``public_max_limit`` is a *setting*. A deployment that lowers it has
+    no document a client can consult, so before this the only way to find
+    a legal page size was to bisect. Both values are safe: the cap is
+    TCKDB's own configuration and the limit is the caller's own request
+    handed back.
+
+    The key and its value are asserted, not merely that ``context`` is
+    populated -- a handler that stuffed in a constant would satisfy the
+    weaker form.
+    """
+    monkeypatch.setattr(settings, "public_max_limit", 10)
+    resp = client.get("/api/v1/scientific/species/search?smiles=X&limit=50")
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "limit_too_large"
+    assert body["context"] == {"limit_max": 10, "limit": 50}
+
+
+def test_a_limit_inside_the_lowered_cap_still_succeeds(client, monkeypatch):
+    """The accept-half, under the same lowered cap.
+
+    Without it the refusal above is equally well satisfied by a service
+    that refuses every paginated read.
+    """
+    monkeypatch.setattr(settings, "public_max_limit", 10)
+    resp = client.get("/api/v1/scientific/species/search?smiles=X&limit=10")
+    assert resp.status_code == 200, resp.text
+
+
+def test_offset_too_large_publishes_the_cap_and_the_supplied_offset(
+    client, monkeypatch
+):
+    """The sibling, and the one reachable against shipped settings.
+
+    Lowered here anyway so the asserted cap is a number this test chose,
+    which is what makes ``offset_max`` an assertion about the response
+    rather than about the configuration.
+    """
+    monkeypatch.setattr(settings, "public_max_offset", 5)
+    resp = client.get(
+        "/api/v1/scientific/reactions/search?reactants=A&products=B&offset=6"
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "offset_too_large"
+    assert body["context"] == {"offset_max": 5, "offset": 6}
+
+
+def test_an_offset_on_the_boundary_still_succeeds(client, monkeypatch):
+    """Exactly at the cap is accepted; the refusal is ``>``, not ``>=``."""
+    monkeypatch.setattr(settings, "public_max_offset", 5)
+    resp = client.get(
+        "/api/v1/scientific/reactions/search?reactants=A&products=B&offset=5"
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_geometry_too_large_publishes_the_cap_and_the_atom_count(
+    client, db_session, monkeypatch
+):
+    """Both numbers, and the second one is the arguable half.
+
+    ``atoms`` is a server-side measurement, so it looks like the thing
+    the disclosure rule withholds. It is not: it is the atom count of one
+    record the caller named by handle -- chemistry, not a count of
+    TCKDB's holdings -- and it is strictly less than this same endpoint
+    returns for any request under the cap, which lists every atom
+    individually. Nothing about the size of the corpus is recoverable
+    from it.
+    """
+    from tests.services.scientific_read._factories import make_geometry
+
+    geom = make_geometry(db_session, natoms=12, xyz_text="placeholder")
+    monkeypatch.setattr(settings, "max_geometry_atoms_public", 5)
+
+    resp = client.get(f"/api/v1/scientific/geometries/{geom.public_ref}")
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "geometry_too_large"
+    assert body["context"] == {"max_atoms": 5, "atoms": 12}
+
+
+def test_smiles_too_long_publishes_the_maximum_and_the_supplied_length(
+    client,
+):
+    """A schema-layer cap, raised from the wire package's error type.
+
+    ``app.schemas.reads`` sits on the wire side and raises
+    ``CodedValidationError`` rather than the backend's subclass; the same
+    handler reads both, which is what this asserts through the wire.
+
+    ``context`` carries the length and not the string. That is a choice
+    about ``context`` only, and the assertion below says so precisely
+    rather than over-claiming: on this path ``detail`` is FastAPI's
+    request-validation error, which echoes the offending ``input`` back
+    verbatim -- documented behaviour that ``app.api.error_contract``
+    already names as the reason clients must not parse ``detail``.
+    Nothing about that is a disclosure problem: the string is the
+    caller's own, which the rule on ``Shape`` permits explicitly. It is
+    a reason not to duplicate a 2 KB value into ``context`` as well.
+    """
+    too_long = "C" * (MAX_SMILES_LENGTH + 1)
+    resp = client.post(
+        "/api/v1/scientific/kinetics/search",
+        json={"reactants": [too_long], "products": ["O"]},
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "smiles_too_long"
+    assert body["context"] == {
+        "max_length": MAX_SMILES_LENGTH,
+        "length": MAX_SMILES_LENGTH + 1,
+    }
+    assert too_long not in json.dumps(body["context"]), (
+        "context duplicated the caller's SMILES; the length is the whole "
+        "repair and the string only grows the body"
+    )
+
+
+def test_a_smiles_on_the_length_boundary_is_accepted(client):
+    """Exactly at the maximum passes the bound.
+
+    A 2048-character carbon chain matches nothing, so this asserts the
+    *bound* rather than the search: a 200 with no records is the right
+    answer and a 422 is not.
+    """
+    at_limit = "C" * MAX_SMILES_LENGTH
+    resp = client.post(
+        "/api/v1/scientific/kinetics/search",
+        json={"reactants": [at_limit], "products": ["O"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_query_too_expensive_publishes_the_cap_but_not_the_row_count(
+    client, db_session, monkeypatch
+):
+    """The disclosure line, asserted as an absence.
+
+    ``context`` carries ``section`` -- which sub-array was the offender,
+    and therefore what to drop from ``include=`` -- and that section's
+    ``cap``. It does **not** carry ``len(block)``, which is how many
+    calculation rows TCKDB holds for this record.
+
+    Why that matters: with the count published, a caller sets the cap
+    low, sweeps every record, and reads TCKDB's holdings profile and
+    roughly its upload schedule off a stream of cheap 422s. That is the
+    enumeration exposure ``docs/specs/public_identifier_policy.md``
+    (§"Why this matters now", item 3) refuses to leak through primary
+    keys, and it would be worse here: a key leaks the count once, a
+    countable refusal leaks it per query, forever.
+
+    The absence is asserted over the **whole serialized body**, not just
+    ``context``. ``detail`` is published too, and it carried the count
+    until this change -- an omission from one and not the other would be
+    decorative.
+    """
+    entry = _seed_reaction_entry_with_n_calculations(db_session, label="Q", n=7)
+    monkeypatch.setattr(settings, "max_full_calculations_public", 1)
+
+    resp = client.get(
+        f"/api/v1/scientific/reaction-entries/{entry.public_ref}/full"
+        "?include=calculations"
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["code"] == "query_too_expensive"
+    assert body["context"] == {"section": "calculations", "cap": 1}
+
+    # 7 is the measured value, and 1 is the cap, so the two cannot be
+    # confused. Integers are extracted as literals rather than
+    # substring-matched, so a leaked ``17`` somewhere would not be read
+    # as a leaked ``7`` and a public ref containing the digit would not
+    # fail this.
+    serialized = json.dumps(body)
+    assert 7 not in {int(t) for t in re.findall(r"\d+", serialized)}, (
+        "the refusal published how many calculation rows TCKDB holds for "
+        "this record. That is a measurement of the corpus, not of the "
+        "request: see the disclosure line on app.api.code_catalogue.Shape. "
+        f"Body: {serialized}"
+    )
+
+
+def test_a_full_expansion_inside_the_cap_still_returns_its_rows(
+    client, db_session, monkeypatch
+):
+    """The accept-half for the same section, seeded identically.
+
+    Without it, every assertion above is satisfied by a ``/full`` route
+    that refuses ``include=calculations`` unconditionally -- and the
+    absence assertion in particular is satisfied by a route that returns
+    no numbers at all.
+    """
+    entry = _seed_reaction_entry_with_n_calculations(db_session, label="P", n=7)
+    monkeypatch.setattr(settings, "max_full_calculations_public", 10)
+
+    resp = client.get(
+        f"/api/v1/scientific/reaction-entries/{entry.public_ref}/full"
+        "?include=calculations"
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["calculations"]) == 7

--- a/backend/tests/api/test_api_untested_refusals_tier_de.py
+++ b/backend/tests/api/test_api_untested_refusals_tier_de.py
@@ -59,6 +59,8 @@ import base64
 import copy
 import hashlib
 import io
+import json
+import re
 
 import pytest
 from botocore.exceptions import ClientError
@@ -104,6 +106,38 @@ def _assert_code(response, expected: str, *, status: int = 422) -> dict:
         f"at {response.status_code}. detail={body.get('detail')!r}"
     )
     return body
+
+
+def _assert_number_absent_from_body(
+    body: dict, measured: int, what: str
+) -> None:
+    """No integer anywhere in the published body equals *measured*.
+
+    The disclosure line on ``app.api.code_catalogue.Shape`` (2026-08-18):
+    a cap refusal publishes the threshold and never the measured value
+    that crossed it, where that value describes the corpus rather than
+    the caller's own request. A count of matching records, or of rows a
+    table holds, is a fact about how much data exists -- the enumeration
+    exposure ``docs/specs/public_identifier_policy.md`` refuses to leak
+    through primary keys, and worse here because a countable refusal
+    leaks it once per query rather than once.
+
+    Asserted over the **whole serialized body**, not just ``context``.
+    ``detail`` is published too and carried these counts until the caps
+    were reclassified; an omission from one and not the other would be
+    decorative.
+
+    Integers are extracted as literals rather than substring-matched, so
+    a cap of 1 and a count of 12 cannot be confused, and a test seeding
+    two records does not fail because ``2`` appears inside a public ref.
+    """
+    serialized = json.dumps(body)
+    found = {int(token) for token in re.findall(r"\d+", serialized)}
+    assert measured not in found, (
+        f"the refusal published {what} ({measured}). That is a measurement "
+        "of the corpus, not of the caller's request -- see the disclosure "
+        f"line on app.api.code_catalogue.Shape. Body: {serialized}"
+    )
 
 
 # ===========================================================================
@@ -425,10 +459,30 @@ def test_a_composed_search_refuses_a_candidate_set_it_cannot_traverse(
     """
     monkeypatch.setattr(settings, "public_max_limit", 1)
     monkeypatch.setattr(settings, "public_max_offset", 0)
-    _assert_code(
+    body = _assert_code(
         client.post(_THERMO_SEARCH_URL, json={"formula": "C5H12", "limit": 1}),
         "composed_search_candidate_limit_exceeded",
     )
+
+    # Since 2026-08-18 this is a Shape.relationship code, and it is one of
+    # the four that publish the threshold and withhold the measurement.
+    #
+    # ``max_traversable`` is ``public_max_offset + page_size`` -- TCKDB's
+    # own configuration, and the whole repair, since it tells the caller
+    # how much narrowing the query needs. It is published.
+    assert body["context"] == {
+        "resource": "species discovery candidates",
+        "max_traversable": 1,
+    }, body
+
+    # ``expected_total`` -- how many records in the corpus matched -- is
+    # not. A refusal that reports an exact match count turns any filter
+    # into a free census endpoint, which is the enumeration exposure
+    # ``docs/specs/public_identifier_policy.md`` rejects integer primary
+    # keys for. Two pentanes are seeded, so 2 is the measured value; the
+    # assertion is over the whole serialized body because ``detail`` is
+    # published too and carried the count until this change.
+    _assert_number_absent_from_body(body, 2, "how many records matched")
 
 
 def test_the_same_search_within_the_bound_is_accepted(
@@ -533,17 +587,35 @@ def test_an_all_reactions_export_over_its_cap_is_refused(
     """One reaction in the corpus, a cap of zero.
 
     The seed is a real reaction deposited through the ordinary upload
-    route, so the count in the refusal is a count of real rows. The
+    route, so the count the refusal measures is a count of real rows. The
     request is the same one the accept-half makes.
+
+    Since 2026-08-18 this is a ``Shape.relationship`` code that publishes
+    its cap, and it is the sharpest of the four withheld measurements:
+    ``all=true`` is by construction the one export request whose size the
+    caller did not state, and the number it crosses is an unfiltered
+    ``SELECT`` over ``reaction_entry`` -- TCKDB's total holdings. Echoing
+    it back is not echoing the caller's own request; it is answering a
+    census question no route offers.
     """
     assert client.post(_REACTION_URL, json=_bundle(_map())).status_code == 201
     login_as(_api_curator_user)
     monkeypatch.setitem(iter_export_ndjson.__kwdefaults__, "all_cap", 0)
-    _assert_code(
+    body = _assert_code(
         client.get(
             _EXPORT_URL, params={"all": "true", "min_review_status": "under_review"}
         ),
         "export_all_cap_exceeded",
+    )
+
+    # The threshold and what kind of record it counts: enough for a
+    # client to know the request cannot be made whole, and which seed to
+    # narrow to instead.
+    assert body["context"] == {"cap": 0, "record_type": "reaction_entry"}, body
+
+    # One reaction entry was deposited above, so 1 is the measured value.
+    _assert_number_absent_from_body(
+        body, 1, "how many reaction entries TCKDB holds"
     )
 
 
@@ -584,6 +656,10 @@ def test_an_all_species_ml_export_over_its_cap_is_refused(
     ``export_all_cap_exceeded`` learns nothing about the ML surface, and
     the catalogue says so. One species entry is deposited so the refusal
     counts something real.
+
+    The same disclosure call as its native sibling, over a different
+    table: the cap is published, the ``species_entry`` row count is
+    logged.
     """
     assert (
         client.post("/api/v1/uploads/conformers", json=_CONFORMER_PAYLOAD).status_code
@@ -591,12 +667,17 @@ def test_an_all_species_ml_export_over_its_cap_is_refused(
     )
     login_as(_api_curator_user)
     monkeypatch.setitem(iter_ml_species_ndjson.__kwdefaults__, "all_cap", 0)
-    _assert_code(
+    body = _assert_code(
         client.get(
             _ML_EXPORT_URL,
             params={"all": "true", "min_review_status": "under_review"},
         ),
         "ml_export_all_cap_exceeded",
+    )
+
+    assert body["context"] == {"cap": 0, "record_type": "species_entry"}, body
+    _assert_number_absent_from_body(
+        body, 1, "how many species entries TCKDB holds"
     )
 
 

--- a/backend/tests/api/test_error_contract_catalogue_gate.py
+++ b/backend/tests/api/test_error_contract_catalogue_gate.py
@@ -574,14 +574,33 @@ class TestOneMessageDeclaresOneCode:
     """
 
     def test_the_scan_sees_the_messages_it_is_written_over(self):
-        """An empty scan would make the next assertion prove nothing."""
+        """An empty scan would make the next assertion prove nothing.
+
+        The floor named ``limit_too_large`` and ``offset_too_large``
+        until 2026-08-18, when the cap family became
+        ``Shape.relationship`` and both moved to
+        ``Surface.coded_exception`` so they could carry their cap in
+        ``context``. They are no longer in ``MESSAGE_PREFIX_CODES``, so
+        this scan -- which reads only that surface -- correctly stops
+        seeing them, and naming them here would pin a spelling the tree
+        no longer has.
+
+        Re-pointed rather than dropped: the floor still names three
+        concrete codes that must be visible, and two of them are still
+        raised from ``validate_pagination``'s own module, so a scan that
+        stops reading ``scientific_read/common.py`` still fails here.
+        """
         messages = _messages_opening_with_a_promotable_code()
         assert len(messages) > 40, (
             f"only {len(messages)} coded messages found; the scan has stopped "
             "reading the tree and the assertion below is vacuous"
         )
         codes = {text.split(":", 1)[0] for _path, _line, text in messages}
-        for expected in ("invalid_pagination", "limit_too_large", "offset_too_large"):
+        for expected in (
+            "invalid_pagination",
+            "client_sort_not_supported",
+            "composed_search_pagination_changed",
+        ):
             assert expected in codes, sorted(codes)
 
     def test_no_coded_message_names_a_second_code(self):
@@ -616,14 +635,40 @@ class TestOneMessageDeclaresOneCode:
         the tree must be classified as ambiguous, and must actually
         degrade when the envelope reads it. Without this the gate could be
         broken -- a pattern that matches nothing -- and stay green.
+
+        The historical shape is still asserted, because it is still the
+        shape the gate exists for. What moved is the *repaired* half: as
+        of 2026-08-18 ``limit_too_large`` is a ``coded_exception``
+        carrying its cap in ``context``, so it is no longer promotable
+        out of a sentence at all and ``_promoted`` of it is now
+        ``validation_error`` by design rather than by defect. Asserting
+        the old value would be asserting the gate's opposite. A code that
+        *is* still ``message_prefix`` is used for the positive half, so
+        the detector is still shown saying yes as well as no -- and the
+        historical pair keeps its own assertion, one line below, so this
+        change tightens the test rather than trading one case for
+        another.
         """
         regressed = "invalid_pagination: limit_too_large: limit must be <= 200 (got 999)"
         assert len(set(_NESTED_CODE_PATTERN.findall(regressed))) > 1
         assert _promoted(regressed) == "validation_error"
 
-        repaired = "limit_too_large: limit must be <= 200 (got 999)"
+        # A code that left MESSAGE_PREFIX_CODES cannot be promoted from
+        # prose even when it is the only token: that is the whole point
+        # of declaring it on the exception instead.
+        assert _promoted("limit_too_large: limit must be <= 200 (got 999)") == (
+            "validation_error"
+        )
+
+        still_ambiguous = (
+            "invalid_pagination: composed_search_invalid_page: page is wrong"
+        )
+        assert len(set(_NESTED_CODE_PATTERN.findall(still_ambiguous))) > 1
+        assert _promoted(still_ambiguous) == "validation_error"
+
+        repaired = "composed_search_invalid_page: page is wrong"
         assert len(set(_NESTED_CODE_PATTERN.findall(repaired))) == 1
-        assert _promoted(repaired) == "limit_too_large"
+        assert _promoted(repaired) == "composed_search_invalid_page"
 
 
 class TestTheLegacyDetailPathIsGatedToo:

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -222,6 +222,17 @@ id). A code that names a **thing** — `unknown_release`, `missing_filter`
 on `code` first and enrich from `context` if it is there; never make a
 non-empty `context` a precondition for handling a refusal.
 
+Cap refusals (`limit_too_large`, `offset_too_large`, `geometry_too_large`,
+`smiles_too_long`, `query_too_expensive`, the two `*_all_cap_exceeded`
+codes and `composed_search_candidate_limit_exceeded`) are relationships
+and carry **the limit** — read it and retry against it rather than
+hardcoding a number, because these caps are deployment settings and a
+self-hosted TCKDB may run different ones. They will never tell you how
+much data is on the far side of the cap: no match count, no row count,
+in `context` or `detail`. That is deliberate, not a gap to report — an
+exact count off a cheap refusal would turn any filter into a census of
+the server's holdings.
+
 Use `rejection_code(exc.code)` rather than `RejectionCode(exc.code)`: a
 server is routinely newer than the client pinned against it, and a code
 added since must return `None` rather than raise inside your own error

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.52.2"
+version = "0.52.3"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/docs/clients/generic-client-targeting.md
+++ b/docs/clients/generic-client-targeting.md
@@ -475,9 +475,41 @@ knowing before you write a branch that reads it:
   stable across a restore or between two deployments and no public
   surface is keyed on one.
 - A code that names a **thing** — `unknown_release`, `missing_filter`,
-  `limit_too_large` — is already the whole message. `context` may be `{}`
-  and that is the honest answer, not a gap: there is no second fact to
-  report.
+  `unknown_include_token` — is already the whole message. `context` may
+  be `{}` and that is the honest answer, not a gap: there is no second
+  fact to report.
+
+### Cap refusals tell you the cap (since 2026-08-18)
+
+`limit_too_large` was the example in the second bullet above until
+2026-08-18. It is now a relationship code, and so is every other cap:
+
+| code | `context` |
+|---|---|
+| `limit_too_large` | `limit_max`, `limit` |
+| `offset_too_large` | `offset_max`, `offset` |
+| `geometry_too_large` | `max_atoms`, `atoms` |
+| `smiles_too_long` | `max_length`, `length` |
+| `export_all_cap_exceeded` | `cap`, `record_type` |
+| `ml_export_all_cap_exceeded` | `cap`, `record_type` |
+| `query_too_expensive` | `section`, `cap` |
+| `composed_search_candidate_limit_exceeded` | `resource`, and `max_traversable` or `offset_max` |
+
+The reason is retry: these caps are **deployment settings**, not
+constants in this document, so a self-hosted or lab TCKDB may run
+different numbers and a refusal that did not state them left you
+bisecting. Read the threshold out of `context` and retry against it —
+do not hardcode 200, and do not scrape the sentence.
+
+**What a cap refusal will never tell you** is how much data is on the
+other side of the cap. The last four rows publish the threshold and
+stop there: no match count, no row count, no corpus total, in `context`
+or in `detail`. This is deliberate and is not a bug to report — an
+exact match count off a cheap refusal would make every filter a census
+endpoint, which is the enumeration exposure TCKDB avoids elsewhere by
+not exposing sequential row ids. If you need to know how large a result
+set is, page it or ask a curator for bulk access; do not expect the
+refusal to say.
 
 So: read `context` where the code names a relationship, and treat `{}`
 as normal everywhere else. Do not make a populated `context` a

--- a/docs/specs/public_read_abuse_controls.md
+++ b/docs/specs/public_read_abuse_controls.md
@@ -198,6 +198,45 @@ code.
 so cutting it lower in config is honored, but raising it above 200
 has no effect.
 
+### What a cap refusal discloses (decided 2026-08-18)
+
+Every code in the table above puts its **threshold** in the error
+envelope's `context`, so a client can retry against the value this
+deployment actually runs rather than the default printed here. Publishing
+a cap is not an abuse control: it is discoverable in about three requests
+by halving the supplied value, the control is the cap being *enforced*
+rather than secret, and it describes our configuration rather than
+anyone's data. A refusal that withheld it was un-actionable — the only
+remedy was to bisect.
+
+The **measured value that crossed the cap** is a separate question and is
+not published where it describes the corpus rather than the caller's own
+request:
+
+| what the number is | example | published? |
+|---|---|---|
+| the configured threshold | `PUBLIC_MAX_OFFSET` | yes |
+| the caller's own request, echoed | the `limit` they sent | yes |
+| a property of one named record | a geometry's atom count | yes — chemistry, and strictly less than a successful read of the same record returns |
+| a count of rows TCKDB holds | how many records matched; how many `reaction_entry` rows exist | **no** — logged only |
+
+The last row is the enumeration exposure
+`docs/specs/public_identifier_policy.md` (§"Why this matters now", item
+3) rejects sequential integer primary keys for: they "leak the total
+count of objects (and roughly the upload schedule) of every table". A
+refusal that reports an exact count is worse than a primary key, because
+a key leaks the count once while a countable refusal leaks it per query,
+cheaply, forever. Four codes are on that side —
+`export_all_cap_exceeded`, `ml_export_all_cap_exceeded`,
+`query_too_expensive` and `composed_search_candidate_limit_exceeded` —
+and their counts are absent from `detail` as well as `context`, since
+both are published.
+
+The rule itself lives on `Shape` in `backend/app/api/code_catalogue.py`
+("The disclosure line"), and the absences are asserted per code in
+`backend/tests/api/test_api_query_caps.py` and
+`backend/tests/api/test_api_untested_refusals_tier_de.py`.
+
 The `/reaction-entries/{id}/full` cap applies regardless of how the
 section was requested — there is no way to evade it by enumerating
 `include=` tokens vs. `include=all`.


### PR DESCRIPTION
## Plain language first

When TCKDB refuses a request for being too big — too many rows per page,
too deep a page, too large a geometry, too long a SMILES, an export of
everything — it sends back a small JSON object with a machine-readable
`code`, a sentence for a human, and a `context` object for structured
facts. Until now the cap refusals put **nothing** in `context`. So a
program that wanted to retry with a legal value had to either guess, or
scrape the number out of the English sentence it is explicitly told never
to parse.

That is un-actionable advice, and it is the same defect diagnosed at
length in *Tell "no such selection" from "which selection?"*: advice that
cannot be followed teaches people to stop reading advice. Worse here,
because every one of these caps is a **deployment setting** — a
self-hosted or lab TCKDB may run different numbers, so there is no
document anywhere with the right value in it.

So all eight cap codes now publish their cap.

**But there are two numbers in a cap refusal, and only one of them is
safe to publish.** "You asked for 5000, the maximum is 500" is fine —
5000 is the caller's own request handed back, and 500 describes our
configuration. "Your query would have matched 4,300,000 rows" is not:
that is a measurement of *how much data exists*, and a refusal that
reports it turns any filter into a free census of the database. Four of
the eight were measuring the corpus, so they publish the threshold and
say nothing else. The count goes to the log.

*Software terms:* the *envelope* is the fixed shape of the JSON error
body (`code` / `detail` / `context`); a *surface* is the mechanism by
which a code reaches that body; `Shape` is the classification introduced
by *Say which error codes owe a client structured facts, and pay four of
them* recording whether a code names one thing or a relation between
things, and therefore whether it owes `context` at all.

---

## The re-derived list

Not taken from the previous PR's description. Measured over
`app.api.code_catalogue.CATALOGUE` on this branch by matching every code
name against `too_large|too_long|cap|limit|exceed|_max|size|length|
long|large|expensive|budget|timeout|quota`, then reading each hit:

| code | status | in the family? |
|---|---|---|
| `limit_too_large` | 422 | ✅ |
| `offset_too_large` | 422 | ✅ |
| `geometry_too_large` | 422 | ✅ |
| `smiles_too_long` | 422 | ✅ |
| `export_all_cap_exceeded` | 422 | ✅ |
| `ml_export_all_cap_exceeded` | 422 | ✅ |
| `query_too_expensive` | 422 | ✅ |
| `composed_search_candidate_limit_exceeded` | 422 | ✅ |
| `freq_list_exceeds_geometry_degrees_of_freedom` | 422 | no — already `relationship`, already populated |
| `query_timeout` | 503 | no — an outage, not a cap |
| `rate_limit_exceeded` | 429 | **adjacent, see below** |
| `selection_no_longer_approved` | 422 | no — matched on "approved", not a cap |

The eight are exactly the eight named in the brief. Two adjacent codes
are worth recording rather than silently skipping:

- **`rate_limit_exceeded` is a cap and already does what this PR does.**
  `app/api/rate_limit.py:386` already sends
  `context={"bucket": …, "retry_after_seconds": …}` — a threshold and a
  retry instruction. It is classified `Shape.thing`, which is not a
  contradiction (`owes_context` is a floor, not a ceiling: a thing code
  *may* carry context). It is left alone: it is outside the family Calvin
  named, it is a `response_literal` whose catalogue entry a sibling agent
  may be editing, and it is not broken. But it is worth noting that the
  overrule matches what the tree already did on the one cap nobody
  argued about.
- **`freq_list_exceeds_geometry_degrees_of_freedom`** matches the word
  scan and is already a relationship carrying `context={"locations": …}`.
  Unchanged.

---

## The per-code classification

All eight move `Shape.thing` → `Shape.relationship` (the shape
declaration is what makes `owes_context` fire) and
`Surface.message_prefix` → `Surface.coded_exception`, because a plain
`ValueError` has nowhere to put structured facts. Every one raises with
`message_prefix=True`, so `str(exc)` — and therefore the published
`detail` — is byte-identical, **except** the four where the count had to
come out of the sentence.

### Publish the threshold *and* the measured value (4)

| code | `context` | why the second number is safe |
|---|---|---|
| `limit_too_large` | `limit_max`, `limit` | `limit` is the caller's own request echoed back |
| `offset_too_large` | `offset_max`, `offset` | same |
| `smiles_too_long` | `max_length`, `length` | the length of the caller's own string |
| `geometry_too_large` | `max_atoms`, `atoms` | **argued below** |

### Publish the threshold and nothing else (4)

| code | `context` | the withheld number |
|---|---|---|
| `export_all_cap_exceeded` | `cap`, `record_type` | `len(all_ids)` — an unfiltered `SELECT` over `reaction_entry` |
| `ml_export_all_cap_exceeded` | `cap`, `record_type` | the same over `species_entry` |
| `query_too_expensive` | `section`, `cap` | `len(block)` — rows TCKDB holds for the requested record |
| `composed_search_candidate_limit_exceeded` | `resource`, and `max_traversable` **or** `offset_max` | `expected_total` — how many records matched |

---

## The doubtful ones, argued

### 1. I found **four** corpus measurements, not two

The brief flagged `query_too_expensive` and
`composed_search_candidate_limit_exceeded`. Reading the raise sites, the
two `*_all_cap_exceeded` codes are the *purest* cases in the family and
were not on the list:

```python
all_ids = session.scalars(select(ReactionEntry.id)).all()   # no WHERE
if len(all_ids) > all_cap:
    raise ValueError(f"...refusing to export {len(all_ids)} reaction entries...")
```

That is a total row count of a table, published in `detail`, to anyone
who can reach the export route. It is the enumeration signal
`docs/specs/public_identifier_policy.md` (§"Why this matters now", item
3) rejects sequential integer primary keys for, in as many words: they
"leak the total count of objects (and roughly the upload schedule) of
every table". And `all=true` is by construction the one export request
whose size the caller did not state, so echoing the count is not echoing
their own request — it is answering a census question no route offers.

### 2. `geometry_too_large` publishes its measured value, and I think that is right

`atoms` is a server-side measurement, so by the letter of the rule it
looks withheld. Two reasons it is not:

- **It is chemistry, not holdings.** `geometry.natoms` is how many atoms
  the *molecule* has — a property of one record the caller named by
  handle. It is not a count of what TCKDB stores. No amount of sweeping
  recovers a corpus size from it.
- **It discloses strictly less than a success does.** Any request under
  the cap returns every atom of that geometry individually. Refusing the
  request and reporting "12 atoms" cannot leak more than granting it
  would.

This is the discriminator I wrote into the rule, because "did the server
compute it" does not separate the categories — the server computes
`limit_max` too. What separates them is **what the number is about**: a
count of rows TCKDB stores is holdings; anything else is not.

### 3. `composed_search_candidate_limit_exceeded` has two raise sites and they are not the same question

`collect_bounded_pages` raises it twice.

- The **first** compares `expected_total` (the match count) against
  `public_max_offset + page_size`. The bound is published as
  `max_traversable`; the match count is not.
- The **second** simply ran past the offset bound while paging and
  measures nothing at all. It publishes `offset_max` and there is no
  withheld number.

Treating them as one disclosure decision would have withheld a number
from the second site for no reason.

### 4. Withholding from `context` alone would have been decorative

`detail` is published too, and in all four cases it was the place the
count actually lived. So the count is removed from the sentence as well,
and the absence assertions are written **over the whole serialized
body**, not over `context`. This is the one place a `detail` string
changes; the other four codes' `detail` is byte-identical.

### 5. Where the count went

`logger.info` at each of the four sites — "the server-side measurement
stays in the log". Each log line is phrased so the code is **not** in the
code position (`"export refused as export_all_cap_exceeded; …"`, not
`"export_all_cap_exceeded: …"`), because
`TestNoLoggerFormatStringSitsInTheCodePosition` correctly went red on the
first draft: in this codebase a snake_case token in front of a colon is
how a code is declared, and a log line declares nothing.

---

## The rule, written somewhere durable

On `Shape` in `backend/app/api/code_catalogue.py`, under **"The
disclosure line"** — the class that owns the classification, so a future
reader deciding what to put in a new relationship's `context` finds it
where they are already looking:

> **Publish the THRESHOLD. Never publish the MEASURED VALUE that crossed
> it, where that value describes the corpus rather than the caller's own
> request.**

with the three categories (threshold / the caller's own request echoed
back / a server-side measurement of the corpus), the
`public_identifier_policy.md` citation, the chemistry-vs-holdings
discriminator, and the four codes that sit on the withheld side.

The module docstring's **"Caps are things"** bullet — which invited this
overrule — is rewritten as "Caps are relationships. Overruled
2026-08-18", carrying the argument that won and the "publishing a cap is
not a security concern" reasoning, so the next reader sees the decision
rather than only its outcome.

`app/api/error_contract.py` used `limit_too_large` as its worked example
of a *thing*. That is now false; it is moved to the relationship bullet
and the change is stated out loud rather than quietly edited.

Three more places carry the consequence, because a rule recorded only
where it is implemented is a rule nobody outside the backend can find:

- **`docs/specs/public_read_abuse_controls.md`** — the spec that owns
  the cap table gains a *"What a cap refusal discloses"* section with the
  four-row category table, the `public_identifier_policy.md` citation,
  and the "publishing a cap is not an abuse control" reasoning. This is
  the document an operator lowering `PUBLIC_MAX_OFFSET` reads.
- **`docs/clients/generic-client-targeting.md`** — a per-code table of
  the new `context` keys, an instruction to retry against the published
  threshold rather than hardcoding 200, and an explicit statement that
  the absent count is deliberate and **not a gap to report**.
- **`clients/python/README.md`** — its list of legitimate `context`
  contents said "a count" without qualification, which is now a
  half-truth. Same caveat, shorter.

---

## The absence assertions and their mutations

Each mutation was landed in the working tree, the named test run, then
reverted; `git diff --stat` verified afterwards.

| # | mutation | expected | observed |
|---|---|---|---|
| M1 | drop `context=` from `limit_too_large` | its wire test red | **1 failed** (`assert body["context"] == {"limit_max": 10, "limit": 50}`) |
| M2 | add `"rows": len(block)` to `query_too_expensive`'s `context` | its test red | **1 failed** — but on the *equality* assertion |
| M2b | leak `len(block)` into `query_too_expensive`'s **`detail`** only | the **absence** assertion red | **1 failed**, and only that one |
| M3 | leak `expected_total` into `composed_search_candidate_limit_exceeded`'s `detail` | absence assertion red | **1 failed** |
| M4 | leak `len(all_ids)` into `export_all_cap_exceeded`'s `detail` | absence assertion red | **1 failed** |
| M5 | add `"held": len(all_ids)` to `ml_export_all_cap_exceeded`'s `context` | its test red | **1 failed** |

**M2b is the one that matters.** M2 proved only that the equality
assertion works — which it would have done for any change. M2b puts the
count somewhere equality cannot see it, and the absence assertion is the
only thing in the suite that fires:

```
AssertionError: the refusal published how many calculation rows TCKDB holds
for this record. ... Body: {"code": "query_too_expensive", "detail":
"query_too_expensive: /full expansion for section 'calculations' would return
7 rows, over the public cap of 1. ...", "context": {"section": "calculations",
"cap": 1}}
```

An absence assertion never seen to fail is not evidence; these four have
now each been seen to fail.

**How the absence is asserted.** Integer *literals* are extracted from
the serialized body (`re.findall(r"\d+", …)`) and the measured value must
not be among them — rather than a substring check, so a cap of `1` and a
count of `12` cannot be confused and a public ref containing the digit
does not fail the test. Seeds are chosen so the measured value cannot
collide with the cap (7 rows against a cap of 1; 2 matches against a
bound of 1; 1 entry against a cap of 0).

**Accept-halves.** Every refusal has one in the same file: a limit inside
the lowered cap, an offset exactly *on* the boundary, a SMILES exactly at
the maximum, a geometry under the cap, a `/full` expansion under the cap
that returns all 7 rows, and (pre-existing, unchanged) the under-cap
export and ML export and the in-bound composed search.

**No assertion is "context is non-empty".** Every one is a full equality
against the exact dict.

---

## One pre-existing assertion had to be tightened — and it is not the one the brief predicted

The brief warned about `test_api_kinetics_search.py:96`, which pins
`pressure_alias_conflict`'s `context` empty. **That code is not in this
family and that assertion is untouched** — it remains the next tranche's
problem.

What did have to move is `test_error_contract_catalogue_gate.py`, and it
is exactly the obstacle the previous PR predicted for the
`*_handle_conflict` family: a carefully-reasoned gate written over a
spelling this change removes. Two assertions in
`TestOneMessageDeclaresOneCode` name `limit_too_large` and
`offset_too_large` as `message_prefix` codes. They are no longer in
`MESSAGE_PREFIX_CODES`, so the scan correctly stops seeing them.

Both were **re-pointed, not relaxed**:

- `test_the_scan_sees_the_messages_it_is_written_over` still names three
  concrete codes that must be visible, two of which are still raised from
  `scientific_read/common.py`, so a scan that stops reading that file
  still fails here. The `> 40` floor is untouched.
- `test_the_scan_would_notice_a_second_token` **gains** assertions rather
  than trading them. It keeps the historical
  `"invalid_pagination: limit_too_large: …"` ambiguity case; adds a
  positive assertion that `limit_too_large` alone is now *correctly*
  unpromotable from prose (which is the whole point of declaring it on
  the exception); and adds a fresh ambiguous/repaired pair over a code
  that is still `message_prefix`, so the detector is still shown saying
  yes as well as no. Two assertions became five.

`TestNoLoggerFormatStringSitsInTheCodePosition` also went red, on the
first draft of the four new `logger.info` calls. That is the gate working
on new code rather than a spelling problem, and the fix was to reword the
log lines, not the gate.

Mechanically verified that this PR adds no new empty-`context`
assertions: `git diff -U0 -- backend/tests | grep '^+' | grep -c
'context"] == {}'` returns **0**. (Measured on `main`, the count of
pre-existing such assertions is **19** across 13 files, not the 20-27 the
brief cites. None of the 19 pins a cap code.)

---

## Re-derived counts

| | before | after |
|---|---|---|
| entries / distinct codes | 170 / 168 | 170 / 168 |
| `Shape.relationship` | 65 entries / 63 codes | **73 / 71** |
| `Shape.thing` | 105 | **97** |
| `Surface.message_prefix` | 73 | **65** |
| `Surface.coded_exception` | 68 | **76** |

---

## Commands run

```bash
# from backend/
conda run -n tckdb_env pytest tests/api/test_api_query_caps.py \
    tests/api/test_api_untested_refusals_tier_de.py \
    tests/api/test_error_contract_catalogue_gate.py \
    tests/api/test_api_code_catalogue.py -q
DB_TEST_NAME=tckdb_test_caps244 conda run -n tckdb_env pytest tests/ -q
#   -> 8259 passed, 14 skipped in 2721.04s
conda run -n tckdb_env ruff check app tests scripts     # All checks passed
conda run -n tckdb_env mypy                             # no issues, 183 files
conda run -n tckdb_env python scripts/check_runtime_ascii.py

# from clients/python/
conda run -n tckdb_env pytest -q                        # 1371 passed

# from schemas/python/tckdb-schemas/
conda run -n tckdb_env pytest -q                        # 38 passed
```

`git diff` was read from the repository root throughout. The full suite
was run against an isolated `tckdb_test_caps244` database because sibling
agents were sharing the default one (the suite's own concurrency banner
reported five other runs on the same PostgreSQL server).

---

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no column, no enum in
`app/db/models/common.py`. `Shape` is an enum in `app/api/`, not a
database type.

## Environment variables

**None added.** Four existing settings become *visible* to clients
through `context` — `public_max_limit`, `public_max_offset`,
`max_geometry_atoms_public` and the `max_full_*_public` family — which is
the intended effect, not a side effect.

## Client version

`clients/python/pyproject.toml` 0.52.2 → **0.52.3**. Checked against
`origin/main`, not the branch point: `origin/main` is 0.52.2, so 0.52.3
is unclaimed. The README changed because its list of legitimate `context`
contents included "a count" without qualification, which is now a
half-truth; it gains the cap table's rule and the "will never tell you
how much is behind the cap" caveat.

The generated `clients/python/src/tckdb_client/rejection_codes.py` is
**not** regenerated and does not need to be: the generator reads
`client_facing()` codes/statuses and `never_retryable()` codes, and this
PR changes no code string, no status, no `reach`, no `replay`, and moves
no surface to or from `generic_fallback`/`accidental_prefix`.
`test_client_rejection_codes_generated.py` passes.

## No database primary keys in bodies

DR-0028 Req 2 holds. Every published value is a setting, a module
constant, a caller-supplied number, a section name, a record-type name,
or a resource label. The DR-0028 body observer reports clean across the
touched suites.

---

## Things in the brief I found to be false

1. **"At least two are genuinely on the wrong side of that line."** Four
   are. `export_all_cap_exceeded` and `ml_export_all_cap_exceeded` were
   publishing unfiltered table row counts in `detail` and were not on the
   brief's list of suspects.
2. **"20-27 pre-existing `context == {}` assertions across 15 files."**
   Measured on `main`: **19** assertions across **13** files. The
   substance of the warning is right; the count is not.
3. **`test_api_kinetics_search.py:96` did not need tightening.** It pins
   `pressure_alias_conflict`, which is not in this family. The prediction
   that "one of yours may be frozen that way" turned out to apply to a
   different mechanism — the catalogue gate's static scan, not an
   empty-`context` assertion.
4. **The line as stated is slightly narrower than the wire.** On
   `smiles_too_long`, `detail` echoes the caller's 2049-character SMILES
   back verbatim — FastAPI's request-validation error includes the
   rejected `input`. That is permitted ("echoing the caller's own request
   is fine") but it is worth naming, because a first draft of the test
   asserted the string was absent from the body and was wrong. The
   assertion now says what it can honestly say: the string is not
   duplicated into `context`.
