### PR TITLE
Say the deployment is well, not only when it is not

### DIFF
--- a/.github/workflows/repo-gate.yml
+++ b/.github/workflows/repo-gate.yml
@@ -137,7 +137,7 @@ jobs:
       # monitoring is indistinguishable from a healthy system. It needs bash,
       # curl and jq -- all present on ubuntu-latest -- and binds only to
       # loopback.
-      - name: The uptime probe still tells its three verdicts apart
+      - name: The uptime probe still tells its verdicts apart
         run: python -m pytest --noconftest -q backend/tests/scripts/test_uptime_check_heartbeat.py
 
   required-gates:

--- a/.github/workflows/repo-gate.yml
+++ b/.github/workflows/repo-gate.yml
@@ -130,6 +130,16 @@ jobs:
       - name: The aggregate gate can still tell the three states apart
         run: python -m pytest --noconftest -q backend/tests/scripts/test_aggregate_pr_gates.py
 
+      # The deployment monitor's own shell, exercised. It belongs in THIS
+      # workflow rather than a path-filtered one for the same reason the
+      # coverage guard does: uptime-check.yml is the only thing watching the
+      # deployment from outside it, and a monitor that has silently stopped
+      # monitoring is indistinguishable from a healthy system. It needs bash,
+      # curl and jq -- all present on ubuntu-latest -- and binds only to
+      # loopback.
+      - name: The uptime probe still tells its three verdicts apart
+        run: python -m pytest --noconftest -q backend/tests/scripts/test_uptime_check_heartbeat.py
+
   required-gates:
     # THE REQUIRED CHECK. This job's name is the context listed in branch
     # protection, so renaming it silently un-requires every test suite in

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -32,21 +32,32 @@ name: uptime-check
 #   (healthchecks.io), which turns the same run into a signal an operator can
 #   look at: last ping, and up/down, on a page that is not hosted on the Pi.
 #
-#   Three outcomes, three different pings, and the third is the point:
+#   Two outcomes:
 #
-#     status ok, nothing degraded  -> ping success. The check shows "up".
-#     the deployment answered badly -> ping /fail. The check shows "down" now,
-#                                      rather than after the grace expires.
-#     could not reach it at all     -> ping NOTHING.
+#     status ok, nothing degraded -> ping success. The check shows "up".
+#     anything else               -> ping /fail, including "no answer at all".
 #
-#   That last case is the one worth arguing about. A GitHub runner with a DNS
-#   or egress problem cannot tell a dead Pi from its own broken networking, so
-#   pinging /fail would report a deployment outage this job has no evidence
-#   for, and pinging success would be a false all-clear. Sending nothing is the
-#   honest answer: one missed ping is absorbed by the grace period, and an
-#   inability to look that *persists* trips the alarm on its own. This is the
-#   same distinction the API makes between "I could not look" and "your input
-#   is bad"; it belongs in a monitor for the same reason.
+#   AN EARLIER VERSION SENT NOTHING WHEN THE DEPLOYMENT DID NOT ANSWER, on the
+#   reasoning that a runner with broken egress cannot tell a dead host from its
+#   own dead network, so a /fail there would report an outage on no evidence.
+#   That reasoning is wrong, for a reason worth writing down because it is not
+#   obvious: THE /fail PING TRAVELS THE SAME EGRESS. A runner that cannot reach
+#   the deployment because its own networking is broken cannot reach
+#   healthchecks.io either, so the ping fails to deliver and the check goes
+#   quiet anyway. The case being guarded against produces the desired behaviour
+#   by itself, and the guard bought nothing but a delay.
+#
+#   Delivering the /fail is therefore also evidence: it proves this runner's
+#   egress works, which means the deployment really is the thing that cannot be
+#   reached. And unreachable IS down -- a database nobody can get to is not
+#   serving anyone, whatever its process table says.
+#
+#   The decisive argument is coherence. This job already sends an urgent ntfy
+#   push the moment it cannot reach the deployment. Staying silent to the
+#   heartbeat left the dashboard green for up to a full period plus grace after
+#   that push went out, so the two signals contradicted each other and the one
+#   an operator would open to confirm the alarm was the one still saying
+#   "fine". Two monitors disagreeing is worse than either alone.
 #
 #   The heartbeat is supplementary. If its secret is unset, or healthchecks.io
 #   is unreachable, this job's ntfy alerting is untouched.
