### PR TITLE
Tell "I could not look" apart from "your code is bad"

### DIFF
--- a/backend/scripts/aggregate_pr_gates.py
+++ b/backend/scripts/aggregate_pr_gates.py
@@ -58,11 +58,44 @@ A run that exists and concluded anything other than ``success`` -- including
 ``skipped``, which for a whole run means every job was skipped and no gate
 actually executed -- is a failure.
 
+WHEN GITHUB ITSELF IS THE THING THAT FAILED
+-------------------------------------------
+Every state above is read through the Actions API, so an API that will
+not answer is a fourth state: *gate state unknown*. It is not a fourth
+outcome. Until 2026-08-18 a single HTTP error anywhere in the run listing
+exited 2 with the message ``GitHub API error 504``, which on a required
+check reads, to everyone who sees it, as "your code is bad". During the
+2026-08-17 GitHub incident that happened repeatedly: on one pull request
+``Required gates`` went red at 53 seconds with every underlying gate
+green, and re-running the job alone -- no code change -- turned it green.
+
+So API failures are now classified rather than lumped:
+
+  * ``429``, ``500``, ``502``, ``503``, ``504`` are transient by
+    definition and are retried with exponential backoff, honouring
+    ``Retry-After`` when GitHub sends one.
+  * ``401`` and ``404`` are not. They mean a bad token or the wrong
+    repository, and no amount of waiting fixes either; retrying them
+    would hide a real misconfiguration behind a several-minute timeout.
+  * ``403`` is ambiguous on GitHub -- it is both "you may not do that"
+    and "you are rate limited". The **headers** decide, not the status:
+    ``Retry-After``, or ``X-RateLimit-Remaining: 0``, means wait;
+    anything else is a permissions failure and fails fast. Reading the
+    status alone misclassifies one of the two, in whichever direction.
+
+When retries are exhausted the exit is still non-zero -- a check that
+could not look must not report green -- but the message says so in those
+words: gate state could not be determined, and this is not a test
+failure. The retry uses the same injected ``sleep`` as the poll loop
+below, so the whole thing stays deterministic under test and bounded by
+the same deadline.
+
 RE-RUNS
 -------
 Branch protection reads the latest check for a context. If you re-run a
 gate workflow after a failure, re-run this job too ("Re-run failed jobs"
 on the Repo Gate run); it will re-read the gates' current conclusions.
