### PR TITLE
Say "you did not ask", not "there is none"

### DIFF
--- a/backend/app/api/routes/scientific/_response.py
+++ b/backend/app/api/routes/scientific/_response.py
@@ -46,6 +46,14 @@ DETAIL_SCOPE = "detail"
 SEARCH_SCOPE = "search"
 FULL_SCOPE = "full"
 ANYWHERE_SCOPE = "anywhere"
+# The document root itself. ``/reaction-entries/{id}/full`` keeps its ten
+# include-gated sections *beside* ``request`` and ``review_summary`` rather
+# than under any ``record``/``records`` key, so none of the scopes above can
+# reach them. ``FULL_SCOPE`` is the trap in the neighbourhood: it is named
+# after the same route but yields that document's *embedded record lists*,
+# which is where ``trust`` lives and where the document's own sections do
+# not. Reaching for it here is a silent no-op, not an error.
+DOCUMENT_SCOPE = "document"
 
 # The composite ``/reaction-entries/{id}/full`` document embeds records
 # under these three keys rather than under ``record``/``records``.
@@ -176,20 +184,244 @@ ASSESSMENTS_SECTION = IncludeGatedSections(
     sections={"assessments": ("assessments",)},
 )
 
+# ---------------------------------------------------------------------------
+# Per-surface tables
+#
+# Every entry below was read off the service module that owns the token
+# vocabulary — the ``if "<token>" in includes:`` that decides whether the
+# field is built — and never off a list of nullable fields on the record
+# schema. That distinction is the whole of decision 2 and it is not
+# stylistic: most of what is ``| None`` on these records is an ungated
+# scientific fact. ``nasa9``, ``chebyshev``, ``plog_entries``, ``wilhoit``,
+# ``group_additivity``, ``assignment_scheme``, ``supersession``,
+# ``literature``, ``software_release`` and their kind are *absent facts
+# about the chemistry*, not unrequested sections, and none of them appears
+# in any table here. If one ever does, the wire stops being able to say
+# "this record has no NASA-9 polynomial" — which is the original defect
+# restored from the other side.
+# ---------------------------------------------------------------------------
+
+# ``GET /species/search``. The four summaries sit two levels below the
+# record root, at ``records[*].entries[*]``, and no token name equals its
+# field name. ``include=review`` is legal here and gates nothing — every
+# entry already carries its review badge (``services/…/species.py``).
+SPECIES_SEARCH_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/species/search",
+    sections={
+        "thermo": ("thermo_summary",),
+        "statmech": ("statmech_summary",),
+        "transport": ("transport_summary",),
+        "conformers": ("conformers_summary",),
+    },
+)
+
+# ``GET /reaction-entries/{id}/kinetics``. One token, two fields — the
+# reason the table maps to a *tuple* rather than a name. A live probe sees
+# only ``interpretation_assignments`` move, because the record measured
+# carried no tunneling block; source is what says both are gated.
+#
+# Deliberately not applied to ``/kinetics/search`` or to the kinetics
+# records embedded in ``/full``: ``interpretations`` is not a legal token
+# on either, so applying it there would not omit an *unrequested* section,
+# it would delete a section no request on that surface can ever produce.
+# Those two keep their permanent ``null`` and the marker registry below
+# reflects that.
+KINETICS_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/reaction-entries/{id}/kinetics",
+    sections={
+        "interpretations": ("interpretation_assignments", "tunneling_application"),
+    },
+)
+
+# ``GET /reaction-entries/{id}/full``. Ten sections at the **document
+# root**, which is why ``DOCUMENT_SCOPE`` had to exist. ``review_records``
+# is not here: it is produced by the separate ``include_review`` query
+# parameter, not by any include token, so no include-driven strip can
+# describe it correctly and it keeps its ``null``. ``review`` is a legal
+# token on this surface that gates nothing at all.
+REACTION_FULL_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/reaction-entries/{id}/full",
+    sections={
+        "species": ("species",),
+        "kinetics": ("kinetics",),
+        "transition_states": ("transition_states",),
+        "calculations": ("calculations",),
+        "path_search": ("path_search",),
+        "irc": ("irc",),
+        "scans": ("scans",),
+        "conformers": ("conformers",),
+        "artifacts": ("artifacts",),
+        "atom_map": ("atom_map",),
+    },
+)
+
+# The three transition-state surfaces share one record vocabulary and one
+# builder, so they share one table. Applied at ``ANYWHERE_SCOPE`` because
+# every one of these fields is materialised at two depths: on the record
+# itself and again on each ``entries[*]`` sibling record beneath it.
+# Verified against a live payload that each name occurs at exactly those
+# depths and nowhere else.
+TRANSITION_STATE_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/transition-states",
+    sections={
+        "entries": ("entries",),
+        "calculations": ("calculations",),
+        "geometries": ("geometries",),
+        "review": ("review_history",),
+        "validation_evidence": ("validation_evidence",),
+    },
+)
+
+# ``/conformers/search``, ``/conformer-groups/{ref}``,
+# ``/conformer-observations/{ref}`` — one vocabulary, two record shapes
+# that carry the same five fields, and the same two-depth nesting as the
+# transition-state family (``observations[*].selections`` and friends).
+# ``assignment_scheme`` is *not* here: no token names it, and it is ``null``
+# because this observation has no scheme.
+CONFORMER_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/conformers",
+    sections={
+        "observations": ("observations",),
+        "selections": ("selections",),
+        "calculations": ("calculations",),
+        "geometries": ("geometries",),
+        "review": ("review_history",),
+    },
+)
+
+# ``/statmech/search``, ``/statmech/{ref}``,
+# ``/species-entries/{id}/statmech`` — one builder, no nesting.
+STATMECH_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/statmech",
+    sections={
+        "source_calculations": ("source_calculations",),
+        "torsions": ("torsions",),
+        "electronic_levels": ("electronic_levels",),
+        "frequencies": ("frequencies",),
+        "conformers": ("conformers",),
+        "review": ("review_history",),
+    },
+)
+
+# ``/transport/search``, ``/transport/{ref}``,
+# ``/species-entries/{id}/transport``.
+TRANSPORT_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/transport",
+    sections={
+        "source_calculations": ("source_calculations",),
+        "review": ("review_history",),
+    },
+)
+
+NETWORK_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/networks",
+    sections={
+        "species": ("species",),
+        "reactions": ("reactions",),
+        "states": ("states",),
+        "channels": ("channels",),
+        "solves": ("solves",),
+        "kinetics": ("kinetics",),
+        "source_calculations": ("source_calculations",),
+        "review": ("review_history",),
+    },
+)
+
+NETWORK_SOLVE_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/network-solves",
+    sections={
+        "bath_gas": ("bath_gas",),
+        "energy_transfer": ("energy_transfer",),
+        "state_energies": ("state_energies",),
+        "channel_barriers": ("channel_barriers",),
+        "kinetics": ("kinetics",),
+        "source_calculations": ("source_calculations",),
+        "review": ("review_history",),
+    },
+)
+
+# ``plog`` and ``points`` each govern a section *and* the two truncation
+# companions that describe it. The companions are built inside the same
+# ``if``, so a caller who did not ask for ``points`` has no more business
+# seeing ``point_count_total`` than ``points`` itself.
+# ``coefficients`` has no top-level companions — its truncation metadata is
+# nested inside the payload it describes and travels with it.
+NETWORK_KINETICS_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/network-kinetics",
+    sections={
+        "coefficients": ("coefficients",),
+        "plog": ("plog", "plog_entry_count_total", "plog_entries_truncated"),
+        "points": ("points", "point_count_total", "points_truncated"),
+        "source_calculations": ("source_calculations",),
+        "review": ("review_history",),
+    },
+)
+
+# ``literature`` is a legal token on both provenance surfaces below and
+# gates nothing: the record's ``literature`` field is built unconditionally
+# from the row's own foreign key, so it is an ungated fact and stays out of
+# both tables.
+FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/frequency-scale-factors",
+    sections={"used_by": ("used_by",)},
+)
+
+ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/energy-correction-schemes",
+    sections={
+        "corrections": ("corrections",),
+        "used_by": ("used_by",),
+    },
+)
+
+# ``/artifacts/search``. ``review`` is legal and gates no data field (the
+# history is built and discarded); ``calculation`` gates three summaries
+# *nested inside* the always-present calculation context rather than a
+# section on the record, and those three are the exact names the
+# collision warning on :class:`IncludeGatedSections` is about. Neither is
+# in the table.
+ARTIFACT_RECORD_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/artifacts/search",
+    sections={"owner": ("owner",)},
+)
+
+# ``GET /literature/{ref}/records``. Note the requested-but-empty case is
+# live here for a second reason: a linked record whose type is not
+# reviewable keeps ``review: null`` even when the token is present.
+LITERATURE_RECORDS_SECTIONS = IncludeGatedSections(
+    surface="/api/v1/scientific/literature/{ref}/records",
+    sections={"review": ("review",)},
+)
+
 # Component-scoped view of the tables above, consumed by
 # ``app.api.public_openapi`` to stamp ``x-tckdb-include-gated`` on the
 # hosted document.
 #
-# A component is listed here only when **every** operation that can return
-# it already omits the property, because the marker is a claim about the
-# hosted runtime and the document must not run ahead of it.
-# ``ScientificCalculationRecord`` is the only such component today: it is
-# returned by the three ``/calculations/*`` operations and nothing else,
-# and all three strip both tables below. Components whose ``trust`` or
-# ``assessments`` is omitted on some operations and nulled on others —
-# ``KineticsRecord``, ``ThermoRecord``,
-# ``ScientificTransitionStateEntryRecord`` — join this registry when the
-# surfaces that null them are flipped, not before.
+# The marker is stamped on a *component property*; the strip is applied by
+# an *operation*. Those do not align on their own, so the registry follows
+# one rule: **a property is marked when it is include-gated on at least one
+# operation that returns the component, and never when any operation
+# returns it unconditionally.** The second half is what keeps the document
+# honest — a marker on a key some operation always sends would tell a
+# machine consumer that a permanently-present field is requestable.
+#
+# Two consequences are visible below and are deliberate.
+#
+# ``KineticsRecord`` is marked for ``trust`` alone. Its ``assessments`` is
+# stripped on both kinetics surfaces but emitted unconditionally by the
+# ``KineticsRecord`` list embedded in ``/reaction-entries/{id}/full``, and
+# its ``interpretation_assignments`` / ``tunneling_application`` are gated
+# only on ``/reaction-entries/{id}/kinetics`` — ``interpretations`` is not
+# a legal token on ``/kinetics/search`` or on ``/full``, so both surfaces
+# emit those two keys unconditionally as ``null``. All three properties
+# therefore fail the second half of the rule and stay unmarked.
+#
+# ``ScientificCalculationRecord`` keeps the two residue properties the
+# rule exists for: ``imaginary_mode_projections`` and ``trust`` are gated
+# on ``/calculations/{ref}`` and unconditionally *absent* on
+# ``/calculations/search``, whose vocabulary lacks both tokens. Absent more
+# often than the marker promises is the harmless direction; present when it
+# promises absent is not.
 INCLUDE_GATED_COMPONENTS: Mapping[str, Mapping[str, str]] = MappingProxyType(
     {
         "ScientificCalculationRecord": MappingProxyType(
@@ -197,6 +429,69 @@ INCLUDE_GATED_COMPONENTS: Mapping[str, Mapping[str, str]] = MappingProxyType(
                 **CALCULATION_RECORD_SECTIONS.fields_by_token(),
                 **TRUST_SECTION.fields_by_token(),
             }
+        ),
+        "SpeciesEntryScientificRecord": MappingProxyType(
+            SPECIES_SEARCH_SECTIONS.fields_by_token()
+        ),
+        "KineticsRecord": MappingProxyType(TRUST_SECTION.fields_by_token()),
+        "ThermoRecord": MappingProxyType(
+            {
+                **TRUST_SECTION.fields_by_token(),
+                **ASSESSMENTS_SECTION.fields_by_token(),
+            }
+        ),
+        "ScientificStatmechRecord": MappingProxyType(
+            {
+                **STATMECH_RECORD_SECTIONS.fields_by_token(),
+                **TRUST_SECTION.fields_by_token(),
+                **ASSESSMENTS_SECTION.fields_by_token(),
+            }
+        ),
+        "ScientificTransportRecord": MappingProxyType(
+            {
+                **TRANSPORT_RECORD_SECTIONS.fields_by_token(),
+                **TRUST_SECTION.fields_by_token(),
+                **ASSESSMENTS_SECTION.fields_by_token(),
+            }
+        ),
+        "ScientificTransitionStateRecord": MappingProxyType(
+            TRANSITION_STATE_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificTransitionStateEntryRecord": MappingProxyType(
+            {
+                **TRANSITION_STATE_RECORD_SECTIONS.fields_by_token(),
+                **TRUST_SECTION.fields_by_token(),
+            }
+        ),
+        "ScientificConformerGroupRecord": MappingProxyType(
+            CONFORMER_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificConformerObservationRecord": MappingProxyType(
+            CONFORMER_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificNetworkRecord": MappingProxyType(
+            NETWORK_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificNetworkSolveRecord": MappingProxyType(
+            NETWORK_SOLVE_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificNetworkKineticsRecord": MappingProxyType(
+            NETWORK_KINETICS_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificFrequencyScaleFactorRecord": MappingProxyType(
+            FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificEnergyCorrectionSchemeRecord": MappingProxyType(
+            ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS.fields_by_token()
+        ),
+        "ScientificArtifactRecord": MappingProxyType(
+            ARTIFACT_RECORD_SECTIONS.fields_by_token()
+        ),
+        "LiteratureLinkedRecordSummary": MappingProxyType(
+            LITERATURE_RECORDS_SECTIONS.fields_by_token()
+        ),
+        "ScientificReactionFullResponse": MappingProxyType(
+            REACTION_FULL_SECTIONS.fields_by_token()
         ),
     }
 )
@@ -219,7 +514,9 @@ def _every_dict(node: Any) -> Iterator[dict[str, Any]]:
 
 def _record_nodes(data: dict[str, Any], scope: str) -> Iterator[dict[str, Any]]:
     """Yield the dicts a strip of *scope* is allowed to pop keys from."""
-    if scope == DETAIL_SCOPE:
+    if scope == DOCUMENT_SCOPE:
+        yield data
+    elif scope == DETAIL_SCOPE:
         record = data.get("record")
         if isinstance(record, dict):
             yield record
@@ -237,8 +534,8 @@ def _record_nodes(data: dict[str, Any], scope: str) -> Iterator[dict[str, Any]]:
     else:
         raise ValueError(
             f"unknown response scope {scope!r}; expected one of "
-            f"{DETAIL_SCOPE!r}, {SEARCH_SCOPE!r}, {FULL_SCOPE!r}, "
-            f"{ANYWHERE_SCOPE!r}"
+            f"{DOCUMENT_SCOPE!r}, {DETAIL_SCOPE!r}, {SEARCH_SCOPE!r}, "
+            f"{FULL_SCOPE!r}, {ANYWHERE_SCOPE!r}"
         )
 
 
