### PR TITLE
Answer "what consumes hydrazine", not "with nothing"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,56 @@ wrapper over a contract that is itself still moving.
 
 ## Unreleased
 
+### Changed
+
+- **Reaction search now means containment, and a one-sided query finally
+  works.** `GET|POST /api/v1/scientific/reactions/search` accepted
+  `reactants` or `products` alone, and the validator said so explicitly —
+  but the matcher compared *both* roles for multiset equality. A query
+  naming only reactants therefore asked for "entries whose reactants are
+  exactly {X} **and** whose products are exactly {}". No reaction has zero
+  products, so a reactants-only search could not match anything, for any
+  input, ever. It returned `200` with an empty result set rather than an
+  error: measured against the hosted instance, `?reactants=NN` answered
+  "no reactions" while the database held 24 hydrazine reactions.
+
+  A **`match`** parameter now selects the comparison, and it defaults to
+  **`contains`**: set containment per role. Every species the caller names
+  must appear in that role; a side left empty constrains nothing. So
+  `?reactants=NN` means "every reaction with NN among its reactants,
+  products unconstrained" — the question a chemist was asking. `match` is
+  accepted on `/scientific/reactions/search` and on
+  `/scientific/kinetics/search`, which resolves reaction identity through
+  the same service and had the same defect.
+
+  Containment is deliberately **set**-based, not multiset. A reaction
+  consuming two NN matches `reactants=NN`, and `reactants=NN&reactants=NN`
+  matches a reaction consuming one. Stoichiometry is not a filter in this
+  mode; a caller who wants counts to line up is asking for a specific
+  equation, and that is what `match=exact` is for. The opposite reading is
+  defensible enough that it is written into the enum's docstring and into
+  the OpenAPI description rather than left to fall out of the code.
+
+  **Breaking for existing callers who supply both sides.** They got exact
+  multiset equality; under the new default they get containment, which
+  returns a superset — a two-species query will now also match the larger
+  reactions that contain those two. **Migration: send `match=exact`**,
+  which reproduces the previous behaviour byte for byte on both endpoints
+  and remains a first-class query (`reaction_ref` does not replace it —
+  you do not always hold the ref). Callers who supply one side were
+  getting an empty list and cannot regress. `direction` is unchanged and
+  composes with `match` on both axes: under `direction=either`,
+  containment is tested in both orientations and `matched_direction`
+  reports which one matched under the same semantics the matcher used.
+
+  Per the pre-1.0 policy above, a minor bump may break an HTTP contract.
+  This one does, which is why it is written down here rather than shipped
+  quietly. No database schema or migration impact: this is a query
+  projection, not a table. **`tckdb-client` 0.53.0 → 0.54.0** (new `match`
+  keyword on `search_reactions` and `search_kinetics`; omitted means the
+  server default applies). **`tckdb-mcp` 0.1.1 → 0.2.0** (new `match`
+  field on `tckdb_search_reactions` and `tckdb_search_kinetics`).
+
 ### Added
 
 - **The base URL now answers a person.** `https://<host>/` served a bare

--- a/README.md
+++ b/README.md
@@ -471,6 +471,12 @@ curl -G "http://127.0.0.1:8010/api/v1/scientific/kinetics/search" \
     --data-urlencode "products=O" \
     --data-urlencode "products=[CH3]"
 
