### PR TITLE
Give the landing page a way into the data

### DIFF
--- a/backend/app/api/landing.py
+++ b/backend/app/api/landing.py
@@ -4,25 +4,42 @@ Everything else this application serves is JSON for a machine. This one
 page is for a person -- specifically the person who was handed the base
 URL in a paper or a README, typed it, and until now received a bare
 ``404 application/json`` blob with no indication that anything was
-there at all. A referee following a URL printed in a manuscript is the
-worst possible audience for that, and was the one getting it.
+there at all.
 
-The page is deliberately austere:
+The page's job is to *lead somewhere*. An earlier version described the
+database in six hundred words and ended in three links, which is a dead
+end dressed as an introduction. The hero is now a search box that
+queries this deployment's own public read API and renders the records
+it gets back, so the first thing a visitor does is get real data out.
+
+Design constraints, in the order they constrain things:
 
 * **Self-contained.** No CDN, no external stylesheet, no web font, no
-  analytics, no JavaScript. Every byte the browser renders arrives in
-  this one response, so the page works on a locked-down network, from
-  an archived copy, and with scripting disabled. The API reference at
-  ``/redoc`` does *not* share this property -- see
-  :func:`app.api.app.create_app` -- which is exactly why the landing
-  page is not built on top of it.
+  remote image, no analytics. Every byte the browser renders arrives in
+  this one response, so the page works on a locked-down network and
+  from an archived copy. The one script on the page is inline and talks
+  only to this same origin, under ``/api/v1``; there is no subresource
+  to fetch and no third party to trust.
+* **Works without JavaScript.** The search form is a real
+  ``<form method="get">`` whose action is the API endpoint itself, so
+  with scripting off it still searches -- the browser simply lands on
+  the JSON instead of a rendered list. The example queries are real
+  links to the same endpoint for the same reason. JavaScript upgrades
+  that form to an in-page search; it is not what makes it work. The
+  identifier picker is the one control that genuinely cannot function
+  without script (an HTML form cannot rename its own field), so it
+  ships ``disabled`` and a ``<noscript>`` block offers a plain form per
+  identifier instead of silently searching the wrong field.
 * **Factual.** It states no record count, no uptime, no funder, no
   institution and no contributor beyond the authors already named in
-  the repository's ``CITATION.cff``. A page that guesses at its own
-  corpus size is worse than a page that omits it, because the reader
-  cannot tell which numbers were guessed.
+  the repository's ``CITATION.cff``. Every number a visitor sees in the
+  results came back from a live request they just made -- including the
+  review counts, which are displayed rather than apologised for.
+  Under-review records are public here and are served; the label says
+  how far a record has been checked, and that is information, not a
+  disclaimer.
 
-The worked example in the hero is not illustrative fiction. The
+The worked example lower down the page is not illustrative fiction. The
 frequency list, the geometry, the code and the sentence are the real
 output of :mod:`app.services.frequency_geometry_linearity` for that
 input, transcribed from an actual run; ``tests/api/test_landing_page.py``
@@ -38,6 +55,9 @@ one deployment shape nobody tests locally.
 """
 
 from __future__ import annotations
+
+import json
+from urllib.parse import quote
 
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
@@ -56,7 +76,44 @@ REPO_URL = "https://github.com/TCKDB/TCKDB"
 #: application factory cannot drift apart.
 REDOC_PATH = "/redoc"
 
-#: The geometry shown in the hero's left panel, and the input the test
+#: The read endpoint the hero searches. Public: no key, no account, and
+#: same-origin from this page, so the browser needs neither CORS nor a
+#: proxy to reach it.
+SPECIES_SEARCH_PATH = "/api/v1/scientific/species/search"
+
+#: The identifiers the picker offers, as ``(query parameter, label)``.
+#: An explicit choice rather than a guess: ``O`` is a valid formula
+#: *and* a valid SMILES meaning two different things, and guessing
+#: wrong returns a confusing empty result instead of an answer.
+SEARCH_FIELDS = (
+    ("formula", "formula"),
+    ("smiles", "SMILES"),
+    ("inchi_key", "InChIKey"),
+)
+
+#: What the box is pre-filled with, and the query the page runs on load
+#: so that nobody's first sight of the search is an empty box.
+SEED_FIELD = "formula"
+SEED_VALUE = "CH3"
+
+#: Offered under the box and again in the empty state. Each is a real
+#: link to the API, so they work with scripting disabled.
+SEARCH_EXAMPLES = (
+    ("formula", "CH3"),
+    ("formula", "H2O"),
+    ("smiles", "[OH]"),
+)
+
+#: Placeholder text per identifier, shown once the picker is live. Each
+#: is a real value in that field's syntax, so the hint doubles as a
+#: worked example of what the field expects.
+SEARCH_PLACEHOLDERS = (
+    ("formula", "CH3"),
+    ("smiles", "[OH]"),
+    ("inchi_key", "WCYWZMWISLQXQU-UHFFFAOYSA-N"),
+)
+
+#: The geometry shown in the worked example, and the input the test
 #: feeds back through the real checker. Carbon dioxide, collinear along
 #: z at a 1.162 A bond length.
 HERO_XYZ = """3
@@ -84,8 +141,8 @@ _PAGE_TEMPLATE = """<!DOCTYPE html>
 <title>TCKDB &mdash; Thermochemical &amp; Kinetics Database</title>
 <meta name="description"
       content="TCKDB is a provenance-tracked database and HTTP API for
-               computational chemistry data. Every deposit is checked, and
-               every objection carries a code and its reasoning.">
+               computational chemistry data. Search it from the landing
+               page; every result carries its review state.">
 <style>
 /*
  * Palette: molecular-orbital phase convention. Two signed colours,
@@ -93,7 +150,7 @@ _PAGE_TEMPLATE = """<!DOCTYPE html>
  * phase, real versus imaginary frequencies, accepted versus flagged.
  * Indigo is the positive lobe and reads as "accepted / real";
  * orange-red is the negative lobe and appears essentially only on the