+The same re-run is the fix for an exhausted-retry exit.
 """
 
 from __future__ import annotations
@@ -113,6 +146,31 @@ NOT_APPLICABLE = "not-applicable"
 #: is terminal is a failure, listed nowhere: an allow-list here is the one
 #: place a new GitHub conclusion string could quietly become a pass.
 SUCCESSFUL_CONCLUSIONS = frozenset({"success"})
+
+#: HTTP statuses that mean "GitHub could not answer just now". Transient
+#: by definition: 429 is the documented rate-limit status, and 5xx is the
+#: server saying the failure is its own.
+RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+#: Statuses that waiting cannot fix. 401 is a missing, expired or
+#: unscoped token. 404 is the wrong repository -- or a token that cannot
+#: see the right one, since GitHub answers 404 rather than 403 rather
+#: than confirm a private repository exists. Retrying either turns a
+#: five-second, legible misconfiguration into a several-minute timeout
+#: that reads like an outage.
+FAIL_FAST_STATUSES = frozenset({401, 404})
+
+#: How many times a retryable call is attempted in total, and the backoff
+#: schedule between attempts (2s, 4s, 8s, 16s -- about half a minute of
+#: waiting, against a poll loop that already tolerates 95 minutes).
+API_ATTEMPTS = 5
+API_BACKOFF_SECONDS = 2.0
+API_MAX_BACKOFF_SECONDS = 30.0
+
+#: A server is allowed to ask for a wait, but not an unbounded one; a
+#: ``Retry-After`` past this is clamped so a malformed or hostile header
+#: cannot park the job until the workflow timeout kills it.
+MAX_RETRY_AFTER_SECONDS = 60.0
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +321,134 @@ def overall_state(states: dict[str, tuple[str, str]]) -> str:
 # ---------------------------------------------------------------------------
 
 
+#: The exception types a call to the GitHub API can fail with.
+#: ``HTTPError`` is a subclass of ``URLError``, so this catches "the
+#: server answered badly" and "there was no answer" alike. ``TimeoutError``
+#: is listed separately because ``urlopen(timeout=...)`` can surface a read
+#: timeout as a bare ``TimeoutError`` rather than wrapping it.
+API_EXCEPTIONS = (urllib.error.URLError, TimeoutError)
+
+
+def _header(error: BaseException, name: str) -> str | None:
+    """One header off an ``HTTPError``, or None if there are no headers.
+
+    ``HTTPError.headers`` is an ``email.message.Message``, whose ``get``
+    is case-insensitive -- which matters, because GitHub sends
+    ``x-ratelimit-remaining`` in lower case and the documentation spells
+    it ``X-RateLimit-Remaining``.
+    """
+    headers = getattr(error, "headers", None)
+    if headers is None:
+        return None
+    value = headers.get(name)
+    return None if value is None else str(value)
+
+
+def forbidden_is_rate_limiting(error: BaseException) -> bool:
+    """Is this 403 a rate limit (wait) or a permissions failure (stop)?
+
+    GitHub overloads 403 for both. A primary rate limit sets
+    ``X-RateLimit-Remaining: 0``; a secondary rate limit sets
+    ``Retry-After``. A permissions failure carries neither -- it still
+    carries rate-limit headers, but with budget remaining, which is
+    exactly what distinguishes it.
+
+    Reading the status alone gets one of the two wrong whichever way you
+    guess: treat all 403s as transient and a token missing ``actions:
+    read`` burns the backoff before failing with a misleading story;
+    treat them all as fatal and a rate limit that would have cleared in
+    sixty seconds blocks a green pull request.
+    """
+    if _header(error, "Retry-After") is not None:
+        return True
+    remaining = _header(error, "X-RateLimit-Remaining")
+    return remaining is not None and remaining.strip() == "0"
+
+
+def is_retryable(error: BaseException) -> bool:
+    """Would trying this same call again plausibly succeed?"""
+    if not isinstance(error, urllib.error.HTTPError):
+        # No HTTP response at all: a reset connection, a DNS hiccup, a read
+        # timeout. Nothing here says the request was wrong, only that it did
+        # not complete.
+        return True
+    if error.code == 403:
+        return forbidden_is_rate_limiting(error)
+    return error.code in RETRYABLE_STATUSES
+
+
+def retry_after_seconds(error: BaseException) -> float | None:
+    """The server's own requested wait, in seconds, if it gave a usable one.
+
+    ``Retry-After`` may also be an HTTP date; that form is ignored rather
+    than parsed, and the caller falls back to its backoff schedule. A
+    wrong wait is worse than no wait.
+    """
+    raw = _header(error, "Retry-After")
+    if raw is None:
+        return None
+    try:
+        value = float(raw.strip())
+    except ValueError:
+        return None
+    return max(0.0, min(value, MAX_RETRY_AFTER_SECONDS))
+
+
+def describe_api_error(error: BaseException) -> str:
+    """An API failure in the terms a reader of the job log needs."""
+    if isinstance(error, urllib.error.HTTPError):
+        # ``url`` is only populated when the error carries a response body;
+        # ``filename`` is set unconditionally by HTTPError.__init__.
+        url = getattr(error, "url", None) or getattr(error, "filename", None)
+        return f"HTTP {error.code} from {url}"
+    reason = getattr(error, "reason", error)
+    return f"{type(error).__name__}: {reason}"
+
+
+def retrying_fetch(
+    fetch: Callable[[str], object],
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    attempts: int = API_ATTEMPTS,
+    backoff_seconds: float = API_BACKOFF_SECONDS,
+    max_backoff_seconds: float = API_MAX_BACKOFF_SECONDS,
+    log: Callable[[str], None] = print,
+) -> Callable[[str], object]:
+    """``fetch``, but transient GitHub failures are retried with backoff.
+
+    Non-retryable failures propagate on the first attempt, deliberately:
+    the classification above is the whole feature, and a wrapper that
+    retried everything would be the blanket retry this replaced.
+    """
+    if attempts < 1:
+        raise ValueError("a fetch that is never attempted cannot answer anything")
+
+    def fetch_with_retries(path: str) -> object:
+        delay = backoff_seconds
+        for attempt in range(1, attempts + 1):
+            try:
+                return fetch(path)
+            except API_EXCEPTIONS as error:
+                if not is_retryable(error):
+                    log(f"{describe_api_error(error)}: waiting cannot fix this, so it is not retried")
+                    raise
+                if attempt == attempts:
+                    log(f"{describe_api_error(error)}: still failing after {attempts} attempts")
+                    raise
+                wait = retry_after_seconds(error)
+                if wait is None:
+                    wait = delay
+                log(
+                    f"{describe_api_error(error)} on attempt {attempt} of {attempts}; "
+                    f"retrying in {wait:g}s -- this is GitHub, not a gate"
+                )
+                sleep(wait)
+                delay = min(delay * 2, max_backoff_seconds)
+        raise AssertionError("unreachable: the loop above always returns or raises")
+
+    return fetch_with_retries
+
+
 def _api_fetch(base_url: str, token: str | None) -> Callable[[str], object]:
     def fetch(path: str) -> object:
         request = urllib.request.Request(f"{base_url}{path}")
@@ -335,6 +521,7 @@ def aggregate(
     repo_root: Path | None = None,
     deadline_seconds: float = 95 * 60,
     poll_seconds: float = 20.0,
+    api_attempts: int = API_ATTEMPTS,
     now: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
     log: Callable[[str], None] = print,
@@ -348,6 +535,13 @@ def aggregate(
         # gate should not depend on a test elsewhere to refuse to be vacuous.
         raise ValueError("no workflows to aggregate; a check over nothing is not a check")
     parsed = {rel: load_workflow(rel, repo_root) for rel in workflows}
+
+    # Every API call below goes through the retry, including the changed-file
+    # listing: a 502 there is exactly as transient, and exactly as capable of
+    # turning a green tree red, as a 502 on the run listing. It reuses this
+    # function's injected ``sleep``, so a test's fake clock covers the
+    # backoff as well as the poll and nothing here ever really waits.
+    fetch = retrying_fetch(fetch, sleep=sleep, attempts=api_attempts, log=log)
 
     changed_files, files_truncated = fetch_changed_files(fetch, repo, pr_number)
     log(f"pull request #{pr_number} changes {len(changed_files)} path(s) at head {head_sha}")
@@ -363,7 +557,9 @@ def aggregate(
         rel: workflow_is_expected(parsed[rel], changed_files, files_truncated=files_truncated) for rel in workflows
     }
     for rel in workflows:
-        log(f"paths: filter for {rel} -> {'expected to run' if expected[rel] else 'not triggered by this pull request'}")
+        log(
+            f"paths: filter for {rel} -> {'expected to run' if expected[rel] else 'not triggered by this pull request'}"
+        )
 
     started = now()
     states: dict[str, tuple[str, str]] = {}
@@ -416,6 +612,57 @@ def _write_summary(states: dict[str, tuple[str, str]], ok: bool) -> None:
         handle.write("\n".join(lines) + "\n")
 
 
+def indeterminate_report(error: BaseException, *, attempts: int = API_ATTEMPTS) -> str:
+    """What to say when the gates' state could not be read at all.
+
+    The old message was ``GitHub API error 504``, on a check named
+    "Required gates". Every reader of that -- author, reviewer, the person
+    deciding whether to re-run -- takes a red required check to mean the
+    code is bad. It is the same defect this repository has spent the week
+    removing from its error contract: a failure that cannot say whether it
+    is *your code* or *my eyesight*. So the first line says which, in
+    words, before any status code appears.
+    """
+    lines = [
+        "GATE STATE COULD NOT BE DETERMINED. This is NOT a test failure:",
+        "no gate reported red. This job was unable to read the gates' state",
+        "from the GitHub API, so it cannot honestly report success either.",
+        "",
+        f"  {describe_api_error(error)}",
+        "",
+    ]
+    if is_retryable(error):
+        lines += [
+            f"That is a transient failure and it was retried {attempts} times with",
+            "backoff before giving up. Nothing about this pull request is implicated.",
+            "",
+            'Re-run this job on its own ("Re-run failed jobs" on the Repo Gate run).',
+            "If it keeps failing, check https://www.githubstatus.com/ before",
+            "looking at the branch.",
+        ]
+    else:
+        lines += [
+            "That status does not clear by waiting, so it was deliberately NOT",
+            "retried: it means this job is misconfigured, not that a gate is red.",
+            "Check that --repo names the right repository and that GITHUB_TOKEN",
+            "still carries the 'actions: read' and 'pull-requests: read' permissions",
+            "granted in .github/workflows/repo-gate.yml.",
+        ]
+    return "\n".join(lines)
+
+
+def _write_indeterminate_summary(error: BaseException, *, attempts: int = API_ATTEMPTS) -> None:
+    """Put the same explanation in the job summary, where people look first."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    body = "\n".join(
+        f"> {line}" if line else ">" for line in indeterminate_report(error, attempts=attempts).split("\n")
+    )
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write(f"## Required gates\n\n{body}\n\nResult: **indeterminate**\n")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
@@ -461,8 +708,13 @@ def main(argv: list[str] | None = None) -> int:
             deadline_seconds=args.deadline_minutes * 60,
             poll_seconds=args.poll_seconds,
         )