+# One side is enough. Matching defaults to containment, so this asks
+# "what reactions consume the OH radical?" and leaves the products free.
+# Add match=exact to ask for one specific equation instead:
+curl -G "http://127.0.0.1:8010/api/v1/scientific/reactions/search" \
+    --data-urlencode "reactants=[OH]"
+
 # Geometry detail by public handle (geom_… ref):
 curl "http://127.0.0.1:8010/api/v1/scientific/geometries/geom_abc123"
 ```

--- a/backend/app/api/routes/scientific/kinetics_search.py
+++ b/backend/app/api/routes/scientific/kinetics_search.py
@@ -15,7 +15,10 @@ from app.schemas.reads.scientific_kinetics_search import (
     KineticsSearchRequest,
     ScientificKineticsSearchResponse,
 )
-from app.schemas.reads.scientific_reactions import ReactionDirectionQuery
+from app.schemas.reads.scientific_reactions import (
+    ReactionDirectionQuery,
+    ReactionMatchMode,
+)
 from app.services.scientific_read.kinetics_search import search_kinetics
 from app.services.scientific_read.public_assessments import (
     attach_kinetics_assessments,
@@ -36,6 +39,7 @@ def kinetics_search_get(
     reactants: list[str] | None = Query(None),
     products: list[str] | None = Query(None),
     direction: ReactionDirectionQuery = Query(ReactionDirectionQuery.either),
+    match: ReactionMatchMode = Query(ReactionMatchMode.contains),
     family: str | None = Query(None),
     reaction_ref: str | None = Query(None),
     reaction_entry_ref: str | None = Query(None),
@@ -70,14 +74,18 @@ def kinetics_search_get(
     """Chemistry-first kinetics search by reactants/products.
 
     Repeated ``reactants=`` and ``products=`` are accepted on the GET form.
-    For complex reactant/product lists (especially with bracket-heavy
-    SMILES), prefer the POST form. Returns kinetics records with the
-    resolved reaction/reaction_entry identity attached.
+    ``match=contains`` (the default) means every queried species must appear
+    in that role and an omitted side constrains nothing; ``match=exact``
+    demands the whole equation. For complex reactant/product lists
+    (especially with bracket-heavy SMILES), prefer the POST form. Returns
+    kinetics records with the resolved reaction/reaction_entry identity
+    attached.
     """
     request = KineticsSearchRequest(
         reactants=reactants or [],
         products=products or [],
         direction=direction,
+        match=match,
         family=family,
         reaction_ref=reaction_ref,
         reaction_entry_ref=reaction_entry_ref,

--- a/backend/app/api/routes/scientific/reactions.py
+++ b/backend/app/api/routes/scientific/reactions.py
@@ -12,6 +12,7 @@ from app.db.models.common import RecordReviewStatus
 from app.schemas.reads.scientific_common import CollapseMode
 from app.schemas.reads.scientific_reactions import (
     ReactionDirectionQuery,
+    ReactionMatchMode,
     ReactionSearchRequest,
     ScientificReactionSearchResponse,
 )
@@ -29,6 +30,7 @@ def reaction_search_get(
     reactants: list[str] | None = Query(None),
     products: list[str] | None = Query(None),
     direction: ReactionDirectionQuery = Query(ReactionDirectionQuery.either),
+    match: ReactionMatchMode = Query(ReactionMatchMode.contains),
     family: str | None = Query(None),
     reaction_ref: str | None = Query(None),
     reaction_entry_ref: str | None = Query(None),
@@ -45,12 +47,18 @@ def reaction_search_get(
 
     Repeated ``reactants=`` and ``products=`` are accepted and preserve list
     order. ``direction=exact`` is rejected (v0). ``sort=`` is rejected (v0).
-    See ``docs/specs/read_api_mvp.md`` §Endpoint 2.
+
+    ``match=contains`` (the default) means set containment per role, so
+    ``?reactants=NN`` returns every reaction with NN among its reactants and
+    leaves the product side unconstrained. ``match=exact`` asks for precisely
+    one equation, both sides, counts included. See
+    ``docs/specs/read_api_mvp.md`` §Endpoint 2.
     """
     request = ReactionSearchRequest(
         reactants=reactants or [],
         products=products or [],
         direction=direction,
+        match=match,
         family=family,
         reaction_ref=reaction_ref,
         reaction_entry_ref=reaction_entry_ref,

--- a/backend/app/schemas/reads/scientific_kinetics_search.py
+++ b/backend/app/schemas/reads/scientific_kinetics_search.py
@@ -39,6 +39,7 @@ from app.schemas.reads.scientific_common import (
 from app.schemas.reads.scientific_kinetics import KineticsRecord
 from app.schemas.reads.scientific_reactions import (
     ReactionDirectionQuery,
+    ReactionMatchMode,
     ReactionParticipantSummary,
 )
 
@@ -50,9 +51,11 @@ from app.schemas.reads.scientific_reactions import (
 class KineticsSearchRequest(BaseModel):
     """Service-layer request for chemistry-first kinetics search.
 
-    Reactants and/or products are required; matching uses the same
-    species-multiset semantics as ``search_reactions``. ``direction=exact``
-    is **not** supported in v0.
+    Reactants and/or products are required; reaction identity is resolved by
+    delegating to ``search_reactions``, so ``direction`` and ``match`` mean
+    exactly what they mean there — ``match`` defaults to ``contains`` (set
+    containment per role), and ``match=exact`` asks for one whole equation.
+    ``direction=exact`` is **not** supported in v0.
     """
 
     # Reaction identity filters
@@ -63,6 +66,7 @@ class KineticsSearchRequest(BaseModel):
         default_factory=list, max_length=_MAX_PARTICIPANTS_PER_REACTION
     )
     direction: ReactionDirectionQuery = ReactionDirectionQuery.either
+    match: ReactionMatchMode = ReactionMatchMode.contains
     family: str | None = Field(default=None, max_length=_MAX_FAMILY_LENGTH)
 
     # Phase C: optional explicit reaction/reaction-entry handles.

--- a/backend/app/schemas/reads/scientific_reactions.py
+++ b/backend/app/schemas/reads/scientific_reactions.py
@@ -48,6 +48,36 @@ class ReactionDirectionQuery(str, Enum):
     either = "either"
 
 
+class ReactionMatchMode(str, Enum):
+    """How a supplied participant list is compared against a stored side.
+
+    ``contains`` (the default) — **set containment per role**: every queried
+    species must appear in that role of the stored reaction. The empty side
+    constrains nothing, so ``reactants=NN`` alone means "NN among the
+    reactants, products unconstrained".
+
+    ``exact`` — multiset equality on *both* roles: precisely this equation,
+    both sides, counts included.
+
+    The default is containment because "reactions involving hydrazine" is
+    what a chemist means by ``reactants=NN``, and answering it with the
+    empty set — which is what multiset equality against an unstated product
+    side must do — is a confidently wrong scientific answer rather than a
+    narrow one.
+
+    Containment is deliberately **set**, not multiset. ``reactants=NN``
+    matches a reaction consuming two NN, and ``reactants=NN&reactants=NN``
+    matches a reaction consuming one. Stoichiometry is not a filter here:
+    a caller who wants counts to line up is asking for a specific equation
+    and should say ``match=exact``. The opposite reading — that a queried
+    multiset must be covered with multiplicity — is defensible enough that
+    it is stated here rather than left to fall out of the implementation.
+    """
+
+    contains = "contains"
+    exact = "exact"
+
+
 class ReactionSearchRequest(BaseModel):
     """Service-layer request model for reaction search."""
 
@@ -60,6 +90,7 @@ class ReactionSearchRequest(BaseModel):
         max_length=_MAX_PARTICIPANTS_PER_REACTION,
     )
     direction: ReactionDirectionQuery = ReactionDirectionQuery.either
+    match: ReactionMatchMode = ReactionMatchMode.contains
     family: str | None = Field(default=None, max_length=_MAX_FAMILY_LENGTH)
 
     # Phase C: explicit handles (refs) — useful when a caller already has

--- a/backend/app/services/scientific_read/kinetics_search.py
+++ b/backend/app/services/scientific_read/kinetics_search.py
@@ -6,8 +6,9 @@ manually.
 
 Composition order (final response ordering):
 
-1. Resolve reaction/reaction_entry candidates using the same multiset
-   matching rules as ``search_reactions`` (direction handling included).
+1. Resolve reaction/reaction_entry candidates using the same matching
+   rules as ``search_reactions`` (``direction`` and ``match`` handling
+   included, so ``match`` defaults to containment here too).
 2. For each surviving reaction_entry, fetch kinetics records using the
    same per-record D9 ordering as ``get_reaction_kinetics``.
 3. Group across reaction_entries deterministically: outer key is the
@@ -121,6 +122,7 @@ def search_kinetics(
                 reactants=request.reactants,
                 products=request.products,
                 direction=request.direction,
+                match=request.match,
                 family=request.family,
                 reaction_ref=request.reaction_ref,
                 reaction_entry_ref=request.reaction_entry_ref,
@@ -261,6 +263,7 @@ def _filter_echo(request: KineticsSearchRequest) -> dict[str, object]:
     if request.products:
         echo["products"] = list(request.products)
     echo["direction"] = request.direction.value
+    echo["match"] = request.match.value
     if request.family is not None:
         echo["family"] = request.family
     if request.temperature_min is not None:

--- a/backend/app/services/scientific_read/reactions.py
+++ b/backend/app/services/scientific_read/reactions.py
@@ -30,6 +30,7 @@ from app.schemas.reads.scientific_common import REVIEW_RANK
 from app.schemas.reads.scientific_reactions import (
     ReactionAvailability,
     ReactionDirectionQuery,
+    ReactionMatchMode,
     ReactionParticipantSummary,
     ReactionScientificRecord,
     ReactionSearchRequest,
@@ -76,8 +77,18 @@ def search_reactions(
     Direction matching is query-time semantics — the schema does not store a
     per-entry direction. ``either`` matches in either orientation; ``forward``
     requires query reactants → stored reactants and query products → stored
-    products; ``reverse`` requires the swap. ``exact`` is **not** supported in
-    v0 (rejected with 422 ``unsupported_direction``).
+    products; ``reverse`` requires the swap. ``direction=exact`` is **not**
+    supported in v0 (rejected with 422 ``unsupported_direction``).
+
+    ``match`` is the orthogonal axis and defaults to ``contains``: every
+    queried species must appear in that role, and a side the caller left
+    empty constrains nothing. So ``reactants=NN`` answers "what consumes
+    hydrazine?" rather than "what turns hydrazine into nothing?" — the
+    latter has no answer and used to be the question this endpoint asked.
+    ``match=exact`` restores multiset equality on both sides for callers who
+    want precisely one equation and do not hold its ``reaction_ref``.
+    Containment is set-based, not multiset; see
+    :class:`~app.schemas.reads.scientific_reactions.ReactionMatchMode`.
 
     Default sort (per L3): ``review_rank ASC, has_kinetics DESC,
     has_transition_state DESC, created_at DESC, id DESC``. Client-supplied
@@ -148,6 +159,7 @@ def search_reactions(
             reactant_species_ids=reactant_species_ids,
             product_species_ids=product_species_ids,
             direction=request.direction,
+            match=request.match,
         )
         # Phase C: narrow the participant-derived candidate set with
         # the explicit ref filters in SQL, so we still pay only one
@@ -251,6 +263,7 @@ def search_reactions(
             reactant_species_ids=reactant_species_ids,
             product_species_ids=product_species_ids,
             requested=request.direction,
+            match=request.match,
         )
 
     family_name_by_id: dict[int, str] = {}
@@ -374,17 +387,59 @@ def _resolve_smiles_to_species_ids(
     return [by_smiles[s] for s in smiles_list if s in by_smiles]
 
 
+def _side_matches(
+    stored: list[int], queried: list[int], match: ReactionMatchMode
+) -> bool:
+    """Test one role (reactants or products) of one orientation.
+
+    ``exact`` is multiset equality — same species, same counts. ``contains``
+    is set containment: every queried species appears in the stored side,
+    counts ignored. An empty ``queried`` is contained in anything, which is
+    what makes a one-sided ``contains`` query leave the other side free.
+    """
+    if match is ReactionMatchMode.exact:
+        return sorted(stored) == sorted(queried)
+    return set(queried).issubset(stored)
+
+
+def _orientation_matches(
+    *,
+    stored_reactants: list[int],
+    stored_products: list[int],
+    queried_reactants: list[int],
+    queried_products: list[int],
+    match: ReactionMatchMode,
+) -> bool:
+    """Test both roles of a single orientation under ``match`` semantics."""
+    return _side_matches(stored_reactants, queried_reactants, match) and _side_matches(
+        stored_products, queried_products, match
+    )
+
+
 def _find_matching_reaction_entry_ids(
     session: Session,
     *,
     reactant_species_ids: list[int],
     product_species_ids: list[int],
     direction: ReactionDirectionQuery,
+    match: ReactionMatchMode,
 ) -> list[int]:
     """Find reaction_entry IDs whose structure participants match the query.
 
-    Match semantics use multisets (counts) of species_id per role. ``exact``
-    direction is rejected upstream of this helper.
+    Two independent axes, and they compose:
+
+    * ``direction`` picks which orientation(s) of the stored entry the query
+      is tried against — ``forward``, ``reverse``, or (default) ``either``.
+    * ``match`` picks how a side is compared once an orientation is chosen —
+      ``contains`` (set containment per role, the default) or ``exact``
+      (multiset equality on both roles).
+
+    Under ``either`` + ``contains``, containment is tested in *both*
+    orientations and an entry matching in either one is returned.
+
+    ``direction=exact`` is rejected upstream of this helper; it is not the
+    same thing as ``match=exact``, which is what "precisely this equation"
+    now means.
     """
     if direction == ReactionDirectionQuery.forward:
         orientations = [(reactant_species_ids, product_species_ids)]
@@ -442,9 +497,13 @@ def _find_matching_reaction_entry_ids(
     matching: list[int] = []
     for entry_id, sides in grouped.items():
         for left, right in orientations:
-            if sorted(sides[ReactionRole.reactant]) == sorted(left) and sorted(
-                sides[ReactionRole.product]
-            ) == sorted(right):
+            if _orientation_matches(
+                stored_reactants=sides[ReactionRole.reactant],
+                stored_products=sides[ReactionRole.product],
+                queried_reactants=left,
+                queried_products=right,
+                match=match,
+            ):
                 matching.append(entry_id)
                 break
     return matching
@@ -571,23 +630,28 @@ def _matched_direction(
     reactant_species_ids: list[int],
     product_species_ids: list[int],
     requested: ReactionDirectionQuery,
+    match: ReactionMatchMode,
 ) -> ReactionDirectionQuery:
     """Determine which orientation of the entry the query actually matched.
 
     For ``forward`` and ``reverse`` the requested orientation is the matched
-    orientation. For ``either``, prefer ``forward`` when query reactants line
-    up with stored reactants; otherwise ``reverse``.
+    orientation. For ``either``, prefer ``forward`` when the query matches the
+    stored orientation *under the same* ``match`` semantics the matcher used;
+    otherwise ``reverse``. Testing this with multiset equality while the
+    matcher used containment would report ``reverse`` for every one-sided
+    ``contains`` query, including the forward ones.
     """
     if requested == ReactionDirectionQuery.forward:
         return ReactionDirectionQuery.forward
     if requested == ReactionDirectionQuery.reverse:
         return ReactionDirectionQuery.reverse
 
-    stored_reactants = sorted(entry_species[ReactionRole.reactant])
-    stored_products = sorted(entry_species[ReactionRole.product])
-    if (
-        sorted(reactant_species_ids) == stored_reactants
-        and sorted(product_species_ids) == stored_products
+    if _orientation_matches(
+        stored_reactants=entry_species[ReactionRole.reactant],
+        stored_products=entry_species[ReactionRole.product],
+        queried_reactants=reactant_species_ids,
+        queried_products=product_species_ids,
+        match=match,
     ):
         return ReactionDirectionQuery.forward
     return ReactionDirectionQuery.reverse
@@ -640,6 +704,7 @@ def _filter_echo(request: ReactionSearchRequest) -> dict[str, object]:
     if request.products:
         echo["products"] = list(request.products)
     echo["direction"] = request.direction.value
+    echo["match"] = request.match.value
     if request.family is not None:
         echo["family"] = request.family
     if request.reaction_ref is not None:

--- a/backend/docs/specs/read_query_api_audit.md
+++ b/backend/docs/specs/read_query_api_audit.md
@@ -371,7 +371,7 @@ non-canonical surface; "✗" means no documented surface answers it.
 | 2 | Find thermo for a species | ✓ | `GET /scientific/species-entries/{id}/thermo` (per-entry), `GET\|POST /scientific/thermo/search` (chemistry-first) | Both support `include=trust` only on the per-entry surface; search lacks trust by policy. |
 | 3 | Find transport for a species | ✓ | `GET /scientific/species-entries/{id}/transport` (per-entry), `GET\|POST /scientific/transport/search` (chemistry-first) | The per-entry surface now mirrors species-entry thermo: review-aware, public-handle, `include=trust` → `computed_transport_v1`. Search still does not expose trust by policy. |
 | 4 | Find statmech for a species | ✓ | `GET /scientific/species-entries/{id}/statmech` (per-entry), `GET\|POST /scientific/statmech/search` (chemistry-first) | The per-entry surface now mirrors species-entry thermo: review-aware, public-handle, `include=trust` → `computed_statmech_v1`. Search still does not expose trust by policy. |
-| 5 | Find reactions by reactants / products | ✓ | `GET\|POST /scientific/reactions/search` | Reactants/products as identifier lists; direction `forward\|reverse\|either`. |
+| 5 | Find reactions by reactants / products | ✓ | `GET\|POST /scientific/reactions/search` | Reactants/products as identifier lists; direction `forward\|reverse\|either`; `match=contains` (default, set containment per role) or `match=exact`. |
 | 6 | Find kinetics for a reaction | ✓ | `GET /scientific/reaction-entries/{id}/kinetics`, `GET\|POST /scientific/kinetics/search` | Per-entry surface exposes `include=trust`; search does not. |
 | 7 | Inspect calculation / provenance for a record | ✓ | `GET /scientific/calculations/{ref_or_id}`, `GET /scientific/reaction-entries/{id}/full` | `/full` is the only composite "provenance projection" today; no generic `/scientific/records/{type}/{id}/provenance`. |
 | 8 | Ask for trust / evidence details on a record | ✓ | record/per-entry reads (calculation, kinetics-per-entry, thermo-per-entry, statmech detail + species-entry statmech, transport detail + species-entry transport, standalone transition-state-entry) plus the composite `/reaction-entries/{id}/full?include=trust` for embedded kinetics + calculations + transition-state entries | Conformer / network sections still lack trust because no rubric exists for them; no top-level reaction-entry or TS-concept aggregation rubric exists yet. |
@@ -1032,6 +1032,7 @@ empty identifier set → 422 `missing_identifier`.
 | reactants (list) | ✓ (max 32; max 2048 chars each) | ✗ |
 | products (list) | ✓ | ✗ |
 | direction | ✓ (`forward\|reverse\|either`; no `exact`) | ✗ |
+| match | ✓ (`contains` default \| `exact`) | ✗ |
 | family | ✓ (string) | ✓ (`reaction_family_id`, `reaction_family_raw`) |
 | reversible | ✗ (implicit via direction) | ✓ |
 | has_kinetics | ✗ | ✗ |

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -18581,7 +18581,7 @@
         "type": "object"
       },
       "KineticsSearchRequest": {
-        "description": "Service-layer request for chemistry-first kinetics search.\n\nReactants and/or products are required; matching uses the same\nspecies-multiset semantics as ``search_reactions``. ``direction=exact``\nis **not** supported in v0.",
+        "description": "Service-layer request for chemistry-first kinetics search.\n\nReactants and/or products are required; reaction identity is resolved by\ndelegating to ``search_reactions``, so ``direction`` and ``match`` mean\nexactly what they mean there — ``match`` defaults to ``contains`` (set\ncontainment per role), and ``match=exact`` asks for one whole equation.\n``direction=exact`` is **not** supported in v0.",
         "properties": {
           "collapse": {
             "$ref": "#/components/schemas/CollapseMode",
@@ -18647,6 +18647,10 @@
             "default": 50,
             "title": "Limit",
             "type": "integer"
+          },
+          "match": {
+            "$ref": "#/components/schemas/ReactionMatchMode",
+            "default": "contains"
           },
           "min_review_status": {
             "anyOf": [
@@ -29163,6 +29167,15 @@
         "title": "ReactionFullSpeciesParticipant",
         "type": "object"
       },
+      "ReactionMatchMode": {
+        "description": "How a supplied participant list is compared against a stored side.\n\n``contains`` (the default) — **set containment per role**: every queried\nspecies must appear in that role of the stored reaction. The empty side\nconstrains nothing, so ``reactants=NN`` alone means \"NN among the\nreactants, products unconstrained\".\n\n``exact`` — multiset equality on *both* roles: precisely this equation,\nboth sides, counts included.\n\nThe default is containment because \"reactions involving hydrazine\" is\nwhat a chemist means by ``reactants=NN``, and answering it with the\nempty set — which is what multiset equality against an unstated product\nside must do — is a confidently wrong scientific answer rather than a\nnarrow one.\n\nContainment is deliberately **set**, not multiset. ``reactants=NN``\nmatches a reaction consuming two NN, and ``reactants=NN&reactants=NN``\nmatches a reaction consuming one. Stoichiometry is not a filter here:\na caller who wants counts to line up is asking for a specific equation\nand should say ``match=exact``. The opposite reading — that a queried\nmultiset must be covered with multiplicity — is defensible enough that\nit is stated here rather than left to fall out of the implementation.",
+        "enum": [
+          "contains",
+          "exact"
+        ],
+        "title": "ReactionMatchMode",
+        "type": "string"
+      },
       "ReactionParticipantSummary": {
         "description": "Reactant or product participant within a reaction-entry record.\n\nPhase B: ``species_entry_ref`` is the public stable handle for the\nparticipant species entry.",
         "properties": {
@@ -29402,6 +29415,10 @@
             "default": 50,
             "title": "Limit",
             "type": "integer"
+          },
+          "match": {
+            "$ref": "#/components/schemas/ReactionMatchMode",
+            "default": "contains"
           },
           "min_review_status": {
             "anyOf": [
@@ -65642,7 +65659,7 @@
     },
     "/api/v1/scientific/kinetics/search": {
       "get": {
-        "description": "Chemistry-first kinetics search by reactants/products.\n\nRepeated ``reactants=`` and ``products=`` are accepted on the GET form.\nFor complex reactant/product lists (especially with bracket-heavy\nSMILES), prefer the POST form. Returns kinetics records with the\nresolved reaction/reaction_entry identity attached.",
+        "description": "Chemistry-first kinetics search by reactants/products.\n\nRepeated ``reactants=`` and ``products=`` are accepted on the GET form.\n``match=contains`` (the default) means every queried species must appear\nin that role and an omitted side constrains nothing; ``match=exact``\ndemands the whole equation. For complex reactant/product lists\n(especially with bracket-heavy SMILES), prefer the POST form. Returns\nkinetics records with the resolved reaction/reaction_entry identity\nattached.",
         "operationId": "kinetics_search_get_api_v1_scientific_kinetics_search_get",
         "parameters": [
           {
@@ -65690,6 +65707,15 @@
             "schema": {
               "$ref": "#/components/schemas/ReactionDirectionQuery",
               "default": "either"
+            }
+          },
+          {
+            "in": "query",
+            "name": "match",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReactionMatchMode",
+              "default": "contains"
             }
           },
           {
@@ -69145,7 +69171,7 @@
     },
     "/api/v1/scientific/reactions/search": {
       "get": {
-        "description": "Discover reaction entries by reactants/products with availability + trust.\n\nRepeated ``reactants=`` and ``products=`` are accepted and preserve list\norder. ``direction=exact`` is rejected (v0). ``sort=`` is rejected (v0).\nSee ``docs/specs/read_api_mvp.md`` §Endpoint 2.",
+        "description": "Discover reaction entries by reactants/products with availability + trust.\n\nRepeated ``reactants=`` and ``products=`` are accepted and preserve list\norder. ``direction=exact`` is rejected (v0). ``sort=`` is rejected (v0).\n\n``match=contains`` (the default) means set containment per role, so\n``?reactants=NN`` returns every reaction with NN among its reactants and\nleaves the product side unconstrained. ``match=exact`` asks for precisely\none equation, both sides, counts included. See\n``docs/specs/read_api_mvp.md`` §Endpoint 2.",
         "operationId": "reaction_search_get_api_v1_scientific_reactions_search_get",
         "parameters": [
           {
@@ -69193,6 +69219,15 @@
             "schema": {
               "$ref": "#/components/schemas/ReactionDirectionQuery",
               "default": "either"
+            }
+          },
+          {
+            "in": "query",
+            "name": "match",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ReactionMatchMode",
+              "default": "contains"
             }
           },
           {

--- a/backend/tests/api/scientific/test_api_reaction_search.py
+++ b/backend/tests/api/scientific/test_api_reaction_search.py
@@ -149,3 +149,134 @@ def test_get_includes_kinetics_count_when_available(client, db_session):
     avail = resp.json()["records"][0]["availability"]
     assert avail["has_kinetics"] is True
     assert avail["kinetics_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# match=contains (default) vs match=exact, over HTTP
+# ---------------------------------------------------------------------------
+
+
+def _setup_two_by_two(db_session, prefix: str):
+    """A + B <=> C + D, so every partial query has something to be partial about."""
+    species = {
+        role: make_species(
+            db_session, smiles=f"{prefix}_{role}", inchi_key=next_inchi_key(prefix)
+        )
+        for role in ("A", "B", "C", "D")
+    }
+    chem = make_chem_reaction(
+        db_session,
+        reactants=[species["A"], species["B"]],
+        products=[species["C"], species["D"]],
+    )
+    return make_reaction_entry(
+        db_session,
+        reaction=chem,
+        reactant_entries=[
+            make_species_entry(db_session, species[r]) for r in ("A", "B")
+        ],
+        product_entries=[
+            make_species_entry(db_session, species[r]) for r in ("C", "D")
+        ],
+    )
+
+
+def test_get_reactants_only_returns_the_reaction(client, db_session):
+    """"What consumes this species?" over HTTP — 200 with a record, not 200 with none."""
+    _setup_two_by_two(db_session, "HCT")
+
+    resp = client.get("/api/v1/scientific/reactions/search?reactants=HCT_A")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["records"]) == 1
+    assert body["pagination"]["total"] == 1
+    assert {p["smiles"] for p in body["records"][0]["reactants"]} == {
+        "HCT_A",
+        "HCT_B",
+    }
+
+
+def test_get_products_only_returns_the_reaction(client, db_session):
+    _setup_two_by_two(db_session, "HPO")
+
+    resp = client.get("/api/v1/scientific/reactions/search?products=HPO_C")
+
+    assert resp.status_code == 200
+    assert len(resp.json()["records"]) == 1
+
+
+def test_get_match_exact_rejects_the_partial_query(client, db_session):
+    """The migration path: ``match=exact`` restores the pre-``match`` answer."""
+    _setup_two_by_two(db_session, "HEX")
+
+    contains = client.get(
+        "/api/v1/scientific/reactions/search?reactants=HEX_A&products=HEX_C"
+    )
+    exact = client.get(
+        "/api/v1/scientific/reactions/search"
+        "?reactants=HEX_A&products=HEX_C&match=exact"
+    )
+
+    assert len(contains.json()["records"]) == 1
+    assert exact.status_code == 200
+    assert exact.json()["records"] == []
+
+
+def test_get_match_exact_still_matches_the_whole_equation(client, db_session):
+    _setup_two_by_two(db_session, "HEW")
+
+    resp = client.get(
+        "/api/v1/scientific/reactions/search"
+        "?reactants=HEW_A&reactants=HEW_B"
+        "&products=HEW_C&products=HEW_D&match=exact"
+    )
+
+    assert resp.status_code == 200
+    assert len(resp.json()["records"]) == 1
+
+
+def test_get_rejects_unknown_match_value(client, db_session):
+    _setup_two_by_two(db_session, "HBAD")
+
+    resp = client.get(
+        "/api/v1/scientific/reactions/search?reactants=HBAD_A&match=subset"
+    )
+
+    assert resp.status_code == 422
+
+
+def test_post_accepts_match_in_body(client, db_session):
+    _setup_two_by_two(db_session, "HPB")
+
+    resp = client.post(
+        "/api/v1/scientific/reactions/search",
+        json={"reactants": ["HPB_A"], "match": "contains"},
+    )
+
+    assert resp.status_code == 200
+    assert len(resp.json()["records"]) == 1
+
+
+def test_response_echoes_the_match_mode(client, db_session):
+    _setup_two_by_two(db_session, "HECH")
+
+    resp = client.get("/api/v1/scientific/reactions/search?reactants=HECH_A")
+
+    assert resp.json()["request"]["filter"]["match"] == "contains"
+
+
+def test_get_direction_reverse_composes_with_contains(client, db_session):
+    """``direction`` and ``match`` are independent axes; check they compose."""
+    _setup_two_by_two(db_session, "HDIR")
+
+    reverse_hit = client.get(
+        "/api/v1/scientific/reactions/search?reactants=HDIR_C&direction=reverse"
+    )
+    reverse_miss = client.get(
+        "/api/v1/scientific/reactions/search?reactants=HDIR_A&direction=reverse"
+    )
+
+    assert len(reverse_hit.json()["records"]) == 1
+    assert reverse_hit.json()["records"][0]["matched_direction"] == "reverse"
+    assert reverse_miss.json()["records"] == []

--- a/backend/tests/services/scientific_read/test_search_kinetics.py
+++ b/backend/tests/services/scientific_read/test_search_kinetics.py
@@ -11,7 +11,10 @@ from app.db.models.common import (
 )
 from app.schemas.reads.scientific_common import CollapseMode
 from app.schemas.reads.scientific_kinetics_search import KineticsSearchRequest
-from app.schemas.reads.scientific_reactions import ReactionDirectionQuery
+from app.schemas.reads.scientific_reactions import (
+    ReactionDirectionQuery,
+    ReactionMatchMode,
+)
 from app.services.scientific_read.kinetics_search import search_kinetics
 from tests.services.scientific_read._factories import (
     make_chem_reaction,
@@ -264,3 +267,70 @@ def test_sort_is_deterministic_across_calls(db_session):
         db_session, KineticsSearchRequest(reactants=["DET1"], products=["DET2"])
     )
     assert r1.model_dump() == r2.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# match=contains vs match=exact
+#
+# Reaction identity here is resolved by delegating to ``search_reactions``,
+# so the semantics are inherited rather than reimplemented. These tests pin
+# that the delegation actually carries ``match`` through — a kinetics search
+# that quietly dropped it would fall back to the server default and give a
+# different answer than the caller asked for.
+# ---------------------------------------------------------------------------
+
+
+def test_reactants_only_kinetics_search_finds_the_reaction(db_session):
+    """"What rate coefficients do we have for reactions consuming X?"."""
+    _setup_reaction_with_kinetics(
+        db_session, reactant_smiles="KCT_A", product_smiles="KCT_B"
+    )
+
+    response = search_kinetics(db_session, KineticsSearchRequest(reactants=["KCT_A"]))
+
+    assert len(response.records) == 1
+
+
+def test_products_only_kinetics_search_finds_the_reaction(db_session):
+    _setup_reaction_with_kinetics(
+        db_session, reactant_smiles="KPO_A", product_smiles="KPO_B"
+    )
+
+    response = search_kinetics(db_session, KineticsSearchRequest(products=["KPO_B"]))
+
+    assert len(response.records) == 1
+
+
+def test_kinetics_match_exact_rejects_a_one_sided_query(db_session):
+    """``match=exact`` reaches the reaction service, so it must still bite."""
+    _setup_reaction_with_kinetics(
+        db_session, reactant_smiles="KEX_A", product_smiles="KEX_B"
+    )
+
+    partial = search_kinetics(
+        db_session,
+        KineticsSearchRequest(
+            reactants=["KEX_A"], match=ReactionMatchMode.exact
+        ),
+    )
+    whole = search_kinetics(
+        db_session,
+        KineticsSearchRequest(
+            reactants=["KEX_A"],
+            products=["KEX_B"],
+            match=ReactionMatchMode.exact,
+        ),
+    )
+
+    assert partial.records == []
+    assert len(whole.records) == 1
+
+
+def test_kinetics_filter_echo_reports_the_match_mode(db_session):
+    _setup_reaction_with_kinetics(
+        db_session, reactant_smiles="KEC_A", product_smiles="KEC_B"
+    )
+
+    response = search_kinetics(db_session, KineticsSearchRequest(reactants=["KEC_A"]))
+
+    assert response.request.filter["match"] == "contains"

--- a/backend/tests/services/scientific_read/test_search_reactions.py
+++ b/backend/tests/services/scientific_read/test_search_reactions.py
@@ -8,6 +8,7 @@ from app.db.models.common import RecordReviewStatus, SubmissionRecordType
 from app.schemas.reads.scientific_common import CollapseMode
 from app.schemas.reads.scientific_reactions import (
     ReactionDirectionQuery,
+    ReactionMatchMode,
     ReactionSearchRequest,
 )
 from app.services.scientific_read.reactions import search_reactions
@@ -130,6 +131,26 @@ def test_direction_either_forward_match_reports_forward(db_session):
     )
     assert len(response.records) == 1
     assert response.records[0].matched_direction == ReactionDirectionQuery.forward
+
+
+def test_reactants_only_query_finds_reactions_consuming_that_species(db_session):
+    """The query that justifies ``match``: "what consumes hydrazine?".
+
+    Before ``match`` existed this returned zero records for every possible
+    input, because the matcher demanded the (empty) product side match the
+    stored product side exactly and no reaction has zero products.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["NN"],
+        products_smiles=["[H][H]", "[N-]=[NH2+]"],
+    )
+
+    response = search_reactions(db_session, ReactionSearchRequest(reactants=["NN"]))
+
+    assert len(response.records) == 1
+    assert response.pagination.total == 1
+    assert {p.smiles for p in response.records[0].reactants} == {"NN"}
 
 
 def test_direction_exact_not_in_v0_enum(db_session):
@@ -289,3 +310,366 @@ def test_collapse_first_applies_before_offset(db_session):
     assert response.pagination.total == 1
     assert response.pagination.post_collapse_total == 1
     assert response.pagination.returned == 0
+
+
+# ---------------------------------------------------------------------------
+# match=contains vs match=exact
+#
+# ``contains`` is set containment per role and is the default; ``exact`` is
+# multiset equality on both roles and is what the endpoint used to do
+# unconditionally. The two axes (``direction``, ``match``) are independent
+# and every combination below is asserted rather than assumed.
+# ---------------------------------------------------------------------------
+
+
+def test_contains_only_products_finds_reactions_producing_that_species(db_session):
+    """The mirror of the reactants-only case: "what produces OH?"."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["CT_A", "CT_B"],
+        products_smiles=["CT_C", "CT_D"],
+    )
+
+    response = search_reactions(db_session, ReactionSearchRequest(products=["CT_C"]))
+
+    assert len(response.records) == 1
+    assert {p.smiles for p in response.records[0].products} == {"CT_C", "CT_D"}
+
+
+def test_contains_both_sides_matches_a_larger_reaction(db_session):
+    """One species named per side; the stored reaction has two on each."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["CB_A", "CB_B"],
+        products_smiles=["CB_C", "CB_D"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(reactants=["CB_A"], products=["CB_C"]),
+    )
+
+    assert len(response.records) == 1
+
+
+def test_exact_rejects_the_partial_query_contains_accepts(db_session):
+    """Same stored reaction, same query, opposite answers — that is the point."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["EX_A", "EX_B"],
+        products_smiles=["EX_C", "EX_D"],
+    )
+
+    partial = ReactionSearchRequest(
+        reactants=["EX_A"],
+        products=["EX_C"],
+        match=ReactionMatchMode.exact,
+    )
+    assert search_reactions(db_session, partial).records == []
+
+    whole = ReactionSearchRequest(
+        reactants=["EX_A", "EX_B"],
+        products=["EX_C", "EX_D"],
+        match=ReactionMatchMode.exact,
+    )
+    assert len(search_reactions(db_session, whole).records) == 1
+
+
+def test_exact_reproduces_the_old_result_for_a_full_query(db_session):
+    """The migration path for callers who relied on the old default.
+
+    A full two-sided query returned exactly this reaction before ``match``
+    existed. ``match=exact`` must still return exactly it, and the default
+    ``contains`` must return it too — containment widens the answer set, it
+    never drops a record the old semantics returned.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["OLD_A", "OLD_B"],
+        products_smiles=["OLD_C"],
+    )
+
+    fields = {"reactants": ["OLD_A", "OLD_B"], "products": ["OLD_C"]}
+    exact = search_reactions(
+        db_session, ReactionSearchRequest(match=ReactionMatchMode.exact, **fields)
+    )
+    default = search_reactions(db_session, ReactionSearchRequest(**fields))
+
+    assert len(exact.records) == 1
+    assert [r.reaction_entry_id for r in default.records] == [
+        r.reaction_entry_id for r in exact.records
+    ]
+
+
+def test_exact_still_rejects_a_reactants_only_query(db_session):
+    """``exact`` keeps the old behaviour, defect included, by explicit request.
+
+    Asking for "reactants exactly {X} and products exactly {}" is still
+    unanswerable. Under ``exact`` that is the caller's stated question, not
+    the endpoint silently substituting one.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["XO_A"],
+        products_smiles=["XO_B"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(reactants=["XO_A"], match=ReactionMatchMode.exact),
+    )
+
+    assert response.records == []
+
+
+def test_contains_is_set_not_multiset_query_names_fewer(db_session):
+    """A reaction consuming two of a species matches a query naming one.
+
+    This is the stoichiometry decision: containment ignores counts. If it
+    were multiset containment this query would return nothing.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["DUP_A", "DUP_A"],
+        products_smiles=["DUP_B"],
+    )
+
+    response = search_reactions(db_session, ReactionSearchRequest(reactants=["DUP_A"]))
+
+    assert len(response.records) == 1
+    assert [p.smiles for p in response.records[0].reactants] == ["DUP_A", "DUP_A"]
+
+
+def test_contains_is_set_not_multiset_query_names_more(db_session):
+    """And the converse: naming a species twice matches a reaction with one.
+
+    Multiset containment in the other direction would reject this. Set
+    semantics accept it, which is the reading the docstring commits to.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["DUPQ_A"],
+        products_smiles=["DUPQ_B"],
+    )
+
+    response = search_reactions(
+        db_session, ReactionSearchRequest(reactants=["DUPQ_A", "DUPQ_A"])
+    )
+
+    assert len(response.records) == 1
+
+
+def test_exact_does_count_stoichiometry(db_session):
+    """``exact`` is the mode that does care: one queried NN != two stored."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["ES_A", "ES_A"],
+        products_smiles=["ES_B"],
+    )
+
+    one = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["ES_A"], products=["ES_B"], match=ReactionMatchMode.exact
+        ),
+    )
+    two = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["ES_A", "ES_A"],
+            products=["ES_B"],
+            match=ReactionMatchMode.exact,
+        ),
+    )
+
+    assert one.records == []
+    assert len(two.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# direction x match composition
+# ---------------------------------------------------------------------------
+
+
+def test_contains_either_matches_the_reverse_orientation(db_session):
+    """A species stored as a product, asked for as a reactant, under ``either``."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["DE_A"],
+        products_smiles=["DE_B", "DE_C"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["DE_B"], direction=ReactionDirectionQuery.either
+        ),
+    )
+
+    assert len(response.records) == 1
+    assert response.records[0].matched_direction == ReactionDirectionQuery.reverse
+
+
+def test_contains_either_reports_forward_for_a_one_sided_forward_match(db_session):
+    """matched_direction must follow the same semantics the matcher used.
+
+    Resolving the orientation with multiset equality while the matcher used
+    containment reports ``reverse`` for every one-sided ``contains`` hit,
+    including this obviously-forward one.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["DF_A", "DF_B"],
+        products_smiles=["DF_C"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["DF_A"], direction=ReactionDirectionQuery.either
+        ),
+    )
+
+    assert len(response.records) == 1
+    assert response.records[0].matched_direction == ReactionDirectionQuery.forward
+
+
+def test_contains_forward_does_not_match_the_reverse_orientation(db_session):
+    """``direction=forward`` still pins the orientation under containment."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["DFW_A"],
+        products_smiles=["DFW_B", "DFW_C"],
+    )
+
+    matched = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["DFW_A"], direction=ReactionDirectionQuery.forward
+        ),
+    )
+    unmatched = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["DFW_B"], direction=ReactionDirectionQuery.forward
+        ),
+    )
+
+    assert len(matched.records) == 1
+    assert unmatched.records == []
+
+
+def test_contains_reverse_matches_only_the_swapped_orientation(db_session):
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["DRV_A"],
+        products_smiles=["DRV_B", "DRV_C"],
+    )
+
+    matched = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["DRV_B"], direction=ReactionDirectionQuery.reverse
+        ),
+    )
+    unmatched = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["DRV_A"], direction=ReactionDirectionQuery.reverse
+        ),
+    )
+
+    assert len(matched.records) == 1
+    assert unmatched.records == []
+
+
+def test_exact_either_still_matches_in_both_orientations(db_session):
+    """``exact`` composes with ``either`` exactly as it did before ``match``."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["EE_A"],
+        products_smiles=["EE_B"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["EE_B"],
+            products=["EE_A"],
+            direction=ReactionDirectionQuery.either,
+            match=ReactionMatchMode.exact,
+        ),
+    )
+
+    assert len(response.records) == 1
+    assert response.records[0].matched_direction == ReactionDirectionQuery.reverse
+
+
+def test_exact_forward_rejects_what_exact_either_accepts(db_session):
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["EF_A"],
+        products_smiles=["EF_B"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["EF_B"],
+            products=["EF_A"],
+            direction=ReactionDirectionQuery.forward,
+            match=ReactionMatchMode.exact,
+        ),
+    )
+
+    assert response.records == []
+
+
+# ---------------------------------------------------------------------------
+# Unknown species and the echo
+# ---------------------------------------------------------------------------
+
+
+def test_contains_query_naming_an_unknown_species_returns_nothing(db_session):
+    """An unresolvable SMILES still short-circuits to empty, under contains too.
+
+    Documented here because it is *not* the same failure as the one this
+    change fixes: the empty answer is caused by the species being unknown to
+    the database, not by the query shape being unanswerable. It is still a
+    silent empty rather than a "no such species" error — see the PR notes.
+    """
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["UNK_A"],
+        products_smiles=["UNK_B"],
+    )
+
+    response = search_reactions(
+        db_session,
+        ReactionSearchRequest(reactants=["UNK_A", "NOT_A_REAL_SPECIES"]),
+    )
+
+    assert response.records == []
+    assert response.pagination.total == 0
+
+
+def test_filter_echo_reports_the_match_mode(db_session):
+    """The mode changes the meaning of the answer, so it is echoed always."""
+    _setup_reaction(
+        db_session,
+        reactants_smiles=["ECHO_A"],
+        products_smiles=["ECHO_B"],
+    )
+
+    default = search_reactions(db_session, ReactionSearchRequest(reactants=["ECHO_A"]))
+    exact = search_reactions(
+        db_session,
+        ReactionSearchRequest(
+            reactants=["ECHO_A"],
+            products=["ECHO_B"],
+            match=ReactionMatchMode.exact,
+        ),
+    )
+
+    assert default.request.filter["match"] == "contains"
+    assert exact.request.filter["match"] == "exact"

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -303,6 +303,9 @@ deployment with no curated selection answers exploratorily.
 
 ```python
 kinetics = client.search_kinetics(reactants=["C[CH2]"], profile="curated")