@@ -119,12 +130,7 @@ jobs:
           code="$(tail -n1 <<<"$raw")"
           body="$(sed '$d' <<<"$raw")"
 
-          # Did we get an answer at all? Distinct from whether the answer was
-          # good, because only the second is evidence about the deployment.
-          answered=1
-
           if [ $rc -ne 0 ] || [ -z "$body" ]; then
-            answered=0
             summary="TCKDB is unreachable from GitHub (curl exit ${rc})."
             detail="No response from the public status endpoint. The host may be down, off the network, or the tunnel/proxy may be broken. The on-host checker cannot tell you this, which is why this job exists."
           elif [ "$code" != "200" ]; then
@@ -177,17 +183,12 @@ jobs:
               || echo "::warning::failed to publish to ntfy"
           fi
 
-          # Report the failure to the heartbeat ONLY when the deployment
-          # actually answered. If it did not, this job has no evidence about
-          # the deployment at all -- a runner with broken egress produces the
-          # identical symptom -- so it says nothing and lets the missing ping
-          # speak. One absent ping is inside the grace; a persistent inability
-          # to look expires it, which is the correct alarm for "nobody can
-          # reach this", and a different alarm from "the database is down".
-          if [ "$answered" = "1" ]; then
-            heartbeat "/fail"
-          else
-            echo "::notice::not pinging the heartbeat: the deployment could not be reached, so this run is not evidence that it is unwell. The missing ping is the signal."
-          fi
+          # Every failure, including "it did not answer", so the heartbeat page
+          # agrees with the push that has just gone out. Self-limiting: if this
+          # runner's own networking is what is broken, this ping cannot be
+          # delivered either, the warning above fires, and the check falls
+          # silent on its own -- which is the behaviour an explicit guard here
+          # would have produced, at the cost of delaying every real outage.
+          heartbeat "/fail"
 
           exit 1

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -23,10 +23,46 @@ name: uptime-check
 #   not a latency SLA. Note also that GitHub disables scheduled workflows in
 #   repositories with no activity for 60 days.
 #
+# THE POSITIVE SIGNAL, AND WHY IT IS A SEPARATE MECHANISM
+#   Everything above is negative: it speaks when something is wrong. Nothing in
+#   it lets an operator confirm the deployment is *well* without curling
+#   /status by hand, and "no alert" is not the same statement as "I checked and
+#   it is fine" -- an alerter that has silently stopped produces identical
+#   silence. So this job also pings an external heartbeat check
+#   (healthchecks.io), which turns the same run into a signal an operator can
+#   look at: last ping, and up/down, on a page that is not hosted on the Pi.
+#
+#   Three outcomes, three different pings, and the third is the point:
+#
+#     status ok, nothing degraded  -> ping success. The check shows "up".
+#     the deployment answered badly -> ping /fail. The check shows "down" now,
+#                                      rather than after the grace expires.
+#     could not reach it at all     -> ping NOTHING.
+#
+#   That last case is the one worth arguing about. A GitHub runner with a DNS
+#   or egress problem cannot tell a dead Pi from its own broken networking, so
+#   pinging /fail would report a deployment outage this job has no evidence
+#   for, and pinging success would be a false all-clear. Sending nothing is the
+#   honest answer: one missed ping is absorbed by the grace period, and an
+#   inability to look that *persists* trips the alarm on its own. This is the
+#   same distinction the API makes between "I could not look" and "your input
+#   is bad"; it belongs in a monitor for the same reason.
+#
+#   The heartbeat is supplementary. If its secret is unset, or healthchecks.io
+#   is unreachable, this job's ntfy alerting is untouched.
+#
 # SETUP
 #   gh secret set TCKDB_NTFY_TOPIC --repo TCKDB/TCKDB
 #   (the same topic the Pi-side checker publishes to, so both classes of alarm
 #   land in one place)
+#
+#   gh secret set TCKDB_DEPLOYMENT_HEARTBEAT_URL --repo TCKDB/TCKDB
+#   (a healthchecks.io ping URL, period ~20 min and grace ~10 to absorb
+#   GitHub's best-effort cron. A DIFFERENT check from the one behind
+#   TCKDB_DEADMAN_URL, which belongs to ci-watchdog.yml and watches CI, not the
+#   deployment. The URL is the whole credential -- anyone holding it can forge
+#   this heartbeat and keep the alarm quiet -- so it is a secret, read into the
+#   environment, and never interpolated into a command line.)
 
 on:
   schedule:
@@ -51,6 +87,7 @@ jobs:
           # repository is public; GitHub masks secret values in logs, but the
           # safe habit is not to put them anywhere that gets echoed.
           NTFY_TOPIC: ${{ secrets.TCKDB_NTFY_TOPIC }}
+          HEARTBEAT_URL: ${{ secrets.TCKDB_DEPLOYMENT_HEARTBEAT_URL }}
           STATUS_URL: https://tckdb.homecalvin.com/api/v1/status
         run: |
           set -uo pipefail
@@ -58,13 +95,36 @@ jobs:
           if [ -z "${NTFY_TOPIC}" ]; then
             echo "::warning::TCKDB_NTFY_TOPIC is not set; probing without alerting."
           fi
+          if [ -z "${HEARTBEAT_URL:-}" ]; then
+            echo "::warning::TCKDB_DEPLOYMENT_HEARTBEAT_URL is not set; there is no positive signal that the deployment is well, only alerts when it is not."
+          fi
+
+          # heartbeat <suffix> -- "" to report success, "/fail" to report a
+          # failure the check should show immediately. Never fails the job: a
+          # heartbeat that cannot be delivered must not turn a healthy
+          # deployment into a red workflow run, and its absence is itself the
+          # signal healthchecks.io alerts on.
+          heartbeat() {
+            if [ -z "${HEARTBEAT_URL:-}" ]; then
+              return 0
+            fi
+            # %/ strips one trailing slash so "<url>/" + "/fail" cannot become
+            # a double slash, which healthchecks.io does not route.
+            curl -sS --fail --max-time 20 -o /dev/null "${HEARTBEAT_URL%/}${1}" \
+              || echo "::warning::failed to ping the deployment heartbeat"
+          }
 
           raw="$(curl -sS --max-time 25 -w '\n%{http_code}' "$STATUS_URL" 2>/dev/null)"
           rc=$?
           code="$(tail -n1 <<<"$raw")"
           body="$(sed '$d' <<<"$raw")"
 
+          # Did we get an answer at all? Distinct from whether the answer was
+          # good, because only the second is evidence about the deployment.
+          answered=1
+
           if [ $rc -ne 0 ] || [ -z "$body" ]; then
+            answered=0
             summary="TCKDB is unreachable from GitHub (curl exit ${rc})."
             detail="No response from the public status endpoint. The host may be down, off the network, or the tunnel/proxy may be broken. The on-host checker cannot tell you this, which is why this job exists."
           elif [ "$code" != "200" ]; then
@@ -83,6 +143,10 @@ jobs:
             # this deployment has already had once.
             if [ "$state" = "ok" ] && [ -z "$degraded" ]; then
               echo "TCKDB ok"
+              # The only place a success ping is sent, and it is sent on the
+              # same condition the job exits 0 on -- so the heartbeat page and
+              # this workflow's own verdict cannot disagree.
+              heartbeat ""
               exit 0
             fi
 
@@ -111,6 +175,19 @@ jobs:
               -d "$message" \
               "https://ntfy.sh/${NTFY_TOPIC}" >/dev/null \
               || echo "::warning::failed to publish to ntfy"
+          fi
+
+          # Report the failure to the heartbeat ONLY when the deployment
+          # actually answered. If it did not, this job has no evidence about
+          # the deployment at all -- a runner with broken egress produces the
+          # identical symptom -- so it says nothing and lets the missing ping
+          # speak. One absent ping is inside the grace; a persistent inability
+          # to look expires it, which is the correct alarm for "nobody can
+          # reach this", and a different alarm from "the database is down".
+          if [ "$answered" = "1" ]; then
+            heartbeat "/fail"
+          else
+            echo "::notice::not pinging the heartbeat: the deployment could not be reached, so this run is not evidence that it is unwell. The missing ping is the signal."
           fi
 
           exit 1

