### PR TITLE
Search reactions, and stop curl globbing a SMILES

### DIFF
--- a/backend/app/api/landing.py
+++ b/backend/app/api/landing.py
@@ -12,6 +12,25 @@ end dressed as an introduction. The hero is now a search box that
 queries this deployment's own public read API and renders the records
 it gets back, so the first thing a visitor does is get real data out.
 
+There are two such searches -- species and reactions -- behind a
+switch rather than stacked, because a reader who wants the second
+should not have to scroll past a page of the first one's results to
+find it. The switch is built by the script; with scripting off both
+panels are simply on the page, each under its own heading, each a
+working ``<form method="get">``.
+
+A reaction query is a **set per side**, and that governs the design of
+the whole reaction control. ``?reactants=A&reactants=B`` asks for the
+reactions whose reactants include both A and B; ``?reactants=A,B``
+asks for a species whose name is the three characters ``A,B``, which
+is not an error and matches nothing -- the worst answer an API can
+give. So no part of this page ever holds a side as one joined string:
+the markup is one ``<input>`` per species, the add button appends
+another input, and both the script's URL builder and
+:func:`reaction_query` emit one parameter per element. The
+``<noscript>`` forms carry repeated same-named inputs, which a plain
+HTML form submits as repeated parameters with no script at all.
+
 Leading somewhere is also a claim about where. Every product a result
 has expands *in place* into the few fields that say what is in it,
 rather than navigating to the nested JSON document the endpoint
@@ -131,6 +150,47 @@ SEARCH_PLACEHOLDERS = (
     ("smiles", "[OH]"),
     ("inchi_key", "WCYWZMWISLQXQU-UHFFFAOYSA-N"),
 )
+
+#: The other read endpoint the hero searches. Public, no key, same
+#: origin, exactly like the species one.
+REACTION_SEARCH_PATH = "/api/v1/scientific/reactions/search"
+
+#: The two sides of a reaction search, as ``(query parameter, label,
+#: singular noun)``. Both are **repeated** parameters: the endpoint
+#: reads ``?reactants=A&reactants=B`` as the set {A, B} and
+#: ``?reactants=A,B`` as one species literally named ``A,B``, which
+#: matches nothing. Every URL this page builds -- in the markup, in the
+#: script and in the ``curl`` example -- therefore emits one parameter
+#: per species and never joins them.
+REACTION_SIDES = (
+    ("reactants", "Reactants", "Reactant"),
+    ("products", "Products", "Product"),
+)
+
+#: What the reaction boxes are pre-filled with. Two-sided on purpose:
+#: it returns records, it shows the shape of the question, and it means
+#: the plain form has no empty field to submit (see
+#: ``REACTION_SIDES`` and the ``required`` attributes in the template).
+SEED_REACTANTS = ("NN",)
+SEED_PRODUCTS = ("[H][H]",)
+
+#: Offered under the reaction boxes and again in its empty state, as
+#: ``(reactants, products)``. The middle one constrains only products
+#: and carries two of them, so the example a reader is most likely to
+#: click is itself the repeated-parameter form.
+REACTION_EXAMPLES = (
+    (("NN",), ()),
+    ((), ("[H][H]", "N=N")),
+    (("[NH2]", "[NH2]"), ()),
+)
+
+#: How many reaction rows the script renders before handing off to the
+#: raw document. One chemical reaction can have many entries -- the
+#: same equation deposited by several submissions -- so an uncapped
+#: render answers a landing-page search with a column of near-identical
+#: cards. The count above them is the endpoint's own total, so the cap
+#: shortens the reading and never the answer.
+REACTION_RENDER_LIMIT = 10
 
 #: The geometry shown in the worked example, and the input the test
 #: feeds back through the real checker. Carbon dioxide, collinear along
@@ -400,7 +460,20 @@ noscript { display: block; margin-top: 1rem; }
   background: var(--surface);
 }
 .fallback p { margin: 0 0 0.6rem; font-size: 0.9375rem; }
-.fallback form { display: inline-flex; gap: 0.35rem; margin: 0 0.5rem 0.4rem 0; }
+/*
+ * ``max-width`` and ``flex-wrap`` because a fallback form can carry
+ * two fields: two inputs at their default size plus a button is wider
+ * than a 360px screen, and an <input> does not shrink below its size
+ * attribute unless it is told it may.
+ */
+.fallback form {
+  display: inline-flex;
+  flex-wrap: wrap;
+  max-width: 100%;
+  gap: 0.35rem;
+  margin: 0 0.5rem 0.4rem 0;
+}
+.fallback input { flex: 1 1 8rem; min-width: 0; }
 .fallback input, .fallback button {
   font-family: var(--mono);
   font-size: var(--fs-data);
@@ -408,6 +481,133 @@ noscript { display: block; margin-top: 1rem; }
   border: 1px solid var(--rule);
   background: var(--paper);
   color: var(--ink);
+}
+.fallback-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0.6rem 0 0.2rem;
+}
+
+/* ---- the species / reactions switch ---- */
+/*
+ * Two searches, one hero. Stacking them would push the second below a
+ * page of the first one's results, and the second is the one this
+ * deployment was most recently asked for; the switch keeps both at the
+ * top and the page the length it was.
+ *
+ * The buttons ship ``hidden`` and the script unhides them, because a
+ * tab that cannot change what is displayed is worse than no tab. With
+ * scripting off there is no switch and both panels are simply on the
+ * page, each under its own heading, each a working form.
+ */
+.modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 1.1rem 0 0;
+}
+/*
+ * ``display: flex`` above beats the user agent's ``[hidden]`` rule, so
+ * without this the switch would be visible to exactly the readers who
+ * cannot use it.
+ */
+.modes[hidden] { display: none; }
+.mode {
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  padding: 0.5rem 1rem;
+  min-height: 2.5rem;
+  cursor: pointer;
+  border: 1.5px solid var(--rule);
+  background: var(--surface);
+  color: var(--phase-pos);
+}
+.mode[aria-selected="true"] {
+  background: var(--phase-pos);
+  color: var(--surface);
+  border-color: var(--phase-pos);
+}
+.search-panel + .search-panel { margin-top: 2rem; }
+
+/* ---- reaction search ---- */
+/*
+ * One input per species, never one input holding several. The endpoint
+ * reads repeated ``reactants=`` as a set and a comma-joined string as
+ * one species named after the whole string, so the control that
+ * collects them is a list of fields and the "add" button appends
+ * another real field rather than a separator to a shared box.
+ */
+.rxn-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.5rem 0.75rem;
+}
+.rxn-side { flex: 1 1 11rem; min-width: 0; }
+.rxn-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 0.3rem;
+}
+.rxn-inputs { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.rxn-inputs input { flex: 1 1 7rem; }
+/*
+ * Narrow first: the two sides cannot sit side by side inside 360px, so
+ * the arrow takes its own centred line between them rather than being
+ * squeezed onto the end of the reactants row, where it reads as a
+ * label for that box instead of as the relation between two.
+ */
+.rxn-arrow {
+  flex: 1 0 100%;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: var(--fs-data);
+  color: var(--muted);
+  padding: 0.1rem 0;
+}
+@media (min-width: 34rem) {
+  .rxn-arrow {
+    flex: 0 0 auto;
+    text-align: left;
+    padding: 0 0 0.7rem;
+  }
+}
+/*
+ * Higher specificity than ``.search button`` on purpose -- that rule is
+ * the big filled submit button, and this one is a quiet secondary
+ * control sitting under the fields it adds to.
+ */
+.search .rxn-add {
+  margin-top: 0.4rem;
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.3rem 0.55rem;
+  min-height: 0;
+  border: 1px solid var(--rule);
+  background: var(--paper);
+  color: var(--phase-pos);
+}
+.search .rxn-add:hover { border-color: var(--phase-pos); }
+.equation {
+  font-family: var(--mono);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
 }
 
 /* ---- results ---- */
@@ -840,11 +1040,21 @@ footer p { max-width: none; margin: 0; }
 <main id="main">
 
   <section class="hero" aria-labelledby="search-heading">
-    <h2 id="search-heading">Search species</h2>
+    <h2 id="search-heading">Search</h2>
     <p class="note">
       Records under review are served, not withheld; every result says how
       far it has been checked.
     </p>
+
+    <div class="modes" id="modes" hidden>
+      <button type="button" class="mode" id="mode-species"
+              aria-controls="panel-species">Species</button>
+      <button type="button" class="mode" id="mode-reactions"
+              aria-controls="panel-reactions">Reactions</button>
+    </div>
+
+    <div class="search-panel" id="panel-species" aria-labelledby="title-species">
+    <h3 class="panel-title" id="title-species">Species</h3>
 
     <form id="search-form" class="search" method="get" action="__SEARCH_PATH__">
       <div class="search-row">
@@ -890,6 +1100,62 @@ __EXAMPLE_CHIPS__
         straight to the API's JSON.
       </p>
     </div>
+    </div>
+
+    <div class="search-panel" id="panel-reactions" aria-labelledby="title-reactions">
+    <h3 class="panel-title" id="title-reactions">Reactions</h3>
+    <p class="note">
+      Either side alone works. <em>Matched in reverse</em> is the equation
+      read right to left.
+    </p>
+
+    <form id="rxn-form" class="search" method="get" action="__REACTION_SEARCH_PATH__">
+      <div class="rxn-row">
+        <div class="rxn-side" role="group" aria-labelledby="rxn-reactants-label">
+          <span class="rxn-label" id="rxn-reactants-label">Reactants</span>
+          <div class="rxn-inputs" id="rxn-reactants">
+__SEED_REACTANT_INPUTS__
+          </div>
+          <button type="button" class="rxn-add" id="rxn-add-reactants" hidden>+ reactant</button>
+        </div>
+        <span class="rxn-arrow" aria-hidden="true">&lt;=&gt;</span>
+        <div class="rxn-side" role="group" aria-labelledby="rxn-products-label">
+          <span class="rxn-label" id="rxn-products-label">Products</span>
+          <div class="rxn-inputs" id="rxn-products">
+__SEED_PRODUCT_INPUTS__
+          </div>
+          <button type="button" class="rxn-add" id="rxn-add-products" hidden>+ product</button>
+        </div>
+        <button type="submit">Search</button>
+      </div>
+    </form>
+
+    <p class="examples" id="rxn-examples">
+      <span>Try</span>
+__REACTION_EXAMPLE_CHIPS__
+    </p>
+
+    <noscript>
+      <div class="fallback">
+        <p>
+          JavaScript is off, so the form above submits as a plain form and
+          needs both sides filled. These ask about one side, and about two
+          species on one side:
+        </p>
+__REACTION_FALLBACK_FORMS__
+      </div>
+    </noscript>
+
+    <div id="rxn-results" class="results" aria-live="polite">
+      <!--
+        Shorter than the species one on purpose: the reader who needs
+        the "without JavaScript this goes to the API's JSON" sentence
+        is the reader whose browser is about to render the
+        ``<noscript>`` block above, which says it.
+      -->
+      <p class="results-status">Results land here.</p>
+    </div>
+    </div>
   </section>
 
   <section aria-labelledby="quickstart-heading">
@@ -899,7 +1165,13 @@ __EXAMPLE_CHIPS__
       open; depositing needs an account.
     </p>
     <pre class="command"><code>TCKDB=<span id="curl-origin">__ORIGIN_PLACEHOLDER__</span>
-curl -s "$TCKDB__SEARCH_PATH__?formula=CH3"</code></pre>
+curl -sg "$TCKDB__SEARCH_PATH__?smiles=[OH]"
+curl -sg "$TCKDB__REACTION_SEARCH_PATH__?products=[H][H]&amp;products=N=N"</code></pre>
+    <p class="note">
+      <code>-g</code> so bracketed SMILES like <code>[OH]</code> are not read
+      as shell globs, and one <code>products=</code> per species: a
+      comma-joined list is one species name, and matches nothing.
+    </p>
     <p>__API-REFERENCE__</p>
     <p>
       A Python client, <code>tckdb-client</code>, handles auth, retries and
@@ -994,14 +1266,28 @@ __HERO_SPECTRUM__
   var out = doc.getElementById("results");
   if (!form || !input || !picker || !out) { return; }
 
+  var rxnForm = doc.getElementById("rxn-form");
+  var rxnOut = doc.getElementById("rxn-results");
+
   var SEARCH = "__SEARCH_PATH__";
   var ENTRY = "/api/v1/scientific/species-entries/";
   var THERMO = "/api/v1/scientific/thermo/search";
   var CONFORMERS = "/api/v1/scientific/conformers/search";
   var CALCULATIONS = "/api/v1/scientific/species-calculations/search";
+  var RXN_SEARCH = "__REACTION_SEARCH_PATH__";
+  var KINETICS = "/api/v1/scientific/reaction-entries/";
+  var TRANSITION_STATES = "/api/v1/scientific/transition-states/search";
 
   var PLACEHOLDERS = __PLACEHOLDERS_JSON__;
   var EXAMPLES = __EXAMPLES_JSON__;
+  var RXN_EXAMPLES = __REACTION_EXAMPLES_JSON__;
+  var RXN_LIMIT = __REACTION_RENDER_LIMIT__;
+  /* ``[[query parameter, singular noun], ...]``, in form order. */
+  var RXN_SIDES = __REACTION_SIDES_JSON__;
+  var SIDE_WORDS = {};
+  for (var sideIndex = 0; sideIndex < RXN_SIDES.length; sideIndex += 1) {
+    SIDE_WORDS[RXN_SIDES[sideIndex][0]] = RXN_SIDES[sideIndex][1];
+  }
   var REVIEW_WORDS = {
     approved: "approved",
     under_review: "under review",
@@ -1009,6 +1295,22 @@ __HERO_SPECTRUM__
     deprecated: "deprecated",
     rejected: "rejected"
   };
+  /*
+   * ``matched_direction`` says which way round the equation had to be
+   * read for the query to match it, and "reverse" is information a
+   * reader needs: their reactants are that reaction's products. It is
+   * on every row rather than only on the reverse ones, so that its
+   * absence never has to be interpreted.
+   */
+  var DIRECTION_WORDS = {
+    forward: "matched forward",
+    reverse: "matched in reverse",
+    either: "matched either way"
+  };
+  var MODES = [
+    ["mode-species", "panel-species", "title-species", function () {}],
+    ["mode-reactions", "panel-reactions", "title-reactions", submitRxn]
+  ];
 
   function make(tag, cls, text) {
     var node = doc.createElement(tag);
@@ -1532,6 +1834,367 @@ __HERO_SPECTRUM__
     });
   }
 