+# One-sided queries mean containment: "kinetics for reactions consuming
+# the ethyl radical", products unconstrained. Pass match="exact" to ask
+# for one specific equation instead (both sides, counts included).
 kinetics["request"]["profile"]                  # what actually answered
 kinetics["request"]["profile_recommendation"]   # what TCKDB recommends
 ```

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-client"
-version = "0.53.0"
+version = "0.54.0"
 description = "Synchronous Python HTTP client and scientific upload builders for the TCKDB API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clients/python/src/tckdb_client/client.py
+++ b/clients/python/src/tckdb_client/client.py
@@ -1170,6 +1170,7 @@ class TCKDBClient:
         reactants: list[str] | None = None,
         products: list[str] | None = None,
         direction: str | None = None,
+        match: str | None = None,
         family: str | None = None,
         reaction_ref: str | None = None,
         reaction_entry_ref: str | None = None,
@@ -1192,11 +1193,21 @@ class TCKDBClient:
 
         Phase C: ``reaction_ref`` / ``reaction_entry_ref`` may be supplied
         as standalone identity filters (no SMILES required).
+
+        ``match`` selects how the supplied species lists are compared with a
+        stored reaction side. The server default is ``"contains"`` — set
+        containment per role, so ``reactants=["NN"]`` alone means "every
+        reaction with NN among its reactants" and leaves the product side
+        unconstrained. ``match="exact"`` asks for precisely one equation,
+        both sides, counts included; it is what this endpoint did
+        unconditionally before the parameter existed. Left ``None`` the
+        field is not sent and the server default applies.
         """
         common = {
             "reactants": reactants,
             "products": products,
             "direction": direction,
+            "match": match,
             "family": family,
             "reaction_ref": reaction_ref,
             "reaction_entry_ref": reaction_entry_ref,
@@ -1410,6 +1421,7 @@ class TCKDBClient:
         reactants: list[str] | None = None,
         products: list[str] | None = None,
         direction: str | None = None,
+        match: str | None = None,
         family: str | None = None,
         reaction_ref: str | None = None,
         reaction_entry_ref: str | None = None,
@@ -1439,11 +1451,15 @@ class TCKDBClient:
         repeated-query-param form. Non-TS-backed kinetics surface with null
         TS-chain provenance fields, exactly like the entry-id detail endpoint.
         ``pressure_bar`` is canonical; ``pressure`` is a deprecated alias.
+        ``match`` means what it means on :meth:`search_reactions` — reaction
+        identity here is resolved by that same service — and defaults
+        server-side to ``"contains"``.
         """
         body = {
             "reactants": reactants,
             "products": products,
             "direction": direction,
+            "match": match,
             "family": family,
             "reaction_ref": reaction_ref,
             "reaction_entry_ref": reaction_entry_ref,

--- a/docs/guides/scientific_query_cookbook.md
+++ b/docs/guides/scientific_query_cookbook.md
@@ -184,7 +184,9 @@ print(f"A = {params['A']} ({params['A_units']}) n = {params['n']}"
 Notes:
 
 - `direction="either"` matches in either forward or reverse orientation; the response says which (`matched_direction`).
-- `direction="exact"` is **not** supported in v0 — the backend returns 422.
+- `direction="exact"` is **not** supported in v0 — the backend returns 422. It is not the same thing as `match="exact"`, which is supported and described below.
+- `match="contains"` (the default) means **set containment per role**: every species you name must appear in that role, and a side you leave out constrains nothing. So `search_kinetics(reactants=["CC"])` on its own is a real query — "kinetics for reactions consuming ethane" — and so is `search_reactions(products=["[OH]"])`. Counts are ignored in this mode: naming one `[OH]` matches a reaction consuming two.
+- `match="exact"` demands the whole equation, both sides, counts included. Use it when you mean one specific reaction and do not hold its `reaction_ref`. Before `match` existed this was the only behaviour, which is why a one-sided query used to come back empty.
 - Non-TS-backed kinetics (experimental, estimated, network-derived, …) come through with `provenance.transition_state_entry_ref = null` and every `ts_*_calculation_ref = null`. That's not an error — it's how the schema signals "no transition-state chain to follow."
 
 ---

--- a/docs/guides/workflow_tool_scientific_reads.md
+++ b/docs/guides/workflow_tool_scientific_reads.md
@@ -270,6 +270,11 @@ repeated-query-param form (`?reactants=A&reactants=B&products=C`).
 `direction="exact"` is **not** supported in v0 — the backend rejects it
 with 422.
 
+`match` is the other axis and defaults to `contains`: every species you
+name must appear in that role, and an omitted side constrains nothing, so
+`reactants=["NN"]` alone asks "what consumes hydrazine?". `match="exact"`
+asks instead for precisely one equation, both sides, counts included.
+
 **Returned entry ids are handles, not prerequisites.** A workflow
 adapter should inspect `review` and `provenance` on each record before
 deciding to reuse it. Importantly:
@@ -420,6 +425,13 @@ Each record carries:
 
 `direction` accepts `forward`, `reverse`, or `either`. `direction=exact`
 is **not** supported in v0 and the backend rejects it with 422.
+
+`match` accepts `contains` (default) or `exact`, and is independent of
+`direction`: `direction` picks which orientation(s) of the stored
+reaction the query is tried against, `match` picks how a side is compared
+once an orientation is chosen. Under `direction=either` containment is
+tested in both orientations and `matched_direction` reports which one
+matched.
 
 If you prefer the GET form (e.g. for a quick interactive lookup with
 plain identifiers), pass `method="GET"`:

--- a/docs/site/querying.md
+++ b/docs/site/querying.md
@@ -24,10 +24,21 @@ curl -G "http://127.0.0.1:8010/api/v1/scientific/kinetics/search" \
     --data-urlencode "reactants=[H][H]" \
     --data-urlencode "products=C" \
     --data-urlencode "products=[H]"
+
+# Reaction search naming only one side.
+curl -G "http://127.0.0.1:8010/api/v1/scientific/reactions/search" \
+    --data-urlencode "reactants=[CH3]"
 ```
 
 Always URL-encode bracketed SMILES with `--data-urlencode`; otherwise
 shells and curl can interpret brackets as URL ranges.