- * verdict.
+ * verdict and on a rejected review state.
  *
  * --phase-neg-text is the same hue darkened until it clears WCAG AA
  * against --paper (4.9:1; the display value is 4.0:1, which is a
@@ -157,6 +214,16 @@ a:hover { text-decoration-thickness: 2px; }
   outline-offset: 3px;
   border-radius: 2px;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
 .skip {
   position: absolute;
   left: -9999px;
@@ -169,7 +236,7 @@ a:hover { text-decoration-thickness: 2px; }
 .skip:focus { left: 0.75rem; top: 0.75rem; z-index: 10; }
 
 /* ---- header ---- */
-header { padding: 4rem 0 0; }
+header { padding: 3rem 0 0; }
 h1 { margin: 0; font-weight: 400; }
 .wordmark {
   display: block;
@@ -187,22 +254,22 @@ h1 { margin: 0; font-weight: 400; }
   color: var(--muted);
 }
 .lede {
-  margin: 1.5rem 0 0;
-  max-width: 34rem;
+  margin: 1.25rem 0 0;
+  max-width: 40rem;
   font-size: var(--fs-lede);
 }
-nav.actions { margin-top: 1.75rem; }
+nav.actions { margin-top: 1.25rem; }
 nav.actions ul {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.6rem;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 .button {
   display: inline-block;
-  padding: 0.55rem 1.05rem;
+  padding: 0.5rem 1rem;
   font-family: var(--mono);
   font-size: var(--fs-data);
   font-weight: 700;
@@ -214,24 +281,264 @@ nav.actions ul {
 .button.secondary { background: transparent; color: var(--phase-pos); }
 
 /* ---- sections ---- */
-section { margin-top: 4rem; }
+section { margin-top: 3.25rem; }
+section.hero { margin-top: 2.5rem; }
 h2 {
   font-family: var(--mono);
   font-size: var(--fs-section);
   font-weight: 700;
   letter-spacing: -0.02em;
-  margin: 0 0 1rem;
+  margin: 0 0 0.6rem;
 }
 h3 {
   font-family: var(--mono);
   font-size: var(--fs-body);
   font-weight: 700;
   letter-spacing: -0.01em;
-  margin: 1.9rem 0 0.35rem;
+  margin: 1.4rem 0 0.35rem;
 }
-p { margin: 0.85rem 0; max-width: 38rem; }
+p { margin: 0.75rem 0; max-width: 38rem; }
+.note { color: var(--muted); font-size: 0.9375rem; }
 
-/* ---- the exchange ---- */
+/* ---- search ---- */
+.search { margin: 1rem 0 0; }
+.search-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+.search select,
+.search input,
+.search button {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  padding: 0.6rem 0.7rem;
+  border: 1.5px solid var(--rule);
+  background: var(--surface);
+  color: var(--ink);
+  line-height: 1.3;
+  min-height: 2.75rem;
+}
+.search select { flex: 0 0 auto; }
+.search select:disabled { color: var(--muted); }
+.search input {
+  flex: 1 1 11rem;
+  min-width: 0;
+  border-color: var(--phase-pos);
+}
+.search button {
+  flex: 0 0 auto;
+  cursor: pointer;
+  font-weight: 700;
+  background: var(--phase-pos);
+  color: var(--surface);
+  border-color: var(--phase-pos);
+}
+.examples {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin: 0.7rem 0 0;
+  max-width: none;
+  font-size: var(--fs-data);
+  color: var(--muted);
+}
+.chip {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  text-decoration: none;
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  color: var(--phase-pos);
+  padding: 0.2rem 0.5rem;
+  overflow-wrap: anywhere;
+}
+.chip:hover { border-color: var(--phase-pos); }
+noscript { display: block; margin-top: 1rem; }
+.fallback {
+  border: 1px solid var(--rule);
+  padding: 0.9rem 1rem;
+  background: var(--surface);
+}
+.fallback p { margin: 0 0 0.6rem; font-size: 0.9375rem; }
+.fallback form { display: inline-flex; gap: 0.35rem; margin: 0 0.5rem 0.4rem 0; }
+.fallback input, .fallback button {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--rule);
+  background: var(--paper);
+  color: var(--ink);
+}
+
+/* ---- results ---- */
+.results { margin-top: 1.25rem; }
+.results-status {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+  margin: 0;
+}
+.results-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+  max-width: none;
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+}
+.results-count { color: var(--ink); font-weight: 700; }
+.record {
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  padding: 0.9rem 1rem 1rem;
+  margin-top: 0.6rem;
+}
+.record-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem 0.75rem;
+}
+.smiles {
+  font-family: var(--mono);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+.record-meta {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+.record-refs {
+  margin: 0.5rem 0 0;
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+  overflow-wrap: anywhere;
+  max-width: none;
+}
+.entry {
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+.entry-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+}
+.entry-kind {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+}
+.entry-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.6rem;
+}
+.pill {
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border: 1px solid var(--rule);
+  color: var(--phase-pos);
+  background: var(--paper);
+  padding: 0.25rem 0.5rem;
+}
+.pill:hover { border-color: var(--phase-pos); }
+.pill-none { color: var(--muted); }
+/*
+ * The review state, on every record. Under review is a normal, honest
+ * state -- most of what is served is in it -- so it is drawn as
+ * information: the same neutral chip as everything else, distinguished
+ * from approved by a hollow rather than filled dot, and always carrying
+ * a word so the state never depends on colour alone. Only deprecated
+ * and rejected borrow the negative phase colour.
+ */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  border: 1px solid var(--rule);
+  background: var(--data-bg);
+  color: var(--ink);
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+.badge .dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  border: 1.5px solid var(--phase-pos);
+  background: transparent;
+}
+.badge-approved .dot { background: var(--phase-pos); }
+.badge-not_reviewed .dot { border-color: var(--muted); }
+.badge-deprecated .dot,
+.badge-rejected .dot {
+  border-color: var(--phase-neg);
+  background: var(--phase-neg);
+}
+.empty, .failure {
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--phase-pos);
+  background: var(--surface);
+  padding: 0.9rem 1rem;
+}
+.failure { border-left-color: var(--phase-neg); }
+.empty p, .failure p { margin: 0 0 0.5rem; max-width: none; }
+.empty p:last-child, .failure p:last-child { margin-bottom: 0; }
+.failure-code {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  font-weight: 700;
+  color: var(--phase-neg-text);
+}
+.failure-detail { font-family: var(--mono); font-size: var(--fs-data); overflow-wrap: anywhere; }
+
+/* ---- the four roles ---- */
+.roles { margin: 0; }
+.roles > div {
+  padding: 0.9rem 0;
+  border-top: 1px solid var(--rule);
+}
+.roles > div:last-child { border-bottom: 1px solid var(--rule); }
+.roles dt {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-family: var(--mono);
+  font-size: var(--fs-body);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.behaviour {
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--phase-pos);
+}
+.roles dd { margin: 0.3rem 0 0; max-width: 38rem; }
+
+/* ---- the worked example ---- */
 /*
  * <figure> carries a 40px side margin by UA default, which on a 360px
  * screen spends 80px of the viewport on nothing and squeezes the
@@ -257,7 +564,7 @@ p { margin: 0.85rem 0; max-width: 38rem; }
 }
 .panel {
   background: var(--surface);
-  padding: 1.1rem 1.25rem 1.35rem;
+  padding: 1rem 1.1rem 1.15rem;
   min-width: 0;
 }
 .panel-label {
@@ -267,7 +574,7 @@ p { margin: 0.85rem 0; max-width: 38rem; }
   letter-spacing: 0.11em;
   text-transform: uppercase;
   color: var(--muted);
-  margin: 0 0 0.85rem;
+  margin: 0 0 0.75rem;
 }
 .panel.verdict .panel-label { color: var(--phase-neg-text); }
 .panel pre {
@@ -284,9 +591,8 @@ p { margin: 0.85rem 0; max-width: 38rem; }
   white-space: pre;
   overflow-x: auto;
   background: var(--data-bg);
-  padding: 0.75rem 0.85rem;
+  padding: 0.7rem 0.8rem;
 }
-.panel pre + .panel-sub { margin-top: 1rem; }
 .panel-sub {
   font-family: var(--mono);
   font-size: var(--fs-label);
@@ -294,7 +600,7 @@ p { margin: 0.85rem 0; max-width: 38rem; }
   letter-spacing: 0.11em;
   text-transform: uppercase;
   color: var(--muted);
-  margin: 1rem 0 0.5rem;
+  margin: 0.9rem 0 0.45rem;
 }
 .verdict-code {
   display: block;
@@ -302,8 +608,7 @@ p { margin: 0.85rem 0; max-width: 38rem; }
   /*
    * Sized to fit the 45-character code on one line at the widest
    * fallback mono face, because a code broken mid-token reads as
-   * damage rather than emphasis. Its prominence comes from the
-   * weight, the phase-negative colour and the rule beside it.
+   * damage rather than emphasis.
    */
   font-size: var(--fs-data);
   font-weight: 700;
@@ -314,57 +619,8 @@ p { margin: 0.85rem 0; max-width: 38rem; }
   border-left: 3px solid var(--phase-neg);
   padding-left: 0.7rem;
 }
-.verdict-body { margin: 0.9rem 0 0; font-size: 0.9375rem; max-width: none; }
+.verdict-body { margin: 0.85rem 0 0; font-size: 0.9375rem; max-width: none; }
 .verdict-body:last-child { margin-bottom: 0; }
