### PR TITLE
Say how many entries have the evidence, not that one does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,56 @@ wrapper over a contract that is itself still moving.
 
 ### Changed
 
+- **A transition state now says how many of its entries have the evidence,
+  not that one does.** `GET /api/v1/scientific/transition-states/{ref}`
+  returned an `evidence_summary` carrying seven `has_*` booleans —
+  `has_opt`, `has_freq`, `has_sp`, `has_irc`, `has_path_search`,
+  `has_geometry_validation`, `has_scf_stability` — OR-ed across **every
+  entry** under the transition state. `has_sp: true` therefore meant "at
+  least one entry somewhere under this TS has a single point", which a
+  reader takes as "this transition state has a single point". The flag was
+  asymmetrically informative: `false` was strong (nothing anywhere has it)
+  while `true` was nearly empty, so it was reliable only in the direction
+  nobody reads it for.
+
+  TS-concept scope now reports **`entry_count`** and an
+  **`evidence_coverage`** block: per evidence kind, how many of those
+  entries have at least one calculation of that kind. Coverage counts
+  *entries*, never calculations — an entry with three `freq` jobs
+  contributes `1` — so a value can never exceed `entry_count` and
+  `sp: 1` against `entry_count: 3` shows an unevenly covered TS at a
+  glance. `count > 0` reproduces the retired boolean exactly.
+
+  A **full** count says coverage is complete, not that the entries are
+  **comparable**: they may sit at different levels of theory, come from
+  different codes, and describe different geometries. Coverage is not
+  consistency; that still requires `include=calculations`.
+
+  **TS-entry scope keeps its booleans** and is unchanged — one entry, one
+  set of calculations, nothing for a `true` to hide behind. That covers
+  `GET /scientific/transition-state-entries/{ref}`, the search surface
+  (which returns entry-grain records and therefore needed no quantifier
+  knob), and the `transition_states[*].evidence_summary` block embedded in
+  `/reaction-entries/{id}/full`.
+
+  **Breaking for callers reading `has_*` off the TS-concept detail
+  endpoint. Migration: `has_x` becomes `evidence_coverage.x > 0`.** The
+  defect is **latent today** — measured against the hosted instance, all
+  34 transition states have exactly one entry, so the OR cannot currently
+  differ from that entry's own value and nobody has been misled yet. It is
+  a bug waiting for its trigger: the first second entry deposited under one
+  transition state (a re-optimisation at another level, say) makes it
+  silently wrong, with nothing in the response to mark the change. Fixing
+  it while it is still latent is why the migration costs one expression
+  rather than a data audit. No database schema or migration impact — this
+  is a read projection, not a table. No client or MCP change: `tckdb-client`
+  types this block as an opaque JSON object and the MCP search allowlist
+  gains no field.
+
+  Sibling of the conformer-group fix in the same release, which replaced
+  the same OR-across-children booleans with `evidence_coverage` at group
+  scope.
+
 - **Reaction search now means containment, and a one-sided query finally
   works.** `GET|POST /api/v1/scientific/reactions/search` accepted
   `reactants` or `products` alone, and the validator said so explicitly —

--- a/backend/app/schemas/reads/scientific_provenance.py
+++ b/backend/app/schemas/reads/scientific_provenance.py
@@ -39,7 +39,7 @@ from app.schemas.reads.scientific_conformer import (
 )
 from app.schemas.reads.scientific_kinetics import KineticsRecord
 from app.schemas.reads.scientific_transition_state import (
-    TransitionStateCalculationEvidenceSummary,
+    TransitionStateEntryEvidenceSummary,
 )
 from app.services.trust.models import TrustFragment
 
@@ -254,7 +254,7 @@ class TransitionStateInFull(BaseModel):
     transition_state_entry_ref: str
     status: TransitionStateEntryStatus | None = None
     review: RecordReviewBadge
-    evidence_summary: TransitionStateCalculationEvidenceSummary
+    evidence_summary: TransitionStateEntryEvidenceSummary
     calculations: dict[str, TransitionStateCalculationSlot] = Field(default_factory=dict)
     dependencies: list[TransitionStateDependency] = Field(default_factory=list)
     trust: TrustFragment | None = None