-    except urllib.error.HTTPError as error:
-        print(f"GitHub API error {error.code} for {error.url}", file=sys.stderr)
+    except API_EXCEPTIONS as error:
+        # Retries have already been exhausted inside aggregate(), or the
+        # failure was one that retrying could not fix. Either way the exit is
+        # non-zero -- a check that could not look must never report green --
+        # but it says which of the two it is.
+        _write_indeterminate_summary(error)
+        print(indeterminate_report(error), file=sys.stderr)
         return 2
 
     _write_summary(states, ok)

--- a/backend/tests/scripts/test_aggregate_pr_gates.py
+++ b/backend/tests/scripts/test_aggregate_pr_gates.py
@@ -9,17 +9,27 @@ shipped four guards that could not fail (#79 a nightly red nobody read,
 #82 a sweep that verified nothing and exited 0, #93 a step that never
 executed, #95 three suites run by no job), and two of the guards written
 to close that family shipped containing it. So the tests below are
-weighted toward the three ways this one could join them:
+weighted toward the four ways this one could join them:
 
   * an absent workflow run read as "legitimately skipped" when it is
     merely late -- a false pass;
   * a failing gate whose conclusion is not one of the strings the folder
     treats as failure -- a false pass;
   * a gate that never appears being waited on forever -- a hang, which
-    on a required check is indistinguishable from a block.
+    on a required check is indistinguishable from a block;
+  * a GitHub API hiccup reported as though a gate had gone red -- a false
+    *fail*, the mirror image of the first three and the one that actually
+    bit, on 2026-08-17, when a 504 blocked a pull request whose gates had
+    all passed.
 
-The decision core is pure and the API is a callable, so all three are
-reachable here without a network.
+The retry tests below assert **attempt counts**, not just outcomes. A
+test that only asserts "a bad status exits non-zero" passes against the
+unfixed code, which is how the defect survived: the outcome was right and
+the number of attempts was the whole bug.
+
+The decision core is pure and the API is a callable, so all four are
+reachable here without a network -- the fourth by handing that callable
+an exception instead of a payload.
 
 Run under ``--noconftest`` by ``.github/workflows/repo-gate.yml`` as well
 as by the backend complement gate, hence the importlib loader below
@@ -31,7 +41,9 @@ ahead of real packages.
 
 from __future__ import annotations
 
+import email.message
 import importlib.util
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -428,6 +440,312 @@ def test_a_red_gate_short_circuits_the_wait():
     ok, _ = drive(api)
     assert not ok
     assert api.run_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Transient GitHub failures vs real ones
+#
+# The property under test is the *number of attempts*, in both directions.
+# "A 504 exits non-zero" and "a 404 exits non-zero" are both true of the
+# code before the retry existed, so neither is evidence of anything.
+# ---------------------------------------------------------------------------
+
+
+def http_error(code: int, **headers: str) -> urllib.error.HTTPError:
+    """A GitHub error response, headers and all."""
+    message = email.message.Message()
+    for name, value in headers.items():
+        message[name.replace("_", "-")] = value
+    return urllib.error.HTTPError("https://api.github.com/repos/o/r/actions/runs", code, "error", message, None)
+
+
+class FlakyFetch:
+    """A fetch that fails ``failures`` times and then answers.
+
+    Counts every call, which is the assertion the retry tests are for.
+    """
+
+    def __init__(self, error: BaseException, failures: int = 10**6, answer: object = "ok"):
+        self.error = error
+        self.failures = failures
+        self.answer = answer
+        self.calls = 0
+
+    def __call__(self, path: str) -> object:
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise self.error
+        return self.answer
+
+
+def wrap(fetch, *, attempts: int = 5):
+    """``retrying_fetch`` with the clock replaced, plus the list of waits."""
+    waits: list[float] = []
+    wrapped = gates.retrying_fetch(
+        fetch,
+        sleep=waits.append,
+        attempts=attempts,
+        backoff_seconds=2.0,
+        max_backoff_seconds=30.0,
+        log=lambda _message: None,
+    )
+    return wrapped, waits
+
+
+def test_the_two_status_sets_are_populated_and_disjoint():
+    """A parametrize over an empty set is a green test that ran nothing.
+
+    Two of the tests below iterate these sets, so emptying either one
+    would turn them into skips rather than failures -- the house defect,
+    reintroduced in the very tests written to close it. Pin the contents
+    directly, where an edit has to argue with a literal.
+    """
+    assert gates.RETRYABLE_STATUSES == {429, 500, 502, 503, 504}
+    assert gates.FAIL_FAST_STATUSES == {401, 404}
+    assert not gates.RETRYABLE_STATUSES & gates.FAIL_FAST_STATUSES
+    assert 403 not in gates.RETRYABLE_STATUSES | gates.FAIL_FAST_STATUSES, "403 is decided by headers, not by a set"
+
+
+@pytest.mark.parametrize("code", sorted(gates.RETRYABLE_STATUSES))
+def test_a_transient_status_is_retried_and_succeeds_when_github_recovers(code):
+    """More than one attempt, and the recovery is actually taken.
+
+    This is the 2026-08-17 incident as a unit: the first call gets a 504
+    from a GitHub that is having a bad minute, the second gets the run
+    listing, and the pull request is not blocked.
+    """
+    fetch = FlakyFetch(http_error(code), failures=2, answer={"workflow_runs": []})
+    wrapped, waits = wrap(fetch)
+
+    assert wrapped("/anything") == {"workflow_runs": []}
+    assert fetch.calls == 3, "a transient status must be retried, not reported as a gate result"
+    assert waits == [2.0, 4.0], "and the retries must back off rather than hammer"
+
+
+@pytest.mark.parametrize("code", sorted(gates.FAIL_FAST_STATUSES))
+def test_a_status_that_cannot_clear_is_attempted_exactly_once(code):
+    """401 and 404 are misconfigurations. Retrying hides them behind a timeout."""
+    fetch = FlakyFetch(http_error(code))
+    wrapped, waits = wrap(fetch)
+
+    with pytest.raises(urllib.error.HTTPError):
+        wrapped("/anything")
+    assert fetch.calls == 1, f"{code} must not be retried; waiting cannot fix it"
+    assert waits == []
+
+
+def test_a_404_is_attempted_exactly_once_even_if_it_would_have_recovered():
+    """The count is the point, so pin it against a server that recovers.
+
+    If 404 were retryable this fetch would answer on the second call and
+    the test would see two attempts and no exception.
+    """
+    fetch = FlakyFetch(http_error(404), failures=1, answer={"workflow_runs": []})
+    wrapped, _ = wrap(fetch)
+
+    with pytest.raises(urllib.error.HTTPError):
+        wrapped("/anything")
+    assert fetch.calls == 1
+
+
+def test_retries_are_bounded_and_the_error_survives_them():
+    fetch = FlakyFetch(http_error(503))
+    wrapped, waits = wrap(fetch, attempts=4)
+
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        wrapped("/anything")
+    assert caught.value.code == 503
+    assert fetch.calls == 4, "exactly the attempt budget, no more and no fewer"
+    assert waits == [2.0, 4.0, 8.0], "one wait between attempts, none after the last"
+
+
+def test_the_backoff_is_capped():
+    fetch = FlakyFetch(http_error(500))
+    wrapped, waits = wrap(fetch, attempts=8)
+
+    with pytest.raises(urllib.error.HTTPError):
+        wrapped("/anything")
+    assert waits == [2.0, 4.0, 8.0, 16.0, 30.0, 30.0, 30.0]
+
+
+def test_a_fetch_that_is_never_attempted_is_refused():
+    """Zero attempts is a wrapper that reports nothing, vacuously."""
+    with pytest.raises(ValueError, match="never attempted"):
+        gates.retrying_fetch(FlakyFetch(http_error(500)), attempts=0)
+
+
+# --- the 403, in both directions -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        pytest.param({"Retry-After": "1"}, id="secondary-rate-limit-retry-after"),
+        pytest.param({"X-RateLimit-Remaining": "0"}, id="primary-rate-limit-exhausted"),
+        pytest.param({"x-ratelimit-remaining": "0"}, id="lowercase-as-github-actually-sends-it"),
+    ],
+)
+def test_a_403_that_the_headers_call_a_rate_limit_is_retried(headers):
+    """GitHub overloads 403. The headers are what tell the two apart."""
+    error = http_error(403, **headers)
+    assert gates.forbidden_is_rate_limiting(error)
+    assert gates.is_retryable(error)
+
+    fetch = FlakyFetch(error, failures=1, answer={"workflow_runs": []})
+    wrapped, _ = wrap(fetch)
+    assert wrapped("/anything") == {"workflow_runs": []}
+    assert fetch.calls == 2, "a rate-limited 403 clears by waiting and must be waited on"
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        pytest.param({}, id="no-headers-at-all"),
+        pytest.param({"X-RateLimit-Remaining": "4998"}, id="budget-remaining-so-not-a-rate-limit"),
+    ],
+)
+def test_a_403_the_headers_do_not_excuse_is_attempted_exactly_once(headers):
+    """A permissions 403 is a missing token scope. Backing off just delays the news."""
+    error = http_error(403, **headers)
+    assert not gates.forbidden_is_rate_limiting(error)
+
+    fetch = FlakyFetch(error, failures=1, answer={"workflow_runs": []})
+    wrapped, waits = wrap(fetch)
+    with pytest.raises(urllib.error.HTTPError):
+        wrapped("/anything")
+    assert fetch.calls == 1, "a permissions 403 must fail fast, not burn the backoff"
+    assert waits == []
+
+
+def test_retry_after_overrides_the_backoff_schedule():
+    fetch = FlakyFetch(http_error(429, Retry_After="7"), failures=1, answer="ok")
+    wrapped, waits = wrap(fetch)
+    assert wrapped("/anything") == "ok"
+    assert waits == [7.0], "the server's own requested wait wins over our schedule"
+
+
+def test_a_hostile_retry_after_is_clamped_and_a_malformed_one_ignored():
+    assert gates.retry_after_seconds(http_error(429, Retry_After="99999")) == gates.MAX_RETRY_AFTER_SECONDS
+    assert gates.retry_after_seconds(http_error(429, Retry_After="Wed, 21 Oct 2026 07:28:00 GMT")) is None
+    assert gates.retry_after_seconds(http_error(429)) is None
+
+
+def test_a_connection_that_never_produced_a_response_is_retried():
+    """No HTTP status at all: a reset, a DNS blip, a read timeout."""
+    fetch = FlakyFetch(urllib.error.URLError("connection reset by peer"), failures=1, answer="ok")
+    wrapped, _ = wrap(fetch)
+    assert wrapped("/anything") == "ok"
+    assert fetch.calls == 2
+
+    fetch = FlakyFetch(TimeoutError("timed out"), failures=1, answer="ok")
+    wrapped, _ = wrap(fetch)
+    assert wrapped("/anything") == "ok"
+    assert fetch.calls == 2
+
+
+# --- the same thing, through the real driver -------------------------------
+
+
+class FlakyApi(FakeApi):
+    """A FakeApi that throws ``error`` on the first ``failures`` run listings."""
+
+    def __init__(self, changed, run_sequence, error: BaseException, failures: int):
+        super().__init__(changed, run_sequence)
+        self.error = error
+        self.failures = failures
+        self.raised = 0
+
+    def __call__(self, path: str):
+        if "/files" not in path and self.raised < self.failures:
+            self.raised += 1
+            raise self.error
+        return super().__call__(path)
+
+
+def test_the_driver_survives_a_transient_error_on_the_run_listing():
+    """The incident, end to end: a 504 mid-poll must not turn a green tree red."""
+    api = FlakyApi(
+        ["backend/app/x.py"],
+        [[own_run(), run(BACKEND_CI, conclusion="success")]],
+        http_error(504),
+        failures=2,
+    )
+    ok, states = drive(api)
+    assert ok, "a 504 on the run listing is not a red gate"
+    assert api.raised == 2, "the transient failures must actually have been hit"
+    assert states[BACKEND_CI][0] == gates.PASSED
+
+
+def test_the_driver_does_not_retry_a_misconfiguration():
+    api = FlakyApi(["backend/app/x.py"], [[own_run()]], http_error(404), failures=1)
+    with pytest.raises(urllib.error.HTTPError):
+        drive(api)
+    assert api.raised == 1, "the 404 must reach the caller on the first attempt"
+
+
+def test_the_driver_gives_up_after_its_attempt_budget():
+    api = FlakyApi(["backend/app/x.py"], [[own_run()]], http_error(502), failures=10**6)
+    with pytest.raises(urllib.error.HTTPError):
+        drive(api)
+    assert api.raised == gates.API_ATTEMPTS
+
+
+# --- what it says when it could not look -----------------------------------
+
+
+def test_the_exhausted_message_says_it_is_not_a_test_failure():
+    """``GitHub API error 504`` on a check named "Required gates" reads as "your code is bad"."""
+    report = gates.indeterminate_report(http_error(504))
+    assert "NOT a test failure" in report
+    assert "COULD NOT BE DETERMINED" in report
+    assert "504" in report
+    assert report.splitlines()[0].startswith("GATE STATE COULD NOT BE DETERMINED")
+    assert "no gate reported red" in report
+
+
+def test_the_fail_fast_message_names_the_misconfiguration_instead():
+    report = gates.indeterminate_report(http_error(404))
+    flowed = " ".join(report.split())  # the message is hard-wrapped; the wording is not
+    assert "NOT a test failure" in flowed
+    assert "not retried" in flowed.lower()
+    assert "githubstatus" not in flowed.lower(), "a 404 is not an outage; do not send the reader there"
+
+
+def test_main_reports_an_exhausted_retry_as_indeterminate(monkeypatch, capsys):
+    """Non-zero, because a check that could not look must not report green."""
+
+    def explode(**_kwargs):
+        raise http_error(504)
+
+    # Do not append this deliberate failure to the real job summary: these
+    # tests run inside the Repo Gate job, where GITHUB_STEP_SUMMARY is set.
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(gates, "aggregate", explode)
+    code = gates.main(
+        ["--event-name", "pull_request", "--repo", "o/r", "--pr-number", "3", "--head-sha", "abc", "--run-id", "9"]
+    )
+    assert code == 2
+    stderr = capsys.readouterr().err
+    assert "NOT a test failure" in stderr
+    assert "504" in stderr
+
+
+def test_main_reports_a_misconfiguration_without_retrying_it(monkeypatch, capsys):
+    """The whole path, not a stubbed aggregate: no sleep happens, so it is fast."""
+    calls: list[str] = []
+
+    def fetch(path: str):
+        calls.append(path)
+        raise http_error(401)
+
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(gates, "_api_fetch", lambda _base, _token: fetch)
+    code = gates.main(
+        ["--event-name", "pull_request", "--repo", "o/r", "--pr-number", "3", "--head-sha", "abc", "--run-id", "9"]
+    )
+    assert code == 2
+    assert len(calls) == 1, "a 401 must not be retried through the real entry point either"
+    assert "NOT a test failure" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## In plain language

