### PR TITLE
Let a depositor name the conformer group they meant

### DIFF
--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -697,13 +697,20 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "actually differs across the candidates (discriminator, "
                 "discriminator_values) and whether the locator has a field "
                 "for it (locator_can_express), because 'be more specific' is "
-                "only advice if there is something to add -- and here there "
-                "is not: the lookup filters on all three locator fields, so "
-                "candidates agree on all three and can only differ by the "
-                "conformer group, which the locator cannot name. Every "
-                "observed refusal therefore reports "
-                "locator_can_express=false, which is the evidence the "
-                "locator needs widening."
+                "only advice if there is something to add. For a long time "
+                "there was not: the lookup filtered on all three locator "
+                "fields, so candidates agreed on all three and could only "
+                "differ by the conformer group, which the locator could "
+                "not name -- every observed refusal reported "
+                "locator_can_express=false, which was the evidence the "
+                "locator needed widening. It has since been widened. The "
+                "locator carries an optional conformer_group_ref, the "
+                "field is filtered on when supplied, and this refusal now "
+                "names it: discriminator=conformer_group_ref, "
+                "locator_can_express=true, and discriminator_values listing "
+                "the cg_ refs to choose between. The code, the status and "
+                "every context key are unchanged -- what changed is that "
+                "the advice can now be followed."
             )),
     ApiCode("applied_energy_correction_source_calculation_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
@@ -1139,7 +1146,23 @@ CATALOGUE: tuple[ApiCode, ...] = (
             "backend/app/services/scientific_read/calculation_paths.py"),
     ApiCode("kinetics_interpretation_conformer_selection_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
-            shape=Shape.relationship),
+            shape=Shape.relationship,
+            note=(
+                "Two raise sites, one repair: cite a conformer record "
+                "belonging to the right species entry. The first holds the "
+                "resolved selection to the interpretation subject's entry; "
+                "the second, added with the locator's conformer_group_ref, "
+                "holds the named conformer group to the entry the locator "
+                "itself names -- a locator whose two halves contradict each "
+                "other. Not a new code, by the argument the sibling "
+                "kinetics_interpretation_statmech_owner_mismatch already "
+                "carries: context['field'] separates them "
+                "(...conformer_selection versus "
+                "...conformer_selection.conformer_group_ref) and the "
+                "corrective action is the same. 422 and not 404 because "
+                "the group exists -- a 404 would tell a depositor to "
+                "deposit a row they can already read."
+            )),
     ApiCode("kinetics_interpretation_statmech_owner_mismatch", 422, Surface.coded_exception,
             "backend/app/services/calculation_ownership.py",
             shape=Shape.relationship,
@@ -1508,6 +1531,27 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "present for the public-ref spelling only, because a row id "
                 "is logged and never echoed (DR-0028 Requirement 2)."
             )),
+    ApiCode("unknown_conformer_group_ref", 404, Surface.coded_exception,
+            "backend/app/services/upload_reference.py",
+            note=(
+                "The third refusal a conformer_selection locator can "
+                "produce, and the newest: it arrived with the locator's "
+                "conformer_group_ref field, which was added because two "
+                "conformer groups under one species entry made the locator "
+                "unanswerable -- every ambiguous_conformer_selection_"
+                "locator refusal reported locator_can_express=false and no "
+                "corrected body existed. Not folded into "
+                "unknown_conformer_selection, by that code's own argument: "
+                "a ref naming nothing is repaired by fixing the string the "
+                "caller wrote, a real group holding no such selection by "
+                "depositing the selection. The third case -- a real group "
+                "belonging to a different species entry -- is neither a "
+                "404 nor a new code: the row exists and the locator "
+                "contradicts itself, so it is 422 kinetics_interpretation_"
+                "conformer_selection_owner_mismatch from the shared "
+                "ownership guard, separated from that code's other raise "
+                "site by context['field']."
+            )),
     ApiCode("unknown_conformer_selection", 404, Surface.coded_exception,
             "backend/app/services/conformer_selection_locator.py",
             note=(
@@ -1518,12 +1562,16 @@ CATALOGUE: tuple[ApiCode, ...] = (
                 "disclosure rule. A conformer_selection content locator is a "
                 "third spelling -- a description, not a name -- so there is "
                 "no caller-written string to quote back and context carries "
-                "the locator's own fields (selection_kind, and "
-                "assignment_scheme_ref when set) instead. The field/kind "
+                "the locator's own fields (selection_kind, plus "
+                "assignment_scheme_ref and conformer_group_ref when set) "
+                "instead. The field/kind "
                 "pair is kept identical to unknown_reference's so a client "
                 "reads one body layout. Paired with "
                 "ambiguous_conformer_selection_locator at 422, which is the "
-                "same locator matching too many rows rather than none."
+                "same locator matching too many rows rather than none, and "
+                "with unknown_conformer_group_ref at 404, which is the "
+                "locator's conformer_group_ref naming no group at all -- a "
+                "different repair, so a different code."
             )),
     ApiCode("unknown_curation_policy", 404, Surface.message_prefix,
             "backend/app/api/routes/releases_admin.py"),

--- a/backend/app/api/code_catalogue.py
+++ b/backend/app/api/code_catalogue.py
@@ -67,7 +67,7 @@ needs -- the borderline calls -- because a classification whose hard cases
 are undocumented is one the next person re-litigates from scratch.
 
 Measured on this file: 73 entries (71 distinct codes) are relationships,
-97 are things. The cap family moved eight of them across on 2026-08-18 --
+98 are things. The cap family moved eight of them across on 2026-08-18 --
 see the first borderline group below.
 
 The groups where the call was genuinely arguable, and the argument:

--- a/backend/app/schemas/workflows/kinetics_upload.py
+++ b/backend/app/schemas/workflows/kinetics_upload.py
@@ -246,11 +246,37 @@ class ChebyshevUpload(SchemaBase):
 
 
 class ConformerSelectionContentRef(SchemaBase):
-    """Content-first locator for a conformer-selection interpretation."""
+    """Content-first locator for a conformer-selection interpretation.
+
+    Set the optional conformer_group_ref (a cg_ public ref, as returned by
+    GET /scientific/conformer-groups) when one species entry owns more than
+    one conformer group. Without it the other three fields can describe
+    several stored selections at once, and the upload is refused with
+    ambiguous_conformer_selection_locator listing the refs to choose from.
+    """
 
     species_entry: SpeciesEntryIdentityPayload
     selection_kind: str = Field(min_length=1)
     assignment_scheme_ref: str | None = Field(default=None, min_length=1)
+    # Optional, always: every payload valid before this field existed is
+    # still valid, and this widens the locator rather than tightening it.
+    #
+    # A public ref and not a label. One species entry owning several
+    # groups is normal -- ``resolve_conformer_group`` mints
+    # ``conformer_1``, ``conformer_2``, ... for each basin it does not
+    # recognise -- and each may carry its own ``lowest_energy`` selection
+    # under no assignment scheme, which
+    # ``uq_conformer_selection_conformer_group_id`` permits because it is
+    # per-group. But ``uq_conformer_group_species_entry_id`` does *not*
+    # declare ``postgresql_nulls_not_distinct``, so a species entry may
+    # also own arbitrarily many *unlabelled* groups, and among those a
+    # label field would discriminate nothing at all.
+    #
+    # A public ref is not a database FK id and this is not the "no FK IDs
+    # in upload schemas" rule being bent: it is the opaque, stable handle
+    # the read API already hands a client for a conformer group, so
+    # citing one is a client naming a record it can see.
+    conformer_group_ref: str | None = Field(default=None, min_length=1)
 
 
 class KineticsInterpretationAssignmentUpload(SchemaBase):

--- a/backend/app/services/conformer_selection_locator.py
+++ b/backend/app/services/conformer_selection_locator.py
@@ -5,9 +5,11 @@ The locator
 ``ConformerSelectionContentRef`` is how a depositor cites a stored
 conformer selection when they hold no handle for it. Instead of a ref they
 *describe* the row — ``{species_entry, selection_kind,
-assignment_scheme_ref}``, read as "the lowest-energy selection for this
-species entry under this scheme" — and the workflow expects the
-description to pick out exactly one row.
+assignment_scheme_ref, conformer_group_ref}``, read as "the lowest-energy
+selection for this species entry under this scheme, in this conformer
+group" — and the workflow expects the description to pick out exactly one
+row. The last field is optional and is the one added last; the rest of
+this module is largely the record of what its absence cost.
 
 Two conditions, two repairs, and one sentence
 ---------------------------------------------