+  /*
+   * ---- reaction search ---------------------------------------------
+   *
+   * The same machinery as above, pointed at the other public search
+   * endpoint, with one difference that governs the whole design: a
+   * reaction query is a *set* per side. The endpoint reads repeated
+   * ``reactants=`` parameters as that set and reads
+   * ``?reactants=A,B`` as one species whose name is the six characters
+   * "A,B" -- a query that is not an error and matches nothing, which is
+   * the worst kind. So there is no place in this page where a side is
+   * ever a single joined string: the markup is one input per species,
+   * the add button appends another input, and rxnUrl emits one
+   * parameter per element.
+   */
+
+  function ask(url) {
+    return fetch(url, { headers: { "Accept": "application/json" } }).then(function (response) {
+      return response.json().then(function (body) {
+        return { ok: response.ok, status: response.status, body: body };
+      }, function () {
+        return { ok: false, status: response.status, body: null };
+      });
+    });
+  }
+
+  function trim(value) {
+    return String(value).replace(/^\\s+|\\s+$/g, "");
+  }
+
+  function rxnUrl(reactants, products, limit) {
+    var parts = [];
+    var i;
+    for (i = 0; i < reactants.length; i += 1) {
+      parts.push("reactants=" + encodeURIComponent(reactants[i]));
+    }
+    for (i = 0; i < products.length; i += 1) {
+      parts.push("products=" + encodeURIComponent(products[i]));
+    }
+    if (limit) { parts.push("limit=" + limit); }
+    /*
+     * No participant and no ref is a real 422 from the endpoint --
+     * missing_reaction_search_filter -- and asking for it is how the
+     * reader is told what the endpoint needs, in the endpoint's own
+     * words, instead of being second-guessed here.
+     */
+    if (!parts.length) { return RXN_SEARCH; }
+    return RXN_SEARCH + "?" + parts.join("&");
+  }
+
+  function rxnEntryUrl(ref) {
+    return RXN_SEARCH + "?reaction_entry_ref=" + encodeURIComponent(ref);
+  }
+
+  function sideBox(side) {
+    return doc.getElementById("rxn-" + side);
+  }
+
+  function sideValues(side) {
+    var nodes = sideBox(side).getElementsByTagName("input");
+    var values = [];
+    for (var i = 0; i < nodes.length; i += 1) {
+      var value = trim(nodes[i].value);
+      if (value) { values.push(value); }
+    }
+    return values;
+  }
+
+  function relabel(side) {
+    var nodes = sideBox(side).getElementsByTagName("input");
+    var word = SIDE_WORDS[side];
+    for (var i = 0; i < nodes.length; i += 1) {
+      nodes[i].setAttribute("aria-label", nodes.length === 1 ? word : word + " " + (i + 1));
+    }
+  }
+
+  function rxnField(side, value) {
+    var node = make("input");
+    node.type = "search";
+    node.name = side;
+    node.value = value || "";
+    node.setAttribute("autocomplete", "off");
+    node.setAttribute("autocapitalize", "off");
+    node.setAttribute("spellcheck", "false");
+    return node;
+  }
+
+  function setSide(side, values) {
+    var box = sideBox(side);
+    clear(box);
+    var list = values && values.length ? values : [""];
+    for (var i = 0; i < list.length; i += 1) {
+      box.appendChild(rxnField(side, list[i]));
+    }
+    relabel(side);
+  }
+
+  function addField(side) {
+    var node = rxnField(side, "");
+    sideBox(side).appendChild(node);
+    relabel(side);
+    node.focus();
+  }
+
+  function sidePhrase(word, values) {
+    return word + " " + values.join(" + ");
+  }
+
+  function rxnLabel(reactants, products) {
+    var parts = [];
+    if (reactants.length) { parts.push(sidePhrase("reactants", reactants)); }
+    if (products.length) { parts.push(sidePhrase("products", products)); }
+    return parts.join("; ");
+  }
+
+  function rxnChip(index) {
+    var pair = RXN_EXAMPLES[index];
+    var node = anchor(rxnUrl(pair[0], pair[1]), "chip rxn-chip", rxnLabel(pair[0], pair[1]));
+    node.setAttribute("data-example", String(index));
+    node.addEventListener("click", function (event) {
+      event.preventDefault();
+      applyExample(pair);
+    });
+    return node;
+  }
+
+  function rxnExampleList(intro) {
+    var node = make("p", "examples");
+    node.appendChild(make("span", null, intro));
+    for (var i = 0; i < RXN_EXAMPLES.length; i += 1) {
+      node.appendChild(rxnChip(i));
+    }
+    return node;
+  }
+
+  function kineticsView(record) {
+    var params = record.parameters || {};
+    var coverage = record.temperature_coverage || {};
+    var span = null;
+    if (coverage.record_min_k !== null && coverage.record_min_k !== undefined) {
+      span = fixed(coverage.record_min_k, 0) + "\\u2013" + fixed(coverage.record_max_k, 0, "K");
+    }
+    var prefactor = null;
+    if (params.A !== null && params.A !== undefined) {
+      prefactor = params.A_units ? params.A + " " + params.A_units : String(params.A);
+    }
+    return {
+      title: (record.model_kind || "kinetics") + " rate",
+      ref: record.kinetics_ref,
+      status: record.review ? record.review.status : null,
+      fields: [
+        ["pre-exponential A", prefactor],
+        ["temperature exponent n", params.n],
+        ["activation energy", fixed(params.Ea_kj_mol, 2, "kJ/mol")],
+        ["fitted over", span],
+        ["direction", record.direction],
+        ["origin", record.scientific_origin]
+      ]
+    };
+  }
+
+  function transitionStateView(record) {
+    var entry = record.transition_state_entry || {};
+    var state = record.transition_state || {};
+    var evidence = record.evidence_summary || {};
+    return {
+      title: state.label || "transition state",
+      ref: entry.transition_state_entry_ref,
+      status: entry.review ? entry.review.status : null,
+      fields: [
+        ["saddle point", entry.status],
+        ["charge", entry.charge],
+        ["multiplicity", entry.multiplicity],
+        ["calculations behind it", evidence.calculation_count]
+      ]
+    };
+  }
+
+  var RXN_SECTIONS = [
+    {
+      key: "kinetics",
+      label: "kinetics",
+      one: "kinetics record",
+      many: "kinetics records",
+      count: function (a) { return a.kinetics_count; },
+      shown: function (a) { return !!a.has_kinetics || !!a.kinetics_count; },
+      url: function (ref) { return KINETICS + encodeURIComponent(ref) + "/kinetics"; },
+      view: kineticsView
+    },
+    {
+      key: "transition-state",
+      label: "transition state",
+      one: "transition state",
+      many: "transition states",
+      shown: function (a) { return !!a.has_transition_state; },
+      url: function (ref) {
+        return TRANSITION_STATES + "?reaction_entry_ref=" + encodeURIComponent(ref);
+      },
+      view: transitionStateView
+    }
+  ];
+
+  function rxnRecordNode(record) {
+    var ref = record.reaction_entry_ref || "";
+    var availability = record.availability || {};
+    var node = make("article", "record");
+
+    var head = make("div", "record-head");
+    head.appendChild(make("span", "equation", record.equation || "(no equation)"));
+    head.appendChild(reviewBadge(record.review ? record.review.status : null));
+    node.appendChild(head);
+
+    var meta = make("p", "record-refs");
+    meta.appendChild(make("span", null,
+      DIRECTION_WORDS[record.matched_direction] || String(record.matched_direction)));
+    if (record.family) {
+      meta.appendChild(doc.createTextNode(" · "));
+      meta.appendChild(make("span", null, record.family));
+    }
+    meta.appendChild(doc.createTextNode(" · "));
+    meta.appendChild(make("span", null, ref));
+    meta.appendChild(doc.createTextNode(" · "));
+    meta.appendChild(anchor(rxnEntryUrl(ref), "raw-link", "this record as raw JSON"));
+    node.appendChild(meta);
+
+    var links = make("div", "entry-links");
+    var panels = make("div", "entry-details");
+    for (var i = 0; i < RXN_SECTIONS.length; i += 1) {
+      if (!RXN_SECTIONS[i].shown(availability)) { continue; }
+      var pair = disclosure(RXN_SECTIONS[i], ref, availability);
+      links.appendChild(pair.button);
+      panels.appendChild(pair.panel);
+    }
+    if (!links.firstChild) {
+      links.appendChild(make("span", "pill pill-none", "no kinetics or transition state yet"));
+    }
+    node.appendChild(links);
+    node.appendChild(panels);
+    return node;
+  }
+
+  function rxnEmptyNode(reactants, products) {
+    var node = make("div", "empty");
+    var asked = rxnLabel(reactants, products);
+    node.appendChild(make("p", null,
+      asked ? "Nothing matched " + asked + "." : "Nothing matched."));
+    node.appendChild(rxnExampleList("These return records:"));
+    return node;
+  }
+
+  function rxnRender(payload, reactants, products) {
+    var records = payload.records || [];
+    if (!records.length) {
+      rxnOut.appendChild(rxnEmptyNode(reactants, products));
+      return;
+    }
+    rxnOut.appendChild(summaryNode(payload));
+    for (var i = 0; i < records.length; i += 1) {
+      rxnOut.appendChild(rxnRecordNode(records[i]));
+    }
+    var pagination = payload.pagination || {};
+    if (pagination.total > records.length) {
+      var more = make("p", "results-status", "Showing the first page.");
+      more.appendChild(doc.createTextNode(" "));
+      more.appendChild(anchor(rxnUrl(reactants, products), "raw-link",
+        "Open the full response as raw JSON"));
+      rxnOut.appendChild(more);
+    }
+  }
+
+  function runRxn(reactants, products) {
+    rxnOut.setAttribute("aria-busy", "true");
+    clear(rxnOut);
+    rxnOut.appendChild(make("p", "results-status", "Searching\\u2026"));
+    ask(rxnUrl(reactants, products, RXN_LIMIT)).then(function (result) {
+      clear(rxnOut);
+      if (result.ok) {
+        rxnRender(result.body || {}, reactants, products);
+      } else {
+        rxnOut.appendChild(failureNode(result.status, result.body));
+      }
+    }, function () {
+      clear(rxnOut);
+      var node = make("div", "failure");
+      node.appendChild(make("p", "failure-detail",
+        "The browser could not reach this deployment's API."));
+      rxnOut.appendChild(node);
+    }).then(function () {
+      rxnOut.setAttribute("aria-busy", "false");
+    });
+  }
+
+  function submitRxn() {
+    runRxn(sideValues("reactants"), sideValues("products"));
+  }
+
+  function applyExample(pair) {
+    setSide("reactants", pair[0]);
+    setSide("products", pair[1]);
+    runRxn(pair[0], pair[1]);
+  }
+
+  /*
+   * ---- the species / reactions switch -------------------------------
+   *
+   * Built here rather than in the markup because a tab control that
+   * cannot change what is shown is a lie. With scripting off the
+   * buttons stay hidden and both panels stay on the page, each under
+   * its own heading and each a working form; this promotes them to a
+   * tablist and takes the now-duplicated headings out.
+   */
+  function setupModes() {
+    var modes = doc.getElementById("modes");
+    if (!modes) { return; }
+    var tabs = [];
+    var panels = [];
+    var i;
+    for (i = 0; i < MODES.length; i += 1) {
+      var tab = doc.getElementById(MODES[i][0]);
+      var panel = doc.getElementById(MODES[i][1]);
+      if (!tab || !panel) { return; }
+      tabs.push(tab);
+      panels.push(panel);
+    }
+    var loaded = [true, false];
+
+    function select(index, focus) {
+      for (var j = 0; j < tabs.length; j += 1) {
+        var on = j === index;
+        tabs[j].setAttribute("aria-selected", on ? "true" : "false");
+        tabs[j].setAttribute("tabindex", on ? "0" : "-1");
+        panels[j].hidden = !on;
+      }
+      if (focus) { tabs[index].focus(); }
+      if (!loaded[index]) {
+        loaded[index] = true;
+        MODES[index][3]();
+      }
+    }
+
+    modes.hidden = false;
+    modes.setAttribute("role", "tablist");
+    for (i = 0; i < tabs.length; i += 1) {
+      tabs[i].setAttribute("role", "tab");
+      panels[i].setAttribute("role", "tabpanel");
+      panels[i].setAttribute("tabindex", "0");
+      panels[i].setAttribute("aria-labelledby", tabs[i].id);
+      var title = doc.getElementById(MODES[i][2]);
+      if (title) { title.hidden = true; }
+      (function (index) {
+        tabs[index].addEventListener("click", function () { select(index, false); });
+        tabs[index].addEventListener("keydown", function (event) {
+          if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") { return; }
+          event.preventDefault();
+          var step = event.key === "ArrowRight" ? 1 : tabs.length - 1;
+          select((index + step) % tabs.length, true);
+        });
+      })(i);
+    }
+    select(0, false);
+  }
+
   function syncField() {
     input.name = picker.value;
     input.setAttribute("placeholder", PLACEHOLDERS[picker.value] || "");
@@ -1565,6 +2228,46 @@ __HERO_SPECTRUM__
         });
       })(links[i]);
     }