`Required gates` is the one check GitHub's branch protection actually looks at, so
it is what decides whether a pull request can merge. It does not run any tests
itself — it asks GitHub's API "did the test workflows pass?" and reports the
answer.

Until now, if that *question* failed — GitHub having a bad minute, a 504 from an
overloaded server — the script gave up immediately and reported a red check with
the message `GitHub API error 504`. To anyone reading it, a red required check
means "your code is broken". It did not mean that. It meant "I could not see".

During the GitHub incident on 2026-08-17 this happened repeatedly. On one pull
request `Required gates` went red at 53 seconds while every underlying test
workflow was green; re-running just that job, changing nothing, turned it green.

This PR teaches the script three things:

1. **Ask again** when the failure is the kind that goes away on its own, waiting a
   little longer each time.
2. **Do not ask again** when the failure is a genuine misconfiguration — a bad
   token, the wrong repository. Retrying those would just turn a five-second,
   legible error into a several-minute one that looks like an outage.
3. **Say which it is.** If it still cannot get an answer, it still fails (a check
   that could not look must never claim green), but the message now begins
   `GATE STATE COULD NOT BE DETERMINED. This is NOT a test failure`.

## The defect

`backend/scripts/aggregate_pr_gates.py`, before this change:

```python
except urllib.error.HTTPError as error:
    print(f"GitHub API error {error.code} for {error.url}", file=sys.stderr)
    return 2
```

