### PR TITLE
Make tckdb-mcp report the version it actually is

### DIFF
--- a/integrations/mcp/src/tckdb_mcp/__init__.py
+++ b/integrations/mcp/src/tckdb_mcp/__init__.py
@@ -7,4 +7,4 @@ It never queries Postgres directly and never imports the backend.
 See ``docs/specs/mcp_readonly_integration.md`` for the full design.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
## In plain language

A Python package carries its version number in two places: `pyproject.toml` (what the packaging tools read) and sometimes `__version__` in the code (what the program reports about itself). For `tckdb-mcp` those two had drifted apart — the metadata said `0.1.1`, the package said `0.1.0`.

Anything asking the running package what version it is got the wrong answer.

## How it happened, and why nothing caught it

I introduced it. #228 needed a new field name in the MCP server's search allowlist, which makes `tckdb-mcp` a changed distributed package, so the repo's guard required a version bump. I bumped `pyproject.toml` and not `__init__.py`.

The guard reads `pyproject.toml` only — correctly, since that is what it exists to protect (two branches claiming one version number). It has no view of a second copy of the string.

Measured across the three packages, `tckdb-mcp` is the only one that declares a version twice:

| package | `pyproject.toml` | `__version__` |
|---|---|---|
| `tckdb-mcp` | `0.1.1` | `0.1.0` ← drifted |
| `tckdb-client` | `0.53.0` | *not declared* |
| `tckdb-schemas` | `0.35.1` | *not declared* |

So this is one package's local convention rather than a house pattern, which is why no test pairs them.

## What this changes

One line. `__version__` becomes `0.1.1`, matching the metadata.

## What this deliberately does not do

**No guard is added.** A test pairing the two strings would cover exactly one package, and the better fix is to stop having two strings: derive `__version__` from `importlib.metadata.version("tckdb-mcp")` so drift is impossible by construction. That changes what the package does at import time — including its behaviour when running from a source tree rather than an install — so it belongs in its own change with its own testing, not folded into a correction.

Flagged here so the option is on the record rather than lost.

## Impact

No schema change, no migration, no new environment variable, no API change. No version bump is required *for this PR* — `tckdb-mcp` is already at `0.1.1` from #228, and this makes the package agree with it.

## Verification

`grep` confirms both files now read `0.1.1`. `backend/scripts/check_package_version_bump.py` reports OK against the merge base. No behavioural test exists or is added, because the change is a literal string in package metadata.