### PR TITLE
Say how many conformers have the evidence, not that one does

### DIFF
--- a/backend/app/api/routes/scientific/conformers.py
+++ b/backend/app/api/routes/scientific/conformers.py
@@ -30,6 +30,7 @@ from app.schemas.reads.scientific_conformer import (
     ScientificConformerObservationDetailResponse,
 )
 from app.schemas.reads.scientific_conformer_search import (
+    ConformerEvidenceMatch,
     ConformersSearchRequest,
     ScientificConformersSearchResponse,
 )
@@ -74,6 +75,9 @@ def scientific_conformers_search_get(
     has_sp: bool | None = Query(None),
     has_geometry_validation: bool | None = Query(None),
     has_scf_stability: bool | None = Query(None),
+    evidence_match: ConformerEvidenceMatch = Query(
+        ConformerEvidenceMatch.any_observation
+    ),
     scientific_origin: ScientificOriginKind | None = Query(None),
     method: str | None = Query(None),
     basis: str | None = Query(None),
@@ -113,6 +117,7 @@ def scientific_conformers_search_get(
         has_sp=has_sp,
         has_geometry_validation=has_geometry_validation,
         has_scf_stability=has_scf_stability,
+        evidence_match=evidence_match,
         scientific_origin=scientific_origin,
         method=method,
         basis=basis,

--- a/backend/app/schemas/reads/scientific_conformer.py
+++ b/backend/app/schemas/reads/scientific_conformer.py
@@ -181,18 +181,95 @@ class ConformerSelectionSummary(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class ConformerCalculationEvidenceSummary(BaseModel):
-    """Bounded calculation-evidence projection for a conformer group or
-    observation.
+class ConformerEvidenceCoverage(BaseModel):
+    """How many observations in scope carry each kind of evidence.
+
+    Every value counts **observations**, never calculations. An
+    observation with three ``freq`` calculations contributes ``1`` to
+    ``freq``, not ``3``. The shared denominator is
+    ``ConformerGroupEvidenceSummary.observation_count``, so a caller
+    reads each field as "*n* of *observation_count*".
+
+    What a full count does and does not say
+    ---------------------------------------
+    ``freq == observation_count`` says the coverage is **complete** —
+    every observation in the basin has at least one frequency
+    calculation. It does **not** say those calculations are
+    *comparable*: the five may sit at five different levels of theory,
+    from five different codes, at five different geometries. A count is
+    honest about coverage, not about consistency. A caller who needs
+    consistency must inspect the per-calculation level-of-theory /
+    software provenance under ``include=calculations``; no number in
+    this block can stand in for that.
+
+    ``0`` is exactly as strong as the old ``has_x is False`` was:
+    nothing in scope carries that evidence.
+    """
+
+    opt: int
+    freq: int
+    sp: int
+    geometry_validation: int
+    scf_stability: int
+
+
+class ConformerGroupEvidenceSummary(BaseModel):
+    """Bounded calculation-evidence projection for a conformer **group**.
 
     ``observation_count`` is the number of observation rows under the
-    group (always ``1`` on the observation detail surface).
-    ``calculation_count`` is the number of calculations whose
-    ``conformer_observation_id`` belongs to the in-scope observation
-    set (the parent group, or this single observation).
+    group. ``calculation_count`` is the number of calculations whose
+    ``conformer_observation_id`` belongs to that observation set.
     ``geometry_count`` is the number of distinct
     ``calculation_output_geometry`` rows reached through that
-    calculation set.
+    calculation set. ``evidence_coverage`` reports, per evidence kind,
+    how many of the ``observation_count`` observations carry it.
+
+    Why counts here and booleans on the observation surface
+    -------------------------------------------------------
+    This block deliberately has a **different shape** from
+    :class:`ConformerObservationEvidenceSummary`. That asymmetry is the
+    point, not an oversight, and it should not be smoothed over.
+
+    A group pools several observations. The booleans this block used to
+    carry (``has_opt`` / ``has_freq`` / …) were a plain OR across all of
+    them, which made them asymmetrically informative: ``false`` was
+    strong (nothing in the group has it) while ``true`` was nearly
+    empty (one calculation out of a hundred made it ``true``). A reader
+    seeing ``has_freq: true`` on a five-observation basin could not tell
+    whether five observations had frequencies or one did. Counts answer
+    that question — ``freq: 2`` with ``observation_count: 5`` shows an
+    unevenly covered basin at a glance — and ``count > 0`` reproduces
+    the old boolean exactly, so nothing that the boolean expressed was
+    lost.
+
+    An observation is a single provenance row, so on that surface the
+    booleans are unambiguous and are kept as they were.
+    """
+
+    observation_count: int | None = None
+    calculation_count: int
+    evidence_coverage: ConformerEvidenceCoverage
+    geometry_count: int
+
+
+class ConformerObservationEvidenceSummary(BaseModel):
+    """Bounded calculation-evidence projection for one conformer
+    **observation**.
+
+    Scope is this single observation: ``observation_count`` is always
+    ``1`` and every ``has_*`` boolean describes that one provenance row,
+    where a boolean is unambiguous — it cannot pool a covered
+    observation with an uncovered one, which is what made the same
+    booleans misleading at group scope (see
+    :class:`ConformerGroupEvidenceSummary`).
+
+    ``calculation_count`` and ``geometry_count`` carry the same meaning
+    as on the group block, restricted to this observation's own
+    calculations.
+
+    As with the group block's counts, ``has_freq: true`` says frequency
+    evidence exists — not that it is comparable with the frequency
+    evidence on any sibling observation.
     """
 
     observation_count: int | None = None
@@ -309,7 +386,7 @@ class ScientificConformerObservationRecord(BaseModel):
     conformer_group: ConformerGroupCoreBlock
     species: ConformerSpeciesContext
     assignment_scheme: ConformerAssignmentSchemeSummary | None = None
-    evidence_summary: ConformerCalculationEvidenceSummary
+    evidence_summary: ConformerObservationEvidenceSummary
     available_sections: AvailableConformerSections
 
     # Optional include blocks
@@ -334,7 +411,7 @@ class ScientificConformerGroupRecord(BaseModel):
     species: ConformerSpeciesContext
     observations_summary: ConformerObservationsSummary
     selection_summary: list[ConformerSelectionSummary] = Field(default_factory=list)
-    evidence_summary: ConformerCalculationEvidenceSummary
+    evidence_summary: ConformerGroupEvidenceSummary
     available_sections: AvailableConformerSections
 
     # Optional include blocks
@@ -371,13 +448,15 @@ class ScientificConformerObservationDetailResponse(BaseModel):
 __all__ = [
     "AvailableConformerSections",
     "ConformerAssignmentSchemeSummary",
-    "ConformerCalculationEvidenceSummary",
     "ConformerCalculationSummary",
+    "ConformerEvidenceCoverage",
     "ConformerGeometryLink",
     "ConformerGroupCoreBlock",
     "ConformerGroupDetailRequest",
+    "ConformerGroupEvidenceSummary",
     "ConformerObservationCoreBlock",
     "ConformerObservationDetailRequest",
+    "ConformerObservationEvidenceSummary",
     "ConformerObservationsSummary",
     "ConformerReviewEntry",
     "ConformerSelectionSummary",

--- a/backend/app/schemas/reads/scientific_conformer_search.py
+++ b/backend/app/schemas/reads/scientific_conformer_search.py
@@ -11,6 +11,7 @@ See ``backend/docs/specs/scientific_conformer_reads.md``.
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -43,6 +44,43 @@ from app.schemas.reads.scientific_common import (
 from app.schemas.reads.scientific_conformer import (
     ScientificConformerGroupRecord,
 )
+
+
+class ConformerEvidenceMatch(str, Enum):
+    """Quantifier applied to the ``has_*`` evidence filters.
+
+    A conformer group holds several observations, so "does this group
+    have frequency evidence?" has two honest readings. This parameter
+    makes the caller pick one at the call site instead of hiding the
+    choice inside a bare boolean.
+
+    ``any_observation`` (default, and the historical behaviour)
+        The group matches ``has_freq=true`` when **at least one** of its
+        observations has a ``freq`` calculation. ``has_freq=false`` is
+        the negation: **no** observation has one.
+
+    ``all_observations``
+        The group matches ``has_freq=true`` when it has at least one
+        observation and **every** observation has a ``freq``
+        calculation — the complete-coverage question the old boolean
+        could not express. ``has_freq=false`` is again the negation of
+        that: the group has at least one observation and **at least one
+        of them lacks** ``freq`` — i.e. coverage is *incomplete*, which
+        includes zero coverage.
+
+    A group with no observations at all matches neither direction under
+    ``all_observations``. "Every observation has freq" must not be
+    vacuously true of a basin with nothing in it.
+
+    The quantifier applies to the whole evidence family
+    (``has_calculations``, ``has_opt``, ``has_freq``, ``has_sp``,
+    ``has_geometries``, ``has_geometry_validation``,
+    ``has_scf_stability``). It is a modifier, not a filter: supplying it
+    alone does not satisfy the at-least-one-filter rule.
+    """
+
+    any_observation = "any_observation"
+    all_observations = "all_observations"
 
 
 class ConformersSearchRequest(BaseModel):
@@ -83,6 +121,9 @@ class ConformersSearchRequest(BaseModel):
     has_sp: bool | None = None
     has_geometry_validation: bool | None = None
     has_scf_stability: bool | None = None
+    evidence_match: ConformerEvidenceMatch = (
+        ConformerEvidenceMatch.any_observation
+    )
 
     # --- provenance filters ----------------------------------------------
     scientific_origin: ScientificOriginKind | None = None
@@ -131,6 +172,7 @@ class ScientificConformersSearchResponse(BaseModel):
 
 
 __all__ = [
+    "ConformerEvidenceMatch",
     "ConformersSearchRequest",
     "RequestEcho",
     "ScientificConformersSearchResponse",

--- a/backend/app/schemas/reads/scientific_provenance.py
+++ b/backend/app/schemas/reads/scientific_provenance.py
@@ -32,8 +32,8 @@ from app.schemas.reads.scientific_common import (
 )
 from app.schemas.reads.scientific_conformer import (
     AvailableConformerSections,
-    ConformerCalculationEvidenceSummary,
     ConformerGroupCoreBlock,
+    ConformerGroupEvidenceSummary,
     ConformerObservationsSummary,
     ConformerSelectionSummary,
 )
@@ -372,7 +372,7 @@ class ReactionFullConformerGroupItem(BaseModel):
     endpoint: str
     conformer_group: ConformerGroupCoreBlock
     observations_summary: ConformerObservationsSummary
-    evidence_summary: ConformerCalculationEvidenceSummary
+    evidence_summary: ConformerGroupEvidenceSummary
     selection_summary: list[ConformerSelectionSummary] = Field(default_factory=list)
     available_sections: AvailableConformerSections
 

--- a/backend/app/services/scientific_read/conformers.py
+++ b/backend/app/services/scientific_read/conformers.py
@@ -56,11 +56,13 @@ from app.schemas.reads.scientific_common import (
 from app.schemas.reads.scientific_conformer import (
     AvailableConformerSections,
     ConformerAssignmentSchemeSummary,
-    ConformerCalculationEvidenceSummary,
     ConformerCalculationSummary,
+    ConformerEvidenceCoverage,
     ConformerGeometryLink,
     ConformerGroupCoreBlock,
+    ConformerGroupEvidenceSummary,
     ConformerObservationCoreBlock,
+    ConformerObservationEvidenceSummary,
     ConformerObservationsSummary,
     ConformerReviewEntry,
     ConformerSelectionSummary,
@@ -189,7 +191,7 @@ def build_group_record(
     obs_ids = [o.id for o in obs_rows]
 
     observations_summary = _build_observations_summary(obs_rows)
-    evidence_summary = _build_evidence_summary(session, obs_ids)
+    evidence_summary = _build_group_evidence_summary(session, obs_ids)
     selection_rows = _load_selection_rows(session, cg.id)
     selection_summary = _build_selection_summary_list(session, selection_rows)
     available = _build_available_sections(
@@ -350,7 +352,7 @@ def _build_observation_record(
     observation.id``).
     """
     obs_ids = [observation.id]
-    evidence = _build_evidence_summary(session, obs_ids)
+    evidence = _build_observation_evidence_summary(session, observation.id)
     available = _build_available_sections(
         session,
         obs_ids=obs_ids,
@@ -491,36 +493,163 @@ def _build_observations_summary(
     )
 
 
-def _build_evidence_summary(
+def _build_group_evidence_summary(
     session: Session, observation_ids: list[int]
-) -> ConformerCalculationEvidenceSummary:
-    """Compute the calculation-evidence summary for a set of observations.
+) -> ConformerGroupEvidenceSummary:
+    """Compute the group-scope calculation-evidence summary.
 
-    Counts and ``has_*`` booleans are aggregates over the calculations
-    whose ``conformer_observation_id`` is in *observation_ids*. The
-    geometry count is over distinct
-    ``calculation_output_geometry.geometry_id`` rows reached through
-    that calc set.
+    ``calculation_count`` and ``geometry_count`` are aggregates over the
+    calculations whose ``conformer_observation_id`` is in
+    *observation_ids* (geometry over distinct
+    ``calculation_output_geometry.geometry_id`` reached through that calc
+    set).
+
+    ``evidence_coverage`` is deliberately **not** a calculation count.
+    Each value is the number of *observations* in *observation_ids* with
+    at least one calculation of that kind — an observation carrying three
+    ``freq`` calculations contributes ``1``. That is what makes the value
+    readable against the shared ``observation_count`` denominator, and it
+    is why the coverage queries count ``DISTINCT
+    Calculation.conformer_observation_id`` rather than
+    ``Calculation.id``.
+
+    This block replaced a set of ``has_*`` booleans that OR-ed every
+    calculation under the group together; see
+    :class:`ConformerGroupEvidenceSummary` for why. ``count > 0``
+    reproduces the retired boolean exactly.
     """
     if not observation_ids:
-        return ConformerCalculationEvidenceSummary(
-            observation_count=len(observation_ids),
+        # No observations: every coverage value is 0 out of 0. Nothing is
+        # vacuously "covered" here — a caller reading ``freq == 0`` against
+        # ``observation_count == 0`` sees an empty basin, not a complete one.
+        return ConformerGroupEvidenceSummary(
+            observation_count=0,
             calculation_count=0,
-            has_opt=False,
-            has_freq=False,
-            has_sp=False,
-            has_geometry_validation=False,
-            has_scf_stability=False,
+            evidence_coverage=ConformerEvidenceCoverage(
+                opt=0,
+                freq=0,
+                sp=0,
+                geometry_validation=0,
+                scf_stability=0,
+            ),
             geometry_count=0,
         )
 
+    # One pass gives both the calculation total (COUNT(id)) and the
+    # per-type observation coverage (COUNT(DISTINCT observation_id)).
+    type_rows = session.execute(
+        select(
+            Calculation.type,
+            func.count(Calculation.id),
+            func.count(func.distinct(Calculation.conformer_observation_id)),
+        )
+        .where(Calculation.conformer_observation_id.in_(observation_ids))
+        .group_by(Calculation.type)
+    ).all()
+    calc_counts: dict[CalculationType, int] = {
+        row[0]: row[1] for row in type_rows
+    }
+    obs_coverage: dict[CalculationType, int] = {
+        row[0]: row[2] for row in type_rows
+    }
+    total = sum(calc_counts.values())
+
+    geometry_validation_coverage = _observation_coverage_via_join(
+        session,
+        observation_ids,
+        joined=CalculationGeometryValidation,
+        onclause=(
+            CalculationGeometryValidation.calculation_id == Calculation.id
+        ),
+    )
+    scf_stability_coverage = _observation_coverage_via_join(
+        session,
+        observation_ids,
+        joined=CalculationSCFStability,
+        onclause=CalculationSCFStability.calculation_id == Calculation.id,
+    )
+    geometry_count = _distinct_geometry_count(session, observation_ids)
+
+    return ConformerGroupEvidenceSummary(
+        observation_count=len(observation_ids),
+        calculation_count=total,
+        evidence_coverage=ConformerEvidenceCoverage(
+            opt=obs_coverage.get(CalculationType.opt, 0),
+            freq=obs_coverage.get(CalculationType.freq, 0),
+            sp=obs_coverage.get(CalculationType.sp, 0),
+            geometry_validation=geometry_validation_coverage,
+            scf_stability=scf_stability_coverage,
+        ),
+        geometry_count=geometry_count,
+    )
+
+
+def _observation_coverage_via_join(
+    session: Session,
+    observation_ids: list[int],
+    *,
+    joined,
+    onclause,
+) -> int:
+    """Count observations with >=1 calculation carrying a joined evidence row.
+
+    DISTINCT is on ``conformer_observation_id``, so an observation with
+    three qualifying calculations still counts once.
+    """
+    return int(
+        session.scalar(
+            select(
+                func.count(
+                    func.distinct(Calculation.conformer_observation_id)
+                )
+            )
+            .select_from(Calculation)
+            .join(joined, onclause)
+            .where(Calculation.conformer_observation_id.in_(observation_ids))
+        )
+        or 0
+    )
+
+
+def _distinct_geometry_count(
+    session: Session, observation_ids: list[int]
+) -> int:
+    return int(
+        session.scalar(
+            select(
+                func.count(func.distinct(CalculationOutputGeometry.geometry_id))
+            )
+            .select_from(CalculationOutputGeometry)
+            .join(
+                Calculation,
+                Calculation.id == CalculationOutputGeometry.calculation_id,
+            )
+            .where(
+                Calculation.conformer_observation_id.in_(observation_ids)
+            )
+        )
+        or 0
+    )
+
+
+def _build_observation_evidence_summary(
+    session: Session, observation_id: int
+) -> ConformerObservationEvidenceSummary:
+    """Compute the observation-scope calculation-evidence summary.
+
+    Scope is one provenance row, so the ``has_*`` booleans here are
+    unambiguous — there is no second observation for a ``true`` to hide.
+    They are kept as booleans for exactly that reason; the group surface
+    reports counts instead (see
+    :class:`ConformerGroupEvidenceSummary`).
+    """
+    observation_ids = [observation_id]
     type_rows = session.execute(
         select(Calculation.type, func.count(Calculation.id))
         .where(Calculation.conformer_observation_id.in_(observation_ids))
         .group_by(Calculation.type)
     ).all()
     type_counts: dict[CalculationType, int] = {row[0]: row[1] for row in type_rows}
-    total = sum(type_counts.values())
 
     has_geom_val = bool(
         session.scalar(
@@ -552,32 +681,16 @@ def _build_evidence_summary(
             )
         )
     )
-    geometry_count = int(
-        session.scalar(
-            select(
-                func.count(func.distinct(CalculationOutputGeometry.geometry_id))
-            )
-            .select_from(CalculationOutputGeometry)
-            .join(
-                Calculation,
-                Calculation.id == CalculationOutputGeometry.calculation_id,
-            )
-            .where(
-                Calculation.conformer_observation_id.in_(observation_ids)
-            )
-        )
-        or 0
-    )
 
-    return ConformerCalculationEvidenceSummary(
+    return ConformerObservationEvidenceSummary(
         observation_count=len(observation_ids),
-        calculation_count=total,
+        calculation_count=sum(type_counts.values()),
         has_opt=type_counts.get(CalculationType.opt, 0) > 0,
         has_freq=type_counts.get(CalculationType.freq, 0) > 0,
         has_sp=type_counts.get(CalculationType.sp, 0) > 0,
         has_geometry_validation=has_geom_val,
         has_scf_stability=has_scf,
-        geometry_count=geometry_count,
+        geometry_count=_distinct_geometry_count(session, observation_ids),
     )
 
 

--- a/backend/app/services/scientific_read/conformers_search.py
+++ b/backend/app/services/scientific_read/conformers_search.py
@@ -57,6 +57,7 @@ from app.schemas.reads.scientific_conformer import (
     ScientificConformerGroupRecord,
 )
 from app.schemas.reads.scientific_conformer_search import (
+    ConformerEvidenceMatch,
     ConformersSearchRequest,
     RequestEcho,
     ScientificConformersSearchResponse,
@@ -97,6 +98,9 @@ _MEANINGFUL_FILTER_FIELDS: tuple[str, ...] = (
     "has_sp",
     "has_geometry_validation",
     "has_scf_stability",
+    # ``evidence_match`` is deliberately absent: it modifies what the
+    # ``has_*`` filters mean but selects nothing on its own, so it must
+    # not satisfy the at-least-one-filter rule.
     "scientific_origin",
     "method",
     "basis",
@@ -388,65 +392,80 @@ def _apply_observation_filters(
     return stmt
 
 
+# The evidence family, in the order the filters are applied. Each entry is
+# ``(request field, extra WHERE clause, extra JOIN)`` against ``Calculation``.
+# One table drives both quantifier modes so ``any`` and ``all`` can never
+# disagree about *which* evidence a name refers to.
+_EVIDENCE_FILTERS: tuple[tuple[str, Any, Any], ...] = (
+    ("has_calculations", None, None),
+    ("has_opt", Calculation.type == CalculationType.opt, None),
+    ("has_freq", Calculation.type == CalculationType.freq, None),
+    ("has_sp", Calculation.type == CalculationType.sp, None),
+    (
+        "has_geometries",
+        None,
+        (
+            CalculationOutputGeometry,
+            CalculationOutputGeometry.calculation_id == Calculation.id,
+        ),
+    ),
+    (
+        "has_geometry_validation",
+        None,
+        (
+            CalculationGeometryValidation,
+            CalculationGeometryValidation.calculation_id == Calculation.id,
+        ),
+    ),
+    (
+        "has_scf_stability",
+        None,
+        (
+            CalculationSCFStability,
+            CalculationSCFStability.calculation_id == Calculation.id,
+        ),
+    ),
+)
+
+
 def _apply_evidence_filters(stmt, request: ConformersSearchRequest):
     """Evidence filters at the conformer-group grain.
 
-    ``has_calculations`` / ``has_opt`` / ``has_freq`` / ``has_sp`` etc.
-    semantics: a group matches iff **at least one** of its
-    observations has at least one matching calculation. This mirrors
-    the TS search's ``has_*`` semantics at TS-entry grain.
-    """
-    if request.has_calculations is not None:
-        ex = _calc_exists_in_group()
-        stmt = stmt.where(ex if request.has_calculations else ~ex)
+    ``request.evidence_match`` chooses the quantifier over the group's
+    observations (see :class:`ConformerEvidenceMatch` for the full
+    contract):
 
-    type_filters: list[tuple[bool | None, CalculationType]] = [
-        (request.has_opt, CalculationType.opt),
-        (request.has_freq, CalculationType.freq),
-        (request.has_sp, CalculationType.sp),
-    ]
-    for want, calc_type in type_filters:
+    - ``any_observation`` (default): ``has_freq=true`` matches a group
+      where at least one observation has a ``freq`` calculation;
+      ``has_freq=false`` matches a group where none does. This is the
+      historical behaviour and is unchanged, so callers that never pass
+      ``evidence_match`` see exactly what they saw before.
+    - ``all_observations``: ``has_freq=true`` matches a group with at
+      least one observation where *every* observation has a ``freq``
+      calculation; ``has_freq=false`` matches a group with at least one
+      observation where *at least one* lacks it (incomplete coverage).
+
+    A group with no observations matches neither direction under
+    ``all_observations`` — an empty basin is not vacuously complete.
+    """
+    all_observations = (
+        request.evidence_match is ConformerEvidenceMatch.all_observations
+    )
+    for field_name, extra_clause, extra_join in _EVIDENCE_FILTERS:
+        want = getattr(request, field_name)
         if want is None:
             continue
-        ex = _calc_exists_in_group(extra_clause=(Calculation.type == calc_type))
-        stmt = stmt.where(ex if want else ~ex)
-
-    if request.has_geometries is not None:
-        ex = (
-            select(CalculationOutputGeometry.geometry_id)
-            .join(
-                Calculation,
-                Calculation.id == CalculationOutputGeometry.calculation_id,
+        if all_observations:
+            stmt = stmt.where(
+                _every_observation_clause(
+                    want, extra_clause=extra_clause, extra_join=extra_join
+                )
             )
-            .join(
-                ConformerObservation,
-                ConformerObservation.id == Calculation.conformer_observation_id,
+        else:
+            ex = _calc_exists_in_group(
+                extra_clause=extra_clause, extra_join=extra_join
             )
-            .where(
-                ConformerObservation.conformer_group_id == ConformerGroup.id
-            )
-            .exists()
-        )
-        stmt = stmt.where(ex if request.has_geometries else ~ex)
-
-    if request.has_geometry_validation is not None:
-        ex = _calc_exists_in_group(
-            extra_join=(
-                CalculationGeometryValidation,
-                CalculationGeometryValidation.calculation_id == Calculation.id,
-            ),
-        )
-        stmt = stmt.where(ex if request.has_geometry_validation else ~ex)
-
-    if request.has_scf_stability is not None:
-        ex = _calc_exists_in_group(
-            extra_join=(
-                CalculationSCFStability,
-                CalculationSCFStability.calculation_id == Calculation.id,
-            ),
-        )
-        stmt = stmt.where(ex if request.has_scf_stability else ~ex)
-
+            stmt = stmt.where(ex if want else ~ex)
     return stmt
 
 
@@ -466,6 +485,50 @@ def _calc_exists_in_group(*, extra_clause=None, extra_join=None):
     if extra_clause is not None:
         sub = sub.where(extra_clause)
     return sub.exists()
+
+
+def _every_observation_clause(want: bool, *, extra_clause=None, extra_join=None):
+    """Clause for the ``all_observations`` quantifier.
+
+    Expressed as "the group has an observation, and (no / some)
+    observation lacks the evidence" rather than a COUNT comparison so it
+    stays a pair of correlated EXISTS the planner can short-circuit.
+
+    The leading "has an observation" term is load-bearing: without it
+    ``NOT EXISTS(observation lacking freq)`` is *true* for a group with
+    zero observations, and an empty basin would be reported as fully
+    covered.
+    """
+    observation_in_group = (
+        ConformerObservation.conformer_group_id == ConformerGroup.id
+    )
+
+    evidence_on_observation = select(Calculation.id).where(
+        Calculation.conformer_observation_id == ConformerObservation.id
+    )
+    if extra_join is not None:
+        evidence_on_observation = evidence_on_observation.join(*extra_join)
+    if extra_clause is not None:
+        evidence_on_observation = evidence_on_observation.where(extra_clause)
+    evidence_on_observation = evidence_on_observation.correlate(
+        ConformerObservation
+    )
+
+    has_any_observation = (
+        select(ConformerObservation.id)
+        .where(observation_in_group)
+        .correlate(ConformerGroup)
+        .exists()
+    )
+    observation_lacking_evidence = (
+        select(ConformerObservation.id)
+        .where(observation_in_group, ~evidence_on_observation.exists())
+        .correlate(ConformerGroup)
+        .exists()
+    )
+    if want:
+        return and_(has_any_observation, ~observation_lacking_evidence)
+    return and_(has_any_observation, observation_lacking_evidence)
 
 
 def _apply_method_basis_software_filters(
@@ -584,9 +647,15 @@ def _empty_response(
 
 
 def _request_filter_echo(request: ConformersSearchRequest) -> dict[str, Any]:
-    """Return the caller's filter inputs verbatim (post-parse)."""
+    """Return the caller's filter inputs verbatim (post-parse).
+
+    ``evidence_match`` is always echoed, including when the caller did
+    not supply it. It changes what the ``has_*`` filters mean, so a
+    response that reported the filters without reporting the quantifier
+    would be ambiguous in exactly the way this parameter exists to fix.
+    """
     out: dict[str, Any] = {}
-    for name in (*_MEANINGFUL_FILTER_FIELDS, "include_rejected", "include_deprecated", "min_review_status"):
+    for name in (*_MEANINGFUL_FILTER_FIELDS, "evidence_match", "include_rejected", "include_deprecated", "min_review_status"):
         value = getattr(request, name)
         if value is None:
             continue

--- a/backend/docs/specs/scientific_conformer_reads.md
+++ b/backend/docs/specs/scientific_conformer_reads.md
@@ -279,22 +279,69 @@ calculation surface so a generic client parser can reuse code.
 
 ### 4.5 Calculation evidence summary (bounded)
 
+The two surfaces are deliberately shaped differently. A group pools
+several observations; an observation is one provenance row.
+
 ```python
-class ConformerCalculationEvidenceSummary(BaseModel):
+class ConformerEvidenceCoverage(BaseModel):
+    opt: int
+    freq: int
+    sp: int
+    geometry_validation: int
+    scf_stability: int
+
+
+class ConformerGroupEvidenceSummary(BaseModel):
+    observation_count: int | None
+    calculation_count: int
+    evidence_coverage: ConformerEvidenceCoverage
+    geometry_count: int
+
+
+class ConformerObservationEvidenceSummary(BaseModel):
+    observation_count: int | None      # always 1
     calculation_count: int
     has_opt: bool
     has_freq: bool
     has_sp: bool
-    has_irc: bool             # rare on conformer obs but kept for parity
-    has_path_search: bool     # ditto
     has_geometry_validation: bool
     has_scf_stability: bool
+    geometry_count: int
 ```
 
-Same shape as `TransitionStateCalculationEvidenceSummary` so the same
-parser handles both. Builder reuses `_build_evidence_summary_for_entries`-
-style helper but keyed off `Calculation.conformer_observation_id ∈
-{ids belonging to this group}`.
+**Group scope reports counts, not booleans.** Until 2026-08 the group
+block carried the same `has_*` booleans as the observation block,
+computed as a plain OR over every calculation under the group. That made
+them asymmetrically informative: `false` was strong (nothing in the
+group has it) while `true` was nearly empty (one calculation out of a
+hundred made it `true`). On a five-observation basin, `has_freq: true`
+could not be told apart from "one of five has frequencies" — which is
+the reading nobody takes from it.
+
+Each `evidence_coverage` value is **the number of observations in scope
+with at least one calculation of that kind**, never the number of
+calculations: an observation with three `freq` calculations contributes
+`1`. The shared denominator is `observation_count`, so a client reads
+`freq: 2` against `observation_count: 5` as "2 of 5". `count > 0`
+reproduces the retired boolean exactly, which is the whole client
+migration.
+
+**What a full count does not say.** `freq == observation_count` says the
+coverage is *complete*, not that the five frequency calculations are
+*comparable* — they may sit at five different levels of theory. A count
+is honest about coverage, not about consistency; a caller who needs
+consistency reads the per-calculation provenance under
+`include=calculations`.
+
+**Observation scope keeps its booleans** because there a boolean cannot
+pool a covered observation with an uncovered one. The two surfaces are
+therefore not parseable by one evidence parser, and that is correct
+rather than an oversight.
+
+Builders: `_build_group_evidence_summary` (coverage via
+`COUNT(DISTINCT Calculation.conformer_observation_id)`) and
+`_build_observation_evidence_summary`, both keyed off
+`Calculation.conformer_observation_id ∈ {ids in scope}`.
 
 ### 4.6 Geometry summary (links only)
 
@@ -325,7 +372,7 @@ class ScientificConformerGroupRecord(BaseModel):
     species: ConformerSpeciesContext
     observations_summary: ConformerObservationsSummary
     selection_summary: list[ConformerSelectionSummary]   # always present, may be []
-    evidence_summary: ConformerCalculationEvidenceSummary
+    evidence_summary: ConformerGroupEvidenceSummary          # counts (§4.5)
     available_sections: AvailableConformerSections
 
     # Optional include blocks
@@ -340,7 +387,7 @@ class ScientificConformerObservationRecord(BaseModel):
     conformer_group: ConformerGroupCoreBlock     # parent context, always present
     species: ConformerSpeciesContext
     assignment_scheme: ConformerAssignmentSchemeSummary | None = None
-    evidence_summary: ConformerCalculationEvidenceSummary
+    evidence_summary: ConformerObservationEvidenceSummary    # booleans (§4.5)
     available_sections: AvailableConformerSections
 
     # Optional include blocks
@@ -464,6 +511,11 @@ has_freq
 has_sp
 has_geometry_validation
 has_scf_stability
+evidence_match                 (any_observation | all_observations —
+                                quantifier for the has_* family, see
+                                §6.2 below; a modifier, not a filter, so
+                                it does not satisfy the at-least-one-
+                                filter rule)
 scientific_origin              (filters at the observation grain — see
                                 §6.1 below)
 method
@@ -499,14 +551,47 @@ belongs to it.
 This matches the way the TS search treats per-entry has_* evidence
 filters at the entry-grain.
 
-### 6.2 At-least-one-filter rule
+### 6.2 `evidence_match` — any vs all observations
+
+The `has_*` evidence filters ask a question about a group, but the
+evidence lives on its observations, so the question has two honest
+readings. `evidence_match` makes the caller pick one at the call site
+rather than hiding the choice inside a bare boolean.
+
+```text
+any_observation (default, historical behaviour)
+  has_freq=true   → at least one observation has a freq calculation
+  has_freq=false  → no observation has one
+
+all_observations
+  has_freq=true   → the group has >=1 observation and EVERY observation
+                    has a freq calculation
+  has_freq=false  → the group has >=1 observation and AT LEAST ONE lacks
+                    it, i.e. coverage is incomplete (zero included)
+```
+
+A group with no observations matches **neither** direction under
+`all_observations`: "every observation has freq" must not be vacuously
+true of a basin with nothing in it. The clause is written as
+`EXISTS(observation) AND (NOT) EXISTS(observation lacking the evidence)`
+precisely so the emptiness term is explicit.
+
+The quantifier applies to the whole evidence family
+(`has_calculations`, `has_opt`, `has_freq`, `has_sp`, `has_geometries`,
+`has_geometry_validation`, `has_scf_stability`). The default keeps
+existing callers on exactly the behaviour they had. `evidence_match` is
+always reported in the response's `request.filter` echo, including when
+defaulted — a filter set echoed without its quantifier would be
+ambiguous in the way the parameter exists to fix.
+
+### 6.3 At-least-one-filter rule
 
 Pure pagination / include / review knobs do not satisfy the filter
 gate. A request that supplies none of the meaningful filters above
 returns 422 `missing_filter`. Same code, same UX as the calculation
 and TS search surfaces.
 
-### 6.3 Default deterministic ordering
+### 6.4 Default deterministic ordering
 
 ```text
 review_rank ASC
@@ -627,7 +712,7 @@ class ReactionFullConformerGroupItem(BaseModel):
     summary: ConformerGroupCoreBlock          # core block reused
     observations_summary: ConformerObservationsSummary
     selection_summary: list[ConformerSelectionSummary]
-    evidence_summary: ConformerCalculationEvidenceSummary
+    evidence_summary: ConformerGroupEvidenceSummary
 ```
 
 Top-level: `conformers: list[ReactionFullSpeciesConformers] | None`.
@@ -866,9 +951,12 @@ Cross-endpoint equality (anti-drift):
 
 ```text
 search record core block == group detail record core block
-group detail evidence_summary == observation detail evidence_summary
-  (when restricted to the observation's id) — only if reuse helper
-  guarantees identity; otherwise document the boundary
+group detail evidence_summary is NOT comparable to observation detail
+  evidence_summary: the group block reports evidence_coverage counts,
+  the observation block reports has_* booleans (§4.5). The boundary is
+  documented rather than papered over; tests assert each shape on its
+  own surface and assert the retired booleans are absent from the group
+  block
 ```
 
 Reaction-full conformer section tests (Phase 3):

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -10345,61 +10345,6 @@
         "title": "ConformerAssignmentScopeKind",
         "type": "string"
       },
-      "ConformerCalculationEvidenceSummary": {
-        "description": "Bounded calculation-evidence projection for a conformer group or\nobservation.\n\n``observation_count`` is the number of observation rows under the\ngroup (always ``1`` on the observation detail surface).\n``calculation_count`` is the number of calculations whose\n``conformer_observation_id`` belongs to the in-scope observation\nset (the parent group, or this single observation).\n``geometry_count`` is the number of distinct\n``calculation_output_geometry`` rows reached through that\ncalculation set.",
-        "properties": {
-          "calculation_count": {
-            "title": "Calculation Count",
-            "type": "integer"
-          },
-          "geometry_count": {
-            "title": "Geometry Count",
-            "type": "integer"
-          },
-          "has_freq": {
-            "title": "Has Freq",
-            "type": "boolean"
-          },
-          "has_geometry_validation": {
-            "title": "Has Geometry Validation",
-            "type": "boolean"
-          },
-          "has_opt": {
-            "title": "Has Opt",
-            "type": "boolean"
-          },
-          "has_scf_stability": {
-            "title": "Has Scf Stability",
-            "type": "boolean"
-          },
-          "has_sp": {
-            "title": "Has Sp",
-            "type": "boolean"
-          },
-          "observation_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Observation Count"
-          }
-        },
-        "required": [
-          "calculation_count",
-          "has_opt",
-          "has_freq",
-          "has_sp",
-          "has_geometry_validation",
-          "has_scf_stability",
-          "geometry_count"
-        ],
-        "title": "ConformerCalculationEvidenceSummary",
-        "type": "object"
-      },
       "ConformerCalculationIn": {
         "additionalProperties": false,
         "description": "A conformer-upload calculation that can be named by a local key.\n\nThe key is what the nested statmech block points at. It exists so a\ndepositor can say \"the statmech's vibrational basis is *that* freq\njob\" using a name they chose, rather than a calculation row id they\nwould have to query for (DR-0029 Requirement 1).\n\nOptional by design: a payload with no statmech cross-references never\nneeds one, and every payload written before keys existed stays valid.\n\n:param key: Optional local name for this calculation, unique within\n    the request. Referenced from\n    ``statmech.source_calculations[*].calculation_key`` and\n    ``statmech.torsions[*].source_scan_calculation_key``.",
@@ -10789,6 +10734,49 @@
         "title": "ConformerContextBlock",
         "type": "object"
       },
+      "ConformerEvidenceCoverage": {
+        "description": "How many observations in scope carry each kind of evidence.\n\nEvery value counts **observations**, never calculations. An\nobservation with three ``freq`` calculations contributes ``1`` to\n``freq``, not ``3``. The shared denominator is\n``ConformerGroupEvidenceSummary.observation_count``, so a caller\nreads each field as \"*n* of *observation_count*\".\n\nWhat a full count does and does not say\n---------------------------------------\n``freq == observation_count`` says the coverage is **complete** —\nevery observation in the basin has at least one frequency\ncalculation. It does **not** say those calculations are\n*comparable*: the five may sit at five different levels of theory,\nfrom five different codes, at five different geometries. A count is\nhonest about coverage, not about consistency. A caller who needs\nconsistency must inspect the per-calculation level-of-theory /\nsoftware provenance under ``include=calculations``; no number in\nthis block can stand in for that.\n\n``0`` is exactly as strong as the old ``has_x is False`` was:\nnothing in scope carries that evidence.",
+        "properties": {
+          "freq": {
+            "title": "Freq",
+            "type": "integer"
+          },
+          "geometry_validation": {
+            "title": "Geometry Validation",
+            "type": "integer"
+          },
+          "opt": {
+            "title": "Opt",
+            "type": "integer"
+          },
+          "scf_stability": {
+            "title": "Scf Stability",
+            "type": "integer"
+          },
+          "sp": {
+            "title": "Sp",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "opt",
+          "freq",
+          "sp",
+          "geometry_validation",
+          "scf_stability"
+        ],
+        "title": "ConformerEvidenceCoverage",
+        "type": "object"
+      },
+      "ConformerEvidenceMatch": {
+        "description": "Quantifier applied to the ``has_*`` evidence filters.\n\nA conformer group holds several observations, so \"does this group\nhave frequency evidence?\" has two honest readings. This parameter\nmakes the caller pick one at the call site instead of hiding the\nchoice inside a bare boolean.\n\n``any_observation`` (default, and the historical behaviour)\n    The group matches ``has_freq=true`` when **at least one** of its\n    observations has a ``freq`` calculation. ``has_freq=false`` is\n    the negation: **no** observation has one.\n\n``all_observations``\n    The group matches ``has_freq=true`` when it has at least one\n    observation and **every** observation has a ``freq``\n    calculation — the complete-coverage question the old boolean\n    could not express. ``has_freq=false`` is again the negation of\n    that: the group has at least one observation and **at least one\n    of them lacks** ``freq`` — i.e. coverage is *incomplete*, which\n    includes zero coverage.\n\nA group with no observations at all matches neither direction under\n``all_observations``. \"Every observation has freq\" must not be\nvacuously true of a basin with nothing in it.\n\nThe quantifier applies to the whole evidence family\n(``has_calculations``, ``has_opt``, ``has_freq``, ``has_sp``,\n``has_geometries``, ``has_geometry_validation``,\n``has_scf_stability``). It is a modifier, not a filter: supplying it\nalone does not satisfy the at-least-one-filter rule.",
+        "enum": [
+          "any_observation",
+          "all_observations"
+        ],
+        "title": "ConformerEvidenceMatch",
+        "type": "string"
+      },
       "ConformerGeometryLink": {
         "description": "One output-geometry link reached through a conformer's\nsupporting calculations.\n\nWraps the existing :class:`CalculationGeometryLinkSummary` shape\nwith the additional ``calculation_ref`` pointer so a caller can\ntell *which* supporting calculation produced this geometry without\na second round-trip. Full XYZ / atom / coordinate payloads remain\nonly behind ``GET /scientific/geometries/{geometry_ref}``.",
         "properties": {
@@ -10977,6 +10965,40 @@
           "species_entry_id"
         ],
         "title": "ConformerGroupDetailRead",
+        "type": "object"
+      },
+      "ConformerGroupEvidenceSummary": {
+        "description": "Bounded calculation-evidence projection for a conformer **group**.\n\n``observation_count`` is the number of observation rows under the\ngroup. ``calculation_count`` is the number of calculations whose\n``conformer_observation_id`` belongs to that observation set.\n``geometry_count`` is the number of distinct\n``calculation_output_geometry`` rows reached through that\ncalculation set. ``evidence_coverage`` reports, per evidence kind,\nhow many of the ``observation_count`` observations carry it.\n\nWhy counts here and booleans on the observation surface\n-------------------------------------------------------\nThis block deliberately has a **different shape** from\n:class:`ConformerObservationEvidenceSummary`. That asymmetry is the\npoint, not an oversight, and it should not be smoothed over.\n\nA group pools several observations. The booleans this block used to\ncarry (``has_opt`` / ``has_freq`` / …) were a plain OR across all of\nthem, which made them asymmetrically informative: ``false`` was\nstrong (nothing in the group has it) while ``true`` was nearly\nempty (one calculation out of a hundred made it ``true``). A reader\nseeing ``has_freq: true`` on a five-observation basin could not tell\nwhether five observations had frequencies or one did. Counts answer\nthat question — ``freq: 2`` with ``observation_count: 5`` shows an\nunevenly covered basin at a glance — and ``count > 0`` reproduces\nthe old boolean exactly, so nothing that the boolean expressed was\nlost.\n\nAn observation is a single provenance row, so on that surface the\nbooleans are unambiguous and are kept as they were.",
+        "properties": {
+          "calculation_count": {
+            "title": "Calculation Count",
+            "type": "integer"
+          },
+          "evidence_coverage": {
+            "$ref": "#/components/schemas/ConformerEvidenceCoverage"
+          },
+          "geometry_count": {
+            "title": "Geometry Count",
+            "type": "integer"
+          },
+          "observation_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observation Count"
+          }
+        },
+        "required": [
+          "calculation_count",
+          "evidence_coverage",
+          "geometry_count"
+        ],
+        "title": "ConformerGroupEvidenceSummary",
         "type": "object"
       },
       "ConformerGroupRead": {
@@ -11273,6 +11295,61 @@
           "review"
         ],
         "title": "ConformerObservationCoreBlock",
+        "type": "object"
+      },
+      "ConformerObservationEvidenceSummary": {
+        "description": "Bounded calculation-evidence projection for one conformer\n**observation**.\n\nScope is this single observation: ``observation_count`` is always\n``1`` and every ``has_*`` boolean describes that one provenance row,\nwhere a boolean is unambiguous — it cannot pool a covered\nobservation with an uncovered one, which is what made the same\nbooleans misleading at group scope (see\n:class:`ConformerGroupEvidenceSummary`).\n\n``calculation_count`` and ``geometry_count`` carry the same meaning\nas on the group block, restricted to this observation's own\ncalculations.\n\nAs with the group block's counts, ``has_freq: true`` says frequency\nevidence exists — not that it is comparable with the frequency\nevidence on any sibling observation.",
+        "properties": {
+          "calculation_count": {
+            "title": "Calculation Count",
+            "type": "integer"
+          },
+          "geometry_count": {
+            "title": "Geometry Count",
+            "type": "integer"
+          },
+          "has_freq": {
+            "title": "Has Freq",
+            "type": "boolean"
+          },
+          "has_geometry_validation": {
+            "title": "Has Geometry Validation",
+            "type": "boolean"
+          },
+          "has_opt": {
+            "title": "Has Opt",
+            "type": "boolean"
+          },
+          "has_scf_stability": {
+            "title": "Has Scf Stability",
+            "type": "boolean"
+          },
+          "has_sp": {
+            "title": "Has Sp",
+            "type": "boolean"
+          },
+          "observation_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observation Count"
+          }
+        },
+        "required": [
+          "calculation_count",
+          "has_opt",
+          "has_freq",
+          "has_sp",
+          "has_geometry_validation",
+          "has_scf_stability",
+          "geometry_count"
+        ],
+        "title": "ConformerObservationEvidenceSummary",
         "type": "object"
       },
       "ConformerObservationRead": {
@@ -12131,6 +12208,10 @@
               }
             ],
             "title": "Conformer Observation Ref"
+          },
+          "evidence_match": {
+            "$ref": "#/components/schemas/ConformerEvidenceMatch",
+            "default": "any_observation"
           },
           "has_calculations": {
             "anyOf": [
@@ -28818,7 +28899,7 @@
             "type": "string"
           },
           "evidence_summary": {
-            "$ref": "#/components/schemas/ConformerCalculationEvidenceSummary"
+            "$ref": "#/components/schemas/ConformerGroupEvidenceSummary"
           },
           "observations_summary": {
             "$ref": "#/components/schemas/ConformerObservationsSummary"
@@ -31987,7 +32068,7 @@
             "$ref": "#/components/schemas/ConformerGroupCoreBlock"
           },
           "evidence_summary": {
-            "$ref": "#/components/schemas/ConformerCalculationEvidenceSummary"
+            "$ref": "#/components/schemas/ConformerGroupEvidenceSummary"
           },
           "geometries": {
             "anyOf": [
@@ -32127,7 +32208,7 @@
             "$ref": "#/components/schemas/ConformerObservationCoreBlock"
           },
           "evidence_summary": {
-            "$ref": "#/components/schemas/ConformerCalculationEvidenceSummary"
+            "$ref": "#/components/schemas/ConformerObservationEvidenceSummary"
           },
           "geometries": {
             "anyOf": [
@@ -63380,6 +63461,15 @@
                 }
               ],
               "title": "Has Scf Stability"
+            }
+          },
+          {
+            "in": "query",
+            "name": "evidence_match",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ConformerEvidenceMatch",
+              "default": "any_observation"
             }
           },
           {

--- a/backend/tests/api/scientific/test_api_scientific_conformers.py
+++ b/backend/tests/api/scientific/test_api_scientific_conformers.py
@@ -205,6 +205,12 @@ def test_cg_detail_observations_summary_counts(client, db_session):
 
 
 def test_cg_detail_evidence_summary_with_calcs(client, db_session):
+    """Rewritten from ``has_opt``/``has_freq``/``has_sp`` booleans.
+
+    Same scenario as before; the group surface now reports observation
+    coverage instead. ``coverage > 0`` is the exact replacement for the
+    retired ``has_x is True``.
+    """
     entry, cg, obs = _make_group_with_obs(db_session)
     _attach_calc(
         db_session,
@@ -222,10 +228,183 @@ def test_cg_detail_evidence_summary_with_calcs(client, db_session):
     ev = body["record"]["evidence_summary"]
     assert ev["observation_count"] == 1
     assert ev["calculation_count"] == 2
-    assert ev["has_opt"] is True
-    assert ev["has_freq"] is True
-    assert ev["has_sp"] is False
+    assert ev["evidence_coverage"] == {
+        "opt": 1,
+        "freq": 1,
+        "sp": 0,
+        "geometry_validation": 0,
+        "scf_stability": 0,
+    }
     assert ev["geometry_count"] == 0
+
+
+def test_cg_detail_evidence_coverage_reports_partial_observation_cover(
+    client, db_session
+):
+    """The case the boolean could not express.
+
+    Two observations under one group; only one has a ``freq``
+    calculation. The retired ``has_freq`` reported ``true`` here, which
+    a reader takes as "this basin has frequency evidence" when half of
+    it does not. Coverage says ``1`` of ``2``.
+    """
+    entry, cg, obs = _make_group_with_obs(db_session, n_observations=2)
+    _attach_calc(
+        db_session,
+        species_entry=entry,
+        conformer_observation=obs[0],
+        calc_type=CalculationType.freq,
+    )
+    _attach_calc(
+        db_session,
+        species_entry=entry,
+        conformer_observation=obs[1],
+        calc_type=CalculationType.opt,
+    )
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["observation_count"] == 2
+    assert ev["calculation_count"] == 2
+    assert ev["evidence_coverage"]["freq"] == 1
+    assert ev["evidence_coverage"]["opt"] == 1
+    # Both kinds would have read ``true`` under the old shape; only the
+    # denominator distinguishes "half covered" from "fully covered".
+    assert ev["evidence_coverage"]["freq"] < ev["observation_count"]
+
+
+def test_cg_detail_evidence_coverage_complete_across_observations(
+    client, db_session
+):
+    """Five of five — the coverage-is-complete reading."""
+    entry, cg, obs = _make_group_with_obs(db_session, n_observations=5)
+    for o in obs:
+        _attach_calc(
+            db_session,
+            species_entry=entry,
+            conformer_observation=o,
+            calc_type=CalculationType.freq,
+        )
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["observation_count"] == 5
+    assert ev["evidence_coverage"]["freq"] == 5
+    assert ev["calculation_count"] == 5
+
+
+def test_cg_detail_evidence_coverage_zero_when_no_observation_has_it(
+    client, db_session
+):
+    """Zero of five — as strong as the old ``has_x is False``."""
+    entry, cg, obs = _make_group_with_obs(db_session, n_observations=5)
+    for o in obs:
+        _attach_calc(
+            db_session,
+            species_entry=entry,
+            conformer_observation=o,
+            calc_type=CalculationType.opt,
+        )
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["observation_count"] == 5
+    assert ev["evidence_coverage"]["opt"] == 5
+    assert ev["evidence_coverage"]["freq"] == 0
+    assert ev["evidence_coverage"]["sp"] == 0
+
+
+def test_cg_detail_evidence_coverage_counts_observations_not_calculations(
+    client, db_session
+):
+    """Three ``freq`` calculations on one observation cover **one**.
+
+    This is the property the whole field rests on: the denominator is
+    observations, so the numerator must be too. A coverage value that
+    counted calculations could exceed ``observation_count`` and would be
+    unreadable against it.
+    """
+    entry, cg, obs = _make_group_with_obs(db_session, n_observations=2)
+    for _ in range(3):
+        _attach_calc(
+            db_session,
+            species_entry=entry,
+            conformer_observation=obs[0],
+            calc_type=CalculationType.freq,
+        )
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["observation_count"] == 2
+    assert ev["calculation_count"] == 3
+    assert ev["evidence_coverage"]["freq"] == 1
+    assert ev["evidence_coverage"]["freq"] <= ev["observation_count"]
+
+
+def test_cg_detail_evidence_coverage_for_validation_and_stability(
+    client, db_session
+):
+    """Coverage for the two joined-evidence kinds, partially covered.
+
+    The covered observation carries **two** validated calculations, so
+    this also pins the counts-observations-not-calculations property on
+    the joined-evidence path — a coverage of ``2`` here would exceed the
+    number of observations that actually have the evidence.
+    """
+    entry, cg, obs = _make_group_with_obs(db_session, n_observations=2)
+    calc_a, _ = _attach_calc(
+        db_session, species_entry=entry, conformer_observation=obs[0]
+    )
+    calc_b, _ = _attach_calc(
+        db_session, species_entry=entry, conformer_observation=obs[0]
+    )
+    _attach_calc(db_session, species_entry=entry, conformer_observation=obs[1])
+    for calc in (calc_a, calc_b):
+        attach_geometry_validation(db_session, calculation=calc)
+        attach_scf_stability(db_session, calculation=calc)
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    coverage = ev["evidence_coverage"]
+    assert ev["observation_count"] == 2
+    assert ev["calculation_count"] == 3
+    assert coverage["geometry_validation"] == 1
+    assert coverage["scf_stability"] == 1
+
+
+def test_cg_detail_evidence_coverage_empty_group(client, db_session):
+    """A basin with no observations is 0 of 0 — never vacuously covered."""
+    _, cg = _make_group(db_session)
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["observation_count"] == 0
+    assert ev["calculation_count"] == 0
+    assert ev["geometry_count"] == 0
+    assert ev["evidence_coverage"] == {
+        "opt": 0,
+        "freq": 0,
+        "sp": 0,
+        "geometry_validation": 0,
+        "scf_stability": 0,
+    }
+
+
+def test_cg_detail_evidence_summary_carries_no_boolean_flags(
+    client, db_session
+):
+    """The misleading group-scope booleans are gone, not merely joined."""
+    entry, cg, obs = _make_group_with_obs(db_session, n_observations=2)
+    _attach_calc(
+        db_session,
+        species_entry=entry,
+        conformer_observation=obs[0],
+        calc_type=CalculationType.freq,
+    )
+    body = client.get(_cg_url(cg.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    for retired in (
+        "has_opt",
+        "has_freq",
+        "has_sp",
+        "has_geometry_validation",
+        "has_scf_stability",
+    ):
+        assert retired not in ev
 
 
 def test_cg_detail_available_sections_present(client, db_session):
@@ -669,6 +848,32 @@ def test_co_detail_evidence_summary_with_validation_evidence(
     assert ev["has_scf_stability"] is True
 
 
+def test_co_detail_evidence_summary_keeps_booleans(client, db_session):
+    """The observation surface is deliberately shaped differently.
+
+    One observation is one provenance row, so a boolean there cannot
+    pool a covered observation with an uncovered one — the failure that
+    forced the group surface onto counts. The booleans stay, and the
+    group's ``evidence_coverage`` block must not appear here.
+    """
+    entry, _, obs = _make_group_with_obs(db_session, n_observations=2)
+    _attach_calc(
+        db_session,
+        species_entry=entry,
+        conformer_observation=obs[0],
+        calc_type=CalculationType.freq,
+    )
+    body = client.get(_co_url(obs[0].public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["observation_count"] == 1
+    assert ev["has_freq"] is True
+    assert ev["has_opt"] is False
+    assert "evidence_coverage" not in ev
+
+    sibling = client.get(_co_url(obs[1].public_ref)).json()
+    assert sibling["record"]["evidence_summary"]["has_freq"] is False
+
+
 # ===========================================================================
 # Conformer search (group grain)
 # ===========================================================================
@@ -919,6 +1124,217 @@ def test_search_by_has_scf_stability(client, db_session):
     body = client.get(_search_url(has_scf_stability="true")).json()
     refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
     assert refs == {cg_a.public_ref}
+
+
+# --- evidence_match (any vs all observations) -------------------------------
+
+
+def _group_with_freq_coverage(db_session, *, label, covered, total):
+    """Build a group of *total* observations where *covered* have freq."""
+    entry, cg, obs = _make_group_with_obs(
+        db_session, label=label, n_observations=total
+    )
+    for index, o in enumerate(obs):
+        _attach_calc(
+            db_session,
+            species_entry=entry,
+            conformer_observation=o,
+            calc_type=(
+                CalculationType.freq if index < covered else CalculationType.opt
+            ),
+        )
+    return entry, cg, obs
+
+
+def test_search_has_freq_defaults_to_any_observation(client, db_session):
+    """Unchanged default: one covered observation is enough to match.
+
+    Existing clients pass no ``evidence_match``; they must keep seeing
+    the partially covered group.
+    """
+    _, cg_partial, _ = _group_with_freq_coverage(
+        db_session, label="partial", covered=1, total=2
+    )
+    _, cg_none, _ = _group_with_freq_coverage(
+        db_session, label="none", covered=0, total=2
+    )
+    body = client.get(_search_url(has_freq="true")).json()
+    refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
+    assert refs == {cg_partial.public_ref}
+    assert cg_none.public_ref not in refs
+
+
+def test_search_has_freq_all_observations_requires_every_observation(
+    client, db_session
+):
+    """``all_observations`` is the question the boolean could not ask."""
+    _, cg_partial, _ = _group_with_freq_coverage(
+        db_session, label="partial", covered=1, total=2
+    )
+    _, cg_full, _ = _group_with_freq_coverage(
+        db_session, label="full", covered=2, total=2
+    )
+    body = client.get(
+        _search_url(has_freq="true", evidence_match="all_observations")
+    ).json()
+    refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
+    assert refs == {cg_full.public_ref}
+    assert cg_partial.public_ref not in refs
+
+    # ...and the same two groups under the default quantifier: both match.
+    any_body = client.get(_search_url(has_freq="true")).json()
+    any_refs = {
+        r["conformer_group"]["conformer_group_ref"] for r in any_body["records"]
+    }
+    assert any_refs == {cg_partial.public_ref, cg_full.public_ref}
+
+
+def test_search_has_freq_all_observations_false_finds_incomplete_cover(
+    client, db_session
+):
+    """Under ``all_observations``, ``false`` means coverage is incomplete."""
+    _, cg_partial, _ = _group_with_freq_coverage(
+        db_session, label="partial", covered=1, total=2
+    )
+    _, cg_full, _ = _group_with_freq_coverage(
+        db_session, label="full", covered=2, total=2
+    )
+    _, cg_none, _ = _group_with_freq_coverage(
+        db_session, label="none", covered=0, total=2
+    )
+    body = client.get(
+        _search_url(has_freq="false", evidence_match="all_observations")
+    ).json()
+    refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
+    assert cg_partial.public_ref in refs
+    assert cg_none.public_ref in refs
+    assert cg_full.public_ref not in refs
+
+
+def test_search_has_freq_any_observations_false_needs_zero_coverage(
+    client, db_session
+):
+    """Default ``false`` stays strict: no observation may have freq."""
+    _, cg_partial, _ = _group_with_freq_coverage(
+        db_session, label="partial", covered=1, total=2
+    )
+    _, cg_none, _ = _group_with_freq_coverage(
+        db_session, label="none", covered=0, total=2
+    )
+    body = client.get(_search_url(has_freq="false")).json()
+    refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
+    assert cg_none.public_ref in refs
+    assert cg_partial.public_ref not in refs
+
+
+def test_search_all_observations_never_matches_an_empty_group(
+    client, db_session
+):
+    """"Every observation has freq" must not be vacuously true of nothing."""
+    _, cg_empty = _make_group(db_session, label="empty")
+    _, cg_full, _ = _group_with_freq_coverage(
+        db_session, label="full", covered=1, total=1
+    )
+    true_body = client.get(
+        _search_url(has_freq="true", evidence_match="all_observations")
+    ).json()
+    true_refs = {
+        r["conformer_group"]["conformer_group_ref"] for r in true_body["records"]
+    }
+    assert cg_empty.public_ref not in true_refs
+    assert cg_full.public_ref in true_refs
+
+    false_body = client.get(
+        _search_url(has_freq="false", evidence_match="all_observations")
+    ).json()
+    false_refs = {
+        r["conformer_group"]["conformer_group_ref"]
+        for r in false_body["records"]
+    }
+    assert cg_empty.public_ref not in false_refs
+
+
+def test_search_all_observations_applies_to_geometry_validation(
+    client, db_session
+):
+    """The quantifier covers the whole evidence family, not just types."""
+    entry, cg_partial, obs_partial = _make_group_with_obs(
+        db_session, label="partial", n_observations=2
+    )
+    calc_a, _ = _attach_calc(
+        db_session, species_entry=entry, conformer_observation=obs_partial[0]
+    )
+    _attach_calc(
+        db_session, species_entry=entry, conformer_observation=obs_partial[1]
+    )
+    attach_geometry_validation(db_session, calculation=calc_a)
+
+    entry_b, cg_full, obs_full = _make_group_with_obs(
+        db_session, label="full", n_observations=2
+    )
+    for o in obs_full:
+        calc, _ = _attach_calc(
+            db_session, species_entry=entry_b, conformer_observation=o
+        )
+        attach_geometry_validation(db_session, calculation=calc)
+
+    body = client.get(
+        _search_url(
+            has_geometry_validation="true",
+            evidence_match="all_observations",
+        )
+    ).json()
+    refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
+    assert refs == {cg_full.public_ref}
+
+
+def test_search_evidence_match_alone_is_not_a_filter(client, db_session):
+    """A modifier must not satisfy the at-least-one-filter rule."""
+    resp = client.get(_search_url(evidence_match="all_observations"))
+    assert resp.status_code == 422
+    assert "missing_filter" in resp.text
+
+
+def test_search_echoes_evidence_match(client, db_session):
+    """The echo must say which quantifier produced the result set."""
+    _, cg, _ = _group_with_freq_coverage(
+        db_session, label="full", covered=1, total=1
+    )
+    default_body = client.get(_search_url(has_freq="true")).json()
+    assert default_body["request"]["filter"]["evidence_match"] == (
+        "any_observation"
+    )
+    explicit_body = client.get(
+        _search_url(has_freq="true", evidence_match="all_observations")
+    ).json()
+    assert explicit_body["request"]["filter"]["evidence_match"] == (
+        "all_observations"
+    )
+    assert cg.public_ref  # the fixture is real, not a no-op
+
+
+def test_search_post_accepts_evidence_match(client, db_session):
+    """GET/POST parity for the new parameter."""
+    _, cg_partial, _ = _group_with_freq_coverage(
+        db_session, label="partial", covered=1, total=2
+    )
+    _, cg_full, _ = _group_with_freq_coverage(
+        db_session, label="full", covered=2, total=2
+    )
+    body = client.post(
+        _search_url(),
+        json={"has_freq": True, "evidence_match": "all_observations"},
+    ).json()
+    refs = {r["conformer_group"]["conformer_group_ref"] for r in body["records"]}
+    assert refs == {cg_full.public_ref}
+    assert cg_partial.public_ref not in refs
+
+
+def test_search_rejects_unknown_evidence_match_value(client, db_session):
+    resp = client.get(
+        _search_url(has_freq="true", evidence_match="most_observations")
+    )
+    assert resp.status_code == 422
 
 
 # --- provenance filters -----------------------------------------------------

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.52.4"
+version = "0.53.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/client.py
+++ b/clients/python/src/tckdb_client/client.py
@@ -2103,6 +2103,7 @@ class TCKDBClient:
         has_sp: bool | None = None,
         has_geometry_validation: bool | None = None,
         has_scf_stability: bool | None = None,
+        evidence_match: str | None = None,
         scientific_origin: str | None = None,
         method: str | None = None,
         basis: str | None = None,
@@ -2120,7 +2121,17 @@ class TCKDBClient:
         profile: str | None = None,
         method_http: _ScientificSearchMethod = "POST",
     ) -> ConformerSearchResponse:
-        """Search conformer groups by species, evidence, or selection state."""
+        """Search conformer groups by species, evidence, or selection state.
+
+        ``evidence_match`` picks the quantifier the ``has_*`` filters use
+        over a group's observations: ``"any_observation"`` (the server
+        default, and the historical behaviour) matches a group where at
+        least one observation carries the evidence; ``"all_observations"``
+        matches only groups where every observation does, and with
+        ``has_x=False`` matches groups whose coverage is incomplete. A
+        group with no observations matches neither under
+        ``"all_observations"``. Leave it ``None`` to keep the default.
+        """
 
         body = {
             "species_ref": species_ref,
@@ -2138,6 +2149,7 @@ class TCKDBClient:
             "has_sp": has_sp,
             "has_geometry_validation": has_geometry_validation,
             "has_scf_stability": has_scf_stability,
+            "evidence_match": evidence_match,
             "scientific_origin": scientific_origin,
             "method": method,
             "basis": basis,

--- a/clients/python/tests/test_typed_parity_methods.py
+++ b/clients/python/tests/test_typed_parity_methods.py
@@ -152,6 +152,35 @@ class TestConformers:
             "has_freq": True,
         }
 
+    def test_search_forwards_evidence_match(self):
+        handler, seen = _capture(_envelope())
+        client, _ = make_client(handler)
+
+        client.search_conformers(
+            species_entry_ref="spe_x",
+            has_freq=True,
+            evidence_match="all_observations",
+        )
+
+        assert json.loads(seen[0].content) == {
+            "species_entry_ref": "spe_x",
+            "has_freq": True,
+            "evidence_match": "all_observations",
+        }
+
+    def test_search_omits_evidence_match_when_not_supplied(self):
+        """Omitted, not defaulted client-side.
+
+        The server owns the default (``any_observation``); a client that
+        spelled it out would freeze today's default into every request.
+        """
+        handler, seen = _capture(_envelope())
+        client, _ = make_client(handler)
+
+        client.search_conformers(species_entry_ref="spe_x", has_freq=True)
+
+        assert "evidence_match" not in json.loads(seen[0].content)
+
     def test_search_get_form(self):
         handler, seen = _capture(_envelope())
         client, _ = make_client(handler)

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Read-only MCP server wrapping the TCKDB scientific API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/mcp/src/tckdb_mcp/tools/scientific_reads.py
+++ b/integrations/mcp/src/tckdb_mcp/tools/scientific_reads.py
@@ -216,6 +216,9 @@ _register_search(
                 "has_sp",
                 "has_geometry_validation",
                 "has_scf_stability",
+                # Quantifier for the has_* family over a group's
+                # observations: any_observation (default) | all_observations.
+                "evidence_match",
                 "scientific_origin",
                 "method",
                 "basis",


### PR DESCRIPTION
## In plain language

A **conformer group** is one basin — one shape of a molecule. Under it sit
several **conformer observations**: separate uploads, each saying "here is that
shape, and here is the computational evidence I have for it."

The read API's group summary used to carry yes/no flags — `has_freq`,
`has_opt`, `has_sp`, and two others — saying whether the basin had that kind of
evidence. The flags were computed by looking at *every* calculation under the
group and answering yes if *any one* of them qualified.

That makes `false` a strong statement (nothing in the whole basin has it) and
`true` a nearly empty one (one calculation out of a hundred makes it `true`).
Read `has_freq: true` on a basin with five observations and you conclude the
basin has frequency evidence — when four of the five may have none. The flag was
only reliable in the direction nobody reads it for.

This PR replaces those group-level flags with **counts**:

```json
"observation_count": 5,
"evidence_coverage": { "opt": 5, "freq": 2, "sp": 5,
                       "geometry_validation": 5, "scf_stability": 0 }
```

`freq: 2` against `observation_count: 5` says "2 of 5" at a glance — the exact
thing the boolean could not say. Nothing was lost: `count > 0` is the old
`true`, and `count == 0` is the old `false`.

Two supporting decisions:

- **Observation-level summaries keep their yes/no flags.** One observation is a
  single record, so there is no second observation for a `true` to hide behind.
  The two surfaces are now shaped differently, and that is deliberate, not an
  oversight; the docstrings say so.
- **The search filter gains a way to ask "all", not just "any".** Previously
  `?has_freq=true` returned any group where *some* observation had frequencies.
  It still does, by default, so nobody's existing query changes. A new
  `?evidence_match=all_observations` asks for groups where *every* observation
  has them. A group with no observations at all matches neither direction — "all
  of nothing" must not read as "complete".

Vocabulary used below: *read API* = the endpoints that hand data out (as opposed
to the upload endpoints); *OpenAPI golden* = a checked-in snapshot of the API's
machine-readable description, so any accidental change to the API shape shows up
as a diff in review; *mutation testing* = deliberately breaking the code to
confirm a test actually fails, since a test that passes either way proves
nothing.

## Breaking read-API change

**Yes — this changes an existing response shape.** Affected surfaces, all at the
conformer-**group** grain:

- `GET /api/v1/scientific/conformer-groups/{ref_or_id}` → `record.evidence_summary`
- `GET|POST /api/v1/scientific/conformers/search` → `records[].evidence_summary`
- `GET /api/v1/scientific/reaction-entries/{id}/full?include=conformers`
  → `conformers[].conformer_groups[].evidence_summary`

### How a client migrates

| before | after |
|---|---|
| `ev["has_opt"]` | `ev["evidence_coverage"]["opt"] > 0` |
| `ev["has_freq"]` | `ev["evidence_coverage"]["freq"] > 0` |
| `ev["has_sp"]` | `ev["evidence_coverage"]["sp"] > 0` |
| `ev["has_geometry_validation"]` | `ev["evidence_coverage"]["geometry_validation"] > 0` |
| `ev["has_scf_stability"]` | `ev["evidence_coverage"]["scf_stability"] > 0` |

One comparison per field, with identical meaning. `observation_count`,
`calculation_count` and `geometry_count` are untouched.

**Not affected:** `GET /api/v1/scientific/conformer-observations/{ref_or_id}`
keeps its `has_*` booleans, and the transition-state evidence summary is a
separate model that this PR does not touch.

Search query parameters are additive only — `evidence_match` defaults to
`any_observation`, which is exactly the pre-existing behaviour, so a client that
never sends it sees no change in its result set.

### The honest residual, written into the field docstring

`freq == observation_count` says the coverage is **complete**. It does **not**
say the five frequency calculations are *comparable* — they may be at five
different levels of theory, from five different codes. A count is honest about
coverage, not about consistency. That sentence is in
`ConformerEvidenceCoverage`'s docstring (and so in the OpenAPI description) so
the field does not quietly become the next thing that reads as an assurance it
is not.

## Schema / migration impact

**None.** This is a read projection over existing tables. No ORM model, no
column, no Alembic revision. Nothing under `backend/alembic/` is touched.

## Package version bump

`clients/python` `0.52.4` → `0.53.0` (minor: new optional `evidence_match`
parameter on `search_conformers`, no removals from the client surface).
`schemas/python/tckdb-schemas` is untouched — its conformer module is the upload
path, unrelated to this read surface.

## What changed

| file | change |
|---|---|
| `backend/app/schemas/reads/scientific_conformer.py` | `ConformerCalculationEvidenceSummary` split into `ConformerGroupEvidenceSummary` (counts) and `ConformerObservationEvidenceSummary` (booleans); new `ConformerEvidenceCoverage` |
| `backend/app/services/scientific_read/conformers.py` | `_build_evidence_summary` split into `_build_group_evidence_summary` / `_build_observation_evidence_summary`; coverage via `COUNT(DISTINCT conformer_observation_id)` |
| `backend/app/schemas/reads/scientific_conformer_search.py` | new `ConformerEvidenceMatch` enum + `evidence_match` field |
| `backend/app/services/scientific_read/conformers_search.py` | evidence filters made table-driven; `all_observations` quantifier; `evidence_match` always echoed |
| `backend/app/api/routes/scientific/conformers.py` | `evidence_match` query parameter |
| `backend/app/schemas/reads/scientific_provenance.py` | `/full` conformer item points at the group summary type |
| `backend/docs/specs/scientific_conformer_reads.md` | §4.5 rewritten; new §6.2 for `evidence_match`; anti-drift note corrected |
| `backend/tests/api/golden/openapi.json` | regenerated |
| `clients/python`, `integrations/mcp` | `evidence_match` plumbed through |

### Counts observations, not calculations

The load-bearing detail: each coverage value is the number of **observations**
with at least one calculation of that kind. An observation with three `freq`
calculations contributes `1`, not `3` — otherwise the numerator could exceed its
own denominator and the "n of m" reading collapses. Enforced in SQL by
`COUNT(DISTINCT Calculation.conformer_observation_id)` on both the per-type
group-by and the joined-evidence (geometry-validation / SCF-stability) queries.

## Tests

### Rewritten from the old boolean semantics (not deleted)

- `test_cg_detail_evidence_summary_with_calcs` — was `assert ev["has_opt"] is True`
  and two siblings; now asserts the whole `evidence_coverage` dict for the same
  scenario.

### New

- **`test_cg_detail_evidence_coverage_reports_partial_observation_cover`** — the
  test that justifies the change: two observations, one with a `freq`
  calculation, coverage reads `1`. The old boolean reported `true` here.
- `test_cg_detail_evidence_coverage_complete_across_observations` — 5 of 5
- `test_cg_detail_evidence_coverage_zero_when_no_observation_has_it` — 0 of 5
- `test_cg_detail_evidence_coverage_counts_observations_not_calculations` — three
  `freq` calculations on one observation count once
- `test_cg_detail_evidence_coverage_for_validation_and_stability` — the joined
  evidence kinds, with two validated calculations on one observation to pin the
  same counts-observations property on that code path
- `test_cg_detail_evidence_coverage_empty_group` — 0 of 0
- `test_cg_detail_evidence_summary_carries_no_boolean_flags` — the retired keys
  are gone, not merely joined
- `test_co_detail_evidence_summary_keeps_booleans` — the observation surface is
  unchanged and carries no `evidence_coverage`
- Search: `test_search_has_freq_defaults_to_any_observation`,
  `..._all_observations_requires_every_observation`,
  `..._all_observations_false_finds_incomplete_cover`,
  `..._any_observations_false_needs_zero_coverage`,
  `test_search_all_observations_never_matches_an_empty_group`,
  `test_search_all_observations_applies_to_geometry_validation`,
  `test_search_evidence_match_alone_is_not_a_filter`,
  `test_search_echoes_evidence_match`,
  `test_search_post_accepts_evidence_match`,
  `test_search_rejects_unknown_evidence_match_value`
- Client: `test_search_forwards_evidence_match`,
  `test_search_omits_evidence_match_when_not_supplied`

### Mutation testing

Four mutations landed in the working tree, confirmed present with `grep`, run,
observed to fail, then reverted — both files verified byte-identical to their
pre-mutation `md5sum` afterwards.

| # | mutation | test that died | observed failure |
|---|---|---|---|
| 1 | coverage column `COUNT(DISTINCT observation_id)` → `COUNT(id)` | `test_cg_detail_evidence_coverage_counts_observations_not_calculations` | `assert 3 == 1` |
| 2 | dropped the `has_any_observation` guard from `_every_observation_clause` | `test_search_all_observations_never_matches_an_empty_group` | empty group appeared in the `all_observations` result set |
| 3 | `all_observations = False` (quantifier ignored) | 5 search tests | partially-covered group matched `all_observations` |
| 4 | dropped `DISTINCT` in `_observation_coverage_via_join` | `test_cg_detail_evidence_coverage_for_validation_and_stability` | `assert 2 == 1` |

## Verification actually run

From `backend/`, conda env `tckdb_env`, exit codes captured with `$?` (not piped
into `tail`):

```
ruff check app tests scripts                 -> All checks passed
bash scripts/test-api.sh                     -> EXIT=0   3137 passed
bash scripts/test-rest.sh                    -> EXIT=0   4891 passed, 14 skipped
bash scripts/test-scientific.sh              -> EXIT=0   2097 passed
```

Plus, outside the gates:

```
clients/python:      pytest tests/  -> 1371 passed
integrations/mcp:    pytest tests/  ->  578 passed
ruff check on the three non-backend files touched -> All checks passed
```

`backend/tests/api/golden/openapi.json` regenerated with
`UPDATE_OPENAPI_GOLDEN=1 pytest tests/api/test_openapi_snapshot.py`; the diff was
read and contains only the intended schema rename/split, the new
`ConformerEvidenceCoverage` / `ConformerEvidenceMatch` components, and the new
`evidence_match` query parameter.

**Client parity ledger: no update needed.** `evidence_match` is a parameter on an
existing operation, not a new operation, so `tckdb_client._parity.COVERAGE` and
`clients/python/docs/api_parity_matrix.md` are unchanged. This was checked by
running `test_openapi_parity.py` and `test_parity_matrix_doc.py` against the
*regenerated* golden rather than by trusting a green tick — and since this PR
does touch `clients/python/**`, the path-filtered `python-client-ci` workflow
will run on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEMrWcGRqbAVoh1Cn3TJ9D