+
+Reaction and kinetics search match by **containment** unless you say
+otherwise: every species you name must appear in that role, and a side you
+leave out is unconstrained. So the last example above means "reactions
+consuming the methyl radical", not "reactions turning methyl into
+nothing". Add `--data-urlencode "match=exact"` when you want precisely one
+equation — both sides, counts included.
 
 ## Python Example
 

--- a/docs/specs/public_read_abuse_controls.md
+++ b/docs/specs/public_read_abuse_controls.md
@@ -262,7 +262,27 @@ start.
 
 `family`, `min_review_status`, and the include-flag options are
 explicitly **not** considered meaningful filters because none of
-them bound the candidate set to a small, predictable size.
+them bound the candidate set to a small, predictable size. Neither is
+`match` (below): it changes how a supplied species list is compared,
+not whether one was supplied.
+
+The **and/or** above is load-bearing and was, for a time, a lie. Until
+the `match` parameter existed the matcher compared both roles for
+multiset equality, so `reactants` alone asked for "reactants exactly
+{X} and products exactly {}" and matched nothing whatever the input.
+The guard admitted the request and the answer came back `200` with an
+empty result set. `match=contains` — the default — is what makes the
+one-sided form mean what this section says it means: every named
+species must appear in that role, and a side left empty constrains
+nothing. `match=exact` restores multiset equality on both sides for a
+caller who wants one specific equation.
+
+Note for the enumeration guard specifically: `contains` widens the
+candidate set relative to `exact`, but it does not unbound it. The
+candidate prefilter is still driven by the supplied species ids, so a
+one-sided query is bounded by the reactions that touch those species —
+not by the size of the table. `limit` and the pagination caps apply
+unchanged.
 
 ---
 

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -436,12 +436,18 @@ direction, or public ref.
 
 At least one discriminator is required: `reactants`, `products`,
 `reaction_ref`, `reaction_entry_ref`, or `family`. Modifiers alone