+  }
+
+  if (rxnForm && rxnOut) {
+    /*
+     * The markup marks every reaction field ``required`` so that a
+     * plain no-script submit can never send ``products=`` empty --
+     * which the endpoint AND-combines and answers with nothing. The
+     * script skips blank fields itself and must therefore let a side
+     * be cleared, so it takes the browser's validation off the form it
+     * has just taken over.
+     */
+    rxnForm.noValidate = true;
+    rxnForm.addEventListener("submit", function (event) {
+      event.preventDefault();
+      submitRxn();
+    });
+
+    for (var s = 0; s < RXN_SIDES.length; s += 1) {
+      (function (name) {
+        var button = doc.getElementById("rxn-add-" + name);
+        if (!button) { return; }
+        button.hidden = false;
+        button.addEventListener("click", function () { addField(name); });
+      })(RXN_SIDES[s][0]);
+    }
+
+    var rxnSeeded = doc.getElementById("rxn-examples");
+    if (rxnSeeded) {
+      var rxnLinks = rxnSeeded.getElementsByTagName("a");
+      for (var r = 0; r < rxnLinks.length; r += 1) {
+        (function (node) {
+          node.addEventListener("click", function (event) {
+            event.preventDefault();
+            applyExample(RXN_EXAMPLES[Number(node.getAttribute("data-example"))]);
+          });
+        })(rxnLinks[r]);
+      }
+    }
+
+    setupModes();
   }
 
   var origin = doc.getElementById("curl-origin");
