### PR TITLE
Show how far a result's evidence has been checked

### DIFF
--- a/backend/app/api/landing.py
+++ b/backend/app/api/landing.py
@@ -39,6 +39,17 @@ clicked a link on a landing page. The raw document is still one click
 away from inside each panel, under a label that says it is raw JSON.
 Nothing on this page takes a reader somewhere they did not expect.
 
+An expanded panel also says **how far its evidence has been checked**,
+which is the claim that distinguishes this database from a folder of
+output files. Each card carries the deterministic rubric's verdict --
+its label, its passed-of-possible check counts, and the named checks
+that are and are not present, collapsed -- alongside, and never in
+place of, the record's human review state. The verdict is opt-in and
+is asked for by name: ``include=trust`` is deliberately outside
+``include=all`` on every surface, so the convenience token would pay
+for a large eager-load chain and deliver no verdict at all. The two
+lists that do not offer the token are not asked, and say so.
+
 Design constraints, in the order they constrain things:
 
 * **Self-contained.** No CDN, no external stylesheet, no web font, no
@@ -809,6 +820,83 @@ button.pill {
   font-family: var(--mono);
   overflow-wrap: anywhere;
 }
+/*
+ * ---- how far the evidence behind a record has been checked ----
+ *
+ * Two independent facts share one card and must never be read as one.
+ * The badge in the card head says whether a *person* has reviewed the
+ * record. This block says how much of the evidence a deterministic
+ * rubric expects is actually present. A record is routinely
+ * "well supported" and "under review" at the same time, so neither is
+ * ever drawn as a stand-in for the other.
+ *
+ * Every grade is drawn in the same neutral chip, on purpose. The API
+ * publishes a *set* of named verdicts -- well_supported,
+ * mostly_supported, partial, sparse, unsupported, hard_failed -- and
+ * does not publish a rank, a score or a severity. Painting them red to
+ * green, or as stars, would assert an ordering that is not in the
+ * contract. The word is the verdict; the named checks inside the
+ * disclosure are the reason for it.
+ */
+.trust {
+  margin-top: 0.6rem;
+  font-size: var(--fs-data);
+}
+.trust-line {
+  margin: 0;
+  max-width: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem 0.5rem;
+}
+.trust-label {
+  font-size: var(--fs-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.trust-grade {
+  font-family: var(--mono);
+  font-weight: 700;
+  border: 1px solid var(--rule);
+  background: var(--data-bg);
+  padding: 0.05rem 0.45rem;
+}
+.trust-tally,
+.trust-rubric,
+.trust-none {
+  font-family: var(--mono);
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+.trust-none { margin: 0; max-width: none; }
+.trust-why { margin-top: 0.45rem; }
+.trust-why > summary {
+  cursor: pointer;
+  color: var(--phase-pos);
+  width: fit-content;
+}
+.trust-checks { margin-top: 0.5rem; }
+.trust-checks-title {
+  margin: 0;
+  max-width: none;
+  font-size: var(--fs-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.trust-check-list {
+  margin: 0.15rem 0 0;
+  padding-left: 1.15rem;
+  font-family: var(--mono);
+}
+.trust-check-list li { overflow-wrap: anywhere; }
+.trust-explains {
+  margin: 0.5rem 0 0;
+  max-width: none;
+  color: var(--muted);
+}
 .detail-raw,
 .raw-link {
   overflow-wrap: anywhere;
@@ -1307,6 +1395,62 @@ __HERO_SPECTRUM__
     reverse: "matched in reverse",
     either: "matched either way"
   };
+  /*
+   * ---- the trust verdict -------------------------------------------
+   *
+   * What a record *has* is one question; how far what it has has been
+   * checked is another, and the second one is the reason this database
+   * exists rather than a folder of output files. The read API answers
+   * it under ``trust`` on the record.
+   *
+   * It is opt-in and is spelled out. ``include=trust`` is deliberately
+   * NOT part of ``include=all`` on any surface, because evaluating a
+   * verdict pulls a large eager-load chain -- nine to twenty-three
+   * entries depending on the surface, up to four hops, one of them
+   * rooted on a collection. A page that reached for the convenience
+   * token would buy that whole graph on every panel, including the
+   * panels that cannot show a verdict at all. So every URL below names
+   * the one token it wants, and none of them names ``all``.
+   *
+   * Two surfaces the page already opens -- the conformer list and the
+   * calculation list -- do not offer the token (asking answers
+   * ``unknown_include_token``). Those panels say the verdict is not
+   * assessed there rather than implying a bad one.
+   */
+  var TRUST_PARAM = "include=trust";
+
+  /*
+   * The rubric's own label set, given readable wording and nothing
+   * else. These are the six values of ``EvidenceBadge`` with the
+   * underscores taken out: no stars, no percentage, no traffic light.
+   * The API publishes named verdicts, not a scale, and a page that
+   * invented one would be asserting an ordering the contract does not
+   * make. Anything unrecognised is printed as it arrived rather than
+   * being bucketed into the nearest known word.
+   */
+  var TRUST_WORDS = {
+    well_supported: "well supported",
+    mostly_supported: "mostly supported",
+    partial: "partial",
+    sparse: "sparse",
+    unsupported: "unsupported",
+    hard_failed: "hard failed"
+  };
+  /*
+   * Absence is a third state and reads as one. A list that carries no
+   * verdict, and a record whose verdict did not arrive, are both "not
+   * assessed" -- never a low grade, which is what silence would look
+   * like next to the cards that do carry one.
+   */
+  var TRUST_NOT_ASSESSED = "evidence completeness not assessed for this record";
+  var TRUST_NOT_ON_LIST =
+    "This list does not carry an evidence verdict, so how far these " +
+    "records have been checked is not assessed here.";
+  var TRUST_VS_REVIEW =
+    "This verdict counts evidence; it is not a review. The badge above " +
+    "says whether a person has looked at the record. The two are " +
+    "independent: a well supported record can be under review, and on " +
+    "this deployment most are.";
   var MODES = [
     ["mode-species", "panel-species", "title-species", function () {}],
     ["mode-reactions", "panel-reactions", "title-reactions", submitRxn]
@@ -1520,7 +1664,15 @@ __HERO_SPECTRUM__
       one: "thermo record",
       many: "thermo records",
       shown: function (a) { return !!a.has_thermo; },
-      url: function (ref) { return THERMO + "?species_entry_ref=" + encodeURIComponent(ref); },
+      url: function (ref) {
+        return THERMO + "?species_entry_ref=" + encodeURIComponent(ref) + "&" + TRUST_PARAM;
+      },
+      /*
+       * The one surface that nests it. A thermo search row is
+       * ``{species, thermo}`` and the verdict rides on the thermo half;
+       * everywhere else the fragment sits on the record itself.
+       */
+      trust: function (record) { return (record.thermo || {}).trust; },
       view: thermoView
     },
     {
@@ -1529,7 +1681,10 @@ __HERO_SPECTRUM__
       one: "statmech record",
       many: "statmech records",
       shown: function (a) { return !!a.has_statmech; },
-      url: function (ref) { return ENTRY + encodeURIComponent(ref) + "/statmech"; },
+      url: function (ref) {
+        return ENTRY + encodeURIComponent(ref) + "/statmech?" + TRUST_PARAM;
+      },
+      trust: function (record) { return record.trust; },
       view: statmechView
     },
     {
@@ -1538,7 +1693,10 @@ __HERO_SPECTRUM__
       one: "transport record",
       many: "transport records",
       shown: function (a) { return !!a.has_transport; },
-      url: function (ref) { return ENTRY + encodeURIComponent(ref) + "/transport"; },
+      url: function (ref) {
+        return ENTRY + encodeURIComponent(ref) + "/transport?" + TRUST_PARAM;
+      },
+      trust: function (record) { return record.trust; },
       view: transportView
     },
     {
@@ -1603,6 +1761,63 @@ __HERO_SPECTRUM__
     return list;
   }
 
+  /*
+   * The named checks behind a verdict. ``ts_single_point_present``
+   * sitting in ``missing_checks`` is the whole point: it turns "why is
+   * this only mostly supported?" from a guess into a list. It ships
+   * collapsed because a card that opens into thirty check names has
+   * traded one wall of text for another.
+   */
+  function checkList(title, names) {
+    var node = make("div", "trust-checks");
+    node.appendChild(make("p", "trust-checks-title", title));
+    var list = make("ul", "trust-check-list");
+    for (var i = 0; i < names.length; i += 1) {
+      list.appendChild(make("li", null, names[i]));
+    }
+    node.appendChild(list);
+    return node;
+  }
+
+  function trustNode(trust) {
+    var node = make("div", "trust");
+    if (!trust || !trust.trust_status) {
+      node.appendChild(make("p", "trust-none", TRUST_NOT_ASSESSED));
+      return node;
+    }
+    var evidence = trust.evidence || {};
+    var line = make("p", "trust-line");
+    line.appendChild(make("span", "trust-label", "evidence"));
+    line.appendChild(make("span", "trust-grade",
+      TRUST_WORDS[trust.trust_status] || String(trust.trust_status)));
+    /*
+     * The rubric's own two counts, and never a percentage: the spec
+     * says the completeness ratio is not to be restated as one, and a
+     * count of named checks is the thing the reader can go and read.
+     */
+    if (evidence.possible_count) {
+      line.appendChild(make("span", "trust-tally",
+        evidence.passed_count + " of " + evidence.possible_count + " checks present"));
+    }
+    if (evidence.rubric) { line.appendChild(make("span", "trust-rubric", evidence.rubric)); }
+    node.appendChild(line);
+    if (evidence.hard_fail_reason) {
+      node.appendChild(make("p", "trust-explains",
+        "A structural check failed outright: " + evidence.hard_fail_reason));
+    }
+    var missing = evidence.missing_checks || [];
+    var passed = evidence.passed_checks || [];
+    if (missing.length || passed.length) {
+      var why = make("details", "trust-why");
+      why.appendChild(make("summary", null, "What the rubric checked"));
+      if (missing.length) { why.appendChild(checkList("not present", missing)); }
+      if (passed.length) { why.appendChild(checkList("present", passed)); }
+      why.appendChild(make("p", "trust-explains", TRUST_VS_REVIEW));
+      node.appendChild(why);
+    }
+    return node;
+  }
+
   function detailBody(section, ref, payload) {
     var fragment = doc.createDocumentFragment();
     var records = payload.records || [];
@@ -1611,16 +1826,27 @@ __HERO_SPECTRUM__
     if (total === null || total === undefined) { total = records.length; }
     fragment.appendChild(make("p", "detail-count", plural(total, section.one, section.many)));
     if (section.note) { fragment.appendChild(make("p", "detail-note", section.note)); }
+    if (!section.trust) { fragment.appendChild(make("p", "detail-note", TRUST_NOT_ON_LIST)); }
     var shown = Math.min(records.length, CARD_LIMIT);
     for (var i = 0; i < shown; i += 1) {
+      var trust = section.trust ? section.trust(records[i]) : null;
       var view = section.view(records[i]);
       var card = make("div", "detail-card");
       var head = make("div", "detail-head");
       head.appendChild(make("span", "detail-title", view.title));
-      if (view.status) { head.appendChild(reviewBadge(view.status)); }
+      /*
+       * The review badge stays in the head, where it has always been,
+       * and stays the record's own review state. The verdict below is
+       * a separate sentence about a separate thing. Where a record
+       * carries no review block of its own the fragment's copy is used
+       * rather than leaving the head silent.
+       */
+      var reviewed = view.status || (trust ? trust.review_status : null);
+      if (reviewed) { head.appendChild(reviewBadge(reviewed)); }
       if (view.ref) { head.appendChild(make("span", "detail-ref", view.ref)); }
       card.appendChild(head);
       card.appendChild(detailFields(view));
+      if (section.trust) { card.appendChild(trustNode(trust)); }
       fragment.appendChild(card);
     }
     if (total > shown) {
@@ -2019,7 +2245,10 @@ __HERO_SPECTRUM__
       many: "kinetics records",
       count: function (a) { return a.kinetics_count; },
       shown: function (a) { return !!a.has_kinetics || !!a.kinetics_count; },
-      url: function (ref) { return KINETICS + encodeURIComponent(ref) + "/kinetics"; },
+      url: function (ref) {
+        return KINETICS + encodeURIComponent(ref) + "/kinetics?" + TRUST_PARAM;
+      },
+      trust: function (record) { return record.trust; },
       view: kineticsView
     },
     {
@@ -2029,8 +2258,10 @@ __HERO_SPECTRUM__
       many: "transition states",
       shown: function (a) { return !!a.has_transition_state; },
       url: function (ref) {
-        return TRANSITION_STATES + "?reaction_entry_ref=" + encodeURIComponent(ref);
+        return TRANSITION_STATES + "?reaction_entry_ref=" + encodeURIComponent(ref) +
+          "&" + TRUST_PARAM;
       },
+      trust: function (record) { return record.trust; },
       view: transitionStateView
     }
   ];

--- a/backend/tests/api/test_landing_page.py
+++ b/backend/tests/api/test_landing_page.py
@@ -98,6 +98,7 @@ from app.api.startup_checks import validate_deployment_safety
 from app.services.frequency_geometry_linearity import (
     evaluate_frequency_list_linearity,
 )
+from app.services.trust.models import EvidenceBadge
 
 #: Every review state the API can put on a record. All five must have a
 #: human word on the page: a badge that falls through to a raw enum name
@@ -991,6 +992,234 @@ class TestResultsExpandInPlace:
         assert len(_noscript_forms(document, SPECIES_SEARCH_PATH)) == len(SEARCH_FIELDS) - 1
         assert document.find("input", id="search-input")
         assert document.find("a", **{"class": "chip"})
+
+
+class TestTrustVerdictIsShown:
+    """An expanded result says how far its evidence has been checked.
+
+    The page already showed what evidence a record *has*. What it did
+    not show is the thing that separates this database from a folder of
+    output files: how much of the evidence a rubric expects is actually
+    there. That verdict rides under ``trust`` on the record and is
+    opt-in.
+
+    Two properties are load-bearing and are checked against the running
+    API rather than against the page's own prose:
+
+    * the token is asked for **by name**. ``include=trust`` is
+      deliberately excluded from ``include=all`` on every surface,
+      because evaluating a verdict pulls a large eager-load chain, so a
+      page that reached for the convenience token would pay for the
+      graph and still get no verdict.
+    * the two lists that cannot serve it are not asked. Both answer
+      ``422 unknown_include_token``, which would replace a working
+      panel with an error.
+    """
+
+    #: Section keys whose list can carry a verdict, and the ones whose
+    #: list cannot. Every section in the script must be in exactly one.
+    TRUST_KEYS = frozenset({"thermo", "statmech", "transport", "kinetics", "transition-state"})
+    NO_TRUST_KEYS = frozenset({"conformers", "calculations"})
+
+    @staticmethod
+    def _section(script: str, key: str) -> str:
+        """One entry of ``SECTIONS`` / ``RXN_SECTIONS``, by its key."""
+        block = re.search(
+            r'\{\s*key: "' + re.escape(key) + r'",(.*?)\n    \}', script, flags=re.DOTALL
+        )
+        assert block is not None, key
+        return block.group(1)
+
+    @staticmethod
+    def _function(script: str, signature: str) -> str:
+        body = re.search(
+            r"function " + re.escape(signature) + r" \{(.*?)\n  \}", script, flags=re.DOTALL
+        )
+        assert body is not None, signature
+        return body.group(1)
+
+    def test_every_section_is_classified_and_none_was_forgotten(self, script):
+        """The two buckets above account for every section on the page.
+
+        Without this, a section added later is silently outside both
+        lists and every other test here keeps passing while saying
+        nothing about it.
+        """
+        keys = set(re.findall(r'\n    \{\n      key: "([^"]+)"', script))
+        assert keys == self.TRUST_KEYS | self.NO_TRUST_KEYS, keys
+
+    def test_a_list_that_can_carry_a_verdict_asks_for_it_by_name(self, script):
+        """``include=trust``, spelled out, on exactly the lists that serve it."""
+        assert 'var TRUST_PARAM = "include=trust";' in script
+        for key in self.TRUST_KEYS:
+            block = self._section(script, key)
+            assert "trust: function (record)" in block, key
+            url = re.search(r"url: function \(ref\) \{(.*?)\n      \}", block, flags=re.DOTALL)
+            assert url is not None, key
+            assert "TRUST_PARAM" in url.group(1), key
+        for key in self.NO_TRUST_KEYS:
+            block = self._section(script, key)
+            assert "trust:" not in block, key
+            assert "TRUST_PARAM" not in block, key
+
+    def test_the_page_never_reaches_for_the_convenience_token(self, script):
+        """``include=all`` would cost the eager-load graph and yield no verdict.
+
+        Not a style preference: ``trust`` is an internal token on every
+        surface here, so ``all`` expands *without* it. Swapping the two
+        would buy the whole selectinload chain and render nothing.
+
+        Asserted over the script's string literals rather than over the
+        page text, because the comment above ``TRUST_PARAM`` names the
+        token it is refusing to use and should keep doing so.
+        """
+        literals = re.findall(r"\"([^\"]*)\"", script)
+        assert literals
+        for literal in literals:
+            assert "include=all" not in literal, literal
+        assert "include=trust" in literals
+
+    @pytest.mark.parametrize(
+        "path",
+        (
+            "/api/v1/scientific/thermo/search?species_entry_ref=spe_x",
+            "/api/v1/scientific/transition-states/search?reaction_entry_ref=rxe_x",
+        ),
+    )
+    def test_asking_for_all_would_not_have_delivered_the_verdict(self, client_factory, path):
+        """The API itself decides this, so ask it.
+
+        Each search echoes the include set it *resolved*. ``trust``
+        resolves to itself; ``all`` resolves to a set that does not
+        contain it. The nonsense token is the control: it proves this
+        endpoint validates the include set at all, so a pass here can
+        never come from the request being rejected earlier for some
+        other reason.
+        """
+        with client_factory() as c:
+            control = c.get(f"{path}&include=zzz_not_a_token")
+            assert control.status_code == 422
+            assert control.json()["code"] == "unknown_include_token"
+
+            asked = c.get(f"{path}&include=trust")
+            assert asked.status_code == 200
+            assert "trust" in asked.json()["request"]["include"]
+
+            convenient = c.get(f"{path}&include=all")
+            assert convenient.status_code == 200
+            assert "trust" not in convenient.json()["request"]["include"]
+
+    @pytest.mark.parametrize(
+        "path",
+        (
+            "/api/v1/scientific/conformers/search?species_entry_ref=spe_x",
+            "/api/v1/scientific/species-calculations/search?species_entry_ref=spe_x",
+        ),
+    )
+    def test_the_lists_that_refuse_the_token_are_not_asked(self, client_factory, path):
+        """Asking these would replace a working panel with a 422."""
+        with client_factory() as c:
+            refused = c.get(f"{path}&include=trust")
+            assert refused.status_code == 422
+            assert refused.json()["code"] == "unknown_include_token"
+
+    def test_every_verdict_the_rubric_can_return_has_a_word(self, script):
+        """No badge may fall through to a raw enum name.
+
+        The label set is read off the rubric's own enum, so a verdict
+        added there fails here until the page has wording for it.
+        """
+        for badge in EvidenceBadge:
+            word = badge.value.replace("_", " ")
+            assert f"{badge.value}: \"{word}\"" in script, badge.value
+
+    def test_the_words_are_the_rubrics_own_and_invent_no_scale(self, script, page):
+        """Named verdicts, not stars, not a percentage, not a traffic light.
+
+        The API publishes a *set* of labels and no ordering over them.
+        Drawing them as a rank would assert something the contract does
+        not, so every grade gets the same neutral chip: one ``.trust-grade``
+        rule, no per-verdict selector, and no negative phase colour
+        anywhere in the block.
+        """
+        css = re.search(r"<style>(.*?)</style>", page, flags=re.DOTALL | re.IGNORECASE).group(1)
+        for selectors, body in re.findall(r"([^{}]+)\{([^}]*)\}", css):
+            if ".trust" not in selectors:
+                continue
+            assert "--phase-neg" not in body, selectors
+        for badge in EvidenceBadge:
+            assert f".trust-{badge.value}" not in css, badge.value
+        # The ratio exists on the wire and is deliberately not restated:
+        # the spec forbids showing it as a percentage, and the counts of
+        # named checks are what a reader can actually follow up.
+        assert "evidence_completeness" not in script
+        assert "passed_count" in script
+        assert "possible_count" in script
+
+    def test_the_verdict_and_the_review_state_stay_two_different_facts(self, script):
+        """A record is routinely well supported *and* under review.
+
+        ``trust_status`` is a deterministic rubric's verdict;
+        ``review.status`` is whether a person has looked. Showing one in
+        place of the other would report the corpus as either better or
+        worse checked than it is, so the card carries both and neither
+        vocabulary leaks into the other's renderer.
+        """
+        trust_words = dict(re.findall(r"\n    (\w+): \"([^\"]+)\"\n?", script))
+        verdicts = {badge.value for badge in EvidenceBadge}
+        grades = {word for key, word in trust_words.items() if key in verdicts}
+        reviews = set(REVIEW_STATES)
+        assert grades, "no verdict wording found"
+        assert grades & reviews == set()
+
+        body = self._function(script, "trustNode(trust)")
+        assert "trust.trust_status" in body
+        assert "reviewBadge" not in body, "the verdict must not be dressed as a review state"
+
+        detail = self._function(script, "detailBody(section, ref, payload)")
+        assert "reviewBadge(reviewed)" in detail
+        # A record with no review block of its own still shows one: the
+        # fragment carries the same field and the head must not go silent.
+        assert "trust ? trust.review_status : null" in detail
+
+    def test_an_absent_verdict_reads_as_not_assessed_rather_than_as_a_bad_one(self, script):
+        """Silence next to graded cards would read as the lowest grade.
+
+        Two absences, one wording: a list that carries no verdict at
+        all, and a record whose verdict did not come back.
+        """
+        messages = re.findall(r"var TRUST_NOT_(?:ASSESSED|ON_LIST) =\s*(.*?);\n", script, re.DOTALL)
+        assert len(messages) == 2
+        for message in messages:
+            assert "not assessed" in message, message
+            for badge in EvidenceBadge:
+                assert badge.value.replace("_", " ") not in message, message
+
+        body = self._function(script, "trustNode(trust)")
+        assert "if (!trust || !trust.trust_status) {" in body
+        assert "TRUST_NOT_ASSESSED" in body
+
+        detail = self._function(script, "detailBody(section, ref, payload)")
+        assert "if (!section.trust) {" in detail
+        assert "TRUST_NOT_ON_LIST" in detail
+
+    def test_the_named_missing_checks_are_shown_and_ship_collapsed(self, script):
+        """"Why only mostly supported?" has a published answer -- show it.
+
+        ``ts_single_point_present`` in ``missing_checks`` is the gap a
+        reader can otherwise only guess at. It ships inside a closed
+        ``<details>`` because a card that opens into thirty check names
+        is the wall of text the expansion exists to avoid.
+        """
+        body = self._function(script, "trustNode(trust)")
+        assert "evidence.missing_checks" in body
+        assert "evidence.passed_checks" in body
+        assert 'make("details", "trust-why")' in body
+        assert 'make("summary", null, "What the rubric checked")' in body
+        assert "open" not in re.sub(r"[^\w]", " ", body).split(), "the detail must ship collapsed"
+        assert 'checkList("not present", missing)' in body
+        assert 'checkList("present", passed)' in body
+        assert "evidence.hard_fail_reason" in body
 
 
 class TestHeroExampleIsReal:


### PR DESCRIPTION
## In plain language

The landing page could already search the database and open a result to show
what is *in* it — a thermo fit, a statmech treatment, a rate expression. It
could not show **how far any of that has been checked**, which is the one thing
that separates TCKDB from a folder of output files.

Each opened card now carries that verdict. It reads, for example:

```
nasa fit   [ ○ under review ]   thm_l4jucjl6azq7wtusozix5576ia
  enthalpy at 298 K   143.89 kJ/mol
  entropy at 298 K    194.40 J/mol/K
  fitted over         10–3000 K
  origin              computed

EVIDENCE  [ partial ]  10 of 20 checks present  computed_thermo_v1
▸ What the rubric checked
```

Two separate facts sit side by side on purpose:

* **under review** — whether a *person* has looked at the record.
* **partial** — the verdict of a deterministic rubric that counts how much of
  the evidence it expects is actually present.

They are independent, and the normal state of this corpus is *well supported*
**and** *under review* at the same time. The card never shows one in place of
the other, and review status is styled as information, never as a warning.

Opening "What the rubric checked" lists the checks by name, split into **not
present** and **present**. That turns "why is this only mostly supported?" from
a guess into an answer — on the transition states in this deployment the missing
entries are things like `irc_evidence_present` and
`geometry_validation_present_for_source_calculations`. It ships collapsed so the
card does not become a wall of text.

Some terms used below, for anyone who does not work on this backend daily:

* **include token** — a query parameter (`?include=…`) that asks a read endpoint
  to attach an optional block to each record. `include=all` is a convenience
  token meaning "attach the usual optional blocks".
* **eager-load chain / `selectinload`** — extra database queries the server runs
  up front to fill in related rows. A long chain is slow and is only worth
  paying for when the caller actually wants what it fetches.
* **mutation testing** — deliberately breaking the code to prove the new tests
  notice. A test that still passes against broken code is testing nothing.

## Why `include=trust` and never `include=all`

`trust` is an **internal** include token on every surface here, which means
`include=all` expands *without* it. That exclusion was shipped deliberately: a
trust evaluation pulls a large eager-load chain (9–23 entries depending on
surface, up to four hops, one rooted on a collection), so making `all` carry it
would buy that graph for every caller who reached for the convenience token.

So the page names the one token it wants. Swapping the two would be doubly
wrong: it would pay for the whole graph on lists that cannot show a verdict, and
it would render no verdict at all.

The API is asked to confirm this rather than the page asserting it — see
`test_asking_for_all_would_not_have_delivered_the_verdict`, which reads the
include set each search says it *resolved*:

| request | resolved include set |
|---|---|
| `thermo/search?…&include=trust` | `['trust']` |
| `thermo/search?…&include=all` | `['artifacts', 'calculations', 'provenance', 'review']` |
| `transition-states/search?…&include=trust` | `['trust']` |
| `transition-states/search?…&include=all` | `['calculations', 'geometries', 'review', 'validation_evidence']` |

A deliberately bogus token is sent alongside as a control, so the test can never
pass because the request was rejected earlier for some unrelated reason.

## Where the verdict comes from, per panel

| Panel | Endpoint | Carries `trust` | Fragment location |
|---|---|---|---|
| thermo | `/scientific/thermo/search` | yes | `record.thermo.trust` |
| statmech | `/scientific/species-entries/{ref}/statmech` | yes | `record.trust` |
| transport | `/scientific/species-entries/{ref}/transport` | yes | `record.trust` |
| kinetics | `/scientific/reaction-entries/{ref}/kinetics` | yes | `record.trust` |
| transition state | `/scientific/transition-states/search` | yes | `record.trust` |
| conformers | `/scientific/conformers/search` | **no** (422 `unknown_include_token`) | — |
| calculations | `/scientific/species-calculations/search` | **no** (422 `unknown_include_token`) | — |

The last two are not asked for the token. Their panels carry one line instead:
"This list does not carry an evidence verdict, so how far these records have
been checked is not assessed here." Absence reads as *not assessed*, never as a
low grade — a record whose fragment simply does not arrive gets the same
treatment.

## No invented scale

Every verdict is drawn in the same neutral chip. The API publishes a **set** of
named labels (`well_supported`, `mostly_supported`, `partial`, `sparse`,
`unsupported`, `hard_failed`) and does not publish a rank, a score or a
severity, so no colour, star rating or traffic light is applied — that would
assert an ordering the contract does not make. The word is the verdict; the
named checks under the disclosure are the reason. This is stated in a comment
above the CSS block and pinned by a test that reads the label set off
`EvidenceBadge` and fails if any per-verdict selector or negative-phase colour
appears.

The rubric's completeness *ratio* is deliberately not restated as a percentage
(the trust spec forbids that); the card shows the rubric's own
`passed_count` / `possible_count` instead.

## Schema and migration impact

**None.** No ORM model, schema, Alembic revision or read-API behaviour changed.
This PR touches the landing page (`/`) and its tests only. No new environment
variable. `test_the_route_table_gains_the_landing_route_and_nothing_else` still
passes.

## Verification actually run

1. `cd backend && conda run -n tckdb_env pytest tests/api/test_landing_page.py -q`
   → **82 passed** (70 before, 12 new).
2. **Mutation testing — three landed, each proved present in the file, each
   caught, each restored to a byte-identical file** (baseline SHA-256
   `ac337ec707bfbc6f38d322115432ca65c573aaa5418c91aff60f392951c256dc`):

   | mutation | in-file proof | result |
   |---|---|---|
   | `TRUST_PARAM = "include=all"` | `landing.py:1409` | **2 failed** — `test_the_page_never_reaches_for_the_convenience_token`, `test_a_list_that_can_carry_a_verdict_asks_for_it_by_name` |
   | `TRUST_NOT_ASSESSED = "unsupported"` (absence reads as a grade) | `landing.py:1434` | **1 failed** — `test_an_absent_verdict_reads_as_not_assessed_rather_than_as_a_bad_one` |
   | drop the `missing_checks` list, ship the disclosure `open` | `landing.py:1802` | **1 failed** — `test_the_named_missing_checks_are_shown_and_ship_collapsed` |

   File hash after each restore: `ac337ec7…c256dc`, identical to baseline.
3. `cd backend && conda run -n tckdb_env ruff check app tests scripts` → `All checks passed!`
4. `cd backend && conda run -n tckdb_env bash scripts/test-api.sh`, exit captured
   with `$?` → **`EXIT=0`**, `3247 passed in 586.97s`.
5. **Rendered and driven against the live host.** The page was rendered from this
   branch and served to headless Chrome as the document for
   `https://tckdb.homecalvin.com/` via CDP `Fetch.fulfillRequest`, so it ran
   same-origin and every `/api/v1` call went to the real deployment (GET only).
   Viewport set with `Emulation.setDeviceMetricsOverride` for an honest 360px,
   and `prefers-color-scheme` forced per run.

   Verdicts observed live, all four different:

   | panel | verdict | counts | rubric |
   |---|---|---|---|
   | thermo (`[CH3]`) | **partial** | 10 of 20 checks present | `computed_thermo_v1` |
   | statmech (`[CH3]`) | **well supported** | 18 of 20 | `computed_statmech_v1` |
   | kinetics (`O + [CH3] <=> C + [OH]`) | **well supported** | 19 of 21 | `computed_kinetics_v1` |
   | transition state (`NN <=> [H][H] + N=N`) | **mostly supported** | 19 of 26 | `computed_transition_state_v2` |

   The conformers and calculations panels rendered the "not assessed here" line.
   `document.scrollWidth === clientWidth` at both 1280px and 360px, before and
   after opening every disclosure — no horizontal document scroll. Checked in
   light and dark.

## Constraints held

Still exactly one `<script>` tag with zero attributes, no `://` in any script
string literal, no external resource of any kind. The trust display is JS-only
and the `<noscript>` fallback forms are untouched. Single `<h1>`. Focus
visibility comes from the existing global `:focus-visible` rule, which covers the
new `<summary>`. No new regex over HTML was added to the tests without
`re.IGNORECASE` (the CSS/script extraction reuses the existing fixtures).