-(`direction`, `min_review_status`) do not constitute a search.
+(`direction`, `match`, `min_review_status`) do not constitute a search.
+
+Matching defaults to containment. `reactants: ["NN"]` on its own returns
+every reaction with NN among its reactants and leaves the product side
+unconstrained; `match: "exact"` asks for one whole equation instead.
 
 ```text
 reactants?: string[]            # non-empty list of non-empty SMILES
 products?: string[]             # non-empty list of non-empty SMILES
 direction?: "forward" | "reverse" | "either"   # default "either"
+match?: "contains" | "exact"    # default "contains" (set containment
+                                #   per role; "exact" = whole equation)
 family?: string
 reaction_ref?: string           # must start with "rxn_"
 reaction_entry_ref?: string     # must start with "rxe_"
@@ -677,13 +683,14 @@ Complements `tckdb_get_reaction_entry_kinetics`.
 
 At least one identity discriminator is **required**: `reactants`,
 `products`, `reaction_ref`, `reaction_entry_ref`, or `family`. Modifiers
-alone (`direction`, temperature/pressure, model_kind, review filters)
-are rejected to avoid unbounded scans.
+alone (`direction`, `match`, temperature/pressure, model_kind, review
+filters) are rejected to avoid unbounded scans.
 
 ```text
 reactants?: string[]                 # non-empty SMILES list
 products?: string[]                  # non-empty SMILES list
 direction?: "forward" | "reverse" | "either"   # modifier; default "either"