@@ -1606,6 +2309,140 @@ def _example_chips() -> str:
             f"{_html_escape(value)}</a>"
         )
     return "\n".join(lines)
+
+
+def reaction_query(reactants: tuple[str, ...], products: tuple[str, ...]) -> str:
+    """The reaction-search URL for one query, as repeated parameters.
+
+    One ``reactants=`` per reactant and one ``products=`` per product.
+    Never ``reactants=A,B``: the endpoint takes each value as one whole
+    species name, so a joined list asks for a species called ``A,B``,
+    which is not an error and matches nothing.
+
+    Used for the example links in the markup, which have to run the
+    same query with scripting off that the script runs with it on.
+    """
+    parts = [f"reactants={_url_quote(value)}" for value in reactants]
+    parts += [f"products={_url_quote(value)}" for value in products]
+    if not parts:
+        return REACTION_SEARCH_PATH
+    return REACTION_SEARCH_PATH + "?" + "&".join(parts)
+
+
+def reaction_label(reactants: tuple[str, ...], products: tuple[str, ...]) -> str:
+    """How one reaction query reads on a chip: ``products A + B``.
+
+    The ``+`` here is a separator a person reads, never one that
+    reaches a URL; :func:`reaction_query` is what builds the URL. The
+    script has the same function so a chip and the empty state label
+    the same query the same way.
+    """
+    parts = []
+    if reactants:
+        parts.append("reactants " + " + ".join(reactants))
+    if products:
+        parts.append("products " + " + ".join(products))
+    return "; ".join(parts)
+
+
+def _side_word(side: str) -> str:
+    """The singular noun for one side, from :data:`REACTION_SIDES`."""
+    return next(word for key, _, word in REACTION_SIDES if key == side)
+
+
+def _reaction_inputs(side: str, values: tuple[str, ...], indent: str) -> str:
+    """One ``<input>`` per species, all ``required``.
+
+    ``required`` is what makes the no-script path correct rather than
+    merely present: the browser refuses to submit a blank field, so a
+    plain GET from this form can never carry ``products=`` with nothing
+    after it -- which the endpoint reads as a filter that matches
+    nothing rather than as an absent one. The script removes the
+    constraint when it takes the form over, because it can skip blank
+    fields properly.
+    """
+    word = _side_word(side)
+    lines = []
+    for index, value in enumerate(values, start=1):
+        label = word if len(values) == 1 else f"{word} {index}"
+        lines.append(
+            f'{indent}<input name="{side}" type="search" value="{_html_escape(value)}"'
+            f' required aria-label="{label}"'
+            ' autocomplete="off" autocapitalize="off" spellcheck="false">'
+        )
+    return "\n".join(lines)
+
+
+def _reaction_example_chips() -> str:
+    lines = []
+    for index, (reactants, products) in enumerate(REACTION_EXAMPLES):
+        href = _html_escape(reaction_query(reactants, products))
+        label = _html_escape(reaction_label(reactants, products))
+        lines.append(
+            f'      <a class="chip rxn-chip" data-example="{index}" href="{href}">'
+            f"{label}</a>"
+        )
+    return "\n".join(lines)
+
+
+def _pair_placeholders(side: str) -> tuple[str, str]:
+    """Two real values for the two-deep fallback form's hints.
+
+    Taken from whichever offered example really carries two species on
+    that side, so the hint is a query that returns records rather than
+    the same value typed twice.
+    """
+    for reactants, products in REACTION_EXAMPLES:
+        values = reactants if side == "reactants" else products
+        if len(values) == 2:
+            return (values[0], values[1])
+    seed = SEED_REACTANTS if side == "reactants" else SEED_PRODUCTS
+    return (seed[0], seed[0])
+
+
+def _reaction_fallback_forms() -> str:
+    """The scripting-off reaction forms: one side each, one and two deep.
+
+    Separate forms per shape for the same reason the species fallback
+    has one form per identifier -- an empty sibling parameter is not an
+    absent one, and a single form covering every shape would always
+    submit some field blank. Every input is ``required``, so the
+    browser will not let one through empty.
+
+    The two-deep forms are the point of this block: a plain HTML form
+    emits repeated same-named inputs as repeated query parameters, so
+    ``reactants=A&reactants=B`` is reachable with no script at all.
+    """
+    blocks = []
+    for side, plural_word, word in REACTION_SIDES:
+        seed = SEED_REACTANTS if side == "reactants" else SEED_PRODUCTS
+        placeholder = _html_escape(seed[0])
+        pair = _pair_placeholders(side)
+        singles = (
+            f'        <span class="fallback-label">one {word.lower()}</span>\n'
+            f'        <form method="get" action="{REACTION_SEARCH_PATH}">\n'
+            f'          <label class="sr-only" for="fallback-{side}">{word}</label>\n'
+            f'          <input id="fallback-{side}" name="{side}" type="search"'
+            f' placeholder="{placeholder}" required>\n'
+            "          <button type=\"submit\">Search</button>\n"
+            "        </form>"
+        )
+        pair_inputs = "\n".join(
+            f'          <label class="sr-only" for="fallback-{side}-{n}">{word} {n}</label>\n'
+            f'          <input id="fallback-{side}-{n}" name="{side}" type="search"'
+            f' placeholder="{_html_escape(pair[n - 1])}" required>'
+            for n in (1, 2)
+        )
+        pairs = (
+            f'        <span class="fallback-label">two {plural_word.lower()}</span>\n'
+            f'        <form method="get" action="{REACTION_SEARCH_PATH}">\n'
+            f"{pair_inputs}\n"
+            "          <button type=\"submit\">Search</button>\n"
+            "        </form>"
+        )
+        blocks.append(singles)
+        blocks.append(pairs)
+    return "\n".join(blocks)
 
 
 def hero_atom_lines() -> tuple[str, ...]:
@@ -1680,6 +2517,21 @@ def _json_pairs(pairs: tuple[tuple[str, str], ...]) -> str:
     return json.dumps([list(pair) for pair in pairs])
 
 
+def _reaction_examples_json() -> str:
+    """The example queries as ``[[reactants, products], ...]``.
+
+    Lists, not a joined string, all the way from here into the script:
+    the shape the page carries a multi-species side in is the shape it
+    sends, so there is nowhere for a comma to be introduced.
+    """
+    return json.dumps([[list(reactants), list(products)] for reactants, products in REACTION_EXAMPLES])
+
+
+def _reaction_sides_json() -> str:
+    """``[[query parameter, singular noun], ...]`` in form order."""
+    return json.dumps([[side, word] for side, _, word in REACTION_SIDES])
+
+
 def _placeholders_json() -> str:
     """Per-identifier ``placeholder`` text, keyed by query parameter.
 
@@ -1724,6 +2576,23 @@ def render_landing_page(*, api_reference_path: str | None) -> str:
     return (
         _PAGE_TEMPLATE.replace("__DOCS_URL__", DOCS_URL)
         .replace("__REPO_URL__", REPO_URL)
+        # Reaction placeholders first: every one of them is a longer
+        # spelling of a species placeholder, and substituting the short
+        # name first would eat the tail of the long one.
+        .replace("__REACTION_SEARCH_PATH__", REACTION_SEARCH_PATH)
+        .replace("__REACTION_EXAMPLE_CHIPS__", _reaction_example_chips())
+        .replace("__REACTION_EXAMPLES_JSON__", _reaction_examples_json())
+        .replace("__REACTION_FALLBACK_FORMS__", _reaction_fallback_forms())
+        .replace("__REACTION_RENDER_LIMIT__", str(REACTION_RENDER_LIMIT))
+        .replace("__REACTION_SIDES_JSON__", _reaction_sides_json())
+        .replace(
+            "__SEED_REACTANT_INPUTS__",
+            _reaction_inputs("reactants", SEED_REACTANTS, " " * 12),
+        )
+        .replace(
+            "__SEED_PRODUCT_INPUTS__",
+            _reaction_inputs("products", SEED_PRODUCTS, " " * 12),
+        )
         .replace("__SEARCH_PATH__", SPECIES_SEARCH_PATH)
         .replace("__FIELD_OPTIONS__", _field_options(SEED_FIELD))
         .replace("__EXAMPLE_CHIPS__", _example_chips())
@@ -1771,14 +2640,22 @@ __all__ = [
     "HERO_TRUE_FREQUENCIES",
     "HERO_XYZ",
     "ORIGIN_PLACEHOLDER",
+    "REACTION_EXAMPLES",
+    "REACTION_RENDER_LIMIT",
+    "REACTION_SEARCH_PATH",
+    "REACTION_SIDES",
     "REDOC_PATH",
     "REPO_URL",
     "SEARCH_EXAMPLES",
     "SEARCH_FIELDS",
     "SEED_FIELD",
+    "SEED_PRODUCTS",
+    "SEED_REACTANTS",
     "SEED_VALUE",
     "SPECIES_SEARCH_PATH",
     "hero_atom_lines",
     "landing_router",
+    "reaction_label",
+    "reaction_query",
     "render_landing_page",
 ]

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -264,7 +264,7 @@ class TestLandingPageResponse:
         """
         with client_factory() as c:
             body = c.get("/").text