@@ -273,10 +570,18 @@ def omit_unrequested_sections(
     out on :class:`IncludeGatedSections` itself.
 
     ``scope`` selects which part of the envelope holds records —
-    ``"detail"`` (the singular ``record``), ``"search"`` (every entry of
-    ``records``), ``"full"`` (the composite ``/reaction-entries/{id}/full``
-    document's embedded record lists) or ``"anywhere"`` (every dict in the
-    payload, for a field that can nest at any depth).
+    ``"document"`` (the response object itself), ``"detail"`` (the singular
+    ``record``), ``"search"`` (every entry of ``records``), ``"full"`` (the
+    composite ``/reaction-entries/{id}/full`` document's embedded record
+    lists) or ``"anywhere"`` (every dict in the payload, for a field that
+    can nest at any depth).
+
+    ``"document"`` and ``"full"`` are the two that name the same route and
+    mean opposite things. ``/reaction-entries/{id}/full`` keeps its own ten
+    sections at the document root, which only ``"document"`` yields;
+    ``"full"`` yields the records embedded *inside* those sections, which is
+    where the nested ``trust`` lives. Neither is a substitute for the other,
+    and the wrong one strips nothing and raises nothing.
     """
     if not isinstance(table, IncludeGatedSections):
         raise TypeError(
@@ -369,14 +674,60 @@ def omit_unrequested_calculation_sections(
     )
 
 
+#: Every declared table, keyed by the constant name. The behaviour test
+#: enumerates *these objects* — not a copy of them — so a table that is
+#: declared and never wired, or wired and never declared, cannot pass.
+ALL_INCLUDE_GATED_TABLES: Mapping[str, IncludeGatedSections] = MappingProxyType(
+    {
+        "ARTIFACT_RECORD_SECTIONS": ARTIFACT_RECORD_SECTIONS,
+        "ASSESSMENTS_SECTION": ASSESSMENTS_SECTION,
+        "CALCULATION_RECORD_SECTIONS": CALCULATION_RECORD_SECTIONS,
+        "CONFORMER_RECORD_SECTIONS": CONFORMER_RECORD_SECTIONS,
+        "ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS": (
+            ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS
+        ),
+        "FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS": (
+            FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS
+        ),
+        "KINETICS_RECORD_SECTIONS": KINETICS_RECORD_SECTIONS,
+        "LITERATURE_RECORDS_SECTIONS": LITERATURE_RECORDS_SECTIONS,
+        "NETWORK_KINETICS_RECORD_SECTIONS": NETWORK_KINETICS_RECORD_SECTIONS,
+        "NETWORK_RECORD_SECTIONS": NETWORK_RECORD_SECTIONS,
+        "NETWORK_SOLVE_RECORD_SECTIONS": NETWORK_SOLVE_RECORD_SECTIONS,
+        "REACTION_FULL_SECTIONS": REACTION_FULL_SECTIONS,
+        "SPECIES_SEARCH_SECTIONS": SPECIES_SEARCH_SECTIONS,
+        "STATMECH_RECORD_SECTIONS": STATMECH_RECORD_SECTIONS,
+        "TRANSITION_STATE_RECORD_SECTIONS": TRANSITION_STATE_RECORD_SECTIONS,
+        "TRANSPORT_RECORD_SECTIONS": TRANSPORT_RECORD_SECTIONS,
+        "TRUST_SECTION": TRUST_SECTION,
+    }
+)
+
+
 __all__ = [
+    "ALL_INCLUDE_GATED_TABLES",
     "ANYWHERE_SCOPE",
+    "ARTIFACT_RECORD_SECTIONS",
     "ASSESSMENTS_SECTION",
     "CALCULATION_RECORD_SECTIONS",
+    "CONFORMER_RECORD_SECTIONS",
     "DETAIL_SCOPE",
+    "DOCUMENT_SCOPE",
+    "ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS",
+    "FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS",
     "FULL_SCOPE",
     "INCLUDE_GATED_COMPONENTS",
+    "KINETICS_RECORD_SECTIONS",
+    "LITERATURE_RECORDS_SECTIONS",
+    "NETWORK_KINETICS_RECORD_SECTIONS",
+    "NETWORK_RECORD_SECTIONS",
+    "NETWORK_SOLVE_RECORD_SECTIONS",
+    "REACTION_FULL_SECTIONS",
     "SEARCH_SCOPE",
+    "SPECIES_SEARCH_SECTIONS",
+    "STATMECH_RECORD_SECTIONS",
+    "TRANSITION_STATE_RECORD_SECTIONS",
+    "TRANSPORT_RECORD_SECTIONS",
     "TRUST_SECTION",
     "IncludeGatedSections",
     "omit_assessments_unless_requested",

--- a/backend/app/api/routes/scientific/artifacts.py
+++ b/backend/app/api/routes/scientific/artifacts.py
@@ -18,6 +18,11 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_current_user, get_db, require_curator_or_admin
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
+from app.api.routes.scientific._response import (
+    ARTIFACT_RECORD_SECTIONS,
+    SEARCH_SCOPE,
+    omit_unrequested_sections,
+)
 from app.db.models.app_user import AppUser
 from app.db.models.common import (
     ArtifactIntegrityDetectionContext,
@@ -153,7 +158,14 @@ def artifacts_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(search_artifacts(session, request))
+    payload = search_artifacts(session, request)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=ARTIFACT_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.post("/search", response_model=ScientificArtifactSearchResponse)
@@ -180,7 +192,14 @@ def artifacts_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(search_artifacts(session, body))
+    payload = search_artifacts(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=ARTIFACT_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.get("/integrity", response_model=ScientificArtifactIntegrityResponse)

--- a/backend/app/api/routes/scientific/conformers.py
+++ b/backend/app/api/routes/scientific/conformers.py
@@ -20,6 +20,11 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
+from app.api.routes.scientific._response import (
+    ANYWHERE_SCOPE,
+    CONFORMER_RECORD_SECTIONS,
+    omit_unrequested_sections,
+)
 from app.db.models.common import (
     ConformerSelectionKind,
     RecordReviewStatus,
@@ -133,8 +138,15 @@ def scientific_conformers_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        search_conformers(session, request_obj)
+    payload = search_conformers(session, request_obj)
+    visibility = apply_internal_ids_visibility(payload)
+    # Every gated block is materialised again on each nested
+    # ``observations[*]`` record, so the strip has to reach both depths.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=CONFORMER_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
     )
 
 
@@ -161,7 +173,16 @@ def scientific_conformers_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(search_conformers(session, body))
+    payload = search_conformers(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    # Every gated block is materialised again on each nested
+    # ``observations[*]`` record, so the strip has to reach both depths.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=CONFORMER_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
+    )
 
 
 @cg_router.get(
@@ -179,12 +200,19 @@ def scientific_conformer_group_detail(
     ref of the form ``cg_…``. Wrong-prefix refs return 422
     ``handle_type_mismatch``; unknown refs / ids return 404.
     """
-    return apply_internal_ids_visibility(
-        get_conformer_group(
-            session,
-            conformer_group_handle=conformer_group_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_conformer_group(
+        session,
+        conformer_group_handle=conformer_group_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    # Every gated block is materialised again on each nested
+    # ``observations[*]`` record, so the strip has to reach both depths.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=CONFORMER_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
     )
 
 
@@ -205,10 +233,17 @@ def scientific_conformer_observation_detail(
     public ref of the form ``co_…``. Same 422 / 404 contract as the
     group surface.
     """
-    return apply_internal_ids_visibility(
-        get_conformer_observation(
-            session,
-            conformer_observation_handle=conformer_observation_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_conformer_observation(
+        session,
+        conformer_observation_handle=conformer_observation_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    # Every gated block is materialised again on each nested
+    # ``observations[*]`` record, so the strip has to reach both depths.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=CONFORMER_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
     )

--- a/backend/app/api/routes/scientific/corrections.py
+++ b/backend/app/api/routes/scientific/corrections.py
@@ -30,6 +30,13 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
+from app.api.routes.scientific._response import (
+    DETAIL_SCOPE,
+    ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+    FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+    SEARCH_SCOPE,
+    omit_unrequested_sections,
+)
 from app.db.models.common import EnergyCorrectionSchemeKind, FrequencyScaleKind
 from app.schemas.reads.scientific_energy_correction_scheme import (
     ScientificEnergyCorrectionSchemeDetailResponse,
@@ -131,8 +138,13 @@ def scientific_frequency_scale_factor_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        search_frequency_scale_factors(session, request_obj)
+    payload = search_frequency_scale_factors(session, request_obj)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -156,8 +168,13 @@ def scientific_frequency_scale_factor_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(
-        search_frequency_scale_factors(session, body)
+    payload = search_frequency_scale_factors(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -178,12 +195,17 @@ def scientific_frequency_scale_factor_detail(
     public ref of the form ``fsf_…``. Wrong-prefix refs return 422
     ``handle_type_mismatch``; unknown refs / ids return 404.
     """
-    return apply_internal_ids_visibility(
-        get_frequency_scale_factor(
-            session,
-            frequency_scale_factor_handle=frequency_scale_factor_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_frequency_scale_factor(
+        session,
+        frequency_scale_factor_handle=frequency_scale_factor_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
     )
 
 
@@ -245,8 +267,13 @@ def scientific_energy_correction_scheme_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        search_energy_correction_schemes(session, request_obj)
+    payload = search_energy_correction_schemes(session, request_obj)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -270,8 +297,13 @@ def scientific_energy_correction_scheme_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(
-        search_energy_correction_schemes(session, body)
+    payload = search_energy_correction_schemes(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -292,12 +324,17 @@ def scientific_energy_correction_scheme_detail(
     a public ref of the form ``ecs_…``. Wrong-prefix refs return 422
     ``handle_type_mismatch``; unknown refs / ids return 404.
     """
-    return apply_internal_ids_visibility(
-        get_energy_correction_scheme(
-            session,
-            energy_correction_scheme_handle=energy_correction_scheme_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_energy_correction_scheme(
+        session,
+        energy_correction_scheme_handle=energy_correction_scheme_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
     )
 
 

--- a/backend/app/api/routes/scientific/kinetics.py
+++ b/backend/app/api/routes/scientific/kinetics.py
@@ -14,7 +14,10 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._response import (
+    KINETICS_RECORD_SECTIONS,
+    SEARCH_SCOPE,
     omit_trust_unless_requested,
+    omit_unrequested_sections,
     prepare_assessment_response,
 )
 from app.db.models.common import KineticsModelKind, RecordReviewStatus
@@ -110,4 +113,10 @@ def reaction_kinetics(
         payload,
         attach_assessments=attach_kinetics_assessments,
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=KINETICS_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )

--- a/backend/app/api/routes/scientific/literature.py
+++ b/backend/app/api/routes/scientific/literature.py
@@ -19,6 +19,11 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
+from app.api.routes.scientific._response import (
+    LITERATURE_RECORDS_SECTIONS,
+    SEARCH_SCOPE,
+    omit_unrequested_sections,
+)
 from app.schemas.reads.scientific_literature import (
     ScientificLiteratureDetailResponse,
 )
@@ -68,12 +73,17 @@ def scientific_literature_records(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        get_literature_records(
-            session,
-            request_obj,
-            literature_handle=literature_ref_or_id,
-        )
+    payload = get_literature_records(
+        session,
+        request_obj,
+        literature_handle=literature_ref_or_id,
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=LITERATURE_RECORDS_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 

--- a/backend/app/api/routes/scientific/networks.py
+++ b/backend/app/api/routes/scientific/networks.py
@@ -8,6 +8,14 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
+from app.api.routes.scientific._response import (
+    DETAIL_SCOPE,
+    NETWORK_KINETICS_RECORD_SECTIONS,
+    NETWORK_RECORD_SECTIONS,
+    NETWORK_SOLVE_RECORD_SECTIONS,
+    SEARCH_SCOPE,
+    omit_unrequested_sections,
+)
 from app.db.models.common import (
     NetworkKineticsModelKind,
     NetworkSolveKind,
@@ -135,8 +143,13 @@ def scientific_networks_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        search_networks(session, request_obj)
+    payload = search_networks(session, request_obj)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -159,7 +172,14 @@ def scientific_networks_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(search_networks(session, body))
+    payload = search_networks(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.get(
@@ -177,12 +197,17 @@ def scientific_network_detail(
     the form ``net_…``. Wrong-prefix refs return 422
     ``handle_type_mismatch``; unknown refs / ids return 404.
     """
-    return apply_internal_ids_visibility(
-        get_network(
-            session,
-            network_handle=network_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_network(
+        session,
+        network_handle=network_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
     )
 
 
@@ -261,8 +286,13 @@ def scientific_network_solves_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        search_network_solves(session, request_obj)
+    payload = search_network_solves(session, request_obj)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_SOLVE_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -285,8 +315,13 @@ def scientific_network_solves_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(
-        search_network_solves(session, body)
+    payload = search_network_solves(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_SOLVE_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -305,12 +340,17 @@ def scientific_network_solve_detail(
     ref of the form ``nsolve_…``. Wrong-prefix refs return 422
     ``handle_type_mismatch``; unknown refs / ids return 404.
     """
-    return apply_internal_ids_visibility(
-        get_network_solve(
-            session,
-            network_solve_handle=network_solve_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_network_solve(
+        session,
+        network_solve_handle=network_solve_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_SOLVE_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
     )
 
 
@@ -390,8 +430,13 @@ def scientific_network_kinetics_search_get(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(
-        search_network_kinetics(session, request_obj)
+    payload = search_network_kinetics(session, request_obj)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_KINETICS_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -414,8 +459,13 @@ def scientific_network_kinetics_search_post(
                 "all search fields in the JSON body."
             ),
         )
-    return apply_internal_ids_visibility(
-        search_network_kinetics(session, body)
+    payload = search_network_kinetics(session, body)
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_KINETICS_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
     )
 
 
@@ -443,10 +493,15 @@ def scientific_network_kinetics_detail(
     ``points_truncated`` + ``point_count_total`` so callers can detect
     the cap and refine their request.
     """
-    return apply_internal_ids_visibility(
-        get_network_kinetics(
-            session,
-            network_kinetics_handle=network_kinetics_ref_or_id,
-            include=parse_include(include),
-        )
+    payload = get_network_kinetics(
+        session,
+        network_kinetics_handle=network_kinetics_ref_or_id,
+        include=parse_include(include),
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=NETWORK_KINETICS_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
     )

--- a/backend/app/api/routes/scientific/provenance.py
+++ b/backend/app/api/routes/scientific/provenance.py
@@ -13,7 +13,13 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
-from app.api.routes.scientific._response import omit_trust_unless_requested
+from app.api.routes.scientific._response import (
+    DOCUMENT_SCOPE,
+    FULL_SCOPE,
+    REACTION_FULL_SECTIONS,
+    omit_trust_unless_requested,
+    omit_unrequested_sections,
+)
 from app.db.models.common import RecordReviewStatus
 from app.schemas.reads.scientific_provenance import (
     ReactionFullReadRequest,
@@ -71,4 +77,16 @@ def reaction_full(
         request=request,
     )
     visibility = apply_internal_ids_visibility(payload)
-    return omit_trust_unless_requested(visibility, payload, scope="full")
+    # Two strips, two scopes, on one response, and they are not
+    # interchangeable. ``FULL_SCOPE`` reaches the records embedded inside
+    # the sections and removes their nested ``trust``; this document's own
+    # ten sections sit at the root, which only ``DOCUMENT_SCOPE`` yields.
+    # Using the route-named scope for the second would strip nothing and
+    # report nothing.
+    visibility = omit_trust_unless_requested(visibility, payload, scope=FULL_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=REACTION_FULL_SECTIONS,
+        scope=DOCUMENT_SCOPE,
+    )

--- a/backend/app/api/routes/scientific/species.py
+++ b/backend/app/api/routes/scientific/species.py
@@ -7,6 +7,11 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
+from app.api.routes.scientific._response import (
+    ANYWHERE_SCOPE,
+    SPECIES_SEARCH_SECTIONS,
+    omit_unrequested_sections,
+)
 from app.db.models.common import (
     RecordReviewStatus,
     SpeciesEntryStateKind,
@@ -74,4 +79,13 @@ def species_search(
         offset=offset,
         limit=limit,
     )
-    return apply_internal_ids_visibility(search_species(session, request))
+    payload = search_species(session, request)
+    visibility = apply_internal_ids_visibility(payload)
+    # The four summaries sit at ``records[*].entries[*]``, two levels below
+    # the record root, so no record-shaped scope reaches them.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=SPECIES_SEARCH_SECTIONS,
+        scope=ANYWHERE_SCOPE,
+    )

--- a/backend/app/api/routes/scientific/species_subresources.py
+++ b/backend/app/api/routes/scientific/species_subresources.py
@@ -29,7 +29,11 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._response import (
+    SEARCH_SCOPE,
+    STATMECH_RECORD_SECTIONS,
+    TRANSPORT_RECORD_SECTIONS,
     omit_trust_unless_requested,
+    omit_unrequested_sections,
     prepare_assessment_response,
 )
 from app.db.models.common import RecordReviewStatus
@@ -106,7 +110,13 @@ def species_statmech(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_statmech_assessments
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=STATMECH_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.get(
@@ -162,4 +172,10 @@ def species_transport(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_transport_assessments
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSPORT_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )

--- a/backend/app/api/routes/scientific/statmech.py
+++ b/backend/app/api/routes/scientific/statmech.py
@@ -22,7 +22,11 @@ from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
 from app.api.routes.scientific._response import (
+    DETAIL_SCOPE,
+    SEARCH_SCOPE,
+    STATMECH_RECORD_SECTIONS,
     omit_trust_unless_requested,
+    omit_unrequested_sections,
     prepare_assessment_response,
 )
 from app.db.models.common import (
@@ -118,7 +122,13 @@ def scientific_statmech_search_get(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_statmech_assessments
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=STATMECH_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.post(
@@ -148,7 +158,13 @@ def scientific_statmech_search_post(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_statmech_assessments
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=STATMECH_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.get(
@@ -174,4 +190,10 @@ def scientific_statmech_detail(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_statmech_assessments
     )
-    return omit_trust_unless_requested(visibility, payload)
+    visibility = omit_trust_unless_requested(visibility, payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=STATMECH_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
+    )

--- a/backend/app/api/routes/scientific/transition_states.py
+++ b/backend/app/api/routes/scientific/transition_states.py
@@ -20,7 +20,9 @@ from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
 from app.api.routes.scientific._response import (
     ANYWHERE_SCOPE,
+    TRANSITION_STATE_RECORD_SECTIONS,
     omit_trust_unless_requested,
+    omit_unrequested_sections,
 )
 from app.db.models.common import (
     RecordReviewStatus,
@@ -145,8 +147,18 @@ def scientific_transition_states_search_get(
     # nulled at depth. ``ANYWHERE_SCOPE`` is licensed here because ``trust``
     # names one thing wherever it occurs in this payload, which
     # ``test_search_trust_include`` asserts rather than assumes.
-    return omit_trust_unless_requested(
+    visibility = omit_trust_unless_requested(
         visibility, payload, scope=ANYWHERE_SCOPE
+    )
+    # Same argument as ``trust`` above, for the same reason: every gated
+    # section on this record is materialised again on each nested
+    # ``entries[*]`` sibling, so a record-shaped scope would leave the
+    # nested copies nulled at depth.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSITION_STATE_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
     )
 
 
@@ -175,8 +187,18 @@ def scientific_transition_states_search_post(
         )
     payload = search_transition_states(session, body)
     visibility = apply_internal_ids_visibility(payload)
-    return omit_trust_unless_requested(
+    visibility = omit_trust_unless_requested(
         visibility, payload, scope=ANYWHERE_SCOPE
+    )
+    # Same argument as ``trust`` above, for the same reason: every gated
+    # section on this record is materialised again on each nested
+    # ``entries[*]`` sibling, so a record-shaped scope would leave the
+    # nested copies nulled at depth.
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSITION_STATE_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
     )
 
 
@@ -204,12 +226,23 @@ def scientific_transition_state_detail(
     supplied *and* the deployment permits it.
     """
     req = TransitionStateDetailRequest(include=parse_include(include))
-    return apply_internal_ids_visibility(
-        get_transition_state(
-            session,
-            transition_state_handle=transition_state_ref_or_id,
-            request=req,
-        )
+    payload = get_transition_state(
+        session,
+        transition_state_handle=transition_state_ref_or_id,
+        request=req,
+    )
+    visibility = apply_internal_ids_visibility(payload)
+    # ``trust`` is not a legal token on the concept surface, so this pop is
+    # unconditional: it removes the ``entries[*].trust`` key that no request
+    # here can ever fill, rather than one the caller declined to ask for.
+    visibility = omit_trust_unless_requested(
+        visibility, payload, scope=ANYWHERE_SCOPE
+    )
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSITION_STATE_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
     )
 
 
@@ -243,4 +276,12 @@ def scientific_transition_state_entry_detail(
         request=req,
     )
     visibility = apply_internal_ids_visibility(payload)
-    return omit_trust_unless_requested(visibility, payload)
+    visibility = omit_trust_unless_requested(
+        visibility, payload, scope=ANYWHERE_SCOPE
+    )
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSITION_STATE_RECORD_SECTIONS,
+        scope=ANYWHERE_SCOPE,
+    )

--- a/backend/app/api/routes/scientific/transport.py
+++ b/backend/app/api/routes/scientific/transport.py
@@ -22,7 +22,11 @@ from app.api.deps import get_db
 from app.api.routes.scientific._common import parse_include
 from app.api.routes.scientific._profile import PROFILE_QUERY_KEYS
 from app.api.routes.scientific._response import (
+    DETAIL_SCOPE,
+    SEARCH_SCOPE,
+    TRANSPORT_RECORD_SECTIONS,
     omit_trust_unless_requested,
+    omit_unrequested_sections,
     prepare_assessment_response,
 )
 from app.db.models.common import (
@@ -113,7 +117,13 @@ def scientific_transport_search_get(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_transport_assessments
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSPORT_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.post("/search", response_model=ScientificTransportSearchResponse)
@@ -137,7 +147,13 @@ def scientific_transport_search_post(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_transport_assessments
     )
-    return omit_trust_unless_requested(visibility, payload, scope="search")
+    visibility = omit_trust_unless_requested(visibility, payload, scope=SEARCH_SCOPE)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSPORT_RECORD_SECTIONS,
+        scope=SEARCH_SCOPE,
+    )
 
 
 @router.get(
@@ -163,4 +179,10 @@ def scientific_transport_detail(
     visibility = prepare_assessment_response(
         session, payload, attach_assessments=attach_transport_assessments
     )
-    return omit_trust_unless_requested(visibility, payload)
+    visibility = omit_trust_unless_requested(visibility, payload)
+    return omit_unrequested_sections(
+        visibility,
+        payload,
+        table=TRANSPORT_RECORD_SECTIONS,
+        scope=DETAIL_SCOPE,
+    )

--- a/backend/app/schemas/reads/scientific_provenance.py
+++ b/backend/app/schemas/reads/scientific_provenance.py
@@ -425,7 +425,25 @@ class ScientificReactionFullResponse(BaseModel):
 
     Sections that are not in the ``include`` set are omitted entirely.
     Sections that are in the ``include`` set are always present (collections
-    as ``[]``, objects as ``null`` when empty).
+    as ``[]``, objects as ``null`` when empty). This document said so for a
+    long time before it was true; the ten include-gated sections below are
+    stripped at the response seam by ``REACTION_FULL_SECTIONS``, which needs
+    the ``document`` scope because they sit at the root rather than under a
+    ``record`` key.
+
+    ``include`` **replaces** the defaults rather than extending them: a bare
+    request resolves to ``species``, ``kinetics`` and ``transition_states``,
+    and ``?include=irc`` resolves to ``irc`` alone. Under the old shape that
+    silently nulled three sections a caller was still expecting; now they are
+    absent and ``request.include`` says why.
+
+    ``review_records`` is the one exception and is deliberately not one of
+    the ten. It is produced by the separate ``include_review`` query
+    parameter, not by any include token, so it keeps its ``null`` when the
+    caller asked for ``include_review=summary`` — an include-driven strip has
+    nothing true to say about a field a different parameter governs, and
+    ``request.include_review`` is echoed beside ``request.include`` so a
+    reader can tell the two states apart.
     """
 
     request: RequestEcho

--- a/backend/docs/specs/machine_consumer_query_contract.md
+++ b/backend/docs/specs/machine_consumer_query_contract.md
@@ -8,7 +8,7 @@ Requirement 10 remains ongoing as each surface expands.
 - Additive response fields are backward compatible. Removing or changing the meaning/type of a field requires a versioned contract.
 - A declared filter is either enforced or rejected. It must never be accepted and ignored.
 - Public refs are stable identifiers. Integer database IDs are deployment-policy fields and are optional in hosted response schemas.
-- An include-gated section that the caller did not request is **omitted** from the response, not returned as `null`. That is the rule; it holds today on `/api/v1/scientific/calculations/*` and for `trust`/`assessments`, and the remaining surfaces are being converted to it one declared table at a time. See [Include-gated sections](#include-gated-sections-absent-means-you-did-not-ask) for the three-state rule and its hard boundary.
+- An include-gated section that the caller did not request is **omitted** from the response, not returned as `null`. That is the rule and it now holds on every scientific read surface. A key that *is* present and `null` therefore says something about the data — this record has no NASA-9 polynomial, no Chebyshev fit, no PLOG entries — and never about the request. See [Include-gated sections](#include-gated-sections-absent-means-you-did-not-ask) for the three-state rule and its hard boundary.
 - Pagination metadata reports `total` for the complete filtered candidate set before collapse and `post_collapse_total` after collapse but before page slicing. Collapse is applied first, so `collapse=first&offset=1` returns an empty page while retaining `total >= 1` and `post_collapse_total = 1`.
 
 ## Include-gated sections: absent means "you did not ask"
@@ -103,14 +103,36 @@ evaluation, so they cannot become two answers.
 
 ### Scope today
 
-`/api/v1/scientific/calculations/*` omits all 18 of its heavy sections, and
-`trust` and `assessments` are omitted wherever their helpers run — which is now
-every surface that declares either, the five search surfaces included. Every
-other include-gated section still serializes as `null`; those surfaces are being
-converted one declared table at a time, and each conversion adds the
-`x-tckdb-include-gated` marker to the hosted OpenAPI document at the same time,
-so the document never claims a key is normally absent before the runtime omits
-it.
+**Every include-gated section on every scientific read surface is omitted when
+it was not requested.** Fifteen declared per-surface tables cover 81 sections
+across 40 operations, and the two cross-cutting tables — `trust` and
+`assessments` — are applied wherever their helpers run, which is every surface
+that declares either. Nothing include-gated serializes as `null` because it was
+not asked for any more.
+
+Two consequences worth stating in the contract rather than leaving to be
+discovered.
+
+`/reaction-entries/{id}/full` keeps its sections at the document root, and
+`include` **replaces** its defaults rather than extending them. A bare request
+resolves to `species`, `kinetics` and `transition_states`; `?include=irc`
+resolves to `irc` alone, and the three defaults are now *absent* rather than
+`null`. That behaviour is not new — the sections were already empty — but it is
+now visible, which is an argument for the change rather than against it.
+`review_records` on that surface is the one gated key that is not include-gated:
+it is produced by the separate `include_review` parameter and keeps its `null`,
+with `request.include_review` echoed beside `request.include` so a reader can
+still tell "you did not ask" from "there are none".
+
+A legal token is not a promise of a field. Several tokens are accepted, echoed
+and produce nothing at all — `review` on `/species/search`, on
+`/reaction-entries/{id}/full` and on `/artifacts/search`, `literature` on
+`/frequency-scale-factors/*` and `/energy-correction-schemes/*`, all four
+content tokens on `/reactions/search`, and every public token on
+`/literature/{ref}` — because the data they name is either already
+unconditional or not carried by that record. None of them is in a declared
+table, so none of them changes shape here, and a caller who supplies one gets
+the same response either way.
 
 ## Ordered requirements
 

--- a/backend/docs/specs/trust_read_api_current.md
+++ b/backend/docs/specs/trust_read_api_current.md
@@ -68,6 +68,15 @@ graph **once per page** rather than once per record, and `include=all` still
 does not expand to `trust` — the graph runs from 9 chain entries on transport
 to 23 on transition-states, and a caller has to ask for that by name.
 
+One surface publishes entry records without publishing their rubric.
+`GET /scientific/transition-states/{ref}?include=entries` returns
+`ScientificTransitionStateEntryRecord`s, which declare `trust`, on an operation
+whose vocabulary has no `trust` token — the concept has no aggregation rubric.
+Those nested `trust` keys used to serialize as `null`, which read as "the entry
+has no verdict" rather than "this operation cannot produce one". They are now
+**absent**; the verdict is one request away on
+`/scientific/transition-state-entries/{ref}?include=trust`.
+
 Internal database ids remain hidden by default. In trust evidence payloads,
 `record_id` is hidden unless `include=internal_ids` is explicitly requested and
 the deployment/user policy allows internal-id exposure.

--- a/backend/tests/api/golden/openapi.json
+++ b/backend/tests/api/golden/openapi.json
@@ -18449,7 +18449,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "trust"
           },
           "tunneling_application": {
             "anyOf": [
@@ -20331,7 +20332,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "review"
           },
           "role": {
             "anyOf": [
@@ -31217,7 +31219,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "owner"
           }
         },
         "required": [
@@ -32098,7 +32101,8 @@
                 "type": "null"
               }
             ],
-            "title": "Calculations"
+            "title": "Calculations",
+            "x-tckdb-include-gated": "calculations"
           },
           "conformer_group": {
             "$ref": "#/components/schemas/ConformerGroupCoreBlock"
@@ -32118,7 +32122,8 @@
                 "type": "null"
               }
             ],
-            "title": "Geometries"
+            "title": "Geometries",
+            "x-tckdb-include-gated": "geometries"
           },
           "observations": {
             "anyOf": [
@@ -32132,7 +32137,8 @@
                 "type": "null"
               }
             ],
-            "title": "Observations"
+            "title": "Observations",
+            "x-tckdb-include-gated": "observations"
           },
           "observations_summary": {
             "$ref": "#/components/schemas/ConformerObservationsSummary"
@@ -32149,7 +32155,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "selection_summary": {
             "items": {
@@ -32170,7 +32177,8 @@
                 "type": "null"
               }
             ],
-            "title": "Selections"
+            "title": "Selections",
+            "x-tckdb-include-gated": "selections"
           },
           "species": {
             "$ref": "#/components/schemas/ConformerSpeciesContext"
@@ -32235,7 +32243,8 @@
                 "type": "null"
               }
             ],
-            "title": "Calculations"
+            "title": "Calculations",
+            "x-tckdb-include-gated": "calculations"
           },
           "conformer_group": {
             "$ref": "#/components/schemas/ConformerGroupCoreBlock"
@@ -32258,7 +32267,8 @@
                 "type": "null"
               }
             ],
-            "title": "Geometries"
+            "title": "Geometries",
+            "x-tckdb-include-gated": "geometries"
           },
           "observations": {
             "anyOf": [
@@ -32272,7 +32282,8 @@
                 "type": "null"
               }
             ],
-            "title": "Observations"
+            "title": "Observations",
+            "x-tckdb-include-gated": "observations"
           },
           "review_history": {
             "anyOf": [
@@ -32286,7 +32297,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "selections": {
             "anyOf": [
@@ -32300,7 +32312,8 @@
                 "type": "null"
               }
             ],
-            "title": "Selections"
+            "title": "Selections",
+            "x-tckdb-include-gated": "selections"
           },
           "species": {
             "$ref": "#/components/schemas/ConformerSpeciesContext"
@@ -32384,7 +32397,8 @@
                 "type": "null"
               }
             ],
-            "title": "Corrections"
+            "title": "Corrections",
+            "x-tckdb-include-gated": "corrections"
           },
           "energy_correction_scheme": {
             "$ref": "#/components/schemas/EnergyCorrectionSchemeCoreBlock"
@@ -32424,7 +32438,8 @@
                 "type": "null"
               }
             ],
-            "title": "Used By"
+            "title": "Used By",
+            "x-tckdb-include-gated": "used_by"
           }
         },
         "required": [
@@ -32539,7 +32554,8 @@
                 "type": "null"
               }
             ],
-            "title": "Used By"
+            "title": "Used By",
+            "x-tckdb-include-gated": "used_by"
           },
           "workflow_tool_release": {
             "anyOf": [
@@ -32845,7 +32861,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "coefficients"
           },
           "evidence_summary": {
             "$ref": "#/components/schemas/NetworkKineticsEvidenceSummary"
@@ -32874,7 +32891,8 @@
                 "type": "null"
               }
             ],
-            "title": "Plog"
+            "title": "Plog",
+            "x-tckdb-include-gated": "plog"
           },
           "plog_entries_truncated": {
             "anyOf": [
@@ -32885,7 +32903,8 @@
                 "type": "null"
               }
             ],
-            "title": "Plog Entries Truncated"
+            "title": "Plog Entries Truncated",
+            "x-tckdb-include-gated": "plog"
           },
           "plog_entry_count_total": {
             "anyOf": [
@@ -32896,7 +32915,8 @@
                 "type": "null"
               }
             ],
-            "title": "Plog Entry Count Total"
+            "title": "Plog Entry Count Total",
+            "x-tckdb-include-gated": "plog"
           },
           "point_count_total": {
             "anyOf": [
@@ -32907,7 +32927,8 @@
                 "type": "null"
               }
             ],
-            "title": "Point Count Total"
+            "title": "Point Count Total",
+            "x-tckdb-include-gated": "points"
           },
           "points": {
             "anyOf": [
@@ -32921,7 +32942,8 @@
                 "type": "null"
               }
             ],
-            "title": "Points"
+            "title": "Points",
+            "x-tckdb-include-gated": "points"
           },
           "points_truncated": {
             "anyOf": [
@@ -32932,7 +32954,8 @@
                 "type": "null"
               }
             ],
-            "title": "Points Truncated"
+            "title": "Points Truncated",
+            "x-tckdb-include-gated": "points"
           },
           "review_history": {
             "anyOf": [
@@ -32946,7 +32969,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "source_calculations": {
             "anyOf": [
@@ -32960,7 +32984,8 @@
                 "type": "null"
               }
             ],
-            "title": "Source Calculations"
+            "title": "Source Calculations",
+            "x-tckdb-include-gated": "source_calculations"
           }
         },
         "required": [
@@ -33020,7 +33045,8 @@
                 "type": "null"
               }
             ],
-            "title": "Channels"
+            "title": "Channels",
+            "x-tckdb-include-gated": "channels"
           },
           "evidence_summary": {
             "$ref": "#/components/schemas/NetworkEvidenceSummary"
@@ -33037,7 +33063,8 @@
                 "type": "null"
               }
             ],
-            "title": "Kinetics"
+            "title": "Kinetics",
+            "x-tckdb-include-gated": "kinetics"
           },
           "literature": {
             "anyOf": [
@@ -33064,7 +33091,8 @@
                 "type": "null"
               }
             ],
-            "title": "Reactions"
+            "title": "Reactions",
+            "x-tckdb-include-gated": "reactions"
           },
           "review_history": {
             "anyOf": [
@@ -33078,7 +33106,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "software_release": {
             "anyOf": [
@@ -33102,7 +33131,8 @@
                 "type": "null"
               }
             ],
-            "title": "Solves"
+            "title": "Solves",
+            "x-tckdb-include-gated": "solves"
           },
           "source_calculations": {
             "anyOf": [
@@ -33116,7 +33146,8 @@
                 "type": "null"
               }
             ],
-            "title": "Source Calculations"
+            "title": "Source Calculations",
+            "x-tckdb-include-gated": "source_calculations"
           },
           "species": {
             "anyOf": [
@@ -33130,7 +33161,8 @@
                 "type": "null"
               }
             ],
-            "title": "Species"
+            "title": "Species",
+            "x-tckdb-include-gated": "species"
           },
           "states": {
             "anyOf": [
@@ -33144,7 +33176,8 @@
                 "type": "null"
               }
             ],