+match?: "contains" | "exact"         # modifier; default "contains"
 family?: string
 reaction_ref?: string                # must start with "rxn_"
 reaction_entry_ref?: string          # must start with "rxe_"

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tckdb-mcp"
-version = "0.1.1"
+version = "0.2.0"
 description = "Read-only MCP server wrapping the TCKDB scientific API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/mcp/src/tckdb_mcp/__init__.py
+++ b/integrations/mcp/src/tckdb_mcp/__init__.py
@@ -7,4 +7,4 @@ It never queries Postgres directly and never imports the backend.
 See ``docs/specs/mcp_readonly_integration.md`` for the full design.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/integrations/mcp/src/tckdb_mcp/tools/kinetics_search.py
+++ b/integrations/mcp/src/tckdb_mcp/tools/kinetics_search.py
@@ -21,7 +21,8 @@ Policy choices enforced here (in addition to server-side validation):
 - ``limit`` is capped at ``config.max_limit`` (default 50).
 - At least one identity discriminator must be supplied
   (``reactants``, ``products``, ``reaction_ref``, ``reaction_entry_ref``,
-  or ``family``). ``direction`` alone is a modifier, not a search.
+  or ``family``). ``direction`` and ``match`` alone are modifiers, not
+  searches.
 """
 
 from __future__ import annotations
@@ -66,6 +67,12 @@ LEGAL_MODEL_KINDS = frozenset({"arrhenius", "modified_arrhenius"})
 # backend/app/schemas/reads/scientific_reactions.py::ReactionDirectionQuery.
 LEGAL_DIRECTIONS = frozenset({"forward", "reverse", "either"})
 
+# Legal ``match`` values from
+# backend/app/schemas/reads/scientific_reactions.py::ReactionMatchMode.
+# ``contains`` is set containment per role and is the server default;
+# ``exact`` is multiset equality on both sides.
+LEGAL_MATCH_MODES = frozenset({"contains", "exact"})
+
 _DEFAULT_INCLUDE: tuple[str, ...] = ("provenance",)
 
 _DISCRIMINATOR_FIELDS: tuple[str, ...] = (
@@ -82,6 +89,7 @@ _ACCEPTED_FIELDS: frozenset[str] = frozenset(
         "reactants",
         "products",
         "direction",
+        "match",
         "family",
         "reaction_ref",
         "reaction_entry_ref",
@@ -137,6 +145,19 @@ INPUT_SCHEMA: dict[str, Any] = {
             "enum": sorted(LEGAL_DIRECTIONS),
             "default": "either",
             "description": "Modifier, not a discriminator on its own.",
+        },
+        "match": {
+            "type": "string",
+            "enum": sorted(LEGAL_MATCH_MODES),
+            "default": "contains",
+            "description": (
+                "How the supplied species lists are compared with a stored "
+                "reaction side. 'contains' (default) means every named "
+                "species must appear in that role and an omitted side is "
+                "unconstrained, so reactants=['NN'] answers 'what consumes "
+                "hydrazine'. 'exact' demands the whole equation, both "
+                "sides, counts included."
+            ),
         },
         "family": {"type": "string"},
         "reaction_ref": {
@@ -261,6 +282,12 @@ def run(
             f"direction must be one of {sorted(LEGAL_DIRECTIONS)!r}; got {direction!r}"
         )
 
+    match_mode = args.get("match")
+    if match_mode is not None and match_mode not in LEGAL_MATCH_MODES:
+        raise invalid_input(
+            f"match must be one of {sorted(LEGAL_MATCH_MODES)!r}; got {match_mode!r}"
+        )
+
     model_kind = args.get("model_kind")
     if model_kind is not None and model_kind not in LEGAL_MODEL_KINDS:
         raise invalid_input(
@@ -316,6 +343,7 @@ def run(
         "reactants": reactants if reactants else None,
         "products": products if products else None,
         "direction": direction,
+        "match": match_mode,
         "family": args.get("family"),
         "reaction_ref": reaction_ref,
         "reaction_entry_ref": reaction_entry_ref,

--- a/integrations/mcp/src/tckdb_mcp/tools/reactions.py
+++ b/integrations/mcp/src/tckdb_mcp/tools/reactions.py
@@ -13,8 +13,8 @@ Policy choices enforced here (in addition to server-side validation):
 - ``limit`` is capped at ``config.max_limit`` (default 50).
 - At least one identity discriminator must be supplied
   (``reactants``, ``products``, ``reaction_ref``, ``reaction_entry_ref``,
-  or ``family``). Modifiers alone (``direction``, ``min_review_status``)
-  are not searchable on their own.
+  or ``family``). Modifiers alone (``direction``, ``match``,
+  ``min_review_status``) are not searchable on their own.
 """
 
 from __future__ import annotations
@@ -28,7 +28,10 @@ from ..http_client import TCKDBHttpClient
 TOOL_NAME = "tckdb_search_reactions"
 TOOL_DESCRIPTION = (
     "Search TCKDB reactions and reaction_entries by reactant/product "
-    "SMILES, direction, family, or public ref. Read-only. At least one "
+    "SMILES, direction, family, or public ref. Read-only. Matching is "
+    "containment by default (match=contains): reactants alone means "
+    "'every reaction with these among its reactants'; match=exact demands "
+    "the whole equation. At least one "
     "discriminator (reactants, products, reaction_ref, reaction_entry_ref, "
     "or family) is required. Returns the server search envelope unchanged."
 )