-        prose = re.sub(r"<style>.*?</style>", "", body, flags=re.DOTALL)
+        prose = re.sub(r"<style>.*?</style>", "", body, flags=re.DOTALL | re.IGNORECASE)
         prose = re.sub(r"<[^>]+>", " ", prose)
         forbidden = re.compile(
             r"\b\d[\d,]*\s*(records?|species|reactions?|calculations?|users?|"
@@ -313,7 +313,7 @@ class TestLandingPageIsSelfContained:
     def test_no_stylesheet_import_or_url_reaches_off_host(self, client_factory):
         with client_factory() as c:
             body = c.get("/").text
-        style = re.search(r"<style>(.*?)</style>", body, flags=re.DOTALL)
+        style = re.search(r"<style>(.*?)</style>", body, flags=re.DOTALL | re.IGNORECASE)
         assert style is not None
         css = style.group(1)
         assert "@import" not in css
@@ -742,8 +742,8 @@ class TestReactionSearchTakesASetPerSide:
             literal for literal in re.findall(r'"([^"]*)"', script)
             if "missing_reaction_search_filter" in literal
         ], "the code is the endpoint's to state, not this page's to guess"
-        prose = re.sub(r"<script>.*?</script>", "", page, flags=re.DOTALL)
-        prose = re.sub(r"<style>.*?</style>", "", prose, flags=re.DOTALL)
+        prose = re.sub(r"<script>.*?</script>", "", page, flags=re.DOTALL | re.IGNORECASE)
+        prose = re.sub(r"<style>.*?</style>", "", prose, flags=re.DOTALL | re.IGNORECASE)
         assert "missing_reaction_search_filter" not in prose
 
     def test_the_render_is_capped_and_never_lies_about_the_total(self, script):
@@ -807,7 +807,7 @@ class TestBothSearchesSurviveWithoutTheSwitch:
         whole document scrolled sideways, which is the one thing the
         narrow layout is not allowed to do.
         """
-        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL).group(1)
+        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL | re.IGNORECASE).group(1)
         form_rule = re.search(r"\.fallback form \{([^}]*)\}", css)
         assert form_rule is not None
         assert "flex-wrap: wrap" in form_rule.group(1)
@@ -827,7 +827,7 @@ class TestReviewStateIsInformation:
         put a warning on the ordinary case, which is both wrong and the
         opposite of what the review model is for.
         """
-        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL).group(1)
+        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL | re.IGNORECASE).group(1)
         flagged = set()
         for selectors, body in re.findall(r"([^{}]+)\{([^}]*)\}", css):
             if "--phase-neg" not in body:

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -22,6 +22,21 @@ The tests are grouped as:
   the page still searches. The one control that cannot work without
   script ships disabled rather than silently searching the wrong
   field, and ``<noscript>`` offers a plain form per identifier.
+* :class:`TestReactionSearchTakesASetPerSide` -- the other search. A
+  reaction query is a set per side, spelled as repeated query
+  parameters; ``?reactants=A,B`` asks for a species named ``A,B`` and
+  answers ``200`` with nothing, so these check the shape of every
+  reaction URL the page builds rather than checking that a box exists.
+* :class:`TestBothSearchesSurviveWithoutTheSwitch` -- the species /
+  reactions switch is script-built. Both panels are markup, and the
+  tab strip ships hidden rather than shipping inert.
+* :class:`TestReviewStateIsInformation` -- ``under_review`` is the
+  ordinary state of a served record and must not be drawn in the
+  colour reserved for a rejected one.
+* :class:`TestShownCommandsRunAsPrinted` -- ``curl`` reads ``[...]``
+  as a glob, so a reader who substitutes ``[OH]`` into a printed
+  command gets a client-side failure that reads as a broken API.
+  Every shown command carries ``-g``.
 * :class:`TestResultsExpandInPlace` -- following a result must not
   drop the reader into a nested JSON document without warning. Each
   product is a disclosure that opens on the page, and every route to
@@ -44,9 +59,10 @@ The tests are grouped as:
 
 from __future__ import annotations
 
+import html
 import re
 from html.parser import HTMLParser
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 
 import pytest
 from fastapi import APIRouter
@@ -63,13 +79,19 @@ from app.api.landing import (
     HERO_FREQUENCIES,
     HERO_TRUE_FREQUENCIES,
     HERO_XYZ,
+    REACTION_EXAMPLES,
+    REACTION_SEARCH_PATH,
+    REACTION_SIDES,
     REPO_URL,
     SEARCH_EXAMPLES,
     SEARCH_FIELDS,
     SEED_FIELD,
+    SEED_PRODUCTS,
+    SEED_REACTANTS,
     SEED_VALUE,
     SPECIES_SEARCH_PATH,
     hero_atom_lines,
+    reaction_query,
     render_landing_page,
 )
 from app.api.startup_checks import validate_deployment_safety
@@ -133,6 +155,23 @@ class _Document(HTMLParser):
             if all(element_attrs.get(key) == value for key, value in attrs.items()):
                 found.append((element_attrs, ancestors))
         return found
+
+
+def _noscript_forms(document: "_Document", action: str) -> list[dict[str, str | None]]:
+    """The ``<noscript>`` forms aimed at one endpoint.
+
+    The page has two searches and therefore two sets of fallback
+    forms. Scoping by action keeps each set's assertions about that
+    set: without it, "every fallback form points at species search"
+    would be false the moment reaction search existed, and the honest
+    repair is to say which forms are being counted rather than to
+    loosen what is required of them.
+    """
+    return [
+        attrs
+        for attrs, ancestors in document.find("form")
+        if "noscript" in ancestors and attrs["action"] == action
+    ]
 
 
 @pytest.fixture(scope="module")
@@ -303,15 +342,24 @@ class TestLiveSearch:
     """
 
     def test_the_search_is_a_real_form_aimed_at_the_public_read_endpoint(self, document):
+        """Two searches, two real GET forms, and nothing else.
+
+        This asserted one form until reaction search was added. It is
+        still an exhaustive assertion -- the count is pinned and both
+        actions are named -- so a third form, or a form aimed anywhere
+        but a public read endpoint, still fails here.
+        """
         forms = [
-            (attrs, ancestors)
+            attrs
             for attrs, ancestors in document.find("form")
             if "noscript" not in ancestors
         ]
-        assert len(forms) == 1
-        attrs, _ = forms[0]
-        assert attrs["action"] == SPECIES_SEARCH_PATH
-        assert attrs["method"] == "get"
+        assert [attrs["action"] for attrs in forms] == [
+            SPECIES_SEARCH_PATH,
+            REACTION_SEARCH_PATH,
+        ]
+        for attrs in forms:
+            assert attrs["method"] == "get"
 
     def test_the_box_is_seeded_with_a_query_that_returns_a_record(self, document):
         """Nobody's first sight of the search is an empty box.