-figcaption {
-  margin-top: 1rem;
-  color: var(--muted);
-  font-size: 0.9375rem;
-  max-width: 40rem;
-}
-/*
- * The single orchestrated moment: the reply arrives a beat after the
- * deposit, in the order a request and its response actually happen.
- * The resting state is fully visible and the keyframes run *from*
- * hidden, so a browser that never runs the animation -- reduced
- * motion, an old engine, a print stylesheet -- shows the panel rather
- * than an empty box.
- */
-@keyframes reply-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: none; }
-}
-.panel.verdict { animation: reply-in 420ms ease-out 380ms backwards; }
-@media (prefers-reduced-motion: reduce) {
-  .panel.verdict { animation: none; }
-}
-
-/* ---- the four roles ---- */
-.roles { margin: 0; }
-.roles > div {
-  padding: 1.15rem 0;
-  border-top: 1px solid var(--rule);
-}
-.roles > div:last-child { border-bottom: 1px solid var(--rule); }
-.roles dt {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.6rem;
-  font-family: var(--mono);
-  font-size: var(--fs-body);
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-.behaviour {
-  font-family: var(--mono);
-  font-size: var(--fs-label);
-  font-weight: 700;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-  color: var(--phase-pos);
-}
-.roles dd { margin: 0.4rem 0 0; max-width: 38rem; }
 
 /* ---- code and prose data ---- */
 code {
@@ -372,6 +628,7 @@ code {
   font-size: 0.9em;
   background: var(--data-bg);
   padding: 0.08em 0.3em;
+  overflow-wrap: anywhere;
 }
 pre.command {
   font-family: var(--mono);
@@ -387,7 +644,7 @@ pre.command code { background: none; padding: 0; }
 
 /* ---- footer ---- */
 footer {
-  margin-top: 4.5rem;
+  margin-top: 3.5rem;
   padding-top: 1.25rem;
   border-top: 1px solid var(--rule);
   color: var(--muted);
@@ -405,19 +662,122 @@ footer p { max-width: none; margin: 0; }
     <span class="fullname">Thermochemical &amp; Kinetics Database</span>
   </h1>
   <p class="lede">
-    Provenance-tracked computational chemistry data, served over HTTP.
-    Every deposit is checked on the way in, and every objection carries a
-    machine-readable code and the reasoning behind it.
+    Provenance-tracked computational chemistry data over a public HTTP API.
+    The reads below need no account and no key.
   </p>
   <nav class="actions" aria-label="Primary">
     <ul>
-      <li><a class="button primary" href="__DOCS_URL__">Documentation</a></li>
-      <li><a class="button secondary" href="__REPO_URL__">Source repository</a></li>
+      __REFERENCE_BUTTON__
+      <li><a class="button __DOCS_BUTTON__" href="__DOCS_URL__">Documentation</a></li>
+      <li><a class="button secondary" href="__REPO_URL__">Source</a></li>
     </ul>
   </nav>
 </header>
 
 <main id="main">
+
+  <section class="hero" aria-labelledby="search-heading">
+    <h2 id="search-heading">Search species</h2>
+    <p class="note">
+      Records under review are served, not withheld; every result says how
+      far it has been checked.
+    </p>
+
+    <form id="search-form" class="search" method="get" action="__SEARCH_PATH__">
+      <div class="search-row">
+        <label class="sr-only" for="search-field">Identifier</label>
+        <select id="search-field" disabled>
+__FIELD_OPTIONS__
+        </select>
+        <label class="sr-only" for="search-input">Search value</label>
+        <input id="search-input" name="__SEED_FIELD__" type="search"
+               value="__SEED_VALUE__" autocomplete="off" autocapitalize="off"
+               spellcheck="false">
+        <button type="submit">Search</button>
+      </div>
+    </form>
+
+    <p class="examples" id="examples">
+      <span>Try</span>
+__EXAMPLE_CHIPS__
+    </p>
+
+    <noscript>
+      <div class="fallback">
+        <p>
+          JavaScript is off, so the box above submits as a plain form and
+          searches by formula. These search the other identifiers:
+        </p>
+        <form method="get" action="__SEARCH_PATH__">
+          <label class="sr-only" for="fallback-smiles">SMILES</label>
+          <input id="fallback-smiles" name="smiles" type="search" placeholder="SMILES">
+          <button type="submit">Search</button>
+        </form>
+        <form method="get" action="__SEARCH_PATH__">
+          <label class="sr-only" for="fallback-inchi-key">InChIKey</label>
+          <input id="fallback-inchi-key" name="inchi_key" type="search" placeholder="InChIKey">
+          <button type="submit">Search</button>
+        </form>
+      </div>
+    </noscript>
+
+    <div id="results" class="results" aria-live="polite">
+      <p class="results-status">
+        Results land here. Without JavaScript the box and examples go
+        straight to the API's JSON.
+      </p>
+    </div>
+  </section>
+
+  <section aria-labelledby="quickstart-heading">
+    <h2 id="quickstart-heading">Quickstart</h2>
+    <p>
+      Everything machine-readable is under <code>/api/v1</code>. Reads are
+      open; depositing needs an account.
+    </p>
+    <pre class="command"><code>TCKDB=<span id="curl-origin">__ORIGIN_PLACEHOLDER__</span>
+curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
+    <p>__API-REFERENCE__</p>
+    <p>
+      A Python client, <code>tckdb-client</code>, handles auth, retries and
+      idempotency:
+    </p>
+    <pre class="command"><code>pip install "git+__REPO_URL__.git#subdirectory=clients/python"</code></pre>
+  </section>
+
+  <section aria-labelledby="roles-heading">
+    <h2 id="roles-heading">Four roles, one per table</h2>
+    <dl class="roles">
+      <div>
+        <dt>identity <span class="behaviour">deduped</span></dt>
+        <dd>
+          One row per distinct species, reaction or transition state, however
+          often submitted.
+        </dd>
+      </div>
+      <div>
+        <dt>provenance <span class="behaviour">append-only</span></dt>
+        <dd>
+          The software, level of theory and literature behind a number, never
+          rewritten.
+        </dd>
+      </div>
+      <div>
+        <dt>result <span class="behaviour">append-only</span></dt>
+        <dd>
+          The number itself. A better calculation adds a row; nothing already
+          cited changes.
+        </dd>
+      </div>
+      <div>
+        <dt>curation <span class="behaviour">overlay</span></dt>
+        <dd>
+          Review state and release selections sit on top of results, never
+          mutating them.
+        </dd>
+      </div>
+    </dl>
+  </section>
 
   <section aria-labelledby="exchange-heading">
     <h2 id="exchange-heading">What a check looks like</h2>
@@ -433,121 +793,24 @@ footer p { max-width: none; margin: 0; }
           <p class="panel-label">TCKDB replies</p>
           <code class="verdict-code">__HERO_CODE__</code>
           <p class="verdict-body">
-            This geometry is linear. A linear three-atom molecule has
-            3N&minus;5 = 4 vibrations, and this list carries 3, the count for a
-            bent molecule. One mode is missing.
-          </p>
-          <p class="verdict-body">
-            The usual cause is a degenerate bending pair reported once: a
-            linear molecule&rsquo;s bends are doubly degenerate, so a parser
-            that de-duplicates equal frequencies drops one component and lands
-            exactly here. The record is accepted and flagged, not refused.
+            Linear geometry: 3N&minus;5 = 4 vibrations, but the list carries
+            three &mdash; a degenerate bend, reported once by a de-duplicating
+            parser. The record is accepted and flagged, not refused.
           </p>
         </div>
       </div>
-      <figcaption>
-        A partial or frozen-atom Hessian produces the same short list
-        honestly, so this check warns rather than refusing. Checks that can be
-        settled from the data alone do refuse, with an HTTP 422 and the same
-        kind of code and reasoning attached.
-      </figcaption>
     </figure>
   </section>
 
-  <section aria-labelledby="roles-heading">
-    <h2 id="roles-heading">How it works</h2>
-    <p>
-      Every table plays exactly one of four roles, and the role fixes how
-      that table may be written. Keeping them apart is what lets a stored
-      number stay fixed while opinions about it change.
-    </p>
-    <dl class="roles">
-      <div>
-        <dt>identity <span class="behaviour">deduped</span></dt>
-        <dd>
-          What a thing is. One row per distinct species, reaction or
-          transition state, however many times it is submitted, carrying no
-          computed values and expressing no preference.
-        </dd>
-      </div>
-      <div>
-        <dt>provenance <span class="behaviour">append-only</span></dt>
-        <dd>
-          How it was produced. The software and release, level of theory,
-          workflow tool and literature behind a number, recorded at deposit
-          and never rewritten.
-        </dd>
-      </div>
-      <div>
-        <dt>result <span class="behaviour">append-only</span></dt>
-        <dd>
-          The number. A better calculation adds a row rather than replacing
-          the earlier one, so nothing already cited changes underneath a
-          reader.
-        </dd>
-      </div>
-      <div>
-        <dt>curation <span class="behaviour">overlay</span></dt>
-        <dd>
-          How far to trust it. Review state and release selections sit on top
-          of the results and never mutate them; a read asks for every
-          candidate with no recommendation, or for an attributed curated
-          selection.
-        </dd>
-      </div>
-    </dl>
-  </section>
-
   <section aria-labelledby="citing-heading">
-    <h2 id="citing-heading">Citing TCKDB</h2>
+    <h2 id="citing-heading">Citing</h2>
     <p>
-      Two different things are citable here, and they are versioned
-      independently. Upgrading the software must not change what a published
-      dataset says, and re-curating a dataset must not require a code
-      release.
-    </p>
-
-    <h3>The software</h3>
-    <p>
-      Cite the software when you use or extend the code. The metadata is in
-      <code>CITATION.cff</code> at the root of the
-      <a href="__REPO_URL__/blob/main/CITATION.cff">source repository</a>,
-      authored by Calvin Pieters and Alon Grinberg Dana and released under
-      the MIT licence. No DOI is minted for it yet: a DOI cannot be
-      retracted, so one is registered when a paper tag is cut rather than
-      speculatively.
-    </p>
-
-    <h3>A dataset release</h3>
-    <p>
-      Cite a dataset release when you use TCKDB&rsquo;s numbers. A release is
-      a separate artifact with its own tag, an immutable SHA-256-checksummed
-      manifest, an attributed selection ledger and its own citation string.
-      Releases are not listed in the software changelog; they are
-      discoverable at <code>GET /api/v1/scientific/releases</code>, and each
-      one carries its own <code>changelog_entry</code>. A published release
-      is never rewritten &mdash; withdrawing one keeps the row and its
-      manifest readable, so an outstanding citation never dangles.
-    </p>
-  </section>
-
-  <section aria-labelledby="api-heading">
-    <h2 id="api-heading">Use the API</h2>
-    <p>
-      Everything machine-readable lives under the base path
-      <code>/api/v1</code>. Reading the public scientific surface needs no
-      account; depositing data does.
-    </p>
-    <p>__API-REFERENCE__</p>
-    <p>
-      A thin Python client, <code>tckdb-client</code>, handles
-      authentication, payload encoding, retries and idempotency. It is
-      published from this repository rather than to PyPI:
-    </p>
-    <pre class="command"><code>pip install "git+__REPO_URL__.git#subdirectory=clients/python"</code></pre>
-    <p>
-      Any HTTP client that can send JSON works just as well; the client
-      package is a convenience, not a requirement.
+      Two citable things, versioned independently. The software:
+      <a href="__REPO_URL__/blob/main/CITATION.cff"><code>CITATION.cff</code></a>
+      in the repository, MIT, no DOI until a paper tag is cut. A dataset
+      release: its own tag, checksummed manifest and
+      <code>changelog_entry</code>, listed at
+      <code>GET /api/v1/scientific/releases</code>.
     </p>
   </section>
 
@@ -555,15 +818,363 @@ footer p { max-width: none; margin: 0; }
 
 <footer>
   <p>
-    Operational status, including the database revision this deployment is
-    running, is reported at
+    Database revision and health:
     <a href="/api/v1/status"><code>/api/v1/status</code></a>.
   </p>
 </footer>
 
+<script>
+/*
+ * Inline, same-origin, no dependencies. Everything below only upgrades
+ * markup that already works: the form is a real GET form aimed at the
+ * API, and the example chips are real links to it. If this script never
+ * runs -- scripting off, an old engine, a parse error -- the page keeps
+ * its behaviour and loses only the in-page rendering.
+ */
+(function () {
+  "use strict";
+
+  if (!window.fetch || !window.Promise) { return; }
+
+  var doc = document;
+  var form = doc.getElementById("search-form");
+  var input = doc.getElementById("search-input");
+  var picker = doc.getElementById("search-field");
+  var out = doc.getElementById("results");
+  if (!form || !input || !picker || !out) { return; }
+
+  var SEARCH = "__SEARCH_PATH__";
+  var ENTRY = "/api/v1/scientific/species-entries/";
+  var THERMO = "/api/v1/scientific/thermo/search";
+  var CONFORMERS = "/api/v1/scientific/conformers/search";
+  var CALCULATIONS = "/api/v1/scientific/species-calculations/search";
+
+  var PLACEHOLDERS = __PLACEHOLDERS_JSON__;
+  var EXAMPLES = __EXAMPLES_JSON__;
+  var REVIEW_WORDS = {
+    approved: "approved",
+    under_review: "under review",
+    not_reviewed: "not reviewed",
+    deprecated: "deprecated",
+    rejected: "rejected"
+  };
+
+  function make(tag, cls, text) {
+    var node = doc.createElement(tag);
+    if (cls) { node.className = cls; }
+    if (text !== undefined && text !== null) { node.textContent = String(text); }
+    return node;
+  }
+
+  function anchor(href, cls, text) {
+    var node = make("a", cls, text);
+    node.setAttribute("href", href);
+    return node;
+  }
+
+  function clear(node) {
+    while (node.firstChild) { node.removeChild(node.firstChild); }
+  }
+
+  function plural(n, one, many) {
+    return n + " " + (n === 1 ? one : many);
+  }
+
+  function searchUrl(field, value) {
+    if (!value) { return SEARCH; }
+    return SEARCH + "?" + encodeURIComponent(field) + "=" + encodeURIComponent(value);
+  }
+
+  function reviewBadge(status, count) {
+    var key = REVIEW_WORDS[status] ? status : "not_reviewed";
+    var word = REVIEW_WORDS[status] || String(status);
+    var node = make("span", "badge badge-" + key);
+    node.appendChild(make("span", "dot"));
+    node.appendChild(make("span", null, count === undefined ? word : count + " " + word));
+    return node;
+  }
+
+  function chip(field, value) {
+    var node = anchor(searchUrl(field, value), "chip", value);
+    node.setAttribute("data-field", field);
+    node.addEventListener("click", function (event) {
+      event.preventDefault();
+      picker.value = field;
+      syncField();
+      input.value = value;
+      run(field, value);
+    });
+    return node;
+  }
+
+  function exampleList(intro) {
+    var node = make("p", "examples");
+    node.appendChild(make("span", null, intro));
+    for (var i = 0; i < EXAMPLES.length; i += 1) {
+      node.appendChild(chip(EXAMPLES[i][0], EXAMPLES[i][1]));
+    }
+    return node;
+  }
+
+  function entryNode(entry) {
+    var ref = entry.species_entry_ref || "";
+    var availability = entry.availability || {};
+    var node = make("div", "entry");
+    var head = make("div", "entry-head");
+    head.appendChild(reviewBadge(entry.review ? entry.review.status : null));
+    head.appendChild(make("span", "entry-kind",
+      (entry.species_entry_kind || "entry") + " / " +
+      (entry.electronic_state_kind || "state")));
+    head.appendChild(make("span", "entry-kind", ref));
+    node.appendChild(head);
+
+    var links = make("div", "entry-links");
+    var encoded = encodeURIComponent(ref);
+    if (availability.has_thermo) {
+      links.appendChild(anchor(THERMO + "?species_entry_ref=" + encoded, "pill", "thermo"));
+    }
+    if (availability.has_statmech) {
+      links.appendChild(anchor(ENTRY + encoded + "/statmech", "pill", "statmech"));
+    }
+    if (availability.has_transport) {
+      links.appendChild(anchor(ENTRY + encoded + "/transport", "pill", "transport"));
+    }
+    if (availability.has_conformers) {
+      links.appendChild(anchor(CONFORMERS + "?species_entry_ref=" + encoded, "pill", "conformers"));
+    }
+    if (availability.calculation_count) {
+      links.appendChild(anchor(
+        CALCULATIONS + "?species_entry_ref=" + encoded,
+        "pill",
+        plural(availability.calculation_count, "calculation", "calculations")));
+    }
+    if (!links.firstChild) {
+      links.appendChild(make("span", "pill pill-none", "no products yet"));
+    }
+    node.appendChild(links);
+    return node;
+  }
+
+  function recordNode(record) {
+    var node = make("article", "record");
+    var head = make("div", "record-head");
+    head.appendChild(make("span", "smiles", record.canonical_smiles || "(no SMILES)"));
+    head.appendChild(make("span", "record-meta",
+      "charge " + record.charge + ", multiplicity " + record.multiplicity));
+    node.appendChild(head);
+
+    var refs = make("p", "record-refs");
+    refs.appendChild(make("span", null, record.inchi_key || ""));
+    refs.appendChild(doc.createTextNode(" \\u00B7 "));
+    refs.appendChild(anchor(searchUrl("species_ref", record.species_ref), null,
+      record.species_ref || "record"));
+    node.appendChild(refs);
+
+    var entries = record.entries || [];
+    for (var i = 0; i < entries.length; i += 1) {
+      node.appendChild(entryNode(entries[i]));
+    }
+    if (!entries.length) {
+      var none = make("div", "entry");
+      none.appendChild(make("span", "entry-kind", "no entries yet"));
+      node.appendChild(none);
+    }
+    return node;
+  }
+
+  function summaryNode(payload) {
+    var pagination = payload.pagination || {};
+    var review = payload.review_summary || {};
+    var node = make("p", "results-summary");
+    var total = pagination.total || 0;
+    node.appendChild(make("span", "results-count", plural(total, "match", "matches")));
+    var order = ["approved", "under_review", "not_reviewed", "deprecated", "rejected"];
+    for (var i = 0; i < order.length; i += 1) {
+      if (review[order[i]]) {
+        node.appendChild(reviewBadge(order[i], review[order[i]]));
+      }
+    }
+    return node;
+  }
+
+  function emptyNode(field, value) {
+    var node = make("div", "empty");
+    node.appendChild(make("p", null,
+      value ? "Nothing matched " + field + " = " + value + "." : "Nothing matched."));
+    node.appendChild(exampleList("These return records:"));
+    return node;
+  }
+
+  function detailText(body) {
+    if (!body) { return ""; }
+    var detail = body.detail;
+    if (typeof detail === "string") { return detail; }
+    if (Object.prototype.toString.call(detail) === "[object Array]") {
+      var parts = [];
+      for (var i = 0; i < detail.length; i += 1) {
+        parts.push(detail[i] && detail[i].msg ? detail[i].msg : JSON.stringify(detail[i]));
+      }
+      return parts.join("; ");
+    }
+    if (detail) { return JSON.stringify(detail); }
+    return "";
+  }
+
+  function failureNode(status, body) {
+    var node = make("div", "failure");
+    var code = body && body.code ? body.code : "http_" + status;
+    node.appendChild(make("p", "failure-code", code));
+    var detail = detailText(body);
+    node.appendChild(make("p", "failure-detail",
+      detail || "The API answered with status " + status + "."));
+    return node;
+  }
+
+  function render(payload, field, value) {
+    var records = payload.records || [];
+    if (!records.length) {
+      out.appendChild(emptyNode(field, value));
+      return;
+    }
+    out.appendChild(summaryNode(payload));
+    for (var i = 0; i < records.length; i += 1) {
+      out.appendChild(recordNode(records[i]));
+    }
+    var pagination = payload.pagination || {};
+    if (pagination.total > records.length) {
+      var more = make("p", "results-status", "Showing the first page.");
+      more.appendChild(doc.createTextNode(" "));
+      more.appendChild(anchor(searchUrl(field, value), null, "Open the full response"));
+      out.appendChild(more);
+    }
+  }
+
+  function run(field, value) {
+    var url = searchUrl(field, value);
+    out.setAttribute("aria-busy", "true");
+    clear(out);
+    out.appendChild(make("p", "results-status", "Searching\\u2026"));
+    fetch(url, { headers: { "Accept": "application/json" } }).then(function (response) {
+      return response.json().then(function (body) {
+        return { ok: response.ok, status: response.status, body: body };
+      }, function () {
+        return { ok: false, status: response.status, body: null };
+      });
+    }).then(function (result) {
+      clear(out);
+      if (result.ok) {
+        render(result.body || {}, field, value);
+      } else {
+        out.appendChild(failureNode(result.status, result.body));
+      }
+    }, function () {
+      clear(out);
+      var node = make("div", "failure");
+      node.appendChild(make("p", "failure-detail",
+        "The browser could not reach this deployment's API."));
+      out.appendChild(node);
+    }).then(function () {
+      out.setAttribute("aria-busy", "false");
+    });
+  }
+
+  function syncField() {
+    input.name = picker.value;
+    input.setAttribute("placeholder", PLACEHOLDERS[picker.value] || "");
+  }
+
+  picker.disabled = false;
+  picker.addEventListener("change", function () {
+    syncField();
+    input.focus();
+  });
+  syncField();
+
+  form.addEventListener("submit", function (event) {
+    event.preventDefault();
+    run(picker.value, input.value.replace(/^\\s+|\\s+$/g, ""));
+  });
+
+  var seeded = doc.getElementById("examples");
+  if (seeded) {
+    var links = seeded.getElementsByTagName("a");
+    for (var i = 0; i < links.length; i += 1) {
+      (function (node) {
+        node.addEventListener("click", function (event) {
+          event.preventDefault();
+          var field = node.getAttribute("data-field");
+          var value = node.textContent;
+          picker.value = field;
+          syncField();
+          input.value = value;
+          run(field, value);
+        });
+      })(links[i]);
+    }
+  }
+
+  var origin = doc.getElementById("curl-origin");
+  if (origin && window.location && window.location.origin) {
+    origin.textContent = window.location.origin;
+  }
+
+  run(picker.value, input.value.replace(/^\\s+|\\s+$/g, ""));
+})();
+</script>
+
 </body>
 </html>
 """
+
+#: Shown in the ``curl`` example until the script replaces it with the
+#: origin the browser is actually on. It is not a URL, deliberately: a
+#: hard-coded hostname would be wrong for every deployment but one, and
+#: the page has no trustworthy way to learn its own public scheme from
+#: the request (nothing in front of it sets forwarded headers this
+#: application is configured to believe).
+ORIGIN_PLACEHOLDER = "&lt;this deployment&rsquo;s base URL&gt;"
+
+
+def _field_options(selected: str) -> str:
+    lines = []
+    for value, label in SEARCH_FIELDS:
+        flag = " selected" if value == selected else ""
+        lines.append(f'          <option value="{value}"{flag}>{label}</option>')
+    return "\n".join(lines)
+
+
+def _example_chips() -> str:
+    lines = []
+    for field, value in SEARCH_EXAMPLES:
+        href = f"{SPECIES_SEARCH_PATH}?{field}={_url_quote(value)}"
+        lines.append(
+            f'      <a class="chip" data-field="{field}" href="{href}">'
+            f"{_html_escape(value)}</a>"
+        )
+    return "\n".join(lines)
+
+
+def _html_escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+    )
+
+
+def _url_quote(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _json_pairs(pairs: tuple[tuple[str, str], ...]) -> str:
+    return json.dumps([list(pair) for pair in pairs])
+
+
+def _placeholders_json() -> str:
+    """Per-identifier ``placeholder`` text, keyed by query parameter.
+
+    Each one is a value that really is in the shape that field wants, so
+    the hint doubles as a worked example of the syntax.
+    """
+    return json.dumps(dict(SEARCH_PLACEHOLDERS))
 
 
 def render_landing_page(*, api_reference_path: str | None) -> str:
@@ -576,31 +1187,45 @@ def render_landing_page(*, api_reference_path: str | None) -> str:
     failure this page was added to remove.
 
     The template carries ``__PLACEHOLDER__`` markers rather than
-    ``str.format`` fields, because the embedded stylesheet is full of
-    braces and escaping every one of them would make the CSS unreadable
-    for no gain.
+    ``str.format`` fields, because the embedded stylesheet and script
+    are full of braces and escaping every one of them would make both
+    unreadable for no gain.
     """
     if api_reference_path:
+        reference_button = (
+            f'<li><a class="button primary" href="{api_reference_path}">API reference</a></li>'
+        )
+        docs_button = "secondary"
         reference_block = (
-            "The full API reference is served at "
+            "The full reference is at "
             f'<a href="{api_reference_path}"><code>{api_reference_path}</code></a>, '
-            "rendered from this deployment's own OpenAPI document. The "
-            f'<a href="{DOCS_URL}">documentation site</a> carries the query '
-            "guides and worked examples."
+            "generated from this deployment's OpenAPI document."
         )
     else:
+        reference_button = ""
+        docs_button = "primary"
         reference_block = (
             "This deployment does not publish an API reference endpoint. The "
             f'<a href="{DOCS_URL}">documentation site</a> carries the endpoint '
-            "reference, query guides and worked examples."
+            "reference and query guides."
         )
     frequencies = "   ".join(f"{value:.1f}" for value in HERO_FREQUENCIES)
     return (
         _PAGE_TEMPLATE.replace("__DOCS_URL__", DOCS_URL)
         .replace("__REPO_URL__", REPO_URL)
+        .replace("__SEARCH_PATH__", SPECIES_SEARCH_PATH)
+        .replace("__FIELD_OPTIONS__", _field_options(SEED_FIELD))
+        .replace("__EXAMPLE_CHIPS__", _example_chips())
+        .replace("__PLACEHOLDERS_JSON__", _placeholders_json())
+        .replace("__EXAMPLES_JSON__", _json_pairs(SEARCH_EXAMPLES))
+        .replace("__ORIGIN_PLACEHOLDER__", ORIGIN_PLACEHOLDER)
+        .replace("__SEED_FIELD__", SEED_FIELD)
+        .replace("__SEED_VALUE__", _html_escape(SEED_VALUE))
         .replace("__HERO_XYZ__", HERO_XYZ)
         .replace("__HERO_FREQUENCIES__", frequencies)
         .replace("__HERO_CODE__", HERO_CODE)
+        .replace("__REFERENCE_BUTTON__", reference_button)
+        .replace("__DOCS_BUTTON__", docs_button)
         .replace("__API-REFERENCE__", reference_block)
     )
 
@@ -633,8 +1258,14 @@ __all__ = [
     "HERO_CODE",
     "HERO_FREQUENCIES",
     "HERO_XYZ",
+    "ORIGIN_PLACEHOLDER",
     "REDOC_PATH",
     "REPO_URL",
+    "SEARCH_EXAMPLES",
+    "SEARCH_FIELDS",
+    "SEED_FIELD",
+    "SEED_VALUE",
+    "SPECIES_SEARCH_PATH",
     "landing_router",
     "render_landing_page",
 ]

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -13,6 +13,15 @@ The tests are grouped as:
 * :class:`TestLandingPageIsSelfContained` -- it fetches nothing. A page
   whose whole argument is that it works on a locked-down network must
   not quietly grow a CDN link.
+* :class:`TestLiveSearch` -- the hero queries this deployment's own
+  public read API and renders what comes back. The structural half is
+  checked against a parsed document rather than a substring: the form
+  is real, aimed at the real endpoint, and works before any script
+  runs.
+* :class:`TestSearchDegradesWithoutJavaScript` -- with scripting off
+  the page still searches. The one control that cannot work without
+  script ships disabled rather than silently searching the wrong
+  field, and ``<noscript>`` offers a plain form per identifier.
 * :class:`TestHeroExampleIsReal` -- the worked example in the hero is
   re-run through the real checker on every test run. If the page and
   ``app.services.frequency_geometry_linearity`` ever disagree, this
@@ -30,6 +39,8 @@ The tests are grouped as:
 from __future__ import annotations
 
 import re
+from html.parser import HTMLParser
+from urllib.parse import quote
 
 import pytest
 from fastapi import APIRouter
@@ -46,6 +57,11 @@ from app.api.landing import (
     HERO_FREQUENCIES,
     HERO_XYZ,
     REPO_URL,
+    SEARCH_EXAMPLES,
+    SEARCH_FIELDS,
+    SEED_FIELD,
+    SEED_VALUE,
+    SPECIES_SEARCH_PATH,
     render_landing_page,
 )
 from app.api.startup_checks import validate_deployment_safety
@@ -57,6 +73,82 @@ from app.services.frequency_geometry_linearity import (
 #: repository's central organising idea, not decoration: every table is
 #: exactly one of them, and the role fixes how the table may be written.
 DATA_ROLES = ("identity", "provenance", "result", "curation")
+
+#: Every review state the API can put on a record. All five must have a
+#: human word on the page: a badge that falls through to a raw enum name
+#: is a badge nobody reads.
+REVIEW_STATES = (
+    "approved",
+    "under review",
+    "not reviewed",
+    "deprecated",
+    "rejected",
+)
+
+_VOID_TAGS = frozenset({"area", "base", "br", "col", "hr", "img", "input", "link", "meta"})
+
+
+class _Document(HTMLParser):
+    """Every start tag as ``(tag, attrs, ancestors)``.
+
+    Substring assertions on a page this size stop meaning anything --
+    ``'name="smiles"' in body`` passes whether or not that input is
+    inside a form, and whether or not the form points anywhere useful.
+    Parsing lets a test say what it actually means: *this* input, in
+    *that* form, whose action is the search endpoint.
+
+    ``HTMLParser`` reads ``<script>`` and ``<style>`` as raw text, so
+    the comparison operators in the inline script are not mistaken for
+    markup.
+    """
+
+    def __init__(self, markup: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.elements: list[tuple[str, dict[str, str | None], tuple[str, ...]]] = []
+        self._open: list[str] = []
+        self.feed(markup)
+
+    def handle_starttag(self, tag, attrs):
+        self.elements.append((tag, dict(attrs), tuple(self._open)))
+        if tag not in _VOID_TAGS:
+            self._open.append(tag)
+
+    def handle_startendtag(self, tag, attrs):
+        self.elements.append((tag, dict(attrs), tuple(self._open)))
+
+    def handle_endtag(self, tag):
+        if tag in self._open:
+            while self._open and self._open.pop() != tag:
+                pass
+
+    def find(self, tag: str, **attrs: str):
+        """All ``tag`` elements whose attributes match, as (attrs, ancestors)."""
+        found = []
+        for name, element_attrs, ancestors in self.elements:
+            if name != tag:
+                continue
+            if all(element_attrs.get(key) == value for key, value in attrs.items()):
+                found.append((element_attrs, ancestors))
+        return found
+
+
+@pytest.fixture(scope="module")
+def page() -> str:
+    """The page as a deployment serving a reference renders it."""
+    return render_landing_page(api_reference_path="/redoc")
+
+
+@pytest.fixture(scope="module")
+def document(page: str) -> _Document:
+    return _Document(page)
+
+
+@pytest.fixture(scope="module")
+def script(page: str) -> str:
+    """The inline script's source, on its own."""
+    match = re.search(r"<script>(.*?)</script>", page, flags=re.DOTALL)
+    assert match is not None, "the page carries no inline script"
+    return match.group(1)
 
 
 @pytest.fixture
@@ -133,12 +225,40 @@ class TestLandingPageResponse:
 
 
 class TestLandingPageIsSelfContained:
-    """No CDN, no external stylesheet, no web font, no script."""
+    """No CDN, no external stylesheet, no web font, no remote anything."""
 
     def test_no_element_fetches_a_subresource(self, client_factory):
+        """Nothing on the page causes a second request to anywhere.
+
+        The page carries one inline ``<script>`` -- the live search --
+        which is why this no longer forbids the tag outright. An inline
+        script fetches nothing at parse time, so the property under
+        test is unchanged; what it now pins is *which* script shapes
+        are allowed. Exactly one, carrying no attributes at all, so
+        ``src``, ``type="module"``, ``integrity`` and every other route
+        to an off-host fetch are excluded by the same assertion.
+        """
         with client_factory() as c:
             body = c.get("/").text
-        assert re.search(r"<(link|script|img|iframe|source|object|embed)\b", body) is None
+        assert re.search(r"<(link|img|iframe|source|object|embed)\b", body) is None
+        assert re.findall(r"<script\b([^>]*)>", body) == [""]
+
+    def test_the_inline_script_reaches_only_this_origin(self, client_factory):
+        """Same-origin paths only: the API is served by this same app.
+
+        A ``fetch`` to another host would defeat every other guarantee
+        on this page while leaving the markup looking self-contained,
+        so the URLs the script builds are checked directly.
+        """
+        with client_factory() as c:
+            body = c.get("/").text
+        source = re.search(r"<script>(.*?)</script>", body, flags=re.DOTALL).group(1)
+        literals = re.findall(r"\"([^\"]*)\"", source)
+        assert literals, "no string literals found -- the script did not parse as expected"
+        for literal in literals:
+            assert "://" not in literal, literal
+            assert not literal.startswith("//"), literal
+        assert SPECIES_SEARCH_PATH in literals
 
     def test_no_stylesheet_import_or_url_reaches_off_host(self, client_factory):
         with client_factory() as c:
@@ -161,6 +281,192 @@ class TestLandingPageIsSelfContained:
         allowed_prefixes = (DOCS_URL, REPO_URL)
         for url in set(re.findall(r"https?://[^\"'\s<>)]+", body)):
             assert url.startswith(allowed_prefixes), url
+
+
+class TestLiveSearch:
+    """The hero queries this deployment and renders what comes back.
+
+    The page's whole purpose is to lead somewhere, and everything here
+    is a way of asking "does it?". The endpoint is the public read API
+    on this same origin, so no key, no CORS and no proxy are involved.
+    """
+
+    def test_the_search_is_a_real_form_aimed_at_the_public_read_endpoint(self, document):
+        forms = [
+            (attrs, ancestors)
+            for attrs, ancestors in document.find("form")
+            if "noscript" not in ancestors
+        ]
+        assert len(forms) == 1
+        attrs, _ = forms[0]
+        assert attrs["action"] == SPECIES_SEARCH_PATH
+        assert attrs["method"] == "get"
+
+    def test_the_box_is_seeded_with_a_query_that_returns_a_record(self, document):
+        """Nobody's first sight of the search is an empty box.
+
+        The seed is a real identifier with real records behind it, and
+        it is in the markup rather than only in the script, so the
+        no-script form is pre-filled with it too.
+        """
+        seeded = document.find("input", id="search-input")
+        assert len(seeded) == 1
+        attrs, _ = seeded[0]
+        assert attrs["name"] == SEED_FIELD
+        assert attrs["value"] == SEED_VALUE
+
+    def test_the_identifier_is_chosen_explicitly_and_never_guessed(self, document):
+        """``O`` is a formula and a SMILES, meaning two different things.
+
+        Sniffing the input would answer one of the two questions the
+        visitor might have asked and silently discard the other, so the
+        field is picked, defaults to formula, and every offered field is
+        a query parameter the endpoint really accepts.
+        """
+        options = [attrs for attrs, ancestors in document.find("option")]
+        assert [attrs["value"] for attrs in options] == [field for field, _ in SEARCH_FIELDS]
+        assert options[0]["value"] == SEED_FIELD
+        assert "selected" in options[0]
+        for attrs in options[1:]:
+            assert "selected" not in attrs
+
+    def test_every_offered_example_is_a_link_that_runs_the_query(self, document):
+        """The examples work before any script does, and after it.
+
+        Each is an ordinary link to the endpoint -- so it is useful with
+        scripting off -- and carries the field it means, so the script
+        can run it in place instead of navigating away.
+        """
+        chips = document.find("a", **{"class": "chip"})
+        assert len(chips) == len(SEARCH_EXAMPLES)
+        for (attrs, _), (field, value) in zip(chips, SEARCH_EXAMPLES, strict=True):
+            assert attrs["data-field"] == field
+            assert attrs["href"] == f"{SPECIES_SEARCH_PATH}?{field}={quote(value, safe='')}"
+
+    def test_the_results_area_is_announced_when_it_changes(self, document):
+        regions = document.find("div", id="results")
+        assert len(regions) == 1
+        assert regions[0][0]["aria-live"] == "polite"
+
+    def test_every_review_state_has_a_word_a_reader_understands(self, script):
+        """Under review is displayed, never hidden and never dressed up.
+
+        Serving records that have not been approved yet, with the label
+        on them, is the point of the review model. All five states are
+        given a human wording so no badge can fall through to a raw
+        enum name.
+        """
+        for state in REVIEW_STATES:
+            assert f'"{state}"' in script, state
+
+    def test_a_result_shows_the_review_state_of_each_entry(self, script):
+        """The badge is built from the record's own review block.
+
+        Not from a default, and not only from the summary counts: a
+        result that renders without saying how far it was checked is
+        the failure this asserts against.
+        """
+        entry_renderer = re.search(
+            r"function entryNode\(entry\) \{(.*?)\n  \}", script, flags=re.DOTALL
+        )
+        assert entry_renderer is not None
+        assert "reviewBadge(entry.review" in entry_renderer.group(1)
+
+    def test_a_result_links_onward_to_its_own_records(self, script):
+        """A landing page that leads nowhere is the defect being fixed.
+
+        Every product the search says a record has becomes a link to
+        the endpoint that serves it, so a visitor can follow a result
+        into the data rather than reading about it.
+        """
+        for path in (
+            "/api/v1/scientific/thermo/search",
+            "/api/v1/scientific/species-entries/",
+            "/api/v1/scientific/conformers/search",
+            "/api/v1/scientific/species-calculations/search",
+        ):
+            assert f'"{path}"' in script, path
+        assert 'searchUrl("species_ref"' in script
+
+    def test_an_empty_result_says_so_and_offers_queries_that_work(self, script):
+        """Most searches will miss. None of them may look broken.
+
+        The corpus is small, so the empty state is a normal outcome: it
+        says plainly that nothing matched and hands back the same
+        examples that do return records.
+        """
+        empty = re.search(r"function emptyNode\(field, value\) \{(.*?)\n  \}", script, re.DOTALL)
+        assert empty is not None
+        assert "Nothing matched" in empty.group(1)
+        assert "exampleList(" in empty.group(1)
+
+    def test_a_submission_with_no_identifier_asks_the_api_and_shows_its_answer(self, script):
+        """The endpoint answers ``missing_identifier`` -- so show that.
+
+        An empty value is deliberately *not* sent as ``?formula=``,
+        which the endpoint reads as a present-but-empty filter and
+        answers with zero matches. Omitting the parameter is what
+        produces the real 422, whose own ``detail`` is then rendered
+        rather than a swallowed error.
+        """
+        assert re.search(r"if \(!value\) \{ return SEARCH; \}", script)
+        assert "body.detail" in script
+        assert "failure-code" in script
+        assert "body.code" in script
+
+
+class TestSearchDegradesWithoutJavaScript:
+    """Scripting off must leave a page that still searches."""
+
+    def test_the_picker_ships_disabled_rather_than_lying_about_the_field(self, document):
+        """An HTML form cannot rename its own field.
+
+        A live-looking picker that cannot change what is submitted
+        would search formula while claiming to search SMILES, which is
+        worse than not offering the control. It is enabled by the
+        script, and ``<noscript>`` explains what to use instead.
+        """
+        pickers = document.find("select", id="search-field")
+        assert len(pickers) == 1
+        assert "disabled" in pickers[0][0]
+        assert "picker.disabled = false" in render_landing_page(api_reference_path=None)
+
+    def test_noscript_carries_a_plain_form_for_each_other_identifier(self, document):
+        """One parameter per request, because empty siblings are not absent.
+
+        ``?formula=CH3&smiles=`` is not "search CH3": the endpoint
+        AND-combines the empty ``smiles`` and returns nothing. So the
+        fallback is one single-field form per identifier rather than
+        one form carrying all three.
+        """
+        fallback_forms = [
+            attrs for attrs, ancestors in document.find("form") if "noscript" in ancestors
+        ]
+        assert fallback_forms
+        for attrs in fallback_forms:
+            assert attrs["action"] == SPECIES_SEARCH_PATH
+            assert attrs["method"] == "get"
+
+        named = {
+            attrs["name"]
+            for attrs, ancestors in document.find("input")
+            if "noscript" in ancestors and attrs.get("name")
+        }
+        offered = {field for field, _ in SEARCH_FIELDS}
+        assert named == offered - {SEED_FIELD}
+        assert len(fallback_forms) == len(named)
+
+    def test_nothing_but_the_rendering_depends_on_the_script(self, document):
+        """The form and the examples are markup, not script output.
+
+        They are asserted here as elements of the parsed document, so a
+        refactor that moved the search UI into JavaScript -- leaving a
+        blank box for anyone with scripting off -- fails rather than
+        passing quietly.
+        """
+        assert document.find("input", id="search-input")
+        assert document.find("button", type="submit")
+        assert document.find("a", **{"class": "chip"})
 
 
 class TestHeroExampleIsReal:

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -146,7 +146,7 @@ def document(page: str) -> _Document:
 @pytest.fixture(scope="module")
 def script(page: str) -> str:
     """The inline script's source, on its own."""
-    match = re.search(r"<script>(.*?)</script>", page, flags=re.DOTALL)
+    match = re.search(r"<script>(.*?)</script>", page, flags=re.DOTALL | re.IGNORECASE)
     assert match is not None, "the page carries no inline script"
     return match.group(1)
 
@@ -240,8 +240,8 @@ class TestLandingPageIsSelfContained:
         """
         with client_factory() as c:
             body = c.get("/").text
-        assert re.search(r"<(link|img|iframe|source|object|embed)\b", body) is None
-        assert re.findall(r"<script\b([^>]*)>", body) == [""]
+        assert re.search(r"<(link|img|iframe|source|object|embed)\b", body, re.IGNORECASE) is None
+        assert re.findall(r"<script\b([^>]*)>", body, re.IGNORECASE) == [""]
 
     def test_the_inline_script_reaches_only_this_origin(self, client_factory):
         """Same-origin paths only: the API is served by this same app.
@@ -252,7 +252,7 @@ class TestLandingPageIsSelfContained:
         """
         with client_factory() as c:
             body = c.get("/").text
-        source = re.search(r"<script>(.*?)</script>", body, flags=re.DOTALL).group(1)
+        source = re.search(r"<script>(.*?)</script>", body, flags=re.DOTALL | re.IGNORECASE).group(1)
         literals = re.findall(r"\"([^\"]*)\"", source)
         assert literals, "no string literals found -- the script did not parse as expected"
         for literal in literals:


### PR DESCRIPTION
## In plain language

If you typed the TCKDB address into a browser, you got a page that explained the
database in 624 words and then stopped. Three links, none of which showed you any
data. This replaces it with a page that **searches the live database in front of
you**.

Type `CH3` (it is already typed in) and the page asks this deployment's own public
API and shows what it found: the molecule, its identifiers, whether anyone has
reviewed it yet, and links straight to its thermodynamics, statistical mechanics,
conformers and the calculations behind it. The API is open — no login, no key —
and the page is served by the same program that serves the API, so the browser can
call it directly with nothing in between.

Two corrections to how the page talks about the data:

- **"Under review" is shown, not hidden.** Records that have not been approved yet
  are public and are served. The badge on each result says how far a record has
  been checked, drawn as ordinary information — the same neutral chip as everything
  else, with a hollow rather than filled dot — not as a warning.
- **The page invents nothing.** Every number on it (match counts, review counts,
  "14 calculations") came back from a request the visitor just made. Nothing about
  corpus size is hard-coded, so nothing goes stale.

Prose is down from **624 words to 249**. The four table roles and the software
vs. dataset citation split are kept, one line each. The CO2 worked example moves
out of the hero and stays, because the page's argument is "this system does not
invent things" and that example is a real checker's real output.

**Software terms used below.** *Same-origin*: the page and the API answer on the
same address, so the browser allows the call without extra permission. *Inline
script*: JavaScript written into the page itself rather than downloaded from
somewhere else. *422*: the HTTP code the API returns when a request is missing
something it needs. *Progressive enhancement*: build it so it works as plain HTML
first, then let JavaScript improve it.

## What is in the search

- **The field is chosen, never guessed** — `formula` (default) / `SMILES` /
  `InChIKey`. `O` is a valid formula *and* a valid SMILES meaning different
  things; sniffing would answer one question and silently discard the other.
- **Seeded with `formula=CH3`**, which returns a record, so nobody's first sight
  of the search is an empty box.
- **Review state on every result**, plus the endpoint's own `review_summary`
  counts above the list.
- **Onward links per entry**, built from the `availability` flags the endpoint
  returns: `thermo/search?species_entry_ref=…`, `species-entries/{ref}/statmech`,
  `…/transport`, `conformers/search?…`, `species-calculations/search?…`, and the
  record itself via `species/search?species_ref=…`.
- **Empty results read as normal**, not broken: "Nothing matched formula = ZZZ9."
  followed by the examples that do return records.
- **An empty submission renders the API's own error.** Note the subtlety:
  `?formula=` is *not* the same as omitting the parameter — the endpoint reads an
  empty string as a present-but-empty filter and answers `200` with zero matches.
  So an empty box sends no parameter at all, which produces the real
  `missing_identifier` 422, and its `detail` is what the page displays.

## Working without JavaScript

The form is a real `<form method="get" action="/api/v1/scientific/species/search">`
and the example chips are real links to the same endpoint, so with scripting off
the page still searches — the browser lands on the JSON instead of a rendered list.

The identifier picker is the single control that genuinely cannot work without
script: **an HTML form cannot rename its own field**. A live-looking picker that
searched `formula` while claiming to search SMILES would be worse than no picker,
so it ships `disabled` and a `<noscript>` block offers one single-field form per
identifier. One field per request matters, because empty siblings are not treated
as absent — verified against the live host:

```
GET …/species/search?formula=CH3                     -> 200, total 1
GET …/species/search?formula=CH3&smiles=&inchi_key=  -> 200, total 0   # AND-combined
```

## Self-containment

Unchanged as a guarantee, tightened as a test. There is exactly one `<script>`, it
is inline, and it carries **no attributes at all** — so `src`, `type="module"` and
`integrity` are excluded by the same assertion. No `<link>`, `<img>`, `<iframe>`,
`<object>`, `<embed>`, `<source>`; no `@import`, no `url()`; no absolute URL on the
page that is not a link a reader clicks.

The `curl` quickstart shows `TCKDB=<this deployment's base URL>` and the script
replaces that with `location.origin`, so it is copy-paste-correct on the live host
and on any self-host. It is **not** derived from the request: nothing in front of
this app sets forwarded headers it is configured to believe, so `request.base_url`
would print `http://` behind the Cloudflare/HTTPS front and hand out a wrong
command. A hard-coded hostname would be wrong for every deployment but one.

## One existing test changed, and why

`TestLandingPageIsSelfContained::test_no_element_fetches_a_subresource` forbade the
`<script>` tag outright. The property it was protecting is "nothing on this page
causes a second request"; an inline script causes none. It now asserts exactly one
script tag with zero attributes, which is **stricter about script shapes** than the
old blanket ban was about anything else, and a new sibling test walks the script's
string literals to reject any `://` or protocol-relative `//host` URL. No other
existing test was weakened, skipped, xfailed or deleted.

## Schema / migration impact

**None.** No ORM model, no Pydantic schema, no Alembic revision, no database
access at all — `render_landing_page` is a pure function of one argument.

## New environment variables

**None.** `EXPOSE_API_REFERENCE` already existed; the page now links `/redoc` when
it is on (and links nothing when it is off, which the existing test still pins).
`/docs` stays 404 by design.

## Route table

Unchanged apart from `/`, which was already there.
`test_the_route_table_gains_the_landing_route_and_nothing_else` still passes: it
builds the app twice, once with the landing router replaced by an empty one, and
diffs the ordered route tables.

## Verification actually run

**Tests** (from `backend/`, since `pytest backend/tests/` with cwd `backend/`
collects zero):

```
conda run -n tckdb_env python -m pytest tests/api/test_landing_page.py -q
  -> 37 passed
conda run -n tckdb_env bash scripts/test-api.sh          # EXIT_CODE captured with $?
  -> EXIT_CODE=0, 3119 passed in 265s
conda run -n tckdb_env ruff check app tests scripts      -> All checks passed!
conda run -n tckdb_env ruff format --check app tests scripts  -> exit 0
```

One honest note on that last line: it exits 0 having formatted nothing, because
`backend/pyproject.toml` sets `[tool.ruff.format] exclude = ["**"]` — `ruff format`
is switched off repo-wide on purpose. Naming a single file on the command line
overrides that exclusion, which I hit once and reverted; the only formatting in
this branch is hand-written.

**CodeQL**: the first push failed it with 3 high-severity `py/bad-tag-filter`
alerts — the three regexes in the *test* file that pull the inline script out of
the rendered page do not match `<SCRIPT>`. They read markup this module generates,
so no case ever varies, but a regex that works only because of what it happens to
be pointed at is the wrong thing to leave in a test. Fixed with `re.IGNORECASE`
in the follow-up commit; no other change.

**Mutation-tested — three tests, each proven to fail on a landed mutation, then
restored and the file proven byte-identical:**

| # | Mutation landed in `landing.py` | Test that failed |
|---|---|---|
| 1 | `<select id="search-field" disabled>` → `<select id="search-field">` | `test_the_picker_ships_disabled_rather_than_lying_about_the_field` |
| 2 | `reviewBadge(entry.review ? entry.review.status : null)` → `reviewBadge("approved")` | `test_a_result_shows_the_review_state_of_each_entry` |
| 3 | `if (!value) { return SEARCH; }` → `if (false) { … }` | `test_a_submission_with_no_identifier_asks_the_api_and_shows_its_answer` |

(Mutations were run against the first commit; the follow-up commit changes only
three `re.IGNORECASE` flags in the test file and leaves every assertion intact.)

Each mutation was confirmed present in `git diff` before running, produced exactly
one failure (36 passed), and was restored with `diff -q` against a pre-mutation
copy reporting identical.

**Rendered and looked at**, in headless Chrome against a local server that proxies
`/api/v1` to the live host, so the page ran its real `fetch` against real public
data:

- Desktop 1280px, light and dark (dark forced by rewriting the
  `prefers-color-scheme` block, since headless Chrome will not emulate it).
- 360px, measured inside a 360px iframe: `clientWidth=360 scrollWidth=360` —
  **no horizontal document scroll**. The only elements wider than the viewport are
  the two `<pre class="command">` blocks, which scroll inside their own boxes.
- Scripting-off shape: script stripped and `<noscript>` unwrapped.
- Live states seen: a real record (`[CH3]`, `spc_atp56uqux2ajao7hvckx7gx7ca`,
  `under review`, 14 calculations), a SMILES search (`[OH]`), an empty result
  (`ZZZ9`), and the real `missing_identifier` 422 with its `detail` rendered.

**Every link the page rendered, resolved against the live host** — all 200:

```
/api/v1/scientific/species/search?formula=CH3 | ?formula=H2O | ?smiles=%5BOH%5D
/api/v1/scientific/species/search?species_ref=spc_atp56uqux2ajao7hvckx7gx7ca
/api/v1/scientific/species-entries/spe_bcbdjwkip75yoziblpntwzblzu/statmech
/api/v1/scientific/thermo/search?species_entry_ref=spe_…
/api/v1/scientific/conformers/search?species_entry_ref=spe_…
/api/v1/scientific/species-calculations/search?species_entry_ref=spe_…
/api/v1/status        /redoc
```

Only GETs were issued against the live deployment. Nothing was posted, no
migration run, no deployed database or `.env.pi` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEMrWcGRqbAVoh1Cn3TJ9D