@@ -45,6 +48,12 @@ LEGAL_INCLUDE_TOKENS = frozenset(
 # (``exact`` is explicitly rejected in v0; the enum does not include it.)
 LEGAL_DIRECTIONS = frozenset({"forward", "reverse", "either"})
 
+# Legal ``match`` values from
+# backend/app/schemas/reads/scientific_reactions.py::ReactionMatchMode.
+# ``contains`` is set containment per role and is the server default;
+# ``exact`` is multiset equality on both sides.
+LEGAL_MATCH_MODES = frozenset({"contains", "exact"})
+
 _DISCRIMINATOR_FIELDS: tuple[str, ...] = (
     "reactants",
     "products",
@@ -58,6 +67,7 @@ _ACCEPTED_FIELDS: frozenset[str] = frozenset(
         "reactants",
         "products",
         "direction",
+        "match",
         "family",
         "reaction_ref",
         "reaction_entry_ref",
@@ -95,6 +105,19 @@ INPUT_SCHEMA: dict[str, Any] = {
             "type": "string",
             "enum": sorted(LEGAL_DIRECTIONS),
             "default": "either",
+        },
+        "match": {
+            "type": "string",
+            "enum": sorted(LEGAL_MATCH_MODES),
+            "default": "contains",
+            "description": (
+                "How the supplied species lists are compared with a stored "
+                "reaction side. 'contains' (default) means every named "
+                "species must appear in that role and an omitted side is "
+                "unconstrained, so reactants=['NN'] answers 'what consumes "
+                "hydrazine'. 'exact' demands the whole equation, both "
+                "sides, counts included."
+            ),
         },
         "family": {"type": "string"},
         "reaction_ref": {
@@ -198,6 +221,12 @@ def run(
             f"direction must be one of {sorted(LEGAL_DIRECTIONS)!r}; got {direction!r}"
         )
 
+    match_mode = args.get("match")
+    if match_mode is not None and match_mode not in LEGAL_MATCH_MODES:
+        raise invalid_input(
+            f"match must be one of {sorted(LEGAL_MATCH_MODES)!r}; got {match_mode!r}"
+        )
+
     offset = args.get("offset", 0)
     if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
         raise invalid_input(f"offset must be a non-negative integer; got {offset!r}")
@@ -239,6 +268,7 @@ def run(
         "reactants": reactants if reactants else None,
         "products": products if products else None,
         "direction": direction,
+        "match": match_mode,
         "family": args.get("family"),
         "reaction_ref": reaction_ref,
         "reaction_entry_ref": reaction_entry_ref,

--- a/integrations/mcp/tests/test_kinetics_search_tool.py
+++ b/integrations/mcp/tests/test_kinetics_search_tool.py
@@ -831,3 +831,33 @@ def test_api_key_header_forwarded_when_set() -> None:
     ks_tool.run(client, _cfg(), {"reactants": ["[OH]"]})
     assert seen[0].get("x-api-key") == "tck_xyz"
     client.close()
+
+
+# ---------------------------------------------------------------------------
+# Match mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("match_mode", ["contains", "exact"])
+def test_legal_match_values_forwarded(match_mode: str) -> None:
+    captured: list[dict[str, Any]] = []
+    client = _make_client(_ok_handler(captured))
+    ks_tool.run(client, _cfg(), {"reactants": ["[OH]", "CC"], "match": match_mode})
+    assert captured[0]["body"]["match"] == match_mode
+    client.close()
+
+
+def test_rejects_unknown_match_mode() -> None:
+    client = _make_client(_ok_handler([]))
+    with pytest.raises(MCPToolError) as excinfo:
+        ks_tool.run(client, _cfg(), {"reactants": ["[OH]"], "match": "subset"})
+    assert excinfo.value.code == "invalid_input"
+    assert "match" in excinfo.value.detail
+    client.close()
+
+
+def test_match_alone_rejected_as_modifier_only() -> None:
+    client = _make_client(_ok_handler([]))
+    with pytest.raises(MCPToolError):
+        ks_tool.run(client, _cfg(), {"match": "contains"})
+    client.close()

--- a/integrations/mcp/tests/test_reactions_tool.py
+++ b/integrations/mcp/tests/test_reactions_tool.py
@@ -483,3 +483,47 @@ def test_api_key_header_forwarded_when_set() -> None:
     reactions_tool.run(client, _cfg(), {"reactants": ["[OH]"]})
     assert seen[0].get("x-api-key") == "tck_xyz"
     client.close()
+
+
+# ---------------------------------------------------------------------------
+# Match mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("match_mode", ["contains", "exact"])
+def test_legal_match_values_forwarded(match_mode: str) -> None:
+    captured: list[dict[str, Any]] = []
+    client = _make_client(_ok_handler(captured))
+    reactions_tool.run(
+        client, _cfg(), {"reactants": ["[OH]", "CC"], "match": match_mode}
+    )
+    assert captured[0]["body"]["match"] == match_mode
+    client.close()
+
+
+def test_rejects_unknown_match_mode() -> None:
+    client = _make_client(_ok_handler([]))
+    with pytest.raises(MCPToolError) as excinfo:
+        reactions_tool.run(client, _cfg(), {"reactants": ["[OH]"], "match": "subset"})
+    assert excinfo.value.code == "invalid_input"
+    assert "match" in excinfo.value.detail
+    client.close()
+
+
+def test_match_alone_is_not_a_discriminator() -> None:
+    """``match`` is a modifier: it cannot stand in for a species or a ref."""
+    client = _make_client(_ok_handler([]))
+    with pytest.raises(MCPToolError) as excinfo:
+        reactions_tool.run(client, _cfg(), {"match": "contains"})
+    assert excinfo.value.code == "invalid_input"
+    assert "discriminator" in excinfo.value.detail
+    client.close()
+
+
+def test_match_omitted_is_not_sent_so_server_default_applies() -> None:
+    """The tool must not hard-code ``contains``; the server owns the default."""
+    captured: list[dict[str, Any]] = []
+    client = _make_client(_ok_handler(captured))
+    reactions_tool.run(client, _cfg(), {"reactants": ["[OH]"]})
+    assert "match" not in captured[0]["body"]
+    client.close()


### PR DESCRIPTION
## In plain language

`/api/v1/scientific/reactions/search` lets you ask "which reactions have these reactants and these products?". You are allowed to fill in only one of the two boxes — the code that checks your request says so in as many words.

But the code that actually *did the search* compared **both** boxes for an exact match. So if you filled in only the reactants box, the empty products box was read as a demand: "…and the reaction must have **no products at all**." Nothing in chemistry has no products. The search could therefore never match anything, whatever you typed, and it did not say so — it returned a normal, successful, empty answer.

Measured against the live public instance before this change:

```
reactants=NN                                             -> 200, total 0
products=%5BH%5D%5BH%5D                                  -> 200, total 0
reactants=NN&products=%5BH%5D%5BH%5D&products=%5BN-%5D%3D%5BNH2%2B%5D -> 200, total 4
reaction_ref=rxn_ss2j4rfyavzwq7oyapbb32oote              -> 200, total 4
                            equation: "NN <=> [H][H] + [N-]=[NH2+]"
```

"What reactions consume hydrazine?" was answered **"none"** by a database holding 24 hydrazine reactions. That is not a narrow answer, it is a confidently wrong one — the failure class this repository treats as the worst kind, because the caller has no way to tell it apart from a real absence.

This PR adds a **`match`** setting with two values and makes the sensible one the default:

- **`match=contains`** (new default) — *containment*: every species you name has to be there in that role, and a box you left empty is simply not a constraint. `reactants=NN` now means "every reaction with hydrazine among its reactants; I don't care what comes out".
- **`match=exact`** — the old behaviour: precisely this equation, both sides. Still a legitimate thing to want, and kept reachable, because `reaction_ref` is not a substitute — you do not always hold the ref for the equation you are thinking of.

*Software terms used below.* A **query parameter** is one of the `?name=value` settings on a URL. A **multiset** is a collection where repeats count (`{A, A, B}` differs from `{A, B}`); a **set** is one where they do not. An **OpenAPI golden file** is a checked-in copy of the machine-readable description of every endpoint, which a test compares against the live app so the contract cannot drift unnoticed. A **mutation test** means deliberately breaking the code to confirm the test suite notices — a suite nobody has tried to break is not evidence of anything.

## The stoichiometry decision, and why it is written down

Containment is **set** containment, not multiset containment. Concretely:

| Reaction in the database | Query | `contains` | `exact` |
|---|---|---|---|
| `NN + NN -> …` | `reactants=NN` | match | no match |
| `NN -> …` | `reactants=NN&reactants=NN` | match | no match |
| `A + B <=> C + D` | `reactants=A&products=C` | match | no match |
| `A + B <=> C + D` | `reactants=A&reactants=B&products=C&products=D` | match | match |

Stoichiometry is deliberately **not** a filter in `contains` mode. Somebody asking "reactions involving hydrazine" is not asking about coefficients; somebody who *is* asking about coefficients is asking for a specific equation, and `match=exact` is that question. The opposite reading — that a queried multiset must be covered with multiplicity — is defensible enough that it is stated in the enum's docstring and in the published OpenAPI description rather than left to fall out of whichever line of Python happened to get written. Two tests pin the choice in both directions (`..._query_names_fewer`, `..._query_names_more`), and one of the mutations below is aimed squarely at it.

## ⚠️ Breaking change, and the migration

**Who is affected:** callers who supply **both** `reactants` and `products`.

**What changes for them:** they used to get exact multiset equality on both sides. Under the new default they get containment, which returns a **superset** — a two-species query will now also match the larger reactions that contain those two species.

**Migration: send `match=exact`.** That reproduces the previous behaviour exactly, on both affected endpoints, and is verified by a test that runs the same query both ways and asserts the record sets are identical (`test_exact_reproduces_the_old_result_for_a_full_query`).

**Who is not affected:** callers supplying only one side. They were receiving an empty list and cannot regress.

TCKDB is pre-1.0 and `CHANGELOG.md` states that minor bumps may break HTTP contracts, so this is permitted — but it is disclosed here and in the changelog rather than slipped in.

## What changed

**`match` is orthogonal to `direction`, and they compose.** `direction` picks *which orientation(s)* of the stored reaction the query is tried against; `match` picks *how a side is compared* once an orientation is chosen. Under `direction=either`, containment is tested in both orientations.

- `backend/app/schemas/reads/scientific_reactions.py` — new `ReactionMatchMode` enum (`contains` / `exact`) carrying the full rationale, and a `match` field on `ReactionSearchRequest` defaulting to `contains`.
- `backend/app/services/scientific_read/reactions.py` — `_find_matching_reaction_entry_ids` takes `match`; the comparison is factored into `_side_matches` / `_orientation_matches` so the matcher and the direction-resolver cannot drift apart.
- **`_matched_direction` is fixed too, and this is a real second bug the change would otherwise have introduced.** It decided forward-vs-reverse with multiset equality. Left alone while the matcher used containment, it would have reported `reverse` for *every* one-sided `contains` hit, including obviously forward ones. It now resolves the orientation under the same semantics the matcher used. `test_contains_either_reports_forward_for_a_one_sided_forward_match` is the guard, and mutation 2 below confirms it bites.
- `backend/app/api/routes/scientific/reactions.py` — `match` on the GET form; the POST form gets it via the body model.
- **`/scientific/kinetics/search` had the identical defect** and is fixed with it: it resolves reaction identity by delegating to `search_reactions`, so a reactants-only kinetics query returned nothing for the same reason. It would have inherited the new default silently — but then `exact` would have become unreachable there, removing a capability with no migration. So `match` is plumbed through `KineticsSearchRequest`, its route, and its filter echo, and tests pin that the delegation actually carries it.
- The response's `request.filter` echo now always reports `match`, on both endpoints. The mode changes what the answer *means*, so a client reading a response can see which question was asked.

## Schema / migration impact

**None.** This is a query projection over existing tables — no model changed, no Alembic revision was written, and none is needed.

## Version bumps

- **`tckdb-client` 0.53.0 → 0.54.0** — new `match=` keyword on `search_reactions()` and `search_kinetics()`. Omitted, the field is not sent and the server default applies.
- **`tckdb-mcp` 0.1.1 → 0.2.0** — `match` added to the accepted-field allowlist, the input schema, and the validator for `tckdb_search_reactions` and `tckdb_search_kinetics`. (The allowlist is `_ACCEPTED_FIELDS`; an unlisted field is rejected outright, which is what caught #228.) `backend/scripts/check_package_version_bump.py` confirms: `Version bump OK for: tckdb-client, tckdb-mcp`.

Pre-existing drift noticed but **not** touched: `integrations/mcp/src/tckdb_mcp/__init__.py` pins `__version__ = "0.1.0"` while `pyproject.toml` was already at `0.1.1` before this branch. Nothing reads the constant and no test pins it; changing it is an unrelated edit and belongs in its own commit.

## Documentation corrected

The docs never stated the matching rule at all — the only precise statement of it lived in the generated OpenAPI description. Meanwhile several docs asserted that a one-sided query was valid, which was not true of the running code:

- `docs/specs/public_read_abuse_controls.md` §3 — the normative "`reactants` **and/or** `products`" sentence. It was a lie until now; the section says so, says what made it true, and notes that `contains` widens the candidate set without unbounding it (the prefilter is still driven by the supplied species ids).
- `docs/guides/scientific_query_cookbook.md` — Recipe 4 now distinguishes `match="exact"` (supported) from `direction="exact"` (rejected with 422), which are easy to confuse.
- `docs/guides/workflow_tool_scientific_reads.md` — both places that state the direction rules.
- `backend/docs/specs/read_query_api_audit.md` — the reaction filter tables.
- `integrations/mcp/README.md` — both tool parameter listings.
- `clients/python/README.md`, `README.md`, `docs/site/querying.md` — the worked examples, including a one-sided one that would previously have returned nothing.
- `CHANGELOG.md` — a `### Changed` entry under Unreleased carrying the breaking notice and the migration.

## Verification actually run

**1. The defect reproduced against unmodified `main` first.** `test_reactants_only_query_finds_reactions_consuming_that_species` was written and run *before* any service code was touched:

```
E       AssertionError: assert 0 == 1
E        +  where 0 = len([])
tests/services/scientific_read/test_search_reactions.py:150: AssertionError
1 failed, 14 deselected
```

**2. Tests added** — 20 service tests + 8 HTTP tests + 4 kinetics-search tests + 7 MCP tool tests, covering: `contains` with only reactants; only products; both sides against a larger reaction; `exact` still exact; `match=exact` reproducing the old result for a full query; `exact` still refusing a one-sided query (by explicit request, not by accident); set-not-multiset in **both** directions; `exact` *does* count stoichiometry; `direction` × `match` composition across `forward`/`reverse`/`either` for both modes; `matched_direction` under one-sided containment; a species appearing twice in a role; a query naming a species that does not exist; and the filter echo.

**No test was weakened, skipped, xfailed or deleted, and none needed rewriting to `match=exact`.** Every pre-existing test was checked against the new default and passes unchanged, because each supplies both sides with the complete species list — for which containment and equality agree. `test_direction_forward_excludes_reverse_match`, `test_direction_either_matches_in_either_orientation`, `test_direction_either_forward_match_reports_forward` and `test_match_with_two_reactants_and_two_products` are the ones that could plausibly have flipped; they were re-run and did not.

**3. Mutation testing — four landed, all four killed.** Each was applied to the working tree, confirmed present in `git diff`, run, then restored and the file checksummed back to `ec5dd95c6ffe46dae8085e73f3eba33c`.

| # | Mutation | Result |
|---|---|---|
| 1 | `set(queried).issubset(stored)` → multiset containment via `Counter` — **aimed at the set-vs-multiset choice** | **killed** by `test_contains_is_set_not_multiset_query_names_more` (1 failed, 47 passed) |
| 2 | `_matched_direction` hard-codes `ReactionMatchMode.exact` instead of honouring `match` | **killed** by `test_contains_either_reports_forward_for_a_one_sided_forward_match` (1 failed, 63 passed) |
| 3 | `direction=either` drops the reverse orientation | **killed** by 4 tests, including two pre-existing ones (4 failed, 60 passed) |
| 4 | default flipped `contains` → `exact` | **killed** by 10 tests (10 failed, 54 passed) |

Mutation 1 is the one that matters most: it is a *plausible* alternative implementation, not obvious sabotage, and exactly one test distinguishes it from the intended semantics.

**4. `conda run -n tckdb_env ruff check app tests scripts` from `backend/`** — `All checks passed!`. `ruff format` was not run on any file (it is excluded repo-wide; naming a file overrides the exclusion). Formatting is by hand.

**5. The three PR gates, exit codes captured with `$?`, not read off a pipe:**

```
SCIENTIFIC_EXIT=0    2126 passed in 183.12s
API_EXIT=0           3145 passed in 301.48s
REST_EXIT=0          4891 passed, 14 skipped in 143.64s
```

The API gate is worth a note: it **failed first** (`API_EXIT=1`), on `test_openapi_matches_golden`, because a docstring was re-wrapped after the golden had been regenerated. The golden was regenerated again and the gate re-run to `API_EXIT=0`. Recording that because it is evidence the snapshot test is not vacuous — it caught a one-line whitespace drift in a 70,000-line file.

Also run: `integrations/mcp` 587 passed (was 578), `clients/python` 1373 passed, `backend/tests/scripts/` 576 passed, `check_package_version_bump.py` clean.

## Reported, deliberately not fixed here: non-canonical SMILES

The brief asked whether `_resolve_smiles_to_species_ids` doing `Species.smiles.in_(smiles_list)` — a raw string comparison — is a second instance of the same silent-wrong-answer pattern.

**It is a real defect of the same family, but it is not specific to this endpoint, and fixing it only here would make things worse.** Evidence:

- The **write path canonicalizes**: `species_resolution.py:99` calls `canonical_species_identity()`, which is `Chem.MolToSmiles(bare, canonical=True)`, and stores that. So `species.smiles` is always RDKit-canonical, and a caller's non-canonical-but-equivalent SMILES compared as a raw string against it silently resolves to nothing.
- Combined with `reactions.py:149-152`, one unrecognised SMILES among three reactants short-circuits the **whole** request to an empty response. So "one typo" and "no such reaction" are indistinguishable to the caller — the same shape of wrong answer as the bug this PR fixes.
- **But every identity-search read surface does the same thing**: `/scientific/species/search` (`species.py:266`, raw `==`), `/scientific/thermo/search` and `/scientific/species-calculations/search` (both delegate into species search), the network-kinetics `source_smiles`/`sink_smiles` filters, and legacy `GET /api/v1/species`. Reaction search is not an outlier. Notably `species.py:298` already uses `mol_from_smiles` for the `formula` filter, so that endpoint knows the cartridge exists and does not apply it to `smiles`.
- The surfaces that *do* canonicalize are `/species/structure-search` (RDKit cartridge) and every `/lookup/*` route (`lookup.py:481-509`, `:645`, `:897`). So two functions in this repo solve the identical problem with opposite policies.

**Decision: follow-up PR, not this one.** Three reasons. (a) Scope — a correct fix changes six endpoints, and doing one of them makes the surface *more* inconsistent than it is today, not less. (b) It would break the existing test suite wholesale: the reaction-search fixtures use non-molecule placeholder strings (`"A1"`, `"CT_A"`, `"ROFF_B"`) that RDKit cannot parse at all, so canonicalization would have to land together with a fixture rewrite across `tests/services/scientific_read/`. (c) The obvious fix is subtly wrong: copying `lookup.py`'s InChIKey match would trade a false-negative for a false-positive, because InChIKey is isotope- and spin-blind by design and would over-match across singlet/triplet states. The right shape is `species_resolution.py`'s — canonicalize the input, then match the `(smiles, charge, multiplicity)` triple — and this endpoint's request schema carries no per-participant charge or multiplicity today, so that is a schema question, not a one-line change.

There is also **no regression guard in either direction**: nothing pins the current raw-match behaviour as intentional, and nothing would catch canonicalization being added. The follow-up should start there.

## Nothing in the brief proved false

The defect, the line numbers, the live measurements, the MCP allowlist requirement and the `curl`-glob aside were all confirmed as described. Two things the brief did not mention and that this PR handles: `_matched_direction` needed the same fix (see above), and `/scientific/kinetics/search` shares the defect through delegation.

One dangling reference found while checking docstrings, pre-existing and untouched: `docs/specs/read_api_mvp.md` is cited by the service docstrings, the published OpenAPI description, and `clients/python/README.md:293`, and **does not exist** in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEMrWcGRqbAVoh1Cn3TJ9D
