### PR TITLE
Lift the include-gated strip into one declared table

### DIFF
--- a/backend/app/api/public_openapi.py
+++ b/backend/app/api/public_openapi.py
@@ -4,15 +4,27 @@ Internal Pydantic models retain integer primary keys because local/debug
 deployments may opt into them.  Hosted JSON removes those keys at the response
 seam.  This module projects the generated schema through the same policy
 without duplicating every response model.
+
+Two runtime policies narrow what a real hosted payload contains without
+narrowing what the generated schema declares, and both are stamped here so
+the document says so rather than merely failing to contradict it:
+
+- ``x-tckdb-policy-hidden: true`` — an internal integer id, removed from
+  ``required`` and absent unless the deployment opts in.
+- ``x-tckdb-include-gated: "<token>"`` — an include-gated section, absent
+  unless the caller supplies that ``include=`` token. Its declared type is
+  unchanged and it is returned whenever it is requested, so this is a
+  narrowing of the payload, not a removal of the field.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from typing import Any
 
 from fastapi import FastAPI
 
+from app.api.routes.scientific._response import INCLUDE_GATED_COMPONENTS
 from app.services.scientific_read.internal_ids import is_internal_id_key
 
 _SCIENTIFIC_PATH_PREFIX = "/api/v1/scientific/"
@@ -82,6 +94,28 @@ def _make_internal_ids_optional(node: object) -> None:
                 _make_internal_ids_optional(item)
 
 
+def _mark_include_gated(
+    component: dict[str, Any], gating: Mapping[str, str]
+) -> None:
+    """Stamp ``x-tckdb-include-gated`` on the properties *gating* names.
+
+    Names come from the declared token -> section tables in
+    ``app.api.routes.scientific._response``, never from a scan of the
+    document, so the marker cannot drift onto a same-named field that is
+    nullable for an unrelated reason. An include-gated property is
+    already declared ``... | None = None`` and so is already absent from
+    ``required``; nothing needs removing, only saying.
+    """
+
+    properties = component.get("properties")
+    if not isinstance(properties, dict):
+        return
+    for name, token in gating.items():
+        property_schema = properties.get(name)
+        if isinstance(property_schema, dict):
+            property_schema["x-tckdb-include-gated"] = token
+
+
 def project_hosted_openapi(schema: dict[str, Any]) -> dict[str, Any]:
     """Mutate and return generated OpenAPI as the hosted public contract."""
 
@@ -90,6 +124,11 @@ def project_hosted_openapi(schema: dict[str, Any]) -> dict[str, Any]:
         component = component_schemas.get(name)
         if isinstance(component, dict):
             _make_internal_ids_optional(component)
+
+    for name, gating in INCLUDE_GATED_COMPONENTS.items():
+        component = component_schemas.get(name)
+        if isinstance(component, dict):
+            _mark_include_gated(component, gating)
 
     validation_error = component_schemas.get("HTTPValidationError")
     if isinstance(validation_error, dict):

--- a/backend/app/api/routes/scientific/_response.py
+++ b/backend/app/api/routes/scientific/_response.py
@@ -1,9 +1,35 @@
-"""Response-boundary helpers for scientific read routes."""
+"""Response-boundary helpers for scientific read routes.
+
+Two things happen at this boundary. The Phase D internal-ID policy is
+applied (``apply_internal_ids_visibility``), and **include-gated sections
+the caller did not ask for are dropped from the serialized payload**.
+This module owns the second one.
+
+Why a key is dropped rather than nulled
+---------------------------------------
+A section that was not requested and a section that does not exist for
+this record are different facts. Sharing one wire value (``null``) makes
+them indistinguishable, and the failure mode of guessing wrong is silent:
+a reader concludes the database is empty. So there are three states and
+three representations::
+
+    not requested                -> key absent
+    requested, nothing there     -> key present, ``null`` (or ``[]``)
+    requested, something there   -> key present, populated
+
+The middle row is deliberate and must survive: collapsing it back into
+the top row restores the same ambiguity from the other direction. See
+``ScientificCalculationRecord``'s docstring in
+``app/schemas/reads/scientific_calculation.py``, which states the rule for
+the surface this machinery was first written for.
+"""
 
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from fastapi.responses import JSONResponse
@@ -12,6 +38,269 @@ from sqlalchemy.orm import Session
 from app.services.scientific_read.internal_ids import apply_internal_ids_visibility
 
 AssessmentAttacher = Callable[[Session, Any], Any]