@@ -45,37 +47,57 @@ on how the row was named.
 
 Why the 422 has to say what *differs*
 -------------------------------------
-"Be more specific" is only advice if there is something to add. The
-locator has three fields and the lookup filters on all three, so **every
-candidate agrees on all three by construction** — and the axis that
-actually separates them is the conformer group, which the locator cannot
-name at all. ``conformer_group`` is unique on ``(species_entry_id,
-label)`` with NULLs distinct, so one species entry may own many groups,
-each able to carry a ``lowest_energy`` selection with a NULL scheme, and
-the locator joins on ``species_entry_id`` alone.
+"Be more specific" is only advice if there is something to add, and while
+the locator had three fields and the lookup filtered on all three, there
+was not. Every candidate agreed on all three by construction, and
+the axis that actually separated them was the conformer group, which the
+locator could not name at all. ``conformer_group`` is unique on
+``(species_entry_id, label)`` with NULLs distinct, so one species entry
+may own many groups (normally: ``resolve_conformer_group`` mints a fresh
+one per unrecognised basin), each able to carry a ``lowest_energy``
+selection with a NULL scheme, and the locator joined on
+``species_entry_id`` alone.
 
-Told only "be more specific", that depositor is being sent to look for a
-field that does not exist. An error whose advice cannot be followed is
+Told only "be more specific", that depositor was being sent to look for a
+field that did not exist. An error whose advice cannot be followed is
 worse than a vague one, because it teaches people to stop reading the
 advice. :func:`discriminate` therefore computes what varies across the
 candidate set and the refusal says it, with
 ``context['locator_can_express']`` stating outright whether the difference
-is one the payload could have expressed.
+is one the payload could have expressed — and every refusal this module
+was written for reported ``false``.
+
+``conformer_group_ref`` is the answer to that ``false``, and it is a
+public ref rather than a label because a label cannot do the job:
+``uq_conformer_group_species_entry_id`` does not declare
+``postgresql_nulls_not_distinct``, so a species entry may own any number
+of *unlabelled* groups and there would be nothing to write in a label
+field. The refusal below is left intact rather than deleted along with
+the defect: it is what a client still receives when the ref is omitted,
+and it now names a field the payload can set.
 
 The three outcomes, and which of them a request can reach
 --------------------------------------------------------
 :func:`discriminate` classifies a candidate set three ways, and only one