-            "title": "States"
+            "title": "States",
+            "x-tckdb-include-gated": "states"
           },
           "workflow_tool_release": {
             "anyOf": [
@@ -33232,7 +33265,8 @@
                 "type": "null"
               }
             ],
-            "title": "Bath Gas"
+            "title": "Bath Gas",
+            "x-tckdb-include-gated": "bath_gas"
           },
           "channel_barriers": {
             "anyOf": [
@@ -33246,7 +33280,8 @@
                 "type": "null"
               }
             ],
-            "title": "Channel Barriers"
+            "title": "Channel Barriers",
+            "x-tckdb-include-gated": "channel_barriers"
           },
           "energy_transfer": {
             "anyOf": [
@@ -33260,7 +33295,8 @@
                 "type": "null"
               }
             ],
-            "title": "Energy Transfer"
+            "title": "Energy Transfer",
+            "x-tckdb-include-gated": "energy_transfer"
           },
           "evidence_summary": {
             "$ref": "#/components/schemas/NetworkSolveEvidenceSummary"
@@ -33277,7 +33313,8 @@
                 "type": "null"
               }
             ],
-            "title": "Kinetics"
+            "title": "Kinetics",
+            "x-tckdb-include-gated": "kinetics"
           },
           "literature": {
             "anyOf": [
@@ -33307,7 +33344,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "software_release": {
             "anyOf": [
@@ -33331,7 +33369,8 @@
                 "type": "null"
               }
             ],
-            "title": "Source Calculations"
+            "title": "Source Calculations",
+            "x-tckdb-include-gated": "source_calculations"
           },
           "state_energies": {
             "anyOf": [
@@ -33345,7 +33384,8 @@
                 "type": "null"
               }
             ],
-            "title": "State Energies"
+            "title": "State Energies",
+            "x-tckdb-include-gated": "state_energies"
           },
           "workflow_tool_release": {
             "anyOf": [
@@ -33405,7 +33445,7 @@
         "type": "string"
       },
       "ScientificReactionFullResponse": {
-        "description": "Response envelope for /api/v1/scientific/reaction-entries/{id}/full.\n\nSections that are not in the ``include`` set are omitted entirely.\nSections that are in the ``include`` set are always present (collections\nas ``[]``, objects as ``null`` when empty).",
+        "description": "Response envelope for /api/v1/scientific/reaction-entries/{id}/full.\n\nSections that are not in the ``include`` set are omitted entirely.\nSections that are in the ``include`` set are always present (collections\nas ``[]``, objects as ``null`` when empty). This document said so for a\nlong time before it was true; the ten include-gated sections below are\nstripped at the response seam by ``REACTION_FULL_SECTIONS``, which needs\nthe ``document`` scope because they sit at the root rather than under a\n``record`` key.\n\n``include`` **replaces** the defaults rather than extending them: a bare\nrequest resolves to ``species``, ``kinetics`` and ``transition_states``,\nand ``?include=irc`` resolves to ``irc`` alone. Under the old shape that\nsilently nulled three sections a caller was still expecting; now they are\nabsent and ``request.include`` says why.\n\n``review_records`` is the one exception and is deliberately not one of\nthe ten. It is produced by the separate ``include_review`` query\nparameter, not by any include token, so it keeps its ``null`` when the\ncaller asked for ``include_review=summary`` — an include-driven strip has\nnothing true to say about a field a different parameter governs, and\n``request.include_review`` is echoed beside ``request.include`` so a\nreader can tell the two states apart.",
         "properties": {
           "artifacts": {
             "anyOf": [
@@ -33419,7 +33459,8 @@
                 "type": "null"
               }
             ],
-            "title": "Artifacts"
+            "title": "Artifacts",
+            "x-tckdb-include-gated": "artifacts"
           },
           "atom_map": {
             "anyOf": [
@@ -33433,7 +33474,8 @@
                 "type": "null"
               }
             ],
-            "title": "Atom Map"
+            "title": "Atom Map",
+            "x-tckdb-include-gated": "atom_map"
           },
           "calculations": {
             "anyOf": [
@@ -33447,7 +33489,8 @@
                 "type": "null"
               }
             ],
-            "title": "Calculations"
+            "title": "Calculations",
+            "x-tckdb-include-gated": "calculations"
           },
           "conformers": {
             "anyOf": [
@@ -33461,7 +33504,8 @@
                 "type": "null"
               }
             ],
