### PR TITLE
Answer a person at the base URL, not a JSON 404

### DIFF
--- a/.env.selfhosted.example
+++ b/.env.selfhosted.example
@@ -123,8 +123,16 @@ TRUSTED_PROXY_HEADER=CF-Connecting-IP
 # MAX_FULL_GEOMETRIES_PUBLIC=100
 # MAX_FULL_ARTIFACTS_PUBLIC=100
 
-# OpenAPI / Swagger / ReDoc. MUST be false for public deployments.
+# Swagger UI, ReDoc and the OpenAPI schema, all three together.
+# MUST be false for public deployments: /docs is an interactive request
+# console pointed at this deployment.
 EXPOSE_API_DOCS=false
+
+# The read-only half of the above. With EXPOSE_API_DOCS=false, setting
+# this true serves ReDoc at /redoc and the schema at /openapi.json, and
+# still leaves /docs unregistered. Safe for a public deployment that
+# wants its API contract discoverable. Defaults to false.
+# EXPOSE_API_REFERENCE=true
 
 # Legacy /api/v1/{thermo,kinetics,...} entity routes. MUST require auth
 # in hosted deployments - they leak integer PKs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,32 @@ wrapper over a contract that is itself still moving.
 
 ## Unreleased
 
+### Added
+
+- **The base URL now answers a person.** `https://<host>/` served a bare
+  `404 application/json` blob, and so did `/docs`, `/redoc` and
+  `/openapi.json`, because hosted deployments set `EXPOSE_API_DOCS=false`
+  and no route was registered at `/` at all. Anyone following the URL a
+  paper prints — a referee, most importantly — got an error object with
+  nothing in it to say a database was there. `/` now serves a
+  self-contained HTML landing page: what TCKDB is, a worked example of a
+  real check refusing to accept a frequency list it cannot justify, the
+  four write-behaviour roles every table plays, how to cite the software
+  versus a dataset release, and where the API starts. It loads no CDN, no
+  web font and no script, so it renders on a locked-down network and with
+  JavaScript disabled. Nothing else about the route table changed: `/` is
+  registered last, matches one exact path, and is excluded from the
+  OpenAPI document.
+- **`EXPOSE_API_REFERENCE`**, a new setting, defaulting to `false`. With
+  `EXPOSE_API_DOCS=false` it registers ReDoc at `/redoc` and the schema at
+  `/openapi.json` and still leaves Swagger UI at `/docs` unregistered.
+  `EXPOSE_API_DOCS` was all-or-nothing, and the startup guard refuses to
+  boot a hosted deployment with it on — correctly, because it brings
+  Swagger's live request console with it. That is not the same risk as
+  publishing the contract, which a hosted instance wants to do. Note that
+  FastAPI's ReDoc page loads its renderer from `cdn.jsdelivr.net` and its
+  fonts from Google Fonts; the landing page does not.
+
 ### Fixed
 
 - **A linear molecule could deposit a frequency list with one vibration

--- a/backend/app/api/app.py
+++ b/backend/app/api/app.py
@@ -8,8 +8,9 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.config import settings
+from app.api.config import Settings, settings
 from app.api.errors import register_exception_handlers
+from app.api.landing import REDOC_PATH, landing_router
 from app.api.logging_config import configure_logging
 from app.api.public_openapi import install_hosted_openapi
 from app.api.rate_limit import RateLimitMiddleware
@@ -65,6 +66,45 @@ async def _lifespan(app: FastAPI):
     # Daemon thread dies with the process — nothing to clean up.
 
 
+#: Paths FastAPI registers for each of the three built-in doc surfaces.
+#: Restated here rather than relying on the framework defaults so the
+#: landing page, the tests and the deployment checklist all name the
+#: same strings.
+SWAGGER_PATH = "/docs"
+OPENAPI_PATH = "/openapi.json"
+
+
+def _docs_kwargs(settings_obj: Settings) -> dict[str, str | None]:
+    """Resolve which of ``/docs``, ``/redoc`` and ``/openapi.json`` exist.
+
+    Passing ``None`` for one of these URLs prevents FastAPI from
+    registering the corresponding route at all, so a disabled surface
+    returns the same 404 as any other unrouted path -- there is nothing
+    behind it to be reached by guessing.
+
+    Three configurations, in precedence order:
+
+    * ``EXPOSE_API_DOCS=true`` (the local/dev default) -- all three,
+      Swagger UI included. Unchanged from before this function existed.
+    * ``EXPOSE_API_DOCS=false`` **and**
+      ``EXPOSE_API_REFERENCE=true`` -- ReDoc and the OpenAPI document,
+      no Swagger UI. This is the hosted posture: publish the contract
+      as a static reference, do not hand an anonymous reader a request
+      console pointed at the live deployment.
+    * both false (the hosted default, and the default for any
+      deployment that sets neither) -- none of the three.
+
+    ``EXPOSE_API_DOCS`` therefore keeps its exact previous meaning for
+    Swagger, and no deployment becomes more exposed by upgrading: the
+    middle case has to be opted into.
+    """
+    if settings_obj.expose_api_docs:
+        return {}
+    if settings_obj.expose_api_reference:
+        return {"docs_url": None, "redoc_url": REDOC_PATH, "openapi_url": OPENAPI_PATH}
+    return {"docs_url": None, "redoc_url": None, "openapi_url": None}
+
+
 def create_app() -> FastAPI:
     configure_logging()
     # Refuse to boot a hosted/public deployment with unsafe settings.
@@ -72,12 +112,7 @@ def create_app() -> FastAPI:
     # fixtures are unaffected. See app/api/startup_checks.py and
     # docs/deployment/production_checklist.md.
     validate_deployment_safety(settings)