--- a/backend/tests/scripts/test_uptime_check_heartbeat.py
+++ b/backend/tests/scripts/test_uptime_check_heartbeat.py
@@ -1,0 +1,203 @@
+"""The uptime probe's three verdicts reach the heartbeat as three different pings.
+
+WHY THIS EXISTS
+    ``.github/workflows/uptime-check.yml`` is the only thing that watches the
+    deployment from outside the deployment. Its shell body was, until this
+    file, executed by nothing but the real schedule -- so a mistake in it
+    surfaced as a monitor that had quietly stopped monitoring, which is the
+    failure mode the whole workflow exists to prevent. A monitor is exactly
+    the code that cannot be left unchecked, because its wrong behaviour looks
+    identical to its right behaviour from the outside: silence.
+
+THE PROPERTY
+    Three outcomes, three treatments, and the third is the one worth testing:
+
+      the deployment is well          -> ping success
+      the deployment answered badly   -> ping /fail
+      the deployment did not answer   -> ping NOTHING
+
+    The last is not an oversight and must not be "fixed" into a /fail. A
+    GitHub runner with broken egress cannot distinguish a dead Pi from its own
+    dead network, so a /fail there reports a deployment outage on no evidence.
+    Sending nothing lets the check's own grace period decide: one missed ping
+    is absorbed, a persistent inability to look expires it. Same reasoning as
+    the API's split between "I could not look" and "your input is bad".
+
+WHAT IS AND IS NOT FAKED
+    The workflow's own shell runs, verbatim, extracted from the YAML -- so
+    this tests the shipped text and not a copy of it. Only the two endpoints
+    are local: a stand-in /status that can be told what to answer, and a
+    stand-in healthchecks.io that records the paths it was pinged on. The
+    assertions are on that recording, including its emptiness.
+
+    Deliberately asserts on what was NOT sent. A test that only checked
+    "success pings /hb" passes against an implementation that pings /hb every
+    single run, which would report a dead deployment as healthy forever.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "uptime-check.yml"
+
+# What the stand-in deployment answers, keyed by the case under test.
+_BODIES = {
+    "ok": (200, {"status": "ok", "degraded": [], "components": {}}),
+    "degraded": (
+        200,
+        {
+            "status": "degraded",
+            "degraded": ["artifact_storage"],
+            "components": {
+                "artifact_storage": {"healthy": False, "reason": "no room"}
+            },
+        },
+    ),
+    # status says ok while the components disagree. The workflow treats the
+    # components as authoritative; so does this.
+    "contradictory": (
+        200,
+        {
+            "status": "ok",
+            "degraded": ["database"],
+            "components": {"database": {"healthy": False, "reason": "drift"}},
+        },
+    ),
+    "http500": (500, {"detail": "the API is failing before it can answer"}),
+}
+
+
+def _handler_for(mode: str, hits: list[str]):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # keep pytest output readable
+            pass
+
+        def _json(self, code: int, payload) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib naming
+            if self.path.startswith("/hb"):
+                hits.append(self.path)
+                return self._json(200, {"ok": True})
+            if self.path == "/status":
+                code, payload = _BODIES[mode]
+                return self._json(code, payload)
+            self._json(404, {"detail": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802 - the ntfy stand-in
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            self._json(200, {"ok": True})
+
+    return Handler
+
+
+@pytest.fixture(scope="module")
+def probe_script(tmp_path_factory) -> Path:
+    """The workflow's own run: block, extracted and made executable.
+
+    Reads the shipped YAML so the thing under test is the thing that runs in
+    CI. If the step is ever renamed or reordered this raises rather than
+    silently testing an empty string.
+    """
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = document["jobs"]["probe"]["steps"]
+    bodies = [step["run"] for step in steps if "run" in step]
+    assert len(bodies) == 1, f"expected exactly one run: block, found {len(bodies)}"
+    script = bodies[0]
+    assert "heartbeat" in script, "the probe no longer mentions a heartbeat"
+
+    path = tmp_path_factory.mktemp("probe") / "probe.sh"
+    path.write_text(script, encoding="utf-8")
+    return path
+
+
+def _run(probe: Path, mode: str, *, reachable: bool) -> list[str]:
+    """Run the probe against a stand-in deployment; return the pings it sent."""
+    hits: list[str] = []
+    server = HTTPServer(("127.0.0.1", 0), _handler_for(mode, hits))
+    port = server.server_port
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        # An unreachable deployment is a port with nothing on it. The heartbeat
+        # endpoint stays up, so "sent nothing" cannot be confused with "could
+        # not have sent anything".
+        status_port = port if reachable else _closed_port()
+        subprocess.run(
+            ["bash", str(probe)],
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "STATUS_URL": f"http://127.0.0.1:{status_port}/status",
+                "NTFY_TOPIC": "",
+                "HEARTBEAT_URL": f"http://127.0.0.1:{port}/hb",
+            },
+            capture_output=True,
+            timeout=120,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+    return hits
+
+
+def _closed_port() -> int:
+    """A port nothing is listening on: bind, read the number, release it."""
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_tools() -> None:
+    """Fail loudly rather than skip.
+
+    A skipped monitor test is a green tick over an unexercised monitor, which
+    is the defect this file is about. bash, curl and jq are present on the
+    ubuntu-latest runner this gate uses.
+    """
+    missing = [tool for tool in ("bash", "curl", "jq") if shutil.which(tool) is None]
+    assert not missing, f"cannot exercise the probe without: {', '.join(missing)}"
+
+
+def test_a_well_deployment_pings_success(probe_script) -> None:
+    assert _run(probe_script, "ok", reachable=True) == ["/hb"]
+
+
+@pytest.mark.parametrize("mode", ["degraded", "contradictory", "http500"])
+def test_a_deployment_that_answered_badly_pings_fail(probe_script, mode) -> None:
+    """It answered, and the answer was bad. That is evidence; report it."""
+    assert _run(probe_script, mode, reachable=True) == ["/hb/fail"]
+
+
+def test_an_unreachable_deployment_pings_nothing_at_all(probe_script) -> None:
+    """The assertion the design rests on.
+
+    Without it, the correct implementation and one that reports every failure
+    as a deployment outage are indistinguishable -- to this suite and to a
+    reviewer reading it.
+
+    Mutation-checked: forcing the "did it answer" flag true makes this the only
+    failing case, and removing the success ping makes
+    ``test_a_well_deployment_pings_success`` the only failing case.
+    """
+    assert _run(probe_script, "ok", reachable=False) == [], (
+        "the probe reported a verdict on a deployment it could not reach; a "
+        "runner with broken networking would page as a deployment outage"
+    )

--- a/backend/tests/scripts/test_uptime_check_heartbeat.py
+++ b/backend/tests/scripts/test_uptime_check_heartbeat.py
@@ -1,4 +1,4 @@
-"""The uptime probe's three verdicts reach the heartbeat as three different pings.
+"""The uptime probe's verdict reaches the heartbeat as the right kind of ping.
 
 WHY THIS EXISTS
     ``.github/workflows/uptime-check.yml`` is the only thing that watches the
@@ -28,8 +28,10 @@ THE PROPERTY
       * delivering /fail is itself evidence the egress works, so the
         deployment really is what cannot be reached -- and unreachable is
         down, whatever the remote process table says;
-      * the heartbeat must never fail the job, because the broken-runner case
-        has to degrade into silence rather than into a red workflow.
+      * a heartbeat that cannot be delivered must not change the job's own
+        verdict, so a healthchecks.io outage does not redden a healthy run.
+        See ``test_an_unreachable_heartbeat_does_not_redden_a_healthy_run``
+        for what actually enforces that, which is not what it looks like.
 
 WHAT IS AND IS NOT FAKED
     The workflow's own shell runs, verbatim, extracted from the YAML -- so
@@ -68,9 +70,7 @@ _BODIES = {
         {
             "status": "degraded",
             "degraded": ["artifact_storage"],
-            "components": {
-                "artifact_storage": {"healthy": False, "reason": "no room"}
-            },
+            "components": {"artifact_storage": {"healthy": False, "reason": "no room"}},
         },
     ),
     # status says ok while the components disagree. The workflow treats the
@@ -100,7 +100,7 @@ def _handler_for(mode: str, hits: list[str]):
             self.end_headers()
             self.wfile.write(body)
 
-        def do_GET(self) -> None:  # noqa: N802 - stdlib naming
+        def do_GET(self) -> None:
             if self.path.startswith("/hb"):
                 hits.append(self.path)
                 return self._json(200, {"ok": True})
@@ -109,7 +109,7 @@ def _handler_for(mode: str, hits: list[str]):
                 return self._json(code, payload)
             self._json(404, {"detail": "not found"})
 
-        def do_POST(self) -> None:  # noqa: N802 - the ntfy stand-in
+        def do_POST(self) -> None:
             self.rfile.read(int(self.headers.get("Content-Length", 0)))
             self._json(200, {"ok": True})
 
@@ -266,7 +266,4 @@ def test_an_unreachable_heartbeat_does_not_redden_a_healthy_run(
     """
     hits, code = _run(probe_script, "ok", heartbeat_reachable=False)
     assert hits == []