+
+# Envelope shapes the strip knows how to walk. ``scope`` names *where the
+# records are*, never *which fields to drop* — that is the table's job and
+# only the table's job.
+DETAIL_SCOPE = "detail"
+SEARCH_SCOPE = "search"
+FULL_SCOPE = "full"
+ANYWHERE_SCOPE = "anywhere"
+
+# The composite ``/reaction-entries/{id}/full`` document embeds records
+# under these three keys rather than under ``record``/``records``.
+_FULL_EMBEDDED_RECORD_SECTIONS = ("kinetics", "calculations", "transition_states")
+
+
+@dataclass(frozen=True)
+class IncludeGatedSections:
+    """A declared table of include token → response field names, per surface.
+
+    The table is the whole safety argument, so it is worth being explicit
+    about what it buys.
+
+    **The strip is structurally incapable of touching a field this table
+    does not name.** :func:`omit_unrequested_sections` computes the set of
+    keys to pop from the table alone — it never inspects a value, never
+    tests for ``None``, and accepts no predicate. There is no argument you
+    can pass it that means "drop the nulls". That is not a convention to
+    be observed; it is the only thing the function can express.
+
+    It has to be that way, because nullability means different things in
+    different places and one of them is a live protocol signal. The Python
+    client (``clients/python/pagination.py``) reads an **absent**
+    ``next_cursor`` as "this server predates the keyset contract, restart
+    the traversal from offset zero" and a **present-and-null**
+    ``next_cursor`` as "this was the last page, you are done". A blanket
+    "omit null optionals" pass would turn every completed traversal into a
+    restart and silently yield the entire result set twice — duplicated
+    records in a chemistry dataset, with no error anywhere. The same rule
+    read from the other side: ``pagination.py`` also tests
+    ``"post_collapse_total" in pagination``, so that field must never
+    start being emitted as an explicit ``null``. Never null a field a
+    client tests for presence, and never omit a field a client tests for
+    nullity.
+
+    **The table is per-surface and explicit rather than derived from field
+    names, because names collide.** One calculation response carries two
+    fields called ``workflow_tool_release``: the record's own provenance
+    field, which is ``null`` because the calculation references no
+    workflow tool and must keep that ``null``; and one nested inside the
+    include-gated ``execution_environment`` block, which disappears with
+    its section. Same name, same response, opposite treatment. Any
+    implementation matching on names gets one of them wrong.
+
+    **The mapping is not the identity.** ``"review" → "review_history"``
+    is a live entry, so deriving a field name from a token name would be
+    wrong on the first surface it met.
+
+    :param surface: human-readable name of the surface this table
+        describes, used in error messages and when auditing the tables.
+    :param sections: include token → the response field names that token
+        governs. A token absent from the caller's resolved include set has
+        every one of its fields popped.
+    """
+
+    surface: str
+    sections: Mapping[str, tuple[str, ...]]
+
+    def __post_init__(self) -> None:
+        normalized = {token: tuple(fields) for token, fields in self.sections.items()}
+        object.__setattr__(self, "sections", MappingProxyType(normalized))
+
+    def fields_to_omit(self, requested: Iterable[str]) -> set[str]:
+        """Return the response field names the resolved include set does not license."""
+        licensed = set(requested)
+        return {
+            field
+            for token, fields in self.sections.items()
+            if token not in licensed
+            for field in fields
+        }
+
+    def fields_by_token(self) -> dict[str, str]:
+        """Return field name → gating token, for documentation surfaces."""
+        return {
+            field: token
+            for token, fields in self.sections.items()
+            for field in fields
+        }
+
+
+# ---------------------------------------------------------------------------
+# Declared tables
+# ---------------------------------------------------------------------------
+
+# Heavy include tokens whose corresponding ``record`` field is omitted
+# when the caller did not opt in, on ``/api/v1/scientific/calculations/*``.
+# Each new heavy include needs one entry and nothing else.
+#
+# ``imaginary_mode_projections`` is in this table without being in the
+# surface's ``_HEAVY_INCLUDE_TOKENS``, which is only possible because the
+# table is declared rather than inferred.
+CALCULATION_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/calculations",
+    sections={
+        "results": ("results",),
+        "dependencies": ("dependencies",),
+        "artifacts": ("artifacts",),
+        "input_geometries": ("input_geometries",),
+        "output_geometries": ("output_geometries",),
+        "geometry_validation": ("geometry_validation",),
+        "scf_stability": ("scf_stability",),
+        "wavefunction_diagnostic": ("wavefunction_diagnostic",),
+        "spin_diagnostic": ("spin_diagnostic",),
+        "parameters": ("parameters",),
+        "constraints": ("constraints",),
+        "review": ("review_history",),
+        "freq_modes": ("freq_modes",),
+        "imaginary_mode_projections": ("imaginary_mode_projections",),
+        "scan": ("scan",),
+        "irc": ("irc",),
+        "path_search": ("path_search",),
+        "execution_environment": ("execution_environment",),
+    },
+)
+
+# ``trust`` and ``assessments`` are single-token tables applied wherever
+# their two long-standing helpers are called. They are one-entry tables
+# rather than bare strings so that every strip in the codebase goes
+# through the same declared-table gate.
+TRUST_SECTION = IncludeGatedSections(
+    surface="trust",
+    sections={"trust": ("trust",)},
+)
+
+ASSESSMENTS_SECTION = IncludeGatedSections(
+    surface="assessments",
+    sections={"assessments": ("assessments",)},
+)
+
+# Component-scoped view of the tables above, consumed by
+# ``app.api.public_openapi`` to stamp ``x-tckdb-include-gated`` on the
+# hosted document.
+#
+# A component is listed here only when **every** operation that can return
+# it already omits the property, because the marker is a claim about the
+# hosted runtime and the document must not run ahead of it.
+# ``ScientificCalculationRecord`` is the only such component today: it is
+# returned by the three ``/calculations/*`` operations and nothing else,
+# and all three strip both tables below. Components whose ``trust`` or
+# ``assessments`` is omitted on some operations and nulled on others —
+# ``KineticsRecord``, ``ThermoRecord``,
+# ``ScientificTransitionStateEntryRecord`` — join this registry when the
+# surfaces that null them are flipped, not before.
+INCLUDE_GATED_COMPONENTS: Mapping[str, Mapping[str, str]] = MappingProxyType(
+    {
+        "ScientificCalculationRecord": MappingProxyType(
+            {
+                **CALCULATION_RECORD_SECTIONS.fields_by_token(),
+                **TRUST_SECTION.fields_by_token(),
+            }
+        ),
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# The strip
+# ---------------------------------------------------------------------------
+
+
+def _every_dict(node: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _every_dict(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _every_dict(value)
+
+
+def _record_nodes(data: dict[str, Any], scope: str) -> Iterator[dict[str, Any]]:
+    """Yield the dicts a strip of *scope* is allowed to pop keys from."""
+    if scope == DETAIL_SCOPE:
+        record = data.get("record")
+        if isinstance(record, dict):
+            yield record
+    elif scope == SEARCH_SCOPE:
+        for record in data.get("records", []) or []:
+            if isinstance(record, dict):
+                yield record
+    elif scope == FULL_SCOPE:
+        for section in _FULL_EMBEDDED_RECORD_SECTIONS:
+            for record in data.get(section, []) or []:
+                if isinstance(record, dict):
+                    yield record
+    elif scope == ANYWHERE_SCOPE:
+        yield from _every_dict(data)
+    else:
+        raise ValueError(
+            f"unknown response scope {scope!r}; expected one of "
+            f"{DETAIL_SCOPE!r}, {SEARCH_SCOPE!r}, {FULL_SCOPE!r}, "
+            f"{ANYWHERE_SCOPE!r}"
+        )
+
+
+def omit_unrequested_sections(
+    visibility: Any,
+    payload: Any,
+    *,
+    table: IncludeGatedSections,
+    scope: str = DETAIL_SCOPE,
+):
+    """Drop the include-gated fields *table* declares and the caller did not request.
+
+    ``visibility`` is whatever
+    :func:`app.services.scientific_read.internal_ids.apply_internal_ids_visibility`
+    returned: either the Pydantic model unchanged (when the deployment
+    allows internal ids *and* the caller opted in) or a
+    :class:`~fastapi.responses.JSONResponse` carrying a pre-stripped dict.
+    In the JSONResponse branch the serialized dict is mutated; in the
+    Pydantic branch it is re-serialized via ``model_dump`` so keys can be
+    dropped too. The OpenAPI / ``response_model`` contract is preserved in
+    both branches because every dropped key is declared
+    ``... | None = None`` on the schema, so the document already permits
+    its absence.
+
+    Distinguishing "did not ask" (key absent) from "asked, no row" (key
+    present, value ``null``) lets clients tell the two cases apart without
+    having to re-read ``request.include``.
+
+    ``table`` must be an :class:`IncludeGatedSections`. That is enforced
+    rather than assumed: the type is the only thing standing between this
+    helper and a blanket null-strip, and the reason it matters is written
+    out on :class:`IncludeGatedSections` itself.
+
+    ``scope`` selects which part of the envelope holds records —
+    ``"detail"`` (the singular ``record``), ``"search"`` (every entry of
+    ``records``), ``"full"`` (the composite ``/reaction-entries/{id}/full``
+    document's embedded record lists) or ``"anywhere"`` (every dict in the
+    payload, for a field that can nest at any depth).
+    """
+    if not isinstance(table, IncludeGatedSections):
+        raise TypeError(
+            "omit_unrequested_sections requires a declared IncludeGatedSections "
+            f"table, got {type(table).__name__!r}. The strip is driven by a "
+            "declared token -> field table and by nothing else: a field no "
+            "table names keeps its null, because nullability is a live "
+            "protocol signal elsewhere in the API (see IncludeGatedSections)."
+        )
+
+    to_drop = table.fields_to_omit(payload.request.include)
+    if not to_drop:
+        return visibility
+
+    if isinstance(visibility, JSONResponse):
+        data = json.loads(visibility.body)
+    else:
+        data = visibility.model_dump(mode="json")
+
+    for record in _record_nodes(data, scope):
+        for key in to_drop:
+            record.pop(key, None)
+
+    return JSONResponse(data)
 
 
 def prepare_assessment_response(
@@ -38,7 +327,7 @@ def omit_trust_unless_requested(
     visibility: Any,
     payload: Any,
     *,
-    scope: str = "detail",
+    scope: str = DETAIL_SCOPE,
 ):
     """Drop ``record.trust`` unless the caller explicitly requested it.
 
@@ -52,49 +341,47 @@ def omit_trust_unless_requested(
       transition-state-entry record so the default ``/full`` payload
       stays byte-identical to its pre-trust-propagation shape.
     """
-    if "trust" in set(payload.request.include):
-        return visibility
-
-    if isinstance(visibility, JSONResponse):
-        data = json.loads(visibility.body)
-    else:
-        data = visibility.model_dump(mode="json")
-
-    if scope == "detail":
-        record = data.get("record")
-        if isinstance(record, dict):
-            record.pop("trust", None)
-    elif scope == "full":
-        for section in ("kinetics", "calculations", "transition_states"):
-            for record in data.get(section, []) or []:
-                if isinstance(record, dict):
-                    record.pop("trust", None)
-    else:
-        for record in data.get("records", []) or []:
-            if isinstance(record, dict):
-                record.pop("trust", None)
-
-    return JSONResponse(data)
+    return omit_unrequested_sections(
+        visibility, payload, table=TRUST_SECTION, scope=scope
+    )
 
 
 def omit_assessments_unless_requested(visibility: Any, payload: Any):
     """Remove opt-in assessment summaries from every nested record by default."""
-    if "assessments" in set(payload.request.include):
-        return visibility
+    return omit_unrequested_sections(
+        visibility, payload, table=ASSESSMENTS_SECTION, scope=ANYWHERE_SCOPE
+    )
 
-    if isinstance(visibility, JSONResponse):
-        data = json.loads(visibility.body)
-    else:
-        data = visibility.model_dump(mode="json")
 
-    def strip(node: Any) -> None:
-        if isinstance(node, dict):
-            node.pop("assessments", None)
-            for value in node.values():
-                strip(value)
-        elif isinstance(node, list):
-            for value in node:
-                strip(value)
+def omit_unrequested_calculation_sections(
+    visibility: Any,
+    payload: Any,
+    *,
+    scope: str = DETAIL_SCOPE,
+):
+    """Drop the heavy ``/calculations/*`` sections the caller did not request.
 
-    strip(data)
-    return JSONResponse(data)
+    ``scope='detail'`` operates on the singular ``record`` field;
+    ``scope='search'`` operates on every entry of the ``records`` list.
+    """
+    return omit_unrequested_sections(
+        visibility, payload, table=CALCULATION_RECORD_SECTIONS, scope=scope
+    )
+
+
+__all__ = [
+    "ANYWHERE_SCOPE",
+    "ASSESSMENTS_SECTION",
+    "CALCULATION_RECORD_SECTIONS",
+    "DETAIL_SCOPE",
+    "FULL_SCOPE",
+    "INCLUDE_GATED_COMPONENTS",
+    "SEARCH_SCOPE",
+    "TRUST_SECTION",
+    "IncludeGatedSections",
+    "omit_assessments_unless_requested",
+    "omit_trust_unless_requested",
+    "omit_unrequested_calculation_sections",
+    "omit_unrequested_sections",
+    "prepare_assessment_response",
+]

--- a/backend/app/api/routes/scientific/calculations.py
+++ b/backend/app/api/routes/scientific/calculations.py
@@ -14,13 +14,15 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
-from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
-from app.api.routes.scientific._response import omit_trust_unless_requested
+from app.api.routes.scientific._response import (
+    omit_trust_unless_requested,
+    omit_unrequested_calculation_sections,
+)
 from app.db.models.common import (
     ArtifactKind,
     CalculationDependencyRole,
@@ -154,7 +156,7 @@ def scientific_calculations_search_get(
     )
     payload = search_calculations(session, request_obj)
     visibility = apply_internal_ids_visibility(payload)
-    visibility = _omit_unrequested_heavy_sections(
+    visibility = omit_unrequested_calculation_sections(
         visibility, payload, scope="search"
     )
     return omit_trust_unless_requested(visibility, payload, scope="search")
@@ -185,7 +187,7 @@ def scientific_calculations_search_post(
         )
     payload = search_calculations(session, body)
     visibility = apply_internal_ids_visibility(payload)
-    visibility = _omit_unrequested_heavy_sections(
+    visibility = omit_unrequested_calculation_sections(
         visibility, payload, scope="search"
     )
     return omit_trust_unless_requested(visibility, payload, scope="search")
@@ -223,84 +225,5 @@ def scientific_calculation_detail(
         request=request,
     )
     visibility = apply_internal_ids_visibility(payload)
-    visibility = _omit_unrequested_heavy_sections(visibility, payload)
+    visibility = omit_unrequested_calculation_sections(visibility, payload)
     return omit_trust_unless_requested(visibility, payload)
-
-
-# ---------------------------------------------------------------------------
-# Conditional-include omission
-# ---------------------------------------------------------------------------
-
-
-# Heavy include tokens whose corresponding ``record`` field is omitted
-# when the caller did not opt in. The mapping is (token → record key) so
-# each new heavy include only needs one entry.
-_OMITTABLE_RECORD_KEYS: dict[str, str] = {
-    "results": "results",
-    "dependencies": "dependencies",
-    "artifacts": "artifacts",
-    "input_geometries": "input_geometries",
-    "output_geometries": "output_geometries",
-    "geometry_validation": "geometry_validation",
-    "scf_stability": "scf_stability",
-    "wavefunction_diagnostic": "wavefunction_diagnostic",
-    "spin_diagnostic": "spin_diagnostic",
-    "parameters": "parameters",
-    "constraints": "constraints",
-    "review": "review_history",
-    "freq_modes": "freq_modes",
-    "imaginary_mode_projections": "imaginary_mode_projections",
-    "scan": "scan",
-    "irc": "irc",
-    "path_search": "path_search",
-    "execution_environment": "execution_environment",
-}
-
-
-def _omit_unrequested_heavy_sections(visibility, payload, *, scope: str = "detail"):
-    """Drop ``record.<key>`` fields for heavy includes the caller didn't request.
-
-    The Phase D :func:`apply_internal_ids_visibility` returns either the
-    Pydantic model unchanged (when the deployment allows internal ids
-    *and* the caller opted in) or a :class:`JSONResponse` carrying a
-    pre-stripped dict. In the JSONResponse branch we mutate the
-    serialized dict; in the Pydantic-model branch we re-serialize via
-    ``model_dump`` so we can also drop keys. The OpenAPI / response_model
-    contract is preserved in both branches because the dropped keys are
-    declared ``... | None = None`` on the schema.
-
-    Distinguishing "did not ask" (key absent) from "asked, no row"
-    (key present, value ``null``) lets clients tell the two cases apart
-    without having to re-read ``request.include``.
-
-    ``scope='detail'`` operates on the singular ``record`` field;
-    ``scope='search'`` operates on every entry of the ``records`` list.
-    """
-    requested = set(payload.request.include)
-    to_drop = {
-        record_key
-        for token, record_key in _OMITTABLE_RECORD_KEYS.items()
-        if token not in requested
-    }
-    if not to_drop:
-        return visibility
-
-    if isinstance(visibility, JSONResponse):
-        import json
-
-        data = json.loads(visibility.body)
-    else:
-        data = visibility.model_dump(mode="json")
-
-    if scope == "detail":
-        record = data.get("record")
-        if isinstance(record, dict):
-            for key in to_drop:
-                record.pop(key, None)
-    else:  # scope == "search"
-        for record in data.get("records", []) or []:
-            if isinstance(record, dict):
-                for key in to_drop:
-                    record.pop(key, None)
-
-    return JSONResponse(data)

--- a/backend/docs/specs/machine_consumer_query_contract.md
+++ b/backend/docs/specs/machine_consumer_query_contract.md
@@ -8,7 +8,74 @@ Requirement 10 remains ongoing as each surface expands.
 - Additive response fields are backward compatible. Removing or changing the meaning/type of a field requires a versioned contract.
 - A declared filter is either enforced or rejected. It must never be accepted and ignored.
 - Public refs are stable identifiers. Integer database IDs are deployment-policy fields and are optional in hosted response schemas.
+- An include-gated section that the caller did not request is **omitted** from the response, not returned as `null`. That is the rule; it holds today on `/api/v1/scientific/calculations/*` and for `trust`/`assessments`, and the remaining surfaces are being converted to it one declared table at a time. See [Include-gated sections](#include-gated-sections-absent-means-you-did-not-ask) for the three-state rule and its hard boundary.
 - Pagination metadata reports `total` for the complete filtered candidate set before collapse and `post_collapse_total` after collapse but before page slicing. Collapse is applied first, so `collapse=first&offset=1` returns an empty page while retaining `total >= 1` and `post_collapse_total = 1`.
+
+## Include-gated sections: absent means "you did not ask"
+
+A section a caller did not request and a section that does not exist for this
+record are different facts. Giving them one wire value makes them
+indistinguishable, and the failure mode of guessing wrong is silent — a reader
+concludes the database is empty. So there are three states and three
+representations:
+
+| Case | Wire |
+|---|---|
+| Not requested | key absent |
+| Requested, nothing there | key present, `null` (or `[]` for a list section) |
+| Requested, something there | key present, populated |
+
+The middle row is as load-bearing as the top one. Collapsing "requested, nothing
+there" into "not requested" restores the same ambiguity from the other
+direction, so a requested-but-empty section keeps its `null`.
+
+`request.include` echoes the **resolved** token set — `include=all` as its
+expansion, and never a token the deployment's policy dropped — so a reader can
+always recover what was asked without inferring it from what came back.
+`available_sections` answers the other question, "is there any of this?", and
+answers it without being asked.
+
+**Omission is not removal.** The field stays declared, stays typed, and is
+returned whenever it is requested. What changes is the wire representation of a
+case the contract never assigned a meaning to, so this sits inside the existing
+contract rather than requiring a versioned one.
+
+### The hard boundary
+
+**Only include-gated sections are omitted. No blanket "drop null optional
+fields" rule applies to a scientific response, at any layer, ever.**
+
+Nullability means different things in different places, and in at least one it
+is a live protocol signal read in the opposite direction. The Python client
+treats an **absent** `next_cursor` as "this server predates the keyset contract
+— restart the traversal from offset zero" and a **present-and-null**
+`next_cursor` as "this was the last page, you are done". A blanket null-strip
+would turn every completed traversal into a restart and silently yield the
+whole result set twice. Fields such as `next_cursor`, `post_collapse_total`,
+`supersession`, `conformer`, `formula`, `software_release.version`,
+`assessment_ref` and `xyz_text` are `X | None` for reasons unrelated to
+`include`, and they keep their `null`. The same rule read from the other side:
+never null a field a client tests for presence, and never omit a field a client
+tests for nullity.
+
+The strip is therefore driven by a declared per-surface token → section table
+(`IncludeGatedSections` in `app/api/routes/scientific/_response.py`) and by
+nothing else. The table is declared rather than derived from field names
+because names collide: one calculation response carries two fields called
+`workflow_tool_release` — the record's own provenance field, which is `null`
+because the calculation references no workflow tool and must stay `null`, and
+one nested inside the include-gated `execution_environment` block, which
+disappears with its section.
+
+### Scope today
+
+`/api/v1/scientific/calculations/*` omits all 18 of its heavy sections, and
+`trust` and `assessments` are omitted wherever their helpers run. Every other
+include-gated section still serializes as `null`; those surfaces are being
+converted one declared table at a time, and each conversion adds the
+`x-tckdb-include-gated` marker to the hosted OpenAPI document at the same time,
+so the document never claims a key is normally absent before the runtime omits
+it.
 
 ## Ordered requirements
 
@@ -16,7 +83,7 @@ Requirement 10 remains ongoing as each surface expands.
 
 2. **Fail closed on ignored filters — implemented.** Non-null `inchi` on species search (including composed thermo and species-calculation search), species-calculation `scientific_origin`, frequency-scale-factor `model_kind`/`software_version`, and energy-correction-scheme `software`/`software_version`/`used_by_thermo` return 422 `unsupported_filter`. No subset of a request is silently applied.
 
-3. **Hosted JSON and OpenAPI agree — implemented.** All successful scientific-response component schemas are followed transitively. Policy-hidden internal-ID properties remain documented but are not required and carry `x-tckdb-policy-hidden: true`. A real hosted, ID-stripped species response is validated against the served OpenAPI document.
+3. **Hosted JSON and OpenAPI agree — implemented.** All successful scientific-response component schemas are followed transitively. Policy-hidden internal-ID properties remain documented but are not required and carry `x-tckdb-policy-hidden: true`. Include-gated section properties remain documented and carry `x-tckdb-include-gated: "<token>"`, naming the `include=` token that produces them; a property is marked only once every operation returning its component omits it, so the document never runs ahead of the runtime. A real hosted, ID-stripped species response is validated against the served OpenAPI document.
 
 4. **Canonical pressure query — implemented.** `pressure_bar` is canonical on reaction-entry and chemistry-first kinetics reads; `pressure` remains a deprecated alias. Both accept only finite positive values at every GET/POST request boundary. After numeric parsing, equal aliases (for example `1` and `1.0`) are canonicalized to `pressure_bar`; any exact inequality returns 422 `pressure_alias_conflict` without tolerance. A valid pressure includes pressure-independent rates; matches exact apparent-pressure records; applies bounded PLOG/Chebyshev coverage; accepts populated falloff/third-body models; and excludes high-pressure-limit, out-of-range, or indeterminate pressure-dependent records. Incompatible records are filtered out rather than silently broadened. A non-null `reaction_path_degeneracy` reports an explicit `convention`: `already_applied` maps to `true/false`, `not_applied` maps to `false/true`, and `unknown` maps to `null/null` for `reported_rate_coefficient_includes_degeneracy` / `apply_to_rate_coefficient`. Legacy rows are backfilled as `unknown`; semantics are never inferred from the numeric degeneracy. Null degeneracy remains unknown, not one.
 

--- a/backend/docs/specs/scientific_calculation_path_includes.md
+++ b/backend/docs/specs/scientific_calculation_path_includes.md
@@ -474,7 +474,8 @@ endpoints, and the `include=all` flip).
    `COUNT(*)` for `point_count`, optional `MIN/MAX(electronic_energy_hartree)`
    for the energy envelope.
 3. Move `scan` out of `_NOT_IMPLEMENTED_INCLUDE_TOKENS`; add
-   `scan → scan` to `_OMITTABLE_RECORD_KEYS`.
+   `scan → scan` to `CALCULATION_RECORD_SECTIONS` (in
+   `app/api/routes/scientific/_response.py`).
 4. Tests: detail + search × {empty, populated, ordering, ID policy,
    combined-with-other-includes, canary-with-still-unimplemented}.
 

--- a/backend/docs/specs/scientific_calculation_reads.md
+++ b/backend/docs/specs/scientific_calculation_reads.md
@@ -125,10 +125,10 @@ time. The guard was removed when it was no longer doing useful work
 Adding a new `include=<token>` to the scientific calculation
 detail/search surface touches six layers. Skipping a step doesn't
 always fail tests — the most common drift is a missing
-`_OMITTABLE_RECORD_KEYS` entry, which makes the field leak as `null`
-on default reads instead of being omitted entirely.
+`CALCULATION_RECORD_SECTIONS` entry, which makes the field leak as
+`null` on default reads instead of being omitted entirely.
 
-> ⚠️ **A missing `_OMITTABLE_RECORD_KEYS` entry causes the field to
+> ⚠️ **A missing `CALCULATION_RECORD_SECTIONS` entry causes the field to
 > leak as `null` on default reads, violating the
 > omitted-unless-requested contract.** This is the failure mode the
 > `include=all` equivalence test catches in CI; without that test,
@@ -163,11 +163,13 @@ When implementing a new heavy include, walk this list in order:
    early), add it to `_NOT_IMPLEMENTED_INCLUDE_TOKENS` so callers
    get `include_not_implemented_yet` instead of an empty payload.
    Remove the token from this set once the loader lands.
-6. **Omittable record keys** — add a `(token → record_key)` entry
-   to `_OMITTABLE_RECORD_KEYS` in
-   `app/api/routes/scientific/calculations.py`. Without this entry
-   the field appears in every default response as `null`,
-   violating the "omitted unless requested" contract.
+6. **Omittable record keys** — add a `(token → record fields)` entry
+   to `CALCULATION_RECORD_SECTIONS` in
+   `app/api/routes/scientific/_response.py` (it lived in
+   `routes/scientific/calculations.py` as `_OMITTABLE_RECORD_KEYS`
+   until the table was generalised). Without this entry the field
+   appears in every default response as `null`, violating the
+   "omitted unless requested" contract.
 7. **`include=all` equivalence coverage** — if the token is
    summary-safe, it is part of the `include=all` expansion. The
    existing `_ALL_EXPANSION_TOKENS` constant in both
@@ -178,7 +180,7 @@ When implementing a new heavy include, walk this list in order:
    constant**. The equivalence test will then prove that
    `include=all` produces the same record as enumerating every
    token explicitly — which is the property that catches drift
-   like a missing `_OMITTABLE_RECORD_KEYS` entry.
+   like a missing `CALCULATION_RECORD_SECTIONS` entry.
 8. **Forbidden-payload defense** — if the include could
    accidentally surface large or sensitive payloads (artifact body
    bytes, per-point arrays, raw XYZ, geometry-atom rows,

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -31678,7 +31678,8 @@
                 "type": "null"
               }
             ],
-            "title": "Artifacts"
+            "title": "Artifacts",
+            "x-tckdb-include-gated": "artifacts"
           },
           "available_sections": {
             "$ref": "#/components/schemas/AvailableCalculationSections"
@@ -31698,7 +31699,8 @@
                 "type": "null"
               }
             ],
-            "title": "Constraints"
+            "title": "Constraints",
+            "x-tckdb-include-gated": "constraints"
           },
           "dependencies": {
             "anyOf": [
@@ -31712,7 +31714,8 @@
                 "type": "null"
               }
             ],
-            "title": "Dependencies"
+            "title": "Dependencies",
+            "x-tckdb-include-gated": "dependencies"
           },
           "execution_environment": {
             "anyOf": [
@@ -31722,7 +31725,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "execution_environment"
           },
           "freq_modes": {
             "anyOf": [
@@ -31736,7 +31740,8 @@
                 "type": "null"
               }
             ],
-            "title": "Freq Modes"
+            "title": "Freq Modes",
+            "x-tckdb-include-gated": "freq_modes"
           },
           "geometry_validation": {
             "anyOf": [
@@ -31750,7 +31755,8 @@
                 "type": "null"
               }
             ],
-            "title": "Geometry Validation"
+            "title": "Geometry Validation",
+            "x-tckdb-include-gated": "geometry_validation"
           },
           "imaginary_mode_projections": {
             "anyOf": [
@@ -31760,7 +31766,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "imaginary_mode_projections"
           },
           "input_geometries": {
             "anyOf": [
@@ -31774,7 +31781,8 @@
                 "type": "null"
               }
             ],
-            "title": "Input Geometries"
+            "title": "Input Geometries",
+            "x-tckdb-include-gated": "input_geometries"
           },
           "irc": {
             "anyOf": [
@@ -31784,7 +31792,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "irc"
           },
           "level_of_theory": {
             "anyOf": [
@@ -31818,7 +31827,8 @@
                 "type": "null"
               }
             ],
-            "title": "Output Geometries"
+            "title": "Output Geometries",
+            "x-tckdb-include-gated": "output_geometries"
           },
           "owner": {
             "$ref": "#/components/schemas/CalculationOwnerSummary"
@@ -31835,7 +31845,8 @@
                 "type": "null"
               }
             ],