-    # Passing ``None`` for the docs URL prevents FastAPI from
-    # registering the route. Hosted deployments default to off via
-    # ``EXPOSE_API_DOCS=false`` (see settings); local/dev leaves it on.
-    docs_kwargs: dict[str, str | None] = {}
-    if not settings.expose_api_docs:
-        docs_kwargs.update(docs_url=None, redoc_url=None, openapi_url=None)
+    docs_kwargs = _docs_kwargs(settings)
     app = FastAPI(
         title="TCKDB",
         version="0.1.0",
@@ -103,6 +138,14 @@ def create_app() -> FastAPI:
     app.add_middleware(RateLimitMiddleware)
     app.add_middleware(RequestIDMiddleware)
     app.include_router(api_router, prefix="/api/v1")
+    # Registered *after* the API router, and matching the single exact
+    # path ``/``. Starlette resolves routes in registration order, so a
+    # router added last can only ever be reached by a request no earlier
+    # route matched -- and ``/`` is not a prefix of ``/api/v1/...``
+    # anyway. Nothing that answered before this line answers differently
+    # after it; tests/api/test_landing_page.py asserts the full route
+    # table is unchanged apart from the one addition.
+    app.include_router(landing_router)
     register_exception_handlers(app)
     install_hosted_openapi(app)
     return app

--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -125,6 +125,29 @@ class Settings(BaseSettings):
     # registers ``/docs``, ``/redoc``, or ``/openapi.json``.
     expose_api_docs: bool = True
 
+    # Read-only API reference exposure, independent of the switch above.
+    #
+    # ``EXPOSE_API_DOCS`` is all-or-nothing and hosted deployments must
+    # keep it off: the startup guard in :mod:`app.api.startup_checks`
+    # refuses to boot a hosted mode with it on, because it registers
+    # Swagger UI at ``/docs`` -- an interactive request console pointed
+    # at the live deployment. That is the thing hosted mode does not
+    # want. It is not the same thing as *published API documentation*,
+    # which a hosted instance very much does want, since the reason
+    # anyone opens the base URL is to find out what the API offers.
+    #
+    # When this is true, ReDoc (``/redoc``) and the OpenAPI document
+    # (``/openapi.json``) are registered and Swagger UI is not. ReDoc
+    # renders the schema as a static reference with no "Try it out"
+    # button, so it publishes the contract without handing an anonymous
+    # reader a request builder.
+    #
+    # Defaults to ``False`` so no existing deployment becomes more
+    # exposed by upgrading; an operator opts in per deployment. It is
+    # deliberately *not* in the startup guard's violation list -- it is
+    # a safe thing to turn on in hosted mode, which is its whole point.
+    expose_api_reference: bool = False
+
     # Legacy entity-read auth gate. The public scientific surface
     # lives under ``/api/v1/scientific/*``; the older
     # ``/api/v1/{thermo,kinetics,...}`` routes pre-date the

--- a/backend/app/api/landing.py
+++ b/backend/app/api/landing.py
@@ -433,10 +433,9 @@ footer p { max-width: none; margin: 0; }
           <p class="panel-label">TCKDB replies</p>
           <code class="verdict-code">__HERO_CODE__</code>
           <p class="verdict-body">
-            This geometry is linear &mdash; its atoms spread across their long
-            axis by 0 of their spread along it. A linear three-atom molecule
-            has 3N&minus;5 = 4 vibrations, and this list carries 3, the count
-            for a bent molecule. One mode is missing.
+            This geometry is linear. A linear three-atom molecule has
+            3N&minus;5 = 4 vibrations, and this list carries 3, the count for a
+            bent molecule. One mode is missing.
           </p>
           <p class="verdict-body">
             The usual cause is a degenerate bending pair reported once: a

--- a/backend/app/api/landing.py
+++ b/backend/app/api/landing.py
@@ -1,0 +1,641 @@
+"""The human-readable landing page served at ``/``.
+
+Everything else this application serves is JSON for a machine. This one
+page is for a person -- specifically the person who was handed the base
+URL in a paper or a README, typed it, and until now received a bare
+``404 application/json`` blob with no indication that anything was
+there at all. A referee following a URL printed in a manuscript is the
+worst possible audience for that, and was the one getting it.
+
+The page is deliberately austere:
+
+* **Self-contained.** No CDN, no external stylesheet, no web font, no
+  analytics, no JavaScript. Every byte the browser renders arrives in
+  this one response, so the page works on a locked-down network, from
+  an archived copy, and with scripting disabled. The API reference at
+  ``/redoc`` does *not* share this property -- see
+  :func:`app.api.app.create_app` -- which is exactly why the landing
+  page is not built on top of it.
+* **Factual.** It states no record count, no uptime, no funder, no
+  institution and no contributor beyond the authors already named in
+  the repository's ``CITATION.cff``. A page that guesses at its own
+  corpus size is worse than a page that omits it, because the reader
+  cannot tell which numbers were guessed.
+
+The worked example in the hero is not illustrative fiction. The
+frequency list, the geometry, the code and the sentence are the real
+output of :mod:`app.services.frequency_geometry_linearity` for that
+input, transcribed from an actual run; ``tests/api/test_landing_page.py``
+re-runs the check and fails if the page and the checker ever disagree.
+An invented example on a page whose entire argument is "this system
+does not invent things" would be self-refuting.
+
+The markup lives in this module as a string rather than as a sibling
+``.html`` file on purpose: ``backend/pyproject.toml`` declares no
+``package-data``, so a non-editable wheel build would ship the module
+and silently drop the file, and the failure would appear only in the
+one deployment shape nobody tests locally.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+from app.api.config import settings
+
+#: Published documentation site, built from ``docs/`` by
+#: ``.github/workflows/docs.yml``.
+DOCS_URL = "https://tckdb.github.io/TCKDB/"
+
+#: Canonical source repository.
+REPO_URL = "https://github.com/TCKDB/TCKDB"
+
+#: Path the ReDoc API reference is registered on when this deployment
+#: serves one. FastAPI's default, kept as a constant so the page and the
+#: application factory cannot drift apart.
+REDOC_PATH = "/redoc"
+
+#: The geometry shown in the hero's left panel, and the input the test
+#: feeds back through the real checker. Carbon dioxide, collinear along
+#: z at a 1.162 A bond length.
+HERO_XYZ = """3
+carbon dioxide
+C   0.000000   0.000000   0.000000
+O   0.000000   0.000000   1.162000
+O   0.000000   0.000000  -1.162000"""
+
+#: The frequency list deposited alongside :data:`HERO_XYZ`: the three
+#: distinct wavenumbers a CO2 harmonic analysis prints. Three is 3N-6,
+#: the count for a *bent* three-atom molecule; a linear one has 3N-5=4,
+#: because the bend is doubly degenerate and a de-duplicating parser
+#: reports it once.
+HERO_FREQUENCIES = (667.0, 1333.0, 2349.0)
+
+#: The code the checker attaches to that deposit. Advisory: the record
+#: is accepted and annotated, not refused.
+HERO_CODE = "freq_list_bent_mode_count_for_linear_geometry"
+
+_PAGE_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TCKDB &mdash; Thermochemical &amp; Kinetics Database</title>
+<meta name="description"
+      content="TCKDB is a provenance-tracked database and HTTP API for
+               computational chemistry data. Every deposit is checked, and
+               every objection carries a code and its reasoning.">
+<style>
+/*
+ * Palette: molecular-orbital phase convention. Two signed colours,
+ * because signed quantities carry meaning in this field -- orbital
+ * phase, real versus imaginary frequencies, accepted versus flagged.
+ * Indigo is the positive lobe and reads as "accepted / real";
+ * orange-red is the negative lobe and appears essentially only on the
+ * verdict.
+ *
+ * --phase-neg-text is the same hue darkened until it clears WCAG AA
+ * against --paper (4.9:1; the display value is 4.0:1, which is a
+ * large-text pass only). The relationship is preserved: one colour for
+ * the mark, one for the same colour set as prose.
+ */
+:root {
+  color-scheme: light dark;
+  --paper: #eef1f5;
+  --surface: #ffffff;
+  --ink: #10131c;
+  --muted: #5c6674;
+  --rule: #cbd3de;
+  --phase-pos: #2b4fa8;
+  --phase-neg: #cf4a26;
+  --phase-neg-text: #b8401e;
+  --data-bg: #e4e9f0;
+
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo,
+          Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
+          sans-serif;
+
+  /* Type scale, 1.25 from a 17px body, with deliberate steps. */
+  --fs-display: clamp(2rem, 1.3rem + 3.1vw, 3.25rem);
+  --fs-lede: clamp(1.0625rem, 1rem + 0.35vw, 1.1875rem);
+  --fs-section: 1.3125rem;
+  --fs-body: 1.0625rem;
+  --fs-data: 0.8125rem;
+  --fs-label: 0.6875rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #0f121a;
+    --surface: #171b26;
+    --ink: #e6eaf2;
+    --muted: #99a3b4;
+    --rule: #2b323f;
+    --phase-pos: #93b0f5;
+    --phase-neg: #ef8a63;
+    --phase-neg-text: #ef8a63;
+    --data-bg: #10141d;
+  }
+}
+* { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+body {
+  margin: 0;
+  padding: 0 1.25rem 4.5rem;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: var(--fs-body);
+  line-height: 1.62;
+}
+header, main, footer { max-width: 52rem; margin-inline: auto; }
+a { color: var(--phase-pos); text-underline-offset: 0.15em; }
+a:hover { text-decoration-thickness: 2px; }
+:focus-visible {
+  outline: 3px solid var(--phase-neg);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+.skip {
+  position: absolute;
+  left: -9999px;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--ink);
+  font-family: var(--mono);
+}
+.skip:focus { left: 0.75rem; top: 0.75rem; z-index: 10; }
+
+/* ---- header ---- */
+header { padding: 4rem 0 0; }
+h1 { margin: 0; font-weight: 400; }
+.wordmark {
+  display: block;
+  font-family: var(--mono);
+  font-size: var(--fs-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.fullname {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: var(--fs-lede);
+  font-weight: 400;
+  color: var(--muted);
+}
+.lede {
+  margin: 1.5rem 0 0;
+  max-width: 34rem;
+  font-size: var(--fs-lede);
+}
+nav.actions { margin-top: 1.75rem; }
+nav.actions ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.button {
+  display: inline-block;
+  padding: 0.55rem 1.05rem;
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  border: 1.5px solid var(--phase-pos);
+}
+.button.primary { background: var(--phase-pos); color: var(--surface); }
+.button.secondary { background: transparent; color: var(--phase-pos); }
+
+/* ---- sections ---- */
+section { margin-top: 4rem; }
+h2 {
+  font-family: var(--mono);
+  font-size: var(--fs-section);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 1rem;
+}
+h3 {
+  font-family: var(--mono);
+  font-size: var(--fs-body);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 1.9rem 0 0.35rem;
+}
+p { margin: 0.85rem 0; max-width: 38rem; }
+
+/* ---- the exchange ---- */
+/*
+ * <figure> carries a 40px side margin by UA default, which on a 360px
+ * screen spends 80px of the viewport on nothing and squeezes the
+ * coordinates the panel exists to show.
+ */
+.exchange-figure { margin: 0; }
+/*
+ * ``minmax(0, 1fr)`` rather than ``1fr``: a grid item's automatic
+ * minimum size is its content, so the wide <pre> of coordinates would
+ * otherwise push the track past the viewport and scroll the whole
+ * document sideways at 360px instead of scrolling inside its own box.
+ */
+.exchange {
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+@media (min-width: 46rem) {
+  .exchange { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+}
+.panel {
+  background: var(--surface);
+  padding: 1.1rem 1.25rem 1.35rem;
+  min-width: 0;
+}
+.panel-label {
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 0.85rem;
+}
+.panel.verdict .panel-label { color: var(--phase-neg-text); }
+.panel pre {
+  margin: 0;
+  font-family: var(--mono);
+  /*
+   * Shrinks just enough that all four XYZ columns fit inside a 360px
+   * viewport rather than scrolling two of them out of sight. The
+   * coordinates are the point of the panel; a reader who has to swipe
+   * to see the z column has not been shown the geometry.
+   */
+  font-size: clamp(0.6875rem, 0.55rem + 0.5vw, var(--fs-data));
+  line-height: 1.55;
+  white-space: pre;
+  overflow-x: auto;
+  background: var(--data-bg);
+  padding: 0.75rem 0.85rem;
+}
+.panel pre + .panel-sub { margin-top: 1rem; }
+.panel-sub {
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 1rem 0 0.5rem;
+}
+.verdict-code {
+  display: block;
+  font-family: var(--mono);
+  /*
+   * Sized to fit the 45-character code on one line at the widest
+   * fallback mono face, because a code broken mid-token reads as
+   * damage rather than emphasis. Its prominence comes from the
+   * weight, the phase-negative colour and the rule beside it.
+   */
+  font-size: var(--fs-data);
+  font-weight: 700;
+  line-height: 1.45;
+  letter-spacing: -0.01em;
+  color: var(--phase-neg-text);
+  overflow-wrap: anywhere;
+  border-left: 3px solid var(--phase-neg);
+  padding-left: 0.7rem;
+}
+.verdict-body { margin: 0.9rem 0 0; font-size: 0.9375rem; max-width: none; }
+.verdict-body:last-child { margin-bottom: 0; }
+figcaption {
+  margin-top: 1rem;
+  color: var(--muted);
+  font-size: 0.9375rem;
+  max-width: 40rem;
+}
+/*
+ * The single orchestrated moment: the reply arrives a beat after the
+ * deposit, in the order a request and its response actually happen.
+ * The resting state is fully visible and the keyframes run *from*
+ * hidden, so a browser that never runs the animation -- reduced
+ * motion, an old engine, a print stylesheet -- shows the panel rather
+ * than an empty box.
+ */
+@keyframes reply-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+.panel.verdict { animation: reply-in 420ms ease-out 380ms backwards; }
+@media (prefers-reduced-motion: reduce) {
+  .panel.verdict { animation: none; }
+}
+
+/* ---- the four roles ---- */
+.roles { margin: 0; }
+.roles > div {
+  padding: 1.15rem 0;
+  border-top: 1px solid var(--rule);
+}
+.roles > div:last-child { border-bottom: 1px solid var(--rule); }
+.roles dt {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-family: var(--mono);
+  font-size: var(--fs-body);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.behaviour {
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--phase-pos);
+}
+.roles dd { margin: 0.4rem 0 0; max-width: 38rem; }
+
+/* ---- code and prose data ---- */
+code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--data-bg);
+  padding: 0.08em 0.3em;
+}
+pre.command {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--phase-pos);
+  padding: 0.8rem 1rem;
+  overflow-x: auto;
+  max-width: 38rem;
+}
+pre.command code { background: none; padding: 0; }
+
+/* ---- footer ---- */
+footer {
+  margin-top: 4.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--rule);
+  color: var(--muted);
+  font-size: 0.9375rem;
+}
+footer p { max-width: none; margin: 0; }
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+
+<header>
+  <h1>
+    <span class="wordmark">TCKDB</span>
+    <span class="fullname">Thermochemical &amp; Kinetics Database</span>
+  </h1>
+  <p class="lede">
+    Provenance-tracked computational chemistry data, served over HTTP.
+    Every deposit is checked on the way in, and every objection carries a
+    machine-readable code and the reasoning behind it.
+  </p>
+  <nav class="actions" aria-label="Primary">
+    <ul>
+      <li><a class="button primary" href="__DOCS_URL__">Documentation</a></li>
+      <li><a class="button secondary" href="__REPO_URL__">Source repository</a></li>
+    </ul>
+  </nav>
+</header>
+
+<main id="main">
+
+  <section aria-labelledby="exchange-heading">
+    <h2 id="exchange-heading">What a check looks like</h2>
+    <figure class="exchange-figure">
+      <div class="exchange">
+        <div class="panel deposit">
+          <p class="panel-label">Deposited</p>
+          <pre>__HERO_XYZ__</pre>
+          <p class="panel-sub">frequencies / cm&#8315;&#185;</p>
+          <pre>__HERO_FREQUENCIES__</pre>
+        </div>
+        <div class="panel verdict">
+          <p class="panel-label">TCKDB replies</p>
+          <code class="verdict-code">__HERO_CODE__</code>
+          <p class="verdict-body">
+            This geometry is linear &mdash; its atoms spread across their long
+            axis by 0 of their spread along it. A linear three-atom molecule
+            has 3N&minus;5 = 4 vibrations, and this list carries 3, the count
+            for a bent molecule. One mode is missing.
+          </p>
+          <p class="verdict-body">
+            The usual cause is a degenerate bending pair reported once: a
+            linear molecule&rsquo;s bends are doubly degenerate, so a parser
+            that de-duplicates equal frequencies drops one component and lands
+            exactly here. The record is accepted and flagged, not refused.
+          </p>
+        </div>
+      </div>
+      <figcaption>
+        A partial or frozen-atom Hessian produces the same short list
+        honestly, so this check warns rather than refusing. Checks that can be
+        settled from the data alone do refuse, with an HTTP 422 and the same
+        kind of code and reasoning attached.
+      </figcaption>
+    </figure>
+  </section>
+
+  <section aria-labelledby="roles-heading">
+    <h2 id="roles-heading">How it works</h2>
+    <p>
+      Every table plays exactly one of four roles, and the role fixes how
+      that table may be written. Keeping them apart is what lets a stored
+      number stay fixed while opinions about it change.
+    </p>
+    <dl class="roles">
+      <div>
+        <dt>identity <span class="behaviour">deduped</span></dt>
+        <dd>
+          What a thing is. One row per distinct species, reaction or
+          transition state, however many times it is submitted, carrying no
+          computed values and expressing no preference.
+        </dd>
+      </div>
+      <div>
+        <dt>provenance <span class="behaviour">append-only</span></dt>
+        <dd>
+          How it was produced. The software and release, level of theory,
+          workflow tool and literature behind a number, recorded at deposit
+          and never rewritten.
+        </dd>
+      </div>
+      <div>
+        <dt>result <span class="behaviour">append-only</span></dt>
+        <dd>
+          The number. A better calculation adds a row rather than replacing
+          the earlier one, so nothing already cited changes underneath a
+          reader.
+        </dd>
+      </div>
+      <div>
+        <dt>curation <span class="behaviour">overlay</span></dt>
+        <dd>
+          How far to trust it. Review state and release selections sit on top
+          of the results and never mutate them; a read asks for every
+          candidate with no recommendation, or for an attributed curated
+          selection.
+        </dd>
+      </div>
+    </dl>
+  </section>
+
+  <section aria-labelledby="citing-heading">
+    <h2 id="citing-heading">Citing TCKDB</h2>
+    <p>
+      Two different things are citable here, and they are versioned
+      independently. Upgrading the software must not change what a published
+      dataset says, and re-curating a dataset must not require a code
+      release.
+    </p>
+
+    <h3>The software</h3>
+    <p>
+      Cite the software when you use or extend the code. The metadata is in
+      <code>CITATION.cff</code> at the root of the
+      <a href="__REPO_URL__/blob/main/CITATION.cff">source repository</a>,
+      authored by Calvin Pieters and Alon Grinberg Dana and released under
+      the MIT licence. No DOI is minted for it yet: a DOI cannot be
+      retracted, so one is registered when a paper tag is cut rather than
+      speculatively.
+    </p>
+
+    <h3>A dataset release</h3>
+    <p>
+      Cite a dataset release when you use TCKDB&rsquo;s numbers. A release is
+      a separate artifact with its own tag, an immutable SHA-256-checksummed
+      manifest, an attributed selection ledger and its own citation string.
+      Releases are not listed in the software changelog; they are
+      discoverable at <code>GET /api/v1/scientific/releases</code>, and each
+      one carries its own <code>changelog_entry</code>. A published release
+      is never rewritten &mdash; withdrawing one keeps the row and its
+      manifest readable, so an outstanding citation never dangles.
+    </p>
+  </section>
+
+  <section aria-labelledby="api-heading">
+    <h2 id="api-heading">Use the API</h2>
+    <p>
+      Everything machine-readable lives under the base path
+      <code>/api/v1</code>. Reading the public scientific surface needs no
+      account; depositing data does.
+    </p>
+    <p>__API-REFERENCE__</p>
+    <p>
+      A thin Python client, <code>tckdb-client</code>, handles
+      authentication, payload encoding, retries and idempotency. It is
+      published from this repository rather than to PyPI:
+    </p>
+    <pre class="command"><code>pip install "git+__REPO_URL__.git#subdirectory=clients/python"</code></pre>
+    <p>
+      Any HTTP client that can send JSON works just as well; the client
+      package is a convenience, not a requirement.
+    </p>
+  </section>
+
+</main>
+
+<footer>
+  <p>
+    Operational status, including the database revision this deployment is
+    running, is reported at
+    <a href="/api/v1/status"><code>/api/v1/status</code></a>.
+  </p>
+</footer>
+
+</body>
+</html>
+"""
+
+
+def render_landing_page(*, api_reference_path: str | None) -> str:
+    """Return the complete landing-page HTML document.
+
+    *api_reference_path* is the path this deployment serves the ReDoc
+    API reference on, or ``None`` when it serves none. It is not a
+    cosmetic difference: a deployment with the reference switched off
+    must not advertise a link that answers 404, which is the precise
+    failure this page was added to remove.
+
+    The template carries ``__PLACEHOLDER__`` markers rather than
+    ``str.format`` fields, because the embedded stylesheet is full of
+    braces and escaping every one of them would make the CSS unreadable
+    for no gain.
+    """
+    if api_reference_path:
+        reference_block = (
+            "The full API reference is served at "
+            f'<a href="{api_reference_path}"><code>{api_reference_path}</code></a>, '
+            "rendered from this deployment's own OpenAPI document. The "
+            f'<a href="{DOCS_URL}">documentation site</a> carries the query '
+            "guides and worked examples."
+        )
+    else:
+        reference_block = (
+            "This deployment does not publish an API reference endpoint. The "
+            f'<a href="{DOCS_URL}">documentation site</a> carries the endpoint '
+            "reference, query guides and worked examples."
+        )
+    frequencies = "   ".join(f"{value:.1f}" for value in HERO_FREQUENCIES)
+    return (
+        _PAGE_TEMPLATE.replace("__DOCS_URL__", DOCS_URL)
+        .replace("__REPO_URL__", REPO_URL)
+        .replace("__HERO_XYZ__", HERO_XYZ)
+        .replace("__HERO_FREQUENCIES__", frequencies)
+        .replace("__HERO_CODE__", HERO_CODE)
+        .replace("__API-REFERENCE__", reference_block)
+    )
+
+
+landing_router = APIRouter()
+
+
+@landing_router.get(
+    "/",
+    include_in_schema=False,
+    response_class=HTMLResponse,
+    summary="Human-readable landing page",
+)
+def landing_page() -> HTMLResponse:
+    """Serve the landing page for whoever typed the bare base URL.
+
+    Excluded from the OpenAPI document deliberately. It is a page, not
+    an operation: nothing generates a client method for it, and listing
+    it would put an HTML response in a schema every consumer reads as
+    the machine contract.
+    """
+    serves_reference = settings.expose_api_docs or settings.expose_api_reference
+    return HTMLResponse(
+        content=render_landing_page(api_reference_path=REDOC_PATH if serves_reference else None)
+    )
+
+
+__all__ = [
+    "DOCS_URL",
+    "HERO_CODE",
+    "HERO_FREQUENCIES",
+    "HERO_XYZ",
+    "REDOC_PATH",
+    "REPO_URL",
+    "landing_router",
+    "render_landing_page",
+]

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -1,0 +1,325 @@
+"""The landing page at ``/`` and the read-only API-reference switch.
+
+Two changes are covered here, because they answer one question: what a
+*person* gets when they type the base URL a paper printed. Before this,
+the answer was ``404 application/json`` at ``/``, ``/docs``, ``/redoc``
+and ``/openapi.json`` alike -- a bare error blob with nothing in it to
+say a database was even there.
+
+The tests are grouped as:
+
+* :class:`TestLandingPageResponse` -- it is served, it is HTML, and it
+  carries the facts it is supposed to carry.
+* :class:`TestLandingPageIsSelfContained` -- it fetches nothing. A page
+  whose whole argument is that it works on a locked-down network must
+  not quietly grow a CDN link.
+* :class:`TestHeroExampleIsReal` -- the worked example in the hero is
+  re-run through the real checker on every test run. If the page and
+  ``app.services.frequency_geometry_linearity`` ever disagree, this
+  fails rather than leaving a plausible-looking fiction on a public
+  page.
+* :class:`TestDocSurfaceExposure` -- the three-way matrix of
+  ``EXPOSE_API_DOCS`` x ``EXPOSE_API_REFERENCE``, including the one
+  that matters for the hosted deployment: ReDoc on, Swagger still 404.
+* :class:`TestLandingPageChangesNoExistingRoute` -- the invariant that
+  adding ``/`` shadowed and reordered nothing, proved by building the
+  same application with the landing router removed and diffing the
+  ordered route table.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api import app as app_module
+from app.api.app import create_app
+from app.api.config import Settings, settings
+from app.api.deps import get_db, get_write_db
+from app.api.landing import (
+    DOCS_URL,
+    HERO_CODE,
+    HERO_FREQUENCIES,
+    HERO_XYZ,
+    REPO_URL,
+    render_landing_page,
+)
+from app.api.startup_checks import validate_deployment_safety
+from app.services.frequency_geometry_linearity import (
+    evaluate_frequency_list_linearity,
+)
+
+#: The four write-behaviour roles the page must name. These are the
+#: repository's central organising idea, not decoration: every table is
+#: exactly one of them, and the role fixes how the table may be written.
+DATA_ROLES = ("identity", "provenance", "result", "curation")
+
+
+@pytest.fixture
+def client_factory(db_session: Session):
+    """Build a fresh app per test so ``create_app`` re-reads settings."""
+
+    def _build() -> TestClient:
+        app = create_app()
+        app.dependency_overrides[get_db] = lambda: db_session
+        app.dependency_overrides[get_write_db] = lambda: db_session
+        return TestClient(app)
+
+    return _build
+
+
+class TestLandingPageResponse:
+    def test_root_serves_html_not_a_json_error(self, client_factory):
+        with client_factory() as c:
+            response = c.get("/")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert "<!DOCTYPE html>" in response.text
+
+    def test_page_links_the_documentation_site_and_the_repository(self, client_factory):
+        with client_factory() as c:
+            body = c.get("/").text
+        assert f'href="{DOCS_URL}"' in body
+        assert f'href="{REPO_URL}"' in body
+
+    def test_page_names_every_data_role_with_its_write_behaviour(self, client_factory):
+        with client_factory() as c:
+            body = c.get("/").text
+        for role in DATA_ROLES:
+            assert f"<dt>{role} " in body, f"landing page does not name the {role} role"
+        # The behaviour word is the load-bearing half of the label: a page
+        # that lists four nouns and omits how each is written has not said
+        # the thing the roles exist to say.
+        assert body.count('<span class="behaviour">append-only</span>') == 2
+        assert '<span class="behaviour">deduped</span>' in body
+        assert '<span class="behaviour">overlay</span>' in body
+
+    def test_page_separates_citing_the_software_from_citing_a_release(self, client_factory):
+        with client_factory() as c:
+            body = c.get("/").text
+        assert "CITATION.cff" in body
+        assert "GET /api/v1/scientific/releases" in body
+        assert "changelog_entry" in body
+
+    def test_page_points_at_the_api_base_path_the_client_and_the_status_route(self, client_factory):
+        with client_factory() as c:
+            body = c.get("/").text
+        assert "<code>/api/v1</code>" in body
+        assert "tckdb-client" in body
+        assert 'href="/api/v1/status"' in body
+
+    def test_page_states_no_corpus_size(self, client_factory):
+        """No invented counts. Every number on the page is from a file.
+
+        The only digits the page may carry are the ones in the worked
+        example (a real check's real input and output) and the version
+        path ``/api/v1``. A record count, a species count or an uptime
+        figure would be a number nobody could source.
+        """
+        with client_factory() as c:
+            body = c.get("/").text
+        prose = re.sub(r"<style>.*?</style>", "", body, flags=re.DOTALL)
+        prose = re.sub(r"<[^>]+>", " ", prose)
+        forbidden = re.compile(
+            r"\b\d[\d,]*\s*(records?|species|reactions?|calculations?|users?|"
+            r"uptime|downloads?)\b",
+            re.IGNORECASE,
+        )
+        assert forbidden.search(prose) is None
+
+
+class TestLandingPageIsSelfContained:
+    """No CDN, no external stylesheet, no web font, no script."""
+
+    def test_no_element_fetches_a_subresource(self, client_factory):
+        with client_factory() as c:
+            body = c.get("/").text
+        assert re.search(r"<(link|script|img|iframe|source|object|embed)\b", body) is None
+
+    def test_no_stylesheet_import_or_url_reaches_off_host(self, client_factory):
+        with client_factory() as c:
+            body = c.get("/").text
+        style = re.search(r"<style>(.*?)</style>", body, flags=re.DOTALL)
+        assert style is not None
+        css = style.group(1)
+        assert "@import" not in css
+        assert "url(" not in css
+
+    def test_every_absolute_url_is_a_link_a_reader_clicks(self, client_factory):
+        """External URLs are allowed as destinations, never as resources.
+
+        A page may link to the documentation site. It may not *load*
+        anything from it -- that is the difference between working on an
+        air-gapped laptop and rendering blank.
+        """
+        with client_factory() as c:
+            body = c.get("/").text
+        allowed_prefixes = (DOCS_URL, REPO_URL)
+        for url in set(re.findall(r"https?://[^\"'\s<>)]+", body)):
+            assert url.startswith(allowed_prefixes), url
+
+
+class TestHeroExampleIsReal:
+    """The worked example is the checker's own output, not a mock-up."""
+
+    def test_the_hero_input_still_produces_the_hero_code(self):
+        warnings = evaluate_frequency_list_linearity(
+            len(HERO_FREQUENCIES),
+            HERO_XYZ,
+            location="calculation.freq.frequencies",
+        )
+        assert [w.code for w in warnings] == [HERO_CODE]
+
+    def test_the_hero_sentence_agrees_with_the_checker_on_the_mode_count(self):
+        """3N-5 = 4 on the page must be 3N-5 = 4 in the message.
+
+        The page paraphrases a long message down to four sentences. This
+        pins the one number in that paraphrase to the number the checker
+        actually produced, so a change to either side is caught here
+        rather than by a reader.
+        """
+        warnings = evaluate_frequency_list_linearity(
+            len(HERO_FREQUENCIES),
+            HERO_XYZ,
+            location="calculation.freq.frequencies",
+        )
+        message = warnings[0].message
+        assert "3N-5 = 4 vibrations" in message
+        page = render_landing_page(api_reference_path=None)
+        assert "3N&minus;5 = 4" in page
+
+    def test_the_page_does_not_call_an_advisory_a_rejection(self):
+        """This check accepts the record. Saying otherwise misrepresents it."""
+        page = render_landing_page(api_reference_path=None)
+        assert "accepted and flagged, not refused" in page
+        assert HERO_CODE in page
+
+    def test_the_hero_deposit_is_shown_verbatim(self):
+        page = render_landing_page(api_reference_path=None)
+        for line in HERO_XYZ.splitlines():
+            assert line in page
+
+
+class TestDocSurfaceExposure:
+    """``EXPOSE_API_DOCS`` x ``EXPOSE_API_REFERENCE``, all three states."""
+
+    def test_docs_on_exposes_swagger_redoc_and_openapi(self, client_factory, monkeypatch):
+        monkeypatch.setattr(settings, "expose_api_docs", True)
+        monkeypatch.setattr(settings, "expose_api_reference", False)
+        with client_factory() as c:
+            assert c.get("/docs").status_code == 200
+            assert c.get("/redoc").status_code == 200
+            assert c.get("/openapi.json").status_code == 200
+
+    def test_reference_on_serves_redoc_and_openapi_but_never_swagger(
+        self, client_factory, monkeypatch
+    ):
+        """The hosted posture. Swagger carries a live request console.
+
+        ReDoc renders the same schema as a static reference with no
+        "Try it out" button, so publishing the contract does not also
+        publish a request builder aimed at the deployment.
+        """
+        monkeypatch.setattr(settings, "expose_api_docs", False)
+        monkeypatch.setattr(settings, "expose_api_reference", True)
+        with client_factory() as c:
+            assert c.get("/docs").status_code == 404
+            assert c.get("/redoc").status_code == 200
+            assert c.get("/openapi.json").status_code == 200
+
+    def test_both_off_registers_none_of_the_three(self, client_factory, monkeypatch):
+        monkeypatch.setattr(settings, "expose_api_docs", False)
+        monkeypatch.setattr(settings, "expose_api_reference", False)
+        with client_factory() as c:
+            assert c.get("/docs").status_code == 404
+            assert c.get("/redoc").status_code == 404
+            assert c.get("/openapi.json").status_code == 404
+
+    def test_the_new_setting_defaults_to_off(self):
+        """Upgrading must not make an existing deployment more exposed."""
+        assert Settings(deployment_mode="local").expose_api_reference is False
+
+    def test_the_reference_is_allowed_in_hosted_mode(self):
+        """It is safe on, which is the entire reason it is a separate flag.
+
+        ``EXPOSE_API_DOCS=true`` is a boot-refusing violation in hosted
+        mode. This one must not be, or a hosted deployment could never
+        publish its own API reference.
+        """
+        hosted = Settings(
+            deployment_mode="hosted_public",
+            auth_allow_open_registration=False,
+            expose_api_docs=False,
+            expose_api_reference=True,
+            legacy_reads_require_auth=True,
+            session_cookie_secure=True,
+            allow_public_internal_ids=False,
+            rate_limit_enabled=True,
+            cors_allow_origins=[],
+            db_statement_timeout_ms=30_000,
+        )
+        validate_deployment_safety(hosted)  # does not raise
+
+    def test_landing_page_links_the_reference_only_when_one_is_served(
+        self, client_factory, monkeypatch
+    ):
+        """A landing page that links to a 404 is the bug being fixed."""
+        monkeypatch.setattr(settings, "expose_api_docs", False)
+        monkeypatch.setattr(settings, "expose_api_reference", False)
+        with client_factory() as c:
+            assert 'href="/redoc"' not in c.get("/").text
+
+        monkeypatch.setattr(settings, "expose_api_reference", True)
+        with client_factory() as c:
+            assert 'href="/redoc"' in c.get("/").text
+
+
+class TestLandingPageChangesNoExistingRoute:
+    def test_the_route_table_gains_the_landing_route_and_nothing_else(self, monkeypatch):
+        """Adding ``/`` shadowed nothing and reordered nothing.
+
+        Built twice from the same factory -- once as shipped, once with
+        the landing router replaced by an empty one -- the two ordered
+        route tables must differ by exactly the ``/`` entry, appended
+        last. Order matters because Starlette resolves routes in
+        registration order, so a route inserted earlier could capture a
+        request an existing route used to answer.
+        """
+        with_landing = [route.path for route in create_app().routes]
+
+        monkeypatch.setattr(app_module, "landing_router", APIRouter())
+        without_landing = [route.path for route in create_app().routes]
+
+        assert with_landing == [*without_landing, "/"]
+
+    def test_no_other_route_claims_the_root_path(self):
+        roots = [route for route in create_app().routes if route.path == "/"]
+        assert len(roots) == 1
+
+    def test_status_and_readyz_are_untouched(self, client_factory):
+        with client_factory() as c:
+            status = c.get("/api/v1/status")
+            readyz = c.get("/api/v1/readyz")
+        assert status.status_code == 200
+        assert status.headers["content-type"].startswith("application/json")
+        assert "status" in status.json()
+        assert readyz.status_code in (200, 503)
+        assert readyz.headers["content-type"].startswith("application/json")
+
+    def test_the_landing_route_is_absent_from_the_openapi_document(
+        self, client_factory, monkeypatch
+    ):
+        """It is a page, not an operation.
+
+        The generated schema is the machine contract: it feeds the
+        golden snapshot and the client's parity ledger. An HTML page
+        listed there would be an operation every consumer has to triage.
+        """
+        monkeypatch.setattr(settings, "expose_api_docs", True)
+        with client_factory() as c:
+            schema = c.get("/openapi.json").json()
+        assert "/" not in schema["paths"]

--- a/docs/deployment/deployment_modes.md
+++ b/docs/deployment/deployment_modes.md
@@ -192,7 +192,9 @@ TCKDB instance it is configured against.
 | Legacy entity routes | Open | `LEGACY_READS_REQUIRE_AUTH=true` | `LEGACY_READS_REQUIRE_AUTH=true` |
 | Open registration | Operator choice | Off (`AUTH_ALLOW_OPEN_REGISTRATION=false`) | Off; seeded accounts |
 | Rate limiting | Optional | Required | Required |
-| OpenAPI / Swagger | Operator choice | Hidden (`EXPOSE_API_DOCS=false`) | Hidden |
+| Swagger UI (`/docs`) | Operator choice | Hidden (`EXPOSE_API_DOCS=false`) | Hidden |
+| API reference (`/redoc`, `/openapi.json`) | Operator choice | Operator choice (`EXPOSE_API_REFERENCE`) | Published (`EXPOSE_API_REFERENCE=true`) |
+| Landing page (`/`) | Always served | Always served | Always served |
 | TLS | Not required | Required (edge cert via Cloudflare or origin cert via proxy) | Required |
 | Secrets management | `.env` on local disk | `.env.selfhosted` outside repo, restricted perms | Operator-managed (vault/secret store) |
 

--- a/docs/deployment/production_checklist.md
+++ b/docs/deployment/production_checklist.md
@@ -43,7 +43,8 @@ Every row below must be set to the indicated value before the API is reachable f
 |---|---|---|
 | `DEPLOYMENT_MODE` | `shared_private` or `hosted_public` | **enforced** Selects the hosted posture and turns on the startup safety guard. See [Deployment mode and startup guard](#deployment-mode-and-startup-guard). |
 | `AUTH_ALLOW_OPEN_REGISTRATION` | `false` | **enforced** Defaults to `true` for local dev convenience. Leaving it `true` in a hosted deployment turns the API into an uncontrolled self-registration endpoint. Seed accounts via `backend/scripts/bootstrap_admin.py` + admin invites instead. |
-| `EXPOSE_API_DOCS` | `false` | **enforced** Defaults to `true`. When `false`, FastAPI never registers `/docs`, `/redoc`, or `/openapi.json`. Hosted deployments either keep docs off entirely or gate them behind a private network. |
+| `EXPOSE_API_DOCS` | `false` | **enforced** Defaults to `true`. When `false`, FastAPI never registers `/docs`, `/redoc`, or `/openapi.json`. It is all-or-nothing and it includes Swagger UI, which is an interactive request console pointed at the live deployment — hence enforced off. To publish the API contract without that console, leave this `false` and set `EXPOSE_API_REFERENCE=true` (next row). |
+| `EXPOSE_API_REFERENCE` | operator choice | Not enforced; **defaults to `false`**. When `true` *and* `EXPOSE_API_DOCS=false`, FastAPI registers ReDoc at `/redoc` and the schema at `/openapi.json`, and still does not register Swagger UI at `/docs`. ReDoc is a static reference with no "Try it out" button. Note that ReDoc's page loads its renderer from a public CDN (`cdn.jsdelivr.net`) and its fonts from Google Fonts; the landing page at `/` does not, and stays readable with those hosts blocked. |
 | `LEGACY_READS_REQUIRE_AUTH` | `true` | **enforced** The `/api/v1/{thermo,kinetics,geometries,...}` legacy routes pre-date the internal-IDs visibility policy and leak integer PKs. They must require auth in hosted deployments. |
 | `ALLOW_PUBLIC_INTERNAL_IDS` | `false` | **enforced** Hides internal integer primary keys from scientific responses. Clients use public refs. Set to `true` only in local/dev/test for compatibility with the legacy id-bearing shape. |
 | `SESSION_COOKIE_SECURE` | `true` | **enforced** Required so browsers only send the session cookie over TLS. Set `false` only when testing a local HTTP-only setup. |
@@ -137,7 +138,8 @@ Settings alone are not enough. Before opening the deployment to traffic:
 - [ ] Migrations are at head: `alembic current` matches `alembic heads`. See [Deployed-DB migration playbook](../../backend/docs/deployment/migrations.md).
 - [ ] At least one admin account has been seeded via `backend/scripts/bootstrap_admin.py`.
 - [ ] `AUTH_ALLOW_OPEN_REGISTRATION=false` is verified by sending `POST /api/v1/auth/register` and confirming the response is `403` or equivalent.
-- [ ] `EXPOSE_API_DOCS=false` is verified by `curl -fsS https://your-host/openapi.json` returning `404`.
+- [ ] `EXPOSE_API_DOCS=false` is verified by `curl -o /dev/null -sw '%{http_code}\n' https://your-host/docs` returning `404`. (With `EXPOSE_API_REFERENCE=true`, `/openapi.json` and `/redoc` return `200` by design; `/docs` must still be `404`.)
+- [ ] `GET /` returns `200 text/html` — the landing page, so a human following the base URL from a paper is not met with a JSON 404.
 - [ ] `LEGACY_READS_REQUIRE_AUTH=true` is verified by hitting `/api/v1/thermo` without credentials and confirming the response is `401`.
 - [ ] `SESSION_COOKIE_SECURE=true` is verified by logging in and confirming the `Set-Cookie` response has `Secure` set.
 - [ ] Rate limits trip under intentional flood: hit `/auth/login` 11 times in one minute from one IP, confirm the 11th returns `429` with a `Retry-After` header.

--- a/docs/deployment/self_hosted_single_node.md
+++ b/docs/deployment/self_hosted_single_node.md
@@ -304,7 +304,8 @@ the placeholders. The non-negotiable hosted toggles:
 | Variable | Required value | Why |
 |---|---|---|
 | `DEPLOYMENT_MODE` | `hosted_public` | Activates the startup safety guard so unsafe values for the rows below cause the API to exit at boot instead of silently misconfiguring production. Use `shared_private` for lab-internal deployments. |
-| `EXPOSE_API_DOCS` | `false` | Don't ship Swagger/ReDoc to the public surface. |
+| `EXPOSE_API_DOCS` | `false` | Don't ship Swagger UI's live request console to the public surface. |
+| `EXPOSE_API_REFERENCE` | operator choice (default `false`) | Set `true` to publish the read-only ReDoc reference at `/redoc` plus `/openapi.json` while `/docs` stays unregistered. |
 | `LEGACY_READS_REQUIRE_AUTH` | `true` | Legacy `/api/v1/{thermo,…}` routes leak integer PKs. |
 | `ALLOW_PUBLIC_INTERNAL_IDS` | `false` | Clients use refs as handles. |
 | `RATE_LIMIT_ENABLED` | `true` | Hosted abuse control is mandatory. |
@@ -863,14 +864,18 @@ curl -s -o /dev/null -w "%{http_code}\n" \
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" \
     https://api.tckdb.example.org/docs
-# expect 404
+# expect 404, always
 curl -s -o /dev/null -w "%{http_code}\n" \
     https://api.tckdb.example.org/openapi.json
-# expect 404
+# expect 404 with EXPOSE_API_REFERENCE unset or false;
+# expect 200 with EXPOSE_API_REFERENCE=true, which is intended
+curl -s -o /dev/null -w "%{http_code}\n" \
+    https://api.tckdb.example.org/
+# expect 200 — the landing page, served regardless of either setting
 ```
 
-If either returns 200, `EXPOSE_API_DOCS=true` slipped through — fix
-`.env.selfhosted` and `systemctl restart tckdb-api`.
+If `/docs` returns 200, `EXPOSE_API_DOCS=true` slipped through — fix
+`.env.selfhosted` and restart the API container.
 
 ### 6. Postgres not publicly reachable
 

--- a/docs/specs/public_read_abuse_controls.md
+++ b/docs/specs/public_read_abuse_controls.md
@@ -369,12 +369,29 @@ routes stay open for ad-hoc inspection.
 
 ### 7.3 OpenAPI / Swagger / ReDoc exposure (F8)
 
-| Setting          | Default | Effect when false |
-| ---------------- | ------- | ----------------- |
-| `EXPOSE_API_DOCS`| `true`  | `/docs`, `/redoc`, and `/openapi.json` are not registered. FastAPI returns 404. |
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `EXPOSE_API_DOCS` | `true` | When false, `/docs`, `/redoc` and `/openapi.json` are not registered. FastAPI returns 404. |
+| `EXPOSE_API_REFERENCE` | `false` | When true *and* `EXPOSE_API_DOCS` is false, `/redoc` and `/openapi.json` are registered and `/docs` is not. |
 
-Hosted production sets this to false. Local/dev leaves it on. The
-scientific API endpoints are unaffected by either mode.
+Hosted production sets `EXPOSE_API_DOCS=false`. Local/dev leaves it on.
+The scientific API endpoints are unaffected by either mode.
+
+The split exists because the two things that switch used to control are
+not the same risk. `/docs` is Swagger UI: an interactive request console
+aimed at the live deployment, and the reason the startup guard refuses to
+boot a hosted mode with `EXPOSE_API_DOCS=true`. `/redoc` renders the same
+schema as a static reference with no "Try it out" control, and publishing
+the contract is a thing a hosted instance positively wants — a reader who
+cannot discover the endpoints is not protected by that, only excluded.
+`EXPOSE_API_REFERENCE` is therefore deliberately absent from the guard's
+violation list, and defaults to false so upgrading exposes nothing new.
+
+One caveat worth stating plainly: the ReDoc page FastAPI generates loads
+its renderer from `cdn.jsdelivr.net` and its fonts from Google Fonts, so
+`/redoc` is blank for a reader who blocks those hosts. The landing page at
+`/` is fully self-contained and carries the citation, data-model and
+API-entry information without loading anything.
 
 ### 7.4 Free-text input bounds (F9)
 


### PR DESCRIPTION
## In plain language

If you typed `https://tckdb.homecalvin.com` into a browser, you got this:

```
{"detail":"Not Found"}
```

Nothing else. Not a page, not a name, not a hint that a scientific database
was on the other end. `/docs`, `/redoc` and `/openapi.json` gave the same
thing. The person most likely to type that URL is a **referee** following a
link printed in a manuscript, and what they saw was an error.

This PR does two things.

1. **`/` now serves a web page.** One HTML file, written by the application
   itself, with the stylesheet embedded in it. It loads nothing from
   anywhere — no fonts, no scripts, no analytics — so it works on a
   locked-down university network, with JavaScript switched off, and from a
   saved copy. It says what TCKDB is, shows one real example of the database
   checking a deposit and objecting to it, explains the four roles every
   table plays, distinguishes citing the *code* from citing a *dataset*, and
   points at where the API begins.

2. **A hosted deployment can now publish its API reference** without also
   publishing a button that fires requests at it.

Some terms, since this is a backend change:

- **OpenAPI document** — a machine-readable JSON file listing every endpoint,
  its parameters and its response shapes. Client libraries are generated from
  it; it is the API's contract.
- **Swagger UI** (`/docs`) — a browser page that renders that contract *and*
  gives every endpoint a "Try it out" button that sends a live request to the
  running server. Useful on a laptop, not something to hand an anonymous
  visitor.
- **ReDoc** (`/redoc`) — renders the same contract as a static reference.
  Reading only. No request button.
- **route table** — the ordered list the web framework walks to decide which
  bit of code answers an incoming URL. Order matters: a route added in the
  wrong place can silently intercept requests another route used to answer.
- **mutation testing** — deliberately breaking your own code to check that
  your tests notice. A test that stays green while the thing it tests is
  broken has verified nothing.

## The landing page

Served at `/`, `200 text/html`, from `backend/app/api/landing.py`.

**The hero is a real check, not a mock-up.** It shows a carbon dioxide
geometry and a three-frequency list going in, and the warning coming back:

```
freq_list_bent_mode_count_for_linear_geometry
```

That geometry is linear, a linear three-atom molecule has 3N−5 = 4
vibrations, the list carries 3, so one mode is missing — usually one half of
a degenerate bending pair collapsed by a de-duplicating parser. The page is
explicit that this is **accepted and flagged, not refused**, because that is
what the check does: a genuinely partial or frozen-atom Hessian produces the
same short list honestly, so it warns rather than rejecting.

Every word of that came from running the real checker. `HERO_XYZ`,
`HERO_FREQUENCIES` and `HERO_CODE` are fed back through
`evaluate_frequency_list_linearity` on every test run, and
`TestHeroExampleIsReal` fails if the page and
`app/services/frequency_geometry_linearity.py` ever disagree. An invented
example on a page whose argument is "this system does not invent things"
would be self-refuting.

**No invented facts.** No record count, no species count, no uptime, no
funder, no institution, no contributor beyond the two authors already in
`CITATION.cff`. `test_page_states_no_corpus_size` enforces the absence.

**Design.** Cool paper ground (`#eef1f5`), near-black with a blue cast for
ink, and two signed accent colours taken from molecular-orbital phase
convention: indigo for accepted/real, orange-red used essentially only on the
verdict. The display face is **monospace** — the subject's whole vernacular
is monospaced, so it is derived from the material rather than applied to it.
The four roles are labelled with their actual write behaviour (`deduped`,
`append-only`, `append-only`, `overlay`) rather than numbered, because the
behaviour is a load-bearing schema fact and a numeral would be decoration.
One piece of motion: the verdict panel arrives a beat after the deposit, in
the order a request and its response happen; the resting state is fully
visible and the keyframes run *from* hidden, so a browser that never runs the
animation shows the panel rather than an empty box, and
`prefers-reduced-motion` turns it off.

**Accessibility and responsiveness.** Skip link, one `h1`, real
`header`/`main`/`section`/`footer`, `aria-labelledby` on each section,
visible focus ring. Light and dark via `prefers-color-scheme`, both passing
WCAG AA on body text. Renders at 360 px with no horizontal document scroll —
verified by measuring `document.documentElement.scrollWidth` inside a 360 px
frame (360, exactly the viewport) after fixing two real defects found by
looking: the grid tracks needed `minmax(0, 1fr)` or the coordinate block
pushed the whole document sideways, and `<figure>`'s 40 px UA side margins
were eating 80 px of a phone screen.

## The docs decision, and the CDN question answered honestly

**Choice: a new setting, `EXPOSE_API_REFERENCE`, defaulting to `false`.**

`EXPOSE_API_DOCS` was not overloaded, for a specific reason. It is
all-or-nothing across `/docs`, `/redoc` and `/openapi.json`, and
`app/api/startup_checks.py` *refuses to boot* a `shared_private` or
`hosted_public` deployment with it on. That refusal is correct: the surface it
gates includes Swagger UI, an interactive request console aimed at the live
deployment. Publishing the API *contract* is a different risk, and one a
hosted instance positively wants to take — a reader who cannot discover the
endpoints is not protected by that, only excluded.

So `_docs_kwargs()` in `app/api/app.py` resolves three states:

| `EXPOSE_API_DOCS` | `EXPOSE_API_REFERENCE` | `/docs` | `/redoc` | `/openapi.json` |
|---|---|---|---|---|
| `true` (local default) | any | 200 | 200 | 200 |
| `false` | `true` | **404** | 200 | 200 |
| `false` | `false` (default) | 404 | 404 | 404 |

The first row is byte-for-byte the previous behaviour, and
`tests/api/test_api_docs_exposure.py` is untouched and still passes. The new
flag defaults off, so **no deployment becomes more exposed by upgrading** — an
operator opts in. It is deliberately *not* added to the startup guard's
violation list, and `test_the_reference_is_allowed_in_hosted_mode` pins that.

**Does FastAPI's built-in ReDoc fetch from a CDN? Yes.** I curled the live
page rather than reading the docstring. `GET /redoc` returns HTML referencing
exactly three external hosts:

```
https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js
https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700
https://fastapi.tiangolo.com/img/favicon.png
```

So `/redoc` is a blank page for a reader who blocks jsdelivr, and the favicon
is served from the FastAPI project's own domain. **The options are:**

1. **Accept the CDN for `/redoc` only** (what this PR does). The landing page
   at `/` stays fully self-contained and carries the citation, data-model and
   API-entry information without loading anything, so a reader behind a
   blocking proxy still gets the substance. Cost: one third-party origin on a
   page most readers will open, and a silent dependency on jsdelivr's uptime.
2. **Vendor the bundle.** Commit `redoc.standalone.js` (~1 MB minified), mount
   it with `StaticFiles`, and serve a custom `/redoc` via `get_redoc_html(...)`
   with `with_google_fonts=False`. No external origins at all, at the cost of a
   1 MB binary blob in a public repository that must be re-vendored for every
   ReDoc security update.

I did not silently ship option 1: it is documented in
`docs/specs/public_read_abuse_controls.md`,
`docs/deployment/production_checklist.md` and `.env.selfhosted.example`, all
of which now state that `/redoc` reaches a CDN and that `/` does not. Say the
word and option 2 is a small follow-up.

## The no-shadowing invariant, proved

`app.include_router(landing_router)` runs **after**
`app.include_router(api_router, prefix="/api/v1")`, matches the single exact
path `/`, and carries `include_in_schema=False`.

`test_the_route_table_gains_the_landing_route_and_nothing_else` builds the
application twice from the same factory — once as shipped, once with
`app_module.landing_router` monkeypatched to an empty `APIRouter` — and
asserts:

```python
assert with_landing == [*without_landing, "/"]
```

Ordered, whole table. Nothing moved; one entry appended. Two supporting
tests: exactly one route claims `/`, and `/` is absent from
`schema["paths"]`, which is why the OpenAPI golden snapshot and the client's
parity ledger are both unchanged (`tests/api/test_openapi_snapshot.py` passes
untouched). `/api/v1/status` and `/api/v1/readyz` are asserted still JSON and
still their previous statuses.

## Schema / migration impact

**None.** No ORM model, no Alembic revision, no database access added. The
landing route touches no session.

## New environment variable

`EXPOSE_API_REFERENCE`, default `false`. Nothing else. No new runtime
dependency — the page is a string in a module and ReDoc is already part of
FastAPI. The HTML lives in Python rather than a sibling `.html` file because
`backend/pyproject.toml` declares no `package-data`, so a non-editable wheel
build would ship the module and silently drop the file.

`check_package_version_bump.py` covers `clients/python`, the schemas package,
the chemkin adapter and the MCP integration — no backend path — so no package
version bump applies.

## Verification actually run

**Mutation testing.** Four mutations, each diffed before running, each
restored and md5-verified identical afterwards.

| # | Mutation | Result |
|---|---|---|
| 1 | `include_in_schema=False` → `True` in `landing.py` | `test_the_landing_route_is_absent_from_the_openapi_document` **failed** — 1 failed, 22 passed |
| 2 | `_docs_kwargs` reference branch returns `docs_url=SWAGGER_PATH` | `test_reference_on_serves_redoc_and_openapi_but_never_swagger` **failed** on `/docs` → 200 — 1 failed, 25 passed |
| 3 | `include_router(landing_router)` moved *before* the API router | `test_the_route_table_gains_the_landing_route_and_nothing_else` **failed**: `At index 4 diff: '/' != '/api/v1/health'` — 1 failed, 22 passed |
| 4 | `HERO_FREQUENCIES` → four modes (a complete linear list) | both `TestHeroExampleIsReal` count tests **failed** (`IndexError`, no warning fires) — 2 failed, 21 passed |

Restoration proved by `md5sum`: `landing.py` back to
`d896277d2a8f7032b9e0643874e9a7de`, `app.py` back to
`83414ec708d5c1c3e6c08a4cbc52f28a`, plus `diff -q` reporting identical.

**Linter**, from `backend/`:

```
conda run -n tckdb_env ruff check app tests scripts           → All checks passed!  CHECK_EXIT=0
conda run -n tckdb_env ruff format --check app tests scripts  → (no output)         FORMAT_EXIT=0
```

**Gates**, from `backend/`, exit code captured directly and not through a pipe:

```
conda run -n tckdb_env bash scripts/test-api.sh   → GATE_EXIT=0
3093 passed, 1 warning in 420.92s (0:07:00)
```

```
conda run -n tckdb_env python -m pytest tests/scripts/test_gate_coverage.py -q → 27 passed
```

`tests/api/test_landing_page.py` sits under `tests/api/`, which is what
`scripts/test-api.sh` selects, so the gate-coverage guard is satisfied.

**Served it and looked at it.** Ran the real app —
`TCKDB_STARTUP_PROBES=false EXPOSE_API_DOCS=false EXPOSE_API_REFERENCE=true uvicorn app.api.app:create_app --factory --port 8099` — and curled:

```
GET /                -> 200 text/html; charset=utf-8
GET /docs            -> 404 application/json
GET /redoc           -> 200 text/html; charset=utf-8
GET /openapi.json    -> 200 application/json
GET /api/v1/status   -> 200 application/json
```

The served `/` contains zero `<link>`, `<script>`, `<img>` or `<iframe>`
elements, and its only absolute URLs are the documentation site, the
repository, the `CITATION.cff` link and the `pip install` line — all
destinations a reader clicks, none a browser fetches.

Rendered it in headless Chrome at 1100 px and at 360 px, in both colour
schemes, and looked at each. What changed after looking: the coordinate block
was scrolling the entire document sideways on a phone (fixed with
`minmax(0, 1fr)` grid tracks and `min-width: 0`); `<figure>`'s default 40 px
side margins were stealing 80 px of a 360 px viewport (zeroed); the data font
now scales down slightly on narrow screens so all four XYZ columns are
visible rather than two; and the error code was breaking mid-token
(`...linear_geomet` / `ry`), so it is now sized to sit on one line at the
widest fallback mono face — its prominence comes from weight, colour and the
rule beside it rather than from size. The one thing I removed after looking,
having been fond of it: the figcaption originally named a *second* error code
(`freq_list_exceeds_geometry_degrees_of_freedom`, a real 422) to show the
blocking case; it now makes the same point in prose without a second example.

## What in the brief turned out to be wrong

Nothing material. The diagnosis was accurate: `app.py:80` did exactly what
the brief said, `EXPOSE_API_DOCS` defaults hosted-off, and there was no `/`
route. Three refinements worth recording:

- `EXPOSE_API_DOCS` is not merely defaulted off in hosted mode — the startup
  guard **refuses to boot** with it on. That is why overloading it was never
  an option, and why the new flag had to be kept out of the violation list.
- `pip install tckdb-client` from PyPI does not exist; the package installs
  from the repository subdirectory, and the page says so rather than implying
  a PyPI release.
- The docs that describe this surface were about to become wrong in four
  places at once (`production_checklist.md`, `deployment_modes.md`,
  `self_hosted_single_node.md`, `public_read_abuse_controls.md`), including a
  verification step instructing an operator to confirm `/openapi.json`
  returns 404. All four are updated in this PR.