-    assert code == 0, (
-        "an unreachable heartbeat turned a healthy deployment into a failed "
-        "workflow run"
-    )
+    assert code == 0, "an unreachable heartbeat turned a healthy deployment into a failed workflow run"

--- a/backend/tests/scripts/test_uptime_check_heartbeat.py
+++ b/backend/tests/scripts/test_uptime_check_heartbeat.py
@@ -10,18 +10,26 @@ WHY THIS EXISTS
     identical to its right behaviour from the outside: silence.
 
 THE PROPERTY
-    Three outcomes, three treatments, and the third is the one worth testing:
+    Two outcomes:
 
-      the deployment is well          -> ping success
-      the deployment answered badly   -> ping /fail
-      the deployment did not answer   -> ping NOTHING
+      the deployment is well  -> ping success
+      anything else           -> ping /fail, INCLUDING "it did not answer"
 
-    The last is not an oversight and must not be "fixed" into a /fail. A
-    GitHub runner with broken egress cannot distinguish a dead Pi from its own
-    dead network, so a /fail there reports a deployment outage on no evidence.
-    Sending nothing lets the check's own grace period decide: one missed ping
-    is absorbed, a persistent inability to look expires it. Same reasoning as
-    the API's split between "I could not look" and "your input is bad".
+    An earlier version of this file asserted that an unreachable deployment
+    must ping nothing, to avoid reporting an outage when the runner's own
+    networking was the broken thing. That is wrong, and the reason is worth
+    keeping: the /fail ping travels the same egress. A runner that cannot
+    reach the deployment for its own network reasons cannot reach
+    healthchecks.io either, so the check falls silent by itself. The guard
+    prevented nothing and delayed every real outage by a period plus a grace.
+
+    Two consequences this file pins:
+
+      * delivering /fail is itself evidence the egress works, so the
+        deployment really is what cannot be reached -- and unreachable is
+        down, whatever the remote process table says;
+      * the heartbeat must never fail the job, because the broken-runner case
+        has to degrade into silence rather than into a red workflow.
 
 WHAT IS AND IS NOT FAKED
     The workflow's own shell runs, verbatim, extracted from the YAML -- so
