### PR TITLE
Show the missing mode, and stop dumping readers in JSON

### DIFF
--- a/backend/app/api/landing.py
+++ b/backend/app/api/landing.py
@@ -12,6 +12,14 @@ end dressed as an introduction. The hero is now a search box that
 queries this deployment's own public read API and renders the records
 it gets back, so the first thing a visitor does is get real data out.
 
+Leading somewhere is also a claim about where. Every product a result
+has expands *in place* into the few fields that say what is in it,
+rather than navigating to the nested JSON document the endpoint
+answers with -- correct for a program, a wall of keys for a person who
+clicked a link on a landing page. The raw document is still one click
+away from inside each panel, under a label that says it is raw JSON.
+Nothing on this page takes a reader somewhere they did not expect.
+
 Design constraints, in the order they constrain things:
 
 * **Self-contained.** No CDN, no external stylesheet, no web font, no
@@ -46,6 +54,17 @@ input, transcribed from an actual run; ``tests/api/test_landing_page.py``
 re-runs the check and fails if the page and the checker ever disagree.
 An invented example on a page whose entire argument is "this system
 does not invent things" would be self-refuting.
+
+That example has to *show* its defect, not assert it. An earlier
+version printed the three deposited frequencies and a sentence saying
+a mode was missing, which is only legible to a reader who already
+knows carbon dioxide's spectrum is 667, 667, 1333, 2349 -- the whole
+point being the 667 that appears twice. Nothing on screen was wrong to
+look at. The panel now prints the deposit above the spectrum the
+molecule has, one frequency per column, with the absent slot drawn as
+an empty cell directly above the frequency that belongs in it. The
+prose is then an explanation of something the reader has already seen
+rather than a substitute for seeing it.
 
 The markup lives in this module as a string rather than as a sibling
 ``.html`` file on purpose: ``backend/pyproject.toml`` declares no
@@ -116,18 +135,36 @@ SEARCH_PLACEHOLDERS = (
 #: The geometry shown in the worked example, and the input the test
 #: feeds back through the real checker. Carbon dioxide, collinear along
 #: z at a 1.162 A bond length.
+#:
+#: The first two lines are the XYZ format's own header -- an atom count
+#: and a comment. They belong to the file the checker parses, so they
+#: live here; the panel renders :func:`hero_atom_lines` instead. A bare
+#: ``3`` alone above three coordinate rows is unremarkable inside a
+#: file and reads on a web page as a stray number.
 HERO_XYZ = """3
 carbon dioxide
 C   0.000000   0.000000   0.000000
 O   0.000000   0.000000   1.162000
 O   0.000000   0.000000  -1.162000"""
 
-#: The frequency list deposited alongside :data:`HERO_XYZ`: the three
-#: distinct wavenumbers a CO2 harmonic analysis prints. Three is 3N-6,
-#: the count for a *bent* three-atom molecule; a linear one has 3N-5=4,
-#: because the bend is doubly degenerate and a de-duplicating parser
-#: reports it once.
-HERO_FREQUENCIES = (667.0, 1333.0, 2349.0)
+#: The vibrational spectrum carbon dioxide actually has. Linear, three
+#: atoms, so 3N-5 = 4 vibrations: the symmetric stretch (~1333), the
+#: asymmetric stretch (~2349), and the bend (~667), which is **doubly
+#: degenerate** -- one bend, in two perpendicular planes, at one
+#: wavenumber -- and is therefore counted twice.
+HERO_TRUE_FREQUENCIES = (667.0, 667.0, 1333.0, 2349.0)
+
+#: The frequency list actually deposited alongside :data:`HERO_XYZ`.
+#:
+#: Derived from the true spectrum by performing exactly the mistake the
+#: example is about -- de-duplicating equal wavenumbers, which drops one
+#: component of the degenerate pair and lands the count on 3N-6, the
+#: count for a *bent* three-atom molecule. Derived rather than typed
+#: because the panel's whole claim is that one of these four modes is
+#: absent from the deposit: computing the deposit from the spectrum
+#: makes that claim a property of the module instead of a coincidence
+#: between two hand-maintained tuples.
+HERO_FREQUENCIES = tuple(dict.fromkeys(HERO_TRUE_FREQUENCIES))
 
 #: The code the checker attaches to that deposit. Advisory: the record
 #: is accepted and annotated, not refused.
@@ -494,6 +531,93 @@ noscript { display: block; margin-top: 1rem; }
   border-color: var(--phase-neg);
   background: var(--phase-neg);
 }