One HTTP error anywhere in the run listing exited non-zero, with no retry.
`Required gates` is a required context on `main`, so a transient GitHub 5xx became
a blocked pull request on a green tree.

## Classification, and why each way

A blanket retry would be wrong — it would hide real misconfiguration behind a
timeout. So failures are classified:

| Status | Behaviour | Reason |
|---|---|---|
| `429`, `500`, `502`, `503`, `504` | **Retry** with backoff | Transient by definition: 429 is the documented rate-limit status; a 5xx is the server saying the failure is its own. Nothing about the request was wrong. |
| `401` | **Fail fast** | Missing, expired or unscoped token. No amount of waiting mints a token. |
| `404` | **Fail fast** | Wrong repository — or a token that cannot see the right one, since GitHub answers 404 rather than 403 rather than confirm a private repo exists. Retrying delays the only useful signal. |
| `403` | **Headers decide** — see below | Ambiguous on GitHub. |
| No HTTP response at all (`URLError`, `TimeoutError`) | **Retry** | A reset connection, a DNS hiccup, a read timeout. The request never completed; nothing says it was wrong. Previously these were not even caught — they produced a traceback and exit 1, which reads as a red gate. |

Backoff is 2s, 4s, 8s, 16s, capped at 30s, five attempts total — roughly thirty
seconds of patience against a poll loop that already tolerates 95 minutes. A
numeric `Retry-After` overrides the schedule (clamped to 60s so a malformed or
hostile header cannot park the job until the workflow timeout kills it); the
HTTP-date form of `Retry-After` is ignored rather than parsed, on the grounds that
a wrong wait is worse than no wait.