-            "title": "Conformers"
+            "title": "Conformers",
+            "x-tckdb-include-gated": "conformers"
           },
           "irc": {
             "anyOf": [
@@ -33475,7 +33519,8 @@
                 "type": "null"
               }
             ],
-            "title": "Irc"
+            "title": "Irc",
+            "x-tckdb-include-gated": "irc"
           },
           "kinetics": {
             "anyOf": [
@@ -33489,7 +33534,8 @@
                 "type": "null"
               }
             ],
-            "title": "Kinetics"
+            "title": "Kinetics",
+            "x-tckdb-include-gated": "kinetics"
           },
           "path_search": {
             "anyOf": [
@@ -33503,7 +33549,8 @@
                 "type": "null"
               }
             ],
-            "title": "Path Search"
+            "title": "Path Search",
+            "x-tckdb-include-gated": "path_search"
           },
           "reaction_entry": {
             "$ref": "#/components/schemas/ReactionEntrySummary"
@@ -33540,7 +33587,8 @@
                 "type": "null"
               }
             ],
-            "title": "Scans"
+            "title": "Scans",
+            "x-tckdb-include-gated": "scans"
           },
           "species": {
             "anyOf": [
@@ -33550,7 +33598,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "species"
           },
           "transition_states": {
             "anyOf": [
@@ -33564,7 +33613,8 @@
                 "type": "null"
               }
             ],
-            "title": "Transition States"
+            "title": "Transition States",
+            "x-tckdb-include-gated": "transition_states"
           }
         },
         "required": [
@@ -34256,7 +34306,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "assessments"
           },
           "available_sections": {
             "$ref": "#/components/schemas/AvailableStatmechSections"
@@ -34273,7 +34324,8 @@
                 "type": "null"
               }
             ],
-            "title": "Conformers"
+            "title": "Conformers",
+            "x-tckdb-include-gated": "conformers"
           },
           "electronic_levels": {
             "anyOf": [
@@ -34287,7 +34339,8 @@
                 "type": "null"
               }
             ],
-            "title": "Electronic Levels"
+            "title": "Electronic Levels",
+            "x-tckdb-include-gated": "electronic_levels"
           },
           "evidence_summary": {
             "$ref": "#/components/schemas/StatmechEvidenceSummary"
@@ -34300,7 +34353,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "frequencies"
           },
           "frequency_scale_factor": {
             "anyOf": [
@@ -34334,7 +34388,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "software_release": {
             "anyOf": [
@@ -34358,7 +34413,8 @@
                 "type": "null"
               }
             ],
-            "title": "Source Calculations"
+            "title": "Source Calculations",
+            "x-tckdb-include-gated": "source_calculations"
           },
           "species": {
             "anyOf": [
@@ -34395,7 +34451,8 @@
                 "type": "null"
               }
             ],
-            "title": "Torsions"
+            "title": "Torsions",
+            "x-tckdb-include-gated": "torsions"
           },
           "transition_state": {
             "anyOf": [
@@ -34415,7 +34472,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "trust"
           },
           "workflow_tool_release": {
             "anyOf": [
@@ -34554,7 +34612,8 @@
                 "type": "null"
               }
             ],
-            "title": "Calculations"
+            "title": "Calculations",
+            "x-tckdb-include-gated": "calculations"
           },
           "entries": {
             "anyOf": [
@@ -34568,7 +34627,8 @@
                 "type": "null"
               }
             ],
-            "title": "Entries"
+            "title": "Entries",
+            "x-tckdb-include-gated": "entries"
           },
           "evidence_summary": {
             "$ref": "#/components/schemas/TransitionStateEntryEvidenceSummary"
@@ -34585,7 +34645,8 @@
                 "type": "null"
               }
             ],
-            "title": "Geometries"
+            "title": "Geometries",
+            "x-tckdb-include-gated": "geometries"
           },
           "reaction": {
             "$ref": "#/components/schemas/TransitionStateReactionContext"
@@ -34602,7 +34663,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "transition_state": {
             "$ref": "#/components/schemas/TransitionStateCoreBlock"
@@ -34618,7 +34680,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "trust"
           },
           "validation": {
             "$ref": "#/components/schemas/TransitionStateValidationDescriptor"
@@ -34635,7 +34698,8 @@
                 "type": "null"
               }
             ],
-            "title": "Validation Evidence"
+            "title": "Validation Evidence",
+            "x-tckdb-include-gated": "validation_evidence"
           }
         },
         "required": [
@@ -34667,7 +34731,8 @@
                 "type": "null"
               }
             ],
-            "title": "Calculations"
+            "title": "Calculations",
+            "x-tckdb-include-gated": "calculations"
           },
           "entries": {
             "anyOf": [
@@ -34681,7 +34746,8 @@
                 "type": "null"
               }
             ],
-            "title": "Entries"
+            "title": "Entries",
+            "x-tckdb-include-gated": "entries"
           },
           "entries_summary": {
             "$ref": "#/components/schemas/TransitionStateEntriesSummary"
@@ -34701,7 +34767,8 @@
                 "type": "null"
               }
             ],
-            "title": "Geometries"
+            "title": "Geometries",
+            "x-tckdb-include-gated": "geometries"
           },
           "reaction": {
             "$ref": "#/components/schemas/TransitionStateReactionContext"
@@ -34718,7 +34785,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "transition_state": {
             "$ref": "#/components/schemas/TransitionStateCoreBlock"
@@ -34735,7 +34803,8 @@
                 "type": "null"
               }
             ],
-            "title": "Validation Evidence"
+            "title": "Validation Evidence",
+            "x-tckdb-include-gated": "validation_evidence"
           }
         },
         "required": [
@@ -34809,7 +34878,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "assessments"
           },
           "available_sections": {
             "$ref": "#/components/schemas/AvailableTransportSections"
@@ -34839,7 +34909,8 @@
                 "type": "null"
               }
             ],
-            "title": "Review History"
+            "title": "Review History",
+            "x-tckdb-include-gated": "review"
           },
           "software_release": {
             "anyOf": [
@@ -34863,7 +34934,8 @@
                 "type": "null"
               }
             ],