-            "title": "Parameters"
+            "title": "Parameters",
+            "x-tckdb-include-gated": "parameters"
           },
           "path_search": {
             "anyOf": [
@@ -31845,7 +31856,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "path_search"
           },
           "provenance": {
             "$ref": "#/components/schemas/CalculationEvidenceProvenanceSummary"
@@ -31858,7 +31870,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "results"
           },
           "review_history": {
             "anyOf": [
@@ -31872,7 +31885,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "scan": {
             "anyOf": [
@@ -31882,7 +31896,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "scan"
           },
           "scf_stability": {
             "anyOf": [
@@ -31896,7 +31911,8 @@
                 "type": "null"
               }
             ],
-            "title": "Scf Stability"
+            "title": "Scf Stability",
+            "x-tckdb-include-gated": "scf_stability"
           },
           "software_release": {
             "anyOf": [
@@ -31920,7 +31936,8 @@
                 "type": "null"
               }
             ],
-            "title": "Spin Diagnostic"
+            "title": "Spin Diagnostic",
+            "x-tckdb-include-gated": "spin_diagnostic"
           },
           "trust": {
             "anyOf": [
@@ -31930,7 +31947,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "trust"
           },
           "wavefunction_diagnostic": {
             "anyOf": [
@@ -31944,7 +31962,8 @@
                 "type": "null"
               }
             ],
-            "title": "Wavefunction Diagnostic"
+            "title": "Wavefunction Diagnostic",
+            "x-tckdb-include-gated": "wavefunction_diagnostic"
           },
           "workflow_tool_release": {
             "anyOf": [

--- a/backend/tests/api/scientific/test_include_gated_sections.py
+++ b/backend/tests/api/scientific/test_include_gated_sections.py
@@ -1,0 +1,324 @@
+"""The include-gated strip drops what a table declares, and nothing else.
+
+The mechanism is easy to state and easy to over-generalise, and the
+over-generalisation is dangerous rather than merely untidy. "Omit an
+unrequested include-gated section" is the rule. "Drop null optional fields
+from responses" is a different rule that looks like a simplification of it
+and would corrupt data: ``clients/python/pagination.py`` reads an *absent*
+``next_cursor`` as "this server predates the keyset contract, restart the
+traversal from offset zero" and a *present-and-null* ``next_cursor`` as
+"this was the last page". Drop that null and every completed traversal
+restarts and yields the whole result set a second time, silently.
+
+So the boundary is tested here structurally rather than trusted: the strip
+takes a declared :class:`IncludeGatedSections` table and computes the keys
+to pop from that table alone, and these tests pin both halves — the fields
+in the table go, and a null field no table names stays, including under the
+widest scope the strip has.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+import pytest
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from app.api.public_openapi import project_hosted_openapi
+from app.api.routes.scientific._response import (
+    ANYWHERE_SCOPE,
+    ASSESSMENTS_SECTION,
+    CALCULATION_RECORD_SECTIONS,
+    INCLUDE_GATED_COMPONENTS,
+    TRUST_SECTION,
+    IncludeGatedSections,
+    omit_unrequested_calculation_sections,
+    omit_unrequested_sections,
+)
+
+
+class _Request(BaseModel):
+    include: list[str]
+
+
+class _Payload(BaseModel):
+    request: _Request
+
+
+def _payload(*include: str) -> _Payload:
+    return _Payload(request=_Request(include=list(include)))
+
+
+def _body(response: Any) -> dict[str, Any]:
+    assert isinstance(response, JSONResponse)
+    return json.loads(response.body)
+
+
+# ---------------------------------------------------------------------------
+# The hard boundary
+# ---------------------------------------------------------------------------
+
+
+def test_the_strip_refuses_a_table_it_cannot_audit():
+    """A bare mapping is not a declared table and is not accepted.
+
+    The type is the only thing standing between this helper and a blanket
+    null-strip, so it is checked rather than assumed. There is deliberately
+    no argument that means "drop the nulls".
+    """
+    visibility = JSONResponse(
+        {"request": {"include": []}, "record": {"trust": {"grade": "a"}}}
+    )
+
+    with pytest.raises(TypeError) as excinfo:
+        omit_unrequested_sections(
+            visibility,
+            _payload(),
+            table={"trust": ("trust",)},  # type: ignore[arg-type]
+        )
+
+    assert "IncludeGatedSections" in str(excinfo.value)
+
+
+def test_a_null_field_no_table_names_survives_the_detail_strip():
+    """``next_cursor`` is in scope, is null, and must still be there."""
+    visibility = JSONResponse(
+        {
+            "request": {"include": []},
+            "record": {
+                "trust": {"grade": "a"},
+                "next_cursor": None,
+                "post_collapse_total": None,
+                "supersession": None,
+            },
+        }
+    )
+
+    record = _body(omit_unrequested_sections(visibility, _payload(), table=TRUST_SECTION))[
+        "record"
+    ]
+
+    assert "trust" not in record
+    assert "next_cursor" in record and record["next_cursor"] is None
+    assert "post_collapse_total" in record and record["post_collapse_total"] is None
+    assert "supersession" in record and record["supersession"] is None
+
+
+def test_a_null_field_no_table_names_survives_the_widest_scope():
+    """``anywhere`` visits every dict in the payload and still pops only the table.
+
+    This is the scope ``assessments`` runs under — it walks the whole tree,
+    so if any scope were going to sweep up a same-shaped null it is this
+    one.
+    """
+    visibility = JSONResponse(
+        {
+            "request": {"include": []},
+            "pagination": {"total": 2, "next_cursor": None},
+            "records": [
+                {
+                    "assessments": {"state": "unassessed"},
+                    "next_cursor": None,
+                    "nested": {"assessments": {"state": "stale"}, "next_cursor": None},
+                }
+            ],
+        }
+    )
+
+    body = _body(
+        omit_unrequested_sections(
+            visibility, _payload(), table=ASSESSMENTS_SECTION, scope=ANYWHERE_SCOPE
+        )
+    )
+
+    record = body["records"][0]
+    assert "assessments" not in record
+    assert "assessments" not in record["nested"]
+    assert "next_cursor" in body["pagination"]
+    assert body["pagination"]["next_cursor"] is None
+    assert "next_cursor" in record and record["next_cursor"] is None
+    assert "next_cursor" in record["nested"] and record["nested"]["next_cursor"] is None
+
+
+def test_two_fields_with_one_name_get_opposite_treatment():
+    """``workflow_tool_release`` twice on one response, two different answers.
+
+    The record's own provenance field is null because the calculation
+    references no workflow tool — a fact about the record, not about the
+    request — so it keeps its null. The identically-named field nested in
+    the include-gated ``execution_environment`` block goes with its
+    section. Any implementation matching on field names gets one of these
+    wrong, which is why the table is declared and per-surface.
+    """
+    visibility = JSONResponse(
+        {
+            "request": {"include": []},
+            "record": {
+                "calculation_ref": "calc_x",
+                "workflow_tool_release": None,
+                "execution_environment": {
+                    "manifest_ref": "eem_x",
+                    "workflow_tool_release": None,
+                },
+            },
+        }
+    )
+
+    record = _body(omit_unrequested_calculation_sections(visibility, _payload()))["record"]
+
+    assert "execution_environment" not in record
+    assert "workflow_tool_release" in record
+    assert record["workflow_tool_release"] is None
+
+
+def test_a_declared_table_cannot_be_edited_at_runtime():
+    """No code path can add ``next_cursor`` to a table after import."""
+    with pytest.raises(TypeError):
+        CALCULATION_RECORD_SECTIONS.sections["surprise"] = ("next_cursor",)  # type: ignore[index]
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        CALCULATION_RECORD_SECTIONS.surface = "elsewhere"  # type: ignore[misc]
+
+
+def test_an_unknown_scope_is_refused_rather_than_guessed():
+    visibility = JSONResponse({"request": {"include": []}, "record": {"trust": {}}})
+
+    with pytest.raises(ValueError):
+        omit_unrequested_sections(
+            visibility, _payload(), table=TRUST_SECTION, scope="records"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The three states
+# ---------------------------------------------------------------------------
+
+
+def test_a_requested_but_empty_section_keeps_its_null():
+    """Requested-with-nothing-there is the middle state and is not omission."""
+    visibility = JSONResponse(
+        {
+            "request": {"include": ["results"]},
+            "record": {"results": None, "artifacts": None},
+        }
+    )
+
+    record = _body(
+        omit_unrequested_calculation_sections(visibility, _payload("results"))
+    )["record"]
+
+    assert "results" in record and record["results"] is None
+    assert "artifacts" not in record
+
+
+def test_the_table_is_not_the_identity_mapping():
+    """``review`` governs ``review_history``, so token names cannot be reused as fields."""
+    assert CALCULATION_RECORD_SECTIONS.sections["review"] == ("review_history",)
+
+    visibility = JSONResponse(
+        {
+            "request": {"include": []},
+            "record": {"review_history": [{"status": "approved"}]},
+        }
+    )
+
+    record = _body(omit_unrequested_calculation_sections(visibility, _payload()))["record"]
+    assert "review_history" not in record
+
+    visibility = JSONResponse(
+        {
+            "request": {"include": ["review"]},
+            "record": {"review_history": [{"status": "approved"}]},
+        }
+    )
+    record = _body(
+        omit_unrequested_calculation_sections(visibility, _payload("review"))
+    )["record"]
+    assert record["review_history"] == [{"status": "approved"}]
+
+
+def test_fields_to_omit_is_computed_from_the_table_alone():
+    table = IncludeGatedSections(
+        surface="test", sections={"a": ("alpha", "alias"), "b": ("beta",)}
+    )
+
+    assert table.fields_to_omit([]) == {"alpha", "alias", "beta"}
+    assert table.fields_to_omit(["a"]) == {"beta"}
+    assert table.fields_to_omit(["a", "b"]) == set()
+    assert table.fields_by_token() == {"alpha": "a", "alias": "a", "beta": "b"}
+
+
+# ---------------------------------------------------------------------------
+# The hosted OpenAPI marker
+# ---------------------------------------------------------------------------
+
+
+def test_the_marker_registry_only_names_declared_sections():
+    """Every marked property comes from a declared table, and there is at least one."""
+    declared: dict[str, str] = {}
+    for table in (CALCULATION_RECORD_SECTIONS, TRUST_SECTION, ASSESSMENTS_SECTION):
+        declared.update(table.fields_by_token())
+
+    assert INCLUDE_GATED_COMPONENTS, "the marker registry enumerates nothing"
+    marked = 0
+    for component, gating in INCLUDE_GATED_COMPONENTS.items():
+        assert gating, f"{component} is registered with no gated properties"
+        for field_name, token in gating.items():
+            assert declared.get(field_name) == token, (
+                f"{component}.{field_name} is marked as gated by {token!r} but no "
+                "declared table says so"
+            )
+            marked += 1
+    assert marked >= 19
+
+
+def test_the_hosted_document_marks_the_gated_properties(client):
+    schema = client.get("/openapi.json").json()
+    components = schema["components"]["schemas"]
+
+    checked = 0
+    for component, gating in INCLUDE_GATED_COMPONENTS.items():
+        properties = components[component]["properties"]
+        required = set(components[component].get("required", []))
+        for field_name, token in gating.items():
+            assert properties[field_name]["x-tckdb-include-gated"] == token
+            # A marked property claims "normally absent", so the document
+            # must not also demand it.
+            assert field_name not in required
+            checked += 1
+
+    assert checked >= 19
+
+
+def test_the_marker_is_not_stamped_on_ungated_properties():
+    """``project_hosted_openapi`` touches the registered names and no others."""
+    schema = {
+        "components": {
+            "schemas": {
+                "ScientificCalculationRecord": {
+                    "properties": {
+                        "results": {"type": "array"},
+                        "workflow_tool_release": {"type": "object"},
+                        "calculation_ref": {"type": "string"},
+                    }
+                },
+                "AnalyticsPagination": {
+                    "properties": {"next_cursor": {"type": "string"}}
+                },
+            }
+        }
+    }
+
+    projected = project_hosted_openapi(schema)
+    record = projected["components"]["schemas"]["ScientificCalculationRecord"][
+        "properties"
+    ]
+    pagination = projected["components"]["schemas"]["AnalyticsPagination"]["properties"]
+
+    assert record["results"]["x-tckdb-include-gated"] == "results"
+    assert "x-tckdb-include-gated" not in record["workflow_tool_release"]
+    assert "x-tckdb-include-gated" not in record["calculation_ref"]
+    assert "x-tckdb-include-gated" not in pagination["next_cursor"]


### PR DESCRIPTION
**This is a pure refactor. No response body on any endpoint changes.** The only
wire-visible change in the whole PR is 19 added annotation keys in the published
OpenAPI document, and the evidence for both claims is below.

This is PR 1 of 3. PR 2 declares the token→section tables for the remaining 45
include-gated operations and turns the strip on (that is the wire-visible one).
PR 3 adds `levels_of_theory` to `evidence_summary`.

## In plain language

TCKDB's read endpoints let a caller ask for extra chunks of a record with
`?include=...`. Today, a chunk you did **not** ask for comes back as `null` —
which is the same thing the server sends when the chunk genuinely does not exist.
Two different facts, one value, and no way to tell them apart. Calvin hit exactly
that within minutes of the transition-state surface going live: a record said
`"calculations": null` while the same payload's `"has_calculations": true` two
lines above was correct, and asking for them returned two calculations.

The fix, decided and already shipped on one surface, is to **leave the key out
entirely** when you did not ask for it. An absent key says "you did not ask" —
the only thing the server actually knows about a section it never queried. A
present key means the server looked.

That fix exists today on `/scientific/calculations/*`, driven by a small lookup
table listing which `include=` token controls which field. This PR lifts that
table and its helper out of the calculations route into the shared response
module, generalises it so any surface can declare its own table, and wires it
back up to exactly the surfaces that already behave this way — so nothing
changes yet. It also teaches the published API document to say "this field is
normally absent unless you ask for it", which it previously had no way to
express.

There is one trap worth spelling out, because it is why this is a *table* and
not a rule like "drop the nulls". Elsewhere in the API, a missing key already
means something else. The Python client reads a **missing** `next_cursor` as
"this server is an old one, start the page walk over from the beginning" and a
**present-but-null** `next_cursor` as "that was the last page, you're done". If
we ever dropped that null, every completed page walk would restart and hand the
caller the entire result set a second time — silently, with no error, producing
duplicated records in a chemistry dataset. So the helper here is built so that
it *cannot* touch a field that is not named in a declared table; that is a
property of its type signature, not a habit.

## What changed

- `backend/app/api/routes/scientific/_response.py`
  - New `IncludeGatedSections` — a frozen, per-surface, declared table of
    `include` token → response field names. Its docstring carries the argument
    for why it is declared rather than derived.
  - New `omit_unrequested_sections(visibility, payload, *, table, scope)` — the
    generalised strip, applied at the `apply_internal_ids_visibility` seam. It
    computes the keys to pop from the table alone; it never inspects a value,
    never tests for `None`, and takes no predicate. Passing anything that is not
    an `IncludeGatedSections` raises `TypeError`.
  - Three declared tables: `CALCULATION_RECORD_SECTIONS` (lifted verbatim from
    `_OMITTABLE_RECORD_KEYS` in `calculations.py`), `TRUST_SECTION`,
    `ASSESSMENTS_SECTION`.
  - `omit_trust_unless_requested` and `omit_assessments_unless_requested` keep
    their signatures and are now thin wrappers over the generalised helper, so
    no call site outside `calculations.py` moves.
  - `scope` gains `"anywhere"` (the whole-tree walk `assessments` already did)
    alongside the existing `"detail"` / `"search"` / `"full"`.
- `backend/app/api/routes/scientific/calculations.py` — `_OMITTABLE_RECORD_KEYS`
  and `_omit_unrequested_heavy_sections` deleted; three call sites now use
  `omit_unrequested_calculation_sections`.
- `backend/app/api/public_openapi.py` — stamps `x-tckdb-include-gated: "<token>"`
  on include-gated properties, mirroring the existing `x-tckdb-policy-hidden`
  machinery. Driven by `INCLUDE_GATED_COMPONENTS`, never by a name scan.
- `backend/tests/api/golden/openapi.json` — regenerated.
- `backend/docs/specs/machine_consumer_query_contract.md` — the contract
  paragraph: the three states, the hard boundary, "omission is not removal", and
  what is in scope today.
- Two calculation-read specs updated to name the table's new home.

Nothing under `clients/python/`, `schemas/python/` or `integrations/mcp/` is
touched, so no package version bump applies. **Schema/migration impact: none.**

### Why the marker is on one component and not on every gated field

`x-tckdb-include-gated` is a claim about the hosted runtime, so a property is
marked only when **every** operation returning its component already omits it.
`ScientificCalculationRecord` is the only component that qualifies today: it is
returned by the three `/calculations/*` operations and nothing else, and all
three strip. `KineticsRecord.trust`, `ThermoRecord.trust` and
`ScientificTransitionStateEntryRecord.trust` are omitted on some operations and
nulled on others, so marking them now would put the document ahead of the
runtime — the opposite of what Requirement 3 asks. They join the registry in
PR 2, in the same commit that flips them.

## Evidence that no response body changed

Every `TestClient` response produced by the full `tests/api/scientific/` suite
(1,635 tests, **1,938 HTTP responses**) was captured three times with a pinned
test order, recording per response: the status, a hash of the body with
sequence-derived ids and timestamps normalised, and a hash of the **set of JSON
key paths** in the body.

The key-path hash is the decisive column: it ignores values entirely, so
fixture randomness and non-rolling-back Postgres sequences cannot move it. The
only thing that can move it is a key appearing or disappearing — which is the
only thing an omission change does, and the only thing this PR claims not to do.

| Comparison | Body-hash differences | Key-path differences |
|---|---|---|
| before → after | 46 | **9, all `/openapi.json`** |
| same code, two runs (noise floor) | 416 | **0** |

Read that as three facts:

1. **Key-path shape has zero run-to-run noise** (0 across two identical-code
   runs), so the shape column is an exact statement, not a statistical one.
2. **Not one scientific API response gained or lost a key.** All 9 key-path
   differences are `/openapi.json` — the document, carrying the 19 new markers.
3. Of the 46 body-hash differences, **37 also occur between two runs of
   identical code** (they are row ids and timestamps in the payload). The 9 that
   do not are the same 9 `/openapi.json` fetches.

The existing trust, assessment and calculation tests pass unmodified; no
behavioural assertion was touched anywhere in this PR.

## Evidence the golden moved only by the marker

A key-by-key structural comparison of the golden before and after:

```
removed keys  : []
changed values: []
added keys    : 19
added keys that are NOT the marker: []
```

All 19 are `components.schemas.ScientificCalculationRecord.properties.<field>.x-tckdb-include-gated`.
Note `review_history` is marked with token `"review"` — the mapping is not the
identity, which is the reason it is a declared table.

## Mutation testing

Three mutations, each landed, confirmed present in `git diff`, run, then
reverted with the file verified byte-identical by `sha256sum`
(`453e5db1…` before and after each).

| Mutation | Caught by |
|---|---|
| Blanket null-strip added after the table-driven pop | 4 new boundary tests, **plus** the landed `test_detail_default_response_carries_summaries_and_review` with `KeyError: 'software_release'` |
| `"review": ("review_history",)` → `("review",)` | `test_the_table_is_not_the_identity_mapping`, `test_the_hosted_document_marks_the_gated_properties`, and the landed `test_detail_review_history_omitted_when_not_requested` |
| The `isinstance(table, IncludeGatedSections)` guard removed | `test_the_strip_refuses_a_table_it_cannot_audit` |

The first is the important one: it is the plausible implementation shortcut that
would corrupt the client's pagination protocol, and a landed production test
catches it as well as the new ones.

## New tests

`backend/tests/api/scientific/test_include_gated_sections.py` (12 tests):

- the strip refuses a table it cannot audit (bare mapping → `TypeError`);
- a null field no table names survives the strip, under `detail` **and** under
  `anywhere`, the widest scope — `next_cursor`, `post_collapse_total`,
  `supersession` all keep their `null`;
- the two `workflow_tool_release` fields on one calculation response get
  opposite treatment (record-level keeps its `null`, the one nested in
  `execution_environment` goes with the section);
- a declared table cannot be edited at runtime;
- an unknown scope is refused rather than guessed;
- a requested-but-empty section keeps its `null` (the middle of the three
  states, which PR 2 must not collapse);
- the token→field mapping is not the identity;
- the marker registry only names fields a declared table declares, with a
  non-vacuous floor of 19;
- the hosted document marks all 19 and none of them is in `required`;
- the marker is not stamped on ungated properties (`workflow_tool_release`,
  `calculation_ref`, a pagination `next_cursor`).

## Verification actually run

- `conda run -n tckdb_env ruff check app tests scripts` from `backend/` — clean.
- `scripts/test-scientific.sh`, `scripts/test-api.sh`, `scripts/test-rest.sh`,
  exit codes captured with `$?` — see the comment below for the numbers.
- The three capture runs above (1,938 responses each).
- Structural golden comparison.
- Three mutations landed, failed, reverted, hash-verified.