--- a/backend/app/schemas/reads/scientific_transition_state.py
+++ b/backend/app/schemas/reads/scientific_transition_state.py
@@ -159,18 +159,100 @@ class TransitionStateCalculationSummary(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class TransitionStateCalculationEvidenceSummary(BaseModel):
-    """Compact calculation-evidence projection for a TS or TS-entry.
+class TransitionStateEvidenceCoverage(BaseModel):
+    """How many TS entries in scope carry each kind of evidence.
 
-    Counts and ``has_*`` booleans are computed from cheap EXISTS-style
-    queries against the calculation tables under the TS entry. Primary
-    calculation refs are deferred to a later PR — the data model does
-    not currently carry a unique notion of "primary" per type, so we
-    expose counts/booleans only.
+    Every value counts **entries**, never calculations. An entry with
+    three ``freq`` calculations contributes ``1`` to ``freq``, not
+    ``3``. The shared denominator is
+    ``TransitionStateEvidenceSummary.entry_count``, so a caller reads
+    each field as "*n* of *entry_count*"; a value can never exceed that
+    denominator, and one that did would mean the query had started
+    counting calculations again.
 
-    For a TS concept, the counts are summed across all entries under
-    the TS. For a TS entry, the counts are restricted to that entry's
-    calculations.
+    What a full count does and does not say
+    ---------------------------------------
+    ``freq == entry_count`` says the coverage is **complete** — every
+    candidate saddle point under this TS has at least one frequency
+    calculation. It does **not** say those calculations are
+    *comparable*: the entries may sit at different levels of theory,
+    come from different codes, and describe different geometries. A
+    count is honest about coverage, not about consistency. A caller who
+    needs consistency must inspect the per-calculation level-of-theory /
+    software provenance under ``include=calculations``; no number in
+    this block can stand in for that.
+
+    ``0`` is exactly as strong as the old ``has_x is False`` was:
+    nothing in scope carries that evidence.
+    """
+
+    opt: int
+    freq: int
+    sp: int
+    irc: int
+    path_search: int
+    geometry_validation: int
+    scf_stability: int
+
+
+class TransitionStateEvidenceSummary(BaseModel):
+    """Compact calculation-evidence projection for a TS **concept**.
+
+    ``entry_count`` is the number of ``transition_state_entry`` rows
+    under the TS — the same number as ``entries_summary.total``,
+    repeated here so the coverage block is readable without
+    cross-referencing another block. ``calculation_count`` is the number
+    of calculations across all of those entries.
+    ``evidence_coverage`` reports, per evidence kind, how many of the
+    ``entry_count`` entries carry it.
+
+    Primary calculation refs are deferred — the data model does not
+    currently carry a unique notion of "primary" per type, so this block
+    exposes counts only.
+
+    Why counts here and booleans on the entry surface
+    -------------------------------------------------
+    This block deliberately has a **different shape** from
+    :class:`TransitionStateEntryEvidenceSummary`. That asymmetry is the
+    point, not an oversight, and it should not be smoothed over.
+
+    A TS concept pools several candidate entries. The booleans this
+    block used to carry (``has_opt`` / ``has_freq`` / …) were a plain OR
+    across all of them, which made them asymmetrically informative:
+    ``false`` was strong (nothing under the TS has it) while ``true``
+    was nearly empty (one calculation under one entry made it ``true``).
+    A reader seeing ``has_sp: true`` on a three-entry TS could not tell
+    whether three entries had single points or one did. Counts answer
+    that question — ``sp: 1`` against ``entry_count: 3`` shows an
+    unevenly covered TS at a glance — and ``count > 0`` reproduces the
+    retired boolean exactly, so nothing the boolean expressed was lost.
+
+    A TS entry is a single candidate saddle point, so on that surface
+    the booleans are unambiguous and are kept as they were.
+    """
+
+    entry_count: int
+    calculation_count: int
+    evidence_coverage: TransitionStateEvidenceCoverage
+
+
+class TransitionStateEntryEvidenceSummary(BaseModel):
+    """Compact calculation-evidence projection for one TS **entry**.
+
+    Scope is this single entry: ``calculation_count`` and every ``has_*``
+    boolean are restricted to the calculations whose
+    ``transition_state_entry_id`` is this entry. A boolean is
+    unambiguous here — it cannot pool a covered entry with an uncovered
+    one, which is what made the same booleans misleading at TS-concept
+    scope (see :class:`TransitionStateEvidenceSummary`).
+
+    Counts and booleans are computed from cheap EXISTS-style queries
+    against the calculation tables. Primary calculation refs are
+    deferred for the same reason as on the concept block.
+
+    As with the concept block's counts, ``has_freq: true`` says
+    frequency evidence exists — not that it is comparable with the
+    frequency evidence on any sibling entry.
     """
 
     calculation_count: int
@@ -272,7 +354,7 @@ class ScientificTransitionStateEntryRecord(BaseModel):
     transition_state_entry: TransitionStateEntryCoreBlock
     transition_state: TransitionStateCoreBlock
     reaction: TransitionStateReactionContext
-    evidence_summary: TransitionStateCalculationEvidenceSummary
+    evidence_summary: TransitionStateEntryEvidenceSummary
     validation: TransitionStateValidationDescriptor
     available_sections: AvailableTransitionStateSections
     calculations: list[TransitionStateCalculationSummary] | None = None
@@ -312,7 +394,7 @@ class ScientificTransitionStateRecord(BaseModel):
     transition_state: TransitionStateCoreBlock
     reaction: TransitionStateReactionContext
     entries_summary: TransitionStateEntriesSummary
-    evidence_summary: TransitionStateCalculationEvidenceSummary
+    evidence_summary: TransitionStateEvidenceSummary
     available_sections: AvailableTransitionStateSections
     entries: list[ScientificTransitionStateEntryRecord] | None = None
     calculations: list[TransitionStateCalculationSummary] | None = None
@@ -349,13 +431,15 @@ __all__ = [
     "ScientificTransitionStateEntryDetailResponse",
     "ScientificTransitionStateEntryRecord",
     "ScientificTransitionStateRecord",
-    "TransitionStateCalculationEvidenceSummary",
     "TransitionStateCalculationSummary",
     "TransitionStateCoreBlock",
     "TransitionStateDetailRequest",
     "TransitionStateEntriesSummary",
     "TransitionStateEntryCoreBlock",
     "TransitionStateEntryDetailRequest",
+    "TransitionStateEntryEvidenceSummary",
+    "TransitionStateEvidenceCoverage",
+    "TransitionStateEvidenceSummary",
     "TransitionStateReactionContext",
     "TransitionStateReviewEntry",
     "TransitionStateValidationEvidenceSummary",

--- a/backend/app/services/scientific_read/provenance.py
+++ b/backend/app/services/scientific_read/provenance.py
@@ -98,7 +98,7 @@ from app.services.scientific_read.transition_states import (
     _TRUST_EAGER_LOADS as _TS_ENTRY_TRUST_EAGER_LOADS,
 )
 from app.services.scientific_read.transition_states import (
-    _build_evidence_summary_for_entries,
+    _build_entry_evidence_summary,
     build_transition_state_entry_trust_fragment,
 )
 
@@ -703,7 +703,7 @@ def _build_transition_states_section(
         # surface so the block surfaced under /full is byte-identical
         # to ``record.evidence_summary`` from
         # ``GET /scientific/transition-state-entries/{ref}``.
-        evidence = _build_evidence_summary_for_entries(session, [ts_entry.id])
+        evidence = _build_entry_evidence_summary(session, ts_entry.id)
         out.append(
             TransitionStateInFull(
                 transition_state_id=ts_entry.transition_state_id,

--- a/backend/app/services/scientific_read/transition_states.py
+++ b/backend/app/services/scientific_read/transition_states.py
@@ -60,13 +60,15 @@ from app.schemas.reads.scientific_transition_state import (
     ScientificTransitionStateEntryDetailResponse,
     ScientificTransitionStateEntryRecord,
     ScientificTransitionStateRecord,
-    TransitionStateCalculationEvidenceSummary,
     TransitionStateCalculationSummary,
     TransitionStateCoreBlock,
     TransitionStateDetailRequest,
     TransitionStateEntriesSummary,
     TransitionStateEntryCoreBlock,
     TransitionStateEntryDetailRequest,
+    TransitionStateEntryEvidenceSummary,
+    TransitionStateEvidenceCoverage,
+    TransitionStateEvidenceSummary,
     TransitionStateReactionContext,
     TransitionStateReviewEntry,
     TransitionStateValidationDescriptor,
@@ -285,9 +287,7 @@ def get_transition_state(
     entry_ids = [e.id for e in entries]
 
     entries_summary = _build_entries_summary(entries)
-    evidence_summary = _build_evidence_summary_for_entries(
-        session, entry_ids
-    )
+    evidence_summary = _build_concept_evidence_summary(session, entry_ids)
     available = _build_available_sections(session, entries, entry_ids)
 
     entry_badges = (
@@ -466,7 +466,7 @@ def _build_entry_record(
     entry_badge: RecordReviewBadge,
     includes: set[str],
 ) -> ScientificTransitionStateEntryRecord:
-    evidence = _build_evidence_summary_for_entries(session, [entry.id])
+    evidence = _build_entry_evidence_summary(session, entry.id)
     available = _build_available_sections(session, [entry], [entry.id])
 
     calcs_block: list[TransitionStateCalculationSummary] | None = None
@@ -679,23 +679,132 @@ def _build_entries_summary(
     return TransitionStateEntriesSummary(total=len(entries), by_status=by_status)
 
 
-def _build_evidence_summary_for_entries(
+def _build_concept_evidence_summary(
     session: Session, entry_ids: list[int]
-) -> TransitionStateCalculationEvidenceSummary:
-    """Compute the calculation-evidence summary for a set of TS entries."""
+) -> TransitionStateEvidenceSummary:
+    """Compute the TS-concept-scope calculation-evidence summary.
+
+    ``calculation_count`` is the total across every entry under the TS —
+    a sum is honest about a sum.
+
+    ``evidence_coverage`` is deliberately **not** a calculation count.
+    Each value is the number of *entries* in *entry_ids* with at least
+    one calculation of that kind, so an entry carrying three ``freq``
+    calculations contributes ``1``. That is what makes the value
+    readable against the ``entry_count`` denominator, and it is why the
+    coverage queries count ``DISTINCT
+    Calculation.transition_state_entry_id`` rather than
+    ``Calculation.id``. Counting calculations here would let a coverage
+    value exceed ``entry_count``, which is nonsense on its face.
+
+    This block replaced a set of ``has_*`` booleans that OR-ed every
+    calculation under the TS together; see
+    :class:`TransitionStateEvidenceSummary` for why. ``count > 0``
+    reproduces the retired boolean exactly.
+    """
     if not entry_ids:
-        return TransitionStateCalculationEvidenceSummary(
+        # No entries: every coverage value is 0 out of 0. Nothing is
+        # vacuously "covered" here — a caller reading ``freq == 0``
+        # against ``entry_count == 0`` sees an empty TS, not a complete
+        # one.
+        return TransitionStateEvidenceSummary(
+            entry_count=0,
             calculation_count=0,
-            has_opt=False,
-            has_freq=False,
-            has_sp=False,
-            has_irc=False,
-            has_path_search=False,
-            has_geometry_validation=False,
-            has_scf_stability=False,
+            evidence_coverage=TransitionStateEvidenceCoverage(
+                opt=0,
+                freq=0,
+                sp=0,
+                irc=0,
+                path_search=0,
+                geometry_validation=0,
+                scf_stability=0,
+            ),
         )
 
-    # Single GROUP BY query: count + per-type presence.
+    # One pass gives both the calculation total (COUNT(id)) and the
+    # per-type entry coverage (COUNT(DISTINCT transition_state_entry_id)).
+    type_rows = session.execute(
+        select(
+            Calculation.type,
+            func.count(Calculation.id),
+            func.count(func.distinct(Calculation.transition_state_entry_id)),
+        )
+        .where(Calculation.transition_state_entry_id.in_(entry_ids))
+        .group_by(Calculation.type)
+    ).all()
+    calc_counts: dict[CalculationType, int] = {row[0]: row[1] for row in type_rows}
+    entry_coverage: dict[CalculationType, int] = {
+        row[0]: row[2] for row in type_rows
+    }
+
+    return TransitionStateEvidenceSummary(
+        entry_count=len(entry_ids),
+        calculation_count=sum(calc_counts.values()),
+        evidence_coverage=TransitionStateEvidenceCoverage(
+            opt=entry_coverage.get(CalculationType.opt, 0),
+            freq=entry_coverage.get(CalculationType.freq, 0),
+            sp=entry_coverage.get(CalculationType.sp, 0),
+            irc=entry_coverage.get(CalculationType.irc, 0),
+            path_search=entry_coverage.get(CalculationType.path_search, 0),
+            geometry_validation=_entry_coverage_via_join(
+                session,
+                entry_ids,
+                joined=CalculationGeometryValidation,
+                onclause=(
+                    CalculationGeometryValidation.calculation_id
+                    == Calculation.id
+                ),
+            ),
+            scf_stability=_entry_coverage_via_join(
+                session,
+                entry_ids,
+                joined=CalculationSCFStability,
+                onclause=CalculationSCFStability.calculation_id
+                == Calculation.id,
+            ),
+        ),
+    )
+
+
+def _entry_coverage_via_join(
+    session: Session,
+    entry_ids: list[int],
+    *,
+    joined,
+    onclause,
+) -> int:
+    """Count TS entries with >=1 calculation carrying a joined evidence row.
+
+    DISTINCT is on ``transition_state_entry_id``, so an entry with three
+    qualifying calculations still counts once.
+    """
+    return int(
+        session.scalar(
+            select(
+                func.count(
+                    func.distinct(Calculation.transition_state_entry_id)
+                )
+            )
+            .select_from(Calculation)
+            .join(joined, onclause)
+            .where(Calculation.transition_state_entry_id.in_(entry_ids))
+        )
+        or 0
+    )
+
+
+def _build_entry_evidence_summary(
+    session: Session, entry_id: int
+) -> TransitionStateEntryEvidenceSummary:
+    """Compute the TS-entry-scope calculation-evidence summary.
+
+    Scope is one candidate saddle point, so the ``has_*`` booleans here
+    are unambiguous — there is no second entry for a ``true`` to hide
+    behind. They are kept as booleans for exactly that reason; the TS
+    concept surface reports counts instead (see
+    :class:`TransitionStateEvidenceSummary`).
+    """
+    entry_ids = [entry_id]
     type_rows = session.execute(
         select(Calculation.type, func.count(Calculation.id))
         .where(Calculation.transition_state_entry_id.in_(entry_ids))
@@ -731,7 +840,7 @@ def _build_evidence_summary_for_entries(
         )
     )
 
-    return TransitionStateCalculationEvidenceSummary(
+    return TransitionStateEntryEvidenceSummary(
         calculation_count=total,
         has_opt=type_counts.get(CalculationType.opt, 0) > 0,
         has_freq=type_counts.get(CalculationType.freq, 0) > 0,

--- a/backend/docs/specs/scientific_transition_state_reads.md
+++ b/backend/docs/specs/scientific_transition_state_reads.md
@@ -88,11 +88,55 @@ Defined in [scientific_transition_state.py](../../app/schemas/reads/scientific_t
 - `TransitionStateReactionContext` — reaction + reaction-entry refs,
   rendered equation (`"A + B <=> C + D"` for reversible, `"->"` for
   irreversible), reaction family name when present.
-- `TransitionStateCalculationEvidenceSummary` — calc count + `has_*`
-  booleans for opt / freq / sp / irc / path_search /
-  geometry_validation / scf_stability. Primary-per-type calculation
-  selection is **deferred** to a later PR — the data model does not
-  currently carry a unique notion of "primary" per type.
+- `TransitionStateEvidenceSummary` — **TS-concept scope**:
+  `entry_count`, `calculation_count`, and an `evidence_coverage` block.
+- `TransitionStateEvidenceCoverage` — per evidence kind (opt / freq /
+  sp / irc / path_search / geometry_validation / scf_stability), how
+  many of the `entry_count` entries have **at least one** calculation
+  of that kind. Every value counts *entries*, never calculations: an
+  entry with three `freq` jobs contributes `1`, so a coverage value can
+  never exceed `entry_count`.
+- `TransitionStateEntryEvidenceSummary` — **TS-entry scope**:
+  `calculation_count` + the `has_*` booleans for the same seven
+  evidence kinds, restricted to this one entry's calculations.
+
+  Primary-per-type calculation selection is **deferred** on both blocks
+  — the data model does not currently carry a unique notion of
+  "primary" per type.
+
+### Why the two scopes have different shapes
+
+The concept block and the entry block deliberately disagree, and the
+disagreement is the design.
+
+Until this split both surfaces shared one class carrying the seven
+`has_*` booleans. At entry scope that is unambiguous — one entry, one
+set of calculations. At concept scope the booleans were an OR across
+every entry under the TS, which made them asymmetrically informative:
+`false` was strong (nothing anywhere under the TS has it) while `true`
+was nearly empty (one calculation under one of many entries). A reader
+seeing `has_sp: true` on a three-entry TS could not tell whether three
+entries had single points or one did — and `true` is the direction
+readers actually act on.
+
+Counts answer the question the boolean could not: `sp: 1` against
+`entry_count: 3` shows an unevenly covered TS at a glance, and
+`count > 0` reproduces the retired boolean exactly, so nothing the
+boolean expressed was lost.
+
+What a **full** count does *not* say: `freq == entry_count` means every
+entry has frequency evidence, not that the entries are **comparable**.
+They may sit at different levels of theory, come from different codes,
+and describe different geometries. Coverage is not consistency; a
+caller who needs consistency must read the per-calculation
+level-of-theory / software provenance under `include=calculations`.
+
+The search surface needs no matching quantifier knob. It returns
+records at the **TS-entry grain**, so its `has_*` filters are already
+scoped to a single entry and were never ambiguous. (This is where the
+transition-state surface differs from the conformer one, whose search
+returns conformer-*group* records and therefore gained an
+`evidence_match=any_observation|all_observations` parameter.)
 - `TransitionStateCalculationSummary` — compact calculation projection
   (ref, type, quality, review, LoT, software, workflow) used by the
   `include=calculations` token. Heavy include sections (results,

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -34524,7 +34524,7 @@
             "title": "Calculations"
           },
           "evidence_summary": {
-            "$ref": "#/components/schemas/TransitionStateCalculationEvidenceSummary"
+            "$ref": "#/components/schemas/TransitionStateEntryEvidenceSummary"
           },
           "geometries": {
             "anyOf": [
@@ -34640,7 +34640,7 @@
             "$ref": "#/components/schemas/TransitionStateEntriesSummary"
           },
           "evidence_summary": {
-            "$ref": "#/components/schemas/TransitionStateCalculationEvidenceSummary"
+            "$ref": "#/components/schemas/TransitionStateEvidenceSummary"
           },
           "geometries": {
             "anyOf": [
@@ -42859,55 +42859,6 @@
         "title": "TorsionTreatmentKind",
         "type": "string"
       },
-      "TransitionStateCalculationEvidenceSummary": {
-        "description": "Compact calculation-evidence projection for a TS or TS-entry.\n\nCounts and ``has_*`` booleans are computed from cheap EXISTS-style\nqueries against the calculation tables under the TS entry. Primary\ncalculation refs are deferred to a later PR — the data model does\nnot currently carry a unique notion of \"primary\" per type, so we\nexpose counts/booleans only.\n\nFor a TS concept, the counts are summed across all entries under\nthe TS. For a TS entry, the counts are restricted to that entry's\ncalculations.",
-        "properties": {
-          "calculation_count": {
-            "title": "Calculation Count",
-            "type": "integer"
-          },
-          "has_freq": {
-            "title": "Has Freq",
-            "type": "boolean"
-          },
-          "has_geometry_validation": {
-            "title": "Has Geometry Validation",
-            "type": "boolean"
-          },
-          "has_irc": {
-            "title": "Has Irc",
-            "type": "boolean"
-          },
-          "has_opt": {
-            "title": "Has Opt",
-            "type": "boolean"
-          },
-          "has_path_search": {
-            "title": "Has Path Search",
-            "type": "boolean"
-          },
-          "has_scf_stability": {
-            "title": "Has Scf Stability",
-            "type": "boolean"
-          },
-          "has_sp": {
-            "title": "Has Sp",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "calculation_count",
-          "has_opt",
-          "has_freq",
-          "has_sp",
-          "has_irc",
-          "has_path_search",
-          "has_geometry_validation",
-          "has_scf_stability"
-        ],
-        "title": "TransitionStateCalculationEvidenceSummary",
-        "type": "object"
-      },
       "TransitionStateCalculationSlot": {
         "description": "One calculation slot within the TS sub-record (ts_opt, ts_freq, etc.).\n\nPhase B: ``calculation_ref`` is the public stable handle alongside\n``calculation_id``.",
         "properties": {
@@ -43170,6 +43121,55 @@
         "title": "TransitionStateEntryCoreBlock",
         "type": "object"
       },
+      "TransitionStateEntryEvidenceSummary": {
+        "description": "Compact calculation-evidence projection for one TS **entry**.\n\nScope is this single entry: ``calculation_count`` and every ``has_*``\nboolean are restricted to the calculations whose\n``transition_state_entry_id`` is this entry. A boolean is\nunambiguous here — it cannot pool a covered entry with an uncovered\none, which is what made the same booleans misleading at TS-concept\nscope (see :class:`TransitionStateEvidenceSummary`).\n\nCounts and booleans are computed from cheap EXISTS-style queries\nagainst the calculation tables. Primary calculation refs are\ndeferred for the same reason as on the concept block.\n\nAs with the concept block's counts, ``has_freq: true`` says\nfrequency evidence exists — not that it is comparable with the\nfrequency evidence on any sibling entry.",
+        "properties": {
+          "calculation_count": {
+            "title": "Calculation Count",
+            "type": "integer"
+          },
+          "has_freq": {
+            "title": "Has Freq",
+            "type": "boolean"
+          },
+          "has_geometry_validation": {
+            "title": "Has Geometry Validation",
+            "type": "boolean"
+          },
+          "has_irc": {
+            "title": "Has Irc",
+            "type": "boolean"
+          },
+          "has_opt": {
+            "title": "Has Opt",
+            "type": "boolean"
+          },
+          "has_path_search": {
+            "title": "Has Path Search",
+            "type": "boolean"
+          },
+          "has_scf_stability": {
+            "title": "Has Scf Stability",
+            "type": "boolean"
+          },
+          "has_sp": {
+            "title": "Has Sp",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "calculation_count",
+          "has_opt",
+          "has_freq",
+          "has_sp",
+          "has_irc",
+          "has_path_search",
+          "has_geometry_validation",
+          "has_scf_stability"
+        ],
+        "title": "TransitionStateEntryEvidenceSummary",
+        "type": "object"
+      },
       "TransitionStateEntryOwnerSummary": {
         "description": "Compact TS / TS-entry owner shape for a calculation.",
         "properties": {
@@ -43319,6 +43319,73 @@
         "title": "TransitionStateEntryStatus",
         "type": "string"
       },
+      "TransitionStateEvidenceCoverage": {
+        "description": "How many TS entries in scope carry each kind of evidence.\n\nEvery value counts **entries**, never calculations. An entry with\nthree ``freq`` calculations contributes ``1`` to ``freq``, not\n``3``. The shared denominator is\n``TransitionStateEvidenceSummary.entry_count``, so a caller reads\neach field as \"*n* of *entry_count*\"; a value can never exceed that\ndenominator, and one that did would mean the query had started\ncounting calculations again.\n\nWhat a full count does and does not say\n---------------------------------------\n``freq == entry_count`` says the coverage is **complete** — every\ncandidate saddle point under this TS has at least one frequency\ncalculation. It does **not** say those calculations are\n*comparable*: the entries may sit at different levels of theory,\ncome from different codes, and describe different geometries. A\ncount is honest about coverage, not about consistency. A caller who\nneeds consistency must inspect the per-calculation level-of-theory /\nsoftware provenance under ``include=calculations``; no number in\nthis block can stand in for that.\n\n``0`` is exactly as strong as the old ``has_x is False`` was:\nnothing in scope carries that evidence.",
+        "properties": {
+          "freq": {
+            "title": "Freq",
+            "type": "integer"
+          },
+          "geometry_validation": {
+            "title": "Geometry Validation",
+            "type": "integer"
+          },
+          "irc": {
+            "title": "Irc",
+            "type": "integer"
+          },
+          "opt": {
+            "title": "Opt",
+            "type": "integer"
+          },
+          "path_search": {
+            "title": "Path Search",
+            "type": "integer"
+          },
+          "scf_stability": {
+            "title": "Scf Stability",
+            "type": "integer"
+          },
+          "sp": {
+            "title": "Sp",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "opt",
+          "freq",
+          "sp",
+          "irc",
+          "path_search",
+          "geometry_validation",
+          "scf_stability"
+        ],
+        "title": "TransitionStateEvidenceCoverage",
+        "type": "object"
+      },
+      "TransitionStateEvidenceSummary": {
+        "description": "Compact calculation-evidence projection for a TS **concept**.\n\n``entry_count`` is the number of ``transition_state_entry`` rows\nunder the TS — the same number as ``entries_summary.total``,\nrepeated here so the coverage block is readable without\ncross-referencing another block. ``calculation_count`` is the number\nof calculations across all of those entries.\n``evidence_coverage`` reports, per evidence kind, how many of the\n``entry_count`` entries carry it.\n\nPrimary calculation refs are deferred — the data model does not\ncurrently carry a unique notion of \"primary\" per type, so this block\nexposes counts only.\n\nWhy counts here and booleans on the entry surface\n-------------------------------------------------\nThis block deliberately has a **different shape** from\n:class:`TransitionStateEntryEvidenceSummary`. That asymmetry is the\npoint, not an oversight, and it should not be smoothed over.\n\nA TS concept pools several candidate entries. The booleans this\nblock used to carry (``has_opt`` / ``has_freq`` / …) were a plain OR\nacross all of them, which made them asymmetrically informative:\n``false`` was strong (nothing under the TS has it) while ``true``\nwas nearly empty (one calculation under one entry made it ``true``).\nA reader seeing ``has_sp: true`` on a three-entry TS could not tell\nwhether three entries had single points or one did. Counts answer\nthat question — ``sp: 1`` against ``entry_count: 3`` shows an\nunevenly covered TS at a glance — and ``count > 0`` reproduces the\nretired boolean exactly, so nothing the boolean expressed was lost.\n\nA TS entry is a single candidate saddle point, so on that surface\nthe booleans are unambiguous and are kept as they were.",
+        "properties": {
+          "calculation_count": {
+            "title": "Calculation Count",
+            "type": "integer"
+          },
+          "entry_count": {
+            "title": "Entry Count",
+            "type": "integer"
+          },
+          "evidence_coverage": {
+            "$ref": "#/components/schemas/TransitionStateEvidenceCoverage"
+          }
+        },
+        "required": [
+          "entry_count",
+          "calculation_count",
+          "evidence_coverage"
+        ],
+        "title": "TransitionStateEvidenceSummary",
+        "type": "object"
+      },
       "TransitionStateIn": {
         "additionalProperties": false,
         "description": "A transition state for one micro reaction.\n\n:param key: Local key for this transition state.\n:param micro_reaction_key: Local key referencing a micro reaction.\n:param charge: Net charge of the TS structure.\n:param multiplicity: Spin multiplicity.\n:param geometry: Geometry of the saddle point (with a reusable key).\n:param calculation: The optimization calculation that produced this TS geometry.\n:param calculations: Additional calculations on this TS (freq, sp, irc).\n:param label: Optional human-readable label.\n:param note: Optional note.",
@@ -43425,7 +43492,7 @@
             "type": "array"
           },
           "evidence_summary": {
-            "$ref": "#/components/schemas/TransitionStateCalculationEvidenceSummary"
+            "$ref": "#/components/schemas/TransitionStateEntryEvidenceSummary"
           },
           "review": {
             "$ref": "#/components/schemas/RecordReviewBadge"

--- a/backend/tests/api/scientific/test_api_scientific_transition_states.py
+++ b/backend/tests/api/scientific/test_api_scientific_transition_states.py
@@ -294,17 +294,211 @@ def test_ts_detail_entries_summary_counts(client, db_session):
 
 
 def test_ts_detail_evidence_summary_counts(client, db_session):
+    """Concept scope: coverage counts, not booleans (single-entry shape).
+
+    Rewritten from the ``has_*`` form when the TS-concept evidence block
+    moved to counts. This is the shape every TS in the live corpus has
+    today — exactly one entry — so it pins the no-regression case:
+    ``count == 1`` where the retired boolean said ``true``, ``0`` where
+    it said ``false``.
+    """
     _, _, ts, entries = _make_reaction_with_ts(db_session)
     lot = make_lot(db_session)
     _attach_calc(db_session, tse=entries[0], calc_type=CalculationType.opt, lot=lot)
     _attach_calc(db_session, tse=entries[0], calc_type=CalculationType.freq, lot=lot)
     body = client.get(_ts_detail_url(ts.public_ref)).json()
     ev = body["record"]["evidence_summary"]
+    assert ev["entry_count"] == 1
     assert ev["calculation_count"] == 2
-    assert ev["has_opt"] is True
-    assert ev["has_freq"] is True
-    assert ev["has_sp"] is False
-    assert ev["has_irc"] is False
+    coverage = ev["evidence_coverage"]
+    assert coverage["opt"] == 1
+    assert coverage["freq"] == 1
+    assert coverage["sp"] == 0
+    assert coverage["irc"] == 0
+    # The retired booleans are gone from this surface entirely — a client
+    # reading ``has_opt`` here must be updated, not silently served a
+    # stale key.
+    assert "has_opt" not in ev
+    assert "has_freq" not in ev
+
+
+def test_ts_detail_evidence_coverage_partial_across_entries(client, db_session):
+    """The case the boolean could not express, and the reason for the PR.
+
+    Two entries under one TS; one has an ``sp`` calculation and one does
+    not. The retired ``has_sp`` OR-ed across entries and reported
+    ``true``, which a reader takes as "this transition state has a
+    single point". Coverage reports ``1`` of ``2``.
+    """
+    _, _, ts, entries = _make_reaction_with_ts(
+        db_session,
+        n_entries=2,
+        statuses=[
+            TransitionStateEntryStatus.optimized,
+            TransitionStateEntryStatus.optimized,
+        ],
+    )
+    lot = make_lot(db_session)
+    _attach_calc(db_session, tse=entries[0], calc_type=CalculationType.opt, lot=lot)
+    _attach_calc(db_session, tse=entries[0], calc_type=CalculationType.sp, lot=lot)
+    _attach_calc(db_session, tse=entries[1], calc_type=CalculationType.opt, lot=lot)
+
+    body = client.get(_ts_detail_url(ts.public_ref)).json()
+    ev = body["record"]["evidence_summary"]
+    assert ev["entry_count"] == 2
+    assert ev["calculation_count"] == 3
+    coverage = ev["evidence_coverage"]
+    # Both entries were optimised; only one has a single point.
+    assert coverage["opt"] == 2
+    assert coverage["sp"] == 1
+    # ``count > 0`` is what the old boolean said. It is still true here,
+    # and still says almost nothing on its own — which is the point.
+    assert coverage["sp"] > 0
+    assert coverage["sp"] < ev["entry_count"]
+
+
+def test_ts_detail_evidence_coverage_all_entries_covered(client, db_session):
+    """Complete coverage reads as ``count == entry_count``."""
+    _, _, ts, entries = _make_reaction_with_ts(
+        db_session,
+        n_entries=3,
+        statuses=[TransitionStateEntryStatus.optimized] * 3,
+    )
+    lot = make_lot(db_session)
+    for entry in entries:
+        _attach_calc(db_session, tse=entry, calc_type=CalculationType.freq, lot=lot)
+
+    ev = client.get(_ts_detail_url(ts.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["entry_count"] == 3
+    assert ev["evidence_coverage"]["freq"] == 3
+    assert ev["evidence_coverage"]["opt"] == 0
+
+
+def test_ts_detail_evidence_coverage_no_entries_covered(client, db_session):
+    """No evidence anywhere reads as ``0`` — as strong as the old ``false``."""
+    _, _, ts, _entries = _make_reaction_with_ts(
+        db_session,
+        n_entries=2,
+        statuses=[TransitionStateEntryStatus.optimized] * 2,
+    )
+    ev = client.get(_ts_detail_url(ts.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["entry_count"] == 2
+    assert ev["calculation_count"] == 0
+    assert ev["evidence_coverage"] == {
+        "opt": 0,
+        "freq": 0,
+        "sp": 0,
+        "irc": 0,
+        "path_search": 0,
+        "geometry_validation": 0,
+        "scf_stability": 0,
+    }
+
+
+def test_ts_detail_evidence_coverage_counts_entries_not_calculations(
+    client, db_session
+):
+    """An entry with several calculations of one kind counts **once**.
+
+    Getting this backwards lets a coverage value exceed ``entry_count``,
+    which is nonsense on its face: "four of two entries have freq".
+    """
+    _, _, ts, entries = _make_reaction_with_ts(
+        db_session,
+        n_entries=2,
+        statuses=[TransitionStateEntryStatus.optimized] * 2,
+    )
+    lot = make_lot(db_session)
+    for _ in range(3):
+        _attach_calc(
+            db_session, tse=entries[0], calc_type=CalculationType.freq, lot=lot
+        )
+    _attach_calc(db_session, tse=entries[1], calc_type=CalculationType.freq, lot=lot)
+
+    ev = client.get(_ts_detail_url(ts.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["entry_count"] == 2
+    # Four freq calculations across two entries.
+    assert ev["calculation_count"] == 4
+    assert ev["evidence_coverage"]["freq"] == 2
+    assert ev["evidence_coverage"]["freq"] <= ev["entry_count"]
+
+
+def test_ts_detail_evidence_coverage_joined_kinds_count_entries(
+    client, db_session
+):
+    """``geometry_validation`` / ``scf_stability`` count entries too.
+
+    These two are reached through a join rather than a calculation type,
+    so they are the ones most likely to drift back to counting rows.
+    """
+    _, _, ts, entries = _make_reaction_with_ts(
+        db_session,
+        n_entries=2,
+        statuses=[TransitionStateEntryStatus.optimized] * 2,
+    )
+    lot = make_lot(db_session)
+    first = _attach_calc(
+        db_session, tse=entries[0], calc_type=CalculationType.opt, lot=lot
+    )
+    second = _attach_calc(
+        db_session, tse=entries[0], calc_type=CalculationType.freq, lot=lot
+    )
+    # Both validated rows sit under the SAME entry — coverage is 1 of 2.
+    attach_geometry_validation(db_session, calculation=first)
+    attach_geometry_validation(db_session, calculation=second)
+    attach_scf_stability(db_session, calculation=first)
+    # The second entry carries a calculation with neither joined row.
+    _attach_calc(db_session, tse=entries[1], calc_type=CalculationType.opt, lot=lot)
+
+    ev = client.get(_ts_detail_url(ts.public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert ev["entry_count"] == 2
+    assert ev["evidence_coverage"]["geometry_validation"] == 1
+    assert ev["evidence_coverage"]["scf_stability"] == 1
+
+
+def test_tse_detail_evidence_summary_keeps_booleans(client, db_session):
+    """Entry scope keeps ``has_*``.
+
+    One entry means one set of calculations, so the boolean cannot pool
+    a covered entry with an uncovered one — there is nothing for a
+    ``true`` to hide behind. The coverage block belongs to the concept
+    surface and is deliberately absent here.
+    """
+    _, _, _ts, entries = _make_reaction_with_ts(
+        db_session,
+        n_entries=2,
+        statuses=[TransitionStateEntryStatus.optimized] * 2,
+    )
+    lot = make_lot(db_session)
+    _attach_calc(db_session, tse=entries[0], calc_type=CalculationType.opt, lot=lot)
+    _attach_calc(db_session, tse=entries[0], calc_type=CalculationType.sp, lot=lot)
+    _attach_calc(db_session, tse=entries[1], calc_type=CalculationType.opt, lot=lot)
+
+    covered = client.get(_tse_detail_url(entries[0].public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert covered["calculation_count"] == 2
+    assert covered["has_opt"] is True
+    assert covered["has_sp"] is True
+    assert covered["has_freq"] is False
+    assert "evidence_coverage" not in covered
+
+    # The sibling entry has no single point, and says so — where the
+    # concept-scope OR reported ``has_sp: true`` for the whole TS.
+    uncovered = client.get(_tse_detail_url(entries[1].public_ref)).json()["record"][
+        "evidence_summary"
+    ]
+    assert uncovered["calculation_count"] == 1
+    assert uncovered["has_opt"] is True
+    assert uncovered["has_sp"] is False
 
 
 def test_ts_detail_available_sections_present(client, db_session):


### PR DESCRIPTION
## In plain language

A **transition state** in TCKDB is the concept — "the saddle point for this
reaction channel". Under it sit one or more **entries**: concrete candidate
geometries, each with its own calculations. Today every transition state has
exactly one entry, but nothing stops a second one being deposited (a
re-optimisation at a different level of theory, for instance).

The read API showed, on the transition-state page, seven yes/no flags:
"has an optimisation", "has a frequency job", "has a single point", and so
on. Those flags were computed by looking at **all** the entries at once and
answering yes if **any** of them had it. So on a transition state with three
entries, "has a single point: yes" could mean three of three, or one of
three — and a reader naturally hears the first. A "no" was trustworthy
(nothing anywhere has it); a "yes" said almost nothing. That is the worst
property a flag can have: it is reliable only in the direction nobody
consults it for.

This PR replaces those flags, on the transition-state page only, with
**counts**: "2 of the 3 entries have a frequency job". The entry page keeps
the yes/no flags, because there one entry means one set of calculations and
a "yes" has nothing to hide behind.

One honesty note carried into the docstrings and the spec: a **full** count
("3 of 3") says coverage is complete, **not** that the three are
*comparable*. They may sit at three different levels of theory, from three
different codes, at three different geometries. Coverage is not consistency,
and no number in this block can stand in for reading the per-calculation
provenance.

## It is latent today — and that is the argument for fixing it, not against

Measured against the hosted instance just now:

```
GET /api/v1/scientific/transition-states/search?has_calculations=true&limit=200
→ 34 entry records, 34 distinct transition_state_ref, max entries under
  one TS = 1
GET …?has_calculations=false → 0 records
```

All 34 transition states have exactly one entry. The OR therefore **cannot
currently differ** from that single entry's own value, and **no user has
been misled**. This PR does not claim the endpoint is producing wrong
answers today.

What it claims is worse in a different way: the field is currently
**incapable of being noticed**. The day someone deposits a second entry
under one transition state, `has_sp: true` silently starts meaning
"one of two" while continuing to render exactly as it did the day before.
Nothing in the response marks the change. Fixing it while it is still
latent costs one expression at each call site; fixing it after costs a data
audit of everything that read the flag in between. The conformer-group
version of this same defect (#228) was found the same way.

## Technical detail

`TransitionStateCalculationEvidenceSummary` was used at two scopes: on the
TS **entry** record (restricted to that entry's calculations) and on the TS
**concept** record, where its own docstring said the counts are summed
across all entries. `calculation_count` summing is honest. The seven
`has_*` booleans were not — at concept scope they OR across every entry.

Split into two classes, mirroring #228's shape and naming
(`ConformerGroupEvidenceSummary` / `ConformerObservationEvidenceSummary` /
`ConformerEvidenceCoverage`):

| | old | new |
|---|---|---|
| TS concept | `TransitionStateCalculationEvidenceSummary` | `TransitionStateEvidenceSummary` — `entry_count`, `calculation_count`, `evidence_coverage` |
| TS entry | same class | `TransitionStateEntryEvidenceSummary` — `calculation_count` + the seven `has_*`, unchanged |
| coverage | — | `TransitionStateEvidenceCoverage` — `opt`, `freq`, `sp`, `irc`, `path_search`, `geometry_validation`, `scf_stability` |

`entry_count` is the shared denominator (the same number as
`entries_summary.total`, repeated so the coverage block reads without a
cross-reference). Coverage counts **entries**, not calculations: the type
query is `COUNT(DISTINCT Calculation.transition_state_entry_id)` grouped by
type, and the two join-reached kinds go through `_entry_coverage_via_join`,
which is DISTINCT on the same column. An entry with three `freq` jobs
contributes `1`. Getting that backwards would let a coverage value exceed
`entry_count` — "four of two entries have freq" — which is why one of the
mutation tests below aims squarely at it.

`count > 0` reproduces the retired boolean exactly, so nothing the boolean
expressed was lost.

### No `evidence_match` quantifier — and why (this is where the brief was wrong)

The brief asked me to find the TS equivalent of `conformers_search.py`'s
boolean filters and, if one existed, add `evidence_match` as #228 did. One
exists (`transition_states_search.py::_apply_evidence_filters`) — but the TS
search returns records at the **TS-entry grain**, not the concept grain. Its
`has_*` filters are already scoped to a single entry and were never
ambiguous, so there is no "any vs all" question to make explicit. Adding a
quantifier there would be a parameter with one meaning.

That is the substantive difference from the conformer surface, whose search
returns conformer-*group* records. It is written into the spec so the next
reader does not try to "restore symmetry". It also means **no MCP allowlist
entry, and therefore no `integrations/mcp`, `clients/python` or
`schemas/python` change — and no version bump.** `tckdb-client` types
`evidence_summary` as an opaque `JSONDict`, so it needed no edit either.

## Breaking read-API change

**Breaking** for callers reading `has_*` off
`GET /api/v1/scientific/transition-states/{ref}`.

**Migration: `has_x` → `evidence_coverage.x > 0`.** Exactly equivalent.

Unchanged and non-breaking:
`GET /scientific/transition-state-entries/{ref}`, the search surface, and
the `transition_states[*].evidence_summary` block inside
`/reaction-entries/{id}/full` (which is built at entry scope) all keep the
booleans.

## Schema / migration impact

**None.** This is a read projection over existing tables — no model change,
no Alembic revision, nothing touched under `backend/alembic/`.

## Version bumps

**None required.** No file under `integrations/mcp/`, `clients/python/` or
`schemas/python/` is modified. `git status` on the branch is eight files,
all under `backend/` plus `CHANGELOG.md`.

## Tests

**Rewritten** (concept scope, `has_*` → counts):

- `test_ts_detail_evidence_summary_counts` — **TS-concept scope**. Was
  asserting `has_opt`/`has_freq`/`has_sp`/`has_irc`. Now asserts
  `entry_count == 1`, `coverage.opt == 1`, `coverage.sp == 0`, and that
  `has_opt`/`has_freq` are **absent** from the payload — a removed field
  must be removed, not silently served stale. This is today's live shape
  (one entry per TS), so it is also the no-regression pin.

**Added** (all TS-concept scope unless noted):

- `test_ts_detail_evidence_coverage_partial_across_entries` — **the test
  that justifies the PR.** Two entries, one with an `sp` calculation and
  one without; asserts `coverage.sp == 1` against `entry_count == 2`. This
  is the case the boolean cannot express and the corpus does not contain,
  so the fixture constructs it.
- `test_ts_detail_evidence_coverage_all_entries_covered` — three entries,
  all with `freq`: `coverage.freq == 3 == entry_count`.
- `test_ts_detail_evidence_coverage_no_entries_covered` — two entries, no
  calculations: every coverage value `0`, asserted as a whole dict.
- `test_ts_detail_evidence_coverage_counts_entries_not_calculations` —
  three `freq` on one entry, one on the other: `calculation_count == 4`
  but `coverage.freq == 2`, and `coverage.freq <= entry_count`.
- `test_ts_detail_evidence_coverage_joined_kinds_count_entries` — the same
  discipline for `geometry_validation` / `scf_stability`, which are reached
  through a join rather than a calculation type and are the two most likely
  to drift back to counting rows.
- `test_tse_detail_evidence_summary_keeps_booleans` — **TS-entry scope.**
  Booleans still present and correct on both entries of a two-entry TS
  (`has_sp: true` on one, `false` on the sibling — where the concept-scope
  OR said `true` for the whole TS), and `evidence_coverage` absent.

**Unchanged, entry scope, verified still passing:**
`test_api_reaction_full.py::test_full_ts_block_includes_evidence_summary`
and `::test_full_ts_evidence_summary_matches_tse_detail` keep asserting
`has_opt` / `has_sp`, correctly — `/full` embeds the entry-scope block. The
TS search tests (`test_search_by_has_opt`, `has_sp`, `has_irc`, the
`has_*=false` set) are untouched for the same reason. Nothing was weakened,
skipped, xfailed or deleted.

## Mutation testing

Three mutations, each landed in the working tree, proven present in
`git diff`, run, shown failing the intended test, then reverted with the
file confirmed byte-identical by SHA-256
(`5213c214e107d82bfa6dfdb6b75422fe9d96f73bf5861263000c6e6fe0028758`
before and after all three).

1. **Coverage counts calculations, not entries** —
   `COUNT(DISTINCT transition_state_entry_id)` → `COUNT(Calculation.id)` in
   the concept GROUP BY.
   → `test_ts_detail_evidence_coverage_counts_entries_not_calculations`
   FAILED: `assert 4 == 2` (coverage exceeded `entry_count`, the exact
   nonsense the test names).
2. **The old OR semantics, reinstated as a count** —
   `sp=entry_coverage.get(...)` → `sp=(len(entry_ids) if … else 0)`.
   → `test_ts_detail_evidence_coverage_partial_across_entries` FAILED:
   `assert 2 == 1`. The justifying test does catch the original defect.
3. **Join coverage counts rows** — `_entry_coverage_via_join`'s
   `COUNT(DISTINCT transition_state_entry_id)` → `COUNT(Calculation.id)`.
   → `test_ts_detail_evidence_coverage_joined_kinds_count_entries` FAILED:
   `assert 2 == 1`.

## Verification actually run

From `backend/`, conda env `tckdb_env`, exit codes captured with `$?` (not
piped to `tail`):

```
ruff check app tests scripts                → All checks passed!   exit 0
bash scripts/test-scientific.sh             → 2132 passed          exit 0
bash scripts/test-api.sh                    → 3184 passed          exit 0
bash scripts/test-rest.sh                   → 4892 passed, 14 skipped  exit 0
bash scripts/update-openapi-golden.sh       → golden regenerated, 3 passed
pytest tests/api/scientific/test_api_scientific_transition_states.py \
       tests/api/scientific/test_api_reaction_full.py
                                            → 151 passed          exit 0
```

`ruff format` was **not** run (repo-wide disabled); formatting is by hand.

Live instance touched **read-only**, via `curl` (WebFetch is 403'd by the
WAF): two GETs against
`/api/v1/scientific/transition-states/search` to establish the 34-TS /
one-entry-each measurement above, plus `/api/v1/health`. No POST, no Pi
change, no deployed database touched. Local scratch DB was `tckdb_test*`
via the standard fixture.

## Files touched outside transition-state files

Two, both mechanical renames of the entry-scope symbol, flagged because the
brief warned another agent may be working in
`backend/app/services/scientific_read/`:

- `backend/app/schemas/reads/scientific_provenance.py` — the `/full` TS
  block's field type, `TransitionStateCalculationEvidenceSummary` →
  `TransitionStateEntryEvidenceSummary`. Same shape, entry scope, no
  behaviour change.
- `backend/app/services/scientific_read/provenance.py` — imports and calls
  `_build_entry_evidence_summary(session, ts_entry.id)` in place of the
  retired `_build_evidence_summary_for_entries(session, [ts_entry.id])`.

Plus `CHANGELOG.md` (an `Unreleased → Changed` entry, since this is a
breaking HTTP contract change and the repo's pre-1.0 policy says those get
written down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEMrWcGRqbAVoh1Cn3TJ9D