-of them is reachable through a route today. That is recorded here rather
-than pruned, because the *unreachable* ones are what the classification
-exists to prove:
+of them is reachable through a route. Which one **changed** when the
+locator gained ``conformer_group_ref``, and the change is the point:
 
 1. **Differs by a locator field** (``selection_kind``,
-   ``assignment_scheme_ref``). Actionable: add the field. Structurally
-   unreachable — those are the two fields the ``WHERE`` clause pins.
+   ``assignment_scheme_ref``, ``conformer_group_ref``). Actionable: add
+   the field. This is now the outcome a request reaches, by way of the
+   third — the ``WHERE`` clause pins the first two always and the third
+   only when it is supplied, so two groups under one species entry differ
+   by a field the depositor *can* set. Before the field existed this
+   outcome was structurally unreachable, and that was the finding.
 2. **Differs by something the locator cannot express** (the conformer
-   group's ``label``, or failing that its ``public_ref``). The only
-   outcome a request reaches, and the evidence that the locator is too
-   narrow.
+   group's ``label``). Now the unreachable one, and unreachable twice
+   over: two candidates sit in two groups, two groups have two public
+   refs, and ``conformer_group_ref`` is ordered ahead of
+   ``conformer_group_label`` — so a label difference never wins the
+   discriminator. Kept, tested over hand-built candidates, and left
+   saying what it says, because ``locator_can_express`` is a published
+   field a client branches on and this is the branch that gives it a
+   ``false`` to mean something.
 3. **Differs by nothing reportable.** A duplicate curation row rather
    than an under-determined request, and worth saying so rather than
    dressing it up as ambiguity. Unreachable while
@@ -150,14 +172,24 @@ class SelectionCandidate:
 _AXES: tuple[str, ...] = (
     "selection_kind",
     "assignment_scheme_ref",
-    "conformer_group_label",
     "conformer_group_ref",
+    "conformer_group_label",
 )
 
 #: The subset of :data:`_AXES` that ``ConformerSelectionContentRef``
 #: actually has a field for. ``species_entry`` is not here because it is
 #: not an axis: the lookup joins on it, so it cannot vary.
-_LOCATOR_AXES: frozenset[str] = frozenset({"selection_kind", "assignment_scheme_ref"})
+#:
+#: ``conformer_group_ref`` joined this set when the locator gained the
+#: field, and that is also why it now precedes ``conformer_group_label``
+#: in :data:`_AXES`. Two candidates in two groups differ by *both*
+#: whenever the labels differ, and only one of the two is a field the
+#: depositor can set -- so the label ordered first would have named the
+#: unusable one and produced a refusal nobody can act on, which is the
+#: exact defect the field was added to end.
+_LOCATOR_AXES: frozenset[str] = frozenset(
+    {"selection_kind", "assignment_scheme_ref", "conformer_group_ref"}
+)
 
 
 @dataclass(frozen=True)
@@ -243,6 +275,7 @@ def unknown_conformer_selection(
     field: str,
     selection_kind: str,
     assignment_scheme_ref: str | None,
+    conformer_group_ref: str | None = None,
 ) -> NotFoundError:
     """Build the 404 for a locator that describes no stored selection.
 
@@ -255,12 +288,22 @@ def unknown_conformer_selection(
     :param assignment_scheme_ref: The scheme public ref the locator asked
         for, if any. Omitted from ``context`` when absent, matching
         ``unknown_reference``'s treatment of ``ref``.
+    :param conformer_group_ref: The group public ref the locator narrowed
+        to, if any. Echoed on the same terms, and for a sharper reason
+        than the others: with it set, the search covered *one* group, so a
+        404 that did not name the group would be describing a search the
+        depositor cannot picture. Absent when the locator did not narrow
+        -- the reference itself is refused earlier, by
+        ``unknown_conformer_group_ref``, so a ref reaching here is one
+        that names a real group of this species entry.
     """
     described = f"selection_kind={selection_kind!r}"
     if assignment_scheme_ref is not None:
         described += f", assignment_scheme_ref={assignment_scheme_ref!r}"
     else:
         described += ", no assignment scheme"
+    if conformer_group_ref is not None:
+        described += f", conformer_group_ref={conformer_group_ref!r}"
     context: dict[str, object] = {
         "field": field,
         "kind": _KIND,
@@ -268,12 +311,23 @@ def unknown_conformer_selection(
     }
     if assignment_scheme_ref is not None:
         context["assignment_scheme_ref"] = assignment_scheme_ref
+    if conformer_group_ref is not None:
+        context["conformer_group_ref"] = conformer_group_ref
+    # The remedy names the group only when the locator did. Told to
+    # "correct the conformer group" by a request that named none, a
+    # depositor is being pointed at a field they did not set -- the same
+    # unfollowable-advice failure the ambiguity refusal was built to avoid.
+    named = (
+        "species entry or conformer group"
+        if conformer_group_ref is not None
+        else "species entry"
+    )
     # No ``"code: "`` prefix in the prose: the exception carries the code
     # as an attribute and the handler passes it through unparsed.
     return NotFoundError(
         f"{field} ({described}) describes no conformer selection for that "
         "species entry in this database. Deposit the conformer selection "
-        "first, or correct the species entry the locator names.",
+        f"first, or correct the {named} the locator names.",
         code=W_UNKNOWN_CONFORMER_SELECTION,
         context=context,
     )

--- a/backend/app/services/upload_reference.py
+++ b/backend/app/services/upload_reference.py
@@ -115,6 +115,18 @@ W_UNKNOWN_CALCULATION_ARTIFACT_REF = "unknown_calculation_artifact_ref"
 #: A ``network_kinetics_ref`` names no network_kinetics row.
 W_UNKNOWN_NETWORK_KINETICS_REF = "unknown_network_kinetics_ref"
 
+#: A ``conformer_selection.conformer_group_ref`` names no conformer group.
+#: Its own code rather than
+#: :data:`app.services.conformer_selection_locator.W_UNKNOWN_CONFORMER_SELECTION`,
+#: by the same argument that split that code from the ambiguity one: the
+#: two repairs are opposite. A ref naming nothing is repaired by
+#: correcting the string the caller wrote; a real group holding no such
+#: selection is repaired by depositing the selection. A group that exists
+#: but belongs to another species entry is neither, and is not a 404 at
+#: all -- the row is there, the request contradicts itself, and that is a
+#: 422 from ``assert_owned_by``.
+W_UNKNOWN_CONFORMER_GROUP_REF = "unknown_conformer_group_ref"
+
 
 def unknown_reference(
     *,
@@ -187,6 +199,7 @@ def unknown_reference(
 __all__ = [
     "W_UNKNOWN_CALCULATION_ARTIFACT_REF",
     "W_UNKNOWN_CALCULATION_REF",
+    "W_UNKNOWN_CONFORMER_GROUP_REF",
     "W_UNKNOWN_NETWORK_KINETICS_REF",
     "W_UNKNOWN_STATMECH_REF",
     "W_UNKNOWN_TRANSITION_STATE_ENTRY_REF",

--- a/backend/app/workflows/kinetics.py
+++ b/backend/app/workflows/kinetics.py
@@ -64,6 +64,7 @@ from app.services.species_resolution import resolve_species, resolve_species_ent
 from app.services.upload_reference import (
     W_UNKNOWN_CALCULATION_ARTIFACT_REF,
     W_UNKNOWN_CALCULATION_REF,
+    W_UNKNOWN_CONFORMER_GROUP_REF,
     W_UNKNOWN_STATMECH_REF,
     W_UNKNOWN_TRANSITION_STATE_ENTRY_REF,
     unknown_reference,
@@ -304,6 +305,53 @@ def _resolve_interpretation_assignments(
             selection_species_entry = resolve_species_entry(
                 session, locator.species_entry, created_by=created_by
             )
+            # ``conformer_group_ref`` is resolved to a row *before* it is
+            # used as a filter, rather than folded into the ``WHERE``
+            # clause below. Folded in, all three of "no such group", "that
+            # group is another species entry's" and "that group holds no
+            # such selection" would arrive as the same empty result and
+            # the same 404 -- three different repairs behind one sentence,
+            # which is the defect this whole module split apart in the
+            # first place.
+            selection_group = None
+            if locator.conformer_group_ref is not None:
+                selection_group = session.execute(
+                    select(ConformerGroup.id, ConformerGroup.species_entry_id).where(
+                        ConformerGroup.public_ref == locator.conformer_group_ref
+                    )
+                ).first()
+                if selection_group is None:
+                    raise unknown_reference(
+                        code=W_UNKNOWN_CONFORMER_GROUP_REF,
+                        field=f"{field}.conformer_selection.conformer_group_ref",
+                        # Snake case, like every other kind on this route
+                        # ("transition_state_entry", "calculation_artifact")
+                        # and like the "conformer_selection" the sibling
+                        # refusals publish: a client keys off one spelling.
+                        kind="conformer_group",
+                        ref=locator.conformer_group_ref,
+                        remedy=(
+                            "Deposit the conformer group first, or correct "
+                            "the ref."
+                        ),
+                    )
+                # A real group belonging to somebody else. Not the 404
+                # above -- the row exists, and telling a depositor to
+                # deposit a row they can already read is advice that
+                # cannot be followed. The locator contradicts itself
+                # instead: its ``species_entry`` and its
+                # ``conformer_group_ref`` name two different subjects, and
+                # exactly one of the two is wrong.
+                assert_owned_by(
+                    subject_noun="conformer group",
+                    row_id=selection_group.id,
+                    row_species_entry_id=selection_group.species_entry_id,
+                    row_transition_state_entry_id=None,
+                    code=W_KINETICS_INTERPRETATION_CONFORMER_SELECTION_OWNER_MISMATCH,
+                    target="conformer_selection locator",
+                    context=f"{field}.conformer_selection.conformer_group_ref",
+                    species_entry_id=selection_species_entry.id,
+                )
             # The scheme join is an OUTER join and was an inner one: the
             # refusal below has to be able to report the scheme each
             # candidate carries, including the NULL-scheme case, and an
@@ -342,6 +390,14 @@ def _resolve_interpretation_assignments(
                 stmt = stmt.where(
                     ConformerAssignmentScheme.public_ref == locator.assignment_scheme_ref
                 )
+            if selection_group is not None:
+                # Filtered on the resolved id, not on the ref again: the
+                # ref has already been held to name a group of this
+                # species entry, and re-deriving it here would be a second
+                # place for the two to disagree.
+                stmt = stmt.where(
+                    ConformerSelection.conformer_group_id == selection_group.id
+                )
             # Unbounded on purpose, where the old lookup took ``limit(2)``:
             # the 422 has to publish an honest ``match_count`` and the
             # values that separate the candidates, and a capped fetch would
@@ -367,6 +423,7 @@ def _resolve_interpretation_assignments(
                     field=f"{field}.conformer_selection",
                     selection_kind=locator.selection_kind,
                     assignment_scheme_ref=locator.assignment_scheme_ref,
+                    conformer_group_ref=locator.conformer_group_ref,
                 )
             if len(candidates) > 1:
                 raise ambiguous_conformer_selection_locator(

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -11422,7 +11422,7 @@
       },
       "ConformerSelectionContentRef": {
         "additionalProperties": false,
-        "description": "Content-first locator for a conformer-selection interpretation.",
+        "description": "Content-first locator for a conformer-selection interpretation.\n\nSet the optional conformer_group_ref (a cg_ public ref, as returned by\nGET /scientific/conformer-groups) when one species entry owns more than\none conformer group. Without it the other three fields can describe\nseveral stored selections at once, and the upload is refused with\nambiguous_conformer_selection_locator listing the refs to choose from.",
         "properties": {
           "assignment_scheme_ref": {
             "anyOf": [
@@ -11435,6 +11435,18 @@
               }
             ],
             "title": "Assignment Scheme Ref"
+          },
+          "conformer_group_ref": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conformer Group Ref"
           },
           "selection_kind": {
             "minLength": 1,

--- a/backend/tests/api/test_api_conformer_selection_locator_codes.py
+++ b/backend/tests/api/test_api_conformer_selection_locator_codes.py
@@ -36,6 +36,9 @@ substrings of ``detail``.
 
 from __future__ import annotations
 
+from sqlalchemy import select
+
+from app.db.models.kinetics import KineticsInterpretationAssignment
 from tests.api.test_api_statmech_citation_ownership import (
     _KINETICS,
     _assignments,
@@ -49,31 +52,44 @@ from tests.services.scientific_read._factories import (
 
 _UNKNOWN = "unknown_conformer_selection"
 _AMBIGUOUS = "ambiguous_conformer_selection_locator"
+_UNKNOWN_GROUP = "unknown_conformer_group_ref"
+_GROUP_OWNER_MISMATCH = "kinetics_interpretation_conformer_selection_owner_mismatch"
 
 #: ``CH3``, the first reactant of the reaction the shared fixture declares.
 _CH3 = {"smiles": "[CH3]", "charge": 0, "multiplicity": 2}
 
+_FIELD = "interpretation_assignments[0].conformer_selection"
+_GROUP_FIELD = f"{_FIELD}.conformer_group_ref"
 
-def _payload(statmechs, *, species_entry=None, selection_kind="lowest_energy"):
+
+def _payload(
+    statmechs,
+    *,
+    species_entry=None,
+    selection_kind="lowest_energy",
+    conformer_group_ref=None,
+):
     """A correct rate whose first reactant also cites a conformer selection.
 
     Everything but the locator is valid: the statmechs are the right ones
     for the right participants and the interpretation set is complete. That
     is what makes a refusal here attributable to the locator rather than to
     one of the four guards above it.
+
+    ``conformer_group_ref`` is added to the locator only when given, so
+    every payload built without it is byte-identical to the one this
+    helper produced before the field existed. The tests that assert the
+    old behaviour is unchanged are therefore asserting it about the same
+    request body, not about a near-miss of it.
     """
+    locator = {
+        "species_entry": species_entry or _CH3,
+        "selection_kind": selection_kind,
+    }
+    if conformer_group_ref is not None:
+        locator["conformer_group_ref"] = conformer_group_ref
     return _rate(
-        _assignments(
-            statmechs,
-            **{
-                "reactant:1": {
-                    "conformer_selection": {
-                        "species_entry": species_entry or _CH3,
-                        "selection_kind": selection_kind,
-                    }
-                }
-            },
-        )
+        _assignments(statmechs, **{"reactant:1": {"conformer_selection": locator}})
     )
 
 
@@ -139,19 +155,23 @@ def test_two_labelled_groups_make_the_locator_ambiguous(client, db_session) -> N
     reachable: two distinct basins, each with a ``lowest_energy`` selection
     under no assignment scheme.
 
-    The discriminating axis is the group *label*, which the locator has no
-    field for — so ``locator_can_express`` is ``False`` and the refusal
-    says the difference cannot be expressed rather than telling the
-    depositor to add something that does not exist.
+    The discriminating axis is the conformer group. The labels differ too
+    and are reported in ``differs_by``, but the axis the refusal *names*
+    is ``conformer_group_ref``, because that is the one the locator has a
+    field for — the label has none, and naming it would send the depositor
+    after something they cannot set. Before that field existed this
+    refusal named the label and reported
+    ``locator_can_express: false``, which meant no corrected request
+    existed at all; ``test_the_new_field_is_optional_and_its_absence_still_refuses``
+    holds the pair.
     """
     entries, statmechs = _seed_participants(db_session)
-    for label in ("basin-A", "basin-B"):
-        attach_conformer_selection(
-            db_session,
-            conformer_group=make_conformer_group(
-                db_session, entries["ch3"], label=label
-            ),
-        )
+    groups = [
+        make_conformer_group(db_session, entries["ch3"], label=label)
+        for label in ("basin-A", "basin-B")
+    ]
+    for group in groups:
+        attach_conformer_selection(db_session, conformer_group=group)
 
     resp = client.post(_KINETICS, json=_payload(statmechs))
 
@@ -164,13 +184,17 @@ def test_two_labelled_groups_make_the_locator_ambiguous(client, db_session) -> N
     ), body
     assert context["kind"] == "conformer_selection", body
     assert context["match_count"] == 2, body
-    assert context["discriminator"] == "conformer_group_label", body
-    assert context["discriminator_values"] == ["basin-A", "basin-B"], body
-    assert context["differs_by"] == [
-        "conformer_group_label",
-        "conformer_group_ref",
+    assert context["discriminator"] == "conformer_group_ref", body
+    assert context["discriminator_values"] == [
+        group.public_ref for group in groups
     ], body
-    assert context["locator_can_express"] is False, body
+    # The label still varies and is still reported; it is simply not the
+    # axis the advice names.
+    assert context["differs_by"] == [
+        "conformer_group_ref",
+        "conformer_group_label",
+    ], body
+    assert context["locator_can_express"] is True, body
 
 
 def test_two_unlabelled_groups_fall_back_to_the_group_ref(client, db_session) -> None:
@@ -181,6 +205,9 @@ def test_two_unlabelled_groups_fall_back_to_the_group_ref(client, db_session) ->
     groups with no label — and then the label separates nothing. Reporting
     the public refs keeps this out of the "differ by nothing" outcome,
     which would have called two real curation rows a duplicate.
+
+    It is also why the locator's new field is a public ref and not a
+    label: here there is no label to write in one.
     """
     entries, statmechs = _seed_participants(db_session)
     groups = [
@@ -201,7 +228,7 @@ def test_two_unlabelled_groups_fall_back_to_the_group_ref(client, db_session) ->
     assert sorted(context["discriminator_values"]) == sorted(
         group.public_ref for group in groups
     ), body
-    assert context["locator_can_express"] is False, body
+    assert context["locator_can_express"] is True, body
 
 
 def test_a_third_group_is_counted_and_listed(client, db_session) -> None:
@@ -213,13 +240,12 @@ def test_a_third_group_is_counted_and_listed(client, db_session) -> None:
     shape of wrong that reads as right.
     """
     entries, statmechs = _seed_participants(db_session)
-    for label in ("basin-A", "basin-B", "basin-C"):
-        attach_conformer_selection(
-            db_session,
-            conformer_group=make_conformer_group(
-                db_session, entries["ch3"], label=label
-            ),
-        )
+    groups = [
+        make_conformer_group(db_session, entries["ch3"], label=label)
+        for label in ("basin-A", "basin-B", "basin-C")
+    ]
+    for group in groups:
+        attach_conformer_selection(db_session, conformer_group=group)
 
     resp = client.post(_KINETICS, json=_payload(statmechs))
 
@@ -227,10 +253,10 @@ def test_a_third_group_is_counted_and_listed(client, db_session) -> None:
     body = resp.json()
     assert body["code"] == _AMBIGUOUS, body
     assert body["context"]["match_count"] == 3, body
+    # All three refs, in label order -- three values, not the first two,
+    # and the depositor picks one of them for ``conformer_group_ref``.
     assert body["context"]["discriminator_values"] == [
-        "basin-A",
-        "basin-B",
-        "basin-C",
+        group.public_ref for group in groups
     ], body
 
 
@@ -295,3 +321,175 @@ def test_the_two_halves_no_longer_share_a_status_or_a_code(
     assert zero.status_code != several.status_code
     assert zero.json()["code"] != several.json()["code"]
     assert zero.json()["context"] != several.json()["context"]
+
+
+# ---------------------------------------------------------------------------
+# The repair: naming the conformer group
+# ---------------------------------------------------------------------------
+
+
+def test_a_group_ref_picks_one_of_two_otherwise_identical_selections(
+    client, db_session
+) -> None:
+    """The scenario the ambiguity refusal had no repair for.
+
+    Two conformer groups under one species entry, each carrying a
+    ``lowest_energy`` selection with no assignment scheme. Every other
+    field of the locator is already pinned -- ``species_entry`` and
+    ``selection_kind`` are what the ``WHERE`` clause filters on and
+    ``assignment_scheme_ref`` is NULL on both rows -- so before
+    ``conformer_group_ref`` existed this request had no accepting form at
+    all, and the 422 said so with ``locator_can_express: false``.
+
+    Asserted on both groups, not one: a filter that ignored the ref would
+    still refuse (two matches), but a filter that always picked the first
+    row would pass for one group and fail for the other.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    groups = [
+        make_conformer_group(db_session, entries["ch3"], label=label)
+        for label in ("basin-A", "basin-B")
+    ]
+    selections = [
+        attach_conformer_selection(db_session, conformer_group=group)
+        for group in groups
+    ]
+
+    for group, selection in zip(groups, selections, strict=True):
+        resp = client.post(
+            _KINETICS,
+            json=_payload(statmechs, conformer_group_ref=group.public_ref),
+        )
+
+        assert resp.status_code == 201, resp.text[:800]
+        # The row that was stored is the one the ref named, not merely
+        # some row: a lookup that resolved to the other group would still
+        # have answered 201, which is the pass this assertion refuses.
+        stored = db_session.scalar(
+            select(KineticsInterpretationAssignment.conformer_selection_id).where(
+                KineticsInterpretationAssignment.kinetics_id == resp.json()["id"],
+                KineticsInterpretationAssignment.subject_key == "reactant:1",
+            )
+        )
+        assert stored == selection.id, (stored, selection.id, group.public_ref)
+
+
+def test_a_group_ref_naming_a_group_of_another_species_entry_is_refused(
+    client, db_session
+) -> None:
+    """The locator's two halves contradict each other.
+
+    ``[OH]``'s group is a real group with a real ``lowest_energy``
+    selection, so this is not "the ref names nothing" -- it is "the ref
+    names something that is not this species entry's". 422 and the
+    ownership code, because the world is consistent and the request is
+    not; a 404 here would tell the depositor to deposit a row that already
+    exists.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    attach_conformer_selection(
+        db_session, conformer_group=make_conformer_group(db_session, entries["ch3"])
+    )
+    foreign = make_conformer_group(db_session, entries["oh"], label="basin-A")
+    attach_conformer_selection(db_session, conformer_group=foreign)
+
+    resp = client.post(
+        _KINETICS, json=_payload(statmechs, conformer_group_ref=foreign.public_ref)
+    )
+
+    assert resp.status_code == 422, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _GROUP_OWNER_MISMATCH, body
+    assert body["context"]["field"] == _GROUP_FIELD, body
+    assert body["context"]["owner_kind"] == "species_entry", body
+    # DR-0028 Requirement 2: the entry that does own it is not disclosed.
+    rendered = str(body)
+    for row_id in (entries["oh"].id, foreign.id):
+        assert str(row_id) not in rendered, (row_id, rendered)
+
+
+def test_a_group_ref_naming_nothing_is_a_404_that_echoes_it(
+    client, db_session
+) -> None:
+    """A ref for a group that is not in this database at all.
+
+    Its own code rather than ``unknown_conformer_selection``: the repair
+    is to correct the ref the caller wrote, not to deposit a selection.
+    The ref is echoed because the caller wrote it -- that is
+    ``unknown_reference``'s disclosure rule for a public ref.
+    """
+    _entries, statmechs = _seed_participants(db_session)
+
+    resp = client.post(
+        _KINETICS,
+        json=_payload(statmechs, conformer_group_ref="cg_notarealconformergroupref"),
+    )
+
+    assert resp.status_code == 404, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _UNKNOWN_GROUP, body
+    assert body["context"]["field"] == _GROUP_FIELD, body
+    assert body["context"]["kind"] == "conformer_group", body
+    assert body["context"]["ref"] == "cg_notarealconformergroupref", body
+
+
+def test_a_named_group_holding_no_such_selection_is_the_selection_404(
+    client, db_session
+) -> None:
+    """The group is right and the selection is missing.
+
+    Distinguished from the two refusals above on purpose: this one *is*
+    repaired by depositing a selection, so it keeps
+    ``unknown_conformer_selection`` -- and the 404 now echoes the group
+    ref, so a depositor can see which group was searched.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    group = make_conformer_group(db_session, entries["ch3"], label="basin-A")
+
+    resp = client.post(
+        _KINETICS, json=_payload(statmechs, conformer_group_ref=group.public_ref)
+    )
+
+    assert resp.status_code == 404, resp.text[:800]
+    body = resp.json()
+    assert body["code"] == _UNKNOWN, body
+    assert body["context"]["conformer_group_ref"] == group.public_ref, body
+    assert body["context"]["selection_kind"] == "lowest_energy", body
+
+
+def test_the_new_field_is_optional_and_its_absence_still_refuses(
+    client, db_session
+) -> None:
+    """One request, both spellings, so the widening cannot be a tightening.
+
+    The same database state answers 422 without the ref and 201 with it.
+    Asserting only the 201 would pass against a build that made the field
+    required; asserting only the 422 would pass against one that ignored
+    the field entirely.
+    """
+    entries, statmechs = _seed_participants(db_session)
+    groups = [
+        make_conformer_group(db_session, entries["ch3"], label=label)
+        for label in ("basin-A", "basin-B")
+    ]
+    for group in groups:
+        attach_conformer_selection(db_session, conformer_group=group)
+
+    without = client.post(_KINETICS, json=_payload(statmechs))
+    with_ref = client.post(
+        _KINETICS, json=_payload(statmechs, conformer_group_ref=groups[0].public_ref)
+    )
+
+    assert (without.status_code, without.json()["code"]) == (
+        422,
+        _AMBIGUOUS,
+    ), without.text[:400]
+    assert with_ref.status_code == 201, with_ref.text[:800]
+    # And the refusal now names a field the payload can actually set,
+    # which is the whole point of the widening.
+    context = without.json()["context"]
+    assert context["discriminator"] == "conformer_group_ref", context
+    assert context["locator_can_express"] is True, context
+    assert sorted(context["discriminator_values"]) == sorted(
+        group.public_ref for group in groups
+    ), context

--- a/backend/tests/services/test_conformer_selection_locator.py
+++ b/backend/tests/services/test_conformer_selection_locator.py
@@ -4,23 +4,34 @@ Why a unit test and not only a wire test
 ----------------------------------------
 :func:`app.services.conformer_selection_locator.discriminate` classifies a
 candidate set three ways, and **only one of the three is reachable through
-a route**:
+a route**. Which one changed when the locator gained
+``conformer_group_ref``, and the flip is the fix:
 
-* *differs by a locator field* cannot happen, because the lookup filters on
-  every field the locator has, so candidates agree on all of them;
+* *differs by a locator field* is now the reachable one. Two conformer
+  groups under one species entry differ by ``conformer_group_ref``, which
+  the payload can set, so the refusal names a field a depositor can act
+  on. Before the field existed this outcome could not happen at all — the
+  lookup filtered on every field the locator had, so candidates agreed on
+  all of them, and that unreachability was the finding that the locator
+  was too narrow;
+* *differs by something the locator cannot express* is now the unreachable
+  one. Only the group ``label`` is inexpressible, and two candidates in
+  two groups always differ by ``public_ref`` as well, which is ordered
+  first;
 * *differs by nothing reportable* cannot happen while
   ``uq_conformer_selection_conformer_group_id`` holds — it permits one
   selection per ``(group, scheme, kind)`` and candidates share scheme and
   kind, so two candidates always sit in two groups and always differ by
   ``conformer_group_ref``.
 
-Both are worth *reporting distinctly* anyway: the first is the outcome
-that would tell a depositor what to add, and its unreachability is the
-finding that the locator is too narrow; the second would be a duplicate
-curation row, which is a different bug and one the depositor should hear
-about rather than be told to be more specific. A branch no test can enter
-is how this repository's recurring defect looks, so the function is pure
-and the classification is pinned here, over hand-built candidates.
+The two unreachable ones are worth *reporting distinctly* anyway:
+``locator_can_express`` is a published field a client branches on, and
+``false`` means nothing if no branch can produce it; and "differ by
+nothing" would be a duplicate curation row, which is a different bug and
+one the depositor should hear about rather than be told to be more
+specific. A branch no test can enter is how this repository's recurring
+defect looks, so the function is pure and the classification is pinned
+here, over hand-built candidates.
 
 The wire half — that the two codes, statuses and context keys reach a
 client, and that a locator matching exactly one selection still succeeds —
@@ -32,7 +43,10 @@ from __future__ import annotations
 import pytest
 
 from app.db.models.common import ConformerSelectionKind
+from app.schemas.workflows.kinetics_upload import ConformerSelectionContentRef
 from app.services.conformer_selection_locator import (
+    _AXES,
+    _LOCATOR_AXES,
     W_AMBIGUOUS_CONFORMER_SELECTION_LOCATOR,
     W_UNKNOWN_CONFORMER_SELECTION,
     SelectionCandidate,
@@ -120,28 +134,59 @@ def test_a_locator_field_wins_over_a_group_difference() -> None:
     )
     assert found.differs_by == (
         "selection_kind",
-        "conformer_group_label",
         "conformer_group_ref",
+        "conformer_group_label",
     ), found
     assert found.discriminator == "selection_kind", found
     assert found.locator_can_express is True, found
 
 
-# ---------------------------------------------------------------------------
-# Outcome 2: differs only by something the locator cannot express
-# ---------------------------------------------------------------------------
+def test_two_groups_are_separated_by_the_ref_and_not_by_the_label() -> None:
+    """The axis a depositor can act on, where two axes vary.
 
-
-def test_a_group_label_difference_is_reported_as_unactionable() -> None:
+    Both groups are labelled, so ``conformer_group_label`` varies and is
+    reported — but the locator has no label field and does have a
+    ``conformer_group_ref`` one, so the ref is what the advice names.
+    Ordering the label first would name the difference a depositor cannot
+    express while a field that expresses it sits unused, which is the
+    defect ``conformer_group_ref`` was added to end.
+    """
     found = discriminate(
         [
             _candidate(1, label="basin-A", group_ref="cgrp_a"),
             _candidate(2, label="basin-B", group_ref="cgrp_b"),
         ]
     )
-    assert found.discriminator == "conformer_group_label", found
-    assert found.locator_can_express is False, found
-    assert found.discriminator_values == ("basin-A", "basin-B"), found
+    assert found.differs_by == (
+        "conformer_group_ref",
+        "conformer_group_label",
+    ), found
+    assert found.discriminator == "conformer_group_ref", found
+    assert found.locator_can_express is True, found
+    assert found.discriminator_values == ("cgrp_a", "cgrp_b"), found
+
+
+def test_every_locator_axis_is_a_field_the_payload_actually_has() -> None:
+    """``locator_can_express`` is a claim about a schema, checked against it.
+
+    The whole refusal turns on this set being the truth about
+    ``ConformerSelectionContentRef``. Nothing else fails if it drifts: a
+    forgotten entry would quietly tell depositors a settable field cannot
+    be set, and a spurious one would tell them to set a field that does
+    not exist — the failure the ref was added to remove, reintroduced by a
+    constant.
+    """
+    fields = set(ConformerSelectionContentRef.model_fields)
+    assert _LOCATOR_AXES <= fields, (_LOCATOR_AXES - fields, fields)
+    assert "conformer_group_ref" in _LOCATOR_AXES, _LOCATOR_AXES
+    # The label is the axis that is *not* expressible, and the reason the
+    # widening is a public ref: ``uq_conformer_group_species_entry_id``
+    # does not declare ``postgresql_nulls_not_distinct``, so one species
+    # entry may own any number of unlabelled groups.
+    assert "conformer_group_label" not in fields, fields
+    assert "conformer_group_label" not in _LOCATOR_AXES, _LOCATOR_AXES
+    # Every axis is either expressible or accounted for as not.
+    assert set(_AXES) - _LOCATOR_AXES == {"conformer_group_label"}, _AXES
 
 
 def test_unlabelled_groups_fall_back_to_the_group_ref() -> None:
@@ -153,13 +198,17 @@ def test_unlabelled_groups_fall_back_to_the_group_ref() -> None:
     public ref is the only handle left. Without this fallback the refusal
     would land in outcome 3 and call two genuinely different curation rows
     a duplicate.
+
+    It is also the case that decided the shape of the locator's new
+    field: there is no label here for a label field to carry, so the
+    handle had to be the public ref.
     """
     found = discriminate(
         [_candidate(1, group_ref="cgrp_a"), _candidate(2, group_ref="cgrp_b")]
     )
     assert found.differs_by == ("conformer_group_ref",), found
     assert found.discriminator == "conformer_group_ref", found
-    assert found.locator_can_express is False, found
+    assert found.locator_can_express is True, found
     assert found.discriminator_values == ("cgrp_a", "cgrp_b"), found
 
 
@@ -170,18 +219,47 @@ def test_one_labelled_and_one_unlabelled_group_still_discriminate() -> None:
             _candidate(2, label="basin-B", group_ref="cgrp_b"),
         ]
     )
+    assert found.discriminator == "conformer_group_ref", found
+    assert found.discriminator_values == ("cgrp_a", "cgrp_b"), found
+    # The label difference is still reported, still with its ``None``
+    # intact -- ``differs_by`` is what tells a human the two groups are
+    # not the same basin under two names.
+    assert found.differs_by == (
+        "conformer_group_ref",
+        "conformer_group_label",
+    ), found
+
+
+# ---------------------------------------------------------------------------
+# Outcome 2: differs only by something the locator cannot express
+# ---------------------------------------------------------------------------
+
+
+def test_a_difference_only_in_the_label_is_reported_as_unactionable() -> None:
+    """The branch ``locator_can_express: false`` exists to reach.
+
+    No two stored rows can have this shape: a public ref identifies a
+    conformer group and a group has one label, so two candidates sharing a
+    ref share a label. The set is hand-built for the same reason outcome 3
+    below is — the classification has a branch for "the axis that
+    separates these is one you cannot write down", and a ``false`` a
+    client branches on means nothing if the branch producing it is never
+    executed. Since ``conformer_group_ref`` joined the locator this is the
+    only way in; before it, this was every refusal the route produced.
+    """
+    candidates = [
+        _candidate(1, label=None, group_ref="cgrp_a"),
+        _candidate(2, label="basin-B", group_ref="cgrp_a"),
+    ]
+    found = discriminate(candidates)
+    assert found.differs_by == ("conformer_group_label",), found
     assert found.discriminator == "conformer_group_label", found
+    assert found.locator_can_express is False, found
     assert found.discriminator_values == (None, "basin-B"), found
     # A ``None`` in the published list must not crash the sentence, which
-    # is the one thing sorting or ``", ".join`` would have done.
+    # is the one thing sorting or a bare ``", ".join`` would have done.
     assert "unlabelled" in str(
-        ambiguous_conformer_selection_locator(
-            field=_FIELD,
-            candidates=[
-                _candidate(1, label=None, group_ref="cgrp_a"),
-                _candidate(2, label="basin-B", group_ref="cgrp_b"),
-            ],
-        )
+        ambiguous_conformer_selection_locator(field=_FIELD, candidates=candidates)
     )
 
 
@@ -229,10 +307,10 @@ def test_the_ambiguity_refusal_publishes_the_documented_context() -> None:
         "field": _FIELD,
         "kind": "conformer_selection",
         "match_count": 3,
-        "differs_by": ["conformer_group_label", "conformer_group_ref"],
-        "discriminator": "conformer_group_label",
-        "discriminator_values": ["basin-A", "basin-B", "basin-C"],
-        "locator_can_express": False,
+        "differs_by": ["conformer_group_ref", "conformer_group_label"],
+        "discriminator": "conformer_group_ref",
+        "discriminator_values": ["cgrp_a", "cgrp_b", "cgrp_c"],
+        "locator_can_express": True,
     }, error.context
     # ``message_prefix=False``: the code is an attribute, and repeating it
     # in the prose puts a second copy where a reword can drop it.
@@ -259,11 +337,15 @@ def test_no_context_value_is_a_row_id() -> None:
 
 
 @pytest.mark.parametrize("scheme_ref", [None, "cas_aaaaaaaaaaaaaaaaaaaaaaaaaa"])
-def test_the_unknown_refusal_echoes_only_what_the_caller_wrote(scheme_ref) -> None:
+@pytest.mark.parametrize("group_ref", [None, "cg_aaaaaaaaaaaaaaaaaaaaaaaaaa"])
+def test_the_unknown_refusal_echoes_only_what_the_caller_wrote(
+    scheme_ref, group_ref
+) -> None:
     error = unknown_conformer_selection(
         field=_FIELD,
         selection_kind="lowest_energy",
         assignment_scheme_ref=scheme_ref,
+        conformer_group_ref=group_ref,
     )
     assert error.code == W_UNKNOWN_CONFORMER_SELECTION
     assert error.context["field"] == _FIELD
@@ -275,6 +357,13 @@ def test_the_unknown_refusal_echoes_only_what_the_caller_wrote(scheme_ref) -> No
         assert "assignment_scheme_ref" not in error.context, error.context
     else:
         assert error.context["assignment_scheme_ref"] == scheme_ref, error.context
+    if group_ref is None:
+        assert "conformer_group_ref" not in error.context, error.context
+        # And the remedy does not send them to a field they never set.
+        assert "conformer group" not in str(error), str(error)
+    else:
+        assert error.context["conformer_group_ref"] == group_ref, error.context
+        assert "conformer group" in str(error), str(error)
 
 
 def test_a_selection_kind_read_back_from_the_database_is_a_token() -> None:

--- a/clients/python/docs/api_parity_matrix.md
+++ b/clients/python/docs/api_parity_matrix.md
@@ -13,8 +13,8 @@ Every operation in the backend's OpenAPI document (`backend/tests/api/golden/ope
 |---|---|
 | typed | 92 |
 | raw_only | 105 |
-| not_applicable | 37 |
-| **total** | **234** |
+| not_applicable | 39 |
+| **total** | **236** |
 
 ## Typed coverage
 
@@ -292,6 +292,8 @@ Admin, auth, and curator-internal surface that a producer/consumer client is not
 
 | Operation | raw HTTP | typed client | iterator | example | contract test |
 |---|---|---|---|---|---|
+| `GET /api/v1/admin/artifact-storage/capacity` | yes | — | — | — | — |
+| `POST /api/v1/admin/artifact-storage/capacity/clear` | yes | — | — | — | — |
 | `GET /api/v1/admin/machine-review/curator-tasks` | yes | — | — | — | — |
 | `POST /api/v1/admin/machine-review/curator-tasks/build-for-submission/{submission_id}` | yes | — | — | — | — |
 | `GET /api/v1/admin/machine-review/curator-tasks/{task_id}` | yes | — | — | — | — |

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.52.3"
+version = "0.52.4"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/_parity.py
+++ b/clients/python/src/tckdb_client/_parity.py
@@ -722,6 +722,15 @@ _RAW_ONLY: tuple[tuple[str, str, str], ...] = tuple(
 _NOT_APPLICABLE: tuple[tuple[str, str, str], ...] = tuple(
     (method, path, _ADMIN_ONLY)
     for method, path in (
+        # Both gated on ``require_admin`` in
+        # ``backend/app/api/routes/admin.py``: an operator reads whether
+        # the object store is refusing writes, and an operator declares
+        # the condition resolved. Arrived with #218 and were untriaged
+        # here until now -- this workflow runs only on ``clients/python``
+        # and ``schemas/`` paths, and #218 touched neither, so the drift
+        # sat green until the next pull request that did.
+        ("GET", "/api/v1/admin/artifact-storage/capacity"),
+        ("POST", "/api/v1/admin/artifact-storage/capacity/clear"),
         ("GET", "/api/v1/admin/machine-review/curator-tasks"),
         (
             "POST",

--- a/clients/python/src/tckdb_client/rejection_codes.py
+++ b/clients/python/src/tckdb_client/rejection_codes.py
@@ -215,6 +215,7 @@ class RejectionCode(str, Enum):
     UNIQUE_CONFLICT = "unique_conflict"
     UNKNOWN_CALCULATION_ARTIFACT_REF = "unknown_calculation_artifact_ref"
     UNKNOWN_CALCULATION_REF = "unknown_calculation_ref"
+    UNKNOWN_CONFORMER_GROUP_REF = "unknown_conformer_group_ref"
     UNKNOWN_CONFORMER_SELECTION = "unknown_conformer_selection"
     UNKNOWN_CURATION_POLICY = "unknown_curation_policy"
     UNKNOWN_INCLUDE_TOKEN = "unknown_include_token"
@@ -530,6 +531,7 @@ REJECTION_STATUSES: dict[RejectionCode, frozenset[int]] = {
     RejectionCode.UNIQUE_CONFLICT: frozenset({409}),
     RejectionCode.UNKNOWN_CALCULATION_ARTIFACT_REF: frozenset({404}),
     RejectionCode.UNKNOWN_CALCULATION_REF: frozenset({404}),
+    RejectionCode.UNKNOWN_CONFORMER_GROUP_REF: frozenset({404}),
     RejectionCode.UNKNOWN_CONFORMER_SELECTION: frozenset({404}),
     RejectionCode.UNKNOWN_CURATION_POLICY: frozenset({404}),
     RejectionCode.UNKNOWN_INCLUDE_TOKEN: frozenset({422}),


### PR DESCRIPTION
## In plain language

TCKDB stores, for each molecule, groups of conformers (the distinct
shapes a molecule can twist into) and, per group, a *selection* — the
curator's note saying which conformer in that group is the lowest-energy
one. When someone uploads a rate coefficient, they can point at one of
those selections so a reader knows exactly which structure the rate was
computed from.

They point at it by *description*, not by name: "the lowest-energy
selection for this species entry, under no assignment scheme". That works
only while the description picks out exactly one stored row. It often did
not. A species entry normally owns several conformer groups — the server
mints a new one every time an upload shows a shape it does not recognise
— and each group can carry its own lowest-energy selection. The
description then matches two rows, and the server refused with 422
`ambiguous_conformer_selection_locator` ("several match; be more
specific").

The problem: **there was nothing to be more specific with.** Every field
the description had was already filled in. The one thing that
distinguishes the two rows is which conformer group they belong to, and
the upload form had no field for it. The server's own error even said so.
The depositor was holding the group's public reference (`cg_…`, the
identifier the read API hands out) and had nowhere to put it. PR #213
diagnosed this and deferred the fix.

This PR adds that field. Some vocabulary, since it is all software terms:
a *locator* is a block of JSON that describes an existing record instead
of naming it; a *public ref* is a short opaque string like
`cg_pxuoiv6p2c…` that TCKDB issues for a record and shows in read
responses — unlike a database row id, it is a stable public handle, which
is why citing one is allowed in an upload; a *code* is the machine-readable
string in an error body that a client program branches on; and the
*catalogue* is the single list of every code the API can return, from
which the Python client's enum is generated.

Three things follow. Naming a group that resolves the ambiguity is now
accepted. Naming a group that does not exist gets its own 404 saying so
(repair: fix the string). Naming a real group that belongs to a *different*
molecule gets a 422 ownership refusal (repair: fix one of the two halves
of the locator that disagree) — not a 404, because telling someone to
deposit a record they can already read is advice nobody can follow.

And the error that started all this now names a field a depositor can
actually set: `discriminator: conformer_group_ref`,
`locator_can_express: true`, with the list of `cg_` refs to choose from.

## Technical detail

`ConformerSelectionContentRef`
(`backend/app/schemas/workflows/kinetics_upload.py`) gains an **optional**
`conformer_group_ref`. Every payload valid before is still valid; this
widens the locator and does not tighten it.

**Why a public ref and not a label.** `uq_conformer_group_species_entry_id`
(`backend/app/db/models/species.py:254-261`) does *not* declare
`postgresql_nulls_not_distinct` — unlike `SpeciesEntry` (:205-214) and
`ConformerSelection` (:363) in the same file — so a species entry may own
arbitrarily many *unlabelled* groups, and among those a label
discriminates nothing. `ConformerGroup` already carries an opaque public
ref via `PublicRefMixin`, prefix `cg`.

**Why this does not violate the no-FK-IDs-in-uploads rule.** A public ref
is not a database FK id. It is the opaque, stable handle the read API
already hands a client (`GET /scientific/conformer-groups/{ref}`), so
citing one is a client naming a record it can see — which is the thing
that rule exists to preserve. No row id is accepted, echoed, or logged
into a response body.

**Resolution** (`_resolve_interpretation_assignments`,
`backend/app/workflows/kinetics.py`). The ref is resolved to a row
*before* being used as a filter, rather than folded into the `WHERE`
clause. Folded in, "no such group", "another entry's group" and "that
group holds no such selection" would all arrive as one empty result and
one 404 — three repairs behind one sentence, the exact defect #213 split
apart. So:

| Condition | Status | Code |
|---|---|---|
| Ref resolves a group of this species entry | 201 | — |
| Ref names no group at all | 404 | `unknown_conformer_group_ref` (**new**) |
| Ref names a group of another species entry | 422 | `kinetics_interpretation_conformer_selection_owner_mismatch` (existing) |
| Group is right, no selection matches | 404 | `unknown_conformer_selection` (existing, now echoes the group ref) |
| Ref omitted, several selections match | 422 | `ambiguous_conformer_selection_locator` (existing, now actionable) |

The one new code follows the existing `W_UNKNOWN_*_REF` family in
`upload_reference.py` and is built by `unknown_reference(ref=…)`, so the
ref is echoed under that helper's disclosure rule. It is catalogued in
`app/api/code_catalogue.py`; it asserts nothing scientific, so it does not
enter the scientific check register. The owner-mismatch case reuses the
existing code through the shared `assert_owned_by` guard rather than
inventing one: the repair is the same class ("cite a record owned by the
right species entry") and `context['field']` separates the two raise
sites, following the precedent stated in
`kinetics_interpretation_statmech_owner_mismatch`'s own catalogue note.

`_LOCATOR_AXES` gains `conformer_group_ref`, and `_AXES` now orders it
**ahead of** `conformer_group_label`, so where both vary the refusal names
the one a payload can set. This flips which classification outcome is
reachable: "differs by a locator field" was structurally unreachable and
is now the one a request reaches; "differs by something the locator cannot
express" is now unreachable. The module docstring asserted the opposite
and has been rewritten; the unreachable branch is kept and unit-tested
over hand-built candidates, because `locator_can_express` is a published
field a client branches on and `false` means nothing if no branch produces
it.

## Schema / migration impact

**None.** No table, column, constraint or enum changes; no Alembic
revision. `uq_conformer_group_species_entry_id` is deliberately left
without `postgresql_nulls_not_distinct` — it would not fix this defect and
would be a breaking migration on any deployment already holding two
unlabelled groups per entry.

## New environment variables

None.

## Verification actually run

Reproduction first, before any fix. Five new API tests were written
against the four-step scenario and run on unmodified `main`:

```
5 failed, 7 passed
E   assert 'request_validation_error' == 'kinetics_interpretation_conformer_selection_owner_mismatch'
E   {'input': 'cg_pxuoiv6p2cuexbkuqdnzileaim', 'loc': [...,'conformer_group_ref'],
    'msg': 'Extra inputs are not permitted', 'type': 'extra_forbidden'}
```

`SchemaBase` sets `extra="forbid"`, so the only field that could repair
the request was rejected outright — the defect exactly as described. The
pre-existing `test_two_labelled_groups_make_the_locator_ambiguous` passed
at the same time asserting `locator_can_express is False`, which is the
other half of it.

**Mutation testing.** Three mutations landed, each proved present in
`git diff`, run, restored, and re-run to identity:

1. `if selection_group is not None and False:` — the ref accepted but
   ignored. → 2 failed
   (`test_a_group_ref_picks_one_of_two_otherwise_identical_selections`,
   `test_the_new_field_is_optional_and_its_absence_still_refuses`).
2. `_AXES` reordered to put `conformer_group_label` back ahead of
   `conformer_group_ref`. → 7 failed across both test files.
3. `assert_owned_by` replaced with a no-op at the group-ownership call. →
   1 failed (`test_a_group_ref_naming_a_group_of_another_species_entry_is_refused`),
   and it failed by answering 404 — confirming that without the guard the
   foreign-group case collapses into the wrong refusal.

After restoring all three: `29 passed`.

**Lint**, from `backend/`:

```
conda run -n tckdb_env ruff check app tests scripts     # All checks passed!
conda run -n tckdb_env ruff format --check app tests scripts   # exit 0
```

**Gates**, from `backend/`, exit codes captured explicitly (not read off a
pipe):

```
conda run -n tckdb_env bash scripts/test-api.sh          EXIT=0   3075 passed
conda run -n tckdb_env bash scripts/test-rest.sh         EXIT=0   4838 passed, 14 skipped
conda run -n tckdb_env bash scripts/test-scientific.sh   EXIT=0   2079 passed
```

The first `test-api.sh` run failed on `test_openapi_snapshot.py` only —
the golden OpenAPI snapshot, which the new optional field legitimately
changes. Regenerated with `UPDATE_OPENAPI_GOLDEN=1`; the diff is one added
optional string property and the schema description, reviewed and
committed. The rerun above is post-regeneration.

`clients/python` tests: initially `1368 passed, 3 failed`, all three in
`tests/test_openapi_parity.py::TestBackendParity`, and all three confirmed
pre-existing by stashing this branch's changes and re-running on the
untouched baseline, where they fail identically. See the second commit.
After it: `1371 passed`, plus `55 passed, 1 skipped` for the CHEMKIN
adapter and `38 passed` for the wire-contract schemas, matching the three
invocations `python-client-ci.yml` makes.

### The second commit, and why it is here

`tckdb_client._parity` classifies every backend operation as typed /
raw_only / not_applicable, and two arrived with #218 —
`GET /api/v1/admin/artifact-storage/capacity` and
`POST /api/v1/admin/artifact-storage/capacity/clear` — with no entry.
The gate did not fire then because `python-client-ci` runs only on
`clients/python/**` and `schemas/**` paths and #218 touched neither; it
fires on the next PR that does, which is this one, taking `Required gates`
red with it. Both routes are `require_admin`-gated in
`backend/app/api/routes/admin.py`, so they take `_ADMIN_ONLY` like every
other `/api/v1/admin` operation in the ledger, and
`docs/api_parity_matrix.md` is regenerated with
`scripts/generate_parity_matrix.py` (not_applicable 37 → 39, total
234 → 236). It is kept as a separate commit because it has nothing to do
with conformer groups — it is only what this PR surfaced.

## Package version

`clients/python/src/tckdb_client/rejection_codes.py` is generated from the
catalogue and gained the new code, so `clients/python/pyproject.toml` is
bumped 0.52.3 → 0.52.4. Nothing under `schemas/python/tckdb-schemas/`
changed, so the wire package is not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEMrWcGRqbAVoh1Cn3TJ9D