## How the 403 is disambiguated

GitHub returns 403 both for "you may not do that" and for "you are going too
fast", so the status alone misclassifies one of the two in whichever direction you
guess. `forbidden_is_rate_limiting()` reads the headers:

* `Retry-After` present → **rate limit** (this is how secondary rate limits
  arrive) → retry.
* `X-RateLimit-Remaining: 0` → **primary rate limit exhausted** → retry.
* Neither — including the common case of rate-limit headers present with budget
  still remaining → **permissions failure** → fail fast.

Header lookup goes through `HTTPError.headers`, an `email.message.Message`, whose
`get` is case-insensitive: GitHub sends `x-ratelimit-remaining` in lower case
while the documentation spells it `X-RateLimit-Remaining`. A test covers the
lower-case spelling explicitly.

`403` is deliberately in neither `RETRYABLE_STATUSES` nor `FAIL_FAST_STATUSES`,
and a test asserts that, so nobody can later resolve the ambiguity by dropping it
into a set.

## Where the retry lives

It reuses the machinery that was already there rather than adding a second one.
`retrying_fetch()` wraps the injectable `fetch` callable inside `aggregate()`,
using **the same injected `sleep`** the poll loop uses. Consequences:

* tests drive it with a fake clock and never actually wait;
* the existing `deadline_seconds` still bounds the whole run;
* the changed-file listing is covered as well as the run listing — a 502 there is
  exactly as transient and exactly as capable of turning a green tree red.