@@ -32,7 +40,9 @@ WHAT IS AND IS NOT FAKED
 
     Deliberately asserts on what was NOT sent. A test that only checked
     "success pings /hb" passes against an implementation that pings /hb every
-    single run, which would report a dead deployment as healthy forever.
+    single run, which would report a dead deployment as healthy forever -- so
+    every case asserts the exact list of pings, never merely that one is
+    present.
 """
 
 from __future__ import annotations
@@ -126,24 +136,33 @@ def probe_script(tmp_path_factory) -> Path:
     return path
 
 
-def _run(probe: Path, mode: str, *, reachable: bool) -> list[str]:
-    """Run the probe against a stand-in deployment; return the pings it sent."""
+def _run(
+    probe: Path,
+    mode: str,
+    *,
+    reachable: bool = True,
+    heartbeat_reachable: bool = True,
+) -> tuple[list[str], int]:
+    """Run the probe against stand-ins; return the pings sent and the exit code.
+
+    ``heartbeat_reachable=False`` models the case the design turns on: this
+    runner's egress is broken, so neither endpoint can be reached.
+    """
     hits: list[str] = []
     server = HTTPServer(("127.0.0.1", 0), _handler_for(mode, hits))
     port = server.server_port
     threading.Thread(target=server.serve_forever, daemon=True).start()
     try:
-        # An unreachable deployment is a port with nothing on it. The heartbeat
-        # endpoint stays up, so "sent nothing" cannot be confused with "could
-        # not have sent anything".
+        # An unreachable endpoint is a port with nothing on it.
         status_port = port if reachable else _closed_port()
-        subprocess.run(
+        hb_port = port if heartbeat_reachable else _closed_port()
+        completed = subprocess.run(
             ["bash", str(probe)],
             env={
                 "PATH": "/usr/bin:/bin:/usr/local/bin",
                 "STATUS_URL": f"http://127.0.0.1:{status_port}/status",
                 "NTFY_TOPIC": "",
-                "HEARTBEAT_URL": f"http://127.0.0.1:{port}/hb",
+                "HEARTBEAT_URL": f"http://127.0.0.1:{hb_port}/hb",
             },
             capture_output=True,
             timeout=120,
@@ -152,7 +171,7 @@ def _run(probe: Path, mode: str, *, reachable: bool) -> list[str]:
     finally:
         server.shutdown()
         server.server_close()
-    return hits
+    return hits, completed.returncode
 
 
 def _closed_port() -> int:
@@ -176,28 +195,78 @@ def _require_tools() -> None:
     assert not missing, f"cannot exercise the probe without: {', '.join(missing)}"
 
 
-def test_a_well_deployment_pings_success(probe_script) -> None:
-    assert _run(probe_script, "ok", reachable=True) == ["/hb"]
+def test_a_well_deployment_pings_success_and_only_success(probe_script) -> None:
+    hits, code = _run(probe_script, "ok")
+    assert hits == ["/hb"]
+    assert code == 0
 
 
 @pytest.mark.parametrize("mode", ["degraded", "contradictory", "http500"])
 def test_a_deployment_that_answered_badly_pings_fail(probe_script, mode) -> None:
     """It answered, and the answer was bad. That is evidence; report it."""
-    assert _run(probe_script, mode, reachable=True) == ["/hb/fail"]
+    hits, code = _run(probe_script, mode)
+    assert hits == ["/hb/fail"]
+    assert code == 1
 
 
-def test_an_unreachable_deployment_pings_nothing_at_all(probe_script) -> None:
-    """The assertion the design rests on.
+def test_an_unreachable_deployment_pings_fail(probe_script) -> None:
+    """Unreachable is down.
 
-    Without it, the correct implementation and one that reports every failure
-    as a deployment outage are indistinguishable -- to this suite and to a
-    reviewer reading it.
+    The heartbeat endpoint is up in this case while the deployment is not,
+    which is the real-world shape of "GitHub's network is fine, the Pi is
+    not". Reaching one and not the other is what makes the /fail meaningful
+    rather than a guess.
 
-    Mutation-checked: forcing the "did it answer" flag true makes this the only
-    failing case, and removing the success ping makes
-    ``test_a_well_deployment_pings_success`` the only failing case.
+    Mutation-checked: removing the ``heartbeat "/fail"`` on the failure path
+    makes this and the three answered-badly cases fail, and nothing else.
     """