+/*
+ * A product's own records, rendered where the reader already is.
+ *
+ * Following one of these pills used to navigate to a nested JSON
+ * document: the right answer for a program, and an unreadable one for
+ * a person who clicked a link on a landing page. The pill is now a
+ * disclosure that expands in place and shows the few fields that
+ * answer *what is in here*, and every route to the raw document is
+ * labelled as one, so nobody arrives at JSON by surprise.
+ */
+button.pill {
+  cursor: pointer;
+  line-height: inherit;
+}
+.pill[aria-expanded="true"] {
+  border-color: var(--phase-pos);
+  background: var(--surface);
+}
+.pill[aria-expanded]::after { content: " +"; }
+.pill[aria-expanded="true"]::after { content: " -"; }
+.entry-details:empty { display: none; }
+.detail {
+  margin-top: 0.7rem;
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--phase-pos);
+  background: var(--paper);
+  padding: 0.75rem 0.9rem;
+}
+.detail-count {
+  margin: 0;
+  max-width: none;
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  font-weight: 700;
+}
+.detail-note,
+.detail-status {
+  margin: 0.4rem 0 0;
+  max-width: none;
+  font-size: 0.9375rem;
+  color: var(--muted);
+}
+.detail-card {
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--rule);
+}
+.detail-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.6rem;
+}
+.detail-title {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+.detail-ref {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+.fields {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  gap: 0.15rem 0.8rem;
+  margin: 0.5rem 0 0;
+  font-size: var(--fs-data);
+}
+.fields dt { color: var(--muted); }
+.fields dd {
+  margin: 0;
+  font-family: var(--mono);
+  overflow-wrap: anywhere;
+}
+.detail-raw,
+.raw-link {
+  overflow-wrap: anywhere;
+}
+.detail-raw {
+  margin: 0.7rem 0 0;
+  max-width: none;
+  font-size: 0.9375rem;
+}
 .empty, .failure {
   border: 1px solid var(--rule);
   border-left: 3px solid var(--phase-pos);
@@ -510,33 +634,6 @@ noscript { display: block; margin-top: 1rem; }
   color: var(--phase-neg-text);
 }
 .failure-detail { font-family: var(--mono); font-size: var(--fs-data); overflow-wrap: anywhere; }
-
-/* ---- the four roles ---- */
-.roles { margin: 0; }
-.roles > div {
-  padding: 0.9rem 0;
-  border-top: 1px solid var(--rule);
-}
-.roles > div:last-child { border-bottom: 1px solid var(--rule); }
-.roles dt {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.6rem;
-  font-family: var(--mono);
-  font-size: var(--fs-body);
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-.behaviour {
-  font-family: var(--mono);
-  font-size: var(--fs-label);
-  font-weight: 700;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-  color: var(--phase-pos);
-}
-.roles dd { margin: 0.3rem 0 0; max-width: 38rem; }
 
 /* ---- the worked example ---- */
 /*
@@ -593,6 +690,72 @@ noscript { display: block; margin-top: 1rem; }
   background: var(--data-bg);
   padding: 0.7rem 0.8rem;
 }
+/*
+ * The deposited list above the spectrum the molecule really has, one
+ * frequency per column. The panel's entire job is "look what TCKDB
+ * caught", so the gap has to be findable by eye before any prose
+ * explains it: the absent mode is an empty dashed cell sitting
+ * directly above the frequency that belongs in it, both drawn in the
+ * negative phase colour, which appears nowhere else in this panel.
+ *
+ * A table rather than an aligned <pre>: two rows of numbers with a row
+ * header each is what a table is, column alignment survives every mono
+ * fallback face, and a screen reader is told which column a value sits
+ * in instead of being read a run of digits.
+ */
+.spectrum-wrap { overflow-x: auto; }
+.spectrum {
+  border-collapse: collapse;
+  margin: 0;
+  width: 100%;
+  font-family: var(--mono);
+  /*
+   * Floors lower than the coordinate block above it. Five columns of
+   * nowrap monospace is the widest thing on the page, and the whole
+   * point is that both rows are in view at once: a 360px reader who
+   * has to swipe the last column into sight loses the comparison the
+   * panel is making.
+   */
+  font-size: clamp(0.625rem, 0.5rem + 0.5vw, var(--fs-data));
+  background: var(--data-bg);
+}
+.spectrum th,
+.spectrum td {
+  padding: 0.4rem 0.25rem;
+  font-weight: 400;
+  text-align: right;
+  white-space: nowrap;
+}
+.spectrum th[scope="row"] {
+  padding-left: 0.5rem;
+  text-align: left;
+  color: var(--muted);
+}
+.spectrum td:last-child { padding-right: 0.5rem; }
+.spectrum tr:first-child > * { padding-top: 0.7rem; }
+.spectrum tr:last-child > * { padding-bottom: 0.7rem; }
+.spectrum .gap { padding: 0.3rem 0.3rem; }
+.gap-mark {
+  display: block;
+  border: 1.5px dashed var(--phase-neg);
+  padding: 0.1rem 0.2rem;
+  color: var(--phase-neg-text);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.spectrum .gap-source {
+  border: 1.5px solid var(--phase-neg);
+  color: var(--phase-neg-text);
+  font-weight: 700;
+}
+.spectrum-caption {
+  margin: 0.6rem 0 0;
+  font-size: 0.9375rem;
+  max-width: none;
+}
+.spectrum-caption b { color: var(--phase-neg-text); }
 .panel-sub {
   font-family: var(--mono);
   font-size: var(--fs-label);
@@ -745,57 +908,45 @@ curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
     <pre class="command"><code>pip install "git+__REPO_URL__.git#subdirectory=clients/python"</code></pre>
   </section>
 
-  <section aria-labelledby="roles-heading">
-    <h2 id="roles-heading">Four roles, one per table</h2>
-    <dl class="roles">
-      <div>
-        <dt>identity <span class="behaviour">deduped</span></dt>
-        <dd>
-          One row per distinct species, reaction or transition state, however
-          often submitted.
-        </dd>
-      </div>
-      <div>
-        <dt>provenance <span class="behaviour">append-only</span></dt>
-        <dd>
-          The software, level of theory and literature behind a number, never
-          rewritten.
-        </dd>
-      </div>
-      <div>
-        <dt>result <span class="behaviour">append-only</span></dt>
-        <dd>
-          The number itself. A better calculation adds a row; nothing already
-          cited changes.
-        </dd>
-      </div>
-      <div>
-        <dt>curation <span class="behaviour">overlay</span></dt>
-        <dd>
-          Review state and release selections sit on top of results, never
-          mutating them.
-        </dd>
-      </div>
-    </dl>
-  </section>
-
   <section aria-labelledby="exchange-heading">
     <h2 id="exchange-heading">What a check looks like</h2>
     <figure class="exchange-figure">
       <div class="exchange">
         <div class="panel deposit">
           <p class="panel-label">Deposited</p>
-          <pre>__HERO_XYZ__</pre>
+          <p class="panel-sub">carbon dioxide, geometry / &#197;</p>
+          <pre>__HERO_GEOMETRY__</pre>
           <p class="panel-sub">frequencies / cm&#8315;&#185;</p>
-          <pre>__HERO_FREQUENCIES__</pre>
+          <div class="spectrum-wrap">
+__HERO_SPECTRUM__
+          </div>
+          <p class="spectrum-caption">
+            The top row is what was deposited. The bottom row is the spectrum
+            carbon dioxide has. <b>667 cm&#8315;&#185; belongs in it twice</b>,
+            and the deposit carries it once.
+          </p>
         </div>
         <div class="panel verdict">
           <p class="panel-label">TCKDB replies</p>
           <code class="verdict-code">__HERO_CODE__</code>
           <p class="verdict-body">
-            Linear geometry: 3N&minus;5 = 4 vibrations, but the list carries
-            three &mdash; a degenerate bend, reported once by a de-duplicating
-            parser. The record is accepted and flagged, not refused.
+            Carbon dioxide is linear, so it has 3N&minus;5 = 4 vibrations:
+            a symmetric stretch, an asymmetric stretch, and a bend.
+          </p>
+          <p class="verdict-body">
+            The bend is <em>doubly degenerate</em>. The molecule bends in two
+            perpendicular planes, and both cost the same energy, so one bend
+            occupies two of the four modes at the same wavenumber.
+          </p>
+          <p class="verdict-body">
+            This list carries that wavenumber once. The usual cause is a
+            parser that de-duplicates equal frequencies, which leaves exactly
+            three &mdash; 3N&minus;6, the vibrational count of a <em>bent</em>
+            three-atom molecule, on a geometry that is not bent.
+          </p>
+          <p class="verdict-body">
+            The record is accepted and flagged, not refused. TCKDB stores the
+            deposit and attaches the code above to it.
           </p>
         </div>
       </div>
@@ -916,6 +1067,317 @@ curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
     return node;
   }
 
+  /*
+   * ---- what a result leads to -------------------------------------
+   *
+   * Every product a record has becomes a disclosure that opens in
+   * place. The panel names the handful of fields that answer what is
+   * in here, and ends with the same endpoint labelled as raw JSON, so
+   * the machine-readable document stays one click away and is never
+   * somewhere a reader lands unawares.
+   *
+   * The numbers shown are the payload own pagination total and the
+   * per-record count fields. Deliberately never the group-scope
+   * has_* booleans in the conformer payload: each is an OR across
+   * every observation in the group, so it reads as a fact about the
+   * conformer while being a fact about the union. Those are being
+   * replaced by counts; until they are, this page shows none of them.
+   */
+
+  function fixed(value, digits, unit) {
+    if (value === null || value === undefined) { return null; }
+    var text = Number(value).toFixed(digits);
+    return unit ? text + " " + unit : text;
+  }
+
+  /*
+   * A software release prints its own name in some deployments
+   * (Gaussian 16, Revision C.02) and not in others (16). Concatenating
+   * unconditionally gives one of those a stutter and the other a bare
+   * number with no product attached, so the name is prepended only
+   * when the version does not already open with it.
+   */
+  function softwareLabel(release) {
+    if (!release) { return null; }
+    var name = release.software;
+    var version = release.version;
+    if (!name) { return version || null; }
+    if (!version) { return name; }
+    return version.indexOf(name) === 0 ? version : name + " " + version;
+  }
+
+  function levelLabel(level) {
+    if (!level) { return null; }
+    if (level.label) { return level.label; }
+    if (!level.method) { return null; }
+    return level.method + (level.basis ? "/" + level.basis : "");
+  }
+
+  function thermoView(record) {
+    var thermo = record.thermo || {};
+    var coverage = thermo.temperature_coverage || {};
+    var primary = (record.provenance || {}).primary_calculation || {};
+    var span = null;
+    if (coverage.record_min_k !== null && coverage.record_min_k !== undefined) {
+      span = fixed(coverage.record_min_k, 0) + "\u2013" + fixed(coverage.record_max_k, 0, "K");
+    }
+    return {
+      title: (thermo.model_kind || "thermo") + " fit",
+      ref: thermo.thermo_ref,
+      status: thermo.review ? thermo.review.status : null,
+      fields: [
+        ["enthalpy at 298 K", fixed(thermo.h298_kj_mol, 2, "kJ/mol")],
+        ["entropy at 298 K", fixed(thermo.s298_j_mol_k, 2, "J/mol/K")],
+        ["fitted over", span],
+        ["level of theory", levelLabel(primary.level_of_theory)],
+        ["origin", thermo.scientific_origin]
+      ]
+    };
+  }
+
+  function statmechView(record) {
+    var statmech = record.statmech || {};
+    var linear = statmech.is_linear;
+    return {
+      title: (statmech.statmech_treatment || "statmech") +
+        (statmech.rigid_rotor_kind ? " / " + statmech.rigid_rotor_kind + " rotor" : ""),
+      ref: statmech.statmech_ref,
+      status: statmech.review ? statmech.review.status : null,
+      fields: [
+        ["point group", statmech.point_group],
+        ["symmetry number", statmech.external_symmetry],
+        ["optical isomers", statmech.optical_isomers],
+        ["linear", linear === null || linear === undefined ? null : (linear ? "yes" : "no")],
+        ["frequency scale factor", fixed(statmech.frequency_scale_factor_value, 4)],
+        ["origin", statmech.scientific_origin]
+      ]
+    };
+  }
+
+  function transportView(record) {
+    var transport = record.transport || {};
+    var evidence = record.evidence_summary || {};
+    return {
+      title: "Lennard-Jones parameters",
+      ref: transport.transport_ref,
+      status: transport.review ? transport.review.status : null,
+      fields: [
+        ["collision diameter", fixed(transport.sigma_angstrom, 3, "\u00C5")],
+        ["well depth", fixed(transport.epsilon_over_k_k, 1, "K")],
+        ["dipole moment", fixed(transport.dipole_debye, 3, "D")],
+        ["source calculations", evidence.source_calculation_count],
+        ["origin", transport.scientific_origin]
+      ]
+    };
+  }
+
+  function conformerView(record) {
+    var group = record.conformer_group || {};
+    var evidence = record.evidence_summary || {};
+    var observations = record.observations_summary || {};
+    var seen = evidence.observation_count;
+    if (seen === null || seen === undefined) { seen = observations.total; }
+    return {
+      title: group.label || "conformer group",
+      ref: group.conformer_group_ref,
+      status: group.review ? group.review.status : null,
+      fields: [
+        ["deposited as", seen === null || seen === undefined
+          ? null
+          : plural(seen, "observation", "observations") + " of this one group"],
+        ["calculations behind it", evidence.calculation_count],
+        ["distinct geometries", evidence.geometry_count]
+      ]
+    };
+  }
+
+  function calculationView(record) {
+    var calculation = record.calculation || {};
+    var energy = record.energy || {};
+    var software = record.software_release || {};
+    var hartree = energy.energy_hartree;
+    return {
+      title: calculation.calculation_type || "calculation",
+      ref: calculation.calculation_ref,
+      status: calculation.review ? calculation.review.status : null,
+      fields: [
+        ["level of theory", levelLabel(record.level_of_theory)],
+        ["software", softwareLabel(software)],
+        ["energy", hartree === null || hartree === undefined
+          ? null
+          : fixed(hartree, 6, "hartree")],
+        ["quality", calculation.calculation_quality]
+      ]
+    };
+  }
+
+  var SECTIONS = [
+    {
+      key: "thermo",
+      label: "thermo",
+      one: "thermo record",
+      many: "thermo records",
+      shown: function (a) { return !!a.has_thermo; },
+      url: function (ref) { return THERMO + "?species_entry_ref=" + encodeURIComponent(ref); },
+      view: thermoView
+    },
+    {
+      key: "statmech",
+      label: "statmech",
+      one: "statmech record",
+      many: "statmech records",
+      shown: function (a) { return !!a.has_statmech; },
+      url: function (ref) { return ENTRY + encodeURIComponent(ref) + "/statmech"; },
+      view: statmechView
+    },
+    {
+      key: "transport",
+      label: "transport",
+      one: "transport record",
+      many: "transport records",
+      shown: function (a) { return !!a.has_transport; },
+      url: function (ref) { return ENTRY + encodeURIComponent(ref) + "/transport"; },
+      view: transportView
+    },
+    {
+      key: "conformers",
+      label: "conformers",
+      one: "conformer group",
+      many: "conformer groups",
+      note: "A conformer group is one torsional basin -- one conformer. Its " +
+        "observations are the deposited instances assigned to that basin, so a " +
+        "group with five observations is one conformer seen five times, not " +
+        "five conformers.",
+      shown: function (a) { return !!a.has_conformers; },
+      url: function (ref) { return CONFORMERS + "?species_entry_ref=" + encodeURIComponent(ref); },
+      view: conformerView
+    },
+    {
+      key: "calculations",
+      label: "calculations",
+      one: "calculation",
+      many: "calculations",
+      count: function (a) { return a.calculation_count; },
+      shown: function (a) { return !!a.calculation_count; },
+      url: function (ref) {
+        return CALCULATIONS + "?species_entry_ref=" + encodeURIComponent(ref);
+      },
+      view: calculationView
+    }
+  ];
+
+  /*
+   * How many records a panel draws before deferring to the raw
+   * document. An entry can carry dozens of calculations, and a landing
+   * page that answers a click with fifty cards has swapped one wall of
+   * text for another. The count above the cards is the real total, so
+   * the cap shortens the reading and never the answer.
+   */
+  var CARD_LIMIT = 5;
+
+  var panelSeq = 0;
+
+  function pillLabel(section, availability) {
+    if (section.count) {
+      return plural(section.count(availability), section.one, section.many);
+    }
+    return section.label;
+  }
+
+  function rawLink(section, ref) {
+    var node = make("p", "detail-raw");
+    node.appendChild(anchor(section.url(ref), "raw-link", "Open this list as raw JSON"));
+    return node;
+  }
+
+  function detailFields(view) {
+    var list = make("dl", "fields");
+    for (var i = 0; i < view.fields.length; i += 1) {
+      var pair = view.fields[i];
+      if (pair[1] === null || pair[1] === undefined || pair[1] === "") { continue; }
+      list.appendChild(make("dt", null, pair[0]));
+      list.appendChild(make("dd", null, pair[1]));
+    }
+    return list;
+  }
+
+  function detailBody(section, ref, payload) {
+    var fragment = doc.createDocumentFragment();
+    var records = payload.records || [];
+    var pagination = payload.pagination || {};
+    var total = pagination.total;
+    if (total === null || total === undefined) { total = records.length; }
+    fragment.appendChild(make("p", "detail-count", plural(total, section.one, section.many)));
+    if (section.note) { fragment.appendChild(make("p", "detail-note", section.note)); }
+    var shown = Math.min(records.length, CARD_LIMIT);
+    for (var i = 0; i < shown; i += 1) {
+      var view = section.view(records[i]);
+      var card = make("div", "detail-card");
+      var head = make("div", "detail-head");
+      head.appendChild(make("span", "detail-title", view.title));
+      if (view.status) { head.appendChild(reviewBadge(view.status)); }
+      if (view.ref) { head.appendChild(make("span", "detail-ref", view.ref)); }
+      card.appendChild(head);
+      card.appendChild(detailFields(view));
+      fragment.appendChild(card);
+    }
+    if (total > shown) {
+      fragment.appendChild(make("p", "detail-note",
+        "Showing the first " + plural(shown, section.one, section.many) + " of " + total + "."));
+    }
+    fragment.appendChild(rawLink(section, ref));
+    return fragment;
+  }
+
+  function loadDetail(panel, section, ref) {
+    clear(panel);
+    panel.appendChild(make("p", "detail-status", "Loading\u2026"));
+    fetch(section.url(ref), { headers: { "Accept": "application/json" } })
+      .then(function (response) {
+        return response.json().then(function (body) {
+          return { ok: response.ok, body: body };
+        }, function () {
+          return { ok: false, body: null };
+        });
+      })
+      .then(function (result) {
+        clear(panel);
+        if (result.ok) {
+          panel.appendChild(detailBody(section, ref, result.body || {}));
+          return;
+        }
+        panel.appendChild(make("p", "detail-status", "This list could not be read."));
+        panel.appendChild(rawLink(section, ref));
+      }, function () {
+        clear(panel);
+        panel.appendChild(make("p", "detail-status",
+          "The browser could not reach this deployment's API."));
+      });
+  }
+
+  function disclosure(section, ref, availability) {
+    panelSeq += 1;
+    var id = "detail-" + section.key + "-" + panelSeq;
+    var button = make("button", "pill", pillLabel(section, availability));
+    button.setAttribute("type", "button");
+    button.setAttribute("aria-expanded", "false");
+    button.setAttribute("aria-controls", id);
+    var panel = make("div", "detail");
+    panel.id = id;
+    panel.hidden = true;
+    var loaded = false;
+    button.addEventListener("click", function () {
+      var open = button.getAttribute("aria-expanded") === "true";
+      button.setAttribute("aria-expanded", open ? "false" : "true");
+      panel.hidden = open;
+      if (!open && !loaded) {
+        loaded = true;
+        loadDetail(panel, section, ref);
+      }
+    });
+    return { button: button, panel: panel };
+  }
+
   function entryNode(entry) {
     var ref = entry.species_entry_ref || "";
     var availability = entry.availability || {};
@@ -929,29 +1391,18 @@ curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
     node.appendChild(head);
 
     var links = make("div", "entry-links");
-    var encoded = encodeURIComponent(ref);
-    if (availability.has_thermo) {
-      links.appendChild(anchor(THERMO + "?species_entry_ref=" + encoded, "pill", "thermo"));
-    }
-    if (availability.has_statmech) {
-      links.appendChild(anchor(ENTRY + encoded + "/statmech", "pill", "statmech"));
-    }
-    if (availability.has_transport) {
-      links.appendChild(anchor(ENTRY + encoded + "/transport", "pill", "transport"));
-    }
-    if (availability.has_conformers) {
-      links.appendChild(anchor(CONFORMERS + "?species_entry_ref=" + encoded, "pill", "conformers"));
-    }
-    if (availability.calculation_count) {
-      links.appendChild(anchor(
-        CALCULATIONS + "?species_entry_ref=" + encoded,
-        "pill",
-        plural(availability.calculation_count, "calculation", "calculations")));
+    var panels = make("div", "entry-details");
+    for (var i = 0; i < SECTIONS.length; i += 1) {
+      if (!SECTIONS[i].shown(availability)) { continue; }
+      var pair = disclosure(SECTIONS[i], ref, availability);
+      links.appendChild(pair.button);
+      panels.appendChild(pair.panel);
     }
     if (!links.firstChild) {
       links.appendChild(make("span", "pill pill-none", "no products yet"));
     }
     node.appendChild(links);
+    node.appendChild(panels);
     return node;
   }
 
@@ -966,8 +1417,10 @@ curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
     var refs = make("p", "record-refs");
     refs.appendChild(make("span", null, record.inchi_key || ""));
     refs.appendChild(doc.createTextNode(" \\u00B7 "));
-    refs.appendChild(anchor(searchUrl("species_ref", record.species_ref), null,
-      record.species_ref || "record"));
+    refs.appendChild(make("span", null, record.species_ref || ""));
+    refs.appendChild(doc.createTextNode(" \u00B7 "));
+    refs.appendChild(anchor(searchUrl("species_ref", record.species_ref), "raw-link",
+      "this record as raw JSON"));
     node.appendChild(refs);
 
     var entries = record.entries || [];
@@ -1044,7 +1497,8 @@ curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
     if (pagination.total > records.length) {
       var more = make("p", "results-status", "Showing the first page.");
       more.appendChild(doc.createTextNode(" "));
-      more.appendChild(anchor(searchUrl(field, value), null, "Open the full response"));
+      more.appendChild(anchor(searchUrl(field, value), "raw-link",
+        "Open the full response as raw JSON"));
       out.appendChild(more);
     }
   }
@@ -1154,6 +1608,64 @@ def _example_chips() -> str:
     return "\n".join(lines)
 
 
+def hero_atom_lines() -> tuple[str, ...]:
+    """The coordinate rows of :data:`HERO_XYZ`, without the XYZ header.
+
+    The header is real and the checker reads it; it is simply not
+    something to put on a web page on its own. See :data:`HERO_XYZ`.
+    """
+    return tuple(HERO_XYZ.splitlines()[2:])
+
+
+def _spectrum_table() -> str:
+    """The deposited frequency list above the true spectrum, gap marked.
+
+    Built from :data:`HERO_TRUE_FREQUENCIES` and :data:`HERO_FREQUENCIES`
+    rather than written out, so the cell drawn as *missing* is the cell
+    the two tuples really disagree about. A hand-written table could
+    mark the wrong column, or keep marking one after the numbers moved,
+    and would look equally convincing either way.
+
+    The comparison is a multiset one: a degenerate pair is two entries
+    with the same value, so matching by value alone would call both of
+    CO2's 667 cm-1 modes present and mark nothing.
+    """
+    remaining = list(HERO_FREQUENCIES)
+    deposited: list[str] = []
+    spectrum: list[str] = []
+    for value in HERO_TRUE_FREQUENCIES:
+        cell = _html_escape(f"{value:.1f}")
+        if value in remaining:
+            remaining.remove(value)
+            deposited.append(f"<td>{cell}</td>")
+            spectrum.append(f"<td>{cell}</td>")
+        else:
+            deposited.append('<td class="gap"><span class="gap-mark">missing</span></td>')
+            spectrum.append(f'<td class="gap-source">{cell}</td>')
+    if remaining:  # pragma: no cover - a constant-only mistake, caught in tests
+        raise ValueError(
+            "the deposited frequency list carries a mode the true spectrum does not: "
+            f"{remaining}"
+        )
+    indent = " " * 12
+    lines = [
+        f'{indent}<table class="spectrum">',
+        f"{indent}<caption class=\"sr-only\">Carbon dioxide vibrational "
+        "frequencies, in reciprocal centimetres: the deposited list above the "
+        'spectrum the molecule has.</caption>',
+        f"{indent}<tr>",
+        f'{indent}<th scope="row">deposited</th>',
+        *(f"{indent}{cell}" for cell in deposited),
+        f"{indent}</tr>",
+        f"{indent}<tr>",
+        f'{indent}<th scope="row">CO<sub>2</sub> has</th>',
+        *(f"{indent}{cell}" for cell in spectrum),
+        f"{indent}</tr>",
+        f"{indent}</table>",
+    ]
+    return "\n".join(lines)
+
+
 def _html_escape(text: str) -> str:
     return (
         text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
@@ -1209,7 +1721,6 @@ def render_landing_page(*, api_reference_path: str | None) -> str:
             f'<a href="{DOCS_URL}">documentation site</a> carries the endpoint '
             "reference and query guides."
         )
-    frequencies = "   ".join(f"{value:.1f}" for value in HERO_FREQUENCIES)
     return (
         _PAGE_TEMPLATE.replace("__DOCS_URL__", DOCS_URL)
         .replace("__REPO_URL__", REPO_URL)
@@ -1221,8 +1732,8 @@ def render_landing_page(*, api_reference_path: str | None) -> str:
         .replace("__ORIGIN_PLACEHOLDER__", ORIGIN_PLACEHOLDER)
         .replace("__SEED_FIELD__", SEED_FIELD)
         .replace("__SEED_VALUE__", _html_escape(SEED_VALUE))
-        .replace("__HERO_XYZ__", HERO_XYZ)
-        .replace("__HERO_FREQUENCIES__", frequencies)
+        .replace("__HERO_GEOMETRY__", "\n".join(hero_atom_lines()))
+        .replace("__HERO_SPECTRUM__", _spectrum_table())
         .replace("__HERO_CODE__", HERO_CODE)
         .replace("__REFERENCE_BUTTON__", reference_button)
         .replace("__DOCS_BUTTON__", docs_button)
@@ -1257,6 +1768,7 @@ __all__ = [
     "DOCS_URL",
     "HERO_CODE",
     "HERO_FREQUENCIES",
+    "HERO_TRUE_FREQUENCIES",
     "HERO_XYZ",
     "ORIGIN_PLACEHOLDER",
     "REDOC_PATH",
@@ -1266,6 +1778,7 @@ __all__ = [
     "SEED_FIELD",
     "SEED_VALUE",
     "SPECIES_SEARCH_PATH",
+    "hero_atom_lines",
     "landing_router",
     "render_landing_page",
 ]

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -22,11 +22,17 @@ The tests are grouped as:
   the page still searches. The one control that cannot work without
   script ships disabled rather than silently searching the wrong
   field, and ``<noscript>`` offers a plain form per identifier.
+* :class:`TestResultsExpandInPlace` -- following a result must not
+  drop the reader into a nested JSON document without warning. Each
+  product is a disclosure that opens on the page, and every route to
+  the raw document says that is what it is.
 * :class:`TestHeroExampleIsReal` -- the worked example in the hero is
   re-run through the real checker on every test run. If the page and
   ``app.services.frequency_geometry_linearity`` ever disagree, this
   fails rather than leaving a plausible-looking fiction on a public
-  page.
+  page. It also has to *show* the defect it describes: the deposited
+  list and the true spectrum are both on screen, with the missing mode
+  marked, so the reader sees the gap before reading about it.
 * :class:`TestDocSurfaceExposure` -- the three-way matrix of
   ``EXPOSE_API_DOCS`` x ``EXPOSE_API_REFERENCE``, including the one
   that matters for the hosted deployment: ReDoc on, Swagger still 404.
@@ -55,6 +61,7 @@ from app.api.landing import (
     DOCS_URL,
     HERO_CODE,
     HERO_FREQUENCIES,
+    HERO_TRUE_FREQUENCIES,
     HERO_XYZ,
     REPO_URL,
     SEARCH_EXAMPLES,
@@ -62,17 +69,13 @@ from app.api.landing import (
     SEED_FIELD,
     SEED_VALUE,
     SPECIES_SEARCH_PATH,
+    hero_atom_lines,
     render_landing_page,
 )
 from app.api.startup_checks import validate_deployment_safety
 from app.services.frequency_geometry_linearity import (
     evaluate_frequency_list_linearity,
 )
-
-#: The four write-behaviour roles the page must name. These are the
-#: repository's central organising idea, not decoration: every table is
-#: exactly one of them, and the role fixes how the table may be written.
-DATA_ROLES = ("identity", "provenance", "result", "curation")
 
 #: Every review state the API can put on a record. All five must have a
 #: human word on the page: a badge that falls through to a raw enum name
@@ -178,17 +181,25 @@ class TestLandingPageResponse:
         assert f'href="{DOCS_URL}"' in body
         assert f'href="{REPO_URL}"' in body
 
-    def test_page_names_every_data_role_with_its_write_behaviour(self, client_factory):
+    def test_the_page_does_not_teach_the_table_role_taxonomy(self, client_factory):
+        """Schema philosophy is documentation, not landing-page content.
+
+        The identity / provenance / result / curation split is how this
+        repository is organised and it is on the documentation site. It
+        answers no question a visitor to the base URL is asking, and a
+        section of it sat between the search box and the worked example
+        for exactly as long as it took someone to read the page.
+
+        This is not a weakened version of the test that used to check
+        the section's wording: that section is deliberately gone, and
+        what replaces its test is the assertion that it stays gone.
+        """
         with client_factory() as c:
             body = c.get("/").text
-        for role in DATA_ROLES:
-            assert f"<dt>{role} " in body, f"landing page does not name the {role} role"
-        # The behaviour word is the load-bearing half of the label: a page
-        # that lists four nouns and omits how each is written has not said
-        # the thing the roles exist to say.
-        assert body.count('<span class="behaviour">append-only</span>') == 2
-        assert '<span class="behaviour">deduped</span>' in body
-        assert '<span class="behaviour">overlay</span>' in body
+        assert "append-only" not in body
+        assert "roles-heading" not in body
+        assert 'class="behaviour"' not in body
+        assert re.search(r"<dt>(identity|provenance|result|curation)\b", body) is None
 
     def test_page_separates_citing_the_software_from_citing_a_release(self, client_factory):
         with client_factory() as c:
@@ -372,12 +383,12 @@ class TestLiveSearch:
         assert entry_renderer is not None
         assert "reviewBadge(entry.review" in entry_renderer.group(1)
 
-    def test_a_result_links_onward_to_its_own_records(self, script):
+    def test_a_result_leads_onward_to_every_product_it_has(self, script):
         """A landing page that leads nowhere is the defect being fixed.
 
-        Every product the search says a record has becomes a link to
-        the endpoint that serves it, so a visitor can follow a result
-        into the data rather than reading about it.
+        Every product the search says a record has gets its own control
+        aimed at the endpoint that serves it, so a visitor can follow a
+        result into the data rather than reading about it.
         """
         for path in (
             "/api/v1/scientific/thermo/search",
@@ -469,6 +480,124 @@ class TestSearchDegradesWithoutJavaScript:
         assert document.find("a", **{"class": "chip"})
 
 
+class TestResultsExpandInPlace:
+    """Following a result must not surprise the reader with raw JSON.
+
+    The endpoints behind a result answer with a nested JSON document.
+    That is the right shape for a client and an unreadable one for a
+    person who clicked a link on a landing page -- and it misleads: an
+    array index reads as a count, an observation total reads as a
+    conformer count. So each product opens on the page instead, and
+    every remaining route to the raw document is labelled as one.
+    """
+
+    def test_each_product_is_a_disclosure_rather_than_a_navigation(self, script):
+        """The pill expands the card; it does not leave the page.
+
+        A ``<button>`` with ``aria-expanded`` rather than an ``<a>``,
+        because an anchor pointing at the JSON is a middle-click away
+        from the wall of keys however its click handler behaves.
+        """
+        assert 'make("button", "pill"' in script
+        assert 'button.setAttribute("aria-expanded", "false")' in script
+        assert 'button.setAttribute("aria-controls", id)' in script
+        assert "loadDetail(panel, section, ref)" in script
+        # No product control is an anchor any more.
+        assert 'anchor(THERMO' not in script
+        assert 'anchor(CONFORMERS' not in script
+        assert 'anchor(CALCULATIONS' not in script
+
+    def test_every_route_to_the_raw_document_says_it_is_raw_json(self, script):
+        """Nobody may be surprised by where a link takes them.
+
+        Three anchors still point at an API document -- the per-product
+        link inside an expanded panel, the per-record one, and the
+        "there are more pages" one -- and each names its destination.
+        The assertion is on the anchors the script builds rather than
+        on a count of the phrase, so an anchor added later without a
+        label fails here.
+
+        The example chips are the one exception and are excluded by
+        name. They are anchors *because* they must work with scripting
+        off, which is the whole reason their ``href`` is the endpoint;
+        with the script running their click is intercepted and never
+        navigates, and the results area says in prose that without
+        JavaScript the examples go to the API's JSON.
+        """
+        anchors = re.findall(r"anchor\((.*?)\);", script, flags=re.DOTALL)
+        json_anchors = [
+            call
+            for call in anchors
+            if ("section.url(" in call or "searchUrl(" in call) and '"chip"' not in call
+        ]
+        assert len(json_anchors) >= 3
+        for call in json_anchors:
+            assert "raw JSON" in call, call
+        assert "the box and examples go" in render_landing_page(api_reference_path=None)
+
+    def test_a_panel_reports_counts_and_never_the_group_scope_booleans(self, script):
+        """``has_*`` on a conformer group is an OR across observations.
+
+        A group-scoped ``has_scf_stability`` says *some* observation in
+        the group has it, while reading as a fact about the conformer.
+        Those fields are being replaced with counts in a separate
+        change; presenting them here would put a wrong sentence on a
+        public page and would still be wrong after the fix lands. The
+        panel shows counts the payload states outright instead.
+        """
+        for field in (
+            "observation_count",
+            "calculation_count",
+            "geometry_count",
+            "source_calculation_count",
+        ):
+            assert field in script, field
+        for boolean in ("has_scf_stability", "has_opt", "has_freq", "has_sp"):
+            assert boolean not in script, boolean
+
+    def test_an_observation_count_is_never_called_a_conformer_count(self, script):
+        """Five observations are one conformer seen five times.
+
+        A conformer group is one torsional basin -- identity, deduped.
+        An observation is one deposited instance assigned to that basin
+        -- provenance, append-only. Labelling the second as the first
+        is the specific misreading this panel exists to prevent, so the
+        count line counts groups and the observation line says what it
+        is counting.
+        """
+        conformers = re.search(
+            r'\{\s*key: "conformers",(.*?)\n    \}', script, flags=re.DOTALL
+        )
+        assert conformers is not None
+        block = conformers.group(1)
+        assert 'one: "conformer group"' in block
+        assert 'many: "conformer groups"' in block
+        assert "torsional basin" in block
+        assert "one conformer seen five times" in block
+        assert "five conformers" in block
+
+        view = re.search(
+            r"function conformerView\(record\) \{(.*?)\n  \}", script, flags=re.DOTALL
+        )
+        assert view is not None
+        assert '"observation", "observations"' in view.group(1)
+        assert "of this one group" in view.group(1)
+
+    def test_the_no_script_fallback_is_untouched_by_the_expansion(self, document):
+        """None of the above may cost the scripting-off reader anything.
+
+        The expansion is script-only by construction: it renders search
+        results, which only exist once a fetch has run. What has to
+        survive is everything that works before one does.
+        """
+        fallback_forms = [
+            attrs for attrs, ancestors in document.find("form") if "noscript" in ancestors
+        ]
+        assert len(fallback_forms) == len(SEARCH_FIELDS) - 1
+        assert document.find("input", id="search-input")
+        assert document.find("a", **{"class": "chip"})
+
+
 class TestHeroExampleIsReal:
     """The worked example is the checker's own output, not a mock-up."""
 
@@ -504,10 +633,94 @@ class TestHeroExampleIsReal:
         assert "accepted and flagged, not refused" in page
         assert HERO_CODE in page
 
-    def test_the_hero_deposit_is_shown_verbatim(self):
+    def test_the_hero_geometry_is_shown_verbatim_without_the_xyz_header(self):
+        """The coordinates are the deposit; the header is file plumbing.
+
+        Every atom row appears exactly as deposited. The count and
+        comment lines do not: alone above three coordinates on a web
+        page, a bare ``3`` reads as a stray number rather than as an
+        XYZ field, and the panel labels the block instead.
+        """
         page = render_landing_page(api_reference_path=None)
-        for line in HERO_XYZ.splitlines():
+        atoms = hero_atom_lines()
+        assert len(atoms) == 3
+        for line in atoms:
             assert line in page
+        assert "<pre>" + "\n".join(atoms) + "</pre>" in page
+        assert ">3\ncarbon dioxide" not in page
+
+    def test_the_true_spectrum_is_the_one_carbon_dioxide_has(self):
+        """3N-5 = 4 modes, with the doubly degenerate bend counted twice.
+
+        Carbon dioxide is linear and has three atoms, so it has four
+        vibrations: two stretches and one bend, and the bend occupies
+        two of the four because it is doubly degenerate. Getting this
+        wrong would put a false spectrum on a public page under a
+        heading claiming it is what the molecule has.
+        """
+        n_atoms = len(hero_atom_lines())
+        assert len(HERO_TRUE_FREQUENCIES) == 3 * n_atoms - 5
+        assert HERO_TRUE_FREQUENCIES == (667.0, 667.0, 1333.0, 2349.0)
+        assert HERO_TRUE_FREQUENCIES.count(667.0) == 2
+
+    def test_the_deposit_is_the_true_spectrum_with_the_degeneracy_collapsed(self):
+        """The deposit is derived by the very mistake being illustrated.
+
+        Exactly one mode short, and short by a duplicate rather than by
+        an arbitrary omission, because a de-duplicating parser is what
+        produces this deposit in the wild.
+        """
+        assert HERO_FREQUENCIES == (667.0, 1333.0, 2349.0)
+        assert len(HERO_FREQUENCIES) == len(HERO_TRUE_FREQUENCIES) - 1
+        assert set(HERO_FREQUENCIES) == set(HERO_TRUE_FREQUENCIES)
+        assert len(HERO_FREQUENCIES) == len(set(HERO_FREQUENCIES))
+
+    def test_the_panel_shows_both_lists_with_the_missing_mode_marked(self):
+        """The gap must be visible, not asserted.
+
+        Three frequencies with nothing unusual about any of them, plus
+        a sentence saying one is missing, is legible only to a reader
+        who already knows the answer. Both rows are on the page, one
+        frequency per column, and the absent slot is a marked cell
+        sitting directly above the frequency that belongs in it.
+        """
+        page = render_landing_page(api_reference_path=None)
+        rows = re.findall(r"<tr>(.*?)</tr>", page, flags=re.DOTALL)
+        assert len(rows) == 2, "the panel should carry the deposit and the spectrum"
+        deposited, spectrum = rows
+
+        assert '<th scope="row">deposited</th>' in deposited
+        assert "has</th>" in spectrum
+
+        # The spectrum row carries every true mode, in order.
+        assert re.findall(r"<td[^>]*>([\d.]+)</td>", spectrum) == [
+            f"{value:.1f}" for value in HERO_TRUE_FREQUENCIES
+        ]
+        # The deposited row carries every deposited mode, and one gap.
+        assert re.findall(r"<td[^>]*>(?:<span[^>]*>)?([\w.]+)", deposited) == [
+            "667.0",
+            "missing",
+            "1333.0",
+            "2349.0",
+        ]
+        assert deposited.count('class="gap"') == 1
+        # The marked cell in the spectrum row is under the marked gap,
+        # and it is the 667 the deposit dropped.
+        marked = re.findall(r'<td class="gap-source">([\d.]+)</td>', spectrum)
+        assert marked == ["667.0"]
+
+    def test_the_panel_explains_the_degeneracy_rather_than_compressing_it(self):
+        """Three ideas in one clause is what made the panel unreadable.
+
+        "a degenerate bend, reported once by a de-duplicating parser"
+        packs the degeneracy, the parser and the consequence into nine
+        words. Each gets its own sentence now, and the word that does
+        the work -- doubly degenerate -- is on the page.
+        """
+        page = render_landing_page(api_reference_path=None)
+        assert "doubly degenerate" in page
+        assert "perpendicular planes" in page
+        assert "de-duplicates equal frequencies" in page
 
 
 class TestDocSurfaceExposure:


### PR DESCRIPTION
Three fixes to the landing page at `/`, all from using the deployed one.

## In plain language

The landing page had three problems.

1. It carried a section explaining how the database's tables are organised
   internally — four "roles", each with a word for how it may be written.
   That is a design note for people writing code against the schema. It is
   already on the documentation site, and it answers no question a visitor
   who typed the base URL is asking. It is gone.

2. The carbon dioxide example claimed a mistake nobody could see. It printed
   three frequencies — `667.0  1333.0  2349.0` — and a sentence saying one
   was missing. Nothing on screen looked wrong, because seeing the problem
   required already knowing what CO2's spectrum is. Carbon dioxide is a
   straight line of three atoms, so it has four vibrations: it stretches two
   ways, and it bends. The bend counts twice, because the molecule can bend
   in two directions at right angles to each other and both cost exactly the
   same energy — so the bend's frequency, 667, appears **twice** in a
   correct list. Some parsers throw away duplicate numbers, and that is how
   the 667 goes missing. The panel now prints the deposit above the real
   spectrum, one number per column, with the missing slot drawn as an empty
   dashed box directly above the 667 that belongs in it. You see the hole
   before you read a word about it.

3. Every link out of a search result went to a raw JSON document — a screen
   of nested keys. Clicking one and getting that is a bad surprise, and it
   invites misreadings: an array index `0` looks like a count of zero, and
   `observations_summary.total: 5` looks like five conformers when it is
   five deposits of the *same* conformer. Results now open where you are.

Terms used below: an *endpoint* is a URL the software answers with data
rather than a page. A *disclosure* is a control that opens more content in
place instead of navigating away. *Raw JSON* is the machine-readable text a
program reads; correct for a program, unreadable as a web page.

## FIX 1 — the four-roles section is deleted

Removed the `<section aria-labelledby="roles-heading">` block and its
`.roles` / `.behaviour` CSS. Nothing is commented out.

`test_page_names_every_data_role_with_its_write_behaviour` is deleted along
with the `DATA_ROLES` constant it used. **This is not test-weakening.** That
test's entire subject is a section this PR deliberately removes; a test
pinning the wording of deleted markup has nothing left to assert. It is
replaced by `test_the_page_does_not_teach_the_table_role_taxonomy`, which
asserts the section stays gone — no `roles-heading`, no `class="behaviour"`,
no `append-only`, no `<dt>identity|provenance|result|curation`. Net test
count on the class is unchanged and the new one has a strictly harder job:
the old one passed on one exact spelling of the section, the new one fails
on any reintroduction of it.

## FIX 2 — the CO2 panel shows the gap

The panel now renders, in the deposit column:

* a labelled geometry block (`carbon dioxide, geometry / Å`) with only the
  three atom rows. The XYZ atom-count and comment lines are still in
  `HERO_XYZ` — the checker parses them — but a bare `3` alone above three
  coordinates reads on a web page as a stray number, so it is not shown.
* a two-row table under `frequencies / cm⁻¹`:

```
deposited     667.0   [MISSING]   1333.0   2349.0
CO₂ has       667.0     667.0     1333.0   2349.0
```

  where `[MISSING]` is a dashed empty cell and the 667.0 beneath it is boxed
  in the same colour. Both use `--phase-neg-text`, which appears nowhere
  else in the panel.
* a caption: "The top row is what was deposited. The bottom row is the
  spectrum carbon dioxide has. **667 cm⁻¹ belongs in it twice**, and the
  deposit carries it once."

The verdict column is four sentences instead of one clause: linearity and
`3N−5 = 4`; what "doubly degenerate" means physically (two perpendicular
bending planes, same energy); that de-duplication lands the count on
`3N−6`, a *bent* molecule's count, on a geometry that is not bent; and that
the record is **accepted and flagged, not refused**.

### Scientific accuracy

A new constant `HERO_TRUE_FREQUENCIES = (667.0, 667.0, 1333.0, 2349.0)` is
the real spectrum. `HERO_FREQUENCIES` is now **derived** from it —
`tuple(dict.fromkeys(HERO_TRUE_FREQUENCIES))` — which is literally the
de-duplicating parser the example is about. The table is built by a multiset
comparison of the two, so the cell drawn "missing" is the cell they actually
disagree about; a hand-written table could mark the wrong column and look
equally convincing.

`TestHeroExampleIsReal` still re-runs the real
`evaluate_frequency_list_linearity` against the panel's numbers and still
pins `3N-5 = 4` on both sides. Four new tests were added: the true spectrum
is `3N−5` for the shown geometry and contains 667 twice; the deposit is the
true spectrum minus exactly one duplicate; both rows render with the gap
marked in the right column; and the prose says "doubly degenerate",
"perpendicular planes" and "de-duplicates equal frequencies" rather than
compressing them.

## FIX 3 — approach taken: (a) inline expansion, with (b) as the escape hatch

**Approach (a) everywhere, plus honest labels on the three remaining JSON
links.** (b) alone was rejected: relabelling the pills "raw JSON" removes
the surprise but leaves the reader with nowhere useful to go, and the
specific misreadings the owner hit (array index as count, observation total
as conformer count) are caused by reading the JSON, so keeping them there
and warning about it fixes nothing. (a) is cheap here because all five
endpoints already return flat summary blocks: the whole renderer is about
120 lines of the same vanilla JS the page already ships, with no new
dependency and no change to the read API.

Each product pill is now a `<button type="button" aria-expanded aria-controls>`
that expands a panel below the card, fetching its endpoint on first open. The
panel shows a count line, then up to five record cards (`CARD_LIMIT`; the
count line always states the real total), each with its public ref and a few
fields:

| section | fields shown |
|---|---|
| thermo | model kind, H(298 K), S(298 K), fitted T range, level of theory, origin |
| statmech | treatment / rotor kind, point group, symmetry number, optical isomers, linear, frequency scale factor, origin |
| transport | collision diameter, well depth, dipole moment, source calculation count, origin |
| conformers | group label, observation count, calculation count, geometry count |
| calculations | type, level of theory, software, energy, quality |

The pills are buttons, not anchors: an anchor pointing at JSON is a
middle-click away from the wall of keys however its click handler behaves.

**Where a reader can still reach raw JSON, it says so:** "Open this list as
raw JSON" at the foot of each panel, "this record as raw JSON" beside the
species ref, and "Open the full response as raw JSON" on the more-pages
line. The example chips are the one exception and are excluded by name in
the test with the reason: they must be anchors so they work with scripting
off, their click is intercepted when the script runs, and the results area
already says in prose that without JavaScript the box and examples go to the
API's JSON.

### Conformer vocabulary

A conformer group is one torsional basin (identity, deduped); an observation
is one deposited instance assigned to it (provenance, append-only). The
count line counts **groups** ("1 conformer group"). The observation field
reads "4 observations of this one group". A note in the panel states the
distinction outright. `test_an_observation_count_is_never_called_a_conformer_count`
pins all of it.

### The read API is not touched

No group-scope `has_*` boolean is presented anywhere on the page —
`has_scf_stability`, `has_opt`, `has_freq`, `has_sp` are all absent from the
script, asserted by
`test_a_panel_reports_counts_and_never_the_group_scope_booleans`. Only counts
the payload states outright are shown, so nothing here becomes wrong when the
counts replacement lands.

## Constraints held

* Still exactly one `<script>` tag with zero attributes; no `://` in any
  script string literal; no `<link>`/`<img>`/`<iframe>`; no `@import` or
  `url(` in CSS. Existing tests pin all of it and still pass.
* No-JS path intact: the picker still ships `disabled`, the `<noscript>`
  block still carries one plain form per non-seed identifier, the search
  form and example chips are still real markup.
* Light and dark verified; `--phase-neg-text` on `--data-bg` is 4.5:1 in
  light and 7.5:1 in dark.
* 360px verified at a true 360 CSS-pixel viewport:
  `document.documentElement.scrollWidth === 360`, no horizontal document
  scroll. The spectrum table's font floor was lowered to `0.625rem` and its
  cell padding tightened so all four frequency columns fit on screen rather
  than scrolling inside their box.
* No invented facts. Every number is either from a live request or from the
  worked example's own constants.
* `test_the_route_table_gains_the_landing_route_and_nothing_else` passes.

## Schema / migration impact

**None.** No ORM model, no Pydantic schema, no Alembic revision, no
environment variable. One API module (`backend/app/api/landing.py`) and its
test file. No route added, removed or reordered.

## Verification actually run

```
$ cd backend && conda run -n tckdb_env ruff check app tests scripts
All checks passed!
RUFF EXIT=0

$ cd backend && conda run -n tckdb_env pytest tests/api/test_landing_page.py -q -p no:randomly
46 passed in 28.48s

$ cd backend && conda run -n tckdb_env bash scripts/test-api.sh > log 2>&1; echo "EXIT=$?"
EXIT=0
3128 passed, 2 warnings in 317.12s (0:05:17)
```

`ruff format` was not run on any file (repo-wide `[tool.ruff.format] exclude`).

### Mutation tests — three landed, each proven in the diff, each restored

Baseline `sha256(app/api/landing.py) = 794a2eac682d8ca01013722b1eca8458…`,
identical after every restore.

1. **Re-added a four-roles section** before the citing section. Diff showed
   `+  <section aria-labelledby="roles-heading">`. →
   `test_the_page_does_not_teach_the_table_role_taxonomy` FAILED
   (`assert 'roles-heading' not in body`). Restored; hash identical.
2. **Marked the wrong column missing** (`remaining = [667.0, 667.0, 2349.0]`,
   which points the gap at 1333 instead of the second 667). Diff showed the
   line. → `test_the_panel_shows_both_lists_with_the_missing_mode_marked`
   FAILED (`At index 1 diff: '667.0' != 'missing'`). Restored; hash
   identical. (An earlier variant that consumed nothing was caught by the
   builder's own guard, so this variant was used to prove the *assertion*
   bites rather than the guard.)
3. **Turned the product pills back into anchors** at the API URL. Diff showed
   `+ links.appendChild(anchor(THERMO + …, "pill", …))`. →
   `test_each_product_is_a_disclosure_rather_than_a_navigation` FAILED
   (`assert 'anchor(THERMO' not in script`). Restored; hash identical.

### Rendered and looked at

Driven through Chrome over CDP against a local harness that serves this
page at `/` and proxies `/api/v1/*` (GET only, read-only) to the live public
host `https://tckdb.homecalvin.com`, so the search ran against real data.

* **Real result** — `formula=CH3` returns one record, `1 under review`.
  Expanding all four pills gave: 3 thermo records (`143.89 kJ/mol`,
  `194.40 J/mol/K`, `10–3000 K`, each with its own `thm_…` ref), 3 statmech
  records (`rrho / asymmetric_top rotor`, `D3h`, symmetry 6, linear no,
  scale 0.9990), **1 conformer group** with "4 observations of this one
  group", 11 calculations behind it, 1 geometry — and `14 calculations`
  showing the first five with "Showing the first 5 calculations of 14."
* **Empty result** — seeded `formula=Xx99`: "Nothing matched formula = Xx99."
  plus the three working example chips.
* **422** — empty value omits the parameter, producing the real
  `missing_identifier` with the API's own detail rendered.
* **No JavaScript** (CDP `setScriptExecutionDisabled`) — picker greyed out,
  `<noscript>` block with the SMILES and InChIKey forms, and the results area
  saying the box and examples go straight to the API's JSON.
* Desktop and 360px, light and dark, all four states.

**Does the CO2 panel make the missing mode obvious at a glance? Yes.** The
eye lands on the dashed `MISSING` box in the top row before reading anything,
and the solid-boxed `667.0` sitting directly beneath it answers "missing
what" without a sentence. At 360px all four columns fit on screen, so the
comparison survives on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEMrWcGRqbAVoh1Cn3TJ9D