## What it says when retries are exhausted

Exit is still non-zero. The message is now (stderr, and appended to
`GITHUB_STEP_SUMMARY` where readers look first):

```
GATE STATE COULD NOT BE DETERMINED. This is NOT a test failure:
no gate reported red. This job was unable to read the gates' state
from the GitHub API, so it cannot honestly report success either.

  HTTP 504 from https://api.github.com/repos/.../actions/runs

That is a transient failure and it was retried 5 times with
backoff before giving up. Nothing about this pull request is implicated.

Re-run this job on its own ("Re-run failed jobs" on the Repo Gate run).
If it keeps failing, check https://www.githubstatus.com/ before
looking at the branch.
```

The fail-fast branch says the other thing instead: that the status does not clear
by waiting, that it was deliberately *not* retried, and which permissions to
check. It does not send the reader to githubstatus.com — a 404 is not an outage,
and a test pins that.

## Attempt counts asserted

The property under test is the **number of attempts**, not the outcome. "A 504
exits non-zero" and "a 404 exits non-zero" are both true of the *unfixed* code, so
neither is evidence of anything. New tests in
`backend/tests/scripts/test_aggregate_pr_gates.py`:

* every status in `RETRYABLE_STATUSES` (parametrized): fails twice then recovers →
  **3 calls**, waits `[2.0, 4.0]`, and the recovered answer is returned;