-            "title": "Source Calculations"
+            "title": "Source Calculations",
+            "x-tckdb-include-gated": "source_calculations"
           },
           "species": {
             "$ref": "#/components/schemas/TransportSpeciesContext"
@@ -34889,7 +34961,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "trust"
           },
           "workflow_tool_release": {
             "anyOf": [
@@ -36147,7 +36220,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "conformers"
           },
           "electronic_state_kind": {
             "$ref": "#/components/schemas/SpeciesEntryStateKind"
@@ -36175,7 +36249,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "statmech"
           },
           "thermo_summary": {
             "anyOf": [
@@ -36185,7 +36260,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "thermo"
           },
           "transport_summary": {
             "anyOf": [
@@ -36195,7 +36271,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "transport"
           }
         },
         "required": [
@@ -41775,7 +41852,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "assessments"
           },
           "evidence_completeness": {
             "$ref": "#/components/schemas/EvidenceCompletenessBreakdown"
@@ -41921,7 +41999,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "x-tckdb-include-gated": "trust"
           },
           "wilhoit": {
             "anyOf": [

--- a/backend/tests/api/scientific/test_api_reaction_atom_map.py
+++ b/backend/tests/api/scientific/test_api_reaction_atom_map.py
@@ -163,8 +163,10 @@ def test_a_mapped_reaction_is_distinguishable_without_a_second_request(client):
     result = _upload(client, _map(equivalent_map_count=6))
     body = _full(client, result["reaction_entry_id"])
 
-    # No ``include`` token was passed.
-    assert body["atom_map"] is None
+    # No ``include`` token was passed, so the per-atom section is absent.
+    # The badge below is the point of the test and is unconditional: whether
+    # a reaction is mapped at all must never be behind a second request.
+    assert "atom_map" not in body
     badges = body["reaction_entry"]["atom_maps"]
     assert len(badges) == 1
     assert badges[0]["source"] == "declared"
@@ -412,5 +414,5 @@ def test_the_atom_map_badge_is_not_subject_to_the_pair_cap(client, monkeypatch):
     monkeypatch.setattr(settings, "max_full_atom_map_pairs_public", 1)
 
     body = _full(client, result["reaction_entry_id"])
-    assert body["atom_map"] is None
+    assert "atom_map" not in body
     assert len(body["reaction_entry"]["atom_maps"]) == 1

--- a/backend/tests/api/scientific/test_api_reaction_full.py
+++ b/backend/tests/api/scientific/test_api_reaction_full.py
@@ -76,9 +76,16 @@ def test_default_omits_non_default_sections(client, db_session):
     resp = client.get(f"/api/v1/scientific/reaction-entries/{entry.id}/full")
     body = resp.json()
     # Default include set: species, kinetics, transition_states only.
-    assert body["calculations"] is None
-    assert body["path_search"] is None
-    assert body["artifacts"] is None
+    # The other seven are include-gated on this operation, so an absent key
+    # is the whole answer: the caller did not ask.
+    assert "calculations" not in body
+    assert "path_search" not in body
+    assert "artifacts" not in body
+    assert body["request"]["include"] == [
+        "kinetics",
+        "species",
+        "transition_states",
+    ]
 
 
 def test_non_ts_backed_kinetics_no_fabricated_ts_links(client, db_session):
@@ -1257,9 +1264,14 @@ def test_full_conformers_section_no_forbidden_payload_keys(
 
 
 def test_full_conformers_section_omitted_by_default(client, db_session):
-    """Without ``include=conformers``, the section is null/absent."""
+    """Without ``include=conformers``, the section key is absent.
+
+    It used to be ``null``, which on a reaction whose reactant *does* have
+    a conformer group read as "there are none" — the exact misreading the
+    omission rule exists to prevent.
+    """
     entry, _, _, _, _ = _entry_with_reactant_conformer(db_session)
     body = client.get(
         f"/api/v1/scientific/reaction-entries/{entry.id}/full"
     ).json()
-    assert body["conformers"] is None
+    assert "conformers" not in body

--- a/backend/tests/api/scientific/test_api_reaction_full_trust.py
+++ b/backend/tests/api/scientific/test_api_reaction_full_trust.py
@@ -441,8 +441,9 @@ def test_full_include_trust_alone_keeps_default_sections(client, db_session):
     assert body["species"] is not None
     assert body["kinetics"] is not None
     assert body["transition_states"] is not None
-    # Calculations not in default include set; still omitted.
-    assert body["calculations"] is None
+    # Calculations not in default include set, so the key is absent —
+    # ``trust`` is a modifier, it does not add sections.
+    assert "calculations" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/scientific/test_api_scientific_conformers.py
+++ b/backend/tests/api/scientific/test_api_scientific_conformers.py
@@ -167,13 +167,14 @@ def test_cg_detail_default_response_shape(client, db_session):
     assert "selection_summary" in record
     assert "evidence_summary" in record
     assert "available_sections" in record
-    # Heavy include blocks omitted by default — Pydantic serializes as null
-    # (the schema fields are ``... | None = None``).
-    assert record["observations"] is None
-    assert record["selections"] is None
-    assert record["calculations"] is None
-    assert record["geometries"] is None
-    assert record["review_history"] is None
+    # Heavy include blocks omitted by default. ``observations_summary``
+    # above still answers "is there any?" without being asked, so nothing
+    # is lost by the key going.
+    assert "observations" not in record
+    assert "selections" not in record
+    assert "calculations" not in record
+    assert "geometries" not in record
+    assert "review_history" not in record
 
 
 def test_cg_detail_review_badge_present(client, db_session):
@@ -764,7 +765,7 @@ def test_co_detail_include_observations_returns_the_basin(client, db_session):
     assert all(o["observations"] is None for o in block)
 
     default = client.get(_co_url(obs[0].public_ref)).json()
-    assert default["record"]["observations"] is None
+    assert "observations" not in default["record"]
 
 
 def test_co_detail_include_selections_surfaces_parent_group_selections(

--- a/backend/tests/api/scientific/test_api_scientific_corrections.py
+++ b/backend/tests/api/scientific/test_api_scientific_corrections.py
@@ -158,7 +158,11 @@ def test_fsf_detail_default_response_shape(client, db_session):
         "available_sections",
     ):
         assert key in record
-    assert record["used_by"] is None
+    assert "used_by" not in record
+    # ``literature`` is *not* include-gated here despite the token of that
+    # name being legal: the field is built from the row's own foreign key
+    # whether or not the token is supplied, so it keeps its null.
+    assert "literature" in record and record["literature"] is None
     # FSF is non-reviewable; the summary is always empty.
     assert body["review_summary"]["total"] == 0
 
@@ -493,8 +497,10 @@ def test_ecs_detail_default_response_shape(client, db_session):
         "available_sections",
     ):
         assert key in record
-    assert record["corrections"] is None
-    assert record["used_by"] is None
+    assert "corrections" not in record
+    assert "used_by" not in record
+    # Same as FSF: the ``literature`` token gates nothing on this surface.
+    assert "literature" in record and record["literature"] is None
 
 
 def test_ecs_detail_include_corrections_all_kinds(client, db_session):

--- a/backend/tests/api/scientific/test_api_scientific_literature.py
+++ b/backend/tests/api/scientific/test_api_scientific_literature.py
@@ -587,7 +587,10 @@ def test_records_endpoint_include_review_adds_badges(client, db_session):
         status=RecordReviewStatus.approved,
     )
     body_no = client.get(_records_url(lit.public_ref)).json()
-    assert body_no["records"][0]["review"] is None
+    # This transport row *is* approved. Under the old shape the default
+    # response said ``review: null``, which is what an unreviewed record
+    # said too.
+    assert "review" not in body_no["records"][0]
 
     body_yes = client.get(
         _records_url(lit.public_ref, include="review")

--- a/backend/tests/api/scientific/test_api_scientific_networks.py
+++ b/backend/tests/api/scientific/test_api_scientific_networks.py
@@ -292,6 +292,8 @@ def test_detail_default_response_shape(client, db_session):
     record = body["record"]
     for key in ("network", "evidence_summary", "available_sections"):
         assert key in record
+    # All eight are include-gated on this operation, and none was asked
+    # for, so none is on the wire.
     for k in (
         "species",
         "reactions",
@@ -302,7 +304,7 @@ def test_detail_default_response_shape(client, db_session):
         "source_calculations",
         "review_history",
     ):
-        assert record[k] is None
+        assert k not in record
 
 
 def test_detail_review_badge_present(client, db_session):
@@ -1180,7 +1182,7 @@ def test_solve_detail_default_response_shape(client, db_session):
         "kinetics",
         "review_history",
     ):
-        assert record[k] is None
+        assert k not in record
 
 
 def test_solve_detail_parent_network_context_present(client, db_session):
@@ -2394,7 +2396,7 @@ def test_nkin_detail_default_response_shape(client, db_session):
         "available_sections",
     ):
         assert key in record
-    # Heavy includes default to None.
+    # Heavy includes are absent by default.
     for key in (
         "coefficients",
         "plog",
@@ -2402,7 +2404,7 @@ def test_nkin_detail_default_response_shape(client, db_session):
         "source_calculations",
         "review_history",
     ):
-        assert record[key] is None
+        assert key not in record
 
 
 def test_nkin_detail_parent_network_context_present(client, db_session):
@@ -2582,16 +2584,18 @@ def test_nkin_detail_plog_metadata_absent_when_plog_not_requested(
 ):
     """PLOG sibling metadata follows the omittable-field pattern.
 
-    With no ``include=plog`` the bare-list field and both sibling
-    metadata fields stay at their unset (``None``) value, mirroring
-    the points / coefficients defaults.
+    The ``plog`` token governs the bare list *and* both sibling metadata
+    fields — they are built inside the same branch — so all three go
+    together. On a record that really does carry PLOG entries this is the
+    difference that matters: ``plog_entry_count_total: null`` read as
+    "zero entries", and the key's absence cannot.
     """
     fx = _make_kinetics(db_session, NetworkKineticsModelKind.plog)
     body = client.get(_nkin_detail_url(fx["kinetics"].public_ref)).json()
     record = body["record"]
-    assert record["plog"] is None
-    assert record["plog_entry_count_total"] is None
-    assert record["plog_entries_truncated"] is None
+    assert "plog" not in record
+    assert "plog_entry_count_total" not in record
+    assert "plog_entries_truncated" not in record
 
 
 def test_nkin_detail_include_points(client, db_session):
@@ -2762,7 +2766,7 @@ def test_nkin_detail_include_all_does_not_include_points(client, db_session):
         _nkin_detail_url(fx["kinetics"].public_ref, include="all")
     ).json()
     # ``points`` must require explicit opt-in even with ``all``.
-    assert body["record"]["points"] is None
+    assert "points" not in body["record"]
 
 
 def test_nkin_detail_internal_ids_restored_when_policy_allows(
@@ -2968,7 +2972,7 @@ def test_nkin_detail_payload_keys_only_appear_when_requested(
     body = client.get(_nkin_detail_url(fx["kinetics"].public_ref)).json()
     rec = body["record"]
     for key in ("coefficients", "plog", "points"):
-        assert rec[key] is None
+        assert key not in rec
 
 
 # ---------------------------------------------------------------------------
@@ -3605,7 +3609,7 @@ def test_nkin_search_include_all_does_not_include_points(client, db_session):
             network_kinetics_ref=fx["kinetics"].public_ref, include="all"
         )
     ).json()
-    assert body["records"][0]["points"] is None
+    assert "points" not in body["records"][0]
 
 
 def test_nkin_search_include_all_does_not_restore_internal_ids(
@@ -3769,10 +3773,11 @@ def test_nkin_detail_include_all_includes_capped_coefficients_and_plog(
     assert len(rec["plog"]) == 1
     assert rec["plog_entries_truncated"] is False
     assert rec["plog_entry_count_total"] == 1
-    # Points excluded from ``include=all``; require explicit opt-in.
-    assert rec["points"] is None
-    assert rec["points_truncated"] is None
-    assert rec["point_count_total"] is None
+    # Points excluded from ``include=all``; require explicit opt-in, so
+    # the key and both its companions are absent.
+    assert "points" not in rec
+    assert "points_truncated" not in rec
+    assert "point_count_total" not in rec
 
 
 def test_nkin_search_record_matches_detail_for_same_kinetics(
@@ -3864,7 +3869,7 @@ def test_nkin_search_default_does_not_inline_payloads(client, db_session):
     ).json()
     rec = body["records"][0]
     for key in ("coefficients", "plog", "points"):
-        assert rec[key] is None
+        assert key not in rec
 
 
 # ===========================================================================

--- a/backend/tests/api/scientific/test_api_scientific_statmech.py
+++ b/backend/tests/api/scientific/test_api_scientific_statmech.py
@@ -160,13 +160,14 @@ def test_detail_default_response_shape(client, db_session):
         "available_sections",
     ):
         assert key in record
-    # Heavy include blocks omitted by default.
-    assert record["source_calculations"] is None
-    assert record["torsions"] is None
-    assert record["electronic_levels"] is None
-    assert record["frequencies"] is None
-    assert record["conformers"] is None
-    assert record["review_history"] is None
+    # Heavy include blocks omitted by default — the key is gone, like
+    # ``trust`` below, not nulled.
+    assert "source_calculations" not in record
+    assert "torsions" not in record
+    assert "electronic_levels" not in record
+    assert "frequencies" not in record
+    assert "conformers" not in record
+    assert "review_history" not in record
     assert "trust" not in record
 
 
@@ -427,14 +428,26 @@ def test_detail_include_all_surfaces_electronic_levels(client, db_session):
     assert len(levels) == 2
 
 
-def test_detail_electronic_levels_none_when_not_included(client, db_session):
-    """Without the token the block is ``None`` even when levels exist."""
+def test_detail_electronic_levels_absent_when_not_included(client, db_session):
+    """Without the token the block is absent even when levels exist.
+
+    This record has an electronic level. Under the old shape the default
+    response said ``electronic_levels: null``, which is what "this species
+    has no electronic levels" also said — the two facts shared one value
+    and the wrong one is the one a reader reaches for.
+    """
     _, _, sm = _make_statmech(db_session)
     attach_statmech_electronic_level(
         db_session, statmech=sm, level_index=1, energy_cm1=0.0, degeneracy=2
     )
     body = client.get(_detail_url(sm.public_ref)).json()
-    assert body["record"]["electronic_levels"] is None
+    assert "electronic_levels" not in body["record"]
+    assert body["request"]["include"] == []
+
+    included = client.get(
+        _detail_url(sm.public_ref, include="electronic_levels")
+    ).json()
+    assert len(included["record"]["electronic_levels"]) == 1
 
 
 def test_detail_include_electronic_levels_empty_when_none_present(

--- a/backend/tests/api/scientific/test_api_scientific_transition_states.py
+++ b/backend/tests/api/scientific/test_api_scientific_transition_states.py
@@ -248,12 +248,13 @@ def test_ts_detail_default_response_shape(client, db_session):
     assert "entries_summary" in record
     assert "evidence_summary" in record
     assert "available_sections" in record
-    # Heavy includes omitted by default — Pydantic emits these as null
-    # rather than absent (the schema uses ``... | None = None``).
-    assert record["entries"] is None
-    assert record["calculations"] is None
-    assert record["geometries"] is None
-    assert record["review_history"] is None
+    # Heavy includes omitted by default. ``entries_summary`` above still
+    # says how many entries there are, so absence costs the reader nothing
+    # and tells them the truth about their own request.
+    assert "entries" not in record
+    assert "calculations" not in record
+    assert "geometries" not in record
+    assert "review_history" not in record
 
 
 def test_ts_detail_review_badge_present(client, db_session):

--- a/backend/tests/api/scientific/test_api_scientific_transport.py
+++ b/backend/tests/api/scientific/test_api_scientific_transport.py
@@ -162,8 +162,8 @@ def test_detail_default_response_shape(client, db_session):
         "available_sections",
     ):
         assert key in record
-    assert record["source_calculations"] is None
-    assert record["review_history"] is None
+    assert "source_calculations" not in record
+    assert "review_history" not in record
 
 
 def test_detail_review_badge_present(client, db_session):

--- a/backend/tests/api/scientific/test_include_gated_sections.py
+++ b/backend/tests/api/scientific/test_include_gated_sections.py
@@ -29,10 +29,14 @@ from pydantic import BaseModel
 
 from app.api.public_openapi import project_hosted_openapi
 from app.api.routes.scientific._response import (
+    ALL_INCLUDE_GATED_TABLES,
     ANYWHERE_SCOPE,
     ASSESSMENTS_SECTION,
     CALCULATION_RECORD_SECTIONS,
+    DOCUMENT_SCOPE,
+    FULL_SCOPE,
     INCLUDE_GATED_COMPONENTS,
+    REACTION_FULL_SECTIONS,
     TRUST_SECTION,
     IncludeGatedSections,
     omit_unrequested_calculation_sections,
@@ -259,7 +263,7 @@ def test_fields_to_omit_is_computed_from_the_table_alone():
 def test_the_marker_registry_only_names_declared_sections():
     """Every marked property comes from a declared table, and there is at least one."""
     declared: dict[str, str] = {}
-    for table in (CALCULATION_RECORD_SECTIONS, TRUST_SECTION, ASSESSMENTS_SECTION):
+    for table in ALL_INCLUDE_GATED_TABLES.values():
         declared.update(table.fields_by_token())
 
     assert INCLUDE_GATED_COMPONENTS, "the marker registry enumerates nothing"
@@ -272,7 +276,7 @@ def test_the_marker_registry_only_names_declared_sections():
                 "declared table says so"
             )
             marked += 1
-    assert marked >= 19
+    assert marked == 98, f"the marker registry names {marked} properties"
 
 
 def test_the_hosted_document_marks_the_gated_properties(client):
@@ -290,7 +294,7 @@ def test_the_hosted_document_marks_the_gated_properties(client):
             assert field_name not in required
             checked += 1
 
-    assert checked >= 19
+    assert checked == 98, f"the hosted document carries {checked} markers"
 
 
 def test_the_marker_is_not_stamped_on_ungated_properties():
@@ -322,3 +326,127 @@ def test_the_marker_is_not_stamped_on_ungated_properties():
     assert "x-tckdb-include-gated" not in record["workflow_tool_release"]
     assert "x-tckdb-include-gated" not in record["calculation_ref"]
     assert "x-tckdb-include-gated" not in pagination["next_cursor"]
+
+
+# ---------------------------------------------------------------------------
+# ``document`` and ``full`` name the same route and mean opposite things
+# ---------------------------------------------------------------------------
+
+
+def _full_document() -> dict[str, Any]:
+    """A ``/reaction-entries/{id}/full`` payload in miniature.
+
+    Its own ten sections sit at the root beside ``request`` and
+    ``review_summary``; the records embedded *inside* two of those sections
+    each carry a nested ``trust``. Those are two different jobs on one
+    response and they need two different scopes.
+    """
+    return {
+        "request": {"include": ["kinetics"], "include_review": "summary"},
+        "reaction_entry": {"reaction_entry_ref": "rxe_x"},
+        "review_summary": {"approved": 1},
+        "kinetics": [{"kinetics_ref": "kin_x", "trust": {"grade": "a"}}],
+        "transition_states": [{"transition_state_ref": "ts_x", "trust": None}],
+        "calculations": None,
+        "irc": None,
+        "scans": None,
+        "atom_map": None,
+        "review_records": None,
+    }
+
+
+def test_the_document_scope_reaches_the_root_sections():
+    visibility = JSONResponse(_full_document())
+
+    body = _body(
+        omit_unrequested_sections(
+            visibility,
+            _payload("kinetics"),
+            table=REACTION_FULL_SECTIONS,
+            scope=DOCUMENT_SCOPE,
+        )
+    )
+
+    assert "kinetics" in body
+    for absent in ("calculations", "irc", "scans", "atom_map", "species"):
+        assert absent not in body
+    # Not a section, and not gated by any include token: ``review_records``
+    # is produced by the separate ``include_review`` parameter, so an
+    # include-driven strip has nothing true to say about it.
+    assert "review_records" in body and body["review_records"] is None
+    assert "request" in body and "review_summary" in body
+
+
+def test_the_full_scope_is_not_a_substitute_for_the_document_scope():
+    """The scope whose name matches the route is a silent no-op here.
+
+    ``FULL_SCOPE`` yields the records embedded in the document, so applying
+    the document's own table through it pops nothing and raises nothing --
+    exactly the shape of mistake this pair of scopes exists to make
+    visible.
+    """
+    visibility = JSONResponse(_full_document())
+
+    body = _body(
+        omit_unrequested_sections(
+            visibility,
+            _payload("kinetics"),
+            table=REACTION_FULL_SECTIONS,
+            scope=FULL_SCOPE,
+        )
+    )
+
+    for still_there in ("calculations", "irc", "scans", "atom_map"):
+        assert still_there in body, (
+            "FULL_SCOPE was expected to leave the root sections untouched; "
+            "if it now strips them the two scopes have converged and one of "
+            "them should be deleted rather than quietly kept"
+        )
+    assert body["calculations"] is None
+
+
+def test_the_full_scope_reaches_the_nested_trust_the_document_scope_cannot():
+    """The other half of the pair, asserted so the no-op above means something."""
+    visibility = JSONResponse(_full_document())
+
+    body = _body(
+        omit_unrequested_sections(
+            visibility, _payload("kinetics"), table=TRUST_SECTION, scope=FULL_SCOPE
+        )
+    )
+    assert "trust" not in body["kinetics"][0]
+    assert "trust" not in body["transition_states"][0]
+
+    visibility = JSONResponse(_full_document())
+    body = _body(
+        omit_unrequested_sections(
+            visibility,
+            _payload("kinetics"),
+            table=TRUST_SECTION,
+            scope=DOCUMENT_SCOPE,
+        )
+    )
+    assert "trust" in body["kinetics"][0]
+
+
+def test_the_document_scope_pops_from_the_root_and_nowhere_deeper():
+    """It must not behave like ``anywhere`` by accident."""
+    visibility = JSONResponse(
+        {
+            "request": {"include": []},
+            "irc": None,
+            "kinetics": [{"kinetics_ref": "kin_x", "irc": None}],
+        }
+    )
+
+    body = _body(
+        omit_unrequested_sections(
+            visibility,
+            _payload(),
+            table=REACTION_FULL_SECTIONS,
+            scope=DOCUMENT_SCOPE,
+        )
+    )
+
+    assert "irc" not in body
+    assert "kinetics" not in body

--- a/backend/tests/api/scientific/test_no_op_include_tokens.py
+++ b/backend/tests/api/scientific/test_no_op_include_tokens.py
@@ -155,7 +155,7 @@ def test_entries_is_absent_on_ts_search_when_not_requested(client, db_session):
     ).json()
 
     assert body["request"]["include"] == []
-    assert all(record["entries"] is None for record in body["records"])
+    assert all("entries" not in record for record in body["records"])
 
 
 def test_include_all_on_ts_search_does_not_expand_to_entries(
@@ -181,7 +181,7 @@ def test_include_all_on_ts_search_does_not_expand_to_entries(
     ).json()
 
     assert "entries" not in body["request"]["include"]
-    assert all(record["entries"] is None for record in body["records"])
+    assert all("entries" not in record for record in body["records"])
 
 
 def test_entries_on_ts_search_shares_one_list_per_parent(client, db_session):
@@ -283,7 +283,7 @@ def test_validation_evidence_is_absent_on_ts_concept_when_not_requested(
         f"/api/v1/scientific/transition-states/{ts.public_ref}"
     ).json()
 
-    assert body["record"]["validation_evidence"] is None
+    assert "validation_evidence" not in body["record"]
 
 
 # ---------------------------------------------------------------------------
@@ -343,7 +343,7 @@ def test_observations_is_absent_on_an_observation_when_not_requested(
         f"/api/v1/scientific/conformer-observations/{observations[0].public_ref}"
     ).json()
 
-    assert body["record"]["observations"] is None
+    assert "observations" not in body["record"]
 
 
 def test_the_group_surface_still_returns_its_observations_without_nesting(

--- a/backend/tests/api/scientific/test_unrequested_sections_are_absent.py
+++ b/backend/tests/api/scientific/test_unrequested_sections_are_absent.py
@@ -1,0 +1,891 @@
+"""Every declared include-gated section is absent until it is asked for.
+
+One parametrised case per operation that owns a declared token -> section
+table. Each case asserts the three states the contract distinguishes:
+
+    not requested            -> the key is **absent**
+    requested, nothing there -> the key is present and ``null`` / ``[]``
+    requested, something there -> the key is present and populated
+
+and asserts that ``request.include`` echoes the resolved set, which is what
+makes the first two interpretable: a reader who can see what was asked can
+read an absent key as "I did not ask" rather than "there is none".
+
+Three things about the shape of this file are deliberate.
+
+**It enumerates the runtime's own table objects, not a copy of them.** The
+cases below name the constants from ``_response``; a table that is declared
+and never wired, or wired and never declared, cannot pass
+:func:`test_the_parametrisation_covers_every_declared_table`.
+
+**It asserts its own case count.** A parametrisation that silently
+enumerates nothing passes green, which is the failure mode this repository
+has been bitten by most often. The count is checked against the declared
+tables rather than written down twice.
+
+**It has no expected-no-field exemption list, and must not grow one.** The
+cases are generated from the *tables*, and a table only ever names a token
+that produces a field. Several legal include tokens on these surfaces
+produce nothing at all — ``review`` on ``/species/search`` and on
+``/reaction-entries/{id}/full``, ``literature`` on the two provenance
+surfaces, ``review`` on ``/artifacts/search``, and every public token on
+``/literature/{ref}`` — and none of them is in a table, so none of them
+needs excusing here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import pytest
+
+from app.api.routes.scientific._response import (
+    ALL_INCLUDE_GATED_TABLES,
+    ANYWHERE_SCOPE,
+    ARTIFACT_RECORD_SECTIONS,
+    ASSESSMENTS_SECTION,
+    CALCULATION_RECORD_SECTIONS,
+    CONFORMER_RECORD_SECTIONS,
+    DETAIL_SCOPE,
+    DOCUMENT_SCOPE,
+    ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+    FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+    KINETICS_RECORD_SECTIONS,
+    LITERATURE_RECORDS_SECTIONS,
+    NETWORK_KINETICS_RECORD_SECTIONS,
+    NETWORK_RECORD_SECTIONS,
+    NETWORK_SOLVE_RECORD_SECTIONS,
+    REACTION_FULL_SECTIONS,
+    SEARCH_SCOPE,
+    SPECIES_SEARCH_SECTIONS,
+    STATMECH_RECORD_SECTIONS,
+    TRANSITION_STATE_RECORD_SECTIONS,
+    TRANSPORT_RECORD_SECTIONS,
+    TRUST_SECTION,
+    IncludeGatedSections,
+    _record_nodes,
+)
+from app.db.models.common import (
+    CalculationType,
+    NetworkChannelKind,
+    NetworkKineticsModelKind,
+    NetworkSolveCalculationRole,
+    NetworkSolveKind,
+    NetworkSpeciesRole,
+    NetworkStateKind,
+    RecordReviewStatus,
+    SubmissionRecordType,
+)
+from tests.services.scientific_read._factories import (
+    attach_artifact,
+    attach_conformer_selection,
+    attach_network_kinetics_chebyshev,
+    attach_network_kinetics_plog,
+    attach_network_kinetics_point,
+    attach_network_solve_bath_gas,
+    attach_network_solve_source_calculation,
+    attach_network_species,
+    attach_network_state_participant,
+    attach_statmech_source_calculation,
+    attach_transport_source_calculation,
+    make_calculation,
+    make_chem_reaction,
+    make_conformer_group,
+    make_conformer_observation,
+    make_energy_correction_scheme,
+    make_frequency_scale_factor,
+    make_kinetics,
+    make_literature,
+    make_lot,
+    make_network,
+    make_network_channel,
+    make_network_kinetics,
+    make_network_solve,
+    make_network_state,
+    make_reaction_entry,
+    make_species,
+    make_species_entry,
+    make_statmech,
+    make_thermo_scalar,
+    make_transition_state,
+    make_transition_state_entry,
+    make_transport,
+    set_review,
+)
+
+# ---------------------------------------------------------------------------
+# The corpus
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def corpus(client, db_session) -> dict[str, Any]:
+    """One small record of every shape the flipped operations return.
+
+    Deliberately built once per test rather than shared: the API session is
+    a transaction that is rolled back, so there is nothing to share.
+    """
+    session = db_session
+    lot = make_lot(session)
+    literature = make_literature(session)
+
+    reactant_species = make_species(session, smiles="CC")
+    reactant = make_species_entry(session, reactant_species)
+    product_species = make_species(session, smiles="C[CH2]", multiplicity=2)
+    product = make_species_entry(session, product_species)
+    set_review(
+        session,
+        record_type=SubmissionRecordType.species_entry,
+        record_id=reactant.id,
+        status=RecordReviewStatus.approved,
+    )
+
+    calculation = make_calculation(
+        session,
+        type=CalculationType.freq,
+        species_entry_id=reactant.id,
+        lot_id=lot.id,
+    )
+    artifact = attach_artifact(session, calculation=calculation)
+
+    thermo = make_thermo_scalar(session, species_entry=reactant)
+    statmech = make_statmech(session, species_entry=reactant)
+    attach_statmech_source_calculation(
+        session, statmech=statmech, calculation=calculation
+    )
+    make_statmech(session, species_entry=product, literature_id=literature.id)
+    transport = make_transport(session, species_entry=reactant)
+    attach_transport_source_calculation(
+        session, transport=transport, calculation=calculation
+    )
+
+    group = make_conformer_group(session, reactant, label="cg-1")
+    observation = make_conformer_observation(session, conformer_group=group)
+    attach_conformer_selection(session, conformer_group=group)
+
+    reaction = make_chem_reaction(
+        session, reactants=[reactant_species], products=[product_species]
+    )
+    reaction_entry = make_reaction_entry(
+        session,
+        reaction=reaction,
+        reactant_entries=[reactant],
+        product_entries=[product],
+    )
+    kinetics = make_kinetics(session, reaction_entry=reaction_entry)
+    transition_state = make_transition_state(
+        session, reaction_entry=reaction_entry, label="ts-1"
+    )
+    ts_entry = make_transition_state_entry(
+        session, transition_state=transition_state
+    )
+
+    network = make_network(session)
+    attach_network_species(
+        session,
+        network=network,
+        species_entry=reactant,
+        role=NetworkSpeciesRole.well,
+    )
+    source_state = make_network_state(
+        session,
+        network=network,
+        kind=NetworkStateKind.well,
+        composition_hash="well-1",
+    )
+    sink_state = make_network_state(
+        session,
+        network=network,
+        kind=NetworkStateKind.bimolecular,
+        composition_hash="bimol-1",
+    )
+    attach_network_state_participant(
+        session, state=source_state, species_entry=reactant
+    )
+    channel = make_network_channel(
+        session,
+        network=network,
+        source_state=source_state,
+        sink_state=sink_state,
+        kind=NetworkChannelKind.isomerization,
+    )
+    solve = make_network_solve(
+        session, network=network, kind=NetworkSolveKind.computed
+    )
+    attach_network_solve_bath_gas(
+        session, solve=solve, species_entry=reactant
+    )
+    attach_network_solve_source_calculation(
+        session,
+        solve=solve,
+        calculation=calculation,
+        role=NetworkSolveCalculationRole.well_energy,
+    )
+    network_kinetics = make_network_kinetics(
+        session,
+        solve=solve,
+        channel=channel,
+        model_kind=NetworkKineticsModelKind.chebyshev,
+    )
+    attach_network_kinetics_chebyshev(session, kinetics=network_kinetics)
+    attach_network_kinetics_plog(session, kinetics=network_kinetics)
+    attach_network_kinetics_point(
+        session,
+        kinetics=network_kinetics,
+        temperature_k=1000.0,
+        pressure_bar=1.0,
+        rate_value=1.0e10,
+    )
+
+    # No ``source_literature`` on either: their ``literature`` field is an
+    # ungated scientific fact and this corpus needs it to be ``null`` so the
+    # boundary assertions have something to stand on.
+    fsf = make_frequency_scale_factor(session, lot=lot)
+    ecs = make_energy_correction_scheme(session, lot=lot)
+
+    session.flush()
+    return {
+        "species_smiles": reactant_species.smiles,
+        "species_entry_ref": reactant.public_ref,
+        "reaction_entry_ref": reaction_entry.public_ref,
+        "transition_state_ref": transition_state.public_ref,
+        "transition_state_entry_ref": ts_entry.public_ref,
+        "conformer_group_ref": group.public_ref,
+        "conformer_observation_ref": observation.public_ref,
+        "statmech_ref": statmech.public_ref,
+        "transport_ref": transport.public_ref,
+        "network_ref": network.public_ref,
+        "network_solve_ref": solve.public_ref,
+        "network_kinetics_ref": network_kinetics.public_ref,
+        "frequency_scale_factor_ref": fsf.public_ref,
+        "energy_correction_scheme_ref": ecs.public_ref,
+        "literature_ref": literature.public_ref,
+        "calculation_ref": calculation.public_ref,
+        "artifact_sha256": artifact.sha256,
+        "thermo_ref": thermo.public_ref,
+        "kinetics_ref": kinetics.public_ref,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The cases
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Case:
+    """One operation, the table it declares, and how to reach it."""
+
+    label: str
+    table: IncludeGatedSections
+    scope: str
+    path: Callable[[dict[str, Any]], str]
+    method: str = "GET"
+    body: Callable[[dict[str, Any]], dict[str, Any]] = lambda c: {}
+    #: Tokens this operation's table declares that this operation's own
+    #: vocabulary does not accept, because the twin surface does. This is
+    #: the residue class the OpenAPI marker rule exists for, and it is one
+    #: entry on one table rather than a general escape hatch: the
+    #: ``/calculations`` table is shared by the search and detail
+    #: operations, and only the detail one accepts
+    #: ``imaginary_mode_projections``. (``trust`` is the same split on the
+    #: same pair, but it lives in ``TRUST_SECTION`` rather than here.)
+    #: Naming it turns a would-be skip into two positive assertions — the
+    #: token really is refused, and the field really is absent.
+    detail_only_tokens: tuple[str, ...] = ()
+
+    def raw(self, client, corpus, include: list[str]):
+        url = self.path(corpus)
+        if self.method == "POST":
+            payload = {**self.body(corpus), "include": include}
+            return client.post(url, json=payload)
+        query = "&".join(f"include={token}" for token in include)
+        joiner = "&" if "?" in url else "?"
+        return client.get(f"{url}{query and joiner + query}")
+
+    def request(self, client, corpus, include: list[str]) -> dict[str, Any]:
+        response = self.raw(client, corpus, include)
+        assert response.status_code == 200, (
+            f"{self.label} include={include}: {response.status_code} "
+            f"{response.text[:400]}"
+        )
+        return response.json()
+
+
+_SCI = "/api/v1/scientific"
+
+
+CASES: tuple[Case, ...] = (
+    Case(
+        "GET /species/search",
+        SPECIES_SEARCH_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: f"{_SCI}/species/search?smiles={c['species_smiles']}",
+    ),
+    Case(
+        "GET /reaction-entries/{ref}/kinetics",
+        KINETICS_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/reaction-entries/{c['reaction_entry_ref']}/kinetics",
+    ),
+    Case(
+        "GET /reaction-entries/{ref}/full",
+        REACTION_FULL_SECTIONS,
+        DOCUMENT_SCOPE,
+        lambda c: f"{_SCI}/reaction-entries/{c['reaction_entry_ref']}/full",
+    ),
+    Case(
+        "GET /transition-states/search",
+        TRANSITION_STATE_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: (
+            f"{_SCI}/transition-states/search"
+            f"?transition_state_ref={c['transition_state_ref']}"
+        ),
+    ),
+    Case(
+        "POST /transition-states/search",
+        TRANSITION_STATE_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: f"{_SCI}/transition-states/search",
+        method="POST",
+        body=lambda c: {"transition_state_ref": c["transition_state_ref"]},
+    ),
+    Case(
+        "GET /transition-states/{ref}",
+        TRANSITION_STATE_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: f"{_SCI}/transition-states/{c['transition_state_ref']}",
+    ),
+    Case(
+        "GET /transition-state-entries/{ref}",
+        TRANSITION_STATE_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: (
+            f"{_SCI}/transition-state-entries/{c['transition_state_entry_ref']}"
+        ),
+    ),
+    Case(
+        "GET /conformers/search",
+        CONFORMER_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: (
+            f"{_SCI}/conformers/search"
+            f"?species_entry_ref={c['species_entry_ref']}"
+        ),
+    ),
+    Case(
+        "POST /conformers/search",
+        CONFORMER_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: f"{_SCI}/conformers/search",
+        method="POST",
+        body=lambda c: {"species_entry_ref": c["species_entry_ref"]},
+    ),
+    Case(
+        "GET /conformer-groups/{ref}",
+        CONFORMER_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: f"{_SCI}/conformer-groups/{c['conformer_group_ref']}",
+    ),
+    Case(
+        "GET /conformer-observations/{ref}",
+        CONFORMER_RECORD_SECTIONS,
+        ANYWHERE_SCOPE,
+        lambda c: (
+            f"{_SCI}/conformer-observations/{c['conformer_observation_ref']}"
+        ),
+    ),
+    Case(
+        "GET /statmech/search",
+        STATMECH_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/statmech/search"
+            f"?species_entry_ref={c['species_entry_ref']}"
+        ),
+    ),
+    Case(
+        "POST /statmech/search",
+        STATMECH_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/statmech/search",
+        method="POST",
+        body=lambda c: {"species_entry_ref": c["species_entry_ref"]},
+    ),
+    Case(
+        "GET /statmech/{ref}",
+        STATMECH_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: f"{_SCI}/statmech/{c['statmech_ref']}",
+    ),
+    Case(
+        "GET /species-entries/{ref}/statmech",
+        STATMECH_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/species-entries/{c['species_entry_ref']}/statmech",
+    ),
+    Case(
+        "GET /transport/search",
+        TRANSPORT_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/transport/search"
+            f"?species_entry_ref={c['species_entry_ref']}"
+        ),
+    ),
+    Case(
+        "POST /transport/search",
+        TRANSPORT_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/transport/search",
+        method="POST",
+        body=lambda c: {"species_entry_ref": c["species_entry_ref"]},
+    ),
+    Case(
+        "GET /transport/{ref}",
+        TRANSPORT_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: f"{_SCI}/transport/{c['transport_ref']}",
+    ),
+    Case(
+        "GET /species-entries/{ref}/transport",
+        TRANSPORT_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/species-entries/{c['species_entry_ref']}/transport",
+    ),
+    Case(
+        "GET /networks/search",
+        NETWORK_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/networks/search?network_ref={c['network_ref']}",
+    ),
+    Case(
+        "POST /networks/search",
+        NETWORK_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/networks/search",
+        method="POST",
+        body=lambda c: {"network_ref": c["network_ref"]},
+    ),
+    Case(
+        "GET /networks/{ref}",
+        NETWORK_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: f"{_SCI}/networks/{c['network_ref']}",
+    ),
+    Case(
+        "GET /network-solves/search",
+        NETWORK_SOLVE_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/network-solves/search?network_ref={c['network_ref']}"
+        ),
+    ),
+    Case(
+        "POST /network-solves/search",
+        NETWORK_SOLVE_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/network-solves/search",
+        method="POST",
+        body=lambda c: {"network_ref": c["network_ref"]},
+    ),
+    Case(
+        "GET /network-solves/{ref}",
+        NETWORK_SOLVE_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: f"{_SCI}/network-solves/{c['network_solve_ref']}",
+    ),
+    Case(
+        "GET /network-kinetics/search",
+        NETWORK_KINETICS_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/network-kinetics/search?network_ref={c['network_ref']}"
+        ),
+    ),
+    Case(
+        "POST /network-kinetics/search",
+        NETWORK_KINETICS_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/network-kinetics/search",
+        method="POST",
+        body=lambda c: {"network_ref": c["network_ref"]},
+    ),
+    Case(
+        "GET /network-kinetics/{ref}",
+        NETWORK_KINETICS_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: f"{_SCI}/network-kinetics/{c['network_kinetics_ref']}",
+    ),
+    Case(
+        "GET /frequency-scale-factors/search",
+        FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/frequency-scale-factors/search"
+            f"?frequency_scale_factor_ref={c['frequency_scale_factor_ref']}"
+        ),
+    ),
+    Case(
+        "POST /frequency-scale-factors/search",
+        FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/frequency-scale-factors/search",
+        method="POST",
+        body=lambda c: {
+            "frequency_scale_factor_ref": c["frequency_scale_factor_ref"]
+        },
+    ),
+    Case(
+        "GET /frequency-scale-factors/{ref}",
+        FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: (
+            f"{_SCI}/frequency-scale-factors/{c['frequency_scale_factor_ref']}"
+        ),
+    ),
+    Case(
+        "GET /energy-correction-schemes/search",
+        ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/energy-correction-schemes/search"
+            f"?energy_correction_scheme_ref={c['energy_correction_scheme_ref']}"
+        ),
+    ),
+    Case(
+        "POST /energy-correction-schemes/search",
+        ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/energy-correction-schemes/search",
+        method="POST",
+        body=lambda c: {
+            "energy_correction_scheme_ref": c["energy_correction_scheme_ref"]
+        },
+    ),
+    Case(
+        "GET /energy-correction-schemes/{ref}",
+        ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: (
+            f"{_SCI}/energy-correction-schemes/"
+            f"{c['energy_correction_scheme_ref']}"
+        ),
+    ),
+    Case(
+        "GET /artifacts/search",
+        ARTIFACT_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/artifacts/search?sha256={c['artifact_sha256']}",
+    ),
+    Case(
+        "POST /artifacts/search",
+        ARTIFACT_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/artifacts/search",
+        method="POST",
+        body=lambda c: {"sha256": c["artifact_sha256"]},
+    ),
+    Case(
+        "GET /literature/{ref}/records",
+        LITERATURE_RECORDS_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/literature/{c['literature_ref']}/records",
+    ),
+    Case(
+        "GET /calculations/search",
+        CALCULATION_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: (
+            f"{_SCI}/calculations/search"
+            f"?species_entry_ref={c['species_entry_ref']}"
+        ),
+        detail_only_tokens=("imaginary_mode_projections",),
+    ),
+    Case(
+        "POST /calculations/search",
+        CALCULATION_RECORD_SECTIONS,
+        SEARCH_SCOPE,
+        lambda c: f"{_SCI}/calculations/search",
+        method="POST",
+        body=lambda c: {"species_entry_ref": c["species_entry_ref"]},
+        detail_only_tokens=("imaginary_mode_projections",),
+    ),
+    Case(
+        "GET /calculations/{ref}",
+        CALCULATION_RECORD_SECTIONS,
+        DETAIL_SCOPE,
+        lambda c: f"{_SCI}/calculations/{c['calculation_ref']}",
+    ),
+)
+
+
+#: Tables applied by :func:`omit_trust_unless_requested` and
+#: :func:`omit_assessments_unless_requested` on many surfaces at once rather
+#: than by a per-operation case. Their behaviour is pinned by
+#: ``test_search_trust_include.py`` and ``test_include_gated_sections.py``.
+_CROSS_CUTTING_TABLES = (TRUST_SECTION, ASSESSMENTS_SECTION)
+
+
+# ---------------------------------------------------------------------------
+# The parametrisation cannot be empty, and cannot drift from the tables
+# ---------------------------------------------------------------------------
+
+
+def test_the_parametrisation_covers_every_declared_table():
+    """No table is declared without a case, and no case invents a table.
+
+    This is the guard against the parametrisation quietly enumerating
+    nothing — the failure mode that passes green. It compares *objects*,
+    so a table copied instead of imported fails here too.
+    """
+    exercised = {id(case.table) for case in CASES}
+    declared = {
+        id(table)
+        for table in ALL_INCLUDE_GATED_TABLES.values()
+        if table not in _CROSS_CUTTING_TABLES
+    }
+
+    assert exercised == declared, (
+        "the cases and the declared tables disagree: "
+        f"{len(exercised)} exercised vs {len(declared)} declared"
+    )
+
+
+def test_the_parametrisation_asserts_its_own_size():
+    """The case count and the section count are both pinned.
+
+    Written as a comparison against the tables rather than as two magic
+    numbers, so adding a section to a table without adding a case fails
+    here instead of passing silently.
+    """
+    assert len(CASES) == 40
+
+    sections_under_test = {
+        (case.table.surface, token, field_name)
+        for case in CASES
+        for token, field_names in case.table.sections.items()
+        for field_name in field_names
+    }
+    declared_sections = {
+        (table.surface, token, field_name)
+        for table in ALL_INCLUDE_GATED_TABLES.values()
+        if table not in _CROSS_CUTTING_TABLES
+        for token, field_names in table.sections.items()
+        for field_name in field_names
+    }
+
+    assert sections_under_test == declared_sections
+    assert len(sections_under_test) == 81
+
+
+# ---------------------------------------------------------------------------
+# The behaviour
+# ---------------------------------------------------------------------------
+
+
+def _nodes(case: Case, body: dict[str, Any]) -> list[dict[str, Any]]:
+    """The dicts the runtime's own strip would have visited for this case."""
+    return list(_record_nodes(body, case.scope))
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.label)
+def test_an_unrequested_section_is_absent(case: Case, client, corpus):
+    body = case.request(client, corpus, include=[])
+    nodes = _nodes(case, body)
+
+    assert nodes, f"{case.label}: no records to assert on — vacuous case"
+
+    default_echo = body["request"]["include"]
+    for token, field_names in case.table.sections.items():
+        if token in default_echo:
+            # ``/full`` answers a bare request with its three default
+            # sections; those are requested, not unrequested.
+            continue
+        for field_name in field_names:
+            for node in nodes:
+                assert field_name not in node, (
+                    f"{case.label}: {field_name!r} is gated by {token!r} and "
+                    "the caller did not ask for it, but the key is on the wire"
+                )
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.label)
+def test_a_requested_section_is_present_and_the_echo_says_so(
+    case: Case, client, corpus
+):
+    for token, field_names in case.table.sections.items():
+        if token in case.detail_only_tokens:
+            continue
+        body = case.request(client, corpus, include=[token])
+        nodes = _nodes(case, body)
+        assert nodes, f"{case.label}: no records to assert on — vacuous case"
+
+        echo = body["request"]["include"]
+        assert token in echo, (
+            f"{case.label}: include={token!r} was accepted but the echo "
+            f"reports {echo!r} — a reader cannot tell what was resolved"
+        )
+
+        for field_name in field_names:
+            assert any(field_name in node for node in nodes), (
+                f"{case.label}: include={token!r} was requested and echoed, "
+                f"but {field_name!r} is on no record"
+            )
+
+
+# ---------------------------------------------------------------------------
+# The middle state, and the fields that are not sections at all
+# ---------------------------------------------------------------------------
+
+
+#: (case label, token, field) triples the corpus deliberately leaves empty.
+#: Requested-and-empty is the state that makes the whole change work, so it
+#: is asserted on named surfaces rather than wherever it happens to occur.
+REQUESTED_BUT_EMPTY = (
+    ("GET /statmech/{ref}", "torsions", "torsions"),
+    ("GET /statmech/{ref}", "electronic_levels", "electronic_levels"),
+    ("GET /conformer-groups/{ref}", "calculations", "calculations"),
+    ("GET /networks/{ref}", "reactions", "reactions"),
+    ("GET /network-solves/{ref}", "channel_barriers", "channel_barriers"),
+    ("GET /frequency-scale-factors/{ref}", "used_by", "used_by"),
+    ("GET /energy-correction-schemes/{ref}", "corrections", "corrections"),
+    ("GET /reaction-entries/{ref}/full", "scans", "scans"),
+)
+
+_BY_LABEL = {case.label: case for case in CASES}
+
+
+@pytest.mark.parametrize(
+    ("label", "token", "field_name"),
+    REQUESTED_BUT_EMPTY,
+    ids=lambda v: v if isinstance(v, str) else str(v),
+)
+def test_a_requested_but_empty_section_keeps_its_null(
+    label, token, field_name, client, corpus
+):
+    """Asked-for-and-empty is present, not absent.
+
+    Collapsing this state back into absence restores the original
+    ambiguity from the other direction: an absent key would again mean
+    either "you did not ask" or "there is none".
+    """
+    case = _BY_LABEL[label]
+    body = case.request(client, corpus, include=[token])
+    nodes = _nodes(case, body)
+    assert nodes, f"{label}: no records to assert on — vacuous case"
+
+    carriers = [node for node in nodes if field_name in node]
+    assert carriers, f"{label}: include={token!r} produced no {field_name!r} key"
+    for node in carriers:
+        assert node[field_name] in (None, [], {}), (
+            f"{label}: {field_name!r} was expected to be requested-but-empty; "
+            f"the corpus now fills it with {node[field_name]!r}, so this case "
+            "no longer tests the middle state and needs a different section"
+        )
+
+
+#: Fields that are ``| None`` for reasons that have nothing to do with
+#: ``include``. Each says something about the chemistry — this record has no
+#: NASA-9 polynomial, no Chebyshev fit, no PLOG entries — and losing the key
+#: loses the ability to say it. No token moves any of them, and the strip
+#: must be structurally unable to.
+UNGATED_NULLABLE_FIELDS = (
+    ("GET /species-entries/{ref}/thermo", "records", "nasa9"),
+    ("GET /species-entries/{ref}/thermo", "records", "wilhoit"),
+    ("GET /species-entries/{ref}/thermo", "records", "group_additivity"),
+    ("GET /species-entries/{ref}/thermo", "records", "points"),
+    ("GET /species-entries/{ref}/thermo", "records", "supersession"),
+    ("GET /reaction-entries/{ref}/kinetics", "records", "chebyshev"),
+    ("GET /reaction-entries/{ref}/kinetics", "records", "plog_entries"),
+    ("GET /reaction-entries/{ref}/kinetics", "records", "falloff"),
+    ("GET /reaction-entries/{ref}/kinetics", "records", "multi_arrhenius"),
+    ("GET /reaction-entries/{ref}/kinetics", "records", "third_body_efficiencies"),
+    ("GET /statmech/{ref}", "record", "literature"),
+    ("GET /statmech/{ref}", "record", "software_release"),
+    ("GET /statmech/{ref}", "record", "workflow_tool_release"),
+    ("GET /statmech/{ref}", "record", "transition_state"),
+    ("GET /networks/{ref}", "record", "literature"),
+    ("GET /networks/{ref}", "record", "software_release"),
+    ("GET /conformer-observations/{ref}", "record", "assignment_scheme"),
+    ("GET /frequency-scale-factors/{ref}", "record", "literature"),
+    ("GET /frequency-scale-factors/{ref}", "record", "workflow_tool_release"),
+    ("GET /energy-correction-schemes/{ref}", "record", "literature"),
+)
+
+
+def _thermo_case(corpus):
+    return f"{_SCI}/species-entries/{corpus['species_entry_ref']}/thermo"
+
+
+@pytest.mark.parametrize(
+    ("label", "envelope", "field_name"),
+    UNGATED_NULLABLE_FIELDS,
+    ids=lambda v: v,
+)
+def test_an_ungated_nullable_field_keeps_its_null(
+    label, envelope, field_name, client, corpus
+):
+    """Absence describes the request; null describes the data.
+
+    This is the assertion an over-broad strip fails and the positive cases
+    do not: every one of these keys is ``null`` on the corpus, none is
+    named by any table, and all of them must still be on the wire — under
+    the default request *and* under ``include=all``, which is where a
+    scope-widening mistake would show.
+    """
+    if label == "GET /species-entries/{ref}/thermo":
+        url = _thermo_case(corpus)
+    else:
+        url = _BY_LABEL[label].path(corpus)
+
+    for query in ("", "?include=all"):
+        response = client.get(f"{url}{query}")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        records = (
+            body["records"] if envelope == "records" else [body["record"]]
+        )
+        assert records, f"{label}: no records to assert on — vacuous case"
+        for record in records:
+            assert field_name in record, (
+                f"{label}{query}: {field_name!r} is nullable for a reason that "
+                "has nothing to do with include= and must not be omitted; "
+                "dropping it makes 'no such fit' and 'you did not ask' the "
+                "same wire value again, from the other side"
+            )
+            assert record[field_name] is None
+
+
+@pytest.mark.parametrize(
+    "case",
+    [c for c in CASES if c.detail_only_tokens],
+    ids=lambda c: c.label,
+)
+def test_a_detail_only_token_is_refused_and_its_field_never_appears(
+    case: Case, client, corpus
+):
+    """The residue class, asserted rather than excused.
+
+    A token its twin accepts and this operation does not leaves the field
+    unconditionally absent here. That is the harmless direction — absent
+    more often than the OpenAPI marker promises — but it has to be true,
+    not assumed, or the marker becomes a claim about a key some operation
+    always sends.
+    """
+    for token in case.detail_only_tokens:
+        response = case.raw(client, corpus, include=[token])
+        assert response.status_code == 422, (
+            f"{case.label}: {token!r} is recorded as detail-only but this "
+            "operation accepted it — the table and the vocabulary have "
+            "converged and this exemption should be deleted"
+        )
+        assert response.json()["code"] == "unknown_include_token"
+
+        for field_name in case.table.sections[token]:
+            for query in ([], ["all"]):
+                body = case.request(client, corpus, include=query)
+                for node in _nodes(case, body):
+                    assert field_name not in node


### PR DESCRIPTION
## In plain language

Ask this API for a transition state and it used to tell you
`"calculations": null`. That reads as "this record has no calculations" —
and the project owner read it exactly that way on a live record whose next
line said `has_calculations: true`, and which returned two calculations the
moment `?include=calculations` was added.

The problem is that one word, `null`, was being used for two different
answers: **"you didn't ask for that"** and **"there isn't any"**. A reader
cannot tell them apart, and guessing wrong makes the database look empty.

The fix is to stop answering the first question with a value at all. From
now on, a section you did not ask for is simply **not in the response**. A
section you *did* ask for is always there — `null` or `[]` if the record
genuinely has none. So:

| you see | it means |
|---|---|
| the key is missing | you did not ask for it |
| the key is there and `null` | you asked, and there is none |
| the key is there with data | you asked, and here it is |

The half of this that is easy to get wrong is the second row. It would be
tempting to "simplify" by dropping every `null` — and that would be the
same bug again, upside down. `"nasa9": null` on a thermo record is a fact
about chemistry: this species has no NASA-9 polynomial. Delete that key and
"no NASA-9 fit" and "you didn't ask" become the same silence. **Absence
describes the request. Null describes the data.** Every table in this PR
was built from the code that decides whether a section gets *queried*,
never from a list of fields that happen to be nullable.

---

## Technical detail

### What changed

Fifteen per-surface `IncludeGatedSections` tables are declared in
`backend/app/api/routes/scientific/_response.py` and wired at the
`apply_internal_ids_visibility` seam, covering **81 sections across 40
operations**. 37 of those operations previously nulled at least one
unrequested section; the three `/calculations/*` operations already omitted
and are included so the enumeration covers every declared table.

| surface | table | scope | sections |
|---|---|---|---|
| `/species/search` | `SPECIES_SEARCH_SECTIONS` | anywhere | 4 (`records[*].entries[*].*_summary`) |
| `/reaction-entries/{id}/kinetics` | `KINETICS_RECORD_SECTIONS` | search | 2 |
| `/reaction-entries/{id}/full` | `REACTION_FULL_SECTIONS` | **document** | 10 |
| `/transition-states/*` (3 ops + POST) | `TRANSITION_STATE_RECORD_SECTIONS` | anywhere | 5 |
| `/conformers/*` (3 ops + POST) | `CONFORMER_RECORD_SECTIONS` | anywhere | 5 |
| `/statmech/*` + species subresource | `STATMECH_RECORD_SECTIONS` | search / detail | 6 |
| `/transport/*` + species subresource | `TRANSPORT_RECORD_SECTIONS` | search / detail | 2 |
| `/networks/*` | `NETWORK_RECORD_SECTIONS` | search / detail | 8 |
| `/network-solves/*` | `NETWORK_SOLVE_RECORD_SECTIONS` | search / detail | 7 |
| `/network-kinetics/*` | `NETWORK_KINETICS_RECORD_SECTIONS` | search / detail | 9 |
| `/frequency-scale-factors/*` | `FREQUENCY_SCALE_FACTOR_RECORD_SECTIONS` | search / detail | 1 |
| `/energy-correction-schemes/*` | `ENERGY_CORRECTION_SCHEME_RECORD_SECTIONS` | search / detail | 2 |
| `/artifacts/search` | `ARTIFACT_RECORD_SECTIONS` | search | 1 |
| `/literature/{ref}/records` | `LITERATURE_RECORDS_SECTIONS` | search | 1 |
| `/calculations/*` | `CALCULATION_RECORD_SECTIONS` (landed in #234) | search / detail | 18 |

### The `document` scope

`/reaction-entries/{id}/full` keeps its ten gated sections at the **document
root**, beside `request` and `review_summary`, so none of the four existing
scopes reaches them. `FULL_SCOPE` is the trap: it is named after the same
route but yields the records embedded *inside* those sections, which is
where the nested `trust` lives. Reaching for it here strips nothing and
raises nothing. Two tests pin that the pair are not interchangeable — one
asserts `document` reaches the root sections, one asserts `full` leaves them
alone and would fail if the two ever converged — and a mutation run confirms
the substitution is caught.

That route now runs **two** strips at two scopes: `FULL_SCOPE` for the
embedded `trust`, `DOCUMENT_SCOPE` for its own ten sections.

### Three per-surface decisions

**`review_records` on `/full` keeps its `null`.** It is produced by the
separate `include_review` query parameter, not by any include token, so an
include-driven strip cannot describe it truthfully: it would be dropped when
`review` was unrequested *and* still dropped when `include_review=full`
supplied it. `request.include_review` is echoed beside `request.include`, so
a reader can still tell "you did not ask" from "there are none" — which is
the property that matters. The response schema docstring now says this
explicitly instead of claiming all unrequested sections are omitted.

**`KineticsRecord.interpretation_assignments` / `.tunneling_application`
are gated on the kinetics detail surface only.** `interpretations` is not a
legal token on `/kinetics/search` or inside `/full`, so applying the table
there would not omit an unrequested section — it would delete a section no
request on that surface can produce. Both keep their `null` on those two
surfaces, and the OpenAPI marker registry leaves them unmarked for exactly
that reason.

**Artifacts' `calculation` token is not in the table.** It gates three
summaries *nested inside* the always-present calculation context —
`level_of_theory`, `software_release`, `workflow_tool_release` — which are
the exact names the mechanism's own collision warning is about, and reaching
them needs a record-relative descent the spec deliberately deferred. `owner`
is the surface's declared section and is the only entry.

### The hard boundary held

`clients/python/pagination.py:231` reads an **absent** `next_cursor` as
"pre-keyset server, restart the traversal from offset zero" and a
**present-and-null** one as "traversal complete". A blanket null-strip would
turn every completed keyset traversal into a restart and silently yield the
whole result set twice. The helper is structurally incapable of that — it
computes the keys to pop from the declared table alone, inspects no value,
and raises `TypeError` on anything that is not an `IncludeGatedSections`.
Nothing in this PR loosens it.

### Assertions: 47 moved, 220 kept

Every moved assertion names a section in the declared table for the
operation under test. Classification was by table, never by field name,
because names collide across surfaces.

| file | test | fields moved | operation |
|---|---|---|---|
| `test_api_reaction_full.py` | `test_default_omits_non_default_sections` | `calculations`, `path_search`, `artifacts` | `/full` |
| | `test_full_conformers_section_omitted_by_default` | `conformers` | `/full` |
| `test_api_reaction_full_trust.py` | `test_full_include_trust_alone_keeps_default_sections` | `calculations` | `/full` |
| `test_api_reaction_atom_map.py` | `test_a_mapped_reaction_is_distinguishable_without_a_second_request` | `atom_map` | `/full` |
| | `test_the_atom_map_badge_is_not_subject_to_the_pair_cap` | `atom_map` | `/full` |
| `test_api_scientific_networks.py` | `test_detail_default_response_shape` | 8 network sections | `/networks/{ref}` |
| | `test_solve_detail_default_response_shape` | 5 solve sections | `/network-solves/{ref}` |
| | `test_nkin_detail_default_response_shape` | 5 | `/network-kinetics/{ref}` |
| | `test_nkin_detail_plog_metadata_absent_when_plog_not_requested` | `plog` + 2 companions | `/network-kinetics/{ref}` |
| | `test_nkin_detail_include_all_does_not_include_points` | `points` | `/network-kinetics/{ref}` |
| | `test_nkin_detail_include_all_includes_capped_coefficients_and_plog` | `points` + 2 companions | `/network-kinetics/{ref}` |
| | `test_nkin_detail_payload_keys_only_appear_when_requested` | `coefficients`, `plog`, `points` | `/network-kinetics/{ref}` |
| | `test_nkin_search_default_does_not_inline_payloads` | same three | `/network-kinetics/search` |
| | `test_nkin_search_include_all_does_not_include_points` | `points` | `/network-kinetics/search` |
| `test_api_scientific_corrections.py` | `test_fsf_detail_default_response_shape` | `used_by` | `/frequency-scale-factors/{ref}` |
| | `test_ecs_detail_default_response_shape` | `corrections`, `used_by` | `/energy-correction-schemes/{ref}` |
| `test_api_scientific_conformers.py` | `test_cg_detail_default_response_shape` | 5 | `/conformer-groups/{ref}` |
| | `test_co_detail_include_observations_returns_the_basin` | `observations` (default half) | `/conformer-observations/{ref}` |
| `test_api_scientific_statmech.py` | `test_detail_default_response_shape` | 6 | `/statmech/{ref}` |
| | `test_detail_electronic_levels_none_when_not_included` → `..._absent_...` | `electronic_levels` | `/statmech/{ref}` |
| `test_api_scientific_transport.py` | `test_detail_default_response_shape` | `source_calculations`, `review_history` | `/transport/{ref}` |
| `test_api_scientific_transition_states.py` | `test_ts_detail_default_response_shape` | 4 | `/transition-states/{ref}` |
| `test_api_scientific_literature.py` | `test_records_endpoint_include_review_adds_badges` | `review` | `/literature/{ref}/records` |
| `test_no_op_include_tokens.py` | 4 tests whose names already said "absent" | `entries` ×2, `validation_evidence`, `observations` | TS search / TS concept / conformer-observation |

Two tests gained a *kept* assertion rather than a moved one:
`test_fsf_detail_default_response_shape` and
`test_ecs_detail_default_response_shape` now assert `literature` is present
and `null`. A `literature` include token is legal on both surfaces and gates
nothing — the field is built from the row's own foreign key either way — so
the plausible-looking table entry would have deleted a fact. That is the
single clearest example of why the tables were read off the service code.

The other 220 `["x"] is None` assertions in the suite were kept. The
collisions the spec warned about are real and each was resolved by surface:
`points` is include-gated on `/network-kinetics/*` and an ungated thermo
fact; `literature` is gated on no surface at all; `path_search` is gated on
`/full` and `/calculations/*` and an ungated field inside kinetics
provenance; `review_history` is gated on eight surfaces and never a
scientific fact.

### The new test

`backend/tests/api/scientific/test_unrequested_sections_are_absent.py` —
112 cases from one seeded corpus.

- One parametrised case per operation, asserting an unrequested section is
  absent, a requested one is present, and `request.include` echoes the
  resolved set.
- It enumerates the **runtime's own table objects** and calls the runtime's
  own `_record_nodes` to decide which dicts to assert on, so a table that is
  declared and never wired, or wired and never declared, fails.
- It asserts its own case count and section count against those tables. An
  emptied parametrisation fails rather than passing green — mutation 2 below.
- **No expected-no-field exemption list**, per the brief. One exemption of a
  different kind exists and is asserted rather than skipped: `detail_only_tokens`
  names `imaginary_mode_projections`, which the shared `/calculations` table
  declares and the search operation's vocabulary does not accept. The test
  asserts the token really is refused `422` there and the field really is
  absent — two positive assertions where a skip would have been.
- 20 cases assert ungated nullable fields are still present-and-`null`, under
  the default request **and** under `include=all`: `nasa9`, `wilhoit`,
  `group_additivity`, `points`, `supersession` on thermo; `chebyshev`,
  `plog_entries`, `falloff`, `multi_arrhenius`, `third_body_efficiencies` on
  kinetics; `literature`, `software_release`, `workflow_tool_release`,
  `transition_state` on statmech; `literature`, `software_release` on
  networks; `assignment_scheme` on conformer observations; `literature` and
  `workflow_tool_release` on FSF; `literature` on ECS.

### OpenAPI

79 more `x-tckdb-include-gated` markers, 98 in total across 18 components,
under the rule the spec settled: **mark a property gated on at least one
operation that returns the component, never one any operation emits
unconditionally.** Which components return which was read off the document
itself rather than assumed.

Golden diff, verified structurally rather than by line count: **79 added, 0
removed, 1 changed** — the changed key is the `/full` response docstring,
edited deliberately. Re-running the projection over the regenerated golden
adds nothing, so it is a fixed point.

`x-tckdb-include-tokens` on the operation is *not* in this PR; the spec
stages it with the documentation work.

---

## Migration

**This is a breaking read-API change.**

A consumer that subscripts an unrequested include-gated section now gets a
`KeyError` instead of `None`. Two ways to fix a call site:

```python
# before
calcs = record["calculations"] or []

# after — either ask for it
record = get("/scientific/transition-state-entries/tse_x?include=calculations")
calcs = record["calculations"] or []

# or read it defensively
calcs = record.get("calculations") or []
```

**No client type change is needed.** Every scientific record TypedDict in
`clients/python/src/tckdb_client/scientific_types.py` is already
`TypedDict, total=False`, so every gated section is `NotRequired` and a type
checker already refused to guarantee the key. Nothing under `clients/python`,
`schemas/python` or `integrations/mcp` is touched by this PR, so **no package
version bump applies** (`clients/python` stays at 0.55.0).

`available_sections` is unaffected and answers the other question — "is there
any?" — without being asked, on every surface that has it.

---

## Schema / migration impact

**None.** No ORM model, no Pydantic field, no Alembic revision. One schema
*docstring* changed (`ScientificReactionFullResponse`), which moves the
OpenAPI `description` and nothing else. No new environment variable.

---

## Verification — the runs that happened

```
$ ruff check app tests scripts                        # from backend/
All checks passed!

$ bash scripts/test-scientific.sh ; echo "EXIT=$?"
2306 passed in 178.91s (0:02:58)
EXIT=0

$ bash scripts/test-api.sh ; echo "EXIT=$?"
3351 passed, 1 warning in 319.61s (0:05:19)
EXIT=0

$ bash scripts/test-rest.sh ; echo "EXIT=$?"
4892 passed, 14 skipped, 27 warnings in 181.36s (0:03:01)
EXIT=0
```

Each gate ran on its own `DB_TEST_NAME` so the three could run concurrently
without sharing a test database.

**Mutation testing — five landed, confirmed in the diff, run, reverted, and
each file re-verified byte-identical by `sha256sum`.**

| # | mutation | caught by |
|---|---|---|
| 1 | `"review": ("review_history", "literature")` — an ungated field added to `STATMECH_RECORD_SECTIONS` | `test_an_ungated_nullable_field_keeps_its_null[GET /statmech/{ref}-record-literature]` (1 failed, 19 passed) |
| 2 | `CASES = ()` — the parametrisation emptied | `test_the_parametrisation_covers_every_declared_table` (`set() == {…}`) and `test_the_parametrisation_asserts_its_own_size` (`0 == 40`); 25 failed, 5 passed |
| 3 | `FULL_SCOPE` instead of `DOCUMENT_SCOPE` on `/full` | `test_an_unrequested_section_is_absent[GET /reaction-entries/{ref}/full]`, `test_default_omits_non_default_sections`, `test_full_conformers_section_omitted_by_default` (3 failed, 81 passed) |
| 4 | `DETAIL_SCOPE` on the `/statmech/search` list envelope — a silent no-op | `test_an_unrequested_section_is_absent[GET /statmech/search]`: *"'source_calculations' is gated by 'source_calculations' and the caller did not ask for it, but the key is on the wire"* (1 failed, 39 passed) |
| 5 | `"torsions"` deleted from `STATMECH_RECORD_SECTIONS` | `test_the_parametrisation_asserts_its_own_size` (`80 == 81`), plus both marker-registry tests (3 failed, 14 passed) |

Mutation 3 is the one the brief called out: the scope whose name matches the
route produces a silent no-op, and the guard catches it.

---

## What the spec got wrong

Reported because the spec asked to be told.

1. **"After PR 2, every legal token produces something" is false.** The spec
   named three no-op tokens and PR #235 fixed those three, but at least
   thirteen remain: `review` on `/species/search` (a source comment calls it
   "a no-op at the data-shape level"), `review` on `/full` and on
   `/artifacts/search`, `literature` on `/frequency-scale-factors/*` and
   `/energy-correction-schemes/*`, seven of the eleven tokens on
   `/reaction-entries/{id}/kinetics` (`provenance`, `calculations`,
   `transition_states`, `path_search`, `irc`, `review`, `artifacts`), and all
   three public tokens on `/literature/{ref}`. This did not require an
   exemption list because the test enumerates the *tables*, not the
   vocabularies — but a test written the other way round would have needed
   one, and the brief's instruction to report rather than add one was the
   right call.

2. **The `interpretations` token gates two fields, not one.** The live
   measurement saw only `interpretation_assignments` move because the record
   probed carried no tunneling block; `tunneling_application` is built in the
   same branch (`services/scientific_read/kinetics.py:562-565`). A table built
   from the measurement alone would have left a permanently-null field.

3. **FSF's gated sections are `used_by` only, not `used_by` + `literature`.**
   The inventory lists both. `literature` is a legal token that gates nothing;
   the field is unconditional. Same on ECS. Putting `literature` in either
   table would have deleted a scientific fact — the failure mode the spec's own
   hard-boundary section exists to prevent, reached through its own inventory.

4. **The contradiction class is not empty.** The spec says decision 1 empties
   it and that the residue is "exactly two properties, both on
   `ScientificCalculationRecord`". `KineticsRecord.assessments` is stripped on
   both kinetics surfaces and emitted unconditionally inside `/full`, and
   `KineticsRecord.interpretation_assignments` / `.tunneling_application` are
   gated on the detail surface and unconditional on `/kinetics/search` and
   `/full`. Three more contradiction-class properties, all on one component,
   all left unmarked.

5. **Artifacts' `calculation` token is include-gated after all**, at nesting
   depth 2 (`records[*].calculation.{level_of_theory,software_release,
   workflow_tool_release}`). The inventory records it as "populated by
   default", which is true of the `calculation` context object and false of
   the three summaries inside it. Left out of this PR deliberately — see above.

Confirmed as stated: the `/full` document-root nulls (measured live on
`rxe_qpwvjtgnwvyer2zdytemwib3te`: `artifacts, atom_map, calculations,
conformers, irc, path_search, review_records, scans` all present-and-null,
echo `['kinetics','species','transition_states']`), `review_records` being
governed by `include_review` rather than a token, `FULL_SCOPE` being a silent
no-op for the document's own sections, and the `points` / `plog` truncation
companions travelling with their sections.