@@ -450,18 +498,17 @@ class TestSearchDegradesWithoutJavaScript:
         fallback is one single-field form per identifier rather than
         one form carrying all three.
         """
-        fallback_forms = [
-            attrs for attrs, ancestors in document.find("form") if "noscript" in ancestors
-        ]
+        fallback_forms = _noscript_forms(document, SPECIES_SEARCH_PATH)
         assert fallback_forms
         for attrs in fallback_forms:
-            assert attrs["action"] == SPECIES_SEARCH_PATH
             assert attrs["method"] == "get"
 
         named = {
             attrs["name"]
             for attrs, ancestors in document.find("input")
-            if "noscript" in ancestors and attrs.get("name")
+            if "noscript" in ancestors
+            and attrs.get("name")
+            and attrs["name"] not in {side for side, _, _ in REACTION_SIDES}
         }
         offered = {field for field, _ in SEARCH_FIELDS}
         assert named == offered - {SEED_FIELD}
@@ -478,6 +525,357 @@ class TestSearchDegradesWithoutJavaScript:
         assert document.find("input", id="search-input")
         assert document.find("button", type="submit")
         assert document.find("a", **{"class": "chip"})
+
+
+class TestReactionSearchTakesASetPerSide:
+    """The half of the hero that searches reactions, not species.
+
+    One property dominates this class and is worth stating once. A
+    reaction query is a *set* per side, and the endpoint spells a set
+    as repeated query parameters::
+
+        ?reactants=NN&reactants=[OH]     the reactions with both among
+                                         their reactants
+        ?reactants=NN,[OH]               one species literally named
+                                         "NN,[OH]"
+
+    The second is not an error. It returns ``200`` with nothing in it,
+    which is the least debuggable answer an API can give -- so the
+    tests below check the *shape of every URL the page builds*, in the
+    markup, in the script, and in the ``curl`` example, rather than
+    checking that a reaction box exists.
+    """
+
+    def test_two_species_on_one_side_become_two_parameters(self):
+        """The mistake this whole design exists to avoid.
+
+        Joining the side with a comma would leave this URL parsing to
+        ``{"reactants": ["[NH2],NN"]}`` -- one value, one species name,
+        nothing matched -- so this fails on exactly that regression and
+        on nothing else.
+        """
+        url = reaction_query(("[NH2]", "NN"), ())
+        assert parse_qs(urlparse(url).query) == {"reactants": ["[NH2]", "NN"]}
+        assert url.count("reactants=") == 2
+        assert "," not in url
+
+    def test_both_sides_repeat_independently(self):
+        url = reaction_query(("NN", "[OH]"), ("N=N", "O"))
+        assert parse_qs(urlparse(url).query) == {
+            "reactants": ["NN", "[OH]"],
+            "products": ["N=N", "O"],
+        }
+
+    def test_a_side_left_out_is_left_out_rather_than_sent_empty(self):
+        """An empty sibling is not an absent one.
+
+        ``?reactants=NN&products=`` is AND-combined by the endpoint and
+        returns nothing, so "unconstrained on the other side" has to be
+        the *absence* of the parameter, never a present-but-blank one.
+        """
+        url = reaction_query(("NN",), ())
+        assert parse_qs(urlparse(url).query, keep_blank_values=True) == {"reactants": ["NN"]}
+        assert "products" not in url
+
+    def test_no_reaction_url_anywhere_on_the_page_joins_a_side(self, page):
+        """Every link, chip and shown command, checked the same way.
+
+        A builder can be correct while one hand-written ``href`` on the
+        page is not, and that ``href`` is what a reader with scripting
+        off actually follows. So this parses every reaction-search URL
+        in the rendered document and asserts no single value carries a
+        separator -- and that at least one of them really does repeat a
+        parameter, or the assertion above it would be vacuous.
+        """
+        urls = re.findall(r'href="([^"]*' + re.escape(REACTION_SEARCH_PATH) + r'[^"]*)"', page)
+        assert urls
+        repeated = 0
+        for raw in urls:
+            query = parse_qs(urlparse(html.unescape(raw)).query, keep_blank_values=True)
+            for name, values in query.items():
+                assert name in {side for side, _, _ in REACTION_SIDES}, name
+                if len(values) > 1:
+                    repeated += 1
+                for value in values:
+                    assert value, "a blank side is an absent side, not an empty parameter"
+                    assert "," not in value, value
+                    assert " " not in value, value
+        assert repeated, "no offered link exercises the repeated-parameter form"
+
+    def test_the_script_builds_one_parameter_per_species(self, script):
+        """The same property, in the code the browser actually runs.
+
+        Checked structurally because the assertion is about a URL the
+        test suite cannot execute: the loop that pushes one
+        ``reactants=`` per element, and the absence of any join with a
+        separator anywhere in the script.
+        """
+        builder = re.search(r"function rxnUrl\(.*?\n  \}", script, flags=re.DOTALL)
+        assert builder is not None
+        source = builder.group(0)
+        for side, _, _ in REACTION_SIDES:
+            assert f'parts.push("{side}=" + encodeURIComponent({side}[i]))' in source, side
+        assert 'parts.join("&")' in source
+        assert 'join(",")' not in script
+        assert 'join(", ")' not in script
+
+    def test_the_chips_and_the_builder_cannot_drift(self, document):
+        """Each offered example is a real link to the query it names."""
+        chips = document.find("a", **{"class": "chip rxn-chip"})
+        assert len(chips) == len(REACTION_EXAMPLES)
+        for index, ((attrs, _), (reactants, products)) in enumerate(
+            zip(chips, REACTION_EXAMPLES, strict=True)
+        ):
+            assert attrs["data-example"] == str(index)
+            assert html.unescape(attrs["href"]) == reaction_query(reactants, products)
+        assert any(len(reactants) > 1 or len(products) > 1 for reactants, products in REACTION_EXAMPLES), (
+            "one offered example must carry two species on a side"
+        )
+
+    def test_the_form_is_seeded_with_a_query_that_returns_records(self, document):
+        """Nobody's first sight of reaction search is an empty box.
+
+        Both sides are seeded, and every field is ``required``: a plain
+        no-script submit therefore cannot send a blank side, which the
+        endpoint would read as a filter matching nothing.
+        """
+        for side, values in (("reactants", SEED_REACTANTS), ("products", SEED_PRODUCTS)):
+            fields = [
+                attrs
+                for attrs, ancestors in document.find("input")
+                if attrs.get("name") == side and "noscript" not in ancestors
+            ]
+            assert [attrs["value"] for attrs in fields] == list(values)
+            for attrs in fields:
+                assert "required" in attrs
+                assert attrs.get("aria-label")
+        assert SEED_REACTANTS and SEED_PRODUCTS
+
+    def test_the_script_takes_the_validation_off_the_form_it_took_over(self, script):
+        """``required`` is for the no-script path and only that path.
+
+        With the script running, blank fields are skipped rather than
+        submitted, so leaving a side empty must be allowed; the browser
+        would otherwise refuse the submit before the handler saw it.
+        """
+        assert "rxnForm.noValidate = true" in script
+        assert "if (value) { values.push(value); }" in script
+
+    def test_noscript_can_still_ask_for_two_species_on_a_side(self, document):
+        """A plain form emits repeated same-named inputs. Use that.
+
+        This is the whole reason the fallback is a set of forms rather
+        than a sentence apologising: without a script, HTML alone can
+        express ``reactants=A&reactants=B``.
+        """
+        forms = _noscript_forms(document, REACTION_SEARCH_PATH)
+        assert forms
+        counted = {}
+        for side, _, _ in REACTION_SIDES:
+            names = [
+                attrs
+                for attrs, ancestors in document.find("input")
+                if "noscript" in ancestors and attrs.get("name") == side
+            ]
+            assert names, side
+            for attrs in names:
+                assert "required" in attrs, "an empty sibling parameter matches nothing"
+            counted[side] = len(names)
+        # One single-field form and one two-field form per side.
+        assert counted == {side: 3 for side, _, _ in REACTION_SIDES}
+        assert len(forms) == 2 * len(REACTION_SIDES)
+
+    def test_a_result_shows_the_equation_and_how_far_it_was_checked(self, script):
+        """The equation is the legible thing; the review state is honest.
+
+        ``under_review`` is a normal state for a served record and is
+        drawn with the same neutral badge as everything else -- the
+        assertion for that is on the stylesheet, in
+        :meth:`TestReviewStateIsInformation.test_only_deprecated_and_rejected_use_the_negative_phase`.
+        """
+        renderer = re.search(r"function rxnRecordNode\(record\) \{.*?\n  \}", script, re.DOTALL)
+        assert renderer is not None
+        source = renderer.group(0)
+        assert 'make("span", "equation", record.equation' in source
+        assert "reviewBadge(record.review" in source
+
+    def test_a_result_says_which_way_round_the_query_matched(self, script):
+        """``reverse`` is information: the reactants asked for are its products."""
+        assert "DIRECTION_WORDS[record.matched_direction]" in script
+        for word in ("matched forward", "matched in reverse", "matched either way"):
+            assert f'"{word}"' in script, word
+
+    def test_a_result_leads_onward_to_the_evidence_it_has(self, script):
+        """A landing page that leads nowhere is the defect being fixed."""
+        for path in (
+            "/api/v1/scientific/reaction-entries/",
+            "/api/v1/scientific/transition-states/search",
+        ):
+            assert f'"{path}"' in script, path
+        sections = re.search(r"var RXN_SECTIONS = \[.*?\n  \];", script, flags=re.DOTALL)
+        assert sections is not None
+        assert "a.has_transition_state" in sections.group(0)
+        assert "a.kinetics_count" in sections.group(0)
+        assert "no kinetics or transition state yet" in script
+
+    def test_an_empty_result_reads_as_an_outcome_and_offers_one_that_works(self, script):
+        empty = re.search(
+            r"function rxnEmptyNode\(reactants, products\) \{.*?\n  \}", script, re.DOTALL
+        )
+        assert empty is not None
+        assert "Nothing matched" in empty.group(0)
+        assert "rxnExampleList(" in empty.group(0)
+        assert '"These return records:"' in script
+
+    def test_a_query_with_no_filter_shows_the_endpoints_own_refusal(self, script, page):
+        """The 422 is ``missing_reaction_search_filter``, so show that.
+
+        Clearing both sides omits every participant parameter, which is
+        what produces the real refusal; its ``code`` and ``detail`` are
+        then rendered. The code is deliberately not written anywhere on
+        this page -- what the reader sees is what the endpoint said.
+        """
+        assert re.search(r"if \(!parts\.length\) \{ return RXN_SEARCH; \}", script)
+        assert "body.code" in script
+        assert "body.detail" in script
+        assert not [
+            literal for literal in re.findall(r'"([^"]*)"', script)
+            if "missing_reaction_search_filter" in literal
+        ], "the code is the endpoint's to state, not this page's to guess"
+        prose = re.sub(r"<script>.*?</script>", "", page, flags=re.DOTALL)
+        prose = re.sub(r"<style>.*?</style>", "", prose, flags=re.DOTALL)
+        assert "missing_reaction_search_filter" not in prose
+
+    def test_the_render_is_capped_and_never_lies_about_the_total(self, script):
+        """The count is the endpoint's; the cap is only how much is drawn."""
+        assert "RXN_LIMIT" in script
+        assert 'parts.push("limit=" + limit)' in script
+        assert "rxnUrl(reactants, products, RXN_LIMIT)" in script
+        # The "more than fits" line links the *uncapped* URL.
+        assert "rxnUrl(reactants, products)" in script
+        assert "Open the full response as raw JSON" in script
+
+    def test_the_results_area_is_announced_when_it_changes(self, document):
+        regions = document.find("div", id="rxn-results")
+        assert len(regions) == 1
+        assert regions[0][0]["aria-live"] == "polite"
+
+
+class TestBothSearchesSurviveWithoutTheSwitch:
+    """The species/reactions switch is an enhancement, never a gate."""
+
+    def test_both_panels_are_markup_before_any_script_runs(self, document):
+        for panel, action in (
+            ("panel-species", SPECIES_SEARCH_PATH),
+            ("panel-reactions", REACTION_SEARCH_PATH),
+        ):
+            found = document.find("div", id=panel)
+            assert len(found) == 1, panel
+            assert "hidden" not in found[0][0], panel
+            assert [
+                attrs
+                for attrs, ancestors in document.find("form")
+                if attrs["action"] == action and "noscript" not in ancestors
+            ], action
+
+    def test_the_switch_ships_hidden_and_the_script_builds_it(self, document, page, script):
+        """A tab that cannot change what is shown is worse than no tab.
+
+        And ``.modes`` sets ``display: flex``, which beats the user
+        agent's ``[hidden]`` rule -- so the stylesheet has to turn it
+        off explicitly or the control would be visible to exactly the
+        readers who cannot use it.
+        """
+        modes = document.find("div", id="modes")
+        assert len(modes) == 1
+        assert "hidden" in modes[0][0]
+        assert ".modes[hidden] { display: none; }" in page
+        assert "modes.hidden = false" in script
+        assert 'modes.setAttribute("role", "tablist")' in script
+        assert 'setAttribute("role", "tabpanel")' in script
+
+    def test_the_page_keeps_exactly_one_top_level_heading(self, document):
+        assert len(document.find("h1")) == 1
+
+    def test_a_two_field_fallback_form_is_allowed_to_wrap(self, page):
+        """Measured, not guessed: this regressed and was caught in a browser.
+
+        A reaction fallback form carries two inputs and a button. At
+        their default size that is 542px of content inside a 360px
+        viewport, and an ``<input>`` will not shrink below its size
+        attribute unless it is told it may -- so with scripting off the
+        whole document scrolled sideways, which is the one thing the
+        narrow layout is not allowed to do.
+        """
+        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL).group(1)
+        form_rule = re.search(r"\.fallback form \{([^}]*)\}", css)
+        assert form_rule is not None
+        assert "flex-wrap: wrap" in form_rule.group(1)
+        assert "max-width: 100%" in form_rule.group(1)
+        input_rule = re.search(r"\.fallback input \{([^}]*)\}", css)
+        assert input_rule is not None
+        assert "min-width: 0" in input_rule.group(1)
+
+
+class TestReviewStateIsInformation:
+    """Under review is a state, not a warning, on every result."""
+
+    def test_only_deprecated_and_rejected_use_the_negative_phase(self, page):
+        """Most of what this deployment serves is under review.
+
+        Drawing that in the colour reserved for a rejected record would
+        put a warning on the ordinary case, which is both wrong and the
+        opposite of what the review model is for.
+        """
+        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL).group(1)
+        flagged = set()
+        for selectors, body in re.findall(r"([^{}]+)\{([^}]*)\}", css):
+            if "--phase-neg" not in body:
+                continue
+            flagged.update(re.findall(r"\.badge-(\w+)", selectors))
+        assert flagged == {"deprecated", "rejected"}
+
+
+class TestShownCommandsRunAsPrinted:
+    """A command a reader pastes has to work when they change the value."""
+
+    def test_every_curl_disables_globbing(self, page):
+        """``curl`` reads ``[...]`` as a glob, and SMILES are full of it.
+
+        ``curl -s ".../search?smiles=[OH]"`` fails in the client before
+        it reaches any server, with an error about a bad range -- which
+        reads as the API being broken. ``-g`` turns globbing off, and
+        every command on the page carries it because the page invites
+        substitution.
+        """
+        commands = re.findall(r"curl [^\n<]*", page)
+        assert commands
+        for command in commands:
+            flags = re.match(r"curl\s+(-[A-Za-z]+)", command)
+            assert flags is not None, command
+            assert "g" in flags.group(1), command
+        assert any("[" in command for command in commands), (
+            "no shown command contains a bracketed SMILES, so -g would be untested"
+        )
+
+    def test_the_page_says_why_the_flag_is_there(self, page):
+        assert "shell globs" in page
+        assert "<code>-g</code>" in page
+
+    def test_the_reaction_command_shows_the_repeated_parameter_form(self, page):
+        """The shape is the lesson, and one shown command teaches it.
+
+        Pasted with a comma instead -- ``?products=[H][H],N=N`` -- the
+        same command returns ``200`` and nothing, so the example has to
+        be the correct shape rather than merely a working URL.
+        """
+        commands = [c for c in re.findall(r"curl [^\n<]*", page) if REACTION_SEARCH_PATH in c]
+        assert len(commands) == 1
+        command = html.unescape(commands[0])
+        query = parse_qs(command.split("?", 1)[1].rstrip('"'))
+        assert len(query["products"]) == 2, command
+        for value in query["products"]:
+            assert "," not in value
 
 
 class TestResultsExpandInPlace:
@@ -590,10 +988,7 @@ class TestResultsExpandInPlace:
         results, which only exist once a fetch has run. What has to
         survive is everything that works before one does.
         """
-        fallback_forms = [
-            attrs for attrs, ancestors in document.find("form") if "noscript" in ancestors
-        ]
-        assert len(fallback_forms) == len(SEARCH_FIELDS) - 1
+        assert len(_noscript_forms(document, SPECIES_SEARCH_PATH)) == len(SEARCH_FIELDS) - 1
         assert document.find("input", id="search-input")
         assert document.find("a", **{"class": "chip"})
 


### PR DESCRIPTION
## In plain language

The front page of TCKDB had a search box that could only look up **species** —
one molecule at a time, by formula, SMILES or InChIKey. It could not look up
**reactions**. This adds that, and fixes a copy-paste example on the same page
that broke the moment anyone typed a radical.

A reaction search is a different shape of question from a species search. A
species is one thing; a reaction side is a *set* of things — "the reactions
that turn hydrazine into molecular hydrogen **and** diimide". The API expects
that set written out as the same parameter repeated:

```
?products=[H][H]&products=N=N        <- two products, correct
?products=[H][H],N=N                 <- one product whose name is
                                        the ten characters "[H][H],N=N"
```

The second one is the trap. It is not rejected. It comes back `200 OK` with an
empty list, which reads as "TCKDB has no such reaction" when what actually
happened is that nothing was ever asked. So the page is built so that a
comma can never get in: there is one text box per species, an **+ reactant** /
**+ product** button that adds another *box* rather than another word in the
same box, and the code that assembles the web address emits one parameter per
box. Three of the tests exist purely to fail if that ever stops being true —
they parse every reaction address the page produces and check that no single
value contains a separator.

The second fix: the page showed `curl -s "…/search?formula=CH3"`, inviting the
reader to swap in their own molecule. `curl` treats square brackets as a
wildcard pattern, so the moment a chemist swaps in a radical — `[OH]`, `[CH3]`,
anything with brackets, which is most of what this database holds — the command
fails on their own machine before it ever reaches the server, with an error
about a bad range. That reads as a broken API. `-g` turns the wildcard off.
Every shown command now has it, one of them uses a bracketed SMILES so the flag
is visibly doing work, and one clause says why.

**Jargon used below.** *422* is the HTTP status meaning "your request was
understood but is not a valid question"; *`<noscript>`* is markup a browser
shows only when JavaScript is switched off; a *disclosure* is a button that
opens a panel in place instead of navigating away; *progressive enhancement*
means the page works as plain HTML and JavaScript only makes it nicer.

## How the multi-species input is handled, and why

**One input per species, plus an add button.** Rejected alternatives:

- *A comma-separated box, split client-side.* The split has to happen
  somewhere, and wherever it happens is a place a comma can survive into a URL.
  It also cannot work at all with scripting off, where a plain form sends the
  box verbatim.
- *A `+`-separated box, in equation style.* `+` occurs **inside SMILES** in
  this very corpus — `[NH-][NH3+]`, `[N-]=[NH2+]` are real deposited species —
  so splitting on it would corrupt the input.
- *Whitespace-separated.* Safe for SMILES, but still a client-side split, and
  still dead without script.

Repeated inputs need no split at all: an HTML form submits repeated same-named
inputs as repeated query parameters, natively, with no JavaScript involved.
The shape of the control *is* the shape of the request.

**The blank-field problem, and how `required` solves it.** An empty sibling is
not an absent one: `?reactants=NN&products=` is AND-combined by the endpoint
and returns nothing (verified live). A plain form has no way to skip a blank
box — so every reaction field carries `required`, the browser refuses to submit
one empty, and both seed values are real. The script then sets
`form.noValidate = true` when it takes the form over, because *it* can skip
blank fields properly and a side must be clearable. The `<noscript>` block
carries one-field and two-field forms per side, so a scripting-off reader can
still ask a one-sided question and still ask a two-species one.

## What the page shows now

- **Seeded** with `reactants=NN & products=[H][H]` — 8 records live, two
  distinct equations, both review states represented. Nobody's first sight of
  it is an empty box.
- **Equation first**, in mono, as the headline of each row.
- **Review state on every row**, same neutral badge as species results.
  `under_review` is the ordinary state of a served record here and is not
  styled as a warning; a stylesheet test pins the negative phase colour to
  `deprecated` and `rejected` only.
- **`matched_direction` worded**: "matched forward" / "matched in reverse" /
  "matched either way". Reverse means the reactants asked for are that
  reaction's products, which is real information, so it is on every row rather
  than only on the reverse ones — an absence never has to be interpreted.
- **Evidence from `availability`**: a `transition state` disclosure and an
  `N kinetics records` disclosure, each expanding in place (label, saddle-point
  status, charge, multiplicity, calculation count / Arrhenius parameters,
  temperature span, origin), each ending in a link labelled as raw JSON. Rows
  with neither say "no kinetics or transition state yet".
- **Empty result** reads as an outcome, not a fault, and hands back the three
  example queries that do return records.
- **422** renders the endpoint's own `code` and `detail`. The string
  `missing_reaction_search_filter` appears nowhere on the page — what the
  reader sees is what the endpoint said.
- **Render cap of 10** rows, with the endpoint's real total above and "Showing
  the first page → Open the full response as raw JSON" below. The cap shortens
  the reading, never the answer.

## Layout

Species and reactions sit behind a two-tab switch inside one hero, rather than
stacked, so the page does not grow by a second column of results. The switch is
built by the script: the tab strip ships `hidden` and both panels ship visible,
each under its own `h3`, each a working `<form method="get">`. With scripting
off there is no switch and both searches are simply there. Arrow keys move
between tabs; the reaction query runs lazily the first time its tab is opened.

Prose grew from 265 to 320 words (paragraph text, `<noscript>` excluded) — not
doubled. Still one `<h1>`, still exactly one `<script>` with zero attributes and
no `://` in any string literal, still no external resource of any kind.

## Schema / migration impact

**None.** No model, no migration, no environment variable, no read-API change.
`backend/app/api/landing.py` and its test file are the only files touched; the
route table gains nothing, and
`test_the_route_table_gains_the_landing_route_and_nothing_else` still passes.

## Verification actually run

Everything below was run; nothing is aspirational.

**Gates**

```
cd backend
conda run -n tckdb_env ruff check app tests scripts        -> All checks passed!
conda run -n tckdb_env bash scripts/test-api.sh; echo $?   -> 3178 passed, EXIT=0
conda run -n tckdb_env pytest tests/api/test_landing_page.py -> 70 passed
```

(`$?` captured directly, not through a pipe — piping to `tail` reports tail's
status and hides a failure.)

**Three existing tests were rewritten, none weakened.** Each had counted a
population that a second search changes; each now names which population it is
counting and asserts at least as much:

- `test_the_search_is_a_real_form_aimed_at_the_public_read_endpoint` asserted
  one non-`<noscript>` form. It now asserts the exact ordered list of two, and
  names both actions — still exhaustive, so a third form still fails it.
- `test_noscript_carries_a_plain_form_for_each_other_identifier` and
  `test_the_no_script_fallback_is_untouched_by_the_expansion` scoped their
  counts to the species fallback via a new `_noscript_forms(document, action)`
  helper. The reaction fallback gets its own assertions rather than being
  folded into a looser one.

**Mutation-tested — three landed, run, failed, restored.** File SHA-256 before
all three and after all three: `6230e675…be1c8` (byte-identical).

| # | Mutation landed | Failing test |
|---|---|---|
| 1 | `reaction_query` joins each side with `,` | `test_two_species_on_one_side_become_two_parameters`, `test_both_sides_repeat_independently`, `test_no_reaction_url_anywhere_on_the_page_joins_a_side` (3 failed, 66 passed) |
| 2 | `curl -sg` → `curl -s` on the species example | `test_every_curl_disables_globbing` (1 failed, 68 passed) |
| 3 | the script's `rxnUrl` joins with `.join(",")` | `test_the_script_builds_one_parameter_per_species` (1 failed, 68 passed) |

Mutation 1 is the one the brief asked for: the diff was confirmed present with
`git diff` before the run, the failure message was
`AssertionError: [H][H],N=N`, and the file was restored to the same hash.

**Driven in a real browser, against real data.** The page was served locally
with `/api/v1/*` proxied (GET only) to `https://tckdb.homecalvin.com`, so its
own fetches hit the live corpus same-origin, and driven over CDP in headless
Chrome 147.

Desktop 1280×900:

| Step | Observed |
|---|---|
| on load | Species tab selected, reaction panel hidden, `formula=CH3` → 1 match |
| click **Reactions** | one request, `?reactants=NN&products=%5BH%5D%5BH%5D&limit=10` → **8 matches, 4 under review, 4 not reviewed**; 8 rows, `NN <=> [H][H] + N=N` and `NN <=> [H][H] + [N-]=[NH2+]`, each with a `transition state` pill |
| expand that pill | `…/transition-states/search?reaction_entry_ref=rxe_xotk…` → *1 transition state · TS3 · under review · tse_lr6s… · saddle point optimized · charge 0 · multiplicity 1 · calculations behind it 3 · Open this list as raw JSON* |
| chip **products [H][H] + N=N** | `?products=%5BH%5D%5BH%5D&products=N%3DN&limit=10` — **two separate `products=`** — 8 matches incl. `[NH-][NH3+] <=> [H][H] + N=N` |
| **+ reactant**, type `[NH2]` twice | `?reactants=%5BNH2%5D&reactants=%5BNH2%5D&…`; the two boxes relabel to "Reactant 1" / "Reactant 2" |
| chip **reactants NN** | 20 matches, 10 rendered, `matched forward` ×8 and **`matched in reverse` ×2** (`[NH2] + [NH2] <=> NN`), tail reads *Showing the first page. Open the full response as raw JSON* |
| a reactant that matches nothing | *Nothing matched reactants NN + c1ccccc1; products N=N.* followed by *These return records:* and the three chips |
| clear both sides, submit | `?limit=10` → 422, rendered as `missing_reaction_search_filter` + *at least one of {reactants, products, reaction_ref, reaction_entry_ref} is required to scope a reaction search.* |
| keyboard | `→` on the Species tab moves focus and selection to Reactions |

360px, measured with `Emulation.setDeviceMetricsOverride` (headless Chrome
enforces a 500px minimum window, so `--window-size=360` silently lays out at
500 and would have measured nothing):

- `innerWidth` 360, `documentElement.scrollWidth` 360 = `clientWidth` 360, on
  both tabs. No horizontal document scroll. The one element wider than the
  viewport is the `<code>` inside `pre.command`, which scrolls inside its own
  `overflow-x: auto` box, as it did before this change.
- Layout: reactants box full width, the `<=>` on its own centred line, products
  box and Search below. (First attempt put the arrow squeezed onto the end of
  the reactants row, where it read as a label for that box; fixed with a
  mobile-first rule.)

Scripting off (`Emulation.setScriptExecutionDisabled`): both panels render
under their own headings, no tab strip, all six fallback forms present.

**A responsive bug this found, and its regression test.** With scripting off at
360px the branch measured **542px** of content against a HEAD baseline of 360 —
the two-field reaction fallback forms. An `<input>` will not shrink below its
size attribute unless told it may. Fixed with `flex-wrap`/`max-width` on
`.fallback form` and `min-width: 0` on `.fallback input`; re-measured at 360.
`test_a_two_field_fallback_form_is_allowed_to_wrap` pins it.

**The `<noscript>` forms were submitted the way a browser would**, against the
live host, by parsing the rendered markup and building each form's successful
controls:

```
200  total=20  /reactions/search?reactants=NN
200  total=4   /reactions/search?reactants=[NH2]&reactants=[NH2]
200  total=12  /reactions/search?products=[H][H]
200  total=8   /reactions/search?products=[H][H]&products=N=N
```

The two-deep forms are the point: those are repeated parameters emitted by
plain HTML with no script running at all.

**Live endpoint facts this was built against** (`curl -sg`, GET only, never
POST): `?reactants=NN` → 20; `?reactants=NN&products=[H][H]` → 8;
`?products=[H][H]&products=N=N` → 8; the comma-joined equivalent
`?products=[H][H],N=N` → **0**; `?reactants=NN&products=` → **0**;
no participant filter → 422 `missing_reaction_search_filter`. No record count
is written into the page: every number a reader sees came back from a request
they just made.