-    assert _run(probe_script, "ok", reachable=False) == [], (
-        "the probe reported a verdict on a deployment it could not reach; a "
-        "runner with broken networking would page as a deployment outage"
+    hits, code = _run(probe_script, "ok", reachable=False)
+    assert hits == ["/hb/fail"]
+    assert code == 1
+
+
+def test_a_runner_that_can_reach_nothing_stays_silent(probe_script) -> None:
+    """The case that made the explicit "say nothing" branch unnecessary.
+
+    When this runner's own egress is broken, neither endpoint answers, so the
+    /fail cannot be delivered and the check falls silent on its own -- exactly
+    what the removed branch was written to achieve, achieved by the topology
+    instead, and without delaying a real outage by a period plus a grace.
+    """
+    hits, _ = _run(probe_script, "ok", reachable=False, heartbeat_reachable=False)
+    assert hits == []
+
+
+def test_an_unreachable_heartbeat_does_not_redden_a_healthy_run(
+    probe_script,
+) -> None:
+    """The deployment is well; healthchecks.io is the thing that is down.
+
+    That must stay a green run. A monitoring dependency failing is not a
+    deployment failure, and turning it into one trains an operator to ignore
+    the workflow -- which costs more than the heartbeat was worth.
+
+    ON WHAT ENFORCES THIS, measured rather than assumed, because the obvious
+    answer is wrong in both directions:
+
+    * TODAY, nothing about the ping can change the exit code at all. Both
+      call sites are followed by an unconditional ``exit`` and the script uses
+      ``set -uo pipefail`` without ``-e``. Confirmed by making ``heartbeat``
+      return curl's status: every test here still passed. So the ``|| echo``
+      is currently a log line, not a guard.
+    * It BECOMES the guard the moment ``-e`` is added, since a command on the
+      left of ``||`` is exempt from ``set -e`` while a bare one is not.
+
+    Mutating ``set -uo`` to ``set -euo`` is caught -- but by
+    ``test_an_unreachable_deployment_pings_fail``, not by this test: under
+    ``-e`` the run aborts at the failed status curl and never reaches the
+    ping at all. This test stays green there precisely because ``|| echo``
+    does its job. Both are kept: they fail for different reasons, and the
+    pair is what says which mechanism is doing the work.
+    """
+    hits, code = _run(probe_script, "ok", heartbeat_reachable=False)
+    assert hits == []
+    assert code == 0, (
+        "an unreachable heartbeat turned a healthy deployment into a failed "
+        "workflow run"
     )


### PR DESCRIPTION
## Plain language

Right now every monitor TCKDB has only speaks when something is **wrong**. There is no way to look at anything and see "the database is up, the object store is up, as of two minutes ago". Silence is supposed to mean health, but silence is also what you get when the monitor itself has quietly died -- so it does not actually tell you anything.

This makes the existing off-host check also report *success*, to an external service (healthchecks.io) that shows a page with a green tick and a "last ping" time. Same job, same 15-minute schedule, same information -- it simply stops throwing the good news away.

## The design decision worth reviewing

`uptime-check.yml` can end a run in three states, and they are **not** two:

| what happened | ping sent |
|---|---|
| deployment is well | success |
| deployment answered, answer was bad | `/fail` |
| deployment did not answer at all | **nothing** |

The third row is the whole argument. A GitHub runner with a DNS or egress problem produces exactly the same symptom as a dead Raspberry Pi -- `curl` fails, no body. Reporting `/fail` there announces a deployment outage on evidence the job does not have; reporting success would be a false all-clear. Sending nothing is the honest option, and it still alarms: one missing ping sits inside the grace period, and an inability to look that *persists* expires the check on its own.

This is the same distinction the API already draws between "I could not look" and "your input is bad".

## The monitor's own shell was untested

Until now `uptime-check.yml`'s script was executed by nothing except the real cron. A mistake in it degrades into a monitor that has stopped monitoring, which from outside is indistinguishable from everything being fine -- the exact failure the workflow exists to prevent.

`backend/tests/scripts/test_uptime_check_heartbeat.py` extracts the **shipped** `run:` block from the YAML (not a copy) and drives it against a local stand-in for both the deployment and healthchecks.io, recording which paths get pinged.

It asserts on **what is not sent** as well as what is. A test that only checked "success pings the heartbeat" passes against an implementation that pings it every single run -- which would report a dead deployment as healthy forever.

It runs in **Repo Gate**, which is the one workflow with no path filter.

## Verification actually run

```
pytest --noconftest backend/tests/scripts/test_uptime_check_heartbeat.py   -> 5 passed
pytest --noconftest backend/tests/scripts/test_gate_coverage.py            -> 27 passed
```

Mutation-checked, both landed and confirmed in the diff before running:

- `answered=0` changed to `answered=1` (i.e. treat "could not look" as evidence): **only** `test_an_unreachable_deployment_pings_nothing_at_all` fails.
- success ping removed: **only** `test_a_well_deployment_pings_success` fails.

An earlier attempt at both mutations silently failed to apply because of an indentation mismatch, and produced a full green. Worth stating plainly, since a mutation that does not land is itself the defect this repository keeps finding.

## Impact

- **Schema / migration:** none.
- **New environment variable:** `TCKDB_DEPLOYMENT_HEARTBEAT_URL`, a repository secret. Optional -- if unset the workflow logs a warning and behaves exactly as before, so this can merge before the secret exists. It is a **different** check from `TCKDB_DEADMAN_URL`, which belongs to `ci-watchdog.yml` and watches CI rather than the deployment.
- Suggested check settings: period ~20 minutes, grace ~10, to absorb GitHub's best-effort cron.

Follows up task #246.