* every status in `FAIL_FAST_STATUSES` (parametrized): **exactly 1 call**, no
  sleeps, error propagates;
* 404 against a server that *would* have recovered on the second call: still
  **exactly 1 call** — the count is pinned against a fixture that would expose a
  silent retry;
* attempt budget: always-503 with `attempts=4` → **exactly 4 calls**, waits
  `[2.0, 4.0, 8.0]` (one between attempts, none after the last);
* backoff cap: `attempts=8` → `[2, 4, 8, 16, 30, 30, 30]`;
* 403 **with** rate-limit headers (three spellings, incl. lower-case) → **2 calls**
  and success; 403 **without** them (and with budget remaining) → **1 call**;
* `Retry-After: 7` → the single wait is `7.0`, not the schedule's `2.0`;
* through the real driver: a 504 on the first two run listings still ends in
  `ok=True` with the gate `PASSED`, and the fixture asserts the failures were
  actually hit; a 404 through the driver reaches the caller after **1** raise; an
  always-502 gives up after exactly `API_ATTEMPTS`;
* `attempts=0` is refused — a fetch that is never attempted cannot answer
  anything;
* `test_the_two_status_sets_are_populated_and_disjoint` pins the set contents, so
  emptying one turns two parametrized tests into *skips* rather than failures.
  (This was found by mutation 1 below, which produced `1 skipped` — the house
  defect reappearing inside the tests written to close it.)

## Mutations run

Both required mutations were applied to the source, the suite re-run, and the
source restored from a byte-for-byte backup.

**1. `RETRYABLE_STATUSES = frozenset()`** → **5 failed, 56 passed, 1 skipped**

```
FAILED test_retry_after_overrides_the_backoff_schedule
FAILED test_the_driver_gives_up_after_its_attempt_budget
FAILED test_retries_are_bounded_and_the_error_survives_them
FAILED test_the_backoff_is_capped
FAILED test_the_driver_survives_a_transient_error_on_the_run_listing
```

**2. `is_retryable` body replaced with `return True`** → **8 failed, 58 passed**

```
FAILED test_the_driver_does_not_retry_a_misconfiguration
FAILED test_the_fail_fast_message_names_the_misconfiguration_instead
FAILED test_a_404_is_attempted_exactly_once_even_if_it_would_have_recovered
FAILED test_a_403_the_headers_do_not_excuse_is_attempted_exactly_once[budget-remaining-so-not-a-rate-limit]
FAILED test_a_403_the_headers_do_not_excuse_is_attempted_exactly_once[no-headers-at-all]
FAILED test_main_reports_a_misconfiguration_without_retrying_it
FAILED test_a_status_that_cannot_clear_is_attempted_exactly_once[404]
FAILED test_a_status_that_cannot_clear_is_attempted_exactly_once[401]
```

## Schema / migration impact

None. No model, schema, migration, environment variable or API surface is
touched. The change is confined to the CI aggregator script and its tests.

## Verification

Run from `backend/`:

```bash
conda run -n tckdb_env python -m pytest --noconftest -q tests/scripts/test_aggregate_pr_gates.py tests/scripts/test_gate_coverage.py
# 94 passed

DB_TEST_NAME=tckdb_test_a5c9d92 conda run -n tckdb_env python -m pytest tests/ -q
# 8292 passed, 14 skipped in 2880.50s (0:48:00)

conda run -n tckdb_env ruff format --check scripts/aggregate_pr_gates.py tests/scripts/test_aggregate_pr_gates.py
conda run -n tckdb_env ruff check scripts/aggregate_pr_gates.py tests/scripts/test_aggregate_pr_gates.py
# both clean
```

`--noconftest` is how `.github/workflows/repo-gate.yml` runs these two files, so
that invocation is the one that matters for the gate itself.